### PR TITLE
feat(ci): smart upstream-monitor with release intelligence + path-aware CodeRabbit profile

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,10 +46,15 @@ reviews:
       instructions: |
         Compaction is crash-safety critical. Every state mutation must be atomic.
         Verify no partial writes can corrupt on-disk state.
-    # Glob (not the bare `src/encryption.rs` path) so the rule survives a
-    # module-vs-single-file refactor — covers the current single-file form,
-    # `src/encryption/` directory layouts, and any future `encryption_*.rs`
-    # split.
+    # Two near-identical blocks (single-file and module-directory layouts)
+    # so the rule survives a module-vs-single-file refactor — covers the
+    # current `src/encryption.rs`, any future `src/encryption_*.rs` split,
+    # and a `src/encryption/` directory. The duplication is intentional;
+    # CodeRabbit's path_instructions schema does not document YAML-anchor
+    # support reliably across versions, so we keep both blocks explicit.
+    # If a future schema cleanly supports anchors, collapse to:
+    #     - &enc-review &enc-glob path: "src/encryption*.rs"
+    #     - <<: *enc-review path: "src/encryption/**"
     - path: "src/encryption*.rs"
       instructions: |
         Security-critical code. Review for timing attacks, nonce reuse, key handling.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,10 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
+    # Single `main` base: feat/#NNN and fix/#NNN are PR source branches per
+    # our convention (CLAUDE.md), not long-lived integration targets — there
+    # are no release/* branches in this repo. Widen this list if that ever
+    # changes.
     base_branches: ["main"]
     ignore_title_keywords: ["WIP", "DO NOT MERGE"]
   path_instructions:
@@ -42,7 +46,16 @@ reviews:
       instructions: |
         Compaction is crash-safety critical. Every state mutation must be atomic.
         Verify no partial writes can corrupt on-disk state.
-    - path: "src/encryption.rs"
+    # Glob (not the bare `src/encryption.rs` path) so the rule survives a
+    # module-vs-single-file refactor — covers the current single-file form,
+    # `src/encryption/` directory layouts, and any future `encryption_*.rs`
+    # split.
+    - path: "src/encryption*.rs"
+      instructions: |
+        Security-critical code. Review for timing attacks, nonce reuse, key handling.
+        RNG must be CSPRNG. No hardcoded keys or IVs. AEAD nonces must never repeat
+        under the same key. Fork-aware reseed must be preserved.
+    - path: "src/encryption/**"
       instructions: |
         Security-critical code. Review for timing attacks, nonce reuse, key handling.
         RNG must be CSPRNG. No hardcoded keys or IVs. AEAD nonces must never repeat

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,8 +25,10 @@ reviews:
     drafts: false
     # Single `main` base: feat/#NNN and fix/#NNN are PR source branches per
     # our convention (CLAUDE.md), not long-lived integration targets — there
-    # are no release/* branches in this repo. Widen this list if that ever
-    # changes.
+    # are no release/* branches in this repo. The `upstream-monitor.yml`
+    # workflow also creates `chore/upstream-sync-*` sync PRs, and those
+    # ALWAYS target `main` (see the `--base main` flag on `gh pr create`).
+    # Widen this list if either convention ever changes.
     base_branches: ["main"]
     ignore_title_keywords: ["WIP", "DO NOT MERGE"]
   path_instructions:
@@ -52,12 +54,22 @@ reviews:
     # Two near-identical blocks (single-file and module-directory layouts)
     # so the rule survives a module-vs-single-file refactor — covers the
     # current `src/encryption.rs`, any future `src/encryption_*.rs` split,
-    # and a `src/encryption/` directory. The duplication is intentional;
-    # CodeRabbit's path_instructions schema does not document YAML-anchor
-    # support reliably across versions, so we keep both blocks explicit.
-    # If a future schema cleanly supports anchors, collapse to:
-    #     - &enc-review &enc-glob path: "src/encryption*.rs"
-    #     - <<: *enc-review path: "src/encryption/**"
+    # and a `src/encryption/` directory.
+    #
+    # Why duplicate instead of consolidate:
+    #   - YAML anchors (&enc-review / *enc-review): CodeRabbit's
+    #     path_instructions schema doesn't document anchor support
+    #     reliably across versions.
+    #   - Brace expansion (`src/encryption{*.rs,/**}`): no schema
+    #     guarantee that CodeRabbit's glob engine supports brace
+    #     expansion — silently no-matching is the failure mode.
+    #   - Single broader glob (`src/encryption*`): may not cross `/`
+    #     in CodeRabbit's matcher → nested files lose context.
+    #
+    # The duplication is intentional given those uncertainties. The
+    # mirrored `⚠️ Keep this block in sync` trailers below remind
+    # editors to update both. Collapse if/when the schema clearly
+    # supports one of the above patterns.
     - path: "src/encryption*.rs"
       instructions: |
         Security-critical code. Review for timing attacks, nonce reuse, key handling.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,8 +16,6 @@ reviews:
   related_issues: true
   related_prs: true
   suggested_labels: true
-  auto_label:
-    enabled: true
   auto_review:
     enabled: true
     auto_incremental_review: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,10 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: "en-US"
-early_access: true
+# Stable channel — early-access features change between releases without
+# notice, which makes review output non-reproducible across runs.
+# Re-enable explicitly only when an early-access feature is needed.
+early_access: false
 
 reviews:
   profile: "assertive"
@@ -60,11 +63,13 @@ reviews:
         Security-critical code. Review for timing attacks, nonce reuse, key handling.
         RNG must be CSPRNG. No hardcoded keys or IVs. AEAD nonces must never repeat
         under the same key. Fork-aware reseed must be preserved.
+        ⚠️ Keep this block in sync with the `src/encryption/**` rule below.
     - path: "src/encryption/**"
       instructions: |
         Security-critical code. Review for timing attacks, nonce reuse, key handling.
         RNG must be CSPRNG. No hardcoded keys or IVs. AEAD nonces must never repeat
         under the same key. Fork-aware reseed must be preserved.
+        ⚠️ Keep this block in sync with the `src/encryption*.rs` rule above.
   tools:
     shellcheck:
       enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,12 +23,12 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: false
-    # Single `main` base: feat/#NNN and fix/#NNN are PR source branches per
-    # our convention (CLAUDE.md), not long-lived integration targets — there
-    # are no release/* branches in this repo. The `upstream-monitor.yml`
-    # workflow also creates `chore/upstream-sync-*` sync PRs, and those
-    # ALWAYS target `main` (see the `--base main` flag on `gh pr create`).
-    # Widen this list if either convention ever changes.
+    # Single `main` base: feat/#NNN and fix/#NNN are PR source branches,
+    # not long-lived integration targets — there are no release/* branches
+    # in this repo. The `upstream-monitor.yml` workflow also creates
+    # `chore/upstream-sync-*` sync PRs, and those ALWAYS target `main`
+    # (see the `--base main` flag on `gh pr create`). Widen this list if
+    # either convention ever changes.
     base_branches: ["main"]
     ignore_title_keywords: ["WIP", "DO NOT MERGE"]
   path_instructions:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,108 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
+language: "en-US"
+early_access: true
+
 reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  commit_status: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
   auto_label:
     enabled: true
-  profile: assertive
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches: ["main"]
+    ignore_title_keywords: ["WIP", "DO NOT MERGE"]
+  path_instructions:
+    - path: "src/**/*.rs"
+      instructions: |
+        Review for memory safety, ownership correctness, and panic-free error handling.
+        No unwrap() on I/O or user-input paths. Prefer Result<T, E> everywhere.
+        No Box<dyn Any> as type bypass. No global mutable state (lazy_static Mutex<HashMap>).
+        Check multi-instance safety: no in-memory-only mutable state that breaks with N replicas.
+    - path: "tests/**"
+      instructions: |
+        Verify test coverage of edge cases and error paths.
+        No unwrap() on paths that test error handling.
+        Tests must have descriptive names and comments explaining WHAT is being tested.
+    - path: "benches/**"
+      instructions: |
+        Check benchmark methodology. Use criterion properly.
+        Measure P99/P999 latency, not just throughput.
+    - path: "src/compaction/**"
+      instructions: |
+        Compaction is crash-safety critical. Every state mutation must be atomic.
+        Verify no partial writes can corrupt on-disk state.
+    - path: "src/encryption.rs"
+      instructions: |
+        Security-critical code. Review for timing attacks, nonce reuse, key handling.
+        RNG must be CSPRNG. No hardcoded keys or IVs. AEAD nonces must never repeat
+        under the same key. Fork-aware reseed must be preserved.
+  tools:
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 120000
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - ".github/copilot-instructions.md"
+      - ".github/instructions/*.instructions.md"
+
+issue_enrichment:
+  labeling:
+    auto_apply_labels: true
+    labeling_instructions:
+      - label: "bug"
+        instructions: "Code defect, incorrect behavior, crash, data corruption, wrong results"
+      - label: "enhancement"
+        instructions: "New feature, new API, new capability not previously available"
+      - label: "performance"
+        instructions: "Optimization, reduced allocations, faster path, benchmark improvement"
+      - label: "refactor"
+        instructions: "Code restructuring without behavior change — renames, extractions, trait threading"
+      - label: "test"
+        instructions: "New tests, test infrastructure, test helpers, flaky test fixes"
+      - label: "ci"
+        instructions: "CI/CD workflows, GitHub Actions, benchmarks pipeline, release automation"
+      - label: "documentation"
+        instructions: "Documentation only — README, doc comments, arch docs, no code changes"
+      - label: "comparator"
+        instructions: "UserComparator threading, custom key ordering, lexicographic vs comparator-aware"
+      - label: "compaction"
+        instructions: "LSM compaction logic, leveled/tiered strategy, L0/L1/L2 overlap, compaction picker"
+      - label: "crash-safety"
+        instructions: "Crash recovery, fsync ordering, atomic writes, WAL correctness, data durability"
+      - label: "encryption"
+        instructions: "Block encryption, AES-GCM, key management, nonce handling"
+      - label: "fs-trait"
+        instructions: "Filesystem abstraction, Fs trait, io_uring, per-level routing, StdFs"
+      - label: "upstream-candidate"
+        instructions: "Fix or feature that could be contributed back to fjall-rs upstream"
+      - label: "fork-only"
+        instructions: "Feature specific to CoordiNode fork — range tombstones, merge operators, prefix bloom, V4 format"

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -106,12 +106,26 @@ jobs:
           echo "New release available: $NEW_RELEASE"
 
       - name: Check skip conditions
-        # Early skip gate — runs BEFORE Build change report and Compose
-        # body steps so cron runs on already-considered upstream HEADs
-        # short-circuit before the expensive Build step (which issues up
-        # to 20 upstream API calls for title resolution per ref). The
-        # merge step still re-checks defensively, but the API-quota
-        # win is here.
+        # Early skip gate — runs BEFORE the expensive Build step (which
+        # issues up to 20 upstream API calls for title resolution).
+        #
+        # Single rule: if a sync artifact (PR or issue) already exists
+        # for THIS upstream HEAD — in any state (open, closed, merged)
+        # — skip. Each sync PR/issue title carries `(upstream@<short>)`
+        # for searchability.
+        #
+        # The state semantics collapse cleanly:
+        #   - open → review in progress, don't stack
+        #   - merged → user accepted; origin/main has advanced, next
+        #     run reads BEHIND=0
+        #   - closed (not merged) → user decided "no" for this HEAD;
+        #     closing the PR IS the "considered" signal, no manual
+        #     state-file edit required
+        # All three reduce to "don't resurface this HEAD until upstream
+        # advances and produces a new short SHA".
+        #
+        # workflow_dispatch input `force=true` bypasses this gate for
+        # explicit "re-surface anyway" runs.
         if: steps.detect.outputs.behind != '0'
         id: skip
         env:
@@ -120,37 +134,28 @@ jobs:
           FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
-          SHOULD_RUN=true
-          REASON=""
 
-          # An open sync PR is unresolved review work — don't stack.
-          # Ensure the label exists first (otherwise the query fails
-          # against a missing label with non-zero exit). Idempotent.
+          # Ensure the `upstream-sync` label exists (gh queries against
+          # a missing label exit non-zero). Idempotent.
           gh label create "upstream-sync" \
             --color "fbca04" \
             --description "Automated upstream synchronization — merge conflicts, release tracking" \
             --force >/dev/null
-          OPEN_SYNC_PRS=$(gh pr list \
-            --label upstream-sync --state open \
-            --json number --jq 'length')
-          if [ "$OPEN_SYNC_PRS" -gt 0 ]; then
-            SHOULD_RUN=false
-            REASON="${OPEN_SYNC_PRS} open sync PR(s) already exist"
-          fi
 
-          # Already-considered upstream HEAD (close-without-merge memory).
-          if [ "$SHOULD_RUN" = "true" ] && [ "$FORCE" != "true" ]; then
-            CONSIDERED_TAG="upstream-sync-considered/${UPSTREAM_HEAD_SHORT}"
-            if git ls-remote --tags --exit-code origin "refs/tags/${CONSIDERED_TAG}" >/dev/null 2>&1; then
+          SHOULD_RUN=true
+          if [ "$FORCE" != "true" ]; then
+            # GitHub search index strips `@` and `#` from query text;
+            # the title fragment `upstream-${UPSTREAM_HEAD_SHORT}` uses
+            # a dash so it survives intact and remains greppable.
+            QUERY="upstream-${UPSTREAM_HEAD_SHORT} in:title label:upstream-sync repo:${GITHUB_REPOSITORY}"
+            COUNT=$(gh api -X GET search/issues -f q="$QUERY" --jq '.total_count')
+            if [ "$COUNT" -gt 0 ]; then
               SHOULD_RUN=false
-              REASON="upstream HEAD ${UPSTREAM_HEAD_SHORT} already considered (tag ${CONSIDERED_TAG})"
+              echo "Skip: ${COUNT} sync artifact(s) for upstream-${UPSTREAM_HEAD_SHORT} already exist (open/closed/merged). Subsequent steps will short-circuit."
             fi
           fi
 
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
-          if [ "$SHOULD_RUN" = "false" ]; then
-            echo "Skip: ${REASON}. Subsequent steps will short-circuit."
-          fi
 
       - name: Build change report
         if: steps.detect.outputs.behind != '0' && steps.skip.outputs.should_run == 'true'
@@ -453,13 +458,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Skip conditions (open sync PR exists, considered-tag for
-          # current upstream HEAD) are evaluated in the earlier
-          # `Check skip conditions` step. This step's `if:` gate
-          # already includes `steps.skip.outputs.should_run == 'true'`,
-          # so we don't re-check here. `upstream-sync` label is also
-          # ensured in the skip step.
-          CONSIDERED_TAG="upstream-sync-considered/${UPSTREAM_HEAD_SHORT}"
+          # Skip conditions (any sync artifact for current upstream HEAD)
+          # are evaluated in the earlier `Check skip conditions` step.
+          # This step's `if:` gate already includes
+          # `steps.skip.outputs.should_run == 'true'`, so we don't re-check
+          # here. `upstream-sync` label is also ensured in the skip step.
+          #
+          # All sync PR / issue titles include the `upstream-<short>`
+          # fragment that the skip-step search looks for. The fragment
+          # uses a dash (not `@` or `#`) so GitHub's search-text
+          # normaliser doesn't strip it.
 
           # Branch name carries the date + run number so a second run on the
           # same UTC day (manual `workflow_dispatch` after the cron run) gets
@@ -484,7 +492,7 @@ jobs:
             # Commit 1: the upstream merge itself — pure upstream content,
             # clean for `git log --first-parent` / blame / "what came from
             # upstream" tooling.
-            git commit -m "chore: sync upstream (${BEHIND} new commits)"
+            git commit -m "chore: sync upstream-${UPSTREAM_HEAD_SHORT} (${BEHIND} new commits)"
 
             # Commit 2 (separate): advance the persisted last-synced tag.
             # Kept out of the merge commit so fork-only bookkeeping doesn't
@@ -508,7 +516,7 @@ jobs:
             git push origin "$SYNC_BRANCH"
 
             gh pr create \
-              --title "chore: sync upstream (${BEHIND} new commits)" \
+              --title "chore: sync upstream-${UPSTREAM_HEAD_SHORT} (${BEHIND} new commits)" \
               --body-file "$BODY_PATH" \
               --base main \
               --head "$SYNC_BRANCH" \
@@ -547,7 +555,7 @@ jobs:
                 echo '```'
                 echo
               } >> "$BODY_PATH"
