### PR TITLE
perf(encryption): replace OsRng with thread-local seeded CSPRNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 default = []
 lz4 = ["dep:lz4_flex"]
 zstd = ["dep:zstd"]
-encryption = ["dep:aes-gcm", "dep:rand_chacha", "dep:rand_core"]
+encryption = ["dep:aes-gcm", "dep:rand_chacha"]
 bytes_1 = ["dep:bytes"]
 metrics = []
 
@@ -42,7 +42,6 @@ varint-rs = "2.2.0"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 aes-gcm = { version = "0.10", optional = true, features = ["aes"] }
 rand_chacha = { version = "0.3", optional = true }
-rand_core = { version = "0.6", optional = true, features = ["std"] }
 
 [dev-dependencies]
 criterion = { version = "0.8.0", features = ["html_reports"] }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -128,13 +128,15 @@ impl Aes256GcmProvider {
 /// errors. This function will panic if OS entropy is unavailable.
 #[cfg(feature = "encryption")]
 fn new_chacha_rng() -> rand_chacha::ChaCha20Rng {
-    use rand_core::SeedableRng;
+    // Use rand_core re-exported by aes_gcm to avoid version-skew with a
+    // direct rand_core dependency.
+    use aes_gcm::aead::rand_core::{OsRng, SeedableRng};
 
     #[expect(
         clippy::expect_used,
         reason = "intentionally panics if OsRng is unavailable"
     )]
-    rand_chacha::ChaCha20Rng::from_rng(rand_core::OsRng)
+    rand_chacha::ChaCha20Rng::from_rng(OsRng)
         .expect("OS RNG should be available for initial CSPRNG seed")
 }
 
@@ -167,8 +169,10 @@ impl ForkAwareRng {
             *rng_ref = new_chacha_rng();
         }
 
-        // Deref-coercion: &mut RefMut<ChaCha20Rng> → &mut ChaCha20Rng.
-        // Explicit `&mut *rng_ref` is denied by clippy::explicit_auto_deref.
+        // The RefMut guard is held while f() runs. This is safe because
+        // f() only generates a 12-byte nonce (no reentrant RNG access).
+        // Deref-coercion: &mut RefMut<ChaCha20Rng> → &mut ChaCha20Rng
+        // (explicit &mut *rng_ref is denied by clippy::explicit_auto_deref).
         f(&mut rng_ref)
     }
 }
@@ -417,7 +421,7 @@ mod tests {
         /// probabilistic RNG output to avoid flaky CI.
         #[test]
         fn fork_aware_rng_reseeds_on_pid_change() {
-            use rand_core::RngCore;
+            use aes_gcm::aead::rand_core::RngCore;
 
             let rng = ForkAwareRng::new();
 
@@ -425,7 +429,8 @@ mod tests {
             let _ = rng.with_rng(|r| r.next_u64());
 
             // Simulate fork by setting a fake PID that differs from the real one.
-            let fake_pid = std::process::id().wrapping_add(1);
+            let current_pid = std::process::id();
+            let fake_pid = current_pid ^ 1;
             rng.pid.set(fake_pid);
             assert_eq!(rng.pid.get(), fake_pid, "PID should be set to fake value");
 


### PR DESCRIPTION
## Summary

- Replace per-block `OsRng` (`getrandom` syscall) with a thread-local `ChaCha20Rng` seeded once from `OsRng` per thread
- Eliminates 1-10 µs syscall overhead per block encryption under contention
- Fork-aware: tracks process ID via `ForkAwareRng` and reseeds after `fork()` to prevent nonce reuse across PIDs
- No security reduction — `ChaCha20Rng` is a CSPRNG with identical guarantees

## Technical Details

- `rand_chacha 0.3` added as optional dep gated behind `encryption` feature (already in transitive dep tree via `aes-gcm` — zero new downloads)
- `rand_core` types (`OsRng`, `SeedableRng`) accessed via `aes_gcm::aead::rand_core` re-export to avoid version-skew with a direct dependency
- Module-scope `thread_local!` with `ForkAwareRng` wrapper — compares `std::process::id()` on each call and reseeds if PID changed
- Single `borrow_mut()` per call — reseed and use share the same `RefMut` guard
- `EncryptionProvider` trait API unchanged; change is internal to `Aes256GcmProvider::encrypt()`

## Known Limitations

- Estimated 5-15% improvement for write-heavy encrypted workloads; no benchmark added yet

## Test Plan

- [x] All 11 encryption unit tests pass (including fork-aware reseed + nonce uniqueness)
- [x] All 3 encryption integration tests pass (`encryption_roundtrip`)
- [x] `cargo clippy --features encryption -- -D warnings` clean

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced encryption feature with improved random number generation infrastructure.
  * Optimized nonce generation with thread-local caching for better performance.
  * Added fork-aware random number generation to ensure security across process forks.

* **Tests**
  * Added tests validating nonce uniqueness and fork-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->