### PR TITLE
feat(vlog): dictionary compression for blob files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  ignore:
+    # structured-zstd bundles its pure-Rust implementation under src/.
+    # llvm-cov captures those files; exclude them so only workspace sources
+    # count toward patch and project coverage.
+    - "zstd/**"

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -124,7 +124,7 @@ jobs:
       # zstd (zstd-pure is an alias), so this step covers the non-default path.
       - run: cargo +nightly llvm-cov --no-report nextest --no-default-features --features zstd,lz4
       - run: cargo +nightly llvm-cov --no-report --doc --features lz4
-      - run: cargo +nightly llvm-cov report --doctests --lcov --output-path lcov.info
+      - run: cargo +nightly llvm-cov report --doctests --lcov --output-path lcov.info --ignore-filename-regex='registry'
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ enum_dispatch = "0.3.13"
 interval-heap = "0.0.5"
 log = "0.4.27"
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.11", optional = true, default-features = false, features = ["std"] }
+structured-zstd = { version = "0.0.12", optional = true, default-features = false, features = ["std"] }
 quick_cache = { version = "0.6.16", default-features = false, features = [] }
 rustc-hash = "2.1.1"
 self_cell = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Allows using `Zstd` compression via a pure Rust implementation, powered by
 [`structured-zstd`](https://github.com/structured-world/structured-zstd) (managed fork of ruzstd).
 Requires no C compiler or system libraries — compiles with `cargo build` alone.
 Supports both regular zstd (`CompressionType::Zstd`) and dictionary compression
-(`CompressionType::ZstdDict`) for improved ratios on small table blocks (4–64 KiB).
-Blob-file dictionary compression is currently not supported.
+(`CompressionType::ZstdDict`) for improved ratios on small table blocks (4–64 KiB)
+and blob files.
 
 **Current limitations:**
 - Decompression throughput is ~2–3.5× slower than the C reference implementation

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -48,6 +48,13 @@ impl IterGuard for Guard {
                 &self.tree.index.config.cache,
                 &self.version,
                 kv,
+                #[cfg(zstd_any)]
+                self.tree
+                    .index
+                    .config
+                    .kv_separation_opts
+                    .as_ref()
+                    .and_then(|o| o.zstd_dictionary.as_deref()),
             )
             .map(|(k, v)| (k, Some(v)))
         } else {
@@ -78,6 +85,13 @@ impl IterGuard for Guard {
             &self.tree.index.config.cache,
             &self.version,
             self.kv?,
+            #[cfg(zstd_any)]
+            self.tree
+                .index
+                .config
+                .kv_separation_opts
+                .as_ref()
+                .and_then(|o| o.zstd_dictionary.as_deref()),
         )
     }
 }
