### PR TITLE
fix(testing): prevent proptest oracle timeouts in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,7 @@ slow-timeout = { period = "10s", terminate-after = 6 }
 
 # Property tests may take longer than unit tests (proptest runs N cases).
 # CI uses PROPTEST_CASES=32; local runs default to 256.
+# Budget: 60s × 4 = 240s (4 min) — enough for 32 cases with compact I/O.
 [[profile.default.overrides]]
 filter = "test(prop_)"
-slow-timeout = { period = "30s", terminate-after = 4 }
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: cargo install cross
       - name: Cross test
         run: cross test -r --features lz4 --target ${{ matrix.target }}
+        env:
+          PROPTEST_CASES: "32"
 
   codecov:
     needs: lint
@@ -93,6 +95,8 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
       - run: cargo llvm-cov --no-report nextest --all-features
+        env:
+          PROPTEST_CASES: "32"
       - run: cargo llvm-cov --no-report --doc --features lz4
       - run: cargo llvm-cov report --doctests --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v5

--- a/tests/prop_btreemap_oracle.rs
+++ b/tests/prop_btreemap_oracle.rs
@@ -128,7 +128,7 @@ fn op_strategy() -> impl Strategy<Value = Op> {
 }
 
 fn ops_strategy() -> impl Strategy<Value = Vec<Op>> {
-    prop::collection::vec(op_strategy(), 10..200)
+    prop::collection::vec(op_strategy(), 10..100)
 }
 
 // ---------------------------------------------------------------------------
@@ -252,6 +252,7 @@ fn run_oracle_test(ops: Vec<Op>) -> Result<(), TestCaseError> {
 proptest! {
     // cases defaults to 256; CI overrides via PROPTEST_CASES=32
     #![proptest_config(ProptestConfig {
+        fork: false,
         max_shrink_iters: 1000,
         .. ProptestConfig::default()
     })]

--- a/tests/prop_mvcc.rs
+++ b/tests/prop_mvcc.rs
@@ -250,6 +250,7 @@ fn run_mvcc_test(ops: Vec<MvccOp>) -> Result<(), TestCaseError> {
 proptest! {
     // cases defaults to 256; CI overrides via PROPTEST_CASES=32
     #![proptest_config(ProptestConfig {
+        fork: false,
         max_shrink_iters: 1000,
         .. ProptestConfig::default()
     })]

--- a/tests/prop_range_tombstone.rs
+++ b/tests/prop_range_tombstone.rs
@@ -137,7 +137,7 @@ fn rt_op_strategy() -> impl Strategy<Value = RtOp> {
 }
 
 fn rt_ops_strategy() -> impl Strategy<Value = Vec<RtOp>> {
-    prop::collection::vec(rt_op_strategy(), 20..300)
+    prop::collection::vec(rt_op_strategy(), 20..150)
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +251,7 @@ fn run_rt_test(ops: Vec<RtOp>) -> Result<(), TestCaseError> {
 proptest! {
     // cases defaults to 256; CI overrides via PROPTEST_CASES=32
     #![proptest_config(ProptestConfig {
+        fork: false,
         max_shrink_iters: 1000,
         .. ProptestConfig::default()
     })]


### PR DESCRIPTION
## Summary

- Increase nextest slow-timeout for prop tests from 120s to 240s
- Set `PROPTEST_CASES=32` in `codecov` and `cross` CI jobs (were defaulting to 256)
- Reduce op sequence ranges: btreemap `200→100`, range_tombstone `300→150`
- Add `fork: false` to all proptest configs to skip subprocess overhead

## Root Cause

Three prop tests (`prop_btreemap_oracle`, `prop_mvcc`, `prop_range_tombstone`) were hitting the 120s nextest terminate threshold. Contributing factors:
1. `codecov` and `cross` jobs didn't set `PROPTEST_CASES` — ran 256 cases instead of 32
2. Large op sequence ranges (up to 300 ops/case) with expensive flush+compact I/O
3. Tight nextest budget (`30s × 4 = 120s`) left no headroom for slower CI runners

## Test Plan

- [x] All prop tests pass locally with `PROPTEST_CASES=32` (13s + 8s + 29s)
- [x] Full test suite passes (`cargo test --all-features`)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #93