### PR TITLE
fix(vlog): replace panic paths in Metadata::from_slice with Result propagation

### DIFF
--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -228,8 +228,8 @@ mod tests {
         let buf = Slice::from(buf);
         let result = Metadata::from_slice(&buf);
         assert!(
-            result.is_err(),
-            "expected Err for missing 'compression', got {result:?}",
+            matches!(result, Err(crate::Error::InvalidHeader("BlobFileMeta"))),
+            "expected Err(InvalidHeader(\"BlobFileMeta\")), got {result:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

- Replace `unwrap_or_else(|| panic!(...))` in `read_u64!`/`read_u128!` macros with `.ok_or(Error::InvalidHeader("BlobFileMeta"))?`
- Replace `.expect()` on `compression`, `key#min`, `key#max` lookups with `.ok_or(...)?`
- Add regression tests for corrupt/truncated metadata returning `Err`

## Technical Details

Pre-existing upstream panic paths in `Metadata::from_slice` would crash on corrupt or partially-written blob file metadata instead of returning a recoverable error. All five `point_read()` call sites that used `panic!`/`expect()` now propagate `InvalidHeader("BlobFileMeta")` via `?`.

## Known Limitations

None — all existing fields covered.

## Test Plan

- [x] `test_blob_file_meta_roundtrip` — existing, passes
- [x] `test_blob_file_meta_truncated_returns_err` — verifies truncated metadata (magic header only) returns `Err`
- [x] `test_blob_file_meta_missing_field_returns_err` — builds valid metadata block with `compression` omitted, verifies `from_slice` returns `Err(InvalidHeader)` (exercises `.ok_or()` paths)

Closes #49