-              ISSUE_TITLE="Upstream sync conflict (${BEHIND} new commits)"
+              ISSUE_TITLE="Upstream sync conflict for upstream-${UPSTREAM_HEAD_SHORT} (${BEHIND} new commits)"
             else
               # Merge failed for a non-conflict reason (dirty tree from a
               # prior step, internal git error, hook refusal). Don't fake a
@@ -562,7 +570,7 @@ jobs:
                 echo "rather than a content conflict. Inspect the workflow run logs."
                 echo
               } >> "$BODY_PATH"
-              ISSUE_TITLE="Upstream sync merge failed without conflicts (${BEHIND} new commits)"
+              ISSUE_TITLE="Upstream sync merge failed without conflicts for upstream-${UPSTREAM_HEAD_SHORT} (${BEHIND} new commits)"
             fi
             append_checklist
 
@@ -572,37 +580,12 @@ jobs:
               --label "upstream-sync"
           fi
 
-          # Mark this exact upstream HEAD as "considered" — applies on
-          # both routes (successful merge / problem report). For a fork
-          # with permanent divergences (renames, cherry-pick-only
-          # relationships), the conflict route is the steady state and
-          # without this tag every cron run would refile the same issue.
-          # The tag stays regardless of how the maintainer dispositions
-          # the surfaced artifact.
-          #
-          # IMPORTANT: tag points at `origin/main` (our own HEAD), not
-          # `upstream/main`. The upstream short SHA lives only in the
-          # tag NAME. Pointing the tag at upstream's HEAD would make
-          # GitHub reject the push when upstream's commits include
-          # workflow file changes — the default GITHUB_TOKEN has no
-          # `workflows: write` scope, so any ref that surfaces unseen
-          # workflow content fails server-side. Pointing at our own
-          # main avoids that check entirely; the tag is a marker, the
-          # target commit is irrelevant.
-          #
-          # `-f` because `actions/checkout` with fetch-depth=0 brings
-          # all origin tags into the local clone, so a force=true
-          # re-run against the same upstream HEAD finds the local tag
-          # already present. Plain `git tag` would abort the step
-          # under `set -e` after the PR/issue had already been opened.
-          # `|| true` on the push is for the remote-side collision
-          # which is harmless (same target).
-          git tag -f "$CONSIDERED_TAG" origin/main
-          # `+refs/tags/...` is the localised refspec form for tag
-          # override (equivalent to `--force` but scoped to just this
-          # ref). `|| true` because a remote-side collision is
-          # harmless (target is identical or only the tag NAME mattered).
-          git push origin "+refs/tags/${CONSIDERED_TAG}" || true
+          # No tag-push here: the "considered" signal is the existence
+          # of the PR/issue artifact itself (queried by title in the
+          # Check skip conditions step). Closing the auto-PR without
+          # merging is the user's "I've seen this" action; the
+          # closed PR remains in repo history and satisfies the
+          # search query, so future runs skip until upstream advances.
 
       - name: Check for merged feature branches
         env:

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -105,7 +105,15 @@ jobs:
                   <(git tag -l --merged "${UPSTREAM_REMOTE}/main" | sort -u)) \
               | grep -E "$SEMVER_RE" | sort -V | tail -1 || true)
           fi
-          UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
+          # Pin abbreviation length: `git rev-parse --short` (no `=N`) returns
+          # the shortest currently-unique prefix, which lengthens as the
+          # repository grows. Because UPSTREAM_HEAD_SHORT is the stable
+          # identifier in PR/issue titles AND the skip-check search query,
+          # a length drift between runs would fail to match the previous
+          # artifact and re-surface the same upstream HEAD as "new".
+          # 12 chars is well above the collision threshold for any
+          # foreseeable upstream history size.
+          UPSTREAM_HEAD_SHORT=$(git rev-parse --short=12 "${UPSTREAM_REMOTE}/main")
           {
             echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG"
             echo "upstream_prev_tag=$UPSTREAM_PREV_TAG"
@@ -346,8 +354,10 @@ jobs:
           # REFS_CAP — readers just iterate them. No per-list cap or
           # "N more" footer needed.
 
-          # Resolve bare refs against UPSTREAM_REPO via a single Issues API call
-          # (PRs are issues under the hood, so we don't need an issue→PR fallback).
+          # Resolve bare refs against UPSTREAM_REPO. One `gh api repos/.../issues/<num>`
+          # request per referenced ref (PRs are issues under the hood, so a single
+          # endpoint covers both — no issue→PR fallback needed). REFS_CAP=20 above
+          # bounds the total number of lookups per workflow run.
           if [ -s /tmp/sync/refs_bare.txt ]; then
             while read -r REF; do
               NUM="${REF#\#}"
@@ -617,7 +627,19 @@ jobs:
                 echo "git fetch upstream main"
                 echo "git checkout -b chore/upstream-sync main"
                 echo "git merge upstream/main"
-                echo "# Resolve conflicts, then push"
+                echo "# ...resolve conflicts in your editor..."
+                echo "git add <resolved-files>"
+                if [ -n "${UPSTREAM_LATEST_TAG}" ]; then
+                  # Advance the sync watermark so the next workflow run's
+                  # release-heading uses this tag as UPSTREAM_PREV_TAG instead
+                  # of the stale baseline. Only emitted when upstream actually
+                  # cut a tag at-or-before the synced HEAD.
+                  echo "mkdir -p .github/state"
+                  echo "echo \"${UPSTREAM_LATEST_TAG}\" > .github/state/last-upstream-sync.txt"
+                  echo "git add .github/state/last-upstream-sync.txt"
+                fi
+                echo "git commit"
+                echo "git push -u origin chore/upstream-sync"
                 echo '```'
                 echo
               } >> "$BODY_PATH"

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -61,8 +61,18 @@ jobs:
           # A future "track upstream pre-releases" feature would extend this
           # pattern explicitly.
           SEMVER_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
-          UPSTREAM_LATEST_TAG=$(git tag -l --sort=-v:refname --merged "${UPSTREAM_REMOTE}/main" \
-            | grep -E "$SEMVER_RE" | head -1 || true)
+          # Intersect "tags actually published on the upstream remote"
+          # with "tags reachable from upstream/main" — guarantees the
+          # picked tag is an upstream-origin tag (not a fork-local
+          # `v4.4.0` that happens to sit on a commit ancestral to
+          # upstream/main via a back-merge or shared base). Mirrors
+          # the safety property the bootstrap fallback below already
+          # has via its own `comm -12`.
+          UPSTREAM_LATEST_TAG=$(comm -12 \
+            <(git ls-remote --tags --refs "$UPSTREAM_REMOTE" \
+                | awk '{sub(/refs\/tags\//,"",$2); print $2}' | sort -u) \
+            <(git tag -l --merged "${UPSTREAM_REMOTE}/main" | sort -u) \
+            | grep -E "$SEMVER_RE" | sort -V | tail -1 || true)
 
           # Prefer the explicit state file. Fall back to inference from
           # `--merged origin/main` only as a BOOTSTRAP for the first sync
@@ -94,6 +104,14 @@ jobs:
             echo "upstream_head_short=$UPSTREAM_HEAD_SHORT"
           } >> "$GITHUB_OUTPUT"
 
+          # NEW_RELEASE drives the heading shape in the sync body; it
+          # does NOT independently trigger a sync. A tag-only release
+          # cut on an upstream HEAD that's already in `origin/main`
+          # (BEHIND=0) is intentionally NOT surfaced — for a fork that
+          # has already decided about that exact upstream code, the
+          # downstream release ceremony is irrelevant. Whatever
+          # release-transition info eventually matters will appear in
+          # the heading of the next BEHIND>0 sync.
           NEW_RELEASE=false
           if [ -n "$UPSTREAM_LATEST_TAG" ] && [ "$UPSTREAM_LATEST_TAG" != "$UPSTREAM_PREV_TAG" ]; then
             NEW_RELEASE=true
@@ -157,6 +175,17 @@ jobs:
 
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
+      # NOTE on the two-half `if:` gate below (and on the two downstream
+      # steps that mirror it): BOTH halves are load-bearing.
+      #   - `behind != '0'` short-circuits when there's nothing to sync.
+      #   - `skip.outputs.should_run == 'true'` short-circuits when the
+      #     current upstream HEAD was already surfaced (open/closed/merged
+      #     PR or issue). Since the `Check skip conditions` step itself
+      #     gates on `behind != '0'`, removing that predicate from any
+      #     downstream `if:` would leave `should_run` as the empty string
+      #     in the behind=0 case and the step would NEVER run. If a
+      #     future edit relaxes either predicate, the other must move
+      #     in lock-step or the step gets silently disabled.
       - name: Build change report
         if: steps.detect.outputs.behind != '0' && steps.skip.outputs.should_run == 'true'
         env:
@@ -346,6 +375,15 @@ jobs:
           # overlap list is a "look here for possible semantic conflicts"
           # hint for the reviewer, not a precise change-summary. Use the
           # PR diff for authoritative final state.
+          #
+          # NOT using `-M` (rename detection) on the upstream diff: with
+          # `-M`, git collapses renames into a single new-path entry.
+          # Without `-M`, an upstream rename of `foo.rs` → `bar.rs` shows
+          # BOTH `foo.rs` (delete) AND `bar.rs` (add). For a fork that
+          # has edited `foo.rs` pre-rename (the common case), the
+          # without-`-M` form catches the overlap on `foo.rs`; with `-M`
+          # the overlap would silently miss because git only emits
+          # `bar.rs`. Coverage > precision for this hint.
           MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
           git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
             | sort -u > /tmp/sync/upstream_files.txt
@@ -619,16 +657,23 @@ jobs:
             if git merge-base --is-ancestor "$BRANCH_TIP" "${UPSTREAM_REMOTE}/main" 2>/dev/null; then
               echo "Branch '$BRANCH' is fully merged into ${UPSTREAM_REMOTE}/main"
 
-              # GitHub's issue-search engine strips `#` from the query
-              # (and from the indexed issue text), so searching for the
-              # raw branch name `feat/#123-foo` would silently miss
-              # existing issues titled "Upstream merged: feat/#123-foo".
-              # Strip `#` from BRANCH before the search; the indexed
-              # title is stripped too so the match works.
+              # `gh issue list --search` is GitHub free-text search:
+              # it tokenises and matches CONTAINS, not exact-title. For
+              # short branch slugs (e.g., `feat/123-foo` after `#`
+              # strip — search drops `#` regardless), this can match
+              # unrelated issues containing those tokens and falsely
+              # suppress a legitimate "Upstream merged" notification.
+              #
+              # Pull a wider candidate set with the same loose search,
+              # then post-filter to EXACT title equality on the client.
+              # The expected title includes the literal `#` (it's part
+              # of the branch convention and lives in the indexed title).
+              EXPECTED_TITLE="Upstream merged: $BRANCH"
               SEARCH_BRANCH="${BRANCH//\#/}"
               EXISTING=$(gh issue list \
                 --search "Upstream merged: $SEARCH_BRANCH" \
-                --state open --json number --jq 'length')
+                --state open --json title \
+                --jq "[.[] | select(.title == \"$EXPECTED_TITLE\")] | length")
               if [ "$EXISTING" = "0" ]; then
                 BODY_FILE=$(mktemp)
                 {

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -114,8 +114,10 @@ jobs:
             BODY="${REST#*$'\t'}"
             SHORT=$(git rev-parse --short "$SHA")
             LINE="- \`$SHORT\` $SUBJECT"
+            # Conventional Commits §5 treats `BREAKING CHANGE:` and
+            # `BREAKING-CHANGE:` as equivalent footer tokens — match both.
             if [[ "$SUBJECT" =~ $BREAKING_RE ]] \
-               || printf '%s\n' "$BODY" | grep -qE '^BREAKING CHANGE:'; then
+               || printf '%s\n' "$BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then
               echo "$LINE" >> /tmp/sync/breaking.txt
             elif [[ "$SUBJECT" =~ $FEAT_RE ]]; then
               echo "$LINE" >> /tmp/sync/feat.txt
@@ -191,6 +193,10 @@ jobs:
                 TITLE_SAFE=$(md_escape "$TITLE")
                 echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE_SAFE}" \
                   >> /tmp/sync/refs.md
+              else
+                # Log to stderr so partial reference output is debuggable
+                # (transient API failures, rate limits, missing issues, etc.).
+                echo "warn: failed to resolve title for ${UPSTREAM_REPO}${REF}" >&2
               fi
             done
           fi
@@ -242,6 +248,7 @@ jobs:
           BODY=/tmp/sync/body.md
           : > "$BODY"
 
+          UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
           if [ "$NEW_RELEASE" = "true" ]; then
             {
               echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → ${UPSTREAM_LATEST_TAG}"
@@ -249,7 +256,10 @@ jobs:
               echo "**Release:** [${UPSTREAM_LATEST_TAG}](https://github.com/${UPSTREAM_REPO}/releases/tag/${UPSTREAM_LATEST_TAG})"
             } >> "$BODY"
           else
-            echo "## Upstream Sync (no new release tag)" >> "$BODY"
+            # In-development commits between releases — anchor the heading
+            # to the last synced tag and the upstream HEAD short SHA so the
+            # baseline is still visible at a glance.
+            echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → main@${UPSTREAM_HEAD_SHORT}" >> "$BODY"
           fi
           {
             echo "**Commits:** ${BEHIND} new since last sync"
@@ -318,7 +328,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)"
+          # Branch name carries the date + run number so a second run on the
+          # same UTC day (manual `workflow_dispatch` after the cron run, or a
+          # re-run while the previous PR is still open) gets a distinct name
+          # and doesn't collide with an existing remote branch / open PR.
+          SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
           git checkout -b "$SYNC_BRANCH" origin/main
 
           # Helper: append the review checklist as the last section of the body.
@@ -334,20 +348,25 @@ jobs:
           }
 
           if git merge --no-commit --no-ff "${UPSTREAM_REMOTE}/main" 2>&1; then
-            # Advance the persisted last-synced tag on every successful merge,
-            # regardless of whether this run detected a release boundary. The
-            # state file is lazily bootstrapped — the first sync run with
-            # behind > 0 writes it; until then, the `git tag --merged
+            append_checklist
+            # Commit 1: the upstream merge itself — pure upstream content,
+            # clean for `git log --first-parent` / blame / "what came from
+            # upstream" tooling.
+            git commit -m "chore: sync upstream (${BEHIND} new commits)"
+
+            # Commit 2 (separate): advance the persisted last-synced tag.
+            # Kept out of the merge commit so fork-only bookkeeping doesn't
+            # mix with upstream content. Lazy-bootstrap: first sync with
+            # behind > 0 writes the file; until then the `git tag --merged
             # origin/main` inference in the detect step covers the gap.
-            # Runs with behind == 0 don't reach this step and don't need to
-            # write the file (state is unchanged).
+            # Runs with behind == 0 don't reach this step.
             if [ -n "${UPSTREAM_LATEST_TAG}" ]; then
               mkdir -p "$(dirname "$STATE_FILE")"
               echo "$UPSTREAM_LATEST_TAG" > "$STATE_FILE"
               git add "$STATE_FILE"
+              git commit -m "chore: bump upstream sync state to ${UPSTREAM_LATEST_TAG}"
             fi
-            append_checklist
-            git commit -m "chore: sync upstream (${BEHIND} new commits)"
+
             git push origin "$SYNC_BRANCH"
 
             gh pr create \
@@ -362,31 +381,50 @@ jobs:
             # nothing to abort and the bare command would fail under `set -e`.
             git merge --abort 2>/dev/null || true
 
