### PR TITLE
fix(get): select highest-seqno entry across all L0 tables

### DIFF
--- a/tests/regression_rt_tombstone.rs
+++ b/tests/regression_rt_tombstone.rs
@@ -4,6 +4,9 @@
 // When `optimize_runs` merges disjoint L0 tables from different flush epochs,
 // a newer point tombstone can end up in a run iterated AFTER an older value,
 // causing `get()` to return stale data instead of None.
+//
+// `optimize_runs` is called on every version creation (flush, compaction),
+// so flushing multiple memtables is sufficient to trigger the reordering.
 
 use lsm_tree::{get_tmp_folder, AbstractTree, AnyTree, Config, SequenceNumberCounter};
 use test_log::test;


### PR DESCRIPTION
## Summary

- Fix point tombstone invisible when range tombstone exists in prior SST
- `optimize_runs` merges disjoint tables from different flush epochs into one run, which can reorder them relative to RT-widened tables in other runs — causing `get()` to return stale data
- Replace early-return-on-first-match in `get_internal_entry_from_tables` with highest-seqno tracking

## Technical Details

When a range tombstone widens an SST's persisted key range (e.g., `[0, 2]` → `[0, 3]`), `optimize_runs` may place that SST in a separate run while merging a newer SST (containing a point tombstone) with an older disjoint SST. The merged run ends up iterated **after** the RT-widened run, so `get()` finds the stale insert before reaching the newer point tombstone.

The fix scans all matching tables and selects the entry with the highest seqno, ensuring the most recent write always wins regardless of run layout.

## Test Plan

- [x] `baseline_point_tombstone_across_ssts` — confirms non-RT cross-SST tombstone works
- [x] `regression_rt_same_sst_then_tombstone_in_next` — simpler RT scenario passes
- [x] `regression_remove_range_then_insert_then_remove` — exact reproducer from issue
- [x] Full test suite (332+ tests) passes

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tombstone shadowing across multiple storage files to ensure point deletions correctly override previous inserts regardless of storage organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->