### PR TITLE
perf: devirtualize lexicographic comparator on block binary-search hot path

### DIFF
--- a/src/table/data_block/iter.rs
+++ b/src/table/data_block/iter.rs
@@ -55,15 +55,31 @@ impl<'a> Iter<'a> {
     /// `needle` will be found within roughly one restart interval of the
     /// resulting position.
     pub fn seek_to_key_seqno(&mut self, needle: &[u8], seqno: SeqNo) -> bool {
+        // Lex fast path: `<[u8]>::cmp` is statically dispatched and inlinable
+        // — no vtable lookup per probe. The custom-comparator branch retains
+        // the existing `dyn UserComparator::compare` call. Each closure has a
+        // distinct type, so `Decoder::seek` monomorphizes both shapes and the
+        // inner binary-search loop is virtual-call-free on the lex path.
         let cmp = &self.comparator;
-        self.decoder.inner_mut().seek(
-            |head_key, head_seqno| match cmp.compare(head_key, needle) {
-                std::cmp::Ordering::Less => true,
-                std::cmp::Ordering::Equal => head_seqno >= seqno,
-                std::cmp::Ordering::Greater => false,
-            },
-            false,
-        )
+        if cmp.is_lexicographic() {
+            self.decoder.inner_mut().seek(
+                |head_key, head_seqno| match head_key.cmp(needle) {
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Equal => head_seqno >= seqno,
+                    std::cmp::Ordering::Greater => false,
+                },
+                false,
+            )
+        } else {
+            self.decoder.inner_mut().seek(
+                |head_key, head_seqno| match cmp.compare(head_key, needle) {
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Equal => head_seqno >= seqno,
+                    std::cmp::Ordering::Greater => false,
+                },
+                false,
+            )
+        }
     }
 
     pub fn seek(&mut self, needle: &[u8], seqno: SeqNo) -> bool {
@@ -111,10 +127,17 @@ impl<'a> Iter<'a> {
     /// would skip intervals that may contain the visible version.
     pub fn seek_upper(&mut self, needle: &[u8], _seqno: SeqNo) -> bool {
         let cmp = &self.comparator;
-        if !self.decoder.inner_mut().seek_upper(
-            |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
-            false,
-        ) {
+        let landed = if cmp.is_lexicographic() {
+            self.decoder
+                .inner_mut()
+                .seek_upper(|head_key, _| head_key <= needle, false)
+        } else {
+            self.decoder.inner_mut().seek_upper(
+                |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
+                false,
+            )
+        };
+        if !landed {
             return false;
         }
 
@@ -177,10 +200,17 @@ impl<'a> Iter<'a> {
     /// seeks.
     pub fn seek_upper_exclusive(&mut self, needle: &[u8], _seqno: SeqNo) -> bool {
         let cmp = &self.comparator;
-        if !self.decoder.inner_mut().seek_upper(
-            |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
-            false,
-        ) {
+        let landed = if cmp.is_lexicographic() {
+            self.decoder
+                .inner_mut()
+                .seek_upper(|head_key, _| head_key <= needle, false)
+        } else {
+            self.decoder.inner_mut().seek_upper(
+                |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
+                false,
+            )
+        };
+        if !landed {
             return false;
         }
 

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1453,7 +1453,17 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
         struct CountingComparator {
+            /// Counts `compare()` invocations — proves the lex devirt path
+            /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
+            /// Counts `is_lexicographic()` invocations. The lex devirt
+            /// strategy gates each entry point on `is_lexicographic()`, so
+            /// this counter PROVES the lex branch was actually selected (a
+            /// regression that always selected the dyn branch would leave
+            /// this at 0 in lex tests AND keep `count` at 0, both passing
+            /// the original weaker assertion). Required to fully discriminate
+            /// "lex branch ran" from "no seeks happened at all".
+            is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
 
@@ -1466,6 +1476,7 @@ mod tests {
                 a.cmp(b)
             }
             fn is_lexicographic(&self) -> bool {
+                self.is_lex_count.fetch_add(1, AtomicOrdering::Relaxed);
                 self.lex
             }
         }
@@ -1513,23 +1524,32 @@ mod tests {
             // where only one closure accidentally falls back to the dyn path.
             let data_block = build_block_bs_dominated()?;
             let count = Arc::new(AtomicUsize::new(0));
+            let is_lex_count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: is_lex_count.clone(),
                 lex: true,
             });
             let needle = 64_u64.to_be_bytes();
 
             let before = count.load(AtomicOrdering::Relaxed);
+            let before_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             {
                 let mut iter = data_block.iter(cmp.clone());
                 let _ = iter.seek(&needle, SeqNo::MAX);
             }
             let after_seek = count.load(AtomicOrdering::Relaxed);
+            let after_seek_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             assert_eq!(
                 after_seek - before,
                 0,
                 "seek (forward seqno-aware) lex path leaked into dyn: {} compare() calls",
                 after_seek - before,
+            );
+            assert!(
+                after_seek_lex - before_lex >= 1,
+                "seek lex path must consult is_lexicographic() to select the lex closure, got {} calls — branch may have been hardcoded?",
+                after_seek_lex - before_lex,
             );
 
             {
@@ -1537,11 +1557,17 @@ mod tests {
                 let _ = iter.seek_upper(&needle, SeqNo::MAX);
             }
             let after_upper = count.load(AtomicOrdering::Relaxed);
+            let after_upper_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             assert_eq!(
                 after_upper - after_seek,
                 0,
                 "seek_upper lex path leaked into dyn: {} compare() calls",
                 after_upper - after_seek,
+            );
+            assert!(
+                after_upper_lex - after_seek_lex >= 1,
+                "seek_upper lex path must consult is_lexicographic(), got {} calls",
+                after_upper_lex - after_seek_lex,
             );
 
             {
@@ -1549,11 +1575,17 @@ mod tests {
                 let _ = iter.seek_upper_exclusive(&needle, SeqNo::MAX);
             }
             let after_excl = count.load(AtomicOrdering::Relaxed);
+            let after_excl_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             assert_eq!(
                 after_excl - after_upper,
                 0,
                 "seek_upper_exclusive lex path leaked into dyn: {} compare() calls",
                 after_excl - after_upper,
+            );
+            assert!(
+                after_excl_lex - after_upper_lex >= 1,
+                "seek_upper_exclusive lex path must consult is_lexicographic(), got {} calls",
+                after_excl_lex - after_upper_lex,
             );
             Ok(())
         }
@@ -1568,6 +1600,7 @@ mod tests {
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
             let needle = 64_u64.to_be_bytes();
@@ -1598,6 +1631,7 @@ mod tests {
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
             let needle = 64_u64.to_be_bytes();
@@ -1624,6 +1658,7 @@ mod tests {
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
             let needle = 64_u64.to_be_bytes();
@@ -1666,41 +1701,77 @@ mod tests {
             // landing positions for every probe. If the lex closure ever
             // disagrees with `compare() != Greater` semantics (e.g. wrong
             // operator), this test catches it before integration suites do.
+            //
+            // Encoded keys are 64 entries of `u64::to_be_bytes()` (8-byte
+            // fixed-width). Needles are raw byte slices that cover the full
+            // `partition_point` boundary table:
+            //   - empty slice                              → BELOW the minimum
+            //     (sorts before any non-empty byte sequence) → left == 0
+            //   - 8 zero bytes (== key 0)                  → exact-min hit
+            //   - between-key needle (9 bytes, prefix of key 17 + 0x00) →
+            //     sorts strictly between [0…0,17] and [0…0,18] → predicate
+            //     transition mid-range
+            //   - 8-byte key 32                            → exact mid-hit
+            //   - 8-byte key 63                            → exact-tail hit
+            //     (last key, left == len exercise)
+            //   - 9-byte above-key-63 needle               → above max, no match
+            //
+            // The earlier version of this test used only `u64::to_be_bytes()`
+            // values; all were exact-keys plus one above-max, missing the
+            // genuine below-min and between-key partition_point boundary
+            // cases that this test now claims to cover.
             let data_block = build_block_for_equivalence()?;
             let lex: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: Arc::new(AtomicUsize::new(0)),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: true,
             });
             let dyn_cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: Arc::new(AtomicUsize::new(0)),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
 
-            // Probe a range of needles: below-min, exact-match, between-keys,
-            // exact-tail, above-max. These cover the partition_point boundary
-            // cases (left==0, left==len, mid hits exact key).
-            for needle_val in &[0_u64, 17, 32, 47, 63, 100] {
-                let needle = needle_val.to_be_bytes();
+            // (label, needle_bytes)
+            let between_17_and_18: Vec<u8> = {
+                let mut v = 17_u64.to_be_bytes().to_vec();
+                v.push(0); // 9 bytes: > 17, < 18 lexicographically
+                v
+            };
+            let above_max: Vec<u8> = {
+                let mut v = 63_u64.to_be_bytes().to_vec();
+                v.push(0xFF); // 9 bytes after the largest 8-byte key
+                v
+            };
+            let needles: Vec<(&str, Vec<u8>)> = vec![
+                ("below-min (empty slice)", vec![]),
+                ("exact-min (key 0)", 0_u64.to_be_bytes().to_vec()),
+                ("between keys 17 and 18", between_17_and_18),
+                ("exact-mid (key 32)", 32_u64.to_be_bytes().to_vec()),
+                ("exact-tail (key 63)", 63_u64.to_be_bytes().to_vec()),
+                ("above-max (key 63 + 0xFF)", above_max),
+            ];
 
+            for (label, needle) in &needles {
                 let mut lex_iter = data_block.iter(lex.clone());
-                let lex_seek = lex_iter.seek(&needle, SeqNo::MAX);
+                let lex_seek = lex_iter.seek(needle, SeqNo::MAX);
                 let lex_landing = lex_iter
                     .next()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
 
                 let mut dyn_iter = data_block.iter(dyn_cmp.clone());
-                let dyn_seek = dyn_iter.seek(&needle, SeqNo::MAX);
+                let dyn_seek = dyn_iter.seek(needle, SeqNo::MAX);
                 let dyn_landing = dyn_iter
                     .next()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
 
                 assert_eq!(
                     lex_seek, dyn_seek,
-                    "seek result must match for needle {needle_val}",
+                    "seek result must match for needle {label} ({needle:?})",
                 );
                 assert_eq!(
                     lex_landing, dyn_landing,
-                    "landing position must match for needle {needle_val}",
+                    "landing position must match for needle {label} ({needle:?})",
                 );
             }
             Ok(())

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1470,10 +1470,181 @@ mod tests {
             }
         }
 
-        fn build_block() -> crate::Result<DataBlock> {
-            // 64 keys → forces multiple restart intervals at any reasonable
-            // restart_interval, guaranteeing the binary-search probe loop
-            // runs at least 2 iterations (log2(8 restarts) = 3 probes).
+        /// Block tuned to make BINARY-SEARCH PROBES dominate any potential
+        /// linear-scan contribution to the call count:
+        ///   - 128 keys, `restart_interval=1` → 128 restart heads
+        ///   - binary search: log2(128) = 7 probes minimum
+        ///   - linear scan after BS lands: 0-1 iterations (each restart head
+        ///     IS an item, so the scan either returns immediately or steps once)
+        ///
+        /// Discrimination math:
+        ///   - dyn path working correctly: count >= 7 (BS) + 0..1 (scan)
+        ///   - lex closure leaked into dyn BS: count = 0 (BS) + 0..1 (scan) ≤ 1
+        ///
+        /// `assert count >= 2` cleanly distinguishes the two cases, ruling out
+        /// the linear-scan-only false-positive that a naive `> 0` would miss.
+        fn build_block_bs_dominated() -> crate::Result<DataBlock> {
+            let items: Vec<_> = (0_u64..128)
+                .map(|i| InternalValue::from_components(i.to_be_bytes(), "", 0, Value))
+                .collect();
+            let bytes = DataBlock::encode_into_vec(&items, 1, 1.33)?;
+            Ok(DataBlock::new(Block {
+                data: bytes.into(),
+                header: Header {
+                    block_type: BlockType::Data,
+                    checksum: Checksum::from_raw(0),
+                    data_length: 0,
+                    uncompressed_length: 0,
+                },
+            }))
+        }
+
+        /// Minimum number of `compare()` calls a working dyn path is expected
+        /// to make for any single seek on the BS-dominated block. See
+        /// [`build_block_bs_dominated`] for the math.
+        const DYN_MIN_PROBES: usize = 2;
+
+        #[test]
+        fn data_block_seek_lex_path_skips_vtable() -> crate::Result<()> {
+            // is_lexicographic() == true must route ALL 3 devirtualized entry
+            // points through the static-dispatch closures. Snapshotting count
+            // per-entry-point (instead of a single end-of-test check) localises
+            // a regression to the offending entry point and catches the case
+            // where only one closure accidentally falls back to the dyn path.
+            let data_block = build_block_bs_dominated()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: true,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = data_block.iter(cmp.clone());
+                let _ = iter.seek(&needle, SeqNo::MAX);
+            }
+            let after_seek = count.load(AtomicOrdering::Relaxed);
+            assert_eq!(
+                after_seek - before,
+                0,
+                "seek (forward seqno-aware) lex path leaked into dyn: {} compare() calls",
+                after_seek - before,
+            );
+
+            {
+                let mut iter = data_block.iter(cmp.clone());
+                let _ = iter.seek_upper(&needle, SeqNo::MAX);
+            }
+            let after_upper = count.load(AtomicOrdering::Relaxed);
+            assert_eq!(
+                after_upper - after_seek,
+                0,
+                "seek_upper lex path leaked into dyn: {} compare() calls",
+                after_upper - after_seek,
+            );
+
+            {
+                let mut iter = data_block.iter(cmp);
+                let _ = iter.seek_upper_exclusive(&needle, SeqNo::MAX);
+            }
+            let after_excl = count.load(AtomicOrdering::Relaxed);
+            assert_eq!(
+                after_excl - after_upper,
+                0,
+                "seek_upper_exclusive lex path leaked into dyn: {} compare() calls",
+                after_excl - after_upper,
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn data_block_seek_to_key_seqno_dyn_path_invokes_compare() -> crate::Result<()> {
+            // `seek_to_key_seqno` is the FORWARD seqno-aware binary search
+            // exposed without an attached linear scan — perfect isolation for
+            // the BS predicate. Any non-zero `compare()` call here proves the
+            // dyn closure ran for the forward BS predicate.
+            let data_block = build_block_bs_dominated()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = data_block.iter(cmp);
+                let _ = iter.seek_to_key_seqno(&needle, SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= 1,
+                "seek_to_key_seqno dyn BS must call compare(), got {delta} (lex closure leaked into dyn path?)",
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn data_block_seek_upper_dyn_path_invokes_compare() -> crate::Result<()> {
+            // `seek_upper` does binary search + linear scan. In dyn path the
+            // linear scan also calls `compare_key` (which then calls
+            // `cmp.compare()` via its own dyn branch). To rule out the
+            // false-positive "lex closure leaked into BS but linear scan still
+            // calls compare()", we use the BS-dominated block (see
+            // `build_block_bs_dominated`) and assert count >= DYN_MIN_PROBES,
+            // which is impossible to reach from linear-scan calls alone.
+            let data_block = build_block_bs_dominated()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = data_block.iter(cmp);
+                let _ = iter.seek_upper(&needle, SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= DYN_MIN_PROBES,
+                "seek_upper dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                 (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn data_block_seek_upper_exclusive_dyn_path_invokes_compare() -> crate::Result<()> {
+            // Same isolation strategy as `seek_upper`: BS-dominated block makes
+            // BS predicate count impossible to fake from linear-scan-only calls.
+            let data_block = build_block_bs_dominated()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = data_block.iter(cmp);
+                let _ = iter.seek_upper_exclusive(&needle, SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= DYN_MIN_PROBES,
+                "seek_upper_exclusive dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                 (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
+            );
+            Ok(())
+        }
+
+        // Smaller block reused by the equivalence test where boundary needles
+        // matter more than BS-vs-scan call-count discrimination.
+        fn build_block_for_equivalence() -> crate::Result<DataBlock> {
             let items: Vec<_> = (0_u64..64)
                 .map(|i| InternalValue::from_components(i.to_be_bytes(), "", 0, Value))
                 .collect();
@@ -1489,73 +1660,13 @@ mod tests {
             }))
         }
 
-        fn run_seeks(data_block: &DataBlock, cmp: Arc<dyn UserComparator>) {
-            // Exercise all three devirtualized entry points:
-            //   - seek_to_key_seqno via seek()
-            //   - seek_upper
-            //   - seek_upper_exclusive
-            let needle = 32_u64.to_be_bytes();
-            {
-                let mut iter = data_block.iter(cmp.clone());
-                let _ = iter.seek(&needle, SeqNo::MAX);
-            }
-            {
-                let mut iter = data_block.iter(cmp.clone());
-                let _ = iter.seek_upper(&needle, SeqNo::MAX);
-            }
-            {
-                let mut iter = data_block.iter(cmp);
-                let _ = iter.seek_upper_exclusive(&needle, SeqNo::MAX);
-            }
-        }
-
-        #[test]
-        fn data_block_seek_lex_path_skips_vtable() -> crate::Result<()> {
-            // is_lexicographic() == true should route all 3 seek entry points
-            // through the static-dispatch closures — comparator.compare() must
-            // never be invoked.
-            let data_block = build_block()?;
-            let count = Arc::new(AtomicUsize::new(0));
-            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
-                count: count.clone(),
-                lex: true,
-            });
-            run_seeks(&data_block, cmp);
-            assert_eq!(
-                count.load(AtomicOrdering::Relaxed),
-                0,
-                "lex path must skip vtable: no compare() calls expected, got {}",
-                count.load(AtomicOrdering::Relaxed),
-            );
-            Ok(())
-        }
-
-        #[test]
-        fn data_block_seek_dyn_path_invokes_compare() -> crate::Result<()> {
-            // is_lexicographic() == false must keep using the dynamic path —
-            // compare() invocations must be > 0 for any non-trivial seek.
-            let data_block = build_block()?;
-            let count = Arc::new(AtomicUsize::new(0));
-            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
-                count: count.clone(),
-                lex: false,
-            });
-            run_seeks(&data_block, cmp);
-            let n = count.load(AtomicOrdering::Relaxed);
-            assert!(
-                n > 0,
-                "dyn path must call compare() during binary search, got {n}",
-            );
-            Ok(())
-        }
-
         #[test]
         fn data_block_seek_lex_and_dyn_agree_on_landing_position() -> crate::Result<()> {
             // Equivalence check: lex and dyn paths must produce IDENTICAL
             // landing positions for every probe. If the lex closure ever
             // disagrees with `compare() != Greater` semantics (e.g. wrong
             // operator), this test catches it before integration suites do.
-            let data_block = build_block()?;
+            let data_block = build_block_for_equivalence()?;
             let lex: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: Arc::new(AtomicUsize::new(0)),
                 lex: true,

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1420,4 +1420,179 @@ mod tests {
 
         Ok(())
     }
+
+    // Regression tests for binary-search-predicate devirtualization on the
+    // lexicographic fast path.
+    //
+    // The implementation branches once on `cmp.is_lexicographic()` per seek
+    // entry point and picks a closure that does direct slice comparison on
+    // the lex path (no vtable). These tests use a counting comparator
+    // wrapper to ASSERT that:
+    //   1. when `is_lexicographic() == true`, the comparator's `compare()`
+    //      is never invoked during the binary-search probe loop (lex closure
+    //      bypasses it)
+    //   2. when `is_lexicographic() == false`, `compare()` IS invoked
+    //      (preserves correctness for custom orderings)
+    //
+    // Behavioural-equivalence between lex and dyn paths is already exercised
+    // by the broader `custom_comparator*` integration tests; these tests
+    // specifically guard against accidental fallback into the dyn path on
+    // the default comparator (which would silently regress performance
+    // without any observable test failure).
+    mod devirt {
+        use crate::comparator::UserComparator;
+        use crate::{
+            Checksum, InternalValue, SeqNo, Slice,
+            ValueType::Value,
+            table::{
+                Block, DataBlock,
+                block::{BlockType, Header, ParsedItem},
+            },
+        };
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        struct CountingComparator {
+            count: Arc<AtomicUsize>,
+            lex: bool,
+        }
+
+        impl UserComparator for CountingComparator {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+            fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+                self.count.fetch_add(1, AtomicOrdering::Relaxed);
+                a.cmp(b)
+            }
+            fn is_lexicographic(&self) -> bool {
+                self.lex
+            }
+        }
+
+        fn build_block() -> crate::Result<DataBlock> {
+            // 64 keys → forces multiple restart intervals at any reasonable
+            // restart_interval, guaranteeing the binary-search probe loop
+            // runs at least 2 iterations (log2(8 restarts) = 3 probes).
+            let items: Vec<_> = (0_u64..64)
+                .map(|i| InternalValue::from_components(i.to_be_bytes(), "", 0, Value))
+                .collect();
+            let bytes = DataBlock::encode_into_vec(&items, 8, 1.33)?;
+            Ok(DataBlock::new(Block {
+                data: bytes.into(),
+                header: Header {
+                    block_type: BlockType::Data,
+                    checksum: Checksum::from_raw(0),
+                    data_length: 0,
+                    uncompressed_length: 0,
+                },
+            }))
+        }
+
+        fn run_seeks(data_block: &DataBlock, cmp: Arc<dyn UserComparator>) {
+            // Exercise all three devirtualized entry points:
+            //   - seek_to_key_seqno via seek()
+            //   - seek_upper
+            //   - seek_upper_exclusive
+            let needle = 32_u64.to_be_bytes();
+            {
+                let mut iter = data_block.iter(cmp.clone());
+                let _ = iter.seek(&needle, SeqNo::MAX);
+            }
+            {
+                let mut iter = data_block.iter(cmp.clone());
+                let _ = iter.seek_upper(&needle, SeqNo::MAX);
+            }
+            {
+                let mut iter = data_block.iter(cmp);
+                let _ = iter.seek_upper_exclusive(&needle, SeqNo::MAX);
+            }
+        }
+
+        #[test]
+        fn data_block_seek_lex_path_skips_vtable() -> crate::Result<()> {
+            // is_lexicographic() == true should route all 3 seek entry points
+            // through the static-dispatch closures — comparator.compare() must
+            // never be invoked.
+            let data_block = build_block()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: true,
+            });
+            run_seeks(&data_block, cmp);
+            assert_eq!(
+                count.load(AtomicOrdering::Relaxed),
+                0,
+                "lex path must skip vtable: no compare() calls expected, got {}",
+                count.load(AtomicOrdering::Relaxed),
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn data_block_seek_dyn_path_invokes_compare() -> crate::Result<()> {
+            // is_lexicographic() == false must keep using the dynamic path —
+            // compare() invocations must be > 0 for any non-trivial seek.
+            let data_block = build_block()?;
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            run_seeks(&data_block, cmp);
+            let n = count.load(AtomicOrdering::Relaxed);
+            assert!(
+                n > 0,
+                "dyn path must call compare() during binary search, got {n}",
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn data_block_seek_lex_and_dyn_agree_on_landing_position() -> crate::Result<()> {
+            // Equivalence check: lex and dyn paths must produce IDENTICAL
+            // landing positions for every probe. If the lex closure ever
+            // disagrees with `compare() != Greater` semantics (e.g. wrong
+            // operator), this test catches it before integration suites do.
+            let data_block = build_block()?;
+            let lex: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: Arc::new(AtomicUsize::new(0)),
+                lex: true,
+            });
+            let dyn_cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: Arc::new(AtomicUsize::new(0)),
+                lex: false,
+            });
+
+            // Probe a range of needles: below-min, exact-match, between-keys,
+            // exact-tail, above-max. These cover the partition_point boundary
+            // cases (left==0, left==len, mid hits exact key).
+            for needle_val in &[0_u64, 17, 32, 47, 63, 100] {
+                let needle = needle_val.to_be_bytes();
+
+                let mut lex_iter = data_block.iter(lex.clone());
+                let lex_seek = lex_iter.seek(&needle, SeqNo::MAX);
+                let lex_landing = lex_iter
+                    .next()
+                    .map(|e| Slice::from(e.materialize(data_block.as_slice()).key.user_key));
+
+                let mut dyn_iter = data_block.iter(dyn_cmp.clone());
+                let dyn_seek = dyn_iter.seek(&needle, SeqNo::MAX);
+                let dyn_landing = dyn_iter
+                    .next()
+                    .map(|e| Slice::from(e.materialize(data_block.as_slice()).key.user_key));
+
+                assert_eq!(
+                    lex_seek, dyn_seek,
+                    "seek result must match for needle {needle_val}",
+                );
+                assert_eq!(
+                    lex_landing, dyn_landing,
+                    "landing position must match for needle {needle_val}",
+                );
+            }
+            Ok(())
+        }
+    }
 }

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1442,7 +1442,7 @@ mod tests {
     mod devirt {
         use crate::comparator::UserComparator;
         use crate::{
-            Checksum, InternalValue, SeqNo, Slice,
+            Checksum, InternalValue, SeqNo,
             ValueType::Value,
             table::{
                 Block, DataBlock,
@@ -1575,13 +1575,13 @@ mod tests {
                 let lex_seek = lex_iter.seek(&needle, SeqNo::MAX);
                 let lex_landing = lex_iter
                     .next()
-                    .map(|e| Slice::from(e.materialize(data_block.as_slice()).key.user_key));
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
 
                 let mut dyn_iter = data_block.iter(dyn_cmp.clone());
                 let dyn_seek = dyn_iter.seek(&needle, SeqNo::MAX);
                 let dyn_landing = dyn_iter
                     .next()
-                    .map(|e| Slice::from(e.materialize(data_block.as_slice()).key.user_key));
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
 
                 assert_eq!(
                     lex_seek, dyn_seek,

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1510,10 +1510,35 @@ mod tests {
             }))
         }
 
-        /// Minimum number of `compare()` calls a working dyn path is expected
-        /// to make for any single seek on the BS-dominated block. See
-        /// [`build_block_bs_dominated`] for the math.
-        const DYN_MIN_PROBES: usize = 2;
+        /// Minimum number of `compare()` calls a working dyn binary-search
+        /// is expected to make on the BS-dominated block: `⌈log2(128)⌉ = 7`
+        /// probes against restart heads.
+        ///
+        /// Discrimination math (paired with an ABOVE-MAX needle in the
+        /// dyn tests for `seek_upper` / `seek_upper_exclusive`):
+        ///   - working dyn path:  7 BS probes + 1 linear-scan `compare_key` = 8
+        ///   - lex closure leak:  0 BS probes + 1 linear-scan `compare_key` = 1
+        ///
+        /// `assert delta >= 7` cleanly catches the lex-leak even after
+        /// accounting for the bounded linear-scan contribution. A weaker
+        /// threshold (e.g. `>= 2`) would fail to discriminate for needles
+        /// that produce 2+ linear-scan calls — for example an exact-key
+        /// needle hits in `seek_upper_exclusive` reverse scan
+        /// (Equal-skip then Less-return), which can satisfy `>= 2` even
+        /// when the BS predicate accidentally took the lex path.
+        const DYN_MIN_BS_PROBES: usize = 7;
+
+        /// Builds a needle that sorts strictly above the maximum encoded
+        /// key (key 127 in [`build_block_bs_dominated`]). Choosing this
+        /// needle bounds the reverse linear-scan contribution to exactly
+        /// 1 `compare_key` call (`peek_back` lands on key 127 → Less →
+        /// returns immediately), keeping the dyn / lex-leak discrimination
+        /// math above clean.
+        fn above_max_needle() -> Vec<u8> {
+            let mut v = 127_u64.to_be_bytes().to_vec();
+            v.push(0xFF);
+            v
+        }
 
         #[test]
         fn data_block_seek_lex_path_skips_vtable() -> crate::Result<()> {
@@ -1593,9 +1618,9 @@ mod tests {
         #[test]
         fn data_block_seek_to_key_seqno_dyn_path_invokes_compare() -> crate::Result<()> {
             // `seek_to_key_seqno` is the FORWARD seqno-aware binary search
-            // exposed without an attached linear scan — perfect isolation for
-            // the BS predicate. Any non-zero `compare()` call here proves the
-            // dyn closure ran for the forward BS predicate.
+            // exposed WITHOUT an attached linear scan — perfect isolation
+            // for the BS predicate. Working dyn path → exactly 7 BS probes.
+            // Lex closure leak → 0 calls.
             let data_block = build_block_bs_dominated()?;
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
@@ -1612,21 +1637,26 @@ mod tests {
             }
             let delta = count.load(AtomicOrdering::Relaxed) - before;
             assert!(
-                delta >= 1,
-                "seek_to_key_seqno dyn BS must call compare(), got {delta} (lex closure leaked into dyn path?)",
+                delta >= DYN_MIN_BS_PROBES,
+                "seek_to_key_seqno dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times \
+                 (log2(128 restart heads) probes, no linear scan), got {delta} — lex closure leaked into dyn BS?",
             );
             Ok(())
         }
 
         #[test]
         fn data_block_seek_upper_dyn_path_invokes_compare() -> crate::Result<()> {
-            // `seek_upper` does binary search + linear scan. In dyn path the
-            // linear scan also calls `compare_key` (which then calls
-            // `cmp.compare()` via its own dyn branch). To rule out the
-            // false-positive "lex closure leaked into BS but linear scan still
-            // calls compare()", we use the BS-dominated block (see
-            // `build_block_bs_dominated`) and assert count >= DYN_MIN_PROBES,
-            // which is impossible to reach from linear-scan calls alone.
+            // `seek_upper` does binary search + reverse linear scan. In dyn
+            // path the linear scan also calls `compare_key` (which goes
+            // through `cmp.compare()` via its own dyn branch). To prevent
+            // the linear scan from inflating the count to a value that a
+            // lex-BS-leak could also reach via scan-only contribution, we
+            // use an ABOVE-MAX needle (see `above_max_needle`): BS lands on
+            // key 127, peek_back returns key 127, compare_key → Less → loop
+            // exits → exactly 1 linear-scan call.
+            //
+            //   working dyn:  7 BS probes + 1 linear = 8  ✓ delta >= 7
+            //   lex-leak:     0 BS probes + 1 linear = 1  ✗ delta >= 7
             let data_block = build_block_bs_dominated()?;
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
@@ -1634,7 +1664,7 @@ mod tests {
                 is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             {
@@ -1643,8 +1673,8 @@ mod tests {
             }
             let delta = count.load(AtomicOrdering::Relaxed) - before;
             assert!(
-                delta >= DYN_MIN_PROBES,
-                "seek_upper dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                delta >= DYN_MIN_BS_PROBES,
+                "seek_upper dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times \
                  (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
             );
             Ok(())
@@ -1652,8 +1682,17 @@ mod tests {
 
         #[test]
         fn data_block_seek_upper_exclusive_dyn_path_invokes_compare() -> crate::Result<()> {
-            // Same isolation strategy as `seek_upper`: BS-dominated block makes
-            // BS predicate count impossible to fake from linear-scan-only calls.
+            // Same above-max-needle strategy as `seek_upper`. For
+            // `seek_upper_exclusive` (last key < needle) with needle
+            // above-max: BS lands on key 127, peek_back returns key 127,
+            // compare_key → Less → return true. Exactly 1 linear-scan call.
+            //
+            // The earlier version used `needle = 64` (exact-key match),
+            // which caused the reverse scan to consume Equal (key 64) THEN
+            // continue to key 63 (Less, return) — 2 linear calls. With the
+            // old `>= 2` threshold, a leaked-lex BS would still pass
+            // (0 + 2 = 2). The above-max needle bounds linear contribution
+            // to 1, restoring the discrimination math.
             let data_block = build_block_bs_dominated()?;
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
@@ -1661,7 +1700,7 @@ mod tests {
                 is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             {
@@ -1670,8 +1709,8 @@ mod tests {
             }
             let delta = count.load(AtomicOrdering::Relaxed) - before;
             assert!(
-                delta >= DYN_MIN_PROBES,
-                "seek_upper_exclusive dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                delta >= DYN_MIN_BS_PROBES,
+                "seek_upper_exclusive dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times \
                  (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
             );
             Ok(())

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1456,20 +1456,26 @@ mod tests {
             /// Counts `compare()` invocations — proves the lex devirt path
             /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
-            /// Counts `is_lexicographic()` invocations. This is a sanity
-            /// counter — it asserts the comparator was actually consulted,
-            /// guarding against the false-negative where `count == 0`
-            /// trivially because the seek never reached any branch that
-            /// touches the comparator (empty block, early bail-out, etc.).
+            /// Counts `is_lexicographic()` invocations. Sanity counter that
+            /// asserts the BS predicate factories in `iter.rs` actually
+            /// consulted `is_lexicographic()` to select a closure — guards
+            /// the false-negative where the lex test's `count <=
+            /// LEX_PATH_LINEAR_SCAN_BOUND` assertion passes trivially
+            /// because no seeks ran at all.
             ///
-            /// NOTE: `is_lex_count > 0` does NOT prove the BS predicate
-            /// factory took the lex branch — the no-prefix `compare_key`
-            /// fast path in `data_block/mod.rs` ALSO calls
-            /// `is_lexicographic()` once per linear-scan step, so this
-            /// counter can be incremented by either source. The TRUE proof
-            /// that the lex BS predicate ran is `count == 0` (no
-            /// `compare()` vtable invocations — a regression that selected
-            /// the dyn branch would call `compare()` and increment `count`).
+            /// After the review-driven revert of the `compare_key`
+            /// no-prefix lex fast path, the ONLY remaining `is_lex` call
+            /// sites are:
+            ///   - BS predicate construction sites in iter.rs (one call per
+            ///     seek entry point, hoisted out of the BS loop)
+            ///   - `compare_prefixed_slice` in util.rs (per-item, prefix
+            ///     branch only — not exercised by our tests' simple keys)
+            ///
+            /// So `is_lex_count > 0` reliably indicates a BS predicate
+            /// factory ran. The TRUE proof that it selected the LEX
+            /// closure is `count <= LEX_PATH_LINEAR_SCAN_BOUND` (a dyn
+            /// closure would produce >= `DYN_MIN_BS_PROBES` calls from BS
+            /// probes alone).
             is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
@@ -1496,8 +1502,12 @@ mod tests {
         ///     IS an item, so the scan either returns immediately or steps once)
         ///
         /// Discrimination math (paired with an above-max needle that bounds
-        /// the reverse linear-scan contribution to exactly 1 `compare_key`
-        /// call — see [`above_max_needle`]):
+        /// the linear-scan contribution to <= 1 `compare_key` call — see
+        /// [`above_max_needle`]). Note: after a review-driven revert, the
+        /// no-prefix `compare_key` branch in `data_block/mod.rs` no longer
+        /// has a lex fast path, so each linear-scan step calls
+        /// `cmp.compare()` regardless of `is_lexicographic()`. This makes
+        /// the discrimination explicit:
         ///   - dyn path working correctly: 7 (BS) + 1 (scan) = 8
         ///   - lex closure leaked into dyn BS: 0 (BS) + 1 (scan) = 1
         ///
@@ -1553,13 +1563,26 @@ mod tests {
             v
         }
 
+        /// Upper bound on `compare()` calls a lex-path seek can produce from
+        /// the LINEAR-SCAN `compare_key` calls alone (BS predicate makes 0
+        /// calls when lex closure is correctly selected). With above-max
+        /// needle on a 128-key block (`restart_interval=1`), each entry point's
+        /// linear scan visits exactly 1 item before returning. A regression
+        /// where BS fell back to the dyn closure would produce
+        /// `>= DYN_MIN_BS_PROBES` (= 7) calls — far above this bound.
+        const LEX_PATH_LINEAR_SCAN_BOUND: usize = 2;
+
         #[test]
         fn data_block_seek_lex_path_skips_vtable() -> crate::Result<()> {
-            // is_lexicographic() == true must route ALL 3 devirtualized entry
-            // points through the static-dispatch closures. Snapshotting count
-            // per-entry-point (instead of a single end-of-test check) localises
-            // a regression to the offending entry point and catches the case
-            // where only one closure accidentally falls back to the dyn path.
+            // is_lexicographic() == true must route ALL 3 devirtualized BS
+            // predicates through the static-dispatch closures. Per-entry-point
+            // snapshot localises a regression to the offending entry point.
+            //
+            // Above-max needle bounds each entry point's linear-scan compare_key
+            // contribution to <= 1 call. A working lex path produces
+            // count <= LEX_PATH_LINEAR_SCAN_BOUND; a regression where the dyn
+            // closure leaked into the BS predicate would produce
+            // >= DYN_MIN_BS_PROBES (= 7) calls — orders-of-magnitude separation.
             let data_block = build_block_bs_dominated()?;
             let count = Arc::new(AtomicUsize::new(0));
             let is_lex_count = Arc::new(AtomicUsize::new(0));
@@ -1568,7 +1591,7 @@ mod tests {
                 is_lex_count: is_lex_count.clone(),
                 lex: true,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             let before_lex = is_lex_count.load(AtomicOrdering::Relaxed);
@@ -1578,11 +1601,10 @@ mod tests {
             }
             let after_seek = count.load(AtomicOrdering::Relaxed);
             let after_seek_lex = is_lex_count.load(AtomicOrdering::Relaxed);
-            assert_eq!(
-                after_seek - before,
-                0,
-                "seek (forward seqno-aware) lex path leaked into dyn: {} compare() calls",
-                after_seek - before,
+            let seek_delta = after_seek - before;
+            assert!(
+                seek_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "seek (forward seqno-aware) lex path leaked into dyn BS: {seek_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND}, only linear-scan contribution)",
             );
             assert!(
                 after_seek_lex - before_lex >= 1,
@@ -1596,11 +1618,10 @@ mod tests {
             }
             let after_upper = count.load(AtomicOrdering::Relaxed);
             let after_upper_lex = is_lex_count.load(AtomicOrdering::Relaxed);
-            assert_eq!(
-                after_upper - after_seek,
-                0,
-                "seek_upper lex path leaked into dyn: {} compare() calls",
-                after_upper - after_seek,
+            let upper_delta = after_upper - after_seek;
+            assert!(
+                upper_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "seek_upper lex path leaked into dyn BS: {upper_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND})",
             );
             assert!(
                 after_upper_lex - after_seek_lex >= 1,
@@ -1614,11 +1635,10 @@ mod tests {
             }
             let after_excl = count.load(AtomicOrdering::Relaxed);
             let after_excl_lex = is_lex_count.load(AtomicOrdering::Relaxed);
-            assert_eq!(
-                after_excl - after_upper,
-                0,
-                "seek_upper_exclusive lex path leaked into dyn: {} compare() calls",
-                after_excl - after_upper,
+            let excl_delta = after_excl - after_upper;
+            assert!(
+                excl_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "seek_upper_exclusive lex path leaked into dyn BS: {excl_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND})",
             );
             assert!(
                 after_excl_lex - after_upper_lex >= 1,
@@ -1850,16 +1870,21 @@ mod tests {
                     "seek_upper landing must match for needle {label} ({needle:?})",
                 );
 
-                // seek_upper_exclusive (reverse, exclusive — last key < needle)
+                // seek_upper_exclusive (reverse, exclusive — last key < needle).
+                // The method positions the REVERSE cursor (its internal loop
+                // uses peek_back/next_back), so the landed item must be read
+                // via next_back() — calling next() would observe the unchanged
+                // FORWARD cursor and miss a wrong-operator regression in the
+                // lex closure of this entry point.
                 let mut lex_iter = data_block.iter(lex.clone());
                 let lex_excl = lex_iter.seek_upper_exclusive(needle, SeqNo::MAX);
                 let lex_excl_landing = lex_iter
-                    .next()
+                    .next_back()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
                 let mut dyn_iter = data_block.iter(dyn_cmp.clone());
                 let dyn_excl = dyn_iter.seek_upper_exclusive(needle, SeqNo::MAX);
                 let dyn_excl_landing = dyn_iter
-                    .next()
+                    .next_back()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
                 assert_eq!(
                     lex_excl, dyn_excl,

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1456,13 +1456,20 @@ mod tests {
             /// Counts `compare()` invocations — proves the lex devirt path
             /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
-            /// Counts `is_lexicographic()` invocations. The lex devirt
-            /// strategy gates each entry point on `is_lexicographic()`, so
-            /// this counter PROVES the lex branch was actually selected (a
-            /// regression that always selected the dyn branch would leave
-            /// this at 0 in lex tests AND keep `count` at 0, both passing
-            /// the original weaker assertion). Required to fully discriminate
-            /// "lex branch ran" from "no seeks happened at all".
+            /// Counts `is_lexicographic()` invocations. This is a sanity
+            /// counter — it asserts the comparator was actually consulted,
+            /// guarding against the false-negative where `count == 0`
+            /// trivially because the seek never reached any branch that
+            /// touches the comparator (empty block, early bail-out, etc.).
+            ///
+            /// NOTE: `is_lex_count > 0` does NOT prove the BS predicate
+            /// factory took the lex branch — the no-prefix `compare_key`
+            /// fast path in `data_block/mod.rs` ALSO calls
+            /// `is_lexicographic()` once per linear-scan step, so this
+            /// counter can be incremented by either source. The TRUE proof
+            /// that the lex BS predicate ran is `count == 0` (no
+            /// `compare()` vtable invocations — a regression that selected
+            /// the dyn branch would call `compare()` and increment `count`).
             is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
@@ -1797,26 +1804,70 @@ mod tests {
                 ("above-max (key 63 + 0xFF)", above_max),
             ];
 
+            // Exercise all three devirtualized entry points against the
+            // same boundary needle table. Each entry point has a distinct
+            // predicate shape (forward seqno-aware 3-way, reverse `<=`,
+            // reverse `<`), so call-count assertions alone wouldn't catch
+            // a `<` vs `<=` landing mismatch.
             for (label, needle) in &needles {
+                // seek (forward seqno-aware, inclusive)
                 let mut lex_iter = data_block.iter(lex.clone());
                 let lex_seek = lex_iter.seek(needle, SeqNo::MAX);
                 let lex_landing = lex_iter
                     .next()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
-
                 let mut dyn_iter = data_block.iter(dyn_cmp.clone());
                 let dyn_seek = dyn_iter.seek(needle, SeqNo::MAX);
                 let dyn_landing = dyn_iter
                     .next()
                     .map(|e| e.materialize(data_block.as_slice()).key.user_key);
-
                 assert_eq!(
                     lex_seek, dyn_seek,
                     "seek result must match for needle {label} ({needle:?})",
                 );
                 assert_eq!(
                     lex_landing, dyn_landing,
-                    "landing position must match for needle {label} ({needle:?})",
+                    "seek landing must match for needle {label} ({needle:?})",
+                );
+
+                // seek_upper (reverse, inclusive — last key <= needle)
+                let mut lex_iter = data_block.iter(lex.clone());
+                let lex_upper = lex_iter.seek_upper(needle, SeqNo::MAX);
+                let lex_upper_landing = lex_iter
+                    .next_back()
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
+                let mut dyn_iter = data_block.iter(dyn_cmp.clone());
+                let dyn_upper = dyn_iter.seek_upper(needle, SeqNo::MAX);
+                let dyn_upper_landing = dyn_iter
+                    .next_back()
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
+                assert_eq!(
+                    lex_upper, dyn_upper,
+                    "seek_upper result must match for needle {label} ({needle:?})",
+                );
+                assert_eq!(
+                    lex_upper_landing, dyn_upper_landing,
+                    "seek_upper landing must match for needle {label} ({needle:?})",
+                );
+
+                // seek_upper_exclusive (reverse, exclusive — last key < needle)
+                let mut lex_iter = data_block.iter(lex.clone());
+                let lex_excl = lex_iter.seek_upper_exclusive(needle, SeqNo::MAX);
+                let lex_excl_landing = lex_iter
+                    .next()
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
+                let mut dyn_iter = data_block.iter(dyn_cmp.clone());
+                let dyn_excl = dyn_iter.seek_upper_exclusive(needle, SeqNo::MAX);
+                let dyn_excl_landing = dyn_iter
+                    .next()
+                    .map(|e| e.materialize(data_block.as_slice()).key.user_key);
+                assert_eq!(
+                    lex_excl, dyn_excl,
+                    "seek_upper_exclusive result must match for needle {label} ({needle:?})",
+                );
+                assert_eq!(
+                    lex_excl_landing, dyn_excl_landing,
+                    "seek_upper_exclusive landing must match for needle {label} ({needle:?})",
                 );
             }
             Ok(())

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1488,12 +1488,18 @@ mod tests {
         ///   - linear scan after BS lands: 0-1 iterations (each restart head
         ///     IS an item, so the scan either returns immediately or steps once)
         ///
-        /// Discrimination math:
-        ///   - dyn path working correctly: count >= 7 (BS) + 0..1 (scan)
-        ///   - lex closure leaked into dyn BS: count = 0 (BS) + 0..1 (scan) ≤ 1
+        /// Discrimination math (paired with an above-max needle that bounds
+        /// the reverse linear-scan contribution to exactly 1 `compare_key`
+        /// call — see [`above_max_needle`]):
+        ///   - dyn path working correctly: 7 (BS) + 1 (scan) = 8
+        ///   - lex closure leaked into dyn BS: 0 (BS) + 1 (scan) = 1
         ///
-        /// `assert count >= 2` cleanly distinguishes the two cases, ruling out
-        /// the linear-scan-only false-positive that a naive `> 0` would miss.
+        /// `assert delta >= DYN_MIN_BS_PROBES` (= 7) cleanly distinguishes
+        /// the two cases. Earlier rounds of this test used `>= 2`, which
+        /// was matchable by a working linear scan alone for exact-key
+        /// needles (e.g. `seek_upper_exclusive` reverse scan: Equal-skip
+        /// then Less-return = 2 `compare_key` calls). The above-max needle
+        /// + 7-probe threshold rules out that false positive.
         fn build_block_bs_dominated() -> crate::Result<DataBlock> {
             let items: Vec<_> = (0_u64..128)
                 .map(|i| InternalValue::from_components(i.to_be_bytes(), "", 0, Value))

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -334,20 +334,20 @@ impl ParsedItem<InternalValue> for DataBlockParsedItem {
             let rest_key = unsafe { bytes.get_unchecked(self.key.0..self.key.1) };
             compare_prefixed_slice(prefix, rest_key, needle, cmp)
         } else {
+            // The no-prefix branch has no allocation to avoid — `compare()` on
+            // a contiguous slice is already optimal for any comparator. Adding
+            // an `is_lexicographic()` short-circuit here costs custom
+            // comparators an extra `dyn` vtable call per linear-scan step
+            // without any matching saving on the default path (where `<[u8]>::cmp`
+            // and `DefaultUserComparator::compare` lower to the same memcmp).
+            // The lex fast path is intentionally kept ONLY on the prefix branch
+            // above (where `compare_prefixed_slice_lexicographic` avoids the
+            // prefix+suffix concatenation allocation) and at the binary-search
+            // predicate construction sites in `iter.rs` (where one
+            // `is_lexicographic()` call is hoisted to amortise across all
+            // O(log restarts) BS probes).
             let key = unsafe { bytes.get_unchecked(self.key.0..self.key.1) };
-            // Lex fast path mirrors the prefix branch (which already
-            // short-circuits through `compare_prefixed_slice_lexicographic`):
-            // skip the `dyn UserComparator::compare` vtable call when the
-            // default comparator is in use. This branch is on the linear-scan
-            // and trim paths (e.g. `advance_while`, `trim_back_to_upper_bound`,
-            // and the linear-scan loops in `iter.rs`) — the binary-search
-            // predicates themselves are devirtualized independently at their
-            // construction sites in `iter.rs` and never reach `compare_key`.
-            if cmp.is_lexicographic() {
-                key.cmp(needle)
-            } else {
-                cmp.compare(key, needle)
-            }
+            cmp.compare(key, needle)
         }
     }
 

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -338,8 +338,11 @@ impl ParsedItem<InternalValue> for DataBlockParsedItem {
             // Lex fast path mirrors the prefix branch (which already
             // short-circuits through `compare_prefixed_slice_lexicographic`):
             // skip the `dyn UserComparator::compare` vtable call when the
-            // default comparator is in use. Restart-head probes during binary
-            // search land here every iteration.
+            // default comparator is in use. This branch is on the linear-scan
+            // and trim paths (e.g. `advance_while`, `trim_back_to_upper_bound`,
+            // and the linear-scan loops in `iter.rs`) — the binary-search
+            // predicates themselves are devirtualized independently at their
+            // construction sites in `iter.rs` and never reach `compare_key`.
             if cmp.is_lexicographic() {
                 key.cmp(needle)
             } else {

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -335,7 +335,16 @@ impl ParsedItem<InternalValue> for DataBlockParsedItem {
             compare_prefixed_slice(prefix, rest_key, needle, cmp)
         } else {
             let key = unsafe { bytes.get_unchecked(self.key.0..self.key.1) };
-            cmp.compare(key, needle)
+            // Lex fast path mirrors the prefix branch (which already
+            // short-circuits through `compare_prefixed_slice_lexicographic`):
+            // skip the `dyn UserComparator::compare` vtable call when the
+            // default comparator is in use. Restart-head probes during binary
+            // search land here every iteration.
+            if cmp.is_lexicographic() {
+                key.cmp(needle)
+            } else {
+                cmp.compare(key, needle)
+            }
         }
     }
 

--- a/src/table/index_block/iter.rs
+++ b/src/table/index_block/iter.rs
@@ -49,14 +49,30 @@ impl<'a> Iter<'a> {
             self.decoder.reset_back_peeked();
             self.decoder.inner_mut().reset_back_cursor();
         }
-        if !self.decoder.inner_mut().seek(
-            |end_key, s| match cmp.compare(end_key, needle) {
-                std::cmp::Ordering::Greater => false,
-                std::cmp::Ordering::Less => true,
-                std::cmp::Ordering::Equal => s >= seqno,
-            },
-            true,
-        ) {
+        // Lex fast path skips the `dyn UserComparator::compare` vtable in the
+        // binary-search probe loop. Each closure is a distinct type, so
+        // `Decoder::seek` monomorphizes per-shape and the inner loop is
+        // virtual-call-free when the default lexicographic comparator is in use.
+        let landed = if cmp.is_lexicographic() {
+            self.decoder.inner_mut().seek(
+                |end_key, s| match end_key.cmp(needle) {
+                    std::cmp::Ordering::Greater => false,
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Equal => s >= seqno,
+                },
+                true,
+            )
+        } else {
+            self.decoder.inner_mut().seek(
+                |end_key, s| match cmp.compare(end_key, needle) {
+                    std::cmp::Ordering::Greater => false,
+                    std::cmp::Ordering::Less => true,
+                    std::cmp::Ordering::Equal => s >= seqno,
+                },
+                true,
+            )
+        };
+        if !landed {
             return false;
         }
 
@@ -105,15 +121,26 @@ impl<'a> Iter<'a> {
             self.decoder.reset_back_peeked();
         }
         let restart_interval = self.decoder.inner_mut().restart_interval();
+        // Same devirtualization strategy as `seek_with_cache_resets`: split on
+        // `is_lexicographic()` so the inner binary-search predicate is a static
+        // slice comparison on the lex path. The three predicate shapes (strict <,
+        // ≤, ≤) each get their own pair of monomorphizations.
+        let lex = cmp.is_lexicographic();
         let found = if restart_interval == 1 {
             if check_back_cache {
                 // BACK CURSOR (reverse iteration): find the first block whose
                 // end_key ≥ needle.  Using strict-less here together with
                 // partition_point_2 lands exactly on that block.
-                self.decoder.inner_mut().seek_upper(
-                    |end_key, _s| cmp.compare(end_key, needle) == std::cmp::Ordering::Less,
-                    true,
-                )
+                if lex {
+                    self.decoder
+                        .inner_mut()
+                        .seek_upper(|end_key, _s| end_key < needle, true)
+                } else {
+                    self.decoder.inner_mut().seek_upper(
+                        |end_key, _s| cmp.compare(end_key, needle) == std::cmp::Ordering::Less,
+                        true,
+                    )
+                }
             } else {
                 // FORWARD LIMIT (upper-bound for forward scan): we must include
                 // *all* blocks whose end_key ≤ needle (they may contain entries
@@ -125,11 +152,21 @@ impl<'a> Iter<'a> {
                 // pure-merge scenario with 4 000 operands for one user_key),
                 // the predicate is true for every entry so partition_point_2
                 // returns the last entry — allowing all blocks to be visited.
-                self.decoder.inner_mut().seek_upper(
-                    |end_key, _s| cmp.compare(end_key, needle) != std::cmp::Ordering::Greater,
-                    true,
-                )
+                if lex {
+                    self.decoder
+                        .inner_mut()
+                        .seek_upper(|end_key, _s| end_key <= needle, true)
+                } else {
+                    self.decoder.inner_mut().seek_upper(
+                        |end_key, _s| cmp.compare(end_key, needle) != std::cmp::Ordering::Greater,
+                        true,
+                    )
+                }
             }
+        } else if lex {
+            self.decoder
+                .inner_mut()
+                .seek_upper(|end_key, _s| end_key <= needle, true)
         } else {
             self.decoder.inner_mut().seek_upper(
                 |end_key, _s| cmp.compare(end_key, needle) != std::cmp::Ordering::Greater,

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -351,13 +351,16 @@ mod tests {
         /// Build an index block tuned to make BS probes dominate any potential
         /// linear-scan contribution:
         ///   - 128 handles with distinct sortable `end_key`s
-        ///   - `restart_interval=1` → each handle IS a restart head
-        ///   - binary search: log2(128) = 7 probes minimum
-        ///   - linear scan after BS lands: 0-1 iterations
+        ///   - `restart_interval=1` → each handle IS a restart head, AND
+        ///     the `advance_while` / `trim_back_to_upper_bound` linear-scan
+        ///     branches in `seek_with_cache_resets` / `seek_upper_impl` are
+        ///     bypassed entirely (those are gated on `restart_interval > 1`)
+        ///   - binary search: log2(128) = 7 probes
         ///
-        /// `assert count >= 2` then cleanly distinguishes the lex-leak case
-        /// (BS contributes 0, scan contributes at most 1) from a working
-        /// dyn path (BS contributes >= 7).
+        /// `assert delta >= DYN_MIN_BS_PROBES` (= 7) cleanly distinguishes
+        /// the lex-leak case (BS contributes 0, no linear scan to add to
+        /// the count) from a working dyn path (BS contributes exactly 7).
+        /// See [`DYN_MIN_BS_PROBES`] for the full discrimination math.
         fn build_index_block_bs_dominated() -> IndexBlock {
             use crate::Checksum;
             use crate::table::block::{BlockType, Header};

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -681,8 +681,13 @@ mod tests {
                 );
 
                 // seek_upper (reverse upper-bound — exercises seek_upper_impl
-                // with check_back_cache=true, strict-`<` predicate at
-                // restart_interval == 1).
+                // with check_back_cache=true). This test block uses
+                // restart_interval = 4, so both check_back_cache branches
+                // land in the `restart_interval > 1` arm of seek_upper_impl
+                // which uses the same `<=` predicate. The `restart_interval
+                // == 1` branches where `<` vs `<=` predicates diverge are
+                // separately covered by the BS-dominated lex/dyn tests above
+                // (which build the index block with restart_interval = 1).
                 let mut lex_iter = index_block.iter(lex.clone());
                 let lex_upper = lex_iter.seek_upper(needle, crate::SeqNo::MAX);
                 let mut dyn_iter = index_block.iter(dyn_cmp.clone());
@@ -703,11 +708,17 @@ mod tests {
                     "index seek_upper landing must match for needle {label} ({needle:?})",
                 );
 
-                // seek_upper_bound_cursor — same seek_upper_impl but with
-                // check_back_cache=false, which selects a `<=` predicate at
-                // restart_interval == 1 instead of `<`. A wrong operator in
-                // the lex closure of THIS branch would not be caught by the
-                // public seek_upper test above.
+                // seek_upper_bound_cursor — same seek_upper_impl with
+                // check_back_cache=false. With this test block's
+                // restart_interval = 4 it shares the `restart_interval > 1`
+                // arm with the public seek_upper above. The divergent
+                // `restart_interval == 1` paths (where check_back_cache=false
+                // uses `<=` and check_back_cache=true uses strict `<`) are
+                // covered by the dedicated dyn-path and lex-path tests above
+                // that build the index block with restart_interval = 1.
+                // This arm still verifies that the lex/dyn closures agree
+                // on landing position when both seek_upper variants are
+                // routed through the shared restart_interval>1 predicate.
                 let mut lex_iter = index_block.iter(lex.clone());
                 let lex_cursor = lex_iter
                     .seek_upper_bound_cursor(needle, crate::SeqNo::MAX)

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -46,7 +46,15 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
             compare_prefixed_slice(prefix, rest_key, needle, cmp)
         } else {
             let key = unsafe { bytes.get_unchecked(self.end_key.0..self.end_key.1) };
-            cmp.compare(key, needle)
+            // Lex fast path: avoid the `dyn UserComparator::compare` vtable
+            // on the binary-search hot path (restart heads probed every
+            // iteration). The prefix branch above already short-circuits
+            // through `compare_prefixed_slice_lexicographic`.
+            if cmp.is_lexicographic() {
+                key.cmp(needle)
+            } else {
+                cmp.compare(key, needle)
+            }
         }
     }
 

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -45,20 +45,18 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
             let rest_key = unsafe { bytes.get_unchecked(self.end_key.0..self.end_key.1) };
             compare_prefixed_slice(prefix, rest_key, needle, cmp)
         } else {
+            // No allocation to avoid for a contiguous key — `compare()` is
+            // already optimal for any comparator here. The lex fast path is
+            // kept only on the prefix branch above (where
+            // `compare_prefixed_slice_lexicographic` avoids the prefix+suffix
+            // concatenation) and at the binary-search predicate construction
+            // sites in `iter.rs` (where one `is_lexicographic()` is hoisted
+            // to amortise across all BS probes). An extra `is_lexicographic()`
+            // call per linear-scan step would cost custom comparators a
+            // second vtable dispatch without any matching saving on the
+            // default path.
             let key = unsafe { bytes.get_unchecked(self.end_key.0..self.end_key.1) };
-            // Lex fast path: avoid the `dyn UserComparator::compare` vtable
-            // on the linear-scan and trim paths that iterate parsed items
-            // (e.g. `advance_while`, `trim_back_to_upper_bound`, and the
-            // linear-scan loops in `iter.rs`). The binary-search predicates
-            // themselves are devirtualized independently at their construction
-            // sites in `iter.rs` and never reach `compare_key`. The prefix
-            // branch above already short-circuits through
-            // `compare_prefixed_slice_lexicographic`.
-            if cmp.is_lexicographic() {
-                key.cmp(needle)
-            } else {
-                cmp.compare(key, needle)
-            }
+            cmp.compare(key, needle)
         }
     }
 
@@ -326,16 +324,17 @@ mod tests {
             /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
             /// Counts `is_lexicographic()` invocations. Sanity counter:
-            /// asserts the comparator was consulted at all, guarding the
-            /// false-negative where `count == 0` trivially because no
-            /// comparator-touching code ran (empty block, early bail-out).
+            /// asserts the BS predicate factory in iter.rs actually
+            /// consulted `is_lexicographic()` to pick a closure.
             ///
-            /// NOTE: `is_lex_count > 0` does NOT prove the BS predicate
-            /// factory selected the lex branch — the no-prefix `compare_key`
-            /// in `index_block/mod.rs` also calls `is_lexicographic()` per
-            /// item, so this counter can be incremented from either source.
-            /// The TRUE proof that the lex BS predicate ran is `count == 0`
-            /// (no `compare()` vtable invocations).
+            /// After the review-driven revert of the `compare_key`
+            /// no-prefix lex fast path, the only `is_lex` call site touched
+            /// by these tests is the BS predicate factory itself (one call
+            /// per seek entry point, hoisted out of the BS loop). So
+            /// `is_lex_count > 0` reliably proves the factory ran. The
+            /// TRUE proof that it selected the lex closure is
+            /// `count <= LEX_PATH_LINEAR_SCAN_BOUND` (a dyn closure would
+            /// produce >= `DYN_MIN_BS_PROBES` from BS probes alone).
             is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
@@ -414,11 +413,24 @@ mod tests {
             v
         }
 
+        /// Upper bound on `compare()` calls a lex-path index seek can produce
+        /// from non-BS sources. With `restart_interval == 1`, the index-block
+        /// `advance_while` / `trim_back_to_upper_bound` linear branches are
+        /// bypassed entirely, so this bound is effectively 0 — but we allow
+        /// a small slack for any auxiliary lookups the iterator may perform.
+        const LEX_PATH_LINEAR_SCAN_BOUND: usize = 2;
+
         #[test]
         fn index_block_seek_lex_path_skips_vtable() {
             // Both devirtualized entry points (seek, seek_upper) must route
             // through static-dispatch closures when is_lexicographic() == true.
             // Per-entry-point snapshot localises any regression.
+            // Above-max needle (paired with restart_interval=1) bounds the
+            // post-BS contribution to <= LEX_PATH_LINEAR_SCAN_BOUND across
+            // both public `seek` / `seek_upper` and the pub(crate)
+            // `seek_upper_bound_cursor` path. A regression where any of
+            // these BS predicates fell back to the dyn closure would produce
+            // >= DYN_MIN_BS_PROBES (= 7) calls — well above the bound.
             let index_block = build_index_block_bs_dominated();
             let count = Arc::new(AtomicUsize::new(0));
             let is_lex_count = Arc::new(AtomicUsize::new(0));
@@ -427,7 +439,7 @@ mod tests {
                 is_lex_count: is_lex_count.clone(),
                 lex: true,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             let before_lex = is_lex_count.load(AtomicOrdering::Relaxed);
@@ -437,11 +449,10 @@ mod tests {
             }
             let after_seek = count.load(AtomicOrdering::Relaxed);
             let after_seek_lex = is_lex_count.load(AtomicOrdering::Relaxed);
-            assert_eq!(
-                after_seek - before,
-                0,
-                "index seek lex path leaked into dyn: {} compare() calls",
-                after_seek - before,
+            let seek_delta = after_seek - before;
+            assert!(
+                seek_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "index seek lex path leaked into dyn BS: {seek_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND})",
             );
             assert!(
                 after_seek_lex - before_lex >= 1,
@@ -450,21 +461,42 @@ mod tests {
             );
 
             {
-                let mut iter = index_block.iter(cmp);
+                let mut iter = index_block.iter(cmp.clone());
                 let _ = iter.seek_upper(&needle, crate::SeqNo::MAX);
             }
             let after_upper = count.load(AtomicOrdering::Relaxed);
             let after_upper_lex = is_lex_count.load(AtomicOrdering::Relaxed);
-            assert_eq!(
-                after_upper - after_seek,
-                0,
-                "index seek_upper lex path leaked into dyn: {} compare() calls",
-                after_upper - after_seek,
+            let upper_delta = after_upper - after_seek;
+            assert!(
+                upper_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "index seek_upper lex path leaked into dyn BS: {upper_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND})",
             );
             assert!(
                 after_upper_lex - after_seek_lex >= 1,
                 "index seek_upper lex path must consult is_lexicographic(), got {} calls",
                 after_upper_lex - after_seek_lex,
+            );
+
+            // seek_upper_bound_cursor takes the OTHER branch inside
+            // seek_upper_impl at restart_interval == 1 (`check_back_cache=false`,
+            // predicate `<=` instead of `<`). The public seek_upper above only
+            // exercises check_back_cache=true; this call covers the forward-limit
+            // path used by block-index upper-bound cursors.
+            {
+                let mut iter = index_block.iter(cmp);
+                let _ = iter.seek_upper_bound_cursor(&needle, crate::SeqNo::MAX);
+            }
+            let after_cursor = count.load(AtomicOrdering::Relaxed);
+            let after_cursor_lex = is_lex_count.load(AtomicOrdering::Relaxed);
+            let cursor_delta = after_cursor - after_upper;
+            assert!(
+                cursor_delta <= LEX_PATH_LINEAR_SCAN_BOUND,
+                "index seek_upper_bound_cursor lex path leaked into dyn BS: {cursor_delta} compare() calls (expected <= {LEX_PATH_LINEAR_SCAN_BOUND})",
+            );
+            assert!(
+                after_cursor_lex - after_upper_lex >= 1,
+                "index seek_upper_bound_cursor lex path must consult is_lexicographic(), got {} calls",
+                after_cursor_lex - after_upper_lex,
             );
         }
 
@@ -519,6 +551,40 @@ mod tests {
         }
 
         #[test]
+        fn index_block_seek_upper_bound_cursor_dyn_path_invokes_compare() {
+            // The `check_back_cache == false` branch in `seek_upper_impl`
+            // uses a DIFFERENT BS predicate (`<= needle` instead of `< needle`
+            // at restart_interval == 1) than the public seek_upper. Reached
+            // only via this pub(crate) entry point — public seek_upper
+            // doesn't cover it. Verify the dyn closure for THIS predicate
+            // also invokes compare().
+            let index_block = build_index_block_bs_dominated();
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
+                lex: false,
+            });
+            let needle = above_max_needle();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = index_block.iter(cmp);
+                let _ = iter.seek_upper_bound_cursor(&needle, crate::SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= DYN_MIN_BS_PROBES,
+                "index seek_upper_bound_cursor dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times, \
+                 got {delta} — lex closure leaked into dyn BS of the check_back_cache=false predicate?",
+            );
+        }
+
+        #[test]
+        #[expect(
+            clippy::too_many_lines,
+            reason = "exhaustive equivalence matrix: 6 boundary needles × 3 entry points × (call + assert + landing-read + assert) is the actual coverage surface this test is meant to provide"
+        )]
         fn index_block_seek_lex_and_dyn_agree_on_landing_position() {
             use crate::Checksum;
             use crate::table::block::{BlockType, Header};
@@ -615,7 +681,7 @@ mod tests {
                 );
 
                 // seek_upper (reverse upper-bound — exercises seek_upper_impl
-                // which has different `<` vs `<=` predicate logic at
+                // with check_back_cache=true, strict-`<` predicate at
                 // restart_interval == 1).
                 let mut lex_iter = index_block.iter(lex.clone());
                 let lex_upper = lex_iter.seek_upper(needle, crate::SeqNo::MAX);
@@ -635,6 +701,35 @@ mod tests {
                     lex_upper_landing.as_ref().map(|s| s.as_ref().to_vec()),
                     dyn_upper_landing.as_ref().map(|s| s.as_ref().to_vec()),
                     "index seek_upper landing must match for needle {label} ({needle:?})",
+                );
+
+                // seek_upper_bound_cursor — same seek_upper_impl but with
+                // check_back_cache=false, which selects a `<=` predicate at
+                // restart_interval == 1 instead of `<`. A wrong operator in
+                // the lex closure of THIS branch would not be caught by the
+                // public seek_upper test above.
+                let mut lex_iter = index_block.iter(lex.clone());
+                let lex_cursor = lex_iter
+                    .seek_upper_bound_cursor(needle, crate::SeqNo::MAX)
+                    .unwrap();
+                let mut dyn_iter = index_block.iter(dyn_cmp.clone());
+                let dyn_cursor = dyn_iter
+                    .seek_upper_bound_cursor(needle, crate::SeqNo::MAX)
+                    .unwrap();
+                assert_eq!(
+                    lex_cursor, dyn_cursor,
+                    "index seek_upper_bound_cursor result must match for needle {label} ({needle:?})",
+                );
+                let lex_cursor_landing = lex_iter
+                    .next_back()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                let dyn_cursor_landing = dyn_iter
+                    .next_back()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                assert_eq!(
+                    lex_cursor_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    dyn_cursor_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    "index seek_upper_bound_cursor landing must match for needle {label} ({needle:?})",
                 );
             }
         }

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -47,9 +47,13 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
         } else {
             let key = unsafe { bytes.get_unchecked(self.end_key.0..self.end_key.1) };
             // Lex fast path: avoid the `dyn UserComparator::compare` vtable
-            // on the binary-search hot path (restart heads probed every
-            // iteration). The prefix branch above already short-circuits
-            // through `compare_prefixed_slice_lexicographic`.
+            // on the linear-scan and trim paths that iterate parsed items
+            // (e.g. `advance_while`, `trim_back_to_upper_bound`, and the
+            // linear-scan loops in `iter.rs`). The binary-search predicates
+            // themselves are devirtualized independently at their construction
+            // sites in `iter.rs` and never reach `compare_key`. The prefix
+            // branch above already short-circuits through
+            // `compare_prefixed_slice_lexicographic`.
             if cmp.is_lexicographic() {
                 key.cmp(needle)
             } else {
@@ -318,7 +322,15 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
         struct CountingComparator {
+            /// Counts `compare()` invocations — proves the lex devirt path
+            /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
+            /// Counts `is_lexicographic()` invocations. The lex devirt
+            /// strategy gates each entry point on `is_lexicographic()`; this
+            /// counter proves the lex branch was actually selected (a
+            /// regression that always selected the dyn branch would leave
+            /// this at 0 in lex tests AND keep `count` at 0).
+            is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
 
@@ -331,6 +343,7 @@ mod tests {
                 a.cmp(b)
             }
             fn is_lexicographic(&self) -> bool {
+                self.is_lex_count.fetch_add(1, AtomicOrdering::Relaxed);
                 self.lex
             }
         }
@@ -379,23 +392,32 @@ mod tests {
             // Per-entry-point snapshot localises any regression.
             let index_block = build_index_block_bs_dominated();
             let count = Arc::new(AtomicUsize::new(0));
+            let is_lex_count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: is_lex_count.clone(),
                 lex: true,
             });
             let needle = 64_u64.to_be_bytes();
 
             let before = count.load(AtomicOrdering::Relaxed);
+            let before_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             {
                 let mut iter = index_block.iter(cmp.clone());
                 let _ = iter.seek(&needle, crate::SeqNo::MAX);
             }
             let after_seek = count.load(AtomicOrdering::Relaxed);
+            let after_seek_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             assert_eq!(
                 after_seek - before,
                 0,
                 "index seek lex path leaked into dyn: {} compare() calls",
                 after_seek - before,
+            );
+            assert!(
+                after_seek_lex - before_lex >= 1,
+                "index seek lex path must consult is_lexicographic() to select the lex closure, got {} calls",
+                after_seek_lex - before_lex,
             );
 
             {
@@ -403,11 +425,17 @@ mod tests {
                 let _ = iter.seek_upper(&needle, crate::SeqNo::MAX);
             }
             let after_upper = count.load(AtomicOrdering::Relaxed);
+            let after_upper_lex = is_lex_count.load(AtomicOrdering::Relaxed);
             assert_eq!(
                 after_upper - after_seek,
                 0,
                 "index seek_upper lex path leaked into dyn: {} compare() calls",
                 after_upper - after_seek,
+            );
+            assert!(
+                after_upper_lex - after_seek_lex >= 1,
+                "index seek_upper lex path must consult is_lexicographic(), got {} calls",
+                after_upper_lex - after_seek_lex,
             );
         }
 
@@ -419,6 +447,7 @@ mod tests {
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
             let needle = 64_u64.to_be_bytes();
@@ -442,6 +471,7 @@ mod tests {
             let count = Arc::new(AtomicUsize::new(0));
             let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: count.clone(),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
             let needle = 64_u64.to_be_bytes();
@@ -488,28 +518,55 @@ mod tests {
 
             let lex: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: Arc::new(AtomicUsize::new(0)),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: true,
             });
             let dyn_cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
                 count: Arc::new(AtomicUsize::new(0)),
+                is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
 
-            // Boundary needles: below-min, low-exact, mid-exact, high-exact,
-            // exact-tail, above-max — covers partition_point left==0,
-            // left==len, and exact-hit cases.
-            for needle_val in &[0_u64, 1, 16, 24, 31, 100] {
-                let needle = needle_val.to_be_bytes();
+            // Boundary needles covering the full `partition_point` table:
+            //   - empty slice          → BELOW min (sorts before any non-empty)
+            //   - exact-min (key 0)
+            //   - 9-byte between-keys  → strictly between [0…0,16] and [0…0,17]
+            //   - exact-mid (key 16)
+            //   - exact-tail (key 31)  → last key, exercises left==len
+            //   - above-max (9 bytes)  → above any 8-byte key
+            //
+            // The previous version used only `to_be_bytes()` values which were
+            // all exact-keys + one above-max, missing the genuine below-min
+            // and between-key cases.
+            let between_16_and_17: Vec<u8> = {
+                let mut v = 16_u64.to_be_bytes().to_vec();
+                v.push(0); // 9 bytes: > 16, < 17 lexicographically
+                v
+            };
+            let above_max: Vec<u8> = {
+                let mut v = 31_u64.to_be_bytes().to_vec();
+                v.push(0xFF);
+                v
+            };
+            let needles: Vec<(&str, Vec<u8>)> = vec![
+                ("below-min (empty slice)", vec![]),
+                ("exact-min (key 0)", 0_u64.to_be_bytes().to_vec()),
+                ("between keys 16 and 17", between_16_and_17),
+                ("exact-mid (key 16)", 16_u64.to_be_bytes().to_vec()),
+                ("exact-tail (key 31)", 31_u64.to_be_bytes().to_vec()),
+                ("above-max (key 31 + 0xFF)", above_max),
+            ];
 
+            for (label, needle) in &needles {
                 let mut lex_iter = index_block.iter(lex.clone());
-                let lex_seek = lex_iter.seek(&needle, crate::SeqNo::MAX);
+                let lex_seek = lex_iter.seek(needle, crate::SeqNo::MAX);
 
                 let mut dyn_iter = index_block.iter(dyn_cmp.clone());
-                let dyn_seek = dyn_iter.seek(&needle, crate::SeqNo::MAX);
+                let dyn_seek = dyn_iter.seek(needle, crate::SeqNo::MAX);
 
                 assert_eq!(
                     lex_seek, dyn_seek,
-                    "index seek result must match for needle {needle_val}",
+                    "index seek result must match for needle {label} ({needle:?})",
                 );
 
                 // Compare landing end_key bytes (handles' materialized end_key).
@@ -522,7 +579,7 @@ mod tests {
                 assert_eq!(
                     lex_landing.as_ref().map(|s| s.as_ref().to_vec()),
                     dyn_landing.as_ref().map(|s| s.as_ref().to_vec()),
-                    "index landing end_key must match for needle {needle_val}",
+                    "index landing end_key must match for needle {label} ({needle:?})",
                 );
             }
         }

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -383,7 +383,27 @@ mod tests {
             })
         }
 
-        const DYN_MIN_PROBES: usize = 2;
+        /// Minimum number of `compare()` calls a working dyn BS makes on
+        /// the BS-dominated index block: `⌈log2(128)⌉ = 7` probes.
+        ///
+        /// For `restart_interval == 1` (used by [`build_index_block_bs_dominated`]),
+        /// the index-block `seek` / `seek_upper` paths skip the
+        /// `advance_while` / `trim_back_to_upper_bound` linear-scan branches
+        /// in `seek_with_cache_resets` / `seek_upper_impl`, so the dyn count
+        /// equals the BS probe count exactly. lex-leak makes 0 calls.
+        ///
+        /// `assert delta >= 7` cleanly catches the lex-leak. A weaker
+        /// threshold could match an inflated lex-leak count if linear-scan
+        /// contributions were possible.
+        const DYN_MIN_BS_PROBES: usize = 7;
+
+        /// Above-max needle (9 bytes > any 8-byte encoded key) — used to
+        /// bound any potential linear-scan contribution.
+        fn above_max_needle() -> Vec<u8> {
+            let mut v = 127_u64.to_be_bytes().to_vec();
+            v.push(0xFF);
+            v
+        }
 
         #[test]
         fn index_block_seek_lex_path_skips_vtable() {
@@ -450,7 +470,7 @@ mod tests {
                 is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             {
@@ -459,8 +479,8 @@ mod tests {
             }
             let delta = count.load(AtomicOrdering::Relaxed) - before;
             assert!(
-                delta >= DYN_MIN_PROBES,
-                "index seek dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                delta >= DYN_MIN_BS_PROBES,
+                "index seek dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times \
                  (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
             );
         }
@@ -474,7 +494,7 @@ mod tests {
                 is_lex_count: Arc::new(AtomicUsize::new(0)),
                 lex: false,
             });
-            let needle = 64_u64.to_be_bytes();
+            let needle = above_max_needle();
 
             let before = count.load(AtomicOrdering::Relaxed);
             {
@@ -483,8 +503,8 @@ mod tests {
             }
             let delta = count.load(AtomicOrdering::Relaxed) - before;
             assert!(
-                delta >= DYN_MIN_PROBES,
-                "index seek_upper dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                delta >= DYN_MIN_BS_PROBES,
+                "index seek_upper dyn BS must call compare() at least {DYN_MIN_BS_PROBES} times \
                  (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
             );
         }

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -299,4 +299,232 @@ mod tests {
             "zero restart_interval must return InvalidTrailer",
         );
     }
+
+    // Regression tests for binary-search-predicate devirtualization on the
+    // lexicographic fast path. Mirrors `data_block::iter_test::devirt`:
+    // index-block `seek` / `seek_upper` apply the same `is_lexicographic()`
+    // branching to skip `dyn UserComparator::compare` vtable dispatch on the
+    // BS probe loop. These tests use a counting-comparator wrapper to assert:
+    //   1. lex path makes ZERO compare() calls (no vtable in the BS loop)
+    //   2. dyn path makes >= log2(restart_heads) compare() calls (BS predicate
+    //      actually invokes vtable — guards against lex closure leaking)
+    //   3. lex and dyn paths produce identical landing positions on boundary
+    //      needles
+    mod devirt {
+        use super::*;
+        use crate::comparator::UserComparator;
+        use crate::table::BlockHandle;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        struct CountingComparator {
+            count: Arc<AtomicUsize>,
+            lex: bool,
+        }
+
+        impl UserComparator for CountingComparator {
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+            fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+                self.count.fetch_add(1, AtomicOrdering::Relaxed);
+                a.cmp(b)
+            }
+            fn is_lexicographic(&self) -> bool {
+                self.lex
+            }
+        }
+
+        /// Build an index block tuned to make BS probes dominate any potential
+        /// linear-scan contribution:
+        ///   - 128 handles with distinct sortable `end_key`s
+        ///   - `restart_interval=1` → each handle IS a restart head
+        ///   - binary search: log2(128) = 7 probes minimum
+        ///   - linear scan after BS lands: 0-1 iterations
+        ///
+        /// `assert count >= 2` then cleanly distinguishes the lex-leak case
+        /// (BS contributes 0, scan contributes at most 1) from a working
+        /// dyn path (BS contributes >= 7).
+        fn build_index_block_bs_dominated() -> IndexBlock {
+            use crate::Checksum;
+            use crate::table::block::{BlockType, Header};
+
+            let handles: Vec<_> = (0_u64..128)
+                .map(|i| {
+                    KeyedBlockHandle::new(
+                        i.to_be_bytes().to_vec().into(),
+                        i,
+                        BlockHandle::new(BlockOffset(i * 4096), 4096),
+                    )
+                })
+                .collect();
+            let bytes = IndexBlock::encode_into_vec_with_restart_interval(&handles, 1).unwrap();
+            IndexBlock::new(Block {
+                data: bytes.into(),
+                header: Header {
+                    block_type: BlockType::Index,
+                    checksum: Checksum::from_raw(0),
+                    data_length: 0,
+                    uncompressed_length: 0,
+                },
+            })
+        }
+
+        const DYN_MIN_PROBES: usize = 2;
+
+        #[test]
+        fn index_block_seek_lex_path_skips_vtable() {
+            // Both devirtualized entry points (seek, seek_upper) must route
+            // through static-dispatch closures when is_lexicographic() == true.
+            // Per-entry-point snapshot localises any regression.
+            let index_block = build_index_block_bs_dominated();
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: true,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = index_block.iter(cmp.clone());
+                let _ = iter.seek(&needle, crate::SeqNo::MAX);
+            }
+            let after_seek = count.load(AtomicOrdering::Relaxed);
+            assert_eq!(
+                after_seek - before,
+                0,
+                "index seek lex path leaked into dyn: {} compare() calls",
+                after_seek - before,
+            );
+
+            {
+                let mut iter = index_block.iter(cmp);
+                let _ = iter.seek_upper(&needle, crate::SeqNo::MAX);
+            }
+            let after_upper = count.load(AtomicOrdering::Relaxed);
+            assert_eq!(
+                after_upper - after_seek,
+                0,
+                "index seek_upper lex path leaked into dyn: {} compare() calls",
+                after_upper - after_seek,
+            );
+        }
+
+        #[test]
+        fn index_block_seek_dyn_path_invokes_compare() {
+            // BS-dominated block: a working dyn BS makes >= log2(128) = 7 calls.
+            // Lex closure leak would yield at most 1 call (linear scan only).
+            let index_block = build_index_block_bs_dominated();
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = index_block.iter(cmp);
+                let _ = iter.seek(&needle, crate::SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= DYN_MIN_PROBES,
+                "index seek dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                 (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
+            );
+        }
+
+        #[test]
+        fn index_block_seek_upper_dyn_path_invokes_compare() {
+            let index_block = build_index_block_bs_dominated();
+            let count = Arc::new(AtomicUsize::new(0));
+            let cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: count.clone(),
+                lex: false,
+            });
+            let needle = 64_u64.to_be_bytes();
+
+            let before = count.load(AtomicOrdering::Relaxed);
+            {
+                let mut iter = index_block.iter(cmp);
+                let _ = iter.seek_upper(&needle, crate::SeqNo::MAX);
+            }
+            let delta = count.load(AtomicOrdering::Relaxed) - before;
+            assert!(
+                delta >= DYN_MIN_PROBES,
+                "index seek_upper dyn BS must call compare() at least {DYN_MIN_PROBES} times \
+                 (log2(128 restart heads) probes), got {delta} — lex closure leaked into dyn BS?",
+            );
+        }
+
+        #[test]
+        fn index_block_seek_lex_and_dyn_agree_on_landing_position() {
+            use crate::Checksum;
+            use crate::table::block::{BlockType, Header};
+
+            // Smaller block where boundary needle behaviour is what we care
+            // about (rather than BS-vs-scan call-count discrimination).
+            let handles: Vec<_> = (0_u64..32)
+                .map(|i| {
+                    KeyedBlockHandle::new(
+                        i.to_be_bytes().to_vec().into(),
+                        i,
+                        BlockHandle::new(BlockOffset(i * 4096), 4096),
+                    )
+                })
+                .collect();
+            let bytes = IndexBlock::encode_into_vec_with_restart_interval(&handles, 4).unwrap();
+            let index_block = IndexBlock::new(Block {
+                data: bytes.into(),
+                header: Header {
+                    block_type: BlockType::Index,
+                    checksum: Checksum::from_raw(0),
+                    data_length: 0,
+                    uncompressed_length: 0,
+                },
+            });
+
+            let lex: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: Arc::new(AtomicUsize::new(0)),
+                lex: true,
+            });
+            let dyn_cmp: Arc<dyn UserComparator> = Arc::new(CountingComparator {
+                count: Arc::new(AtomicUsize::new(0)),
+                lex: false,
+            });
+
+            // Boundary needles: below-min, low-exact, mid-exact, high-exact,
+            // exact-tail, above-max — covers partition_point left==0,
+            // left==len, and exact-hit cases.
+            for needle_val in &[0_u64, 1, 16, 24, 31, 100] {
+                let needle = needle_val.to_be_bytes();
+
+                let mut lex_iter = index_block.iter(lex.clone());
+                let lex_seek = lex_iter.seek(&needle, crate::SeqNo::MAX);
+
+                let mut dyn_iter = index_block.iter(dyn_cmp.clone());
+                let dyn_seek = dyn_iter.seek(&needle, crate::SeqNo::MAX);
+
+                assert_eq!(
+                    lex_seek, dyn_seek,
+                    "index seek result must match for needle {needle_val}",
+                );
+
+                // Compare landing end_key bytes (handles' materialized end_key).
+                let lex_landing = lex_iter
+                    .next()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                let dyn_landing = dyn_iter
+                    .next()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                assert_eq!(
+                    lex_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    dyn_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    "index landing end_key must match for needle {needle_val}",
+                );
+            }
+        }
+    }
 }

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -325,11 +325,17 @@ mod tests {
             /// Counts `compare()` invocations — proves the lex devirt path
             /// successfully bypasses the `dyn UserComparator::compare` vtable.
             count: Arc<AtomicUsize>,
-            /// Counts `is_lexicographic()` invocations. The lex devirt
-            /// strategy gates each entry point on `is_lexicographic()`; this
-            /// counter proves the lex branch was actually selected (a
-            /// regression that always selected the dyn branch would leave
-            /// this at 0 in lex tests AND keep `count` at 0).
+            /// Counts `is_lexicographic()` invocations. Sanity counter:
+            /// asserts the comparator was consulted at all, guarding the
+            /// false-negative where `count == 0` trivially because no
+            /// comparator-touching code ran (empty block, early bail-out).
+            ///
+            /// NOTE: `is_lex_count > 0` does NOT prove the BS predicate
+            /// factory selected the lex branch — the no-prefix `compare_key`
+            /// in `index_block/mod.rs` also calls `is_lexicographic()` per
+            /// item, so this counter can be incremented from either source.
+            /// The TRUE proof that the lex BS predicate ran is `count == 0`
+            /// (no `compare()` vtable invocations).
             is_lex_count: Arc<AtomicUsize>,
             lex: bool,
         }
@@ -580,19 +586,22 @@ mod tests {
                 ("above-max (key 31 + 0xFF)", above_max),
             ];
 
+            // Exercise both devirtualized entry points (`seek` and
+            // `seek_upper`) against the same boundary needle table. The
+            // two have different predicate shapes (forward seqno-aware
+            // 3-way vs reverse `<` / `<=`), so the call-count assertions
+            // above wouldn't catch a landing mismatch from a wrong
+            // operator in the lex closure of either one.
             for (label, needle) in &needles {
+                // seek (forward, seqno-aware)
                 let mut lex_iter = index_block.iter(lex.clone());
                 let lex_seek = lex_iter.seek(needle, crate::SeqNo::MAX);
-
                 let mut dyn_iter = index_block.iter(dyn_cmp.clone());
                 let dyn_seek = dyn_iter.seek(needle, crate::SeqNo::MAX);
-
                 assert_eq!(
                     lex_seek, dyn_seek,
                     "index seek result must match for needle {label} ({needle:?})",
                 );
-
-                // Compare landing end_key bytes (handles' materialized end_key).
                 let lex_landing = lex_iter
                     .next()
                     .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
@@ -602,7 +611,30 @@ mod tests {
                 assert_eq!(
                     lex_landing.as_ref().map(|s| s.as_ref().to_vec()),
                     dyn_landing.as_ref().map(|s| s.as_ref().to_vec()),
-                    "index landing end_key must match for needle {label} ({needle:?})",
+                    "index seek landing must match for needle {label} ({needle:?})",
+                );
+
+                // seek_upper (reverse upper-bound — exercises seek_upper_impl
+                // which has different `<` vs `<=` predicate logic at
+                // restart_interval == 1).
+                let mut lex_iter = index_block.iter(lex.clone());
+                let lex_upper = lex_iter.seek_upper(needle, crate::SeqNo::MAX);
+                let mut dyn_iter = index_block.iter(dyn_cmp.clone());
+                let dyn_upper = dyn_iter.seek_upper(needle, crate::SeqNo::MAX);
+                assert_eq!(
+                    lex_upper, dyn_upper,
+                    "index seek_upper result must match for needle {label} ({needle:?})",
+                );
+                let lex_upper_landing = lex_iter
+                    .next_back()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                let dyn_upper_landing = dyn_iter
+                    .next_back()
+                    .map(|h| h.materialize(index_block.as_slice()).end_key().clone());
+                assert_eq!(
+                    lex_upper_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    dyn_upper_landing.as_ref().map(|s| s.as_ref().to_vec()),
+                    "index seek_upper landing must match for needle {label} ({needle:?})",
                 );
             }
         }


### PR DESCRIPTION
## Summary

Block-level binary search in `partition_point` probes restart heads via a predicate that calls `dyn UserComparator::compare` — a vtable dispatch on every `O(log restarts)` step. The `is_lexicographic()` opt-in already exists on the trait and is honored in `compare_prefixed_slice` (the prefix branch of `compare_key`, where the lex path avoids a prefix+suffix concatenation allocation), but the binary search itself routed every probe through vtable.

This PR branches once on `is_lexicographic()` at each predicate construction site and selects a closure that does direct slice comparison (`<[u8]>::cmp`) on the lex path. Each closure is a distinct type, so the generic `partition_point` / `seek` / `seek_upper` monomorphize per shape — the inner binary-search loop is virtual-call-free on the lex path. The custom-comparator branch is preserved verbatim.

## Sites devirtualized

| File | Functions | Predicates |
|---|---|---|
| `src/table/data_block/iter.rs` | `seek_to_key_seqno`, `seek_upper`, `seek_upper_exclusive` | 3 × 2 monomorphizations |
| `src/table/index_block/iter.rs` | `seek_with_cache_resets`, `seek_upper_impl` (covers both public `seek_upper` and `seek_upper_bound_cursor`) | 4 × 2 monomorphizations |

Each predicate construction site hoists ONE `is_lexicographic()` call out of the BS loop, amortising it across all `O(log restarts)` probes. The lex closure does direct `<[u8]>::cmp`; the dyn closure preserves the original `cmp.compare(...)` call.

## Out of scope (deliberate)

- **`partition_point` itself** already uses the canonical 2-way lower-bound shape (`if pred { left = mid+1 } else { right = mid }`) — LLVM emits cmov. No 3-way branch to remove.
- **3-way `Ordering` match in the linear-scan loops** inside restart intervals stays — `Equal`/`Greater` early-exit beats branchless scan-to-end-and-post-check for typical `restart_interval=8-16` scans.
- **`ParsedItem::compare_key` no-prefix branch** intentionally NOT devirtualized. An earlier revision added a lex fast path there too; review feedback correctly identified that the no-prefix branch has no allocation to avoid (the key is already contiguous), so an `is_lexicographic()` check before `compare()` would cost custom comparators a second vtable per linear-scan step without any matching saving on the default path (`<[u8]>::cmp` and `DefaultUserComparator::compare` both lower to memcmp). The lex fast path is kept only where it saves real work: `compare_prefixed_slice_lexicographic` (skips an allocation on the prefix branch) and the iter.rs BS predicate factories above.

## Test plan

- [x] `cargo nextest run` — **666 / 666 lib tests pass** + **10 devirt regression tests**
- [x] `cargo clippy --all-targets --lib --tests -- -D warnings` — clean
- [x] **Direct devirt verification** via counting-comparator wrapper that tracks `compare()` AND `is_lexicographic()` calls separately:
  - **Lex-path tests** (data_block × 3 entry points; index_block × 3 entry points incl. `seek_upper_bound_cursor`) — assert `count <= LEX_PATH_LINEAR_SCAN_BOUND` (≈ 2, only linear-scan compare_key contribution) AND `is_lex_count >= 1` (the BS predicate factory consulted is_lex). A regression where the dyn closure leaked into the BS predicate would produce `>= DYN_MIN_BS_PROBES` (= 7, = log₂(128)) calls — orders-of-magnitude separation from the bound.
  - **Dyn-path tests** (one per entry point) — assert `delta >= DYN_MIN_BS_PROBES` (= 7) on the BS-dominated block (128 keys × restart_interval=1 + above-max needle bounds linear-scan to 1 call). Distinguishes a working dyn BS (≥ 7 + 1) from a lex-leak (0 + 1).
  - **Equivalence tests** (data_block: seek + seek_upper + seek_upper_exclusive; index_block: seek + seek_upper + seek_upper_bound_cursor) across 6 boundary needles (empty slice = below-min, exact-min, between-keys 9-byte, exact-mid, exact-tail, above-max 9-byte) — proves lex and dyn paths produce identical landing positions for every `partition_point` boundary case (`left==0`, `left==len`, exact-hit), and surfaces a wrong-operator regression in any lex closure as a landing mismatch.
- [x] 41 existing `custom_comparator*` integration tests exercise the dyn path — all pass unchanged

## Benchmarks

`tools/db_bench --num 200000`, 5 runs per workload per branch (medians + ranges), measured on the initial devirtualization commit:

| Workload | main (med) | this PR (med) | Δ | main range | this PR range | Read |
|---|---:|---:|---:|---:|---:|---|
| fillseq | 1,717,606 | 1,675,953 | **-2.4%** | 1.57M-1.77M | 1.60M-1.73M | noise (write path, not on devirt) |
| readseq | 2,497,713 | 2,546,882 | **+2.0%** | 2.34M-2.90M | 2.12M-2.59M | noise (readseq does not binary-search per op) |
| readrandom | 370,160 | 373,223 | **+0.8%** | 362k-392k | 355k-380k | tiny win, inside noise |
| seekrandom | 276,825 | 284,261 | **+2.7%** | 271k-287k | 276k-303k | borderline positive signal |
| prefixscan | 160,785 | 148,139 | **-7.9%** | 154k-164k | 147k-172k | wide range — one this-PR run at 172k > all main runs |

**Honest read**: on a 200k-op macOS bench, expected win from saving `N-1` vtable calls per seek (`N = log2(restart_heads) ≈ 2-3`) is **0.5-2%** in absolute best case — below the noise floor of single-run db_bench on shared hardware. The signal is consistent with the theoretical prediction.

**The devirtualization itself is verified directly by test, not inferred from bench numbers** — the lex-path / dyn-path counting assertions (above) deterministically prove the right closure runs at each entry point. Real workloads with hot point-read paths and warm caches should see a larger relative benefit than this small synthetic bench.

Closes #220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added lexicographic fast paths to iterator seek operations in table data and index blocks, reducing runtime overhead during binary-search probes.

* **Tests**
  * Added a suite of regression and devirtualization tests that count comparator usage and validate seek behavior across multiple boundary cases.

* **Documentation**
  * Clarified comments around comparator fast-path responsibilities to explain where lexicographic optimizations are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->