-            # Insert conflict + manual-resolution sections BEFORE the
-            # checklist so the issue reads top-to-bottom: summary → changes
-            # → conflicts → resolution → checklist.
-            {
-              echo "### Conflicting files"
-              echo
-              echo '```'
-              echo "$CONFLICTS"
-              echo '```'
-              echo
-              echo "### Manual resolution"
-              echo
-              echo '```bash'
-              echo "git remote add upstream ${UPSTREAM_URL}"
-              echo "git fetch upstream main"
-              echo "git checkout -b chore/upstream-sync main"
-              echo "git merge upstream/main"
-              echo "# Resolve conflicts, then push"
-              echo '```'
-              echo
-            } >> "$BODY_PATH"
+            if [ -n "$CONFLICTS" ]; then
+              # Real conflicts — list the files and provide manual-resolution
+              # snippet. Sections go BEFORE the checklist so the issue reads
+              # top-to-bottom: summary → changes → conflicts → resolution
+              # → checklist.
+              {
+                echo "### Conflicting files"
+                echo
+                echo '```'
+                echo "$CONFLICTS"
+                echo '```'
+                echo
+                echo "### Manual resolution"
+                echo
+                echo '```bash'
+                echo "git remote add upstream ${UPSTREAM_URL}"
+                echo "git fetch upstream main"
+                echo "git checkout -b chore/upstream-sync main"
+                echo "git merge upstream/main"
+                echo "# Resolve conflicts, then push"
+                echo '```'
+                echo
+              } >> "$BODY_PATH"
+              ISSUE_TITLE="Upstream sync conflict (${BEHIND} new commits)"
+            else
+              # Merge failed for a non-conflict reason (dirty tree from a
+              # prior step, internal git error, hook refusal). Don't fake a
+              # conflict body — emit a clearly different signal so on-call
+              # investigates the workflow itself.
+              {
+                echo "### Merge failed without conflicts"
+                echo
+                echo "\`git merge --no-commit --no-ff ${UPSTREAM_REMOTE}/main\` returned non-zero"
+                echo "but no unmerged paths were detected. This usually means a"
+                echo "pre-merge refusal (dirty tree, hook rejection, internal git error)"
+                echo "rather than a content conflict. Inspect the workflow run logs."
+                echo
+              } >> "$BODY_PATH"
+              ISSUE_TITLE="Upstream sync merge failed without conflicts (${BEHIND} new commits)"
+            fi
             append_checklist
 
             gh issue create \
-              --title "Upstream sync conflict (${BEHIND} new commits)" \
+              --title "$ISSUE_TITLE" \
               --body-file "$BODY_PATH" \
               --label "upstream-sync"
           fi

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -549,14 +549,26 @@ jobs:
           fi
 
           # Mark this exact upstream HEAD as "considered" — applies on
-          # BOTH branches (successful merge PR + conflict issue). For a
-          # fork with permanent divergences (renames, cherry-pick-only
-          # relationships), the conflict path is the steady state and
+          # both routes (successful merge / problem report). For a fork
+          # with permanent divergences (renames, cherry-pick-only
+          # relationships), the conflict route is the steady state and
           # without this tag every cron run would refile the same issue.
           # The tag stays regardless of how the maintainer dispositions
-          # the surfaced artifact. `|| true` because a tag collision on
-          # an explicit force=true re-run is harmless.
-          git tag "$CONSIDERED_TAG" "${UPSTREAM_REMOTE}/main"
+          # the surfaced artifact.
+          #
+          # IMPORTANT: tag points at `origin/main` (our own HEAD), not
+          # `upstream/main`. The upstream short SHA lives only in the
+          # tag NAME. Pointing the tag at upstream's HEAD would make
+          # GitHub reject the push when upstream's commits include
+          # workflow file changes — the default GITHUB_TOKEN has no
+          # `workflows: write` scope, so any ref that surfaces unseen
+          # workflow content fails server-side. Pointing at our own
+          # main avoids that check entirely; the tag is a marker, the
+          # target commit is irrelevant.
+          #
+          # `|| true` because a tag collision on an explicit
+          # force=true re-run is harmless.
+          git tag "$CONSIDERED_TAG" origin/main
           git push origin "$CONSIDERED_TAG" || true
 
       - name: Check for merged feature branches

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 8 * * 1,4"
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Bypass the 'already-considered tag' skip and open a fresh sync PR even if upstream HEAD was previously surfaced."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -75,8 +80,12 @@ jobs:
             UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
               | grep -E "$SEMVER_RE" | head -1 || true)
           fi
-          echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG" >> "$GITHUB_OUTPUT"
-          echo "upstream_prev_tag=$UPSTREAM_PREV_TAG" >> "$GITHUB_OUTPUT"
+          UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
+          {
+            echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG"
+            echo "upstream_prev_tag=$UPSTREAM_PREV_TAG"
+            echo "upstream_head_short=$UPSTREAM_HEAD_SHORT"
+          } >> "$GITHUB_OUTPUT"
 
           NEW_RELEASE=false
           if [ -n "$UPSTREAM_LATEST_TAG" ] && [ "$UPSTREAM_LATEST_TAG" != "$UPSTREAM_PREV_TAG" ]; then
@@ -149,13 +158,17 @@ jobs:
           # (resolved against UPSTREAM_REPO) and qualified `owner/repo#NNN`
           # (rendered as plain links, not silently rewritten).
           #
-          # Strategy: tokenise the commit text into one candidate per line by
-          # treating whitespace, parens, brackets, commas, semicolons, and
-          # angle brackets as separators, then exact-match each token against
-          # the ref grammar. This prevents file-path citations like
-          # `path/to/file#42` from being misread as `to/file#42` qualified
-          # refs (the inline `grep -oE` form was greedy and matched the
-          # longest substring rather than complete tokens).
+          # Strategy: tokenise the commit text into one candidate per line
+          # by treating whitespace, parens, brackets, commas, semicolons,
+          # angle brackets, exclamation/question marks, AND single/double
+          # quotes + apostrophes as separators, then exact-match each
+          # token against the ref grammar. This prevents file-path
+          # citations like `path/to/file#42` from being misread as
+          # `to/file#42` qualified refs (the inline `grep -oE` form was
+          # greedy and matched the longest substring rather than complete
+          # tokens). Apostrophes are intentionally separators so
+          # `don't#42` tokenises as `don`, `t`, `#42` — `t` and `don`
+          # fail the ref grammar and only `#42` is kept.
           #
           # `owner` grammar follows GitHub's rules: letters/digits/`-`, no
           # leading `-`, no `.` or `_` (which `path` segments freely use).
@@ -292,6 +305,7 @@ jobs:
           NEW_RELEASE: ${{ steps.detect.outputs.new_release }}
           UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
           UPSTREAM_PREV_TAG: ${{ steps.detect.outputs.upstream_prev_tag }}
+          UPSTREAM_HEAD_SHORT: ${{ steps.detect.outputs.upstream_head_short }}
         run: |
           set -euo pipefail
 
@@ -308,7 +322,6 @@ jobs:
             # In-development commits between releases — anchor the heading
             # to the last synced tag and the upstream HEAD short SHA so the
             # baseline is still visible at a glance.
-            UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
             echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → main@${UPSTREAM_HEAD_SHORT}" >> "$BODY"
           fi
           {
@@ -374,7 +387,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BEHIND: ${{ steps.detect.outputs.behind }}
           UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
+          UPSTREAM_HEAD_SHORT: ${{ steps.detect.outputs.upstream_head_short }}
           BODY_PATH: ${{ steps.body.outputs.body_path }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
 
@@ -398,6 +413,27 @@ jobs:
             --json number --jq 'length')
           if [ "$OPEN_SYNC_PRS" -gt 0 ]; then
             echo "Skip: ${OPEN_SYNC_PRS} open sync PR(s) already exist — resolve them before opening another."
+            exit 0
+          fi
+
+          # Skip if this exact upstream HEAD was already surfaced via a
+          # prior sync PR (which the maintainer either merged or closed
+          # without merging — the "considered-but-not-merged" case
+          # matters for forks with permanent divergences from renames /
+          # cherry-picks that intentionally never absorb upstream).
+          #
+          # Mechanism: each successful PR creation pushes a tag
+          # `upstream-sync-considered/<short-sha>` pointing at upstream
+          # HEAD. Re-runs against the same upstream HEAD see the tag
+          # and exit early. New upstream commits → new short SHA → no
+          # tag match → workflow proceeds normally.
+          #
+          # workflow_dispatch input `force: true` bypasses this gate
+          # for explicit "I want to re-surface" runs.
+          CONSIDERED_TAG="upstream-sync-considered/${UPSTREAM_HEAD_SHORT}"
+          if [ "$FORCE" != "true" ] \
+             && git ls-remote --tags --exit-code origin "refs/tags/${CONSIDERED_TAG}" >/dev/null 2>&1; then
+            echo "Skip: upstream HEAD ${UPSTREAM_HEAD_SHORT} already considered (tag ${CONSIDERED_TAG} exists). Use workflow_dispatch with force=true to re-surface."
             exit 0
           fi
 
@@ -453,6 +489,16 @@ jobs:
               --base main \
               --head "$SYNC_BRANCH" \
               --label "upstream-sync"
+
+            # Mark this exact upstream HEAD as "considered" by pushing a
+            # tag that future runs check for. This is what makes
+            # close-without-merge a permanent decision until upstream
+            # advances — the tag stays regardless of PR outcome.
+            # `|| true` because a tag collision is harmless (means we
+            # already surfaced this HEAD; the new PR was a redundant
+            # workflow_dispatch with force=true).
+            git tag "$CONSIDERED_TAG" "${UPSTREAM_REMOTE}/main"
+            git push origin "$CONSIDERED_TAG" || true
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
             # Defensive: if the merge failed before entering merge state

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -667,7 +667,7 @@ jobs:
             --description "Automated upstream synchronization — merge conflicts, release tracking" \
             --force >/dev/null
 
-          # Our branch convention (per CLAUDE.md) is `<type>/#<issue_id>[-slug]`,
+          # Our branch convention is `<type>/#<issue_id>[-slug]`,
           # so the literal `#` is part of every feature/fix branch name. Branches
           # without the leading `#` (e.g., `feat/foo` or `feat/123-foo`) are not
           # produced by our workflow and are intentionally skipped. If the

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -137,8 +137,9 @@ jobs:
         #
         # Single rule: if a sync artifact (PR or issue) already exists
         # for THIS upstream HEAD — in any state (open, closed, merged)
-        # — skip. Each sync PR/issue title carries `(upstream@<short>)`
-        # for searchability.
+        # — skip. Each sync PR/issue title carries `upstream-<short>`
+        # for searchability (dash, not `@`, so GitHub's search-text
+        # normaliser doesn't strip it).
         #
         # The state semantics collapse cleanly:
         #   - open → review in progress, don't stack
@@ -255,6 +256,13 @@ jobs:
             fi
           done < <(git log "origin/main..${UPSTREAM_REMOTE}/main" \
                      --format='%H%x09%s%x09%b' -z)
+          # `%x09` (tab) field separator is safe for current parsing
+          # because we only inspect SUBJECT for prefix patterns and
+          # BODY for `^BREAKING[ -]CHANGE:` at line start — both
+          # tolerant of embedded tabs in BODY. If future parsing reads
+          # arbitrary BODY structure (e.g., counts characters or
+          # parses tables), switch to a multi-character sentinel like
+          # `%H%n--SEP--%n%s%n--SEP--%n%b` to avoid the brittleness.
 
           # Extract referenced issues / PRs. Capture both bare `#NNN`
           # (resolved against UPSTREAM_REPO) and qualified `owner/repo#NNN`
@@ -293,7 +301,7 @@ jobs:
             | sed 's/\.$//' \
             | grep -E '^([A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+)?#[0-9]+$' \
             | sort -u \
-            | head -"$REFS_CAP" \
+            | head -n "$REFS_CAP" \
             | while read -r REF; do
                 if [[ "$REF" == *"/"* ]]; then
                   echo "$REF" >> /tmp/sync/refs_qualified.txt
@@ -392,14 +400,24 @@ jobs:
           # without-`-M` form catches the overlap on `foo.rs`; with `-M`
           # the overlap would silently miss because git only emits
           # `bar.rs`. Coverage > precision for this hint.
-          MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
-          git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
-            | sort -u > /tmp/sync/upstream_files.txt
-          git log "${MERGE_BASE}..origin/main" --not "${UPSTREAM_REMOTE}/main" \
-            --name-only --format= \
-            | grep -v '^$' | sort -u > /tmp/sync/fork_files.txt || true
-          comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt \
-            > /tmp/sync/overlap.txt || true
+          # `git merge-base` returns non-zero when histories are
+          # unrelated (extremely rare for a fork but possible after a
+          # force-push or upstream rewrite). Guard with `|| true` and
+          # skip overlap detection when MERGE_BASE is empty — the
+          # rest of the report still renders.
+          MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main" || true)
+          : > /tmp/sync/overlap.txt
+          if [ -n "$MERGE_BASE" ]; then
+            git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
+              | sort -u > /tmp/sync/upstream_files.txt
+            git log "${MERGE_BASE}..origin/main" --not "${UPSTREAM_REMOTE}/main" \
+              --name-only --format= \
+              | grep -v '^$' | sort -u > /tmp/sync/fork_files.txt || true
+            comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt \
+              > /tmp/sync/overlap.txt || true
+          else
+            echo "warn: no merge-base between origin/main and ${UPSTREAM_REMOTE}/main — fork-overlap detection skipped" >&2
+          fi
 
           # Emit summary counts for use in subsequent steps.
           # Counts go directly into the rendered body in the next step; no
@@ -515,10 +533,12 @@ jobs:
           # uses a dash (not `@` or `#`) so GitHub's search-text
           # normaliser doesn't strip it.
 
-          # Branch name carries the date + run number so a second run on the
-          # same UTC day (manual `workflow_dispatch` after the cron run) gets
-          # a distinct name and doesn't collide with an existing remote branch.
-          SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
+          # Branch name carries date + run number + run attempt so:
+          #   - cron + workflow_dispatch on the same UTC day get distinct
+          #     branches (GITHUB_RUN_NUMBER differs between runs);
+          #   - re-running a failed workflow run gets a distinct branch
+          #     (GITHUB_RUN_ATTEMPT increments while RUN_NUMBER stays).
+          SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$SYNC_BRANCH" origin/main
 
           # Helper: append the review checklist as the last section of the body.
@@ -676,12 +696,15 @@ jobs:
               # then post-filter to EXACT title equality on the client.
               # The expected title includes the literal `#` (it's part
               # of the branch convention and lives in the indexed title).
+              # Pass EXPECTED_TITLE to jq via `--arg` (not string
+              # interpolation) so any quote/backslash in BRANCH
+              # cannot break the jq filter syntax.
               EXPECTED_TITLE="Upstream merged: $BRANCH"
               SEARCH_BRANCH="${BRANCH//\#/}"
               EXISTING=$(gh issue list \
                 --search "Upstream merged: $SEARCH_BRANCH" \
                 --state open --json title \
-                --jq "[.[] | select(.title == \"$EXPECTED_TITLE\")] | length")
+                | jq --arg t "$EXPECTED_TITLE" '[.[] | select(.title == $t)] | length')
               if [ "$EXISTING" = "0" ]; then
                 BODY_FILE=$(mktemp)
                 {

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -240,11 +240,18 @@ jobs:
           # cleanly. The post-tokenise regex then exact-matches the ref
           # grammar, dropping accidental candidates like file-path
           # citations (`path/to/file#42`) which have multiple slashes.
+          #
+          # Refs are capped pre-split (REFS_CAP=20 total of any type).
+          # Refs are second-tier info — the sync report's primary value
+          # is "upstream has N new commits, mergeable: yes/no". Curious
+          # readers can drill into the commit log for the full set.
+          REFS_CAP=20
           git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%s%n%b' \
             | tr -s '[:space:](){}[],;<>!?"'"'" '\n' \
             | sed 's/\.$//' \
             | grep -E '^([A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+)?#[0-9]+$' \
             | sort -u \
+            | head -"$REFS_CAP" \
             | while read -r REF; do
                 if [[ "$REF" == *"/"* ]]; then
                   echo "$REF" >> /tmp/sync/refs_qualified.txt
@@ -285,15 +292,14 @@ jobs:
           }
 
           : > /tmp/sync/refs.md
-          # Both ref lists are capped to keep PR/issue bodies bounded when an
-          # upstream sync brings in many references. Bare refs are also
-          # API-rate-limit-bound (one title lookup per ref).
-          REFS_CAP=20
+          # Bare and qualified ref files are already capped pre-split by
+          # REFS_CAP — readers just iterate them. No per-list cap or
+          # "N more" footer needed.
 
           # Resolve bare refs against UPSTREAM_REPO via a single Issues API call
           # (PRs are issues under the hood, so we don't need an issue→PR fallback).
           if [ -s /tmp/sync/refs_bare.txt ]; then
