### PR TITLE
build(deps): update all dependencies + adopt upstream blob-tree clear() fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ enum_dispatch = "0.3.13"
 interval-heap = "0.0.5"
 log = "0.4.27"
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.12", optional = true, default-features = false, features = ["std"] }
+structured-zstd = { version = "0.0.21", optional = true, default-features = false, features = ["std"] }
 quick_cache = { version = "0.6.16", default-features = false, features = [] }
 rustc-hash = "2.1.1"
 self_cell = "1.2.0"
@@ -53,7 +53,7 @@ criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"
 nanoid = "0.4.0"
 proptest = "1"
-rand = "0.9.2"
+rand = "0.10.1"
 strum = { version = "0.27.2", features = ["derive"] }
 test-log = "0.2.18"
 

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -1,5 +1,5 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::{Rng, RngCore};
+use rand::RngExt;
 
 // Not really worth it anymore on new CPUs...?
 fn fast_block_index(c: &mut Criterion) {
@@ -36,7 +36,7 @@ fn standard_filter_construction(c: &mut Criterion) {
 
         b.iter(|| {
             let mut key = [0; 16];
-            rng.fill_bytes(&mut key);
+            rng.fill(&mut key[..]);
 
             filter.set_with_hash(Builder::get_hash(&key));
         });
@@ -47,7 +47,7 @@ fn standard_filter_construction(c: &mut Criterion) {
 
         b.iter(|| {
             let mut key = [0; 16];
-            rng.fill_bytes(&mut key);
+            rng.fill(&mut key[..]);
 
             filter.set_with_hash(Builder::get_hash(&key));
         });

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -337,7 +337,13 @@ pub trait AbstractTree: sealed::Sealed {
     fn active_memtable(&self) -> Arc<Memtable>;
 
     /// Returns the tree type.
-    fn tree_type(&self) -> crate::TreeType;
+    fn tree_type(&self) -> crate::TreeType {
+        if self.tree_config().kv_separation_opts.is_some() {
+            crate::TreeType::Blob
+        } else {
+            crate::TreeType::Standard
+        }
+    }
 
     /// Seals the active memtable.
     fn rotate_memtable(&self) -> Option<Arc<Memtable>>;

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -348,7 +348,25 @@ impl AbstractTree for BlobTree {
     }
 
     fn clear(&self) -> crate::Result<()> {
-        self.index.clear()
+        let config = self.tree_config();
+        let mut versions = self.get_version_history_lock();
+
+        versions.upgrade_version(
+            &config.path,
+            |v| {
+                let mut copy = v.clone();
+                copy.active_memtable = Arc::new(Memtable::new(
+                    self.index.memtable_id_counter.next(),
+                    config.comparator.clone(),
+                ));
+                copy.sealed_memtables = Arc::default();
+                copy.version = Version::new(v.version.id() + 1, self.tree_type());
+                Ok(copy)
+            },
+            &config.seqno,
+            &config.visible_seqno,
+            &*config.fs,
+        )
     }
 
     fn major_compact(
@@ -635,10 +653,6 @@ impl AbstractTree for BlobTree {
 
     fn active_memtable(&self) -> Arc<Memtable> {
         self.index.active_memtable()
-    }
-
-    fn tree_type(&self) -> crate::TreeType {
-        crate::TreeType::Blob
     }
 
     fn rotate_memtable(&self) -> Option<Arc<Memtable>> {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -332,10 +332,11 @@ impl AbstractTree for Tree {
     }
 
     fn clear(&self) -> crate::Result<()> {
+        let config = self.tree_config();
         let mut versions = self.get_version_history_lock();
 
         versions.upgrade_version(
-            &self.config.path,
+            &config.path,
             |v| {
                 let mut copy = v.clone();
                 copy.active_memtable = Arc::new(Memtable::new(
@@ -346,9 +347,9 @@ impl AbstractTree for Tree {
                 copy.version = Version::new(v.version.id() + 1, self.tree_type());
                 Ok(copy)
             },
-            &self.config.seqno,
-            &self.config.visible_seqno,
-            &*self.config.fs,
+            &config.seqno,
+            &config.visible_seqno,
+            &*config.fs,
         )
     }
 
@@ -643,10 +644,6 @@ impl AbstractTree for Tree {
             .expect("lock is poisoned")
             .latest_version()
             .active_memtable
-    }
-
-    fn tree_type(&self) -> crate::TreeType {
-        crate::TreeType::Standard
     }
 
     #[expect(clippy::significant_drop_tightening)]

--- a/tests/blob_tree_clear_reopen.rs
+++ b/tests/blob_tree_clear_reopen.rs
@@ -1,0 +1,36 @@
+use lsm_tree::AbstractTree;
+
+/// Regression for upstream #286: `BlobTree::clear()` must reset the
+/// version history (active memtable, sealed memtables, version id) like
+/// `Tree::clear()`, otherwise a subsequent reopen of the tree fails to
+/// recover a consistent state and the on-disk blob tree is corrupted.
+#[test_log::test]
+fn blob_tree_clear_then_reopen_succeeds() -> lsm_tree::Result<()> {
+    let folder = lsm_tree::get_tmp_folder();
+    let seqno = lsm_tree::SequenceNumberCounter::default();
+
+    {
+        let tree = lsm_tree::Config::new(
+            &folder,
+            seqno.clone(),
+            lsm_tree::SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(lsm_tree::KvSeparationOptions::default()))
+        .open()?;
+
+        tree.insert("foo", b"1", 0);
+        tree.clear()?;
+    }
+
+    {
+        let _tree = lsm_tree::Config::new(
+            &folder,
+            seqno.clone(),
+            lsm_tree::SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(lsm_tree::KvSeparationOptions::default()))
+        .open()?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Dependency refresh**: all crates in `Cargo.toml` / `Cargo.lock` bumped to latest, including major-version bumps that required code changes.
- **Adopted upstream bug fix** (fjall-rs/lsm-tree#286): `BlobTree::clear()` was corrupting the on-disk tree by skipping the version-manifest update, causing recovery to fail on reopen with *"Tried to open a BlobTree, but the existing tree is of type StandardTree"*. Cherry-picked upstream `db394880`, adapted to our diverged `Memtable::new(id, comparator)` signature and `&*config.fs` argument, plus rewrote the new default `tree_type()` impl in idiomatic `if/else` to satisfy our stricter `deny(clippy::all)` (`obfuscated_if_else`, `unnecessary_lazy_evaluations`).

## Commits

1. `build(deps)` — `cargo update` for ~30 semver-compatible bumps; manifest bumps for `structured-zstd 0.0.12 → 0.0.21` (our maintained fork; each pre-1.0 bump is breaking) and `rand 0.9 → 0.10` (dev-dep major bump — adapted `benches/bloom.rs` to `RngExt::random()` and `Rng::fill()` after `RngCore` was removed from rand crate root).
2. `test(blob_tree)` — regression test reproducing upstream #286: insert into kv-separated tree → `clear()` → reopen fails. Written **before** the fix per the test-first protocol; failed cleanly on stock code.
3. `fix` — cherry-pick of upstream `db394880` adapted to our fork. After the fix the regression test passes.

## Upstream sync analysis

Post-divergence commits in `fjall-rs/lsm-tree:main` evaluated for adoption:

| Upstream | Adopted | Reason |
|---|---|---|
| `bad4fe0a` (seqno of point-read ingested items) | ❌ | Our refactor already adjusts `global_seqno` at the `get` / `get_with_block` caller level, so the bug doesn't reproduce here. |
| `db394880` + `557cd0db` (clear() blob tree corruption #286) | ✅ | Real bug, also present in our fork — adopted with regression test. |
| `05c082ff` + `a8db0880` (`Slice::as_slice()` convenience) | ❌ | Pure API addition; `Slice` already implements `Deref<Target=[u8]>`. Can be added separately if needed. |

Open upstream issues triaged: none are confirmed bugs (only #289 — ingestion-pinning enhancement).

## Test plan

- [x] `cargo check --all-features --all-targets` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo nextest run --all-features` — 1271 passed, 6 skipped
- [x] `cargo test --doc --all-features` — 41 passed, 2 ignored
- [x] New regression test `blob_tree_clear_then_reopen_succeeds` fails on stock fork, passes after the fix

Closes #235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AbstractTree trait now provides a default tree type selection based on configuration.

* **Bug Fixes**
  * Fixed BlobTree clear operation to properly reset version history, preventing potential corruption when reopening the tree.

* **Chores**
  * Updated dependencies: structured-zstd and rand.

* **Tests**
  * Added regression test for blob tree clear and reopen operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->