### PR TITLE
refactor(memtable): replace Mutex with RwLock for range-tombstone concurrency

### DIFF
--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -197,8 +197,9 @@ impl Memtable {
     /// Panics if the internal `RwLock` is poisoned.
     #[must_use]
     pub fn insert_range_tombstone(&self, start: UserKey, end: UserKey, seqno: SeqNo) -> u64 {
-        // flag_rotated() is called by the host crate (fjall) before rotation;
-        // this crate never sets it directly. The assert catches misuse by callers
+        // flag_rotated() (which sets requested_rotation) is called by the host
+        // crate (fjall) before rotation; this crate never sets it directly.
+        // The assert catches misuse by callers
         // in debug builds — intentionally debug-only because post-rotation writes
         // are structurally prevented by the host (sealed memtables are behind Arc
         // with no write path exposed), and an atomic load here would add overhead


### PR DESCRIPTION
## Summary

- Replace `Mutex<IntervalTree>` with `RwLock<IntervalTree>` for the memtable range-tombstone field
- Read-heavy suppression queries (`query_suppression`, `range_tombstones_sorted`, `range_tombstone_count`) now take a shared read lock — concurrent readers no longer serialize
- `insert_range_tombstone` takes an exclusive write lock (infrequent operation)
- After rotation is requested via `requested_rotation`, the tree is treated as read-only by convention (the `RwLock` is still used for synchronization, but there should be no further writes)
- `std::sync::RwLock` may be reader-biased on some platforms; writer starvation is not a concern because range deletes are rare, the write critical section is O(log n) with small n, and memtable rotation makes the tree read-only
- `debug_assert!(!is_flagged_for_rotation())` in `insert_range_tombstone` catches post-rotation misuse by callers in debug builds
- Panic-on-poison policy preserved from original Mutex implementation (poisoned lock = prior panic during write, tree in unknown state)

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — all tests pass, 0 failures
- [x] `cargo clippy --lib --tests` — no new warnings
- [x] `rwlock_read_while_read_held_succeeds` — dual mpsc channels ensure cross-thread read guard overlap; unwind-safe (no deadlock on assertion failure)
- [x] `range_tombstones_concurrent_read_write_writers_observable` — Barrier-synchronized 4 readers + 2 writers; post-join suppression asserts confirm writer completion (mid-loop assertion intentionally omitted — `std::sync::RwLock` may be reader-biased)
- [x] `range_tombstones_populated_tree_concurrent_reads_succeed` — 8 readers on 50-tombstone tree
- [x] `suppression_queries_concurrent_readers_no_panic` — 8 threads doing suppression queries

Closes #31