-            head -"$REFS_CAP" /tmp/sync/refs_bare.txt | while read -r REF; do
+            while read -r REF; do
               NUM="${REF#\#}"
               TITLE=$(gh api "repos/${UPSTREAM_REPO}/issues/${NUM}" --jq '.title' 2>/dev/null || true)
               if [ -n "$TITLE" ]; then
@@ -311,27 +317,17 @@ jobs:
                 echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — _title unavailable_" \
                   >> /tmp/sync/refs.md
               fi
-            done
-            BARE_TOTAL=$(wc -l < /tmp/sync/refs_bare.txt | tr -d ' ')
-            if [ "$BARE_TOTAL" -gt "$REFS_CAP" ]; then
-              REMAINING=$((BARE_TOTAL - REFS_CAP))
-              echo "- _…and ${REMAINING} more bare ref(s) not shown — see commit log_" >> /tmp/sync/refs.md
-            fi
+            done < /tmp/sync/refs_bare.txt
           fi
           # Qualified refs: render as link without title resolution (cross-repo,
-          # may not be readable without extra auth). Symmetric cap.
+          # may not be readable without extra auth).
           if [ -s /tmp/sync/refs_qualified.txt ]; then
-            head -"$REFS_CAP" /tmp/sync/refs_qualified.txt | while read -r REF; do
+            while read -r REF; do
               REPO_PART="${REF%%#*}"
               NUM="${REF##*#}"
               echo "- [${REF}](https://github.com/${REPO_PART}/issues/${NUM})" \
                 >> /tmp/sync/refs.md
-            done
-            QUAL_TOTAL=$(wc -l < /tmp/sync/refs_qualified.txt | tr -d ' ')
-            if [ "$QUAL_TOTAL" -gt "$REFS_CAP" ]; then
-              REMAINING=$((QUAL_TOTAL - REFS_CAP))
-              echo "- _…and ${REMAINING} more qualified ref(s) not shown — see commit log_" >> /tmp/sync/refs.md
-            fi
+            done < /tmp/sync/refs_qualified.txt
           fi
 
           # Fork overlap: files touched by upstream (since the last shared
@@ -640,8 +636,15 @@ jobs:
             if git merge-base --is-ancestor "$BRANCH_TIP" "${UPSTREAM_REMOTE}/main" 2>/dev/null; then
               echo "Branch '$BRANCH' is fully merged into ${UPSTREAM_REMOTE}/main"
 
+              # GitHub's issue-search engine strips `#` from the query
+              # (and from the indexed issue text), so searching for the
+              # raw branch name `feat/#123-foo` would silently miss
+              # existing issues titled "Upstream merged: feat/#123-foo".
+              # Strip `#` from BRANCH before the search; the indexed
+              # title is stripped too so the match works.
+              SEARCH_BRANCH="${BRANCH//\#/}"
               EXISTING=$(gh issue list \
-                --search "Upstream merged: $BRANCH" \
+                --search "Upstream merged: $SEARCH_BRANCH" \
                 --state open --json number --jq 'length')
               if [ "$EXISTING" = "0" ]; then
                 BODY_FILE=$(mktemp)

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -76,7 +76,6 @@ jobs:
 
       - name: Build change report
         if: steps.detect.outputs.behind != '0'
-        id: report
         env:
           BEHIND: ${{ steps.detect.outputs.behind }}
           NEW_RELEASE: ${{ steps.detect.outputs.new_release }}
@@ -166,12 +165,14 @@ jobs:
                 fi
               done || true
 
-          # Markdown-escape a title so backticks / pipes / brackets in
-          # upstream issue titles don't break the surrounding list-item
-          # rendering or link syntax. Single-quoted sed expressions are
-          # intentional — the backticks are literal characters to match,
-          # not command substitutions (shellcheck SC2016 is a false positive
-          # for sed scripts).
+          # Markdown-escape a title so backticks / pipes / brackets / angle
+          # brackets in upstream issue titles don't break the surrounding
+          # list-item rendering, link syntax, or trigger Markdown's raw-HTML
+          # pass (a title like `Use <T> as bound` would otherwise have
+          # `<T>` interpreted as an unknown HTML tag and stripped).
+          # Single-quoted sed expressions are intentional — backticks are
+          # literal characters to match, not command substitutions
+          # (shellcheck SC2016 is a false positive for sed scripts).
           # shellcheck disable=SC2016
           md_escape() {
             printf '%s' "$1" \
@@ -179,14 +180,21 @@ jobs:
                     -e 's/`/\\`/g' \
                     -e 's/|/\\|/g' \
                     -e 's/\[/\\[/g' \
-                    -e 's/\]/\\]/g'
+                    -e 's/\]/\\]/g' \
+                    -e 's/</\&lt;/g' \
+                    -e 's/>/\&gt;/g'
           }
 
           : > /tmp/sync/refs.md
+          # Both ref lists are capped to keep PR/issue bodies bounded when an
+          # upstream sync brings in many references. Bare refs are also
+          # API-rate-limit-bound (one title lookup per ref).
+          REFS_CAP=20
+
           # Resolve bare refs against UPSTREAM_REPO via a single Issues API call
           # (PRs are issues under the hood, so we don't need an issue→PR fallback).
           if [ -s /tmp/sync/refs_bare.txt ]; then
-            head -20 /tmp/sync/refs_bare.txt | while read -r REF; do
+            head -"$REFS_CAP" /tmp/sync/refs_bare.txt | while read -r REF; do
               NUM="${REF#\#}"
               TITLE=$(gh api "repos/${UPSTREAM_REPO}/issues/${NUM}" --jq '.title' 2>/dev/null || true)
               if [ -n "$TITLE" ]; then
@@ -199,16 +207,26 @@ jobs:
                 echo "warn: failed to resolve title for ${UPSTREAM_REPO}${REF}" >&2
               fi
             done
+            BARE_TOTAL=$(wc -l < /tmp/sync/refs_bare.txt | tr -d ' ')
+            if [ "$BARE_TOTAL" -gt "$REFS_CAP" ]; then
+              REMAINING=$((BARE_TOTAL - REFS_CAP))
+              echo "- _…and ${REMAINING} more bare ref(s) not shown — see commit log_" >> /tmp/sync/refs.md
+            fi
           fi
           # Qualified refs: render as link without title resolution (cross-repo,
-          # may not be readable without extra auth).
+          # may not be readable without extra auth). Symmetric cap.
           if [ -s /tmp/sync/refs_qualified.txt ]; then
-            while read -r REF; do
+            head -"$REFS_CAP" /tmp/sync/refs_qualified.txt | while read -r REF; do
               REPO_PART="${REF%%#*}"
               NUM="${REF##*#}"
               echo "- [${REF}](https://github.com/${REPO_PART}/issues/${NUM})" \
                 >> /tmp/sync/refs.md
-            done < /tmp/sync/refs_qualified.txt
+            done
+            QUAL_TOTAL=$(wc -l < /tmp/sync/refs_qualified.txt | tr -d ' ')
+            if [ "$QUAL_TOTAL" -gt "$REFS_CAP" ]; then
+              REMAINING=$((QUAL_TOTAL - REFS_CAP))
+              echo "- _…and ${REMAINING} more qualified ref(s) not shown — see commit log_" >> /tmp/sync/refs.md
+            fi
           fi
 
           # Fork overlap: files touched by upstream (since the last shared
@@ -218,21 +236,16 @@ jobs:
           MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
           git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
             | sort -u > /tmp/sync/upstream_files.txt
-          git log origin/main --not "${UPSTREAM_REMOTE}/main" \
+          git log "${MERGE_BASE}..origin/main" --not "${UPSTREAM_REMOTE}/main" \
             --name-only --format= \
             | grep -v '^$' | sort -u > /tmp/sync/fork_files.txt || true
           comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt \
             > /tmp/sync/overlap.txt || true
 
           # Emit summary counts for use in subsequent steps.
-          {
-            echo "breaking=$(wc -l < /tmp/sync/breaking.txt | tr -d ' ')"
-            echo "feat=$(wc -l < /tmp/sync/feat.txt | tr -d ' ')"
-            echo "fix=$(wc -l < /tmp/sync/fix.txt | tr -d ' ')"
-            echo "perf=$(wc -l < /tmp/sync/perf.txt | tr -d ' ')"
-            echo "other=$(wc -l < /tmp/sync/other.txt | tr -d ' ')"
-            echo "overlap=$(wc -l < /tmp/sync/overlap.txt | tr -d ' ')"
-          } >> "$GITHUB_OUTPUT"
+          # Counts go directly into the rendered body in the next step; no
+          # downstream step consumes them as workflow outputs, so we don't
+          # emit step outputs here (was unused noise on every run).
 
       - name: Compose structured body (head)
         if: steps.detect.outputs.behind != '0'
@@ -248,7 +261,6 @@ jobs:
           BODY=/tmp/sync/body.md
           : > "$BODY"
 
