### PR TITLE
refactor(fs): migrate crate::file::read_exact to FsFile::read_at

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -2,8 +2,8 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use crate::Slice;
-use std::{fs::File, io::Write, path::Path};
+use crate::{fs::FsFile, Slice};
+use std::{io::Write, path::Path};
 
 pub const MAGIC_BYTES: [u8; 4] = [b'L', b'S', b'M', 3];
 
@@ -12,10 +12,10 @@ pub const BLOBS_FOLDER: &str = "blobs";
 pub const CURRENT_VERSION_FILE: &str = "current";
 
 /// Reads bytes from a file using `pread`.
-pub fn read_exact(file: &File, offset: u64, size: usize) -> std::io::Result<Slice> {
+pub fn read_exact(file: &impl FsFile, offset: u64, size: usize) -> std::io::Result<Slice> {
     // SAFETY: This slice builder starts uninitialized, but we know its length
     //
-    // We use read_at/seek_read which give us the number of bytes read
+    // We use FsFile::read_at which gives us the number of bytes read
     // If that number does not match the slice length, the function errors,
     // so the (partially) uninitialized buffer is discarded
     //
@@ -24,35 +24,13 @@ pub fn read_exact(file: &File, offset: u64, size: usize) -> std::io::Result<Slic
     #[expect(unsafe_code, reason = "see safety")]
     let mut builder = unsafe { Slice::builder_unzeroed(size) };
 
-    {
-        let bytes_read: usize;
+    let bytes_read = file.read_at(&mut builder, offset)?;
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::FileExt;
-
-            bytes_read = file.read_at(&mut builder, offset)?;
-        }
-
-        #[cfg(windows)]
-        {
-            use std::os::windows::fs::FileExt;
-
-            bytes_read = file.seek_read(&mut builder, offset)?;
-        }
-
-        #[cfg(not(any(unix, windows)))]
-        {
-            compile_error!("unsupported platform");
-            unimplemented!();
-        }
-
-        if bytes_read != size {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                format!("read_exact({bytes_read}) at {offset} did not read enough bytes {size}; file has length {}", file.metadata()?.len()),
-            ));
-        }
+    if bytes_read != size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("read_exact({bytes_read}) at {offset} did not read enough bytes {size}; file has length {}", file.metadata()?.len),
+        ));
     }
 
     Ok(builder.freeze().into())

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -21,10 +21,10 @@ pub(crate) use trailer::{Trailer, TRAILER_START_MARKER};
 use crate::{
     coding::{Decode, Encode},
     encryption::EncryptionProvider,
+    fs::FsFile,
     table::BlockHandle,
     Checksum, CompressionType, Slice,
 };
-use std::fs::File;
 
 /// Safety cap on block payload size (256 MiB).
 ///
@@ -267,7 +267,7 @@ impl Block {
     /// Pipeline: read → verify checksum → decrypt → decompress.
     /// When `encryption` is `None`, the decrypt step is skipped.
     pub fn from_file(
-        file: &File,
+        file: &impl FsFile,
         handle: BlockHandle,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -3,12 +3,13 @@
 // (found in the LICENSE-* files in the repository)
 
 use super::{Block, BlockHandle, DataBlock};
+use crate::fs::FsFile;
 use crate::{
     checksum::ChecksumType, coding::Decode, comparator::default_comparator,
     table::block::BlockType, CompressionType, KeyRange, SeqNo, TableId,
 };
 use byteorder::{LittleEndian, ReadBytesExt};
-use std::{fs::File, ops::Deref};
+use std::ops::Deref;
 
 /// Nanosecond timestamp.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -98,7 +99,7 @@ fn validated_kv_seqno(kv_seqno: SeqNo, max_seqno: SeqNo) -> crate::Result<SeqNo>
 impl ParsedMeta {
     #[expect(clippy::expect_used, clippy::too_many_lines)]
     pub fn load_with_handle(
-        file: &File,
+        file: &impl FsFile,
         handle: &BlockHandle,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
     ) -> crate::Result<Self> {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     comparator::SharedComparator,
     descriptor_table::DescriptorTable,
     file_accessor::FileAccessor,
+    fs::FsFile,
     range_tombstone::RangeTombstone,
     table::{
         block::{BlockType, ParsedItem},
@@ -120,7 +121,7 @@ impl Table {
                 };
 
             // Read the exact region using pread-style helper
-            let buf = crate::file::read_exact(&fd, *handle.offset(), handle.size() as usize)?;
+            let buf = crate::file::read_exact(&*fd, *handle.offset(), handle.size() as usize)?;
 
             // If we opened the file here, cache the FD for future accesses
             if fd_cache_miss {
@@ -429,7 +430,7 @@ impl Table {
 
     fn read_tli(
         regions: &ParsedRegions,
-        file: &File,
+        file: &impl FsFile,
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
     ) -> crate::Result<IndexBlock> {
@@ -502,7 +503,7 @@ impl Table {
 
             let block = Self::read_tli(
                 &regions,
-                &file,
+                &*file,
                 metadata.index_block_compression,
                 encryption.as_deref(),
             )?;
@@ -528,7 +529,7 @@ impl Table {
 
             let block = Self::read_tli(
                 &regions,
-                &file,
+                &*file,
                 metadata.index_block_compression,
                 encryption.as_deref(),
             )?;
@@ -553,7 +554,7 @@ impl Table {
 
         let pinned_filter_index = if let Some(filter_tli_handle) = regions.filter_tli {
             let block = Block::from_file(
-                &file,
+                &*file,
                 filter_tli_handle,
                 metadata.index_block_compression,
                 encryption.as_deref(),
@@ -573,7 +574,7 @@ impl Table {
                     );
 
                     let block = Block::from_file(
-                        &file,
+                        &*file,
                         filter_handle,
                         crate::CompressionType::None, // NOTE: We never write a filter block with compression
                         encryption.as_deref(),
@@ -600,7 +601,7 @@ impl Table {
         let range_tombstones = if let Some(rt_handle) = regions.range_tombstones {
             log::trace!("Loading range tombstone block, with rt_ptr={rt_handle:?}");
             let block = Block::from_file(
-                &file,
+                &*file,
                 rt_handle,
                 crate::CompressionType::None,
                 encryption.as_deref(),

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -84,7 +84,7 @@ pub fn load_block(
         (Arc::new(fd), true)
     };
 
-    let block = Block::from_file(&fd, *handle, compression, encryption)?;
+    let block = Block::from_file(&*fd, *handle, compression, encryption)?;
 
     if block.header.block_type != block_type {
         return Err(crate::Error::InvalidTag((


### PR DESCRIPTION
## Summary

- Change `file::read_exact()` to accept `&impl FsFile` instead of `&std::fs::File`, delegating to `FsFile::read_at()` and removing platform-specific `#[cfg(unix)]`/`#[cfg(windows)]` code from the function
- Propagate the `FsFile` trait bound to `Block::from_file`, `Table::read_tli`, and `ParsedMeta::load_with_handle`
- Explicit deref `Arc<File>` at call sites where generic type inference requires it

## Technical Details

`read_exact()` previously duplicated the platform-specific pread logic that already exists in the `FsFile` trait impl for `std::fs::File`. This removes that duplication and makes `read_exact()` work with any `FsFile` implementation, enabling pluggable filesystem backends for the read path.

No behavioral changes — all existing callers pass `std::fs::File` which implements `FsFile`.

## Test Plan

- All 431 unit tests pass
- All integration tests pass
- All proptest tests pass
- `cargo clippy --lib` clean

Closes #89