### PR TITLE
feat: add is_valid_scan_boundary to PrefixExtractor trait

### DIFF
--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -202,7 +202,7 @@ mod tests {
         assert!(!extractor.is_valid_scan_boundary(b""));
     }
 
-    /// Extractor that overrides `is_valid_scan_boundary` with an O(1) sentinel
+    /// Extractor that overrides `is_valid_scan_boundary` with an O(1) length
     /// check instead of iterating all prefixes via the default implementation.
     struct FixedLengthPrefix;
 


### PR DESCRIPTION
## Summary

- Rename `is_valid_prefix_boundary` → `is_valid_scan_boundary` to better express the method's purpose: validating scan boundaries, not just prefix validity
- Expand documentation with explicit contract, default implementation notes, and override guidance
- Add tests for a custom extractor (`FixedLengthPrefix`) that overrides `is_valid_scan_boundary` with an O(1) check

## Technical Details

The default implementation is preserved — it's correct for well-behaved extractors whose `prefixes()` returns sub-slices of the input key. The expanded docs clarify two override scenarios: performance (O(1) sentinel check vs iteration) and correctness (extractors producing non-sub-slice prefixes).

## Test Plan

- All 27 unit tests pass (including 2 new `custom_scan_boundary_*` tests)
- All 12 prefix bloom integration tests pass
- Full `cargo test` clean

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed core validation hook and clarified its contract and boundary semantics; updated filtering to use the new hook, which may change which items are eligible for certain skip/optimization paths.

* **Tests**
  * Expanded coverage with a new fixed-length extractor scenario and additional assertions for custom valid/invalid boundary outcomes and prefix iteration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->