-          UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
           if [ "$NEW_RELEASE" = "true" ]; then
             {
               echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → ${UPSTREAM_LATEST_TAG}"
@@ -259,6 +271,7 @@ jobs:
             # In-development commits between releases — anchor the heading
             # to the last synced tag and the upstream HEAD short SHA so the
             # baseline is still visible at a glance.
+            UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
             echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → main@${UPSTREAM_HEAD_SHORT}" >> "$BODY"
           fi
           {
@@ -328,10 +341,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Skip if a previous sync PR is still open (review in progress).
+          # Otherwise every cron run (Mon/Thu) + every workflow_dispatch
+          # would stack new sync PRs on top of unresolved ones.
+          OPEN_SYNC_PRS=$(gh pr list \
+            --label upstream-sync --state open \
+            --json number --jq 'length')
+          if [ "$OPEN_SYNC_PRS" -gt 0 ]; then
+            echo "Skip: ${OPEN_SYNC_PRS} open sync PR(s) already exist — resolve them before opening another."
+            exit 0
+          fi
+
           # Branch name carries the date + run number so a second run on the
-          # same UTC day (manual `workflow_dispatch` after the cron run, or a
-          # re-run while the previous PR is still open) gets a distinct name
-          # and doesn't collide with an existing remote branch / open PR.
+          # same UTC day (manual `workflow_dispatch` after the cron run) gets
+          # a distinct name and doesn't collide with an existing remote branch.
           SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
           git checkout -b "$SYNC_BRANCH" origin/main
 
@@ -364,7 +387,13 @@ jobs:
               mkdir -p "$(dirname "$STATE_FILE")"
               echo "$UPSTREAM_LATEST_TAG" > "$STATE_FILE"
               git add "$STATE_FILE"
-              git commit -m "chore: bump upstream sync state to ${UPSTREAM_LATEST_TAG}"
+              # Between-release runs re-write the same tag → staged diff
+              # is empty. Skip the bump commit in that case; an unguarded
+              # `git commit` would fail under `set -e` and abort the step
+              # before `git push` / `gh pr create`.
+              if ! git diff --cached --quiet; then
+                git commit -m "chore: bump upstream sync state to ${UPSTREAM_LATEST_TAG}"
+              fi
             fi
 
             git push origin "$SYNC_BRANCH"
@@ -373,7 +402,8 @@ jobs:
               --title "chore: sync upstream (${BEHIND} new commits)" \
               --body-file "$BODY_PATH" \
               --base main \
-              --head "$SYNC_BRANCH"
+              --head "$SYNC_BRANCH" \
+              --label "upstream-sync"
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
             # Defensive: if the merge failed before entering merge state
@@ -395,6 +425,10 @@ jobs:
                 echo
                 echo "### Manual resolution"
                 echo
+                # User-facing snippet: keep the conventional `upstream`
+                # remote name (literal, not `${UPSTREAM_REMOTE}`) so it
+                # matches what developers actually type locally and
+                # remains valid regardless of the workflow's env block.
                 echo '```bash'
                 echo "git remote add upstream ${UPSTREAM_URL}"
                 echo "git fetch upstream main"

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Bypass the 'already-considered tag' skip and open a fresh sync PR even if upstream HEAD was previously surfaced."
+        description: "Bypass the skip-when-already-surfaced check (which queries existing sync PRs/issues by title) and open a fresh sync artifact even if the current upstream HEAD was previously surfaced."
         type: boolean
         default: false
 

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -2,7 +2,7 @@ name: Upstream Monitor
 
 on:
   schedule:
-    - cron: "0 8 * * 1,4"
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -183,10 +183,19 @@ jobs:
             # the title fragment `upstream-${UPSTREAM_HEAD_SHORT}` uses
             # a dash so it survives intact and remains greppable.
             QUERY="upstream-${UPSTREAM_HEAD_SHORT} in:title label:upstream-sync repo:${GITHUB_REPOSITORY}"
-            COUNT=$(gh api -X GET search/issues -f q="$QUERY" --jq '.total_count')
-            if [ "$COUNT" -gt 0 ]; then
-              SHOULD_RUN=false
-              echo "Skip: ${COUNT} sync artifact(s) for upstream-${UPSTREAM_HEAD_SHORT} already exist (open/closed/merged). Subsequent steps will short-circuit."
+            # Best-effort lookup: a transient search/issues failure (rate
+            # limit, 5xx, network blip) must NOT block surfacing upstream
+            # changes. On lookup failure, default to SHOULD_RUN=true and
+            # log a warning — at worst we re-surface an already-considered
+            # HEAD (the maintainer can resolve the dup), which is strictly
+            # better than silently dropping the sync run.
+            if COUNT=$(gh api -X GET search/issues -f q="$QUERY" --jq '.total_count' 2>/dev/null); then
+              if [ "$COUNT" -gt 0 ]; then
+                SHOULD_RUN=false
+                echo "Skip: ${COUNT} sync artifact(s) for upstream-${UPSTREAM_HEAD_SHORT} already exist (open/closed/merged). Subsequent steps will short-circuit."
+              fi
+            else
+              echo "warn: search/issues lookup failed (rate limit / API error). Treating as not-yet-surfaced; sync run will proceed." >&2
             fi
           fi
 
@@ -230,6 +239,27 @@ jobs:
           FIX_RE='^fix(\([^)]*\))?:'
           PERF_RE='^perf(\([^)]*\))?:'
 
+          # Escape Markdown metacharacters in commit subjects. Upstream
+          # subjects can contain backticks, brackets, pipes, leading `#`,
+          # `@mentions`, etc. — un-escaped, they would corrupt the rendered
+          # categorised list or trigger unintended notifications in this
+          # repo. Defined inline (not shared with the refs.md step) because
+          # bash functions don't cross `run:` boundaries.
+          md_escape() {
+            sed -e 's/`/\\`/g' \
+                -e 's/|/\\|/g' \
+                -e 's/\[/\\[/g' \
+                -e 's/\]/\\]/g' \
+                -e 's/(/\\(/g' \
+                -e 's/)/\\)/g' \
+                -e 's/</\\</g' \
+                -e 's/>/\\>/g' \
+                -e 's/\*/\\*/g' \
+                -e 's/_/\\_/g' \
+                -e 's/#/\\#/g' \
+                -e 's/@/\\@/g'
+          }
+
           # Read NUL-delimited records from `git log -z`. Each record holds
           # `SHA\tSUBJECT\tBODY`; BODY may contain its own newlines (footers,
           # multi-paragraph descriptions). We split fields via parameter
@@ -241,7 +271,8 @@ jobs:
             SUBJECT="${REST%%$'\t'*}"
             BODY="${REST#*$'\t'}"
             SHORT=$(git rev-parse --short "$SHA")
-            LINE="- \`$SHORT\` $SUBJECT"
+            SUBJECT_SAFE=$(printf '%s' "$SUBJECT" | md_escape)
+            LINE="- \`$SHORT\` $SUBJECT_SAFE"
             # Conventional Commits §5 treats `BREAKING CHANGE:` and
             # `BREAKING-CHANGE:` as equivalent footer tokens — match both.
             # Heuristic limitation: a `revert: <breaking change>` commit
@@ -707,25 +738,28 @@ jobs:
             if git merge-base --is-ancestor "$BRANCH_TIP" "${UPSTREAM_REMOTE}/main" 2>/dev/null; then
               echo "Branch '$BRANCH' is fully merged into ${UPSTREAM_REMOTE}/main"
 
-              # `gh issue list --search` is GitHub free-text search:
-              # it tokenises and matches CONTAINS, not exact-title. For
-              # short branch slugs (e.g., `feat/123-foo` after `#`
-              # strip — search drops `#` regardless), this can match
-              # unrelated issues containing those tokens and falsely
-              # suppress a legitimate "Upstream merged" notification.
-              #
-              # Pull a wider candidate set with the same loose search,
-              # then post-filter to EXACT title equality on the client.
-              # The expected title includes the literal `#` (it's part
-              # of the branch convention and lives in the indexed title).
-              # Pass EXPECTED_TITLE to jq via `--arg` (not string
-              # interpolation) so any quote/backslash in BRANCH
-              # cannot break the jq filter syntax.
+              # Dedupe via the same search/issues endpoint the skip-gate
+              # above uses, for two reasons:
+              #   1. `--state all` semantics: a closed "Upstream merged"
+              #      issue means the maintainer already acknowledged this
+              #      branch — closing it shouldn't cause the next run to
+              #      re-create it (which `gh issue list --state open` would).
+              #   2. No implicit pagination cap: `gh issue list` defaults to
+              #      a small page size and silently truncates; search/issues
+              #      returns total_count over the full match set, so the
+              #      post-filter is reliable.
+              # GitHub search strips `#` from query text, so SEARCH_BRANCH
+              # uses the dashed form. EXPECTED_TITLE keeps the literal `#`
+              # (it's part of the indexed title) and is passed to jq via
+              # `--arg` so any quote/backslash in BRANCH can't break filter
+              # syntax. We post-filter to exact-title match on the client
+              # because search is CONTAINS-tokenised, not exact-title.
               EXPECTED_TITLE="Upstream merged: $BRANCH"
               SEARCH_BRANCH="${BRANCH//\#/}"
-              EXISTING=$(gh issue list \
-                --search "Upstream merged: $SEARCH_BRANCH" \
-                --state open --json title \
+              EXISTING_JSON=$(gh api -X GET search/issues \
+                -f q="Upstream merged: ${SEARCH_BRANCH} label:upstream-sync repo:${GITHUB_REPOSITORY}" \
+                --jq '[.items[] | {title}]' 2>/dev/null || echo '[]')
+              EXISTING=$(printf '%s' "$EXISTING_JSON" \
                 | jq --arg t "$EXPECTED_TITLE" '[.[] | select(.title == $t)] | length')
               if [ "$EXISTING" = "0" ]; then
                 BODY_FILE=$(mktemp)

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -489,16 +489,6 @@ jobs:
               --base main \
               --head "$SYNC_BRANCH" \
               --label "upstream-sync"
-
-            # Mark this exact upstream HEAD as "considered" by pushing a
-            # tag that future runs check for. This is what makes
-            # close-without-merge a permanent decision until upstream
-            # advances — the tag stays regardless of PR outcome.
-            # `|| true` because a tag collision is harmless (means we
-            # already surfaced this HEAD; the new PR was a redundant
-            # workflow_dispatch with force=true).
-            git tag "$CONSIDERED_TAG" "${UPSTREAM_REMOTE}/main"
-            git push origin "$CONSIDERED_TAG" || true
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
             # Defensive: if the merge failed before entering merge state
@@ -557,6 +547,17 @@ jobs:
               --body-file "$BODY_PATH" \
               --label "upstream-sync"
           fi
+
+          # Mark this exact upstream HEAD as "considered" — applies on
+          # BOTH branches (successful merge PR + conflict issue). For a
+          # fork with permanent divergences (renames, cherry-pick-only
+          # relationships), the conflict path is the steady state and
+          # without this tag every cron run would refile the same issue.
+          # The tag stays regardless of how the maintainer dispositions
+          # the surfaced artifact. `|| true` because a tag collision on
+          # an explicit force=true re-run is harmless.
+          git tag "$CONSIDERED_TAG" "${UPSTREAM_REMOTE}/main"
+          git push origin "$CONSIDERED_TAG" || true
 
       - name: Check for merged feature branches
         env:

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -87,14 +87,22 @@ jobs:
           if [ -f "$STATE_FILE" ]; then
             UPSTREAM_PREV_TAG=$(tr -d '[:space:]' < "$STATE_FILE")
           else
-            # Intersect "tags reachable from origin/main" with "tags
-            # reachable from upstream/main" — guarantees the inferred
-            # tag is upstream-origin and excludes fork-local release
-            # tags (e.g., our own `v4.4.0`) that would otherwise be
-            # mistaken for a previous upstream sync point.
+            # Triple intersection — mirrors UPSTREAM_LATEST_TAG safety:
+            #   (a) tags actually PUBLISHED on the upstream remote
+            #       (`git ls-remote --tags --refs` — not just present
+            #       in the local tag DB, which contains fork tags too),
+            #   (b) tags reachable from origin/main,
+            #   (c) tags reachable from upstream/main.
+            # A fork-local `v4.4.0` that happens to sit on a commit
+            # reachable from both main heads via back-merge would
+            # still survive (a) ∩ (b) ∩ (c) only if upstream also
+            # publishes that exact tag name — which it doesn't.
             UPSTREAM_PREV_TAG=$(comm -12 \
-              <(git tag -l --merged "origin/main" | sort) \
-              <(git tag -l --merged "${UPSTREAM_REMOTE}/main" | sort) \
+              <(git ls-remote --tags --refs "$UPSTREAM_REMOTE" \
+                  | awk '{sub(/refs\/tags\//,"",$2); print $2}' | sort -u) \
+              <(comm -12 \
+                  <(git tag -l --merged "origin/main" | sort -u) \
+                  <(git tag -l --merged "${UPSTREAM_REMOTE}/main" | sort -u)) \
               | grep -E "$SEMVER_RE" | sort -V | tail -1 || true)
           fi
           UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -8,10 +8,16 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+
+env:
+  UPSTREAM_REMOTE: upstream
+  UPSTREAM_URL: https://github.com/fjall-rs/lsm-tree.git
+  UPSTREAM_REPO: fjall-rs/lsm-tree
 
 jobs:
   check-upstream:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,111 +26,278 @@ jobs:
           fetch-depth: 0
 
       - name: Add upstream remote
-        run: git remote add upstream https://github.com/fjall-rs/lsm-tree.git
+        run: git remote add "$UPSTREAM_REMOTE" "$UPSTREAM_URL"
 
-      - name: Fetch upstream and origin
+      - name: Fetch upstream and origin (with tags)
         run: |
-          git fetch upstream main
+          git fetch --tags "$UPSTREAM_REMOTE" main
           git fetch origin main
 
-      - name: Check for new upstream commits
-        id: check
+      - name: Detect upstream changes and release
+        id: detect
         run: |
-          BEHIND=$(git rev-list origin/main..upstream/main --count)
-          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
-          echo "Commits behind upstream: $BEHIND"
+          set -euo pipefail
 
-      - name: Try merge and create PR or issue
-        if: steps.check.outputs.behind > 0
+          BEHIND=$(git rev-list "origin/main..${UPSTREAM_REMOTE}/main" --count)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+
+          UPSTREAM_LATEST_TAG=$(git tag -l --sort=-v:refname --merged "${UPSTREAM_REMOTE}/main" \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "upstream_prev_tag=$UPSTREAM_PREV_TAG" >> "$GITHUB_OUTPUT"
+
+          NEW_RELEASE=false
+          if [ -n "$UPSTREAM_LATEST_TAG" ] && [ "$UPSTREAM_LATEST_TAG" != "$UPSTREAM_PREV_TAG" ]; then
+            NEW_RELEASE=true
+          fi
+          echo "new_release=$NEW_RELEASE" >> "$GITHUB_OUTPUT"
+
+          echo "Commits behind upstream: $BEHIND"
+          echo "Upstream latest tag: ${UPSTREAM_LATEST_TAG:-<none>}"
+          echo "Upstream tag in our main: ${UPSTREAM_PREV_TAG:-<none>}"
+          echo "New release available: $NEW_RELEASE"
+
+      - name: Build change report
+        if: steps.detect.outputs.behind > 0
+        id: report
+        env:
+          BEHIND: ${{ steps.detect.outputs.behind }}
+          NEW_RELEASE: ${{ steps.detect.outputs.new_release }}
+          UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
+          UPSTREAM_PREV_TAG: ${{ steps.detect.outputs.upstream_prev_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/sync
+          : > /tmp/sync/breaking.txt
+          : > /tmp/sync/feat.txt
+          : > /tmp/sync/fix.txt
+          : > /tmp/sync/perf.txt
+          : > /tmp/sync/other.txt
+
+          # Categorise each new upstream commit by conventional commit prefix.
+          git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%H%x09%s' \
+            | while IFS=$'\t' read -r SHA SUBJECT; do
+                SHORT=$(git rev-parse --short "$SHA")
+                LINE="- \`$SHORT\` $SUBJECT"
+                case "$SUBJECT" in
+                  *"BREAKING CHANGE"*|*"!:"*)
+                    echo "$LINE" >> /tmp/sync/breaking.txt ;;
+                  feat:*|feat\(*)
+                    echo "$LINE" >> /tmp/sync/feat.txt ;;
+                  fix:*|fix\(*)
+                    echo "$LINE" >> /tmp/sync/fix.txt ;;
+                  perf:*|perf\(*)
+                    echo "$LINE" >> /tmp/sync/perf.txt ;;
+                  *)
+                    echo "$LINE" >> /tmp/sync/other.txt ;;
+                esac
+              done
+
+          # Extract referenced upstream issue/PR numbers from commit
+          # subjects + bodies; resolve titles via API for the first 20.
+          git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%s%n%b' \
+            | grep -oE '#[0-9]+' | sort -u > /tmp/sync/refs_raw.txt || true
+
+          : > /tmp/sync/refs.md
+          if [ -s /tmp/sync/refs_raw.txt ]; then
+            head -20 /tmp/sync/refs_raw.txt | while read -r REF; do
+              NUM="${REF#\#}"
+              TITLE=$(gh issue view "$NUM" --repo "$UPSTREAM_REPO" --json title --jq '.title' 2>/dev/null \
+                || gh pr view "$NUM" --repo "$UPSTREAM_REPO" --json title --jq '.title' 2>/dev/null \
+                || true)
+              if [ -n "$TITLE" ]; then
+                echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE}" \
+                  >> /tmp/sync/refs.md
+              fi
+            done
+          fi
+
+          # Fork overlap: files touched by both upstream (since last shared
+          # commit) AND our fork (commits in origin/main not in upstream/main).
+          MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
+          git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" | sort -u > /tmp/sync/upstream_files.txt
+          git diff --name-only "$MERGE_BASE..origin/main" | sort -u > /tmp/sync/fork_files.txt
+          comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt > /tmp/sync/overlap.txt || true
+
+          # Emit summary counts for use in subsequent steps.
+          {
+            echo "breaking=$(wc -l < /tmp/sync/breaking.txt | tr -d ' ')"
+            echo "feat=$(wc -l < /tmp/sync/feat.txt | tr -d ' ')"
+            echo "fix=$(wc -l < /tmp/sync/fix.txt | tr -d ' ')"
+            echo "perf=$(wc -l < /tmp/sync/perf.txt | tr -d ' ')"
+            echo "other=$(wc -l < /tmp/sync/other.txt | tr -d ' ')"
+            echo "overlap=$(wc -l < /tmp/sync/overlap.txt | tr -d ' ')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compose structured body
+        if: steps.detect.outputs.behind > 0
+        id: body
+        env:
+          BEHIND: ${{ steps.detect.outputs.behind }}
+          NEW_RELEASE: ${{ steps.detect.outputs.new_release }}
+          UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
+          UPSTREAM_PREV_TAG: ${{ steps.detect.outputs.upstream_prev_tag }}
+        run: |
+          set -euo pipefail
+
+          BODY=/tmp/sync/body.md
+          : > "$BODY"
+
+          if [ "$NEW_RELEASE" = "true" ]; then
+            {
+              echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-<none>} → ${UPSTREAM_LATEST_TAG}"
+              echo
+              echo "**Release:** [${UPSTREAM_LATEST_TAG}](https://github.com/${UPSTREAM_REPO}/releases/tag/${UPSTREAM_LATEST_TAG})"
+            } >> "$BODY"
+          else
+            echo "## Upstream Sync (no new release tag)" >> "$BODY"
+          fi
+          {
+            echo "**Commits:** ${BEHIND} new since last sync"
+            echo "**Upstream:** [${UPSTREAM_REPO}](https://github.com/${UPSTREAM_REPO})"
+            echo
+            echo "### Changes by category"
+            echo
+          } >> "$BODY"
+
+          emit_section() {
+            local title="$1" file="$2"
+            if [ -s "$file" ]; then
+              {
+                echo "#### ${title} ($(wc -l < "$file" | tr -d ' '))"
+                echo
+                cat "$file"
+                echo
+              } >> "$BODY"
+            fi
+          }
+
+          emit_section "⚠️ Breaking" /tmp/sync/breaking.txt
+          emit_section "✨ Features" /tmp/sync/feat.txt
+          emit_section "🐛 Fixes"    /tmp/sync/fix.txt
+          emit_section "⚡ Performance" /tmp/sync/perf.txt
+          emit_section "📝 Other"    /tmp/sync/other.txt
+
+          if [ -s /tmp/sync/refs.md ]; then
+            {
+              echo "### Referenced upstream issues / PRs"
+              echo
+              cat /tmp/sync/refs.md
+              echo
+            } >> "$BODY"
+          fi
+
+          if [ -s /tmp/sync/overlap.txt ]; then
+            {
+              echo "### Fork overlap — files modified by both upstream and our fork"
+              echo
+              echo "Manual review recommended (semantic conflicts possible even on clean merge):"
+              echo
+              while read -r FILE; do
+                echo "- \`${FILE}\`"
+              done < /tmp/sync/overlap.txt
+              echo
+            } >> "$BODY"
+          fi
+
+          {
+            echo "### Review checklist"
+            echo
+            echo "- [ ] Breaking changes evaluated for fork impact"
+            echo "- [ ] Overlapping files reviewed for semantic conflicts"
+            echo "- [ ] Fork-specific tests pass with upstream changes"
+            echo "- [ ] \`coordinode-lsm-tree\` version bumped in consumer projects if upstream cuts a release"
+          } >> "$BODY"
+
+          echo "body_path=$BODY" >> "$GITHUB_OUTPUT"
+
+      - name: Try merge and create PR or conflict issue
+        if: steps.detect.outputs.behind > 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BEHIND: ${{ steps.check.outputs.behind }}
+          BEHIND: ${{ steps.detect.outputs.behind }}
+          BODY_PATH: ${{ steps.body.outputs.body_path }}
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)"
           git checkout -b "$SYNC_BRANCH" origin/main
 
-          if git merge --no-commit --no-ff upstream/main 2>&1; then
-            git commit -m "chore: sync upstream ($BEHIND new commits)"
+          if git merge --no-commit --no-ff "${UPSTREAM_REMOTE}/main" 2>&1; then
+            git commit -m "chore: sync upstream (${BEHIND} new commits)"
             git push origin "$SYNC_BRANCH"
 
             gh pr create \
-              --title "chore: sync upstream ($BEHIND new commits)" \
-              --body "$(cat <<'EOF'
-          ## Upstream Sync
-
-          Automated sync from [fjall-rs/lsm-tree](https://github.com/fjall-rs/lsm-tree) main branch.
-
-          **Commits behind:** ${{ steps.check.outputs.behind }}
-
-          ### Review checklist
-          - [ ] Review upstream changes for breaking modifications
-          - [ ] Verify our patches still apply cleanly
-          - [ ] Run full test suite
-          EOF
-          )" \
+              --title "chore: sync upstream (${BEHIND} new commits)" \
+              --body-file "$BODY_PATH" \
               --base main \
               --head "$SYNC_BRANCH"
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
             git merge --abort
 
+            {
+              echo
+              echo "### Conflicting files"
+              echo
+              echo '```'
+              echo "$CONFLICTS"
+              echo '```'
+              echo
+              echo "### Manual resolution"
+              echo
+              echo '```bash'
+              echo "git remote add upstream ${UPSTREAM_URL}"
+              echo "git fetch upstream main"
+              echo "git checkout -b chore/upstream-sync main"
+              echo "git merge upstream/main"
+              echo "# Resolve conflicts, then push"
+              echo '```'
+            } >> "$BODY_PATH"
+
             gh issue create \
-              --title "Upstream sync conflict ($BEHIND new commits)" \
-              --body "$(cat <<EOF
-          ## Upstream Sync Conflict
-
-          Automated merge from [fjall-rs/lsm-tree](https://github.com/fjall-rs/lsm-tree) main branch failed due to conflicts.
-
-          **Commits behind:** $BEHIND
-
-          ### Conflicting files
-          \`\`\`
-          $CONFLICTS
-          \`\`\`
-
-          ### Resolution
-          Manual merge required:
-          \`\`\`bash
-          git remote add upstream https://github.com/fjall-rs/lsm-tree.git
-          git fetch upstream main
-          git checkout -b chore/upstream-sync main
-          git merge upstream/main
-          # Resolve conflicts, then push
-          \`\`\`
-          EOF
-          )" \
-              --label "upstream-sync"
+              --title "Upstream sync conflict (${BEHIND} new commits)" \
+              --body-file "$BODY_PATH"
           fi
 
       - name: Check for merged feature branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch upstream main
+          set -euo pipefail
 
-          for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/feat/#* refs/remotes/origin/fix/#*); do
+          for ref in $(git for-each-ref --format='%(refname:short)' \
+                         'refs/remotes/origin/feat/#*' \
+                         'refs/remotes/origin/fix/#*'); do
             BRANCH="${ref#origin/}"
             BRANCH_TIP=$(git rev-parse "$ref")
 
-            if git merge-base --is-ancestor "$BRANCH_TIP" upstream/main 2>/dev/null; then
-              echo "Branch '$BRANCH' is fully merged into upstream/main"
+            if git merge-base --is-ancestor "$BRANCH_TIP" "${UPSTREAM_REMOTE}/main" 2>/dev/null; then
+              echo "Branch '$BRANCH' is fully merged into ${UPSTREAM_REMOTE}/main"
 
-              EXISTING=$(gh issue list --search "Upstream merged: $BRANCH" --state open --json number --jq 'length')
+              EXISTING=$(gh issue list \
+                --search "Upstream merged: $BRANCH" \
+                --state open --json number --jq 'length')
               if [ "$EXISTING" = "0" ]; then
+                BODY_FILE=$(mktemp)
+                {
+                  echo "Branch \`$BRANCH\` has been fully merged into ${UPSTREAM_REPO} main branch."
+                  echo
+                  echo "This branch can likely be deleted. Please verify and clean up."
+                  echo
+                  echo "**Branch tip:** \`$BRANCH_TIP\`"
+                } > "$BODY_FILE"
                 gh issue create \
                   --title "Upstream merged: $BRANCH" \
-                  --body "$(cat <<EOF
-          Branch \`$BRANCH\` has been fully merged into upstream's main branch.
-
-          This branch can likely be deleted. Please verify and clean up.
-
-          **Branch tip:** \`$BRANCH_TIP\`
-          EOF
-          )" \
-                  --label "upstream-sync"
+                  --body-file "$BODY_FILE"
+                rm -f "$BODY_FILE"
               fi
             fi
           done

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -357,7 +357,10 @@ jobs:
               --head "$SYNC_BRANCH"
           else
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
-            git merge --abort
+            # Defensive: if the merge failed before entering merge state
+            # (e.g., internal git error rather than conflicts), there's
+            # nothing to abort and the bare command would fail under `set -e`.
+            git merge --abort 2>/dev/null || true
 
             # Insert conflict + manual-resolution sections BEFORE the
             # checklist so the issue reads top-to-bottom: summary → changes

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -51,9 +51,16 @@ jobs:
           UPSTREAM_LATEST_TAG=$(git tag -l --sort=-v:refname --merged "${UPSTREAM_REMOTE}/main" \
             | grep -E "$SEMVER_RE" | head -1 || true)
 
-          # Prefer the explicit state file; fall back to inference from
-          # `--merged origin/main` if the file is missing (first run) or
-          # if a non-merge sync strategy ever desyncs the inference.
+          # Prefer the explicit state file. Fall back to inference from
+          # `--merged origin/main` only as a BOOTSTRAP for the first sync
+          # — once the file is written by the merge step, future runs read
+          # it directly. The inference is best-effort: `--merged` lists
+          # tags reachable from `origin/main`, which can return an older
+          # tag than what was actually synced last (e.g., if our main
+          # hasn't merged the upstream commit the latest stable tag points
+          # at) or an empty string for a freshly forked branch with no
+          # tags merged yet. That mismatch only matters until the first
+          # successful sync writes the state file.
           if [ -f "$STATE_FILE" ]; then
             UPSTREAM_PREV_TAG=$(tr -d '[:space:]' < "$STATE_FILE")
           else
@@ -166,10 +173,16 @@ jobs:
               done || true
 
           # Markdown-escape a title so backticks / pipes / brackets / angle
-          # brackets in upstream issue titles don't break the surrounding
-          # list-item rendering, link syntax, or trigger Markdown's raw-HTML
-          # pass (a title like `Use <T> as bound` would otherwise have
-          # `<T>` interpreted as an unknown HTML tag and stripped).
+          # brackets / emphasis markers in upstream issue titles don't
+          # break the surrounding list-item rendering, link syntax, or
+          # heading parse:
+          #   - `<` / `>` → `&lt;` / `&gt;`  (raw-HTML pass would eat
+          #     `Use <T> as bound`)
+          #   - `*` / `_` → escaped (`fix *foo* path` would render in
+          #     italics; `__bar__` would render in bold)
+          #   - `#` → escaped (titles like `#42 regression` at the start
+          #     of a line in a list item could otherwise be parsed as a
+          #     heading)
           # Single-quoted sed expressions are intentional — backticks are
           # literal characters to match, not command substitutions
           # (shellcheck SC2016 is a false positive for sed scripts).
@@ -182,7 +195,10 @@ jobs:
                     -e 's/\[/\\[/g' \
                     -e 's/\]/\\]/g' \
                     -e 's/</\&lt;/g' \
-                    -e 's/>/\&gt;/g'
+                    -e 's/>/\&gt;/g' \
+                    -e 's/\*/\\*/g' \
+                    -e 's/_/\\_/g' \
+                    -e 's/#/\\#/g'
           }
 
           : > /tmp/sync/refs.md
@@ -202,9 +218,15 @@ jobs:
                 echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE_SAFE}" \
                   >> /tmp/sync/refs.md
               else
-                # Log to stderr so partial reference output is debuggable
-                # (transient API failures, rate limits, missing issues, etc.).
-                echo "warn: failed to resolve title for ${UPSTREAM_REPO}${REF}" >&2
+                # API lookup failed (404, transient error, private/withheld
+                # issue, rate limit, etc.). Render the ref as a plain link
+                # without a title rather than dropping it — the reader still
+                # sees the upstream commit referenced something, and the
+                # link will resolve if/when access is granted. Log to stderr
+                # so the failed lookups are debuggable from workflow logs.
+                echo "warn: failed to resolve title for ${UPSTREAM_REPO}${REF} (rendering without title)" >&2
+                echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — _title unavailable_" \
+                  >> /tmp/sync/refs.md
               fi
             done
             BARE_TOTAL=$(wc -l < /tmp/sync/refs_bare.txt | tr -d ' ')
@@ -230,9 +252,16 @@ jobs:
           fi
 
           # Fork overlap: files touched by upstream (since the last shared
-          # commit) AND by fork-specific commits (commits on origin/main that
-          # are NOT in upstream/main — excludes upstream commits we already
-          # merged in, which would otherwise drown out the signal).
+          # commit) AND by fork-specific commits (commits on origin/main
+          # since MERGE_BASE that are NOT in upstream/main).
+          #
+          # `--name-only --format=` emits one path per file per commit, so
+          # the fork-side set includes any file touched by ANY fork-only
+          # commit in the window — even if a later fork commit reverted
+          # the change. This produces a deliberately broad signal: the
+          # overlap list is a "look here for possible semantic conflicts"
+          # hint for the reviewer, not a precise change-summary. Use the
+          # PR diff for authoritative final state.
           MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
           git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
             | sort -u > /tmp/sync/upstream_files.txt
@@ -329,7 +358,10 @@ jobs:
           echo "body_path=$BODY" >> "$GITHUB_OUTPUT"
 
       - name: Try merge and create PR or conflict issue
-        if: steps.detect.outputs.behind != '0'
+        # Gated on the body step succeeding so a body-composition failure
+        # doesn't cascade into a confusing "ambiguous redirect" when this
+        # step tries to append to an empty BODY_PATH.
+        if: steps.detect.outputs.behind != '0' && steps.body.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BEHIND: ${{ steps.detect.outputs.behind }}
@@ -340,6 +372,15 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Ensure the `upstream-sync` label exists in the repo.
+          # `gh pr create --label` / `gh issue create --label` exit non-zero
+          # for unknown labels, which would abort this step before any
+          # artifact is produced. `--force` makes the call idempotent.
+          gh label create "upstream-sync" \
+            --color "fbca04" \
+            --description "Automated upstream synchronization — merge conflicts, release tracking" \
+            --force >/dev/null
 
           # Skip if a previous sync PR is still open (review in progress).
           # Otherwise every cron run (Mon/Thu) + every workflow_dispatch
@@ -469,11 +510,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Ensure the `upstream-sync` label exists (same idempotent call
+          # as the merge step). Required because `gh issue create --label`
+          # exits non-zero for unknown labels and would abort the step.
+          gh label create "upstream-sync" \
+            --color "fbca04" \
+            --description "Automated upstream synchronization — merge conflicts, release tracking" \
+            --force >/dev/null
+
           # Our branch convention (per CLAUDE.md) is `<type>/#<issue_id>[-slug]`,
           # so the literal `#` is part of every feature/fix branch name. Branches
           # without the leading `#` (e.g., `feat/foo` or `feat/123-foo`) are not
           # produced by our workflow and are intentionally skipped. If the
           # convention changes, broaden these patterns.
+          #
+          # Patterns are single-quoted so the shell doesn't expand the `*`
+          # (a `nullglob`-enabled shell would otherwise risk silent
+          # expansion before `git for-each-ref` ever sees the glob).
           for ref in $(git for-each-ref --format='%(refname:short)' \
                          'refs/remotes/origin/feat/#*' \
                          'refs/remotes/origin/fix/#*'); do

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -14,6 +14,7 @@ env:
   UPSTREAM_REMOTE: upstream
   UPSTREAM_URL: https://github.com/fjall-rs/lsm-tree.git
   UPSTREAM_REPO: fjall-rs/lsm-tree
+  STATE_FILE: .github/state/last-upstream-sync.txt
 
 jobs:
   check-upstream:
@@ -43,8 +44,16 @@ jobs:
 
           UPSTREAM_LATEST_TAG=$(git tag -l --sort=-v:refname --merged "${UPSTREAM_REMOTE}/main" \
             | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+
+          # Prefer the explicit state file; fall back to inference from
+          # `--merged origin/main` if the file is missing (first run) or
+          # if a non-merge sync strategy ever desyncs the inference.
+          if [ -f "$STATE_FILE" ]; then
+            UPSTREAM_PREV_TAG=$(tr -d '[:space:]' < "$STATE_FILE")
+          else
+            UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
+              | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          fi
           echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "upstream_prev_tag=$UPSTREAM_PREV_TAG" >> "$GITHUB_OUTPUT"
 
@@ -56,11 +65,11 @@ jobs:
 
           echo "Commits behind upstream: $BEHIND"
           echo "Upstream latest tag: ${UPSTREAM_LATEST_TAG:-<none>}"
-          echo "Upstream tag in our main: ${UPSTREAM_PREV_TAG:-<none>}"
+          echo "Last synced upstream tag: ${UPSTREAM_PREV_TAG:-<none>}"
           echo "New release available: $NEW_RELEASE"
 
       - name: Build change report
-        if: steps.detect.outputs.behind > 0
+        if: steps.detect.outputs.behind != '0'
         id: report
         env:
           BEHIND: ${{ steps.detect.outputs.behind }}
@@ -78,50 +87,85 @@ jobs:
           : > /tmp/sync/perf.txt
           : > /tmp/sync/other.txt
 
-          # Categorise each new upstream commit by conventional commit prefix.
-          git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%H%x09%s' \
-            | while IFS=$'\t' read -r SHA SUBJECT; do
-                SHORT=$(git rev-parse --short "$SHA")
-                LINE="- \`$SHORT\` $SUBJECT"
-                case "$SUBJECT" in
-                  *"BREAKING CHANGE"*|*"!:"*)
-                    echo "$LINE" >> /tmp/sync/breaking.txt ;;
-                  feat:*|feat\(*)
-                    echo "$LINE" >> /tmp/sync/feat.txt ;;
-                  fix:*|fix\(*)
-                    echo "$LINE" >> /tmp/sync/fix.txt ;;
-                  perf:*|perf\(*)
-                    echo "$LINE" >> /tmp/sync/perf.txt ;;
-                  *)
-                    echo "$LINE" >> /tmp/sync/other.txt ;;
-                esac
+          # Categorise each new upstream commit by anchored conventional-commit prefix.
+          # `<type>(scope)?!?:` — `!` after type marks BREAKING; `BREAKING CHANGE`
+          # in commit body (not subject) is the canonical conventional-commit footer
+          # marker, so we also scan body lines.
+          BREAKING_RE='^[a-z]+(\([^)]*\))?!:'
+          FEAT_RE='^feat(\([^)]*\))?:'
+          FIX_RE='^fix(\([^)]*\))?:'
+          PERF_RE='^perf(\([^)]*\))?:'
+
+          while IFS=$'\t' read -r SHA SUBJECT BODY; do
+            SHORT=$(git rev-parse --short "$SHA")
+            LINE="- \`$SHORT\` $SUBJECT"
+            if [[ "$SUBJECT" =~ $BREAKING_RE ]] || echo "$BODY" | grep -qE '^BREAKING CHANGE:'; then
+              echo "$LINE" >> /tmp/sync/breaking.txt
+            elif [[ "$SUBJECT" =~ $FEAT_RE ]]; then
+              echo "$LINE" >> /tmp/sync/feat.txt
+            elif [[ "$SUBJECT" =~ $FIX_RE ]]; then
+              echo "$LINE" >> /tmp/sync/fix.txt
+            elif [[ "$SUBJECT" =~ $PERF_RE ]]; then
+              echo "$LINE" >> /tmp/sync/perf.txt
+            else
+              echo "$LINE" >> /tmp/sync/other.txt
+            fi
+          done < <(git log "origin/main..${UPSTREAM_REMOTE}/main" \
+                     --format='%H%x09%s%x09%b' -z \
+                     | tr '\0' '\n')
+
+          # Extract referenced issues / PRs. Capture both bare `#NNN`
+          # (resolved against UPSTREAM_REPO) and qualified `owner/repo#NNN`
+          # (rendered as plain links, not silently rewritten).
+          : > /tmp/sync/refs_bare.txt
+          : > /tmp/sync/refs_qualified.txt
+          git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%s%n%b' \
+            | grep -oE '([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+' \
+            | sort -u \
+            | while read -r REF; do
+                if [[ "$REF" == *"/"* ]]; then
+                  echo "$REF" >> /tmp/sync/refs_qualified.txt
+                else
+                  echo "$REF" >> /tmp/sync/refs_bare.txt
+                fi
               done
 
-          # Extract referenced upstream issue/PR numbers from commit
-          # subjects + bodies; resolve titles via API for the first 20.
-          git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%s%n%b' \
-            | grep -oE '#[0-9]+' | sort -u > /tmp/sync/refs_raw.txt || true
-
           : > /tmp/sync/refs.md
-          if [ -s /tmp/sync/refs_raw.txt ]; then
-            head -20 /tmp/sync/refs_raw.txt | while read -r REF; do
+          # Resolve bare refs against UPSTREAM_REPO via a single Issues API call
+          # (PRs are issues under the hood, so we don't need an issue→PR fallback).
+          if [ -s /tmp/sync/refs_bare.txt ]; then
+            head -20 /tmp/sync/refs_bare.txt | while read -r REF; do
               NUM="${REF#\#}"
-              TITLE=$(gh issue view "$NUM" --repo "$UPSTREAM_REPO" --json title --jq '.title' 2>/dev/null \
-                || gh pr view "$NUM" --repo "$UPSTREAM_REPO" --json title --jq '.title' 2>/dev/null \
-                || true)
+              TITLE=$(gh api "repos/${UPSTREAM_REPO}/issues/${NUM}" --jq '.title' 2>/dev/null || true)
               if [ -n "$TITLE" ]; then
                 echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE}" \
                   >> /tmp/sync/refs.md
               fi
             done
           fi
+          # Qualified refs: render as link without title resolution (cross-repo,
+          # may not be readable without extra auth).
+          if [ -s /tmp/sync/refs_qualified.txt ]; then
+            while read -r REF; do
+              REPO_PART="${REF%%#*}"
+              NUM="${REF##*#}"
+              echo "- [${REF}](https://github.com/${REPO_PART}/issues/${NUM})" \
+                >> /tmp/sync/refs.md
+            done < /tmp/sync/refs_qualified.txt
+          fi
 
-          # Fork overlap: files touched by both upstream (since last shared
-          # commit) AND our fork (commits in origin/main not in upstream/main).
+          # Fork overlap: files touched by upstream (since the last shared
+          # commit) AND by fork-specific commits (commits on origin/main that
+          # are NOT in upstream/main — excludes upstream commits we already
+          # merged in, which would otherwise drown out the signal).
           MERGE_BASE=$(git merge-base origin/main "${UPSTREAM_REMOTE}/main")
-          git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" | sort -u > /tmp/sync/upstream_files.txt
-          git diff --name-only "$MERGE_BASE..origin/main" | sort -u > /tmp/sync/fork_files.txt
-          comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt > /tmp/sync/overlap.txt || true
+          git diff --name-only "$MERGE_BASE..${UPSTREAM_REMOTE}/main" \
+            | sort -u > /tmp/sync/upstream_files.txt
+          git log origin/main --not "${UPSTREAM_REMOTE}/main" \
+            --name-only --format= \
+            | grep -v '^$' | sort -u > /tmp/sync/fork_files.txt || true
+          comm -12 /tmp/sync/upstream_files.txt /tmp/sync/fork_files.txt \
+            > /tmp/sync/overlap.txt || true
 
           # Emit summary counts for use in subsequent steps.
           {
@@ -133,8 +177,8 @@ jobs:
             echo "overlap=$(wc -l < /tmp/sync/overlap.txt | tr -d ' ')"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Compose structured body
-        if: steps.detect.outputs.behind > 0
+      - name: Compose structured body (head)
+        if: steps.detect.outputs.behind != '0'
         id: body
         env:
           BEHIND: ${{ steps.detect.outputs.behind }}
@@ -184,7 +228,7 @@ jobs:
 
           if [ -s /tmp/sync/refs.md ]; then
             {
-              echo "### Referenced upstream issues / PRs"
+              echo "### Referenced issues / PRs"
               echo
               cat /tmp/sync/refs.md
               echo
@@ -204,22 +248,18 @@ jobs:
             } >> "$BODY"
           fi
 
-          {
-            echo "### Review checklist"
-            echo
-            echo "- [ ] Breaking changes evaluated for fork impact"
-            echo "- [ ] Overlapping files reviewed for semantic conflicts"
-            echo "- [ ] Fork-specific tests pass with upstream changes"
-            echo "- [ ] \`coordinode-lsm-tree\` version bumped in consumer projects if upstream cuts a release"
-          } >> "$BODY"
-
+          # NOTE: review checklist is appended LAST by the merge step so that
+          # on the conflict path, the conflict + manual-resolution section can
+          # be inserted before it (rather than trailing the checklist out of
+          # reading order).
           echo "body_path=$BODY" >> "$GITHUB_OUTPUT"
 
       - name: Try merge and create PR or conflict issue
-        if: steps.detect.outputs.behind > 0
+        if: steps.detect.outputs.behind != '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BEHIND: ${{ steps.detect.outputs.behind }}
+          UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
           BODY_PATH: ${{ steps.body.outputs.body_path }}
         run: |
           set -euo pipefail
@@ -230,7 +270,27 @@ jobs:
           SYNC_BRANCH="chore/upstream-sync-$(date +%Y%m%d)"
           git checkout -b "$SYNC_BRANCH" origin/main
 
+          # Helper: append the review checklist as the last section of the body.
+          append_checklist() {
+            {
+              echo "### Review checklist"
+              echo
+              echo "- [ ] Breaking changes evaluated for fork impact"
+              echo "- [ ] Overlapping files reviewed for semantic conflicts"
+              echo "- [ ] Fork-specific tests pass with upstream changes"
+              echo "- [ ] \`coordinode-lsm-tree\` version bumped in consumer projects if upstream cuts a release"
+            } >> "$BODY_PATH"
+          }
+
           if git merge --no-commit --no-ff "${UPSTREAM_REMOTE}/main" 2>&1; then
+            # Advance the persisted last-synced tag so future runs read it
+            # directly (no inference from `--merged` git history shape).
+            if [ -n "${UPSTREAM_LATEST_TAG}" ]; then
+              mkdir -p "$(dirname "$STATE_FILE")"
+              echo "$UPSTREAM_LATEST_TAG" > "$STATE_FILE"
+              git add "$STATE_FILE"
+            fi
+            append_checklist
             git commit -m "chore: sync upstream (${BEHIND} new commits)"
             git push origin "$SYNC_BRANCH"
 
@@ -243,8 +303,10 @@ jobs:
             CONFLICTS=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
             git merge --abort
 
+            # Insert conflict + manual-resolution sections BEFORE the
+            # checklist so the issue reads top-to-bottom: summary → changes
+            # → conflicts → resolution → checklist.
             {
-              echo
               echo "### Conflicting files"
               echo
               echo '```'
@@ -260,11 +322,14 @@ jobs:
               echo "git merge upstream/main"
               echo "# Resolve conflicts, then push"
               echo '```'
+              echo
             } >> "$BODY_PATH"
+            append_checklist
 
             gh issue create \
               --title "Upstream sync conflict (${BEHIND} new commits)" \
-              --body-file "$BODY_PATH"
+              --body-file "$BODY_PATH" \
+              --label "ci"
           fi
 
       - name: Check for merged feature branches
@@ -296,7 +361,8 @@ jobs:
                 } > "$BODY_FILE"
                 gh issue create \
                   --title "Upstream merged: $BRANCH" \
-                  --body-file "$BODY_FILE"
+                  --body-file "$BODY_FILE" \
+                  --label "ci"
                 rm -f "$BODY_FILE"
               fi
             fi

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -42,8 +42,14 @@ jobs:
           BEHIND=$(git rev-list "origin/main..${UPSTREAM_REMOTE}/main" --count)
           echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
 
+          # Match fjall-rs's `v`-prefixed stable semver only. Pre-release tags
+          # like `v1.2.3-rc1` and build-metadata like `v1.2.3+build.5` are
+          # intentionally excluded — we don't auto-sync unstable releases.
+          # A future "track upstream pre-releases" feature would extend this
+          # pattern explicitly.
+          SEMVER_RE='^v[0-9]+\.[0-9]+\.[0-9]+$'
           UPSTREAM_LATEST_TAG=$(git tag -l --sort=-v:refname --merged "${UPSTREAM_REMOTE}/main" \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+            | grep -E "$SEMVER_RE" | head -1 || true)
 
           # Prefer the explicit state file; fall back to inference from
           # `--merged origin/main` if the file is missing (first run) or
@@ -52,7 +58,7 @@ jobs:
             UPSTREAM_PREV_TAG=$(tr -d '[:space:]' < "$STATE_FILE")
           else
             UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
-              | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+              | grep -E "$SEMVER_RE" | head -1 || true)
           fi
           echo "upstream_latest_tag=$UPSTREAM_LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "upstream_prev_tag=$UPSTREAM_PREV_TAG" >> "$GITHUB_OUTPUT"
@@ -64,8 +70,8 @@ jobs:
           echo "new_release=$NEW_RELEASE" >> "$GITHUB_OUTPUT"
 
           echo "Commits behind upstream: $BEHIND"
-          echo "Upstream latest tag: ${UPSTREAM_LATEST_TAG:-<none>}"
-          echo "Last synced upstream tag: ${UPSTREAM_PREV_TAG:-<none>}"
+          echo "Upstream latest tag: ${UPSTREAM_LATEST_TAG:-(none)}"
+          echo "Last synced upstream tag: ${UPSTREAM_PREV_TAG:-(none)}"
           echo "New release available: $NEW_RELEASE"
 
       - name: Build change report
@@ -96,10 +102,20 @@ jobs:
           FIX_RE='^fix(\([^)]*\))?:'
           PERF_RE='^perf(\([^)]*\))?:'
 
-          while IFS=$'\t' read -r SHA SUBJECT BODY; do
+          # Read NUL-delimited records from `git log -z`. Each record holds
+          # `SHA\tSUBJECT\tBODY`; BODY may contain its own newlines (footers,
+          # multi-paragraph descriptions). We split fields via parameter
+          # expansion rather than `IFS=$'\t' read` so internal newlines stay
+          # inside BODY and don't get treated as record separators.
+          while IFS= read -r -d '' RECORD; do
+            SHA="${RECORD%%$'\t'*}"
+            REST="${RECORD#*$'\t'}"
+            SUBJECT="${REST%%$'\t'*}"
+            BODY="${REST#*$'\t'}"
             SHORT=$(git rev-parse --short "$SHA")
             LINE="- \`$SHORT\` $SUBJECT"
-            if [[ "$SUBJECT" =~ $BREAKING_RE ]] || echo "$BODY" | grep -qE '^BREAKING CHANGE:'; then
+            if [[ "$SUBJECT" =~ $BREAKING_RE ]] \
+               || printf '%s\n' "$BODY" | grep -qE '^BREAKING CHANGE:'; then
               echo "$LINE" >> /tmp/sync/breaking.txt
             elif [[ "$SUBJECT" =~ $FEAT_RE ]]; then
               echo "$LINE" >> /tmp/sync/feat.txt
@@ -111,16 +127,34 @@ jobs:
               echo "$LINE" >> /tmp/sync/other.txt
             fi
           done < <(git log "origin/main..${UPSTREAM_REMOTE}/main" \
-                     --format='%H%x09%s%x09%b' -z \
-                     | tr '\0' '\n')
+                     --format='%H%x09%s%x09%b' -z)
 
           # Extract referenced issues / PRs. Capture both bare `#NNN`
           # (resolved against UPSTREAM_REPO) and qualified `owner/repo#NNN`
           # (rendered as plain links, not silently rewritten).
