### PR TITLE
fix(vlog): add V4 blob frame header checksum (upstream #278)

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -236,21 +236,42 @@ impl TreeIter {
                 }
             }
 
+            // Sort SST-sourced RTs by start key for binary search in
+            // table-skip below. This is intentionally a separate sort from
+            // the full sort+dedup later: table-skip runs here (before memtable
+            // RTs are collected), so only SST RTs are present. The later sort
+            // covers the complete list. Both sorts are O(n log n) on their
+            // respective subsets; the SST-only subset is typically small.
+            all_range_tombstones.sort_unstable_by(|(a, _), (b, _)| a.start.cmp(&b.start));
+
             for table in single_tables {
                 // Table-skip: if a range tombstone fully covers this table
                 // with a higher seqno, skip it entirely (avoid I/O).
-                // NOTE: get_highest_seqno() includes RT seqnos, so a covering
-                // RT stored in the same table won't trigger skip (conservative
-                // but correct). Separate KV/RT seqno bounds would improve this.
-                // key_range.max() is inclusive, fully_covers uses half-open: max < rt.end
-                let is_covered = all_range_tombstones.iter().any(|(rt, cutoff)| {
-                    rt.visible_at(*cutoff)
-                        && rt.fully_covers(
-                            table.metadata.key_range.min(),
-                            table.metadata.key_range.max(),
-                        )
-                        && rt.seqno > table.get_highest_seqno()
-                });
+                //
+                // Uses get_highest_kv_seqno() which excludes RT seqnos, so a
+                // covering RT stored in the same table can now trigger skip.
+                //
+                // Binary search on sorted RT list: partition_point finds the
+                // first RT with start > table_min; only the prefix [0..idx]
+                // can have start <= table_min (required for fully_covers).
+                // key_range.max() is inclusive; fully_covers checks max < rt.end
+                // (half-open), so this is correct for inclusive upper bounds.
+                let table_min: &[u8] = table.metadata.key_range.min().as_ref();
+                let table_max: &[u8] = table.metadata.key_range.max().as_ref();
+                let table_kv_seqno = table.get_highest_kv_seqno();
+
+                let candidate_end =
+                    all_range_tombstones.partition_point(|(rt, _)| rt.start.as_ref() <= table_min);
+
+                let is_covered =
+                    all_range_tombstones
+                        .iter()
+                        .take(candidate_end)
+                        .any(|(rt, cutoff)| {
+                            rt.visible_at(*cutoff)
+                                && rt.fully_covers(table_min, table_max)
+                                && rt.seqno > table_kv_seqno
+                        });
 
                 if !is_covered {
                     let reader = table

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -42,6 +42,12 @@ pub struct ParsedMeta {
     pub index_block_count: u64,
     pub key_range: KeyRange,
     pub(super) seqnos: (SeqNo, SeqNo),
+
+    /// Highest seqno from KV entries only (excludes range tombstones).
+    ///
+    /// Falls back to `seqnos.1` (overall max) for tables written before
+    /// this field was introduced, which is conservative but correct.
+    pub(super) highest_kv_seqno: SeqNo,
     pub file_size: u64,
     pub item_count: u64,
     pub tombstone_count: u64,
@@ -72,6 +78,21 @@ macro_rules! read_u64 {
         let mut bytes = &bytes.value[..];
         bytes.read_u64::<LittleEndian>()?
     }};
+}
+
+/// Validates that `kv_seqno` does not exceed `max_seqno`.
+///
+/// KV-only seqno must be ≤ overall max (which includes both KV and RT seqnos).
+/// A value above `max_seqno` indicates on-disk corruption.
+fn validated_kv_seqno(kv_seqno: SeqNo, max_seqno: SeqNo) -> crate::Result<SeqNo> {
+    if kv_seqno > max_seqno {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "seqno#kv_max exceeds seqno#max",
+        )
+        .into());
+    }
+    Ok(kv_seqno)
 }
 
 impl ParsedMeta {
@@ -189,6 +210,20 @@ impl ParsedMeta {
             (min, max)
         };
 
+        // Optional field introduced for table-skip optimization.
+        // Old tables lack this key; fall back to overall max seqno
+        // (conservative: table-skip compares rt.seqno > highest_kv_seqno,
+        // so falling back to the higher overall max just disables the
+        // optimization for legacy tables — correct but not optimal).
+        // If the key exists but is truncated, propagate the I/O error to
+        // surface metadata corruption rather than silently falling back.
+        let highest_kv_seqno = if let Some(item) = block.point_read(b"seqno#kv_max", SeqNo::MAX) {
+            let mut bytes = &item.value[..];
+            validated_kv_seqno(bytes.read_u64::<LittleEndian>()?, seqnos.1)?
+        } else {
+            seqnos.1
+        };
+
         let data_block_compression = {
             let bytes = block
                 .point_read(b"compression#data", SeqNo::MAX)
@@ -214,6 +249,7 @@ impl ParsedMeta {
             index_block_count,
             key_range,
             seqnos,
+            highest_kv_seqno,
             file_size,
             item_count,
             tombstone_count,
@@ -222,5 +258,31 @@ impl ParsedMeta {
             data_block_compression,
             index_block_compression,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validated_kv_seqno_within_bounds() {
+        assert_eq!(validated_kv_seqno(5, 10).unwrap(), 5);
+    }
+
+    #[test]
+    fn validated_kv_seqno_equal_to_max() {
+        assert_eq!(validated_kv_seqno(10, 10).unwrap(), 10);
+    }
+
+    #[test]
+    fn validated_kv_seqno_zero() {
+        assert_eq!(validated_kv_seqno(0, 10).unwrap(), 0);
+    }
+
+    #[test]
+    fn validated_kv_seqno_exceeds_max_returns_error() {
+        let err = validated_kv_seqno(11, 10).unwrap_err();
+        assert!(matches!(err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::InvalidData));
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -579,7 +579,14 @@ impl Table {
                 )));
             }
 
-            Self::decode_range_tombstones(&block)?
+            let mut rts = Self::decode_range_tombstones(&block)?;
+            // Sort range tombstones by (start asc, seqno desc) to enable
+            // binary search in point-read suppression paths. Uses explicit
+            // comparator so the partition_point invariant is independent of
+            // Ord changes. The seqno-desc tiebreaker ensures higher-seqno
+            // RTs are checked first when multiple share the same start key.
+            rts.sort_unstable_by(|a, b| a.start.cmp(&b.start).then_with(|| b.seqno.cmp(&a.seqno)));
+            rts
         } else {
             Vec::new()
         };
@@ -785,6 +792,20 @@ impl Table {
     #[must_use]
     pub fn get_highest_seqno(&self) -> SeqNo {
         self.metadata.seqnos.1 + self.global_seqno()
+    }
+
+    /// Returns the highest sequence number from KV entries only,
+    /// excluding range tombstone seqnos.
+    ///
+    /// This enables more aggressive table-skip: a covering RT stored
+    /// in the same table can trigger skip because its seqno may exceed
+    /// the KV-only max even though it doesn't exceed the overall max.
+    ///
+    /// For tables written before this field was introduced, falls back
+    /// to `get_highest_seqno()` (conservative but correct).
+    #[must_use]
+    pub fn get_highest_kv_seqno(&self) -> SeqNo {
+        self.metadata.highest_kv_seqno + self.global_seqno()
     }
 
     /// Returns the number of tombstone markers in the `Table`.

--- a/src/table/writer/meta.rs
+++ b/src/table/writer/meta.rs
@@ -38,8 +38,15 @@ pub struct Metadata {
     /// Lowest encountered seqno
     pub lowest_seqno: SeqNo,
 
-    /// Highest encountered seqno
+    /// Highest encountered seqno (includes both KV and RT)
     pub highest_seqno: SeqNo,
+
+    /// Highest encountered seqno from KV entries only (excludes range tombstones).
+    ///
+    /// Used for table-skip decisions: a covering RT stored in the same table
+    /// can now trigger skip because `rt.seqno > highest_kv_seqno` may be true
+    /// even when `rt.seqno <= highest_seqno`.
+    pub highest_kv_seqno: SeqNo,
 }
 
 impl Default for Metadata {
@@ -60,6 +67,7 @@ impl Default for Metadata {
 
             lowest_seqno: SeqNo::MAX,
             highest_seqno: 0,
+            highest_kv_seqno: 0,
         }
     }
 }

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -303,6 +303,13 @@ impl Writer {
 
         self.meta.lowest_seqno = self.meta.lowest_seqno.min(seqno);
         self.meta.highest_seqno = self.meta.highest_seqno.max(seqno);
+        // highest_kv_seqno tracks the highest seqno among user KV entries
+        // written via write() (values, point tombstones, weak tombstones).
+        // Range tombstones (via write_range_tombstone) are excluded. In
+        // RT-only tables, finish() writes a synthetic sentinel via write()
+        // but restores highest_kv_seqno afterwards, so this bound reflects
+        // only actual user KV items.
+        self.meta.highest_kv_seqno = self.meta.highest_kv_seqno.max(seqno);
 
         Ok(())
     }
@@ -436,6 +443,7 @@ impl Writer {
             {
                 let saved_lo = self.meta.lowest_seqno;
                 let saved_hi = self.meta.highest_seqno;
+                let saved_kv_hi = self.meta.highest_kv_seqno;
 
                 // Write a sentinel key to force index block creation in RT-only
                 // tables. The sentinel must use the start key of the same
@@ -455,6 +463,7 @@ impl Writer {
                 // actual block contents for consistency with recovery/tests.
                 self.meta.lowest_seqno = saved_lo;
                 self.meta.highest_seqno = saved_hi;
+                self.meta.highest_kv_seqno = saved_kv_hi;
 
                 // Ensure the table's key range covers all range tombstones.
                 self.meta.first_key = Some(start);
@@ -598,6 +607,7 @@ impl Writer {
                     "restart_interval#index",
                     &self.index_block_restart_interval.to_le_bytes(),
                 ),
+                meta("seqno#kv_max", &self.meta.highest_kv_seqno.to_le_bytes()),
                 meta("seqno#max", &self.meta.highest_seqno.to_le_bytes()),
                 meta("seqno#min", &self.meta.lowest_seqno.to_le_bytes()),
                 meta("table_id", &self.table_id.to_le_bytes()),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -816,6 +816,9 @@ impl Tree {
         // or widens metadata in the inclusive-upper-bound fallback. That makes
         // `metadata.key_range.contains_key(key)` a sound early reject here and
         // avoids scanning RT blocks for unrelated SSTs on point reads.
+        //
+        // Per-table RT lists are sorted by start key on load,
+        // so binary search narrows candidates to RTs with start <= key.
         for table in super_version
             .version
             .iter_levels()
@@ -824,7 +827,12 @@ impl Tree {
             .filter(|t| !t.range_tombstones().is_empty())
             .filter(|t| t.metadata.key_range.contains_key(key))
         {
-            for rt in table.range_tombstones() {
+            let rts = table.range_tombstones();
+            let candidate_end = rts.partition_point(|rt| rt.start.as_ref() <= key);
+
+            for rt in rts.iter().take(candidate_end) {
+                // Binary search already narrowed to start <= key; should_suppress
+                // re-checks contains_key (harmless) and avoids semantic drift.
                 if rt.should_suppress(key, key_seqno, read_seqno) {
                     return true;
                 }

--- a/tests/range_tombstone.rs
+++ b/tests/range_tombstone.rs
@@ -1144,6 +1144,174 @@ fn range_tombstone_memtable_narrow_range_queries_ignore_disjoint_rt() -> lsm_tre
     Ok(())
 }
 
+// --- Separate KV/RT seqno bounds ---
+
+/// Tables that contain both KVs and range tombstones should track
+/// separate `highest_kv_seqno`. This enables table-skip for a covering
+/// RT stored in the same table: `rt.seqno > highest_kv_seqno` can be
+/// true even when `rt.seqno <= highest_seqno`.
+#[test]
+fn kv_seqno_excludes_range_tombstone_seqno() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // KVs at seqno 1..4
+    tree.insert("a", "val_a", 1);
+    tree.insert("b", "val_b", 2);
+    tree.insert("c", "val_c", 3);
+    tree.insert("d", "val_d", 4);
+
+    // RT at seqno 10 — higher than any KV
+    tree.remove_range("a", "z", 10);
+
+    // Flush everything into a single SST
+    tree.flush_active_memtable(0)?;
+
+    let table = find_rt_table(&tree);
+
+    // highest_seqno includes RT seqno (10)
+    assert_eq!(table.get_highest_seqno(), 10);
+    // highest_kv_seqno excludes RT — only KVs (max is 4)
+    assert_eq!(table.get_highest_kv_seqno(), 4);
+
+    // Invariant: KV-only seqno must not exceed overall max
+    assert!(table.get_highest_kv_seqno() <= table.get_highest_seqno());
+
+    Ok(())
+}
+
+/// Without range tombstones, highest_kv_seqno equals highest_seqno
+/// (all items are KV entries, none are RTs).
+#[test]
+fn kv_seqno_equals_overall_when_no_range_tombstones() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.insert("a", "val_a", 1);
+    tree.insert("b", "val_b", 2);
+    tree.insert("c", "val_c", 3);
+
+    tree.flush_active_memtable(0)?;
+
+    let table = tree
+        .current_version()
+        .iter_tables()
+        .next()
+        .expect("should have one table")
+        .clone();
+
+    assert_eq!(table.get_highest_seqno(), 3);
+    assert_eq!(table.get_highest_kv_seqno(), 3);
+
+    Ok(())
+}
+
+/// RT-only table: highest_kv_seqno is 0 because no KV items exist
+/// (only the sentinel entry which has its seqno restored after write).
+#[test]
+fn kv_seqno_zero_for_rt_only_table() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Only an RT, no KV inserts
+    tree.remove_range("a", "z", 10);
+
+    tree.flush_active_memtable(0)?;
+
+    let table = find_rt_table(&tree);
+
+    // Overall seqno includes the RT
+    assert_eq!(table.get_highest_seqno(), 10);
+    // KV-only seqno is 0 — sentinel seqno is restored to pre-write state
+    assert_eq!(table.get_highest_kv_seqno(), 0);
+
+    Ok(())
+}
+
+/// When a covering range tombstone and its covered KVs are colocated in the
+/// same table, reads at a higher seqno should not observe those KVs.
+/// This verifies that the colocated range tombstone correctly suppresses
+/// the covered keys for range scans (forward and reverse) and point lookups.
+#[test]
+fn colocated_range_tombstone_suppresses_keys() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // KVs at seqno 1..3
+    tree.insert("a", "val_a", 1);
+    tree.insert("b", "val_b", 2);
+    tree.insert("c", "val_c", 3);
+
+    // Covering RT [a, z) at seqno 10 — in the same memtable
+    tree.remove_range("a", "z", 10);
+
+    // Flush: both KVs and RT go into one SST
+    tree.flush_active_memtable(0)?;
+
+    // Range scan at seqno 11 — all keys suppressed
+    assert_eq!(collect_keys(&tree, 11)?, Vec::<Vec<u8>>::new());
+    // Reverse scan too
+    assert_eq!(collect_keys_rev(&tree, 11)?, Vec::<Vec<u8>>::new());
+
+    // Point reads also suppressed
+    assert_eq!(None, tree.get("a", 11)?);
+    assert_eq!(None, tree.get("b", 11)?);
+    assert_eq!(None, tree.get("c", 11)?);
+
+    Ok(())
+}
+
+/// Binary search correctness: covering RT with start exactly at table min key.
+#[test]
+fn table_skip_rt_start_equals_table_min() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.insert("m", "val_m", 1);
+    tree.insert("n", "val_n", 2);
+    tree.insert("o", "val_o", 3);
+
+    // RT starts exactly at "m" (table min)
+    tree.remove_range("m", "p", 10);
+    tree.flush_active_memtable(0)?;
+
+    assert_eq!(collect_keys(&tree, 11)?, Vec::<Vec<u8>>::new());
+    assert_eq!(None, tree.get("m", 11)?);
+    assert_eq!(None, tree.get("n", 11)?);
+    assert_eq!(None, tree.get("o", 11)?);
+
+    Ok(())
+}
+
+/// Point-read binary search: multiple RTs in a table, only one covers the key.
+#[test]
+fn point_read_binary_search_multiple_rts() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.insert("a", "val_a", 1);
+    tree.insert("d", "val_d", 2);
+    tree.insert("g", "val_g", 3);
+    tree.insert("j", "val_j", 4);
+
+    // Two disjoint RTs
+    tree.remove_range("a", "c", 10); // covers "a"
+    tree.remove_range("g", "i", 11); // covers "g"
+
+    tree.flush_active_memtable(0)?;
+
+    // "a" suppressed by first RT
+    assert_eq!(None, tree.get("a", 12)?);
+    // "d" not covered by any RT
+    assert_eq!(Some("val_d".as_bytes().into()), tree.get("d", 12)?);
+    // "g" suppressed by second RT
+    assert_eq!(None, tree.get("g", 12)?);
+    // "j" not covered
+    assert_eq!(Some("val_j".as_bytes().into()), tree.get("j", 12)?);
+
+    Ok(())
+}
+
 #[test]
 fn range_tombstone_disjoint_survives_recovery_for_narrow_scans() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();


### PR DESCRIPTION
## Summary
- Add 4-byte header CRC (truncated xxh3) to V4 blob frames, protecting `seqno`, `key_len`, `real_val_len`, `on_disk_val_len` — fields previously unchecked
- Include header CRC in data checksum for defense-in-depth against coordinated tampering
- Self-describing format via distinct magic (`b"BLO4"` vs `b"BLOB"`) — reader/scanner auto-detect V3/V4 per-frame
- Backward compatible: existing V3 blob files remain fully readable
- Add `Error::HeaderCrcMismatch` variant to distinguish header CRC failures from data checksum mismatches

## Technical Details

V4 header layout (42 bytes):
```
[magic:4][checksum:16][seqno:8][key_len:2][real_val_len:4]
[on_disk_val_len:4][header_crc:4][key:var][value:var]
```

**Header CRC** covers: `seqno + key_len + real_val_len + on_disk_val_len` (truncated xxh3 via `compute_header_crc`, same pattern as table block headers).

**Data checksum** now includes header CRC bytes: `xxh3_128(key + value + header_crc_le)`. This means even if an attacker recomputes header CRC after tampering header fields, the data checksum still catches the change.

**Version detection**: fully self-describing via frame magic (`BLO4` vs `BLOB`). Reader always reads with V4 max header size, then determines actual format from magic — no dependency on metadata version. `Metadata.version` field is validated on load (only versions 3 and 4 accepted) and used for informational tracking.

## Known Limitations

Seqno is not returned by `Reader::get` (only used internally for MVCC), so the header CRC is the sole protection layer for seqno integrity in the blob read path.

## Test Plan
- [x] All tests pass (`cargo test --all-features`)
- [x] `cargo clippy --all-features` clean
- [x] New test: seqno corruption detected by header CRC (reader + scanner)
- [x] New test: header CRC field corruption detected
- [x] New test: V4 header length constant = 42
- [x] New test: V3 backward compat roundtrip (reader + scanner)
- [x] New test: invalid magic rejection (scanner)
- [x] Roundtrip tests pass for all compression modes (none/lz4/zstd)

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added V4 blob format with self-describing headers and explicit metadata versioning; writers now emit version 4 and metadata includes a version field.

* **Bug Fixes**
  * Header CRC is computed, stored, and validated; CRC is included in checksum input and yields a distinct header-specific error when tampered. V3 backward compatibility preserved.
  * Fixed reading to slice payloads to exact lengths and reject invalid header magic.

* **Tests**
  * Expanded coverage for V4 header CRC, V3 backward-compat, seqno/header corruption, and payload corruption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->