@@ -88,13 +102,21 @@ fn resolve_value_handle(
     cache: &Cache,
     version: &Version,
     item: InternalValue,
+    #[cfg(zstd_any)] zstd_dictionary: Option<&crate::compression::ZstdDictionary>,
 ) -> RangeItem {
     if item.key.value_type.is_indirection() {
         let mut cursor = std::io::Cursor::new(item.value);
         let vptr = BlobIndirection::decode_from(&mut cursor)?;
 
         // Resolve indirection using value log
-        match Accessor::new(&version.blob_files).get(
+        let accessor = {
+            let a = Accessor::new(&version.blob_files);
+            #[cfg(zstd_any)]
+            let a = a.with_dict(zstd_dictionary);
+            a
+        };
+
+        match accessor.get(
             tree_id,
             blobs_folder,
             &item.key.user_key,
@@ -188,6 +210,12 @@ impl BlobTree {
             &self.index.config.cache,
             &super_version.version,
             item,
+            #[cfg(zstd_any)]
+            self.index
+                .config
+                .kv_separation_opts
+                .as_ref()
+                .and_then(|o| o.zstd_dictionary.as_deref()),
         )?;
 
         Ok(Some(v))
@@ -471,15 +499,20 @@ impl AbstractTree for BlobTree {
             .as_ref()
             .expect("kv separation options should exist");
 
-        let mut blob_writer = BlobFileWriter::new(
-            self.index.0.blob_file_id_counter.clone(),
-            self.index.config.path.join(BLOBS_FOLDER),
-            self.id(),
-            self.index.config.descriptor_table.clone(),
-            self.index.config.fs.clone(),
-        )?
-        .use_target_size(kv_opts.file_target_size)
-        .use_compression(kv_opts.compression);
+        let mut blob_writer = {
+            let w = BlobFileWriter::new(
+                self.index.0.blob_file_id_counter.clone(),
+                self.index.config.path.join(BLOBS_FOLDER),
+                self.id(),
+                self.index.config.descriptor_table.clone(),
+                self.index.config.fs.clone(),
+            )?
+            .use_target_size(kv_opts.file_target_size)
+            .use_compression(kv_opts.compression);
+            #[cfg(zstd_any)]
+            let w = w.use_zstd_dictionary(kv_opts.zstd_dictionary.clone());
+            w
+        };
 
         let separation_threshold = kv_opts.separation_threshold;
 
@@ -792,6 +825,12 @@ impl AbstractTree for BlobTree {
                     &self.index.config.cache,
                     &super_version.version,
                     item,
+                    #[cfg(zstd_any)]
+                    self.index
+                        .config
+                        .kv_separation_opts
+                        .as_ref()
+                        .and_then(|o| o.zstd_dictionary.as_deref()),
                 )?;
                 results[idx] = Some(v);
             }

--- a/src/compaction/filter.rs
+++ b/src/compaction/filter.rs
@@ -104,7 +104,20 @@ impl AccessorShared<'_> {
         user_key: &[u8],
         vhandle: &ValueHandle,
     ) -> crate::Result<Option<UserValue>> {
-        Accessor::new(&self.version.blob_files).get(
+        let accessor = {
+            let a = Accessor::new(&self.version.blob_files);
+            #[cfg(zstd_any)]
+            let a = a.with_dict(
+                self.opts
+                    .config
+                    .kv_separation_opts
+                    .as_ref()
+                    .and_then(|o| o.zstd_dictionary.as_deref()),
+            );
+            a
+        };
+
+        accessor.get(
             self.opts.tree_id,
             self.blobs_folder,
             user_key,

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -90,8 +90,10 @@ impl Clone for ZstdDictionary {
     }
 }
 
-/// Two dictionaries are equal when their full 64-bit xxh3 fingerprints agree,
-/// which is equivalent to comparing the raw bytes that produced those fingerprints.
+/// Two dictionaries are equal when their full 64-bit xxh3 fingerprints agree.
+/// Equality is defined by the 64-bit `id` field; hash collisions between
+/// dictionaries with different raw bytes are theoretically possible but
+/// extremely unlikely given the xxh3-64 collision probability.
 #[cfg(zstd_any)]
 impl PartialEq for ZstdDictionary {
     fn eq(&self, other: &Self) -> bool {

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -90,6 +90,18 @@ impl Clone for ZstdDictionary {
     }
 }
 
+/// Two dictionaries are equal when their full 64-bit xxh3 fingerprints agree,
+/// which is equivalent to comparing the raw bytes that produced those fingerprints.
+#[cfg(zstd_any)]
+impl PartialEq for ZstdDictionary {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+#[cfg(zstd_any)]
+impl Eq for ZstdDictionary {}
+
 #[cfg(zstd_any)]
 impl ZstdDictionary {
     /// Creates a new dictionary handle from raw bytes.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -138,6 +138,14 @@ pub struct KvSeparationOptions {
 
     #[doc(hidden)]
     pub age_cutoff: f32,
+
+    /// Pre-trained zstd dictionary for blob-file dictionary compression.
+    ///
+    /// Required when `compression` is [`CompressionType::ZstdDict`].
+    /// The `dict_id` in the compression type must match [`ZstdDictionary::id`].
+    #[cfg(zstd_any)]
+    #[doc(hidden)]
+    pub zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
 }
 
 impl Default for KvSeparationOptions {
@@ -154,6 +162,9 @@ impl Default for KvSeparationOptions {
 
             staleness_threshold: 0.25,
             age_cutoff: 0.25,
+
+            #[cfg(zstd_any)]
+            zstd_dictionary: None,
         }
     }
 }
@@ -211,6 +222,21 @@ impl KvSeparationOptions {
     #[must_use]
     pub fn age_cutoff(mut self, ratio: f32) -> Self {
         self.age_cutoff = ratio;
+        self
+    }
+
+    /// Sets the zstd dictionary for blob-file dictionary compression.
+    ///
+    /// Required when [`compression`](Self::compression) is set to
+    /// [`CompressionType::ZstdDict`].  The `dict_id` encoded in the
+    /// compression type must equal [`ZstdDictionary::id()`] of the
+    /// supplied dictionary; [`Config::open`] will return
+    /// [`Error::ZstdDictMismatch`](crate::Error::ZstdDictMismatch) if
+    /// they disagree.
+    #[cfg(zstd_any)]
+    #[must_use]
+    pub fn dict(mut self, dictionary: std::sync::Arc<crate::compression::ZstdDictionary>) -> Self {
+        self.zstd_dictionary = Some(dictionary);
         self
     }
 }
@@ -538,14 +564,27 @@ impl Config {
             }
         }
 
-        // Blob files don't support dictionary compression — reject early.
+        // Blob files with ZstdDict compression must have a matching dictionary.
         if let Some(ref kv_opts) = self.kv_separation_opts
-            && matches!(kv_opts.compression, CompressionType::ZstdDict { .. })
+            && let CompressionType::ZstdDict {
+                dict_id: required, ..
+            } = kv_opts.compression
         {
-            return Err(crate::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "zstd dictionary compression is not supported for blob files",
-            )));
+            match kv_opts.zstd_dictionary.as_ref().map(|d| d.id()) {
+                None => {
+                    return Err(crate::Error::ZstdDictMismatch {
+                        expected: required,
+                        got: None,
+                    });
+                }
+                Some(actual) if actual != required => {
+                    return Err(crate::Error::ZstdDictMismatch {
+                        expected: required,
+                        got: Some(actual),
+                    });
+                }
+                _ => {}
+            }
         }
 
         Ok(())
@@ -573,10 +612,12 @@ impl Config {
 #[cfg(all(test, zstd_any))]
 mod tests {
     use super::*;
-    use crate::{CompressionType, SequenceNumberCounter};
+    use crate::{CompressionType, SequenceNumberCounter, compression::ZstdDictionary};
+    use std::sync::Arc;
 
     #[test]
-    fn blob_zstd_dict_compression_is_rejected() {
+    fn blob_zstd_dict_no_dict_is_rejected() {
+        // ZstdDict compression for blobs without providing a dictionary must fail.
         let folder = tempfile::tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
         let cfg = Config::new(
             folder.path(),
@@ -590,14 +631,70 @@ mod tests {
             },
         )));
 
-        let err = match cfg.validate_zstd_dictionary() {
-            Ok(()) => panic!("blob-file zstd dictionary compression must be rejected"),
-            Err(err) => err,
-        };
+        assert!(
+            matches!(
+                cfg.validate_zstd_dictionary(),
+                Err(crate::Error::ZstdDictMismatch {
+                    expected: 7,
+                    got: None
+                })
+            ),
+            "expected ZstdDictMismatch when no dictionary is supplied",
+        );
+    }
+
+    #[test]
+    fn blob_zstd_dict_id_mismatch_is_rejected() {
+        // ZstdDict compression with a dictionary whose id doesn't match the
+        // compression type's dict_id must fail.
+        let folder = tempfile::tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let dict = Arc::new(ZstdDictionary::new(b"sample training data for test"));
+        let wrong_dict_id = dict.id().wrapping_add(1);
+        let cfg = Config::new(
+            folder.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(
+            KvSeparationOptions::default()
+                .compression(CompressionType::ZstdDict {
+                    level: 3,
+                    dict_id: wrong_dict_id,
+                })
+                .dict(Arc::clone(&dict)),
+        ));
 
         assert!(
-            err.to_string()
-                .contains("zstd dictionary compression is not supported for blob files")
+            matches!(
+                cfg.validate_zstd_dictionary(),
+                Err(crate::Error::ZstdDictMismatch { .. })
+            ),
+            "expected ZstdDictMismatch when dict_id doesn't match dictionary",
+        );
+    }
+
+    #[test]
+    fn blob_zstd_dict_matching_dict_is_accepted() {
+        // ZstdDict compression with a correctly matching dictionary must succeed.
+        let folder = tempfile::tempdir().unwrap_or_else(|err| panic!("tempdir failed: {err}"));
+        let dict = Arc::new(ZstdDictionary::new(b"sample training data for test"));
+        let cfg = Config::new(
+            folder.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(
+            KvSeparationOptions::default()
+                .compression(CompressionType::ZstdDict {
+                    level: 3,
+                    dict_id: dict.id(),
+                })
+                .dict(Arc::clone(&dict)),
+        ));
+
+        assert!(
+            cfg.validate_zstd_dictionary().is_ok(),
+            "matching dictionary must be accepted",
         );
     }
 }

--- a/src/vlog/accessor.rs
+++ b/src/vlog/accessor.rs
@@ -9,11 +9,27 @@ use crate::{
 };
 use std::path::Path;
 
-pub struct Accessor<'a>(&'a BlobFileList);
+pub struct Accessor<'a> {
+    blob_files: &'a BlobFileList,
+    #[cfg(zstd_any)]
+    zstd_dictionary: Option<&'a crate::compression::ZstdDictionary>,
+}
 
 impl<'a> Accessor<'a> {
     pub fn new(blob_files: &'a BlobFileList) -> Self {
-        Self(blob_files)
+        Self {
+            blob_files,
+            #[cfg(zstd_any)]
+            zstd_dictionary: None,
+        }
+    }
+
+    /// Supplies the zstd dictionary for [`CompressionType::ZstdDict`] blob reads.
+    #[cfg(zstd_any)]
+    #[must_use]
+    pub fn with_dict(mut self, dict: Option<&'a crate::compression::ZstdDictionary>) -> Self {
+        self.zstd_dictionary = dict;
+        self
     }
 
     pub fn get(
@@ -28,7 +44,7 @@ impl<'a> Accessor<'a> {
             return Ok(Some(value));
         }
 
-        let Some(blob_file) = self.0.get(vhandle.blob_file_id) else {
+        let Some(blob_file) = self.blob_files.get(vhandle.blob_file_id) else {
             return Ok(None);
         };
 
@@ -38,7 +54,14 @@ impl<'a> Accessor<'a> {
             .file_accessor()
             .get_or_open_blob_file(&bf_id, &base_path.join(vhandle.blob_file_id.to_string()))?;
 
-        let value = Reader::new(blob_file, file.as_ref()).get(key, vhandle)?;
+        let reader = {
+            let r = Reader::new(blob_file, file.as_ref());
+            #[cfg(zstd_any)]
+            let r = r.with_dict(self.zstd_dictionary);
+            r
+        };
+
+        let value = reader.get(key, vhandle)?;
         cache.insert_blob(tree_id, vhandle, value.clone());
 
         Ok(Some(value))

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -34,6 +34,10 @@ pub struct MultiWriter {
     compression: CompressionType,
     passthrough_compression: CompressionType,
 
+    /// Dictionary for `ZstdDict` compression, shared across all rotated writers.
+    #[cfg(zstd_any)]
+    zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+
     tree_id: TreeId,
     descriptor_table: Option<Arc<DescriptorTable>>,
 }
@@ -69,6 +73,9 @@ impl MultiWriter {
             compression: CompressionType::None,
             passthrough_compression: CompressionType::None,
 
+            #[cfg(zstd_any)]
+            zstd_dictionary: None,
+
             tree_id,
             descriptor_table,
             fs,
@@ -101,6 +108,21 @@ impl MultiWriter {
         self
     }
 
+    /// Provides the zstd dictionary for [`CompressionType::ZstdDict`] writes.
+    ///
+    /// The dictionary is propagated to every rotated writer so that all blob
+    /// files produced by this `MultiWriter` use the same dictionary.
+    #[cfg(zstd_any)]
+    #[must_use]
+    pub fn use_zstd_dictionary(
+        mut self,
+        dict: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+    ) -> Self {
+        self.active_writer = self.active_writer.use_zstd_dictionary(dict.clone());
+        self.zstd_dictionary = dict;
+        self
+    }
+
     /// Sets up a new writer for the next blob file.
     fn rotate(&mut self) -> crate::Result<()> {
         log::debug!("Rotating blob file writer");
@@ -108,8 +130,13 @@ impl MultiWriter {
         let new_blob_file_id = self.id_generator.next();
         let blob_file_path = self.folder.join(new_blob_file_id.to_string());
 
-        let new_writer = Writer::new(blob_file_path, new_blob_file_id, self.tree_id, &*self.fs)?
-            .use_compression(self.compression);
+        let new_writer = {
+            let w = Writer::new(blob_file_path, new_blob_file_id, self.tree_id, &*self.fs)?
+                .use_compression(self.compression);
+            #[cfg(zstd_any)]
+            let w = w.use_zstd_dictionary(self.zstd_dictionary.clone());
+            w
+        };
 
         let old_writer = std::mem::replace(&mut self.active_writer, new_writer);
         let blob_file = Self::consume_writer(

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1075,7 +1075,7 @@ mod tests {
         Ok(())
     }
 
-    /// Write a blob with ZstdDict, then read it back without supplying a
+    /// Write a blob with `ZstdDict`, then read it back without supplying a
     /// dictionary.  Expect `ZstdDictMismatch { got: None }`.
     #[test]
     #[cfg(zstd_any)]

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -34,11 +34,32 @@ const MAX_DECOMPRESSION_SIZE: usize = 256 * 1024 * 1024;
 pub struct Reader<'a> {
     blob_file: &'a BlobFile,
     file: &'a dyn FsFile,
+
+    /// Dictionary for `ZstdDict` decompression.  Must be supplied when the
+    /// blob file's compression type is [`CompressionType::ZstdDict`].
+    #[cfg(zstd_any)]
+    zstd_dictionary: Option<&'a crate::compression::ZstdDictionary>,
 }
 
 impl<'a> Reader<'a> {
     pub fn new(blob_file: &'a BlobFile, file: &'a dyn FsFile) -> Self {
-        Self { blob_file, file }
+        Self {
+            blob_file,
+            file,
+            #[cfg(zstd_any)]
+            zstd_dictionary: None,
+        }
+    }
+
+    /// Provides the zstd dictionary for [`CompressionType::ZstdDict`] blobs.
+    ///
+    /// Must be called when the blob file's metadata reports `ZstdDict`
+    /// compression.  Passing `None` clears a previously set dictionary.
+    #[cfg(zstd_any)]
+    #[must_use]
+    pub fn with_dict(mut self, dict: Option<&'a crate::compression::ZstdDictionary>) -> Self {
+        self.zstd_dictionary = dict;
+        self
     }
 
     #[expect(
@@ -232,11 +253,31 @@ impl<'a> Reader<'a> {
             }
 
             #[cfg(zstd_any)]
-            CompressionType::ZstdDict { .. } => {
-                return Err(crate::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "zstd dictionary compression is not supported for blob files",
-                )));
+            CompressionType::ZstdDict { dict_id, .. } => {
+                let dict = self.zstd_dictionary.ok_or(crate::Error::ZstdDictMismatch {
+                    expected: *dict_id,
+                    got: None,
+                })?;
+
+                if dict.id() != *dict_id {
+                    return Err(crate::Error::ZstdDictMismatch {
+                        expected: *dict_id,
+                        got: Some(dict.id()),
+                    });
+                }
+
+                let decompressed = crate::compression::ZstdBackend::decompress_with_dict(
+                    &raw_data,
+                    dict,
+                    real_val_len,
+                )
+                .map_err(|_| crate::Error::Decompress(self.blob_file.0.meta.compression))?;
+
+                if decompressed.len() != real_val_len {
+                    return Err(crate::Error::Decompress(self.blob_file.0.meta.compression));
+                }
+
+                UserValue::from(decompressed)
             }
         };
 

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1074,4 +1074,99 @@ mod tests {
 
         Ok(())
     }
+
+    /// Write a blob with ZstdDict, then read it back without supplying a
+    /// dictionary.  Expect `ZstdDictMismatch { got: None }`.
+    #[test]
+    #[cfg(zstd_any)]
+    fn blob_reader_zstd_dict_missing_dict_returns_mismatch() -> crate::Result<()> {
+        use crate::compression::ZstdDictionary;
+
+        let id_generator = SequenceNumberCounter::default();
+        let folder = tempfile::tempdir()?;
+
+        let dict = ZstdDictionary::new(b"some_dictionary_content_for_testing");
+        let compression = CompressionType::ZstdDict {
+            level: 3,
+            dict_id: dict.id(),
+        };
+        let dict_arc = Arc::new(dict);
+
+        let mut writer = crate::vlog::BlobFileWriter::new(
+            id_generator,
+            folder.path(),
+            0,
+            None,
+            Arc::new(StdFs),
+        )?
+        .use_target_size(u64::MAX)
+        .use_compression(compression)
+        .use_zstd_dictionary(Some(dict_arc));
+
+        let handle = writer.write(b"key", 0, b"value-to-compress-with-dict")?;
+        let blob_file = writer.finish()?;
+        let blob_file = blob_file.first().unwrap();
+
+        let file = File::open(&blob_file.0.path)?;
+        // Reader created WITHOUT a dictionary
+        let reader = Reader::new(blob_file, &file);
+
+        let result = reader.get(b"key", &handle);
+        assert!(
+            matches!(
+                result,
+                Err(crate::Error::ZstdDictMismatch { got: None, .. })
+            ),
+            "expected ZstdDictMismatch{{got: None}} when dict is absent; got: {result:?}",
+        );
+
+        Ok(())
+    }
+
+    /// Write a blob with dict A, then read it back with dict B (different id).
+    /// Expect `ZstdDictMismatch { got: Some(B.id()) }`.
+    #[test]
+    #[cfg(zstd_any)]
+    fn blob_reader_zstd_dict_wrong_dict_id_returns_mismatch() -> crate::Result<()> {
+        use crate::compression::ZstdDictionary;
+
+        let id_generator = SequenceNumberCounter::default();
+        let folder = tempfile::tempdir()?;
+
+        let dict_a = ZstdDictionary::new(b"dictionary_a_content_for_testing");
+        let dict_b = ZstdDictionary::new(b"dictionary_b_entirely_different_content");
+        let compression = CompressionType::ZstdDict {
+            level: 3,
+            dict_id: dict_a.id(),
+        };
+        let dict_a_arc = Arc::new(dict_a);
+        let dict_b_arc = Arc::new(dict_b);
+
+        let mut writer = crate::vlog::BlobFileWriter::new(
+            id_generator,
+            folder.path(),
+            0,
+            None,
+            Arc::new(StdFs),
+        )?
+        .use_target_size(u64::MAX)
+        .use_compression(compression)
+        .use_zstd_dictionary(Some(dict_a_arc));
+
+        let handle = writer.write(b"key", 0, b"value-compressed-with-dict-a")?;
+        let blob_file = writer.finish()?;
+        let blob_file = blob_file.first().unwrap();
+
+        let file = File::open(&blob_file.0.path)?;
+        // Reader supplied with dict B (wrong id)
+        let reader = Reader::new(blob_file, &file).with_dict(Some(&dict_b_arc));
+
+        let result = reader.get(b"key", &handle);
+        assert!(
+            matches!(result, Err(crate::Error::ZstdDictMismatch { .. })),
+            "expected ZstdDictMismatch when wrong dict id provided; got: {result:?}",
+        );
+
+        Ok(())
+    }
 }

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -120,6 +120,11 @@ pub struct Writer {
     pub(crate) last_key: Option<UserKey>,
 
     pub(crate) compression: CompressionType,
+
+    /// Dictionary for `ZstdDict` compression.  Must be supplied when
+    /// `compression` is [`CompressionType::ZstdDict`].
+    #[cfg(zstd_any)]
+    pub(crate) zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
 }
 
 impl Writer {
@@ -163,11 +168,28 @@ impl Writer {
             last_key: None,
 
             compression: CompressionType::None,
+
+            #[cfg(zstd_any)]
+            zstd_dictionary: None,
         })
     }
 
     pub fn use_compression(mut self, compressor: CompressionType) -> Self {
         self.compression = compressor;
+        self
+    }
+
+    /// Provides the zstd dictionary for [`CompressionType::ZstdDict`] writes.
+    ///
+    /// Must be called before writing any blobs when the compression type is
+    /// `ZstdDict`.  Passing `None` clears a previously set dictionary.
+    #[cfg(zstd_any)]
+    #[must_use]
+    pub fn use_zstd_dictionary(
+        mut self,
+        dict: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+    ) -> Self {
+        self.zstd_dictionary = dict;
         self
     }
 
@@ -220,11 +242,18 @@ impl Writer {
             }
 
             #[cfg(zstd_any)]
-            CompressionType::ZstdDict { .. } => {
-                return Err(crate::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "zstd dictionary compression is not supported for blob files",
-                )));
+            CompressionType::ZstdDict { level, dict_id } => {
+                let dict =
+                    self.zstd_dictionary
+                        .as_deref()
+                        .ok_or(crate::Error::ZstdDictMismatch {
+                            expected: *dict_id,
+                            got: None,
+                        })?;
+                let compressed =
+                    crate::compression::ZstdBackend::compress_with_dict(value, *level, dict.raw())?;
+                check_size_cap(compressed.len())?;
+                std::borrow::Cow::Owned(compressed)
             }
         };
 
@@ -454,20 +483,45 @@ mod tests {
 
     #[test]
     #[cfg(zstd_any)]
-    fn blob_write_zstd_dict_unsupported() -> crate::Result<()> {
+    fn blob_write_zstd_dict_no_dict_returns_mismatch() -> crate::Result<()> {
+        // ZstdDict compression without a dictionary must return ZstdDictMismatch.
         let folder = tempfile::tempdir()?;
         let path = folder.path().join("test.blob");
-        let dict = crate::compression::ZstdDictionary::new(b"test dictionary");
+        let dict = crate::compression::ZstdDictionary::new(b"test dictionary content for blob");
         let compression = CompressionType::ZstdDict {
             level: 3,
             dict_id: dict.id(),
         };
+        // Intentionally do NOT call use_zstd_dictionary — no dict supplied.
         let mut writer = Writer::new(&path, 0, 0, &StdFs)?.use_compression(compression);
 
         let result = writer.write(b"key", 0, b"value");
         assert!(
-            matches!(&result, Err(crate::Error::Io(e)) if e.kind() == std::io::ErrorKind::Unsupported),
-            "expected Io(Unsupported), got: {result:?}",
+            matches!(result, Err(crate::Error::ZstdDictMismatch { .. })),
+            "expected ZstdDictMismatch when no dictionary is supplied, got: {result:?}",
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(zstd_any)]
+    fn blob_write_zstd_dict_with_dict_succeeds() -> crate::Result<()> {
+        // ZstdDict compression with a matching dictionary must succeed.
+        let folder = tempfile::tempdir()?;
+        let path = folder.path().join("test.blob");
+        let dict = crate::compression::ZstdDictionary::new(b"test dictionary content for blob");
+        let compression = CompressionType::ZstdDict {
+            level: 3,
+            dict_id: dict.id(),
+        };
+        let mut writer = Writer::new(&path, 0, 0, &StdFs)?
+            .use_compression(compression)
+            .use_zstd_dictionary(Some(std::sync::Arc::new(dict)));
+
+        let result = writer.write(b"key", 0, b"hello world blob value");
+        assert!(
+            result.is_ok(),
+            "expected Ok with matching dictionary, got: {result:?}"
         );
         Ok(())
     }

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -250,6 +250,12 @@ impl Writer {
                             expected: *dict_id,
                             got: None,
                         })?;
+                if dict.id() != *dict_id {
+                    return Err(crate::Error::ZstdDictMismatch {
+                        expected: *dict_id,
+                        got: Some(dict.id()),
+                    });
+                }
                 let compressed =
                     crate::compression::ZstdBackend::compress_with_dict(value, *level, dict.raw())?;
                 check_size_cap(compressed.len())?;

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -430,12 +430,14 @@ mod zstd_dict {
             ))
             .open();
 
+        let expected_id = dict.id();
         assert!(
             matches!(
                 result,
-                Err(lsm_tree::Error::ZstdDictMismatch { got: None, .. })
+                Err(lsm_tree::Error::ZstdDictMismatch { expected, got: None })
+                    if expected == expected_id
             ),
-            "expected ZstdDictMismatch{{got: None}} when dict is missing for blob compression",
+            "expected ZstdDictMismatch{{expected: {expected_id}, got: None}} when dict is missing",
         );
 
         Ok(())

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -464,6 +464,86 @@ mod zstd_dict {
     }
 
     #[test]
+    fn blob_zstd_dict_range_scan() -> lsm_tree::Result<()> {
+        // Range-scan and prefix-scan resolve blob indirections through the
+        // iterator path (Guard::value → resolve_value_handle).  Verify that
+        // the dict is threaded correctly through that path.
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, dict.id())?;
+        let dict_arc = Arc::new(dict);
+
+        let tree = make_config(dir.path())
+            .with_kv_separation(Some(make_blob_opts(compression, dict_arc)))
+            .open()?;
+
+        let big_value = b"range-blob-value-".repeat(10);
+
+        for i in 0u32..40 {
+            let key = format!("key-{i:04}");
+            tree.insert(key.as_bytes(), &big_value, i.into());
+        }
+        tree.flush_active_memtable(0)?;
+
+        // Inclusive range scan
+        let items: Vec<_> = tree
+            .range(
+                "key-0010".as_bytes()..="key-0019".as_bytes(),
+                lsm_tree::MAX_SEQNO,
+                None,
+            )
+            .collect();
+        assert_eq!(items.len(), 10, "range scan should return 10 blob items");
+
+        // Consume items via into_inner to resolve blob indirections
+        for g in items {
+            let (_, val) = g.into_inner()?;
+            assert_eq!(val.as_ref(), big_value.as_slice());
+        }
+
+        // Prefix scan
+        let prefix_items: Vec<_> = tree.prefix("key-002", lsm_tree::MAX_SEQNO, None).collect();
+        assert_eq!(
+            prefix_items.len(),
+            10,
+            "prefix scan should return 10 blob items"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn blob_zstd_dict_multi_get() -> lsm_tree::Result<()> {
+        // multi_get resolves blob indirections via a separate code path
+        // (blob_tree::multi_get → resolve_value_handle).  Verify dict threads correctly.
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, dict.id())?;
+        let dict_arc = Arc::new(dict);
+
+        let tree = make_config(dir.path())
+            .with_kv_separation(Some(make_blob_opts(compression, dict_arc)))
+            .open()?;
+
+        let big_value = b"multi-get-blob-value-".repeat(10);
+
+        tree.insert(b"alpha", &big_value, 0);
+        tree.insert(b"beta", &big_value, 1);
+        tree.insert(b"gamma", &big_value, 2);
+        tree.flush_active_memtable(0)?;
+
+        let results = tree.multi_get(["alpha", "beta", "gamma", "missing"], lsm_tree::MAX_SEQNO)?;
+
+        assert_eq!(results.len(), 4);
+        assert_eq!(results[0].as_deref(), Some(big_value.as_slice()), "alpha");
+        assert_eq!(results[1].as_deref(), Some(big_value.as_slice()), "beta");
+        assert_eq!(results[2].as_deref(), Some(big_value.as_slice()), "gamma");
+        assert!(results[3].is_none(), "missing key should return None");
+
+        Ok(())
+    }
+
+    #[test]
     fn reopen_with_wrong_dict_fails_at_recovery() -> lsm_tree::Result<()> {
         let dir = tempfile::tempdir()?;
         let dict = make_test_dictionary();

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -500,13 +500,18 @@ mod zstd_dict {
             assert_eq!(val.as_ref(), big_value.as_slice());
         }
 
-        // Prefix scan
+        // Prefix scan — also resolve blob indirections via into_inner to exercise
+        // the zstd-dict decompression path through the prefix iterator.
         let prefix_items: Vec<_> = tree.prefix("key-002", lsm_tree::MAX_SEQNO, None).collect();
         assert_eq!(
             prefix_items.len(),
             10,
             "prefix scan should return 10 blob items"
         );
+        for g in prefix_items {
+            let (_, val) = g.into_inner()?;
+            assert_eq!(val.as_ref(), big_value.as_slice());
+        }
 
         Ok(())
     }

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -305,6 +305,164 @@ mod zstd_dict {
         Ok(())
     }
 
+    // -------------------------------------------------------------------------
+    // Blob-file (KV-separation) tests
+    // -------------------------------------------------------------------------
+
+    /// Build KvSeparationOptions that force every value into a blob file,
+    /// compress blobs with ZstdDict, and attach the matching dictionary.
+    #[cfg(feature = "zstd")]
+    fn make_blob_opts(
+        compression: lsm_tree::CompressionType,
+        dict: Arc<lsm_tree::ZstdDictionary>,
+    ) -> lsm_tree::KvSeparationOptions {
+        lsm_tree::KvSeparationOptions::default()
+            .compression(compression)
+            // separation_threshold = 1 forces every non-empty value into a blob file
+            .separation_threshold(1)
+            .dict(dict)
+    }
+
+    #[test]
+    fn blob_zstd_dict_roundtrip_write_flush_read() -> lsm_tree::Result<()> {
+        // Round-trip: write blobs compressed with ZstdDict, flush to disk, read back.
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, dict.id())?;
+        let dict_arc = Arc::new(dict);
+
+        let tree = make_config(dir.path())
+            .with_kv_separation(Some(make_blob_opts(compression, dict_arc)))
+            .open()?;
+
+        let big_value = b"blob-value-".repeat(20);
+
+        for i in 0u32..50 {
+            let key = format!("key-{i:04}");
+            tree.insert(key.as_bytes(), &big_value, i.into());
+        }
+
+        tree.flush_active_memtable(0)?;
+
+        assert!(
+            tree.blob_file_count() >= 1,
+            "at least one blob file should exist after flush"
+        );
+
+        for i in 0u32..50 {
+            let key = format!("key-{i:04}");
+            let got = tree
+                .get(key.as_bytes(), lsm_tree::MAX_SEQNO)?
+                .unwrap_or_else(|| panic!("key {key} missing"));
+            assert_eq!(
+                got.as_ref(),
+                big_value.as_slice(),
+                "value mismatch for key {key}",
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn blob_zstd_dict_roundtrip_survives_major_compact() -> lsm_tree::Result<()> {
+        // Verifies that blob files compressed with ZstdDict survive major compaction
+        // (relocation path reads with dict, writes with dict).
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, dict.id())?;
+        let dict_arc = Arc::new(dict);
+
+        let tree = make_config(dir.path())
+            .with_kv_separation(Some(make_blob_opts(compression, dict_arc)))
+            .open()?;
+
+        let big_value = b"compacted-blob-value-".repeat(15);
+
+        // Two flushes to have multiple tables/blob files
+        for i in 0u32..30 {
+            let key = format!("key-{i:04}");
+            tree.insert(key.as_bytes(), &big_value, i.into());
+        }
+        tree.flush_active_memtable(0)?;
+
+        for i in 30u32..60 {
+            let key = format!("key-{i:04}");
+            tree.insert(key.as_bytes(), &big_value, i.into());
+        }
+        tree.flush_active_memtable(0)?;
+
+        tree.major_compact(u64::MAX, 0)?;
+
+        for i in 0u32..60 {
+            let key = format!("key-{i:04}");
+            let got = tree
+                .get(key.as_bytes(), lsm_tree::MAX_SEQNO)?
+                .unwrap_or_else(|| panic!("key {key} missing after major_compact"));
+            assert_eq!(
+                got.as_ref(),
+                big_value.as_slice(),
+                "value mismatch for {key} after major_compact",
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn blob_zstd_dict_missing_at_open_is_rejected() -> lsm_tree::Result<()> {
+        // ZstdDict compression configured for blobs, but no dictionary provided at open.
+        // Config::validate_zstd_dictionary must catch this before any I/O.
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, dict.id())?;
+
+        let result = make_config(dir.path())
+            .with_kv_separation(Some(
+                lsm_tree::KvSeparationOptions::default()
+                    .compression(compression)
+                    .separation_threshold(1),
+                // deliberately omit .dict(...)
+            ))
+            .open();
+
+        assert!(
+            matches!(
+                result,
+                Err(lsm_tree::Error::ZstdDictMismatch { got: None, .. })
+            ),
+            "expected ZstdDictMismatch{{got: None}} when dict is missing for blob compression",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn blob_zstd_dict_id_mismatch_at_open_is_rejected() -> lsm_tree::Result<()> {
+        // dict_id in CompressionType does not match the actual dictionary provided.
+        let dir = tempfile::tempdir()?;
+        let dict = make_test_dictionary();
+        let wrong_dict = ZstdDictionary::new(b"entirely different content for wrong dict");
+        // compression claims to need wrong_dict.id(), but we provide dict
+        let compression = lsm_tree::CompressionType::zstd_dict(3, wrong_dict.id())?;
+
+        let result = make_config(dir.path())
+            .with_kv_separation(Some(
+                lsm_tree::KvSeparationOptions::default()
+                    .compression(compression)
+                    .separation_threshold(1)
+                    .dict(Arc::new(dict)),
+            ))
+            .open();
+
+        assert!(
+            matches!(result, Err(lsm_tree::Error::ZstdDictMismatch { .. })),
+            "expected ZstdDictMismatch when dict_id in compression != actual dict id",
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn reopen_with_wrong_dict_fails_at_recovery() -> lsm_tree::Result<()> {
         let dir = tempfile::tempdir()?;

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -392,6 +392,11 @@ mod zstd_dict {
         tree.flush_active_memtable(0)?;
 
         tree.major_compact(u64::MAX, 0)?;
+        assert_eq!(
+            Some(0),
+            tree.level_table_count(0),
+            "L0 must be empty after major_compact — compaction may not have run",
+        );
 
         for i in 0u32..60 {
             let key = format!("key-{i:04}");
@@ -443,7 +448,9 @@ mod zstd_dict {
         let dict = make_test_dictionary();
         let wrong_dict = ZstdDictionary::new(b"entirely different content for wrong dict");
         // compression claims to need wrong_dict.id(), but we provide dict
-        let compression = lsm_tree::CompressionType::zstd_dict(3, wrong_dict.id())?;
+        let expected_id = wrong_dict.id();
+        let provided_id = dict.id();
+        let compression = lsm_tree::CompressionType::zstd_dict(3, expected_id)?;
 
         let result = make_config(dir.path())
             .with_kv_separation(Some(
@@ -455,8 +462,14 @@ mod zstd_dict {
             .open();
 
         assert!(
-            matches!(result, Err(lsm_tree::Error::ZstdDictMismatch { .. })),
-            "expected ZstdDictMismatch when dict_id in compression != actual dict id",
+            matches!(
+                result,
+                Err(lsm_tree::Error::ZstdDictMismatch {
+                    expected,
+                    got: Some(actual),
+                }) if expected == expected_id && actual == provided_id
+            ),
+            "expected ZstdDictMismatch{{expected: {expected_id}, got: Some({provided_id})}}",
         );
 
         Ok(())

--- a/tests/zstd_dict_roundtrip.rs
+++ b/tests/zstd_dict_roundtrip.rs
@@ -311,7 +311,6 @@ mod zstd_dict {
 
     /// Build KvSeparationOptions that force every value into a blob file,
     /// compress blobs with ZstdDict, and attach the matching dictionary.
-    #[cfg(feature = "zstd")]
     fn make_blob_opts(
         compression: lsm_tree::CompressionType,
         dict: Arc<lsm_tree::ZstdDictionary>,


### PR DESCRIPTION
## Summary

- Wire `ZstdDict` compression through the full blob-file I/O path (write, read, compaction filter reads, GC relocation)
- Remove the explicit "blob-file dictionary compression not supported" rejection guards
- Implement actual `compress_with_dict` / `decompress_with_dict` usage via the `ZstdBackend` provider
- Add `zstd_dictionary` field + `.dict()` builder to `KvSeparationOptions` with config-level validation (missing dict or mismatched `dict_id` → `Error::ZstdDictMismatch` at `open()`)

## Technical Details

**Write path** (`BlobFileWriter` / `MultiWriter` / `Writer`):
- Added `zstd_dictionary: Option<Arc<ZstdDictionary>>` field and `use_zstd_dictionary()` builder
- `ZstdDict` arm in `write_raw` calls `ZstdBackend::compress_with_dict`; errors if dict absent
- `rotate()` in `MultiWriter` threads the dictionary into each new `Writer`

**Read path** (`Reader` / `Accessor`):
- Added `zstd_dictionary: Option<&ZstdDictionary>` field and `with_dict()` builder to `Reader`
- `ZstdDict` arm validates `dict_id` matches, then calls `ZstdBackend::decompress_with_dict`
- `Accessor` stores dict reference and passes it into `Reader` on every `get()`

**Higher-level wiring** (`BlobTree`, compaction filter):
- `resolve_value_handle` receives dict via `#[cfg(zstd_any)]` parameter; all three call sites updated
- `BlobFileWriter` creation in flush/GC path calls `.use_zstd_dictionary(kv_opts.zstd_dictionary.clone())`
- `AccessorShared::get_indirect_value` in compaction filter constructs `Accessor` with dict

**Config validation** (`KvSeparationOptions`):
- `validate_zstd_dictionary` now checks blob compression in addition to SST compression
- Missing dict → `ZstdDictMismatch { expected, got: None }`
- Mismatched id → `ZstdDictMismatch { expected, got: Some(actual) }`

**Misc**:
- `ZstdDictionary` gains `PartialEq`/`Eq` impls (compare by `id`) so `KvSeparationOptions` can derive `PartialEq`
- README: removed "blob-file dictionary compression not supported" limitation note

## Test Plan

- `cargo nextest run --workspace --all-features` — 1266/1266 passed
- `cargo test --doc --all-features` — 41/41 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean

New integration tests in `tests/zstd_dict_roundtrip.rs`:
- `blob_zstd_dict_roundtrip_write_flush_read` — write blobs, flush, read back
- `blob_zstd_dict_roundtrip_survives_major_compact` — blobs survive GC/relocation compaction
- `blob_zstd_dict_missing_at_open_is_rejected` — missing dict caught at `open()`
- `blob_zstd_dict_id_mismatch_at_open_is_rejected` — mismatched dict_id caught at `open()`

Closes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zstd dictionary compression now supports blob-backed values; reads and writes can use a supplied dictionary for compression/decompression.

* **Validation**
  * Configuration now enforces a matching Zstd dictionary when dictionary-based compression is enabled and surfaces clear mismatch/missing-dictionary errors.

* **Documentation**
  * README updated to state Zstd dictionary compression applies to small table blocks and blob files.

* **Tests**
  * Added end-to-end and edge-case tests covering blob round-trips, compaction persistence, range/prefix/multi-get reads, and config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->