+          #
+          # Strategy: tokenise the commit text into one candidate per line by
+          # treating whitespace, parens, brackets, commas, semicolons, and
+          # angle brackets as separators, then exact-match each token against
+          # the ref grammar. This prevents file-path citations like
+          # `path/to/file#42` from being misread as `to/file#42` qualified
+          # refs (the inline `grep -oE` form was greedy and matched the
+          # longest substring rather than complete tokens).
+          #
+          # `owner` grammar follows GitHub's rules: letters/digits/`-`, no
+          # leading `-`, no `.` or `_` (which `path` segments freely use).
+          # `repo` is more permissive: letters/digits + `.` `_` `-`.
           : > /tmp/sync/refs_bare.txt
           : > /tmp/sync/refs_qualified.txt
+          # Token separators include sentence punctuation so refs at the end
+          # of a sentence (`Closes fjall-rs/lsm-tree#456.`) get split off
+          # cleanly. The post-tokenise regex then exact-matches the ref
+          # grammar, dropping accidental candidates like file-path
+          # citations (`path/to/file#42`) which have multiple slashes.
           git log "origin/main..${UPSTREAM_REMOTE}/main" --format='%s%n%b' \
-            | grep -oE '([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+' \
+            | tr -s '[:space:](){}[],;<>!?"'"'" '\n' \
+            | sed 's/\.$//' \
+            | grep -E '^([A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9._-]+)?#[0-9]+$' \
             | sort -u \
             | while read -r REF; do
                 if [[ "$REF" == *"/"* ]]; then
