### PR TITLE
test: add end-to-end corruption test for seqno#kv_max metadata

### DIFF
--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -1803,7 +1803,7 @@ fn meta_seqno_kv_max_corruption_returns_invalid_data() -> crate::Result<()> {
         let trailer = sfa::Reader::from_reader(&mut f)?;
         let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
 
-        let result = ParsedMeta::load_with_handle(&f, &regions.metadata);
+        let result = ParsedMeta::load_with_handle(&f, &regions.metadata, None);
 
         let err = result.expect_err("corrupted seqno#kv_max should cause an error");
         assert!(


### PR DESCRIPTION
## Summary
- Add `meta_seqno_kv_max_corruption_returns_invalid_data` test that exercises the on-disk validation path for `seqno#kv_max` in `ParsedMeta::load_with_handle`
- Writes a valid table, tampers the persisted `seqno#kv_max` to exceed `seqno#max`, recomputes the block checksum so corruption reaches the metadata validation layer, and asserts `InvalidData`

## Test Plan
- `cargo test meta_seqno_kv_max_corruption_returns_invalid_data` passes
- Full lib test suite (424 tests) passes

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end corruption detection test to validate data integrity checks when metadata is corrupted and system responses appropriately with error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->