### PR TITLE
fix(compaction): preserve range tombstones covering gaps between output tables

### DIFF
--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -177,18 +177,22 @@ impl MultiWriter {
                             // Widen last_key so point reads for keys in the
                             // gap will consult this table for RT suppression.
                             //
-                            // Guard: clipped.end is exclusive but last_key is
-                            // inclusive.  When clipped.end == clip_upper (the
-                            // next table's first key), setting last_key to that
-                            // value would make adjacent tables' key_ranges
-                            // overlap, breaking Run::get_for_key_cmp.  Only
-                            // widen when strictly less than clip_upper.
+                            // Only widen during rotation (clip_upper is Some)
+                            // where we know the exact boundary.  For the final
+                            // table (clip_upper is None) widening with the
+                            // derived exclusive bound could overlap a non-
+                            // compacted adjacent table at the same level.
+                            //
+                            // Even during rotation, clipped.end must be
+                            // strictly less than clip_upper (the next table's
+                            // first key) — equality would make key_ranges
+                            // overlap, breaking Run::get_for_key_cmp.
                             //
                             // Only last_key needs widening: intersect_opt
                             // already clamps clipped.start >= first_key.
                             if let Some(existing) = &mut writer.meta.last_key {
                                 let safe = clip_upper
-                                    .map_or(true, |upper| clipped.end.as_ref() < upper.as_ref());
+                                    .is_some_and(|upper| clipped.end.as_ref() < upper.as_ref());
                                 if safe && clipped.end.as_ref() > existing.as_ref() {
                                     *existing = clipped.end.clone();
                                 }


### PR DESCRIPTION
## Summary

- Fix RT clipping during compaction table rotation: clip to `[first_key, next_table_first_key)` instead of `[first_key, upper_bound(last_key))`, preserving RTs that span the gap between output tables
- Widen table `key_range` metadata to include gap-covering RTs so point reads consult the correct table — guarded to avoid disjoint-run overlap when `clipped.end == clip_upper`
- Add regression tests: gap-covering RT preservation + key_range disjointness when RT spans past next table

## Technical Details

When `MultiWriter` rotates during compaction, `write_rts_to_writer` clipped each range tombstone to the output table's KV key range `[first_key, upper_bound(last_key))`. If compaction produced tables `[a,l]` and `[q,z]`, an RT `[m,p)` fell entirely in the gap and was dropped by both tables — silently losing delete semantics for keys in lower levels.

The fix passes `self.current_key` (the first key of the **next** table) as the clip upper bound during rotation. This extends the "responsibility range" of the finishing table to cover the gap.

The table's `key_range.last_key` is widened to include the clipped RT's end **only when strictly less than `clip_upper`** — setting it to exactly `clip_upper` would make adjacent tables' key_ranges overlap and break `Run::get_for_key_cmp` for the boundary key.

## Known Limitations

- With the current compaction architecture (major_compact merges all tables, leveled pulls in overlapping tables recursively), the gap scenario is unlikely in practice. The fix is defensive for future partial/incremental compaction strategies.
- When an RT spans past the next table's first key (`clipped.end == clip_upper`), `last_key` is NOT widened to avoid disjoint-run overlap. Gap keys in this edge case may not be found for RT suppression via the key_range filter.

## Test Plan

- [x] `clip_preserves_rt_covering_gap_between_output_tables` — MultiWriter with forced rotation, RT in gap preserved
- [x] `clip_rt_spanning_next_table_does_not_overlap_key_ranges` — RT spans past next table, key_ranges stay disjoint
- [x] All lib tests pass (484)
- [x] All range_tombstone integration tests pass (41)
- [x] `cargo clippy --all-features -- -D warnings` clean

Closes #32