@@ -128,7 +162,23 @@ jobs:
                 else
                   echo "$REF" >> /tmp/sync/refs_bare.txt
                 fi
-              done
+              done || true
+
+          # Markdown-escape a title so backticks / pipes / brackets in
+          # upstream issue titles don't break the surrounding list-item
+          # rendering or link syntax. Single-quoted sed expressions are
+          # intentional — the backticks are literal characters to match,
+          # not command substitutions (shellcheck SC2016 is a false positive
+          # for sed scripts).
+          # shellcheck disable=SC2016
+          md_escape() {
+            printf '%s' "$1" \
+              | sed -e 's/\\/\\\\/g' \
+                    -e 's/`/\\`/g' \
+                    -e 's/|/\\|/g' \
+                    -e 's/\[/\\[/g' \
+                    -e 's/\]/\\]/g'
+          }
 
           : > /tmp/sync/refs.md
           # Resolve bare refs against UPSTREAM_REPO via a single Issues API call
@@ -138,7 +188,8 @@ jobs:
               NUM="${REF#\#}"
               TITLE=$(gh api "repos/${UPSTREAM_REPO}/issues/${NUM}" --jq '.title' 2>/dev/null || true)
               if [ -n "$TITLE" ]; then
-                echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE}" \
+                TITLE_SAFE=$(md_escape "$TITLE")
+                echo "- [${UPSTREAM_REPO}${REF}](https://github.com/${UPSTREAM_REPO}/issues/${NUM}) — ${TITLE_SAFE}" \
                   >> /tmp/sync/refs.md
               fi
             done
@@ -193,7 +244,7 @@ jobs:
 
           if [ "$NEW_RELEASE" = "true" ]; then
             {
-              echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-<none>} → ${UPSTREAM_LATEST_TAG}"
+              echo "## Upstream Sync: ${UPSTREAM_PREV_TAG:-(none)} → ${UPSTREAM_LATEST_TAG}"
               echo
               echo "**Release:** [${UPSTREAM_LATEST_TAG}](https://github.com/${UPSTREAM_REPO}/releases/tag/${UPSTREAM_LATEST_TAG})"
             } >> "$BODY"
@@ -283,8 +334,13 @@ jobs:
           }
 
           if git merge --no-commit --no-ff "${UPSTREAM_REMOTE}/main" 2>&1; then
-            # Advance the persisted last-synced tag so future runs read it
-            # directly (no inference from `--merged` git history shape).
+            # Advance the persisted last-synced tag on every successful merge,
+            # regardless of whether this run detected a release boundary. The
+            # state file is lazily bootstrapped — the first sync run with
+            # behind > 0 writes it; until then, the `git tag --merged
+            # origin/main` inference in the detect step covers the gap.
+            # Runs with behind == 0 don't reach this step and don't need to
+            # write the file (state is unchanged).
             if [ -n "${UPSTREAM_LATEST_TAG}" ]; then
               mkdir -p "$(dirname "$STATE_FILE")"
               echo "$UPSTREAM_LATEST_TAG" > "$STATE_FILE"
@@ -329,7 +385,7 @@ jobs:
             gh issue create \
               --title "Upstream sync conflict (${BEHIND} new commits)" \
               --body-file "$BODY_PATH" \
-              --label "ci"
+              --label "upstream-sync"
           fi
 
       - name: Check for merged feature branches
@@ -338,6 +394,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Our branch convention (per CLAUDE.md) is `<type>/#<issue_id>[-slug]`,
+          # so the literal `#` is part of every feature/fix branch name. Branches
+          # without the leading `#` (e.g., `feat/foo` or `feat/123-foo`) are not
+          # produced by our workflow and are intentionally skipped. If the
+          # convention changes, broaden these patterns.
           for ref in $(git for-each-ref --format='%(refname:short)' \
                          'refs/remotes/origin/feat/#*' \
                          'refs/remotes/origin/fix/#*'); do
@@ -362,7 +423,7 @@ jobs:
                 gh issue create \
                   --title "Upstream merged: $BRANCH" \
                   --body-file "$BODY_FILE" \
-                  --label "ci"
+                  --label "upstream-sync"
                 rm -f "$BODY_FILE"
               fi
             fi

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -15,6 +15,14 @@ env:
   UPSTREAM_URL: https://github.com/fjall-rs/lsm-tree.git
   UPSTREAM_REPO: fjall-rs/lsm-tree
   STATE_FILE: .github/state/last-upstream-sync.txt
+  # All implicit-target `gh` calls (label create, pr list, pr create,
+  # issue create) must target OUR repo. Without GH_REPO set, gh infers
+  # the target from git remotes — and we add `upstream` (fjall-rs) as
+  # a remote in the first step, which can take precedence and route
+  # write operations to a repo where our GITHUB_TOKEN has no access
+  # (403). `gh api repos/${UPSTREAM_REPO}/issues/${NUM}` calls use an
+  # explicit path so they're unaffected by GH_REPO.
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   check-upstream:

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -77,8 +77,15 @@ jobs:
           if [ -f "$STATE_FILE" ]; then
             UPSTREAM_PREV_TAG=$(tr -d '[:space:]' < "$STATE_FILE")
           else
-            UPSTREAM_PREV_TAG=$(git tag -l --sort=-v:refname --merged "origin/main" \
-              | grep -E "$SEMVER_RE" | head -1 || true)
+            # Intersect "tags reachable from origin/main" with "tags
+            # reachable from upstream/main" — guarantees the inferred
+            # tag is upstream-origin and excludes fork-local release
+            # tags (e.g., our own `v4.4.0`) that would otherwise be
+            # mistaken for a previous upstream sync point.
+            UPSTREAM_PREV_TAG=$(comm -12 \
+              <(git tag -l --merged "origin/main" | sort) \
+              <(git tag -l --merged "${UPSTREAM_REMOTE}/main" | sort) \
+              | grep -E "$SEMVER_RE" | sort -V | tail -1 || true)
           fi
           UPSTREAM_HEAD_SHORT=$(git rev-parse --short "${UPSTREAM_REMOTE}/main")
           {
@@ -98,8 +105,55 @@ jobs:
           echo "Last synced upstream tag: ${UPSTREAM_PREV_TAG:-(none)}"
           echo "New release available: $NEW_RELEASE"
 
-      - name: Build change report
+      - name: Check skip conditions
+        # Early skip gate — runs BEFORE Build change report and Compose
+        # body steps so cron runs on already-considered upstream HEADs
+        # short-circuit before the expensive Build step (which issues up
+        # to 20 upstream API calls for title resolution per ref). The
+        # merge step still re-checks defensively, but the API-quota
+        # win is here.
         if: steps.detect.outputs.behind != '0'
+        id: skip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_HEAD_SHORT: ${{ steps.detect.outputs.upstream_head_short }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          SHOULD_RUN=true
+          REASON=""
+
+          # An open sync PR is unresolved review work — don't stack.
+          # Ensure the label exists first (otherwise the query fails
+          # against a missing label with non-zero exit). Idempotent.
+          gh label create "upstream-sync" \
+            --color "fbca04" \
+            --description "Automated upstream synchronization — merge conflicts, release tracking" \
+            --force >/dev/null
+          OPEN_SYNC_PRS=$(gh pr list \
+            --label upstream-sync --state open \
+            --json number --jq 'length')
+          if [ "$OPEN_SYNC_PRS" -gt 0 ]; then
+            SHOULD_RUN=false
+            REASON="${OPEN_SYNC_PRS} open sync PR(s) already exist"
+          fi
+
+          # Already-considered upstream HEAD (close-without-merge memory).
+          if [ "$SHOULD_RUN" = "true" ] && [ "$FORCE" != "true" ]; then
+            CONSIDERED_TAG="upstream-sync-considered/${UPSTREAM_HEAD_SHORT}"
+            if git ls-remote --tags --exit-code origin "refs/tags/${CONSIDERED_TAG}" >/dev/null 2>&1; then
+              SHOULD_RUN=false
+              REASON="upstream HEAD ${UPSTREAM_HEAD_SHORT} already considered (tag ${CONSIDERED_TAG})"
+            fi
+          fi
+
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          if [ "$SHOULD_RUN" = "false" ]; then
+            echo "Skip: ${REASON}. Subsequent steps will short-circuit."
+          fi
+
+      - name: Build change report
+        if: steps.detect.outputs.behind != '0' && steps.skip.outputs.should_run == 'true'
         env:
           BEHIND: ${{ steps.detect.outputs.behind }}
           NEW_RELEASE: ${{ steps.detect.outputs.new_release }}
@@ -139,6 +193,12 @@ jobs:
             LINE="- \`$SHORT\` $SUBJECT"
             # Conventional Commits §5 treats `BREAKING CHANGE:` and
             # `BREAKING-CHANGE:` as equivalent footer tokens — match both.
+            # Heuristic limitation: a `revert: <breaking change>` commit
+            # that re-introduces a breaking change is NOT caught here
+            # and falls through to "Other". Catching reverts requires
+            # walking parent commits, which is out of scope for the
+            # categoriser; reviewers should rely on the "Other" section
+            # as a catch-all for these cases.
             if [[ "$SUBJECT" =~ $BREAKING_RE ]] \
                || printf '%s\n' "$BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then
               echo "$LINE" >> /tmp/sync/breaking.txt
@@ -215,6 +275,8 @@ jobs:
                     -e 's/|/\\|/g' \
                     -e 's/\[/\\[/g' \
                     -e 's/\]/\\]/g' \
+                    -e 's/(/\\(/g' \
+                    -e 's/)/\\)/g' \
                     -e 's/</\&lt;/g' \
                     -e 's/>/\&gt;/g' \
                     -e 's/\*/\\*/g' \
@@ -298,7 +360,7 @@ jobs:
           # emit step outputs here (was unused noise on every run).
 
       - name: Compose structured body (head)
-        if: steps.detect.outputs.behind != '0'
+        if: steps.detect.outputs.behind != '0' && steps.skip.outputs.should_run == 'true'
         id: body
         env:
           BEHIND: ${{ steps.detect.outputs.behind }}
@@ -382,60 +444,26 @@ jobs:
         # Gated on the body step succeeding so a body-composition failure
         # doesn't cascade into a confusing "ambiguous redirect" when this
         # step tries to append to an empty BODY_PATH.
-        if: steps.detect.outputs.behind != '0' && steps.body.outcome == 'success'
+        if: steps.detect.outputs.behind != '0' && steps.skip.outputs.should_run == 'true' && steps.body.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BEHIND: ${{ steps.detect.outputs.behind }}
           UPSTREAM_LATEST_TAG: ${{ steps.detect.outputs.upstream_latest_tag }}
           UPSTREAM_HEAD_SHORT: ${{ steps.detect.outputs.upstream_head_short }}
           BODY_PATH: ${{ steps.body.outputs.body_path }}
-          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Ensure the `upstream-sync` label exists in the repo.
-          # `gh pr create --label` / `gh issue create --label` exit non-zero
-          # for unknown labels, which would abort this step before any
-          # artifact is produced. `--force` makes the call idempotent.
-          gh label create "upstream-sync" \
-            --color "fbca04" \
-            --description "Automated upstream synchronization — merge conflicts, release tracking" \
-            --force >/dev/null
-
-          # Skip if a previous sync PR is still open (review in progress).
-          # Otherwise every cron run (Mon/Thu) + every workflow_dispatch
-          # would stack new sync PRs on top of unresolved ones.
-          OPEN_SYNC_PRS=$(gh pr list \
-            --label upstream-sync --state open \
-            --json number --jq 'length')
-          if [ "$OPEN_SYNC_PRS" -gt 0 ]; then
-            echo "Skip: ${OPEN_SYNC_PRS} open sync PR(s) already exist — resolve them before opening another."
-            exit 0
-          fi
-
-          # Skip if this exact upstream HEAD was already surfaced via a
-          # prior sync PR (which the maintainer either merged or closed
-          # without merging — the "considered-but-not-merged" case
-          # matters for forks with permanent divergences from renames /
-          # cherry-picks that intentionally never absorb upstream).
-          #
-          # Mechanism: each successful PR creation pushes a tag
-          # `upstream-sync-considered/<short-sha>` pointing at upstream
-          # HEAD. Re-runs against the same upstream HEAD see the tag
-          # and exit early. New upstream commits → new short SHA → no
-          # tag match → workflow proceeds normally.
-          #
-          # workflow_dispatch input `force: true` bypasses this gate
-          # for explicit "I want to re-surface" runs.
+          # Skip conditions (open sync PR exists, considered-tag for
+          # current upstream HEAD) are evaluated in the earlier
+          # `Check skip conditions` step. This step's `if:` gate
+          # already includes `steps.skip.outputs.should_run == 'true'`,
+          # so we don't re-check here. `upstream-sync` label is also
+          # ensured in the skip step.
           CONSIDERED_TAG="upstream-sync-considered/${UPSTREAM_HEAD_SHORT}"
-          if [ "$FORCE" != "true" ] \
-             && git ls-remote --tags --exit-code origin "refs/tags/${CONSIDERED_TAG}" >/dev/null 2>&1; then
-            echo "Skip: upstream HEAD ${UPSTREAM_HEAD_SHORT} already considered (tag ${CONSIDERED_TAG} exists). Use workflow_dispatch with force=true to re-surface."
-            exit 0
-          fi
 
           # Branch name carries the date + run number so a second run on the
           # same UTC day (manual `workflow_dispatch` after the cron run) gets
@@ -566,10 +594,19 @@ jobs:
           # main avoids that check entirely; the tag is a marker, the
           # target commit is irrelevant.
           #
-          # `|| true` because a tag collision on an explicit
-          # force=true re-run is harmless.
-          git tag "$CONSIDERED_TAG" origin/main
-          git push origin "$CONSIDERED_TAG" || true
+          # `-f` because `actions/checkout` with fetch-depth=0 brings
+          # all origin tags into the local clone, so a force=true
+          # re-run against the same upstream HEAD finds the local tag
+          # already present. Plain `git tag` would abort the step
+          # under `set -e` after the PR/issue had already been opened.
+          # `|| true` on the push is for the remote-side collision
+          # which is harmless (same target).
+          git tag -f "$CONSIDERED_TAG" origin/main
+          # `+refs/tags/...` is the localised refspec form for tag
+          # override (equivalent to `--force` but scoped to just this
+          # ref). `|| true` because a remote-side collision is
+          # harmless (target is identical or only the tag NAME mattered).
+          git push origin "+refs/tags/${CONSIDERED_TAG}" || true
 
       - name: Check for merged feature branches
         env:


### PR DESCRIPTION
> Supersedes #259 (closed unmerged for a clean review history after the previous PR accumulated 70+ resolved threads across 9 review rounds). Same branch, same scope, same body.

## Summary

Two CI tooling files. Together they upgrade the fork's upstream-sync flow from "count commits and try a merge" to a Dependabot-style dependency-aware sync surface that respects maintainer decisions.

- **`.github/workflows/upstream-monitor.yml`** — full rewrite. Surfaces upstream changes as a structured PR (clean merge) or issue (conflict), categorises commits by Conventional Commits, anchors the report to a release tag when one is available, resolves referenced upstream issues/PRs to titles, flags fork-overlap files for manual review, and tracks "already considered" upstream HEADs so a closed sync PR isn't auto-recreated until upstream advances.
- **`.coderabbit.yaml`** — expanded from a 7-line stub to a full path-aware review profile: knowledge-base linked to the project's `copilot-instructions.md` + `instructions/*.instructions.md`, path-specific review focus for security/compaction/encryption areas, full label-enrichment catalog matching the repo's actual label set.

## What the maintainer sees on a sync run

Each run produces ONE artifact for the current upstream HEAD:

- **Clean merge** → sync PR with title `chore: sync upstream-<short> (N new commits)`, body containing release detection, conventional-commit categorisation (Breaking ⚠️ / Features ✨ / Fixes 🐛 / Performance ⚡ / Other 📝), referenced upstream issues/PRs with resolved titles, fork-overlap file list, and a review checklist.
- **Conflict** → issue with title `Upstream sync conflict for upstream-<short> (N new commits)` carrying the same context plus a manual-resolution snippet. This is the steady state for forks with permanent rename / cherry-pick divergences.
- **Pre-merge failure** (dirty tree, internal git error) → distinct issue title `Upstream sync merge failed without conflicts for upstream-<short>` so on-call investigates the workflow rather than chasing phantom conflicts.

## "Already considered" semantic

Maintainer interactions on the auto-PR/issue ARE the considered signal — no separate state file edit or tag bump needed:

- **Open** → review in progress, future runs skip via `gh search issues "upstream-<short> in:title label:upstream-sync"`.
- **Merged** → user accepted; origin/main advances; next run reads `BEHIND=0` naturally.
- **Closed without merge** → user said "no" for this upstream HEAD; closed PR/issue still satisfies the title search, future runs skip until upstream advances (new short SHA → no search match → new artifact surfaced).

`workflow_dispatch` input `force=true` bypasses the skip for explicit "re-surface anyway" runs.

## Other workflow behaviour locked in

- **State file** `.github/state/last-upstream-sync.txt` — written on each successful merge, lazily bootstrapped via `--merged origin/main ∩ --merged upstream/main` (intersection guarantees only upstream-origin tags qualify, fork's own releases excluded).
- **Idempotent label create** — `upstream-sync` label is `--force`-created at the top of every gh-creating step so a deleted/missing label doesn't abort the workflow.
- **Early skip gate** — skip-check runs before the expensive Build step (up to 20 upstream API calls per ref), short-circuiting cron noise.
- **Sync-branch naming** — `chore/upstream-sync-<date>-<run-number>` avoids same-UTC-day collisions on re-runs.
- **Body composition** — checklist appended last on both routes (success / conflict); conflict block inserted before checklist for top-to-bottom reading order.
- **GH_REPO** pinned at workflow env level so `gh` calls don't accidentally route to the upstream remote.
- **md_escape** covers `` ` `` `|` `[` `]` `(` `)` `<` `>` `*` `_` `#` so arbitrary upstream issue titles can't break the rendered markdown.
- **Pre-split refs cap** — at most 20 referenced issues/PRs rendered per sync report; the report's primary value is "upstream has N new, mergeable: yes/no" rather than exhaustive ref enumeration.

## `.coderabbit.yaml` deliverables

- `profile: assertive`, `poem: false`, `auto_incremental_review: true`, `drafts: false`, `early_access: false` (stable channel for reproducible reviews).
- `path_instructions` for `src/**/*.rs`, `tests/**`, `benches/**`, `src/compaction/**`, `src/encryption*.rs` + `src/encryption/**` (mirrored blocks with `⚠️ Keep in sync` trailer; brace expansion + YAML anchors rejected as schema-uncertain).
- `knowledge_base.code_guidelines.filePatterns` → `.github/copilot-instructions.md` + `.github/instructions/*.instructions.md`.
- `issue_enrichment.labeling.auto_apply_labels: true` with 14 labels matching this repo's actual catalog (`bug`, `enhancement`, `performance`, `refactor`, `test`, `ci`, `documentation`, `comparator`, `compaction`, `crash-safety`, `encryption`, `fs-trait`, `upstream-candidate`, `fork-only`).
- `base_branches: ["main"]` documented inline (sync PRs also target `main`).

## Test plan

- [x] YAML parses (both files)
- [x] yamllint clean (both files)
- [x] shellcheck clean (every `run: |` block)
- [x] Locally tested: NUL-record parser handles multi-line commit body with `BREAKING CHANGE:` footer (2 records in / 2 categorised); ref-tokeniser strips path/to/file#42 false-positives and captures `fjall-rs/lsm-tree#456.` cross-repo refs after trailing-`.` strip; conventional-commit regex anchors prevent false-positive breaking-change classification.
- [x] Live-tested end-to-end via 5 `workflow_dispatch` runs on this branch — caught and fixed: (a) `gh` routing through upstream remote → pinned `GH_REPO`; (b) `git push` of tag pointing at upstream rejected for workflow files → simplified mechanism to title-search (no tags); (c) skip-check ordering moved before expensive Build for API-quota savings.
- [x] Close-without-merge respected: closing the test sync issue → next `workflow_dispatch` correctly emits `Skip: N sync artifact(s) for upstream-<short> already exist`.

## Out of scope (tracked separately if revisited)

- `force=true` in cron mode (currently dispatch-only).
- Multi-branch base support (sync always targets `main`; widen `base_branches` if that changes).
- Pre-release upstream tags (semver regex intentionally stable-only).

Closes #126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded upstream sync: run daily, added manual "force" resurfacing, longer timeouts, env-based state handling, improved detection and structured summaries of upstream releases, safer branch/merge handling, and clearer automated issue/PR creation on failures or conflicts.
  * Expanded review automation: set default language and disabled early-access, broader review checks and path scopes, enabled linters and GitHub checks with increased timeout, auto-review/chat auto-replies, enriched labeling and knowledge-base scopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
