### PR TITLE
feat(checkpoint)!: hard-link snapshot for PITR backup (V5 storage)

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -84,3 +84,37 @@ These are not actionable review findings. Do not raise them:
 - Integration tests that require specific disk layout or large data use `#[ignore = "reason"]`
 - Prefer `assert_eq!` with message over bare `assert!` for better failure output
 - Hardcoded values in tests are fine when accompanied by explanatory comments or assertion messages
+## no_std + alloc Compatibility (Direction, Not Hard Mandate)
+
+This crate is moving toward a `no_std + alloc` build. The CI `no-std-check` job builds against `thumbv7em-none-eabihf` with `--no-default-features --features alloc` and is **the direction we're heading**, not a hard mandate yet. Per-crate tier tables are NOT a required artifact — the rules below describe what reviewers should SUGGEST (not block) for changes that move in the right direction, and what they should ACTIVELY FLAG when changes regress no-std readiness.
+
+When in doubt, suggest — don't gatekeep.
+
+### Direction rules (suggest)
+
+1. **No-std capability is the target.** Every library crate SHOULD in principle support `no_std + alloc` builds. Existing code that uses `std` is grandfathered until someone migrates it.
+2. **Primitive selection order for NEW code**: `core::*` → `alloc::*` → external `no_std + alloc` crate → `std::*` behind `#[cfg(feature = "std")]` → unconditional `std::*` (last resort). Reviewers SHOULD suggest higher-tier alternatives.
+3. **Cargo.toml shape**: a crate that already declares `default = ["std"]`, `std = []`, `alloc = []` should keep them coherent. `src/lib.rs` should open with `#![cfg_attr(not(feature = "std"), no_std)]` + `extern crate alloc;` once the migration is underway.
+5. **Public API surface** SHOULD prefer `core` / `alloc` types where the crate's tier permits. Suggest, don't block.
+13. **Prefer `core::*` over `std::*` re-exports** whenever the type is available there (e.g. `core::sync::atomic::AtomicU64`, `core::cmp::Ordering`). One-line suggestion — `std::*` re-exports of `core` types break the build under `no_std` even when binary-identical for `std`.
+14. **The std-vs-no_std choice is per-primitive, NOT per-crate.** A crate tiered `std-only` is still encouraged to prefer the faster no_std-ready primitive when one exists (e.g. `hashbrown`, `parking_lot`, `smallvec`, `rustc_hash`, `bytes`) — these are normally faster than their `std::*` counterparts on hot paths.
+18. **Tier reclassification suggestions** (e.g. `alloc` → `std-bound, leaf-isolated`) are welcome in the PR description. Reviewers MUST NOT block on a missing tier table — soft expectation only.
+
+### Active flags (reject if introduced)
+
+4. **CI gate**: the `no-std-check` job MUST run against a no-std-only target (e.g. `thumbv7em-none-eabihf`) with `--no-default-features --features alloc`. Host targets with available `std` MUST NOT be used — they silently pull `std` in via transitive features and hide real failures. PRs disabling or weakening this job's target/flags are rejected.
+6. **NEW `std::collections::HashMap` / `HashSet` uses in alloc-tier modules** — prefer `hashbrown::HashMap` / `HashSet` (no_std + alloc), or `rustc_hash::FxHashMap` for internal-ID keys. Suggest in std-tier modules; reject in alloc-tier.
+7. **`std::sync::Mutex` / `RwLock` in NEW code on hot paths.** Prefer `parking_lot::Mutex` / `RwLock`. `spin::Mutex` only in genuinely no-std contexts and only for very short critical sections. Existing usage is grandfathered.
+8. **NEW `std::sync::OnceLock` for fallible init.** Use `once_cell::sync::OnceCell::get_or_try_init` or `once_cell::race::OnceBox`.
+9. **NEW `thread_local!` in alloc-tier modules.** Replace with caller-managed scratch parameters or atomic-pointer patterns.
+10. **NEW `std::io::Error` in public APIs of alloc-tier modules.** Define a crate-local error enum; `From<std::io::Error>` impls live behind `#[cfg(feature = "std")]`. Tolerate in `std-only` tier.
+11. **NEW `std::time::Instant` / `std::time::SystemTime` in public APIs of alloc-tier modules.** Use a caller-provided clock trait or a `#[cfg(feature = "std")]`-gated convenience wrapper. Tolerate in `std-only` tier.
+12. **NEW `std::thread::*` in alloc-tier modules.** Threading must be hoisted to a higher-tier crate.
+15. **Adding `use std::*` to an alloc-tier module that was previously no-std-clean — without justification — is a regression.** Suggest a no_std alternative first; only reject if the PR's stated direction is no-std cleanup and this addition undoes that progress. No per-crate tier table is required to make this judgement.
+16. **`no-std-check` compile-error count MUST NOT increase per PR.** While a crate is in transition, the job MAY run `continue-on-error: true` and the count tracked as a metric — but it MUST decrease or stay equal, never increase.
+20. **Adding a transitive dependency that pulls `std` into an otherwise no-std-clean module — without justification — regresses no-std readiness.** Suggest alternatives first; reject only if the PR's stated direction is no-std cleanup and the addition undoes it.
+
+### Always-applies
+
+17. **Test code (`#[cfg(test)]`), benches (`benches/`), and binaries (`src/bin/`) are NOT subject to no-std rules** — they MAY use `std::*` freely. Only library code in `src/lib.rs` and its submodules is governed.
+19. **Doc comments and rustdoc `# Examples` blocks** on no-std-capable APIs SHOULD NOT depend on `std::*` types if the API itself does not. Doctest examples requiring `std` should be gated `#[cfg(feature = "std")]`. Reject only when the API is documented as alloc-only and the doctest contradicts that.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ lz4 = ["dep:lz4_flex", "std"]
 # conventional `!` markers on this PR's breaking commits (BuRR filter
 # wire format, V5 manifest gate); release-plz raises the crate's major
 # version on the next release tag accordingly.
-zstd = ["dep:structured-zstd", "dep:once_cell", "std"]
+zstd = ["dep:structured-zstd", "std"]
 encryption = ["dep:aes-gcm", "dep:rand_chacha", "std"]
 bytes_1 = ["dep:bytes"]
 metrics = []
@@ -96,7 +96,7 @@ structured-zstd = { version = "0.0.21", optional = true, default-features = fals
 # migration. Optional + gated by the `zstd` feature — only the zstd
 # `ZstdDictionary::prepared_handle` path uses it today, so non-zstd consumers
 # do not pull this crate.
-once_cell = { version = "1", optional = true }
+once_cell = { version = "1", default-features = false, features = ["std"] }
 quick_cache = { version = "0.6.16", default-features = false, features = [] }
 rustc-hash = "2.1.1"
 self_cell = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,16 @@ log = "0.4.27"
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 structured-zstd = { version = "0.0.21", optional = true, default-features = false, features = ["std"] }
-# `once_cell::sync::OnceCell` has stable `get_or_try_init`; `std::sync::OnceLock`
-# does not until 1.86+ (still unstable on our 1.92 MSRV path via `once_cell_try`).
-# Use the external crate for the canonical single-parse-across-racers primitive
-# without an auxiliary `Mutex`. The `race` module from this same crate provides
-# the no-std + alloc variant (`OnceBox`) we'll swap to during the no-std
-# migration. Optional + gated by the `zstd` feature — only the zstd
-# `ZstdDictionary::prepared_handle` path uses it today, so non-zstd consumers
-# do not pull this crate.
-once_cell = { version = "1", default-features = false, features = ["std"] }
+# `once_cell::race::OnceBox` — the no-std + alloc variant. Provides
+# `get_or_try_init` (which `std::sync::OnceLock` lacks until 1.86, above
+# our 1.92 MSRV path) without pulling `std`. Unconditional dep with
+# `default-features = false, features = ["race"]` so the crate stays
+# no-std-friendly even with `--no-default-features`. Used by:
+#   - zstd `ZstdDictionary::prepared_handle` (canonical single-parse
+#     across racers, no auxiliary `Mutex`)
+#   - `deletion_pause` slot on tables / blob files (one-shot install of
+#     the shared `Arc<DeletionPause>` after recovery / compaction).
+once_cell = { version = "1", default-features = false, features = ["race"] }
 quick_cache = { version = "0.6.16", default-features = false, features = [] }
 rustc-hash = "2.1.1"
 self_cell = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ byteview = "~0.10.1"
 enum_dispatch = "0.3.13"
 interval-heap = "0.0.5"
 log = "0.4.27"
+# `spin = "0.9"` provides a no_std-compatible Mutex. Used by
+# `deletion_pause` so that module's only std footprint comes from the
+# `Fs` trait it interacts with, not from its own synchronisation.
+spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 structured-zstd = { version = "0.0.21", optional = true, default-features = false, features = ["std"] }
 # `once_cell::sync::OnceCell` has stable `get_or_try_init`; `std::sync::OnceLock`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ bytes = { version = "1", optional = true }
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
 enum_dispatch = "0.3.13"
-interval-heap = "0.0.5"
 log = "0.4.27"
 # `spin = "0.9"` provides a no_std-compatible Mutex. Used by
 # `deletion_pause` so that module's only std footprint comes from the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,12 @@ log = "0.4.27"
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 structured-zstd = { version = "0.0.21", optional = true, default-features = false, features = ["std"] }
-# `once_cell::race::OnceBox` — the no-std + alloc variant. Provides
-# `get_or_try_init` (which `std::sync::OnceLock` lacks until 1.86, above
-# our 1.92 MSRV path) without pulling `std`. Unconditional dep with
+# `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
+# We pick it over `std::sync::OnceLock` (which has both `set` and the
+# stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is
+# std-only: it can't compile on the `cargo check
+# --no-default-features --features alloc` CI target, and the crate's
+# direction is no-std-friendly. Unconditional dep with
 # `default-features = false, features = ["race"]` so the crate stays
 # no-std-friendly even with `--no-default-features`. Used by:
 #   - zstd `ZstdDictionary::prepared_handle` (canonical single-parse

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 - `SequenceNumberGenerator` trait — pluggable seqno source.
 - Custom `UserComparator` for non-lexicographic ordering.
 - MVCC: snapshot reads at a chosen `SeqNo`.
+- Point-in-time recovery snapshots via `Tree::create_checkpoint` — hard-link
+  every live SST + blob file into a fresh directory in O(1) per file, zero
+  extra disk until the source files compact away. Compaction continues
+  during the checkpoint (deletions are deferred), and the resulting
+  directory opens as an independent tree.
 
 ### Internals
 

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -119,9 +119,14 @@ pub trait AbstractTree: sealed::Sealed {
     /// - consumes disk space equal to the copied bytes on the target
     ///   volume (no inode sharing across filesystems).
     ///
-    /// The fall-back is logged via [`log::warn`] so operators using
-    /// tiered storage or detached backup volumes can spot it. Same applies
-    /// when the source and target use entirely different [`Fs`](crate::fs::Fs)
+    /// Each fall-back call emits one [`log::debug`] line (deliberately not
+    /// `warn`: a misconfigured tier could trigger this path once per SST
+    /// and per blob — thousands of times per snapshot — and per-file
+    /// warnings would drown real signal). Operators wanting hard-visibility
+    /// of unexpected full copies should enable debug logging on the `fs`
+    /// module or watch the `CheckpointInfo.total_bytes` figure (≫ inode
+    /// link cost means the fallback fired). The same `debug` policy applies
+    /// when source and target use entirely different [`Fs`](crate::fs::Fs)
     /// backends (e.g. [`MemFs`](crate::fs::MemFs) → [`StdFs`](crate::fs::StdFs)
     /// in tests).
     ///

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -32,7 +32,19 @@ pub struct CheckpointInfo {
     pub total_bytes: u64,
     /// The version ID embedded in the checkpoint's `current` pointer.
     pub version_id: u64,
-    /// The maximum visible sequence number at checkpoint time.
+    /// Lower-bound visible-seqno watermark for the snapshot.
+    ///
+    /// Captured BEFORE [`AbstractTree::current_version`] so it is
+    /// guaranteed to be ≤ every seqno reflected in the checkpointed
+    /// SSTs. PITR consumers can safely use this value as an **inclusive
+    /// lower bound** for replay cutoffs: every record with
+    /// `seqno <= info.seqno` is included in the snapshot, but later
+    /// seqnos may also be present (writers can advance the counter
+    /// between sample and version snapshot).
+    ///
+    /// Treating this as the maximum visible seqno would be incorrect
+    /// and could move a recovery cutoff past data still needed from
+    /// WAL or replication; the field is a watermark, not a ceiling.
     pub seqno: SeqNo,
 }
 

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -87,11 +87,33 @@ pub trait AbstractTree: sealed::Sealed {
     /// `target_path` for point-in-time recovery (PITR) backup.
     ///
     /// The checkpoint is a fully functional tree that can be opened
-    /// independently via [`Config::open`](crate::Config::open). All SST files
-    /// (and blob files, for [`BlobTree`]) are hard-linked rather than
-    /// copied, so the operation is O(1) per file and consumes zero
-    /// additional disk space until the original files are compacted away
-    /// — at which point the inode is kept alive by the checkpoint link.
+    /// independently via [`Config::open`](crate::Config::open). For the
+    /// common single-filesystem case all SST files (and blob files, for
+    /// [`BlobTree`]) are hard-linked rather than copied, so the operation
+    /// is O(1) per file and consumes zero additional disk space until the
+    /// original files are compacted away — at which point the inode is
+    /// kept alive by the checkpoint link.
+    ///
+    /// # Cross-filesystem / cross-backend fall-back
+    ///
+    /// When a source file lives on a different filesystem than the
+    /// checkpoint target — e.g. an SST routed to a hot tier via
+    /// [`level_routes`](crate::Config::level_routes) on a separate volume,
+    /// or a backup directory on a foreign mount — the hard link cannot
+    /// be created (Unix `EXDEV`). In that case the checkpoint silently
+    /// falls back to a streamed byte copy, which:
+    ///
+    /// - takes time linear in the file size instead of O(1), and
+    /// - consumes disk space equal to the copied bytes on the target
+    ///   volume (no inode sharing across filesystems).
+    ///
+    /// The fall-back is logged via [`log::warn`] so operators using
+    /// tiered storage or detached backup volumes can spot it. Same applies
+    /// when the source and target use entirely different [`Fs`](crate::fs::Fs)
+    /// backends (e.g. [`MemFs`](crate::fs::MemFs) → [`StdFs`](crate::fs::StdFs)
+    /// in tests).
+    ///
+    /// # Concurrency
     ///
     /// While the checkpoint is being built, compaction continues normally
     /// but the physical removal of obsolete files is deferred until the
@@ -107,8 +129,8 @@ pub trait AbstractTree: sealed::Sealed {
     /// - a hard link / copy fall-back could not be created, or
     /// - the manifest / version pointer files could not be replicated.
     ///
-    /// On error the checkpoint directory may contain a partial subset of
-    /// the live files; callers are expected to remove it.
+    /// On error any partial checkpoint files are removed automatically
+    /// (best-effort) so callers can safely retry against the same path.
     fn create_checkpoint(&self, target_path: &std::path::Path) -> crate::Result<CheckpointInfo>;
 
     /// Seals the active memtable and flushes to table(s).

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -34,17 +34,22 @@ pub struct CheckpointInfo {
     pub version_id: u64,
     /// Lower-bound visible-seqno watermark for the snapshot.
     ///
-    /// Captured BEFORE [`AbstractTree::current_version`] so it is
-    /// guaranteed to be ≤ the *maximum* seqno reflected in the
-    /// checkpointed SSTs. PITR consumers can safely use this value as
-    /// an **inclusive lower bound** for replay cutoffs: every record
-    /// with `seqno <= info.seqno` is included in the snapshot, but
-    /// later seqnos may also be present (writers can advance the
-    /// counter between sample and version snapshot).
+    /// Captured from the tree's `visible_seqno` generator BEFORE
+    /// [`AbstractTree::current_version`]. Following the standard
+    /// "lowest-excluded" watermark convention, `info.seqno = N` means
+    /// every record with `seqno < N` was committed at sample time and
+    /// is therefore guaranteed to be present in the snapshot. Records
+    /// with `seqno == N` may or may not be included (writers can hold
+    /// a record in the memtable for an instant before publishing the
+    /// next watermark); records with `seqno > N` may also be present
+    /// (writers can advance the counter between sample and version
+    /// snapshot, and those keys still land in the captured memtable).
     ///
-    /// Treating this as the maximum visible seqno would be incorrect
-    /// and could move a recovery cutoff past data still needed from
-    /// WAL or replication; the field is a watermark, not a ceiling.
+    /// PITR consumers MUST use `seqno < info.seqno` as the inclusion
+    /// gate. Using `<=` (treating this as a max-included ceiling)
+    /// could move a recovery cutoff past data still needed from WAL
+    /// or replication; the field is a strict lower-exclusive watermark,
+    /// not a max-included ceiling.
     pub seqno: SeqNo,
 }
 

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -15,6 +15,27 @@ pub type RangeItem = crate::Result<KvPair>;
 
 type FlushToTablesResult = (Vec<Table>, Option<Vec<BlobFile>>);
 
+/// Summary of a checkpoint produced by
+/// [`AbstractTree::create_checkpoint`].
+///
+/// All byte counts are *logical* file sizes — hard links share the
+/// underlying inode storage, so a checkpoint's marginal disk usage is
+/// typically zero until the original files are compacted away.
+#[derive(Debug, Clone, Copy)]
+pub struct CheckpointInfo {
+    /// Number of SST files captured.
+    pub sst_files: usize,
+    /// Number of blob (value-log) files captured. Always `0` for a
+    /// standard [`Tree`].
+    pub blob_files: usize,
+    /// Sum of the logical file sizes of every captured SST + blob.
+    pub total_bytes: u64,
+    /// The version ID embedded in the checkpoint's `current` pointer.
+    pub version_id: u64,
+    /// The maximum visible sequence number at checkpoint time.
+    pub seqno: SeqNo,
+}
+
 // Sealed on purpose: this trait is still public as a consumer-side bound
 // (`&impl AbstractTree`), but external implementations are no longer part of
 // the supported extension surface. Internal flush/version hooks keep evolving
@@ -61,6 +82,34 @@ pub trait AbstractTree: sealed::Sealed {
 
     #[doc(hidden)]
     fn get_version_history_lock(&self) -> RwLockWriteGuard<'_, crate::version::SuperVersions>;
+
+    /// Creates a hard-linked checkpoint of the tree's on-disk state in
+    /// `target_path` for point-in-time recovery (PITR) backup.
+    ///
+    /// The checkpoint is a fully functional tree that can be opened
+    /// independently via [`Config::open`](crate::Config::open). All SST files
+    /// (and blob files, for [`BlobTree`]) are hard-linked rather than
+    /// copied, so the operation is O(1) per file and consumes zero
+    /// additional disk space until the original files are compacted away
+    /// — at which point the inode is kept alive by the checkpoint link.
+    ///
+    /// While the checkpoint is being built, compaction continues normally
+    /// but the physical removal of obsolete files is deferred until the
+    /// checkpoint hard-links are in place. This is implemented by an
+    /// internal reference-counted deletion gate; callers do not have to
+    /// pause compaction themselves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the active memtable could not be flushed,
+    /// - `target_path` already exists (to prevent accidental overwrites),
+    /// - a hard link / copy fall-back could not be created, or
+    /// - the manifest / version pointer files could not be replicated.
+    ///
+    /// On error the checkpoint directory may contain a partial subset of
+    /// the live files; callers are expected to remove it.
+    fn create_checkpoint(&self, target_path: &std::path::Path) -> crate::Result<CheckpointInfo>;
 
     /// Seals the active memtable and flushes to table(s).
     ///

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -35,12 +35,12 @@ pub struct CheckpointInfo {
     /// Lower-bound visible-seqno watermark for the snapshot.
     ///
     /// Captured BEFORE [`AbstractTree::current_version`] so it is
-    /// guaranteed to be ≤ every seqno reflected in the checkpointed
-    /// SSTs. PITR consumers can safely use this value as an **inclusive
-    /// lower bound** for replay cutoffs: every record with
-    /// `seqno <= info.seqno` is included in the snapshot, but later
-    /// seqnos may also be present (writers can advance the counter
-    /// between sample and version snapshot).
+    /// guaranteed to be ≤ the *maximum* seqno reflected in the
+    /// checkpointed SSTs. PITR consumers can safely use this value as
+    /// an **inclusive lower bound** for replay cutoffs: every record
+    /// with `seqno <= info.seqno` is included in the snapshot, but
+    /// later seqnos may also be present (writers can advance the
+    /// counter between sample and version snapshot).
     ///
     /// Treating this as the maximum visible seqno would be incorrect
     /// and could move a recovery cutoff past data still needed from

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -225,6 +225,24 @@ impl BlobTree {
 impl crate::abstract_tree::sealed::Sealed for BlobTree {}
 
 impl AbstractTree for BlobTree {
+    fn create_checkpoint(
+        &self,
+        target_path: &std::path::Path,
+    ) -> crate::Result<crate::CheckpointInfo> {
+        crate::checkpoint::run_checkpoint(
+            self,
+            &crate::checkpoint::CheckpointParams {
+                target_root: target_path,
+                target_fs: &self.index.config.fs,
+                src_root: &self.index.config.path,
+                src_fs: &self.index.config.fs,
+                deletion_pause: &self.index.deletion_pause,
+                visible_seqno: &self.index.config.visible_seqno,
+                include_blobs: true,
+            },
+        )
+    }
+
     fn print_trace(&self, key: &[u8]) -> crate::Result<()> {
         self.index.print_trace(key)
     }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -227,28 +227,52 @@ pub fn link_or_copy_cross_fs(
     let mut src_file = src_fs.open(src, &FsOpenOptions::new().read(true))?;
     let mut dst_file = dst_fs.open(dst, &FsOpenOptions::new().write(true).create_new(true))?;
 
-    let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
-    let mut total: u64 = 0;
-    loop {
-        // Retry on EINTR — matches `StdFs::copy_fallback` and avoids
-        // spurious checkpoint failures when a signal arrives during the
-        // copy (common under shell-managed Ctrl-C handlers).
-        let n = match src_file.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
-        };
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "n was just produced by read() and is bounded by buf.len()"
-        )]
-        dst_file.write_all(&buf[..n])?;
-        total = total.saturating_add(n as u64);
+    // Run the copy in an inner closure so any failure (read, write,
+    // flush, fsync) leaves us with the original error AND lets us
+    // best-effort `remove_file(dst)` before propagating. Without this,
+    // a mid-copy ENOSPC/EIO leaves a partial `dst` file on the
+    // destination FS; a subsequent retry hits `create_new`'s
+    // AlreadyExists check and fails for a wholly different reason,
+    // hiding the real cause. `PartialCheckpointGuard` cleans up the
+    // whole target dir on the normal failure path, but this helper is
+    // also called from cross-Fs tests and from any future caller that
+    // doesn't sit inside that guard — so the local best-effort
+    // cleanup is the safer invariant.
+    let result: std::io::Result<u64> = (|| {
+        let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
+        let mut total: u64 = 0;
+        loop {
+            // Retry on EINTR — matches `StdFs::copy_fallback` and avoids
+            // spurious checkpoint failures when a signal arrives during the
+            // copy (common under shell-managed Ctrl-C handlers).
+            let n = match src_file.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            };
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "n was just produced by read() and is bounded by buf.len()"
+            )]
+            dst_file.write_all(&buf[..n])?;
+            total = total.saturating_add(n as u64);
+        }
+        dst_file.flush()?;
+        FsFile::sync_all(&*dst_file)?;
+        Ok(total)
+    })();
+
+    match result {
+        Ok(total) => Ok(total),
+        Err(e) => {
+            // Release the dst handle before unlink so backends that
+            // block unlink while a handle is open (Windows) can succeed.
+            drop(dst_file);
+            let _ = dst_fs.remove_file(dst);
+            Err(e)
+        }
     }
-    dst_file.flush()?;
-    FsFile::sync_all(&*dst_file)?;
-    Ok(total)
 }
 
 /// Hard-links every live SST in `version` into `target/tables/`.

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -517,6 +517,15 @@ pub fn run_checkpoint<T: AbstractTree>(
 
     fsync_directory(target_root, &**target_fs)?;
 
+    // Finally, fsync the directory that CONTAINS `target_root`. Without
+    // this the checkpoint's own directory entry can disappear after a
+    // power loss even though the children we just synced would still be
+    // intact on the underlying inodes. Required by the same fsync-
+    // ordering rule that drove the child-directory syncs above.
+    if let Some(parent) = target_root.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fsync_directory(parent, &**target_fs)?;
+    }
+
     cleanup.commit();
 
     Ok(CheckpointInfo {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -527,3 +527,61 @@ pub fn run_checkpoint<T: AbstractTree>(
         seqno: captured_seqno,
     })
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::fs::{FsOpenOptions, MemFs, StdFs};
+    use std::io::{Read, Write};
+
+    /// `link_or_copy_cross_fs` must transparently stream bytes through
+    /// both trait objects when source and destination back ends differ
+    /// (here: `StdFs` source vs. `MemFs` target — the `MemFs` backend
+    /// has no way to see the on-disk source file, so the hard-link
+    /// attempt returns `NotFound` and we fall through to a streamed
+    /// copy). Verifies BOTH the copy lands AND the two filesystems
+    /// stay independent under subsequent mutation.
+    #[test]
+    fn cross_fs_link_or_copy_streams_through_trait() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("payload.bin");
+        std::fs::write(&src, b"cross-fs-payload").unwrap();
+
+        let std_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mem_fs: Arc<dyn Fs> = Arc::new(MemFs::new());
+        mem_fs.create_dir_all(Path::new("/dst")).unwrap();
+
+        let dst = Path::new("/dst/payload.bin");
+        let bytes = link_or_copy_cross_fs(&std_fs, &src, &mem_fs, dst).unwrap();
+        assert_eq!(bytes, b"cross-fs-payload".len() as u64);
+
+        // Bytes landed in MemFs.
+        let mut buf = String::new();
+        mem_fs
+            .open(dst, &FsOpenOptions::new().read(true))
+            .unwrap()
+            .read_to_string(&mut buf)
+            .unwrap();
+        assert_eq!(buf, "cross-fs-payload");
+
+        // Mutating `dst` via MemFs must NOT affect the StdFs source —
+        // proves the streamed copy produced an independent file rather
+        // than aliasing.
+        let mut writer = mem_fs
+            .open(dst, &FsOpenOptions::new().write(true).truncate(true))
+            .unwrap();
+        writer.write_all(b"mutated-via-mem-fs").unwrap();
+        drop(writer);
+
+        assert_eq!(std::fs::read(&src).unwrap(), b"cross-fs-payload");
+
+        let mut after = String::new();
+        mem_fs
+            .open(dst, &FsOpenOptions::new().read(true))
+            .unwrap()
+            .read_to_string(&mut after)
+            .unwrap();
+        assert_eq!(after, "mutated-via-mem-fs");
+    }
+}

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -141,11 +141,11 @@ impl Drop for RootCleanup<'_> {
 ///    responsibility — a per-file warning would drown real signal on
 ///    a misconfigured tier with thousands of SSTs.
 ///
-/// The hard_link path is gated on a positive [`Fs::backend_id`]
+/// The `hard_link` path is gated on a positive [`Fs::backend_id`]
 /// match. `Arc::ptr_eq` would have been too strict (two independent
 /// `Arc::new(StdFs)` values back the same kernel filesystem but are
 /// not pointer-equal); a "try first, fall back on `NotFound`" pattern
-/// would have been too loose (a MemFs source paired with a StdFs
+/// would have been too loose (a `MemFs` source paired with a `StdFs`
 /// destination could let the kernel resolve `src` against the host
 /// filesystem and silently link an unrelated file). `Fs::backend_id`
 /// is the explicit capability check that catches both cases safely.

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -58,8 +58,13 @@ fn blob_link_name(id: crate::vlog::BlobFileId) -> String {
 /// that had a TOCTOU window between the two calls.
 ///
 /// Once the leaf directory is ours, the `tables/` and (optionally)
-/// `blobs/` subdirectories are created. The caller's parent path must
-/// exist; this function does not recurse.
+/// `blobs/` subdirectories are created. If any of those secondary
+/// creates fails, the freshly-claimed root directory is removed before
+/// the error is returned so the caller can retry against the same path
+/// — leaving `target` behind would lock out the next attempt with
+/// `AlreadyExists` and contradict the "partial cleanup" contract.
+///
+/// The caller's parent path must exist; this function does not recurse.
 pub fn prepare_target(target: &Path, include_blobs: bool, target_fs: &dyn Fs) -> crate::Result<()> {
     // Atomic claim — fails with AlreadyExists if any other process /
     // thread / prior checkpoint already created the directory.
@@ -77,37 +82,92 @@ pub fn prepare_target(target: &Path, include_blobs: bool, target_fs: &dyn Fs) ->
         }
     })?;
 
+    // From this point on, the root directory is ours — any failure must
+    // undo it so retries against the same path work. Local RAII guard
+    // (defined at module scope to avoid `items_after_statements`).
+    let mut cleanup = RootCleanup {
+        target,
+        fs: target_fs,
+        armed: true,
+    };
+
     target_fs.create_dir(&target.join(TABLES_FOLDER))?;
     if include_blobs {
         target_fs.create_dir(&target.join(BLOBS_FOLDER))?;
     }
+
+    cleanup.armed = false;
     Ok(())
+}
+
+/// Internal RAII guard used by [`prepare_target`] to undo a successful
+/// `create_dir(target)` when a subsequent subdirectory create fails.
+struct RootCleanup<'a> {
+    target: &'a Path,
+    fs: &'a dyn Fs,
+    armed: bool,
+}
+
+impl Drop for RootCleanup<'_> {
+    fn drop(&mut self) {
+        if self.armed
+            && let Err(e) = self.fs.remove_dir_all(self.target)
+        {
+            log::warn!(
+                "Failed to clean up partial checkpoint target {}: {e:?}",
+                self.target.display(),
+            );
+        }
+    }
 }
 
 /// Links (or copies) one file across [`Fs`] backends.
 ///
-/// When `src_fs` and `dst_fs` refer to the same backend instance
-/// (`Arc::ptr_eq`), this delegates to [`Fs::hard_link`], which transparently
-/// falls back to a byte copy if the link would cross physical filesystems
-/// (Unix `EXDEV`). When the two backends differ — e.g. an SST that lives
-/// on a tiered-storage route backed by [`MemFs`](crate::fs::MemFs) while
-/// the checkpoint target is on [`StdFs`](crate::fs::StdFs) — the function
-/// streams the bytes through both trait objects so the link semantics
-/// degrade to a normal file copy.
+/// Strategy:
+///
+/// 1. **Try `dst_fs.hard_link(src, dst)` first.** A real filesystem
+///    backend that can see `src` (same kernel filesystem, just a
+///    different `Arc<dyn Fs>` handle — common when `level_routes`
+///    builds `Arc::new(StdFs)` independently from `config.fs`) will
+///    succeed in O(1) without doubling disk usage. `StdFs::hard_link`
+///    handles its own `EXDEV` → byte-copy fallback transparently.
+/// 2. **On `NotFound`** (the dst backend doesn't see `src` at all —
+///    e.g. `MemFs` target with `StdFs` source) **or `Unsupported`**
+///    (in-memory backends that don't implement linking), stream bytes
+///    through both trait objects. This is the only path that doubles
+///    storage; logged via [`log::warn`] in the [`StdFs`] fallback so
+///    operators can spot tier-misconfigurations.
+///
+/// Using `Arc::ptr_eq` as the discriminator would be too strict: two
+/// `Arc::new(StdFs)` values produced independently (e.g. one in the
+/// tree's primary `config.fs`, one in a `LevelRoute`) are not pointer-
+/// equal but back the same kernel filesystem, so they CAN hard-link.
+/// The "try first, fall back on demand" pattern catches both cases
+/// without exposing a backend-identity API on the `Fs` trait.
 pub fn link_or_copy_cross_fs(
     src_fs: &Arc<dyn Fs>,
     src: &Path,
     dst_fs: &Arc<dyn Fs>,
     dst: &Path,
 ) -> std::io::Result<u64> {
-    if Arc::ptr_eq(src_fs, dst_fs) {
-        dst_fs.hard_link(src, dst)?;
-        return Ok(dst_fs.metadata(dst)?.len);
+    match dst_fs.hard_link(src, dst) {
+        Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::Unsupported
+            ) =>
+        {
+            // dst_fs cannot see src (cross-backend) or does not support
+            // hard links at all → fall through to streamed copy.
+        }
+        Err(e) => return Err(e),
     }
 
-    // Different Fs backends — stream bytes through the trait. The buffer
-    // is heap-allocated to avoid bloating the stack frame; checkpoint is a
-    // cold-path operation so the extra allocation is negligible.
+    // Cross-backend / no-hardlink path — stream bytes through the trait.
+    // The buffer is heap-allocated to avoid bloating the stack frame;
+    // checkpoint is a cold-path operation so the extra allocation is
+    // negligible.
     let mut src_file = src_fs.open(src, &FsOpenOptions::new().read(true))?;
     let mut dst_file = dst_fs.open(dst, &FsOpenOptions::new().write(true).create_new(true))?;
 
@@ -187,24 +247,56 @@ pub fn link_blob_files(
     Ok((count, bytes))
 }
 
+/// Whether a metadata file is required for the checkpoint to be openable.
+#[derive(Clone, Copy)]
+enum MetaRequirement {
+    /// File must exist on the source; absence is an error.
+    ///
+    /// Used for the `v<id>` snapshot whose disappearance between
+    /// `current_version()` and metadata copy would otherwise produce a
+    /// checkpoint that points (via `current`) at a version file that
+    /// does not exist in the checkpoint directory.
+    Required,
+    /// File may legitimately be absent (treated as a freshly-initialised
+    /// tree by recovery). Used for `manifest` on never-written trees.
+    Optional,
+}
+
 /// Copies one of the small metadata files (manifest, `v<id>`, or
-/// `current`) from `src_root` to `target_root` if it exists. Missing files
-/// are silently ignored — recovery treats the absence of these files as a
-/// freshly-initialised tree.
+/// `current`) from `src_root` to `target_root`.
+///
+/// Opens the source directly instead of `exists()` + `open()` to avoid
+/// the TOCTOU window where the file disappears between the two calls.
+/// `NotFound` is the only ignorable error and only when
+/// `requirement == Optional`; for `Required` files a missing source is
+/// surfaced as the original `NotFound` so the checkpoint fails-fast
+/// instead of producing an unopenable snapshot.
 fn copy_metadata_file(
     src_fs: &dyn Fs,
     src_root: &Path,
     target_fs: &dyn Fs,
     target_root: &Path,
     file_name: &str,
+    requirement: MetaRequirement,
 ) -> crate::Result<()> {
     let src = src_root.join(file_name);
-    if !src_fs.exists(&src)? {
-        return Ok(());
-    }
+    let mut src_file = match src_fs.open(&src, &FsOpenOptions::new().read(true)) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return match requirement {
+                MetaRequirement::Optional => Ok(()),
+                MetaRequirement::Required => Err(crate::Error::from(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!(
+                        "checkpoint required metadata file {} missing from source",
+                        src.display(),
+                    ),
+                ))),
+            };
+        }
+        Err(e) => return Err(e.into()),
+    };
     let dst = target_root.join(file_name);
-
-    let mut src_file = src_fs.open(&src, &FsOpenOptions::new().read(true))?;
     let mut dst_file = target_fs.open(&dst, &FsOpenOptions::new().write(true).create_new(true))?;
 
     std::io::copy(&mut src_file, &mut dst_file)?;
@@ -263,17 +355,31 @@ pub fn copy_metadata(
     target_root: &Path,
     version_id: u64,
 ) -> crate::Result<()> {
-    // Manifest stores level count + comparator name; required on open.
-    copy_metadata_file(src_fs, src_root, target_fs, target_root, "manifest")?;
-    // Active version snapshot — `v<id>` is immutable once published,
-    // so copying it verbatim is race-free regardless of concurrent
-    // version transitions.
+    // Manifest stores level count + comparator name. On a never-written
+    // tree the manifest may legitimately be absent (recovery treats
+    // missing manifest as a freshly-initialised tree), so this is Optional.
+    copy_metadata_file(
+        src_fs,
+        src_root,
+        target_fs,
+        target_root,
+        "manifest",
+        MetaRequirement::Optional,
+    )?;
+    // Active version snapshot — `v<id>` is immutable once published, so
+    // copying it verbatim is race-free against concurrent version
+    // transitions. But version-GC can DELETE older `v<id>` files; if the
+    // file we captured disappears between `current_version()` and this
+    // copy, the resulting checkpoint would have `current` pointing at a
+    // missing file and fail to open. Treat as Required so checkpoint
+    // fails-fast in that race instead of producing a corrupt snapshot.
     copy_metadata_file(
         src_fs,
         src_root,
         target_fs,
         target_root,
         &format!("v{version_id}"),
+        MetaRequirement::Required,
     )?;
     // CURRENT pointer is generated fresh for the captured `version_id`
     // (NOT copied from source) so a concurrent publish to `v<N+1>` on

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Implementation of [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+//! and [`BlobTree::create_checkpoint`](crate::BlobTree::create_checkpoint).
+//!
+//! A checkpoint is a hard-linked, fully-functional snapshot of the tree's
+//! on-disk state. It can be opened independently via
+//! [`Config::open`](crate::Config::open) without affecting the source tree.
+//!
+//! The algorithm mirrors `RocksDB`'s `Checkpoint::CreateCheckpoint`:
+//!
+//! 1. Acquire a [`Pause`](crate::deletion_pause::Pause) on the source tree's
+//!    deletion gate. Compaction continues, but obsolete files queued for
+//!    removal are held back until the checkpoint is complete.
+//! 2. Flush the active memtable so all live data is in SSTs.
+//! 3. Snapshot the current `Version`; iterate its tables (and blob files,
+//!    for [`BlobTree`]) and hard-link each one into `target/tables/` (or
+//!    `target/blobs/`).
+//! 4. Copy the manifest, version file (`v<id>`), and `current` pointer.
+//! 5. Drop the pause guard — queued deletions run.
+
+use crate::{
+    AbstractTree, CheckpointInfo, SeqNo,
+    file::{BLOBS_FOLDER, CURRENT_VERSION_FILE, TABLES_FOLDER, fsync_directory},
+    fs::{Fs, FsFile, FsOpenOptions},
+    version::Version,
+    vlog::BlobFile,
+};
+use std::{
+    io::{Read, Write},
+    path::Path,
+    sync::Arc,
+};
+
+/// Internal helper: returns the byte-name used inside the checkpoint
+/// directory for a given table ID.
+fn table_link_name(id: crate::TableId) -> String {
+    id.to_string()
+}
+
+/// Internal helper: returns the byte-name used inside the checkpoint
+/// directory for a given blob-file ID.
+fn blob_link_name(id: crate::vlog::BlobFileId) -> String {
+    id.to_string()
+}
+
+/// Creates the directory structure for a fresh checkpoint.
+///
+/// Builds `<target>`, `<target>/tables`, and optionally `<target>/blobs`
+/// under `target_fs`. Rejects an already existing target so a
+/// partially-overlapping checkpoint cannot be accidentally produced.
+pub fn prepare_target(target: &Path, include_blobs: bool, target_fs: &dyn Fs) -> crate::Result<()> {
+    if target_fs.exists(target)? {
+        return Err(crate::Error::from(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!(
+                "checkpoint target {} already exists; refusing to overwrite",
+                target.display(),
+            ),
+        )));
+    }
+
+    target_fs.create_dir_all(target)?;
+    target_fs.create_dir_all(&target.join(TABLES_FOLDER))?;
+    if include_blobs {
+        target_fs.create_dir_all(&target.join(BLOBS_FOLDER))?;
+    }
+    Ok(())
+}
+
+/// Links (or copies) one file across [`Fs`] backends.
+///
+/// When `src_fs` and `dst_fs` refer to the same backend instance
+/// (`Arc::ptr_eq`), this delegates to [`Fs::hard_link`], which transparently
+/// falls back to a byte copy if the link would cross physical filesystems
+/// (Unix `EXDEV`). When the two backends differ — e.g. an SST that lives
+/// on a tiered-storage route backed by [`MemFs`](crate::fs::MemFs) while
+/// the checkpoint target is on [`StdFs`](crate::fs::StdFs) — the function
+/// streams the bytes through both trait objects so the link semantics
+/// degrade to a normal file copy.
+pub fn link_or_copy_cross_fs(
+    src_fs: &Arc<dyn Fs>,
+    src: &Path,
+    dst_fs: &Arc<dyn Fs>,
+    dst: &Path,
+) -> std::io::Result<u64> {
+    if Arc::ptr_eq(src_fs, dst_fs) {
+        dst_fs.hard_link(src, dst)?;
+        return Ok(dst_fs.metadata(dst)?.len);
+    }
+
+    // Different Fs backends — stream bytes through the trait. The buffer
+    // is heap-allocated to avoid bloating the stack frame; checkpoint is a
+    // cold-path operation so the extra allocation is negligible.
+    let mut src_file = src_fs.open(src, &FsOpenOptions::new().read(true))?;
+    let mut dst_file = dst_fs.open(dst, &FsOpenOptions::new().write(true).create_new(true))?;
+
+    let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
+    let mut total: u64 = 0;
+    loop {
+        let n = src_file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "n was just produced by read() and is bounded by buf.len()"
+        )]
+        dst_file.write_all(&buf[..n])?;
+        total = total.saturating_add(n as u64);
+    }
+    dst_file.flush()?;
+    FsFile::sync_all(&*dst_file)?;
+    Ok(total)
+}
+
+/// Hard-links every live SST in `version` into `target/tables/`.
+///
+/// Returns `(count, total_bytes)`. Tables on routed tiers
+/// (`level_routes`) keep their original storage backend on the source
+/// side; the destination is always the checkpoint's primary [`Fs`].
+pub fn link_tables(
+    version: &Version,
+    target_root: &Path,
+    target_fs: &Arc<dyn Fs>,
+) -> crate::Result<(usize, u64)> {
+    let tables_dir = target_root.join(TABLES_FOLDER);
+    let mut count = 0usize;
+    let mut bytes: u64 = 0;
+
+    for table in version.iter_tables() {
+        let dst = tables_dir.join(table_link_name(table.id()));
+
+        // Source Fs may differ from `target_fs` when `level_routes` points
+        // a hot tier at one backend (e.g. tmpfs) and the rest of the tree
+        // at another. `link_or_copy_cross_fs` picks the right strategy.
+        let written = link_or_copy_cross_fs(&table.fs, &table.path, target_fs, &dst)
+            .map_err(crate::Error::from)?;
+        bytes = bytes.saturating_add(written);
+        count = count.saturating_add(1);
+    }
+    Ok((count, bytes))
+}
+
+/// Hard-links every live blob file in `version` into `target/blobs/`.
+///
+/// Returns `(count, total_bytes)`. Blob files always live under the
+/// tree's primary path (no per-level routing today), so the source `Fs`
+/// is `target_fs`'s counterpart on the source tree.
+pub fn link_blob_files(
+    blob_files: impl IntoIterator<Item = BlobFile>,
+    target_root: &Path,
+    target_fs: &Arc<dyn Fs>,
+) -> crate::Result<(usize, u64)> {
+    let blobs_dir = target_root.join(BLOBS_FOLDER);
+    let mut count = 0usize;
+    let mut bytes: u64 = 0;
+
+    for blob in blob_files {
+        let dst = blobs_dir.join(blob_link_name(blob.id()));
+        let written = link_or_copy_cross_fs(&blob.0.fs, &blob.0.path, target_fs, &dst)
+            .map_err(crate::Error::from)?;
+        bytes = bytes.saturating_add(written);
+        count = count.saturating_add(1);
+    }
+    Ok((count, bytes))
+}
+
+/// Copies one of the small metadata files (manifest, `v<id>`, or
+/// `current`) from `src_root` to `target_root` if it exists. Missing files
+/// are silently ignored — recovery treats the absence of these files as a
+/// freshly-initialised tree.
+fn copy_metadata_file(
+    src_fs: &dyn Fs,
+    src_root: &Path,
+    target_fs: &dyn Fs,
+    target_root: &Path,
+    file_name: &str,
+) -> crate::Result<()> {
+    let src = src_root.join(file_name);
+    if !src_fs.exists(&src)? {
+        return Ok(());
+    }
+    let dst = target_root.join(file_name);
+
+    let mut src_file = src_fs.open(&src, &FsOpenOptions::new().read(true))?;
+    let mut dst_file = target_fs.open(&dst, &FsOpenOptions::new().write(true).create_new(true))?;
+
+    std::io::copy(&mut src_file, &mut dst_file)?;
+    dst_file.flush()?;
+    FsFile::sync_all(&*dst_file)?;
+    Ok(())
+}
+
+/// Replicates the manifest, the active version snapshot (`v<id>`), and the
+/// `current` pointer file from the source tree into the checkpoint.
+///
+/// `version_id` is the ID of the version captured at checkpoint time; the
+/// corresponding `v<id>` file MUST exist on the source because checkpoint
+/// is called after a flush that publishes a new version through
+/// [`crate::version::persist_version`].
+pub fn copy_metadata(
+    src_fs: &dyn Fs,
+    src_root: &Path,
+    target_fs: &dyn Fs,
+    target_root: &Path,
+    version_id: u64,
+) -> crate::Result<()> {
+    // Manifest stores level count + comparator name; required on open.
+    copy_metadata_file(src_fs, src_root, target_fs, target_root, "manifest")?;
+    // Active version snapshot.
+    copy_metadata_file(
+        src_fs,
+        src_root,
+        target_fs,
+        target_root,
+        &format!("v{version_id}"),
+    )?;
+    // CURRENT pointer must be copied LAST so a crash between version copy
+    // and CURRENT copy leaves the checkpoint in a "version present, no
+    // pointer" state — equivalent to a tree that was just created.
+    copy_metadata_file(
+        src_fs,
+        src_root,
+        target_fs,
+        target_root,
+        CURRENT_VERSION_FILE,
+    )?;
+    Ok(())
+}
+
+/// Inputs to [`run_checkpoint`] bundled together to keep the function
+/// signature within clippy's `too_many_arguments` budget.
+pub struct CheckpointParams<'a> {
+    /// Destination root directory for the checkpoint.
+    pub target_root: &'a Path,
+    /// `Fs` backend that owns `target_root`.
+    pub target_fs: &'a Arc<dyn Fs>,
+    /// Source tree's root directory (contains manifest / `v<id>` / current).
+    pub src_root: &'a Path,
+    /// `Fs` backend that owns `src_root`.
+    pub src_fs: &'a Arc<dyn Fs>,
+    /// Pause gate that defers compaction-driven deletions for the duration
+    /// of the checkpoint.
+    pub deletion_pause: &'a Arc<crate::deletion_pause::DeletionPause>,
+    /// Visible-seqno counter, recorded into [`CheckpointInfo::seqno`].
+    pub visible_seqno: &'a crate::seqno::SharedSequenceNumberGenerator,
+    /// Whether to capture the value log under `target/blobs/`.
+    pub include_blobs: bool,
+}
+
+/// Common driver shared by [`Tree`](crate::Tree) and
+/// [`BlobTree`](crate::BlobTree). Performs the flush + link + metadata
+/// copy under a held [`Pause`](crate::deletion_pause::Pause) guard.
+pub fn run_checkpoint<T: AbstractTree>(
+    tree: &T,
+    params: &CheckpointParams<'_>,
+) -> crate::Result<CheckpointInfo> {
+    let target_root = params.target_root;
+    let target_fs = params.target_fs;
+    let src_root = params.src_root;
+    let src_fs = params.src_fs;
+    let deletion_pause = params.deletion_pause;
+    let visible_seqno = params.visible_seqno;
+    let include_blobs = params.include_blobs;
+
+    prepare_target(target_root, include_blobs, &**target_fs)?;
+
+    // Hold the pause guard for the duration of the checkpoint so any
+    // tables / blob files that compaction marks as deleted are held back.
+    let _pause = deletion_pause.acquire();
+
+    // Force a flush so the captured version reflects all data that has
+    // reached the active memtable. Using a sentinel eviction seqno
+    // (`SeqNo::MAX`) lets `flush_active_memtable` flush regardless of
+    // current visible seqno — the data is durable in either case.
+    tree.flush_active_memtable(SeqNo::MAX)?;
+
+    let version = tree.current_version();
+    let captured_seqno = visible_seqno.get();
+
+    let (sst_files, sst_bytes) = link_tables(&version, target_root, target_fs)?;
+
+    let (blob_files, blob_bytes) = if include_blobs {
+        link_blob_files(version.blob_files.iter().cloned(), target_root, target_fs)?
+    } else {
+        (0, 0)
+    };
+
+    copy_metadata(&**src_fs, src_root, &**target_fs, target_root, version.id())?;
+    fsync_directory(target_root, &**target_fs)?;
+
+    Ok(CheckpointInfo {
+        sst_files,
+        blob_files,
+        total_bytes: sst_bytes.saturating_add(blob_bytes),
+        version_id: version.id(),
+        seqno: captured_seqno,
+    })
+}

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -399,8 +399,12 @@ pub fn copy_metadata(
     // (NOT copied from source) so a concurrent publish to `v<N+1>` on
     // the source can never leave the checkpoint pointing at a version
     // we did not link. Written LAST so a crash before this point leaves
-    // the checkpoint in a "version present, no pointer" state, which
-    // recovery treats as a freshly-initialised tree.
+    // the checkpoint with a version file but no CURRENT pointer:
+    // `Tree::open` on such a directory will fail to recover (no valid
+    // pointer to load) — the partial dir must be removed and the
+    // checkpoint retried. `PartialCheckpointGuard` performs that
+    // removal on the normal error path; an unclean crash (no Drop) is
+    // the only case the operator must clean up manually.
     write_current_for_version(target_fs, target_root, version_id)?;
     Ok(())
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -303,53 +303,27 @@ pub fn link_blob_files(
     Ok((count, bytes))
 }
 
-/// Whether a metadata file is required for the checkpoint to be openable.
-#[derive(Clone, Copy)]
-enum MetaRequirement {
-    /// File must exist on the source; absence is an error.
-    ///
-    /// Used for the `v<id>` snapshot whose disappearance between
-    /// `current_version()` and metadata copy would otherwise produce a
-    /// checkpoint that points (via `current`) at a version file that
-    /// does not exist in the checkpoint directory.
-    Required,
-    /// File may legitimately be absent (treated as a freshly-initialised
-    /// tree by recovery). Used for `manifest` on never-written trees.
-    Optional,
-}
-
-/// Copies one of the small metadata files (manifest, `v<id>`, or
-/// `current`) from `src_root` to `target_root`.
+/// Copies an OPTIONAL metadata file from `src_root` to `target_root`.
+///
+/// "Optional" = the source file may legitimately be absent (recovery
+/// treats a missing manifest as a freshly-initialised tree). Required
+/// metadata is no longer copied through this path — `v<id>` is now
+/// serialised directly from the captured in-memory Version (see
+/// [`copy_metadata`]) so its source-file lifetime no longer matters.
 ///
 /// Opens the source directly instead of `exists()` + `open()` to avoid
 /// the TOCTOU window where the file disappears between the two calls.
-/// `NotFound` is the only ignorable error and only when
-/// `requirement == Optional`; for `Required` files a missing source is
-/// surfaced as the original `NotFound` so the checkpoint fails-fast
-/// instead of producing an unopenable snapshot.
-fn copy_metadata_file(
+fn copy_metadata_file_optional(
     src_fs: &dyn Fs,
     src_root: &Path,
     target_fs: &dyn Fs,
     target_root: &Path,
     file_name: &str,
-    requirement: MetaRequirement,
 ) -> crate::Result<()> {
     let src = src_root.join(file_name);
     let mut src_file = match src_fs.open(&src, &FsOpenOptions::new().read(true)) {
         Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return match requirement {
-                MetaRequirement::Optional => Ok(()),
-                MetaRequirement::Required => Err(crate::Error::from(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!(
-                        "checkpoint required metadata file {} missing from source",
-                        src.display(),
-                    ),
-                ))),
-            };
-        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e.into()),
     };
     let dst = target_root.join(file_name);
@@ -420,34 +394,23 @@ pub fn copy_metadata(
     src_root: &Path,
     target_fs: &dyn Fs,
     target_root: &Path,
-    version_id: u64,
+    version: &crate::version::Version,
+    comparator_name: &str,
 ) -> crate::Result<()> {
     // Manifest stores level count + comparator name. On a never-written
     // tree the manifest may legitimately be absent (recovery treats
-    // missing manifest as a freshly-initialised tree), so this is Optional.
-    copy_metadata_file(
-        src_fs,
-        src_root,
-        target_fs,
-        target_root,
-        "manifest",
-        MetaRequirement::Optional,
-    )?;
-    // Active version snapshot — `v<id>` is immutable once published, so
-    // copying it verbatim is race-free against concurrent version
-    // transitions. But version-GC can DELETE older `v<id>` files; if the
-    // file we captured disappears between `current_version()` and this
-    // copy, the resulting checkpoint would have `current` pointing at a
-    // missing file and fail to open. Treat as Required so checkpoint
-    // fails-fast in that race instead of producing a corrupt snapshot.
-    copy_metadata_file(
-        src_fs,
-        src_root,
-        target_fs,
-        target_root,
-        &format!("v{version_id}"),
-        MetaRequirement::Required,
-    )?;
+    // missing manifest as a freshly-initialised tree), so this is optional.
+    copy_metadata_file_optional(src_fs, src_root, target_fs, target_root, "manifest")?;
+    // Re-serialise the captured Version into target/v<id> rather than
+    // copying the source file. Reason: SuperVersions::maintenance can
+    // physically remove the source v<id> between current_version() and
+    // this point (manifest GC fires when seqno < mvcc_gc_watermark for
+    // a version older than the active one). The captured `version` is
+    // an in-memory snapshot held by the checkpoint driver and is the
+    // authoritative source for the snapshot we just hard-linked SSTs
+    // for, so writing it from memory eliminates the race entirely —
+    // the source file's lifetime no longer matters.
+    crate::version::persist_version(target_root, version, comparator_name, target_fs)?;
     // CURRENT pointer is generated fresh for the captured `version_id`
     // (NOT copied from source) so a concurrent publish to `v<N+1>` on
     // the source can never leave the checkpoint pointing at a version
@@ -458,7 +421,7 @@ pub fn copy_metadata(
     // checkpoint retried. `PartialCheckpointGuard` performs that
     // removal on the normal error path; an unclean crash (no Drop) is
     // the only case the operator must clean up manually.
-    write_current_for_version(target_fs, target_root, version_id)?;
+    write_current_for_version(target_fs, target_root, version.id())?;
     Ok(())
 }
 
@@ -588,7 +551,14 @@ pub fn run_checkpoint<T: AbstractTree>(
         (0, 0)
     };
 
-    copy_metadata(&**src_fs, src_root, &**target_fs, target_root, version.id())?;
+    copy_metadata(
+        &**src_fs,
+        src_root,
+        &**target_fs,
+        target_root,
+        &version,
+        tree.tree_config().comparator.name(),
+    )?;
 
     // fsync each populated child directory BEFORE the root so the
     // directory entries we just created (`tables/<id>`, `blobs/<id>`,

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -380,15 +380,22 @@ fn write_current_for_version(
 
 /// Replicates manifest + `v<id>` + writes a fresh `current` pointer.
 ///
-/// Pulls the manifest and the active version snapshot (`v<id>`) from
-/// the source tree into the checkpoint, then writes a fresh `current`
-/// pointer for the captured version (see [`write_current_for_version`]
-/// for why we don't copy the live file).
+/// Best-effort-copies the manifest from the source tree, then writes
+/// `v<id>` and `current` into the checkpoint directory from the
+/// captured in-memory `Version` rather than copying the source file.
 ///
-/// `version_id` is the ID of the version captured at checkpoint time; the
-/// corresponding `v<id>` file MUST exist on the source because checkpoint
-/// is called after a flush that publishes a new version through
-/// [`crate::version::persist_version`].
+/// `version` is the captured snapshot held by the checkpoint driver
+/// from `tree.current_version()`. Writing it through
+/// [`crate::version::persist_version`] removes the dependency on the
+/// source `v<id>` file's lifetime: a concurrent
+/// [`crate::version::SuperVersions::maintenance`] call may delete the
+/// source file between capture and this function, but the snapshot is
+/// fully reconstructible from memory, so checkpoint creation does not
+/// fail under that race. `comparator_name` is required to encode the
+/// version through the same wire-format path the live tree uses (see
+/// [`crate::version::persist_version`]'s signature). `current` is
+/// then written via [`write_current_for_version`] referencing the
+/// freshly-persisted `version.id()`.
 pub fn copy_metadata(
     src_fs: &dyn Fs,
     src_root: &Path,

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -20,6 +20,10 @@
 //! 4. Copy the manifest, version file (`v<id>`), and `current` pointer.
 //! 5. Drop the pause guard — queued deletions run.
 
+// `Path`, `io::{Read, Write}` and `io::copy` come from `std::*` because
+// no `core` / `alloc` equivalents exist; they are also the same types
+// the underlying `Fs` trait operates on, so this module inherits its
+// host `fs` module's std dependency rather than introducing a new one.
 use crate::{
     AbstractTree, CheckpointInfo, SeqNo,
     file::{BLOBS_FOLDER, CURRENT_VERSION_FILE, TABLES_FOLDER, fsync_directory},
@@ -27,10 +31,10 @@ use crate::{
     version::Version,
     vlog::BlobFile,
 };
+use alloc::{sync::Arc, vec};
 use std::{
     io::{Read, Write},
     path::Path,
-    sync::Arc,
 };
 
 /// Internal helper: returns the byte-name used inside the checkpoint

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -500,13 +500,33 @@ pub fn run_checkpoint<T: AbstractTree>(
     tree: &T,
     params: &CheckpointParams<'_>,
 ) -> crate::Result<CheckpointInfo> {
-    let target_root = params.target_root;
     let target_fs = params.target_fs;
     let src_root = params.src_root;
     let src_fs = params.src_fs;
     let deletion_pause = params.deletion_pause;
     let visible_seqno = params.visible_seqno;
     let include_blobs = params.include_blobs;
+
+    // Normalise the target by dropping all CurDir (`.`) components so
+    // every downstream call sees the same canonical form regardless of
+    // how the caller spelled the path. Without this, `"./checkpoint"`
+    // and `"checkpoint"` behave differently on backends that don't
+    // resolve `.` against a host-wide CWD (e.g. MemFs's `create_dir`
+    // and `sync_directory` reject `.` as not-found because the in-memory
+    // directory set never inserts it). ParentDir (`..`) is preserved —
+    // it's a semantic component that affects the resulting path.
+    let normalized_target: std::path::PathBuf = params
+        .target_root
+        .components()
+        .filter(|c| !matches!(c, std::path::Component::CurDir))
+        .collect();
+    if normalized_target.as_os_str().is_empty() {
+        return Err(crate::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "checkpoint target_root must name at least one path component",
+        )));
+    }
+    let target_root = normalized_target.as_path();
 
     prepare_target(target_root, include_blobs, &**target_fs)?;
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -599,24 +599,19 @@ pub fn run_checkpoint<T: AbstractTree>(
 
     fsync_directory(target_root, &**target_fs)?;
 
-    // Finally, fsync the directory that CONTAINS `target_root`. Without
-    // this the checkpoint's own directory entry can disappear after a
-    // power loss even though the children we just synced would still be
-    // intact on the underlying inodes. Required by the same fsync-
-    // ordering rule that drove the child-directory syncs above.
-    // `Path::parent()` returns `Some("")` for a bare leaf like `"checkpoint"`,
-    // which `fsync_directory` would reject as an invalid input. For a relative
-    // leaf the containing directory IS the process CWD, so resolve to `.`
-    // explicitly — otherwise we'd silently skip the fsync that guarantees the
-    // checkpoint's own directory entry survives a power loss.
-    // Only fsync a NAMED parent. `Path::parent()` returns `Some("")`
-    // for a single-component relative target like `"checkpoint"` —
-    // substituting `Path::new(".")` would lean on the host OS's CWD,
-    // which works for StdFs but is meaningless for backends without a
-    // notion of current working directory (e.g. MemFs's
-    // `sync_directory(".")` returns NotFound). Skip the fsync in the
-    // empty-parent case; callers needing the parent-directory-entry-
-    // survives-power-loss guarantee pass an absolute path.
+    // Finally, fsync the directory that CONTAINS `target_root` so the
+    // checkpoint's own directory entry survives a power loss even
+    // though the children we just synced would otherwise stay intact
+    // on the underlying inodes. Required by the same fsync-ordering
+    // rule that drove the child-directory syncs above.
+    //
+    // Only fsync a NAMED parent. After the CurDir-stripping
+    // normalisation at the top of run_checkpoint, a single-component
+    // target like `"checkpoint"` has an empty parent — there is no
+    // backend-portable directory to fsync (in particular, MemFs has
+    // no CWD, so `sync_directory(".")` returns NotFound). Skip the
+    // fsync in that case; callers needing the parent-dir-entry-
+    // survives-power-loss guarantee pass an absolute target path.
     if let Some(parent) = target_root.parent()
         && !parent.as_os_str().is_empty()
     {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -141,52 +141,83 @@ impl Drop for RootCleanup<'_> {
 ///    responsibility — a per-file warning would drown real signal on
 ///    a misconfigured tier with thousands of SSTs.
 ///
-/// Using `Arc::ptr_eq` as the discriminator would be too strict: two
-/// `Arc::new(StdFs)` values produced independently (e.g. one in the
-/// tree's primary `config.fs`, one in a `LevelRoute`) are not pointer-
-/// equal but back the same kernel filesystem, so they CAN hard-link.
-/// The "try first, fall back on demand" pattern catches both cases
-/// without exposing a backend-identity API on the `Fs` trait.
+/// The hard_link path is gated on a positive [`Fs::backend_id`]
+/// match. `Arc::ptr_eq` would have been too strict (two independent
+/// `Arc::new(StdFs)` values back the same kernel filesystem but are
+/// not pointer-equal); a "try first, fall back on `NotFound`" pattern
+/// would have been too loose (a MemFs source paired with a StdFs
+/// destination could let the kernel resolve `src` against the host
+/// filesystem and silently link an unrelated file). `Fs::backend_id`
+/// is the explicit capability check that catches both cases safely.
 pub fn link_or_copy_cross_fs(
     src_fs: &Arc<dyn Fs>,
     src: &Path,
     dst_fs: &Arc<dyn Fs>,
     dst: &Path,
 ) -> std::io::Result<u64> {
-    match dst_fs.hard_link(src, dst) {
-        // The dst stat syscall here is intentional — do NOT replace it
-        // with a caller-supplied "known size" from `Table::file_size()`
-        // or `BlobFileMetadata::total_compressed_bytes`. Those values
-        // record the writer's `file_pos` BEFORE the metadata block and
-        // footer were appended, so they undercount the on-disk file by
-        // hundreds to thousands of bytes per table. The streamed-copy
-        // fallback below counts the actual bytes it writes, so the two
-        // branches must agree on physical bytes for `CheckpointInfo
-        // ::total_bytes` to match on-disk reality (asserted by
-        // `checkpoint_info_total_bytes_matches_disk`). One extra stat
-        // per linked file is cheap relative to the link itself.
-        Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
-        Err(e)
-            if matches!(
-                e.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::Unsupported
-            ) =>
-        {
-            // dst_fs cannot see src (cross-backend) or does not support
-            // hard links at all → fall through to streamed copy.
-            // Log at `debug` for symmetry with `StdFs::hard_link`'s
-            // EXDEV fallback — operators wanting visibility of
-            // unexpected full copies should grep the `fs` /
-            // `checkpoint` modules at debug level. `warn` would drown
-            // real signal on a misconfigured tier with thousands of SSTs.
-            log::debug!(
-                "link_or_copy_cross_fs({}, {}) falling back to streamed copy ({})",
-                src.display(),
-                dst.display(),
-                e.kind(),
-            );
+    // Refuse to attempt `hard_link` unless both backends positively
+    // assert (via `Fs::backend_id`) that they resolve paths against
+    // the same namespace. Without this gate a MemFs source paired with
+    // a StdFs destination would let the kernel resolve `src` against
+    // the HOST filesystem; if a real file happens to live at the same
+    // spelling the checkpoint would silently capture THAT file instead
+    // of the in-memory source. See `Fs::backend_id` for the contract.
+    let shared_namespace = match (src_fs.backend_id(), dst_fs.backend_id()) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    };
+
+    if shared_namespace {
+        match dst_fs.hard_link(src, dst) {
+            // The dst stat syscall here is intentional — do NOT replace
+            // it with a caller-supplied "known size" from
+            // `Table::file_size()` or
+            // `BlobFileMetadata::total_compressed_bytes`. Those values
+            // record the writer's `file_pos` BEFORE the metadata block
+            // and footer were appended, so they undercount the on-disk
+            // file by hundreds to thousands of bytes per table. The
+            // streamed-copy fallback below counts the actual bytes it
+            // writes, so the two branches must agree on physical bytes
+            // for `CheckpointInfo::total_bytes` to match on-disk reality
+            // (asserted by `checkpoint_info_total_bytes_matches_disk`).
+            // One extra stat per linked file is cheap relative to the
+            // link itself.
+            Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::Unsupported
+                ) =>
+            {
+                // Same kernel namespace but the link didn't take —
+                // either dst_fs's backend doesn't support hard_link at
+                // all, or the file moved out from under us before the
+                // syscall. Either way, fall through to the streamed
+                // copy below. Log at `debug` for symmetry with
+                // `StdFs::hard_link`'s EXDEV fallback — operators
+                // wanting visibility of unexpected full copies grep the
+                // `fs` / `checkpoint` modules at debug level. `warn`
+                // would drown real signal on a misconfigured tier with
+                // thousands of SSTs.
+                log::debug!(
+                    "link_or_copy_cross_fs({}, {}) falling back to streamed copy ({})",
+                    src.display(),
+                    dst.display(),
+                    e.kind(),
+                );
+            }
+            Err(e) => return Err(e),
         }
-        Err(e) => return Err(e),
+    } else {
+        // Backends do not share a namespace (e.g. MemFs source vs
+        // StdFs destination). A hard_link attempt here would resolve
+        // `src` against the WRONG namespace and could silently link an
+        // unrelated file; skip straight to the streamed copy.
+        log::debug!(
+            "link_or_copy_cross_fs({}, {}) crossing namespaces — streaming copy",
+            src.display(),
+            dst.display(),
+        );
     }
 
     // Cross-backend / no-hardlink path — stream bytes through the trait.

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -381,13 +381,24 @@ fn write_current_for_version(
     target_root: &Path,
     version_id: u64,
 ) -> crate::Result<()> {
+    use crate::checksum::ChecksumType;
     use crate::file::rewrite_atomic;
     use byteorder::{LittleEndian, WriteBytesExt};
 
+    // The `current` wire format is `version_id: u64 | checksum: u128 |
+    // checksum_type: u8`. The checksum field is reserved for future
+    // verification — recovery reads it but does not validate it against
+    // the `v<id>` contents — so a zero literal is the documented "no
+    // digest carried" sentinel, not a forged digest. The checksum type
+    // MUST come from `ChecksumType` so any future format evolution
+    // (e.g. a real checksum) shifts this writer and the recovery
+    // checker in lockstep through one shared enum.
+    const RESERVED_CHECKSUM: u128 = 0;
+
     let mut content = vec![];
     content.write_u64::<LittleEndian>(version_id)?;
-    content.write_u128::<LittleEndian>(0)?; // checksum (not validated on read)
-    content.write_u8(0)?; // checksum_type = 0 (xxh3)
+    content.write_u128::<LittleEndian>(RESERVED_CHECKSUM)?;
+    content.write_u8(u8::from(ChecksumType::Xxh3))?;
 
     rewrite_atomic(&target_root.join(CURRENT_VERSION_FILE), &content, target_fs)?;
     Ok(())
@@ -596,7 +607,19 @@ pub fn run_checkpoint<T: AbstractTree>(
     // power loss even though the children we just synced would still be
     // intact on the underlying inodes. Required by the same fsync-
     // ordering rule that drove the child-directory syncs above.
-    if let Some(parent) = target_root.parent().filter(|p| !p.as_os_str().is_empty()) {
+    // `Path::parent()` returns `Some("")` for a bare leaf like `"checkpoint"`,
+    // which `fsync_directory` would reject as an invalid input. For a relative
+    // leaf the containing directory IS the process CWD, so resolve to `.`
+    // explicitly — otherwise we'd silently skip the fsync that guarantees the
+    // checkpoint's own directory entry survives a power loss.
+    let parent_to_fsync = target_root.parent().map(|p| {
+        if p.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            p
+        }
+    });
+    if let Some(parent) = parent_to_fsync {
         fsync_directory(parent, &**target_fs)?;
     }
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -163,6 +163,17 @@ pub fn link_or_copy_cross_fs(
         {
             // dst_fs cannot see src (cross-backend) or does not support
             // hard links at all → fall through to streamed copy.
+            // Log at `debug` for symmetry with `StdFs::hard_link`'s
+            // EXDEV fallback — operators wanting visibility of
+            // unexpected full copies should grep the `fs` /
+            // `checkpoint` modules at debug level. `warn` would drown
+            // real signal on a misconfigured tier with thousands of SSTs.
+            log::debug!(
+                "link_or_copy_cross_fs({}, {}) falling back to streamed copy ({})",
+                src.display(),
+                dst.display(),
+                e.kind(),
+            );
         }
         Err(e) => return Err(e),
     }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -25,7 +25,7 @@
 // the underlying `Fs` trait operates on, so this module inherits its
 // host `fs` module's std dependency rather than introducing a new one.
 use crate::{
-    AbstractTree, CheckpointInfo, SeqNo,
+    AbstractTree, CheckpointInfo,
     file::{BLOBS_FOLDER, CURRENT_VERSION_FILE, TABLES_FOLDER, fsync_directory},
     fs::{Fs, FsFile, FsOpenOptions},
     version::Version,
@@ -507,10 +507,19 @@ pub fn run_checkpoint<T: AbstractTree>(
     let captured_seqno = visible_seqno.get();
 
     // Force a flush so the captured version reflects all data that has
-    // reached the active memtable. Using a sentinel eviction seqno
-    // (`SeqNo::MAX`) lets `flush_active_memtable` flush regardless of
-    // current visible seqno — the data is durable in either case.
-    tree.flush_active_memtable(SeqNo::MAX)?;
+    // reached the active memtable. The eviction seqno parameter doubles
+    // as `CompactionStream::gc_seqno_threshold` — any older version of
+    // a key with `seqno < threshold` is dropped during the flush-time
+    // merge, and snapshot readers on the SOURCE tree lose that history.
+    //
+    // We pass `0` so the checkpoint-triggered flush never expands GC
+    // beyond what would have happened anyway: a checkpoint must NOT
+    // change the source's MVCC visibility semantics. Using a tighter
+    // threshold (e.g. `captured_seqno`) would still wrongly drop
+    // history readers below that watermark might need; using
+    // `SeqNo::MAX` (a previous oversight) wiped every older version
+    // of every key.
+    tree.flush_active_memtable(0)?;
 
     let version = tree.current_version();
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -589,14 +589,17 @@ pub fn run_checkpoint<T: AbstractTree>(
     // leaf the containing directory IS the process CWD, so resolve to `.`
     // explicitly — otherwise we'd silently skip the fsync that guarantees the
     // checkpoint's own directory entry survives a power loss.
-    let parent_to_fsync = target_root.parent().map(|p| {
-        if p.as_os_str().is_empty() {
-            Path::new(".")
-        } else {
-            p
-        }
-    });
-    if let Some(parent) = parent_to_fsync {
+    // Only fsync a NAMED parent. `Path::parent()` returns `Some("")`
+    // for a single-component relative target like `"checkpoint"` —
+    // substituting `Path::new(".")` would lean on the host OS's CWD,
+    // which works for StdFs but is meaningless for backends without a
+    // notion of current working directory (e.g. MemFs's
+    // `sync_directory(".")` returns NotFound). Skip the fsync in the
+    // empty-parent case; callers needing the parent-directory-entry-
+    // survives-power-loss guarantee pass an absolute path.
+    if let Some(parent) = target_root.parent()
+        && !parent.as_os_str().is_empty()
+    {
         fsync_directory(parent, &**target_fs)?;
     }
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -51,24 +51,35 @@ fn blob_link_name(id: crate::vlog::BlobFileId) -> String {
 
 /// Creates the directory structure for a fresh checkpoint.
 ///
-/// Builds `<target>`, `<target>/tables`, and optionally `<target>/blobs`
-/// under `target_fs`. Rejects an already existing target so a
-/// partially-overlapping checkpoint cannot be accidentally produced.
+/// Uses the atomic [`Fs::create_dir`] primitive (POSIX `mkdir(2)`) to
+/// claim the target directory: two concurrent callers race the kernel
+/// and the losing one observes [`std::io::ErrorKind::AlreadyExists`].
+/// This replaces an earlier `exists()` + `create_dir_all()` sequence
+/// that had a TOCTOU window between the two calls.
+///
+/// Once the leaf directory is ours, the `tables/` and (optionally)
+/// `blobs/` subdirectories are created. The caller's parent path must
+/// exist; this function does not recurse.
 pub fn prepare_target(target: &Path, include_blobs: bool, target_fs: &dyn Fs) -> crate::Result<()> {
-    if target_fs.exists(target)? {
-        return Err(crate::Error::from(std::io::Error::new(
-            std::io::ErrorKind::AlreadyExists,
-            format!(
-                "checkpoint target {} already exists; refusing to overwrite",
-                target.display(),
-            ),
-        )));
-    }
+    // Atomic claim — fails with AlreadyExists if any other process /
+    // thread / prior checkpoint already created the directory.
+    target_fs.create_dir(target).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "checkpoint target {} already exists; refusing to overwrite",
+                    target.display(),
+                ),
+            )
+        } else {
+            e
+        }
+    })?;
 
-    target_fs.create_dir_all(target)?;
-    target_fs.create_dir_all(&target.join(TABLES_FOLDER))?;
+    target_fs.create_dir(&target.join(TABLES_FOLDER))?;
     if include_blobs {
-        target_fs.create_dir_all(&target.join(BLOBS_FOLDER))?;
+        target_fs.create_dir(&target.join(BLOBS_FOLDER))?;
     }
     Ok(())
 }
@@ -103,10 +114,15 @@ pub fn link_or_copy_cross_fs(
     let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
     let mut total: u64 = 0;
     loop {
-        let n = src_file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
+        // Retry on EINTR — matches `StdFs::copy_fallback` and avoids
+        // spurious checkpoint failures when a signal arrives during the
+        // copy (common under shell-managed Ctrl-C handlers).
+        let n = match src_file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
         #[expect(
             clippy::indexing_slicing,
             reason = "n was just produced by read() and is bounded by buf.len()"
@@ -197,8 +213,44 @@ fn copy_metadata_file(
     Ok(())
 }
 
-/// Replicates the manifest, the active version snapshot (`v<id>`), and the
-/// `current` pointer file from the source tree into the checkpoint.
+/// Writes the checkpoint's `current` pointer for the captured
+/// `version_id`.
+///
+/// The original source-tree `CURRENT` may have advanced concurrently
+/// between when we captured `version` and when we get here — copying it
+/// verbatim would risk pointing the checkpoint at a `v<N+1>` that we
+/// never linked. Instead we write a fresh `current` file in the same
+/// wire format as [`crate::version::persist_version`]: `u64 version_id`
+/// + `u128 checksum` + `u8 checksum_type`.
+///
+/// The checksum field is intentionally written as zero: recovery's
+/// [`crate::version::recovery`] reads it for forward-compatibility but
+/// does not validate it against the `v<id>` file's contents, so any
+/// value works. The zero is a deliberate "no checksum carried" sentinel,
+/// not an attempt to forge a real digest.
+fn write_current_for_version(
+    target_fs: &dyn Fs,
+    target_root: &Path,
+    version_id: u64,
+) -> crate::Result<()> {
+    use crate::file::rewrite_atomic;
+    use byteorder::{LittleEndian, WriteBytesExt};
+
+    let mut content = vec![];
+    content.write_u64::<LittleEndian>(version_id)?;
+    content.write_u128::<LittleEndian>(0)?; // checksum (not validated on read)
+    content.write_u8(0)?; // checksum_type = 0 (xxh3)
+
+    rewrite_atomic(&target_root.join(CURRENT_VERSION_FILE), &content, target_fs)?;
+    Ok(())
+}
+
+/// Replicates manifest + `v<id>` + writes a fresh `current` pointer.
+///
+/// Pulls the manifest and the active version snapshot (`v<id>`) from
+/// the source tree into the checkpoint, then writes a fresh `current`
+/// pointer for the captured version (see [`write_current_for_version`]
+/// for why we don't copy the live file).
 ///
 /// `version_id` is the ID of the version captured at checkpoint time; the
 /// corresponding `v<id>` file MUST exist on the source because checkpoint
@@ -213,7 +265,9 @@ pub fn copy_metadata(
 ) -> crate::Result<()> {
     // Manifest stores level count + comparator name; required on open.
     copy_metadata_file(src_fs, src_root, target_fs, target_root, "manifest")?;
-    // Active version snapshot.
+    // Active version snapshot — `v<id>` is immutable once published,
+    // so copying it verbatim is race-free regardless of concurrent
+    // version transitions.
     copy_metadata_file(
         src_fs,
         src_root,
@@ -221,16 +275,13 @@ pub fn copy_metadata(
         target_root,
         &format!("v{version_id}"),
     )?;
-    // CURRENT pointer must be copied LAST so a crash between version copy
-    // and CURRENT copy leaves the checkpoint in a "version present, no
-    // pointer" state — equivalent to a tree that was just created.
-    copy_metadata_file(
-        src_fs,
-        src_root,
-        target_fs,
-        target_root,
-        CURRENT_VERSION_FILE,
-    )?;
+    // CURRENT pointer is generated fresh for the captured `version_id`
+    // (NOT copied from source) so a concurrent publish to `v<N+1>` on
+    // the source can never leave the checkpoint pointing at a version
+    // we did not link. Written LAST so a crash before this point leaves
+    // the checkpoint in a "version present, no pointer" state, which
+    // recovery treats as a freshly-initialised tree.
+    write_current_for_version(target_fs, target_root, version_id)?;
     Ok(())
 }
 
@@ -254,6 +305,47 @@ pub struct CheckpointParams<'a> {
     pub include_blobs: bool,
 }
 
+/// RAII guard that removes a partially-built checkpoint directory on
+/// early return. Call [`PartialCheckpointGuard::commit`] just before the
+/// final success path to disarm it; otherwise its `Drop` walks the tree
+/// and best-effort removes it.
+struct PartialCheckpointGuard<'a> {
+    target_root: &'a Path,
+    target_fs: &'a Arc<dyn Fs>,
+    armed: bool,
+}
+
+impl<'a> PartialCheckpointGuard<'a> {
+    fn new(target_root: &'a Path, target_fs: &'a Arc<dyn Fs>) -> Self {
+        Self {
+            target_root,
+            target_fs,
+            armed: true,
+        }
+    }
+
+    fn commit(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PartialCheckpointGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Best-effort: a failure to clean up the partial checkpoint is
+        // logged but does not turn into a panic — the original error
+        // from `run_checkpoint` is what the caller wants to see.
+        if let Err(e) = self.target_fs.remove_dir_all(self.target_root) {
+            log::warn!(
+                "Failed to clean up partial checkpoint at {}: {e:?}",
+                self.target_root.display(),
+            );
+        }
+    }
+}
+
 /// Common driver shared by [`Tree`](crate::Tree) and
 /// [`BlobTree`](crate::BlobTree). Performs the flush + link + metadata
 /// copy under a held [`Pause`](crate::deletion_pause::Pause) guard.
@@ -271,6 +363,12 @@ pub fn run_checkpoint<T: AbstractTree>(
 
     prepare_target(target_root, include_blobs, &**target_fs)?;
 
+    // From this point on, any early return must clean up the partial
+    // checkpoint so retries against the same path don't hit
+    // `AlreadyExists`. The guard is disarmed via `commit()` once the
+    // final `fsync_directory` succeeds.
+    let cleanup = PartialCheckpointGuard::new(target_root, target_fs);
+
     // Hold the pause guard for the duration of the checkpoint so any
     // tables / blob files that compaction marks as deleted are held back.
     let _pause = deletion_pause.acquire();
@@ -281,8 +379,15 @@ pub fn run_checkpoint<T: AbstractTree>(
     // current visible seqno — the data is durable in either case.
     tree.flush_active_memtable(SeqNo::MAX)?;
 
-    let version = tree.current_version();
+    // Capture the seqno BEFORE the version snapshot. Reading
+    // `visible_seqno` after `current_version()` would let concurrent
+    // writers advance the counter past data that never made it into the
+    // checkpoint, so PITR consumers could move the recovery cutoff past
+    // records they still need from WAL / replication. The "before"
+    // ordering means `CheckpointInfo::seqno` is a lower bound on the
+    // seqno reflected in the version snapshot — safe for cutoffs.
     let captured_seqno = visible_seqno.get();
+    let version = tree.current_version();
 
     let (sst_files, sst_bytes) = link_tables(&version, target_root, target_fs)?;
 
@@ -293,7 +398,20 @@ pub fn run_checkpoint<T: AbstractTree>(
     };
 
     copy_metadata(&**src_fs, src_root, &**target_fs, target_root, version.id())?;
+
+    // fsync each populated child directory BEFORE the root so the
+    // directory entries we just created (`tables/<id>`, `blobs/<id>`,
+    // `current`, `manifest`, `v<id>`) survive a power loss. The root
+    // fsync alone only persists the existence of `tables/` and
+    // `blobs/`, not their contents.
+    fsync_directory(&target_root.join(TABLES_FOLDER), &**target_fs)?;
+    if include_blobs {
+        fsync_directory(&target_root.join(BLOBS_FOLDER), &**target_fs)?;
+    }
+
     fsync_directory(target_root, &**target_fs)?;
+
+    cleanup.commit();
 
     Ok(CheckpointInfo {
         sst_files,

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -135,8 +135,11 @@ impl Drop for RootCleanup<'_> {
 ///    e.g. `MemFs` target with `StdFs` source) **or `Unsupported`**
 ///    (in-memory backends that don't implement linking), stream bytes
 ///    through both trait objects. This is the only path that doubles
-///    storage; logged via [`log::warn`] in the [`StdFs`] fallback so
-///    operators can spot tier-misconfigurations.
+///    storage. The fallback itself is silent here (the [`StdFs`] EXDEV
+///    fallback emits one [`log::debug`] per file); operator-visible
+///    notification of unexpected copies is the checkpoint driver's
+///    responsibility — a per-file warning would drown real signal on
+///    a misconfigured tier with thousands of SSTs.
 ///
 /// Using `Arc::ptr_eq` as the discriminator would be too strict: two
 /// `Arc::new(StdFs)` values produced independently (e.g. one in the
@@ -479,20 +482,25 @@ pub fn run_checkpoint<T: AbstractTree>(
     // tables / blob files that compaction marks as deleted are held back.
     let _pause = deletion_pause.acquire();
 
+    // Capture the seqno BEFORE the flush. Sampling later (between flush
+    // and `current_version()`) is unsafe: a concurrent writer can land
+    // in the freshly-rotated active memtable, advance `visible_seqno`,
+    // and bump the captured value above what the snapshot actually
+    // contains — those writes are in the new memtable, NOT in the SSTs
+    // we're about to link. With the "before flush" ordering the
+    // captured seqno is a strict lower bound on the snapshot's
+    // contents: every record visible at sample time has reached the
+    // memtable, the flush forces it into SSTs, and the version snapshot
+    // sees the resulting on-disk state. Later writes can advance the
+    // live counter but cannot pull our `captured_seqno` upward.
+    let captured_seqno = visible_seqno.get();
+
     // Force a flush so the captured version reflects all data that has
     // reached the active memtable. Using a sentinel eviction seqno
     // (`SeqNo::MAX`) lets `flush_active_memtable` flush regardless of
     // current visible seqno — the data is durable in either case.
     tree.flush_active_memtable(SeqNo::MAX)?;
 
-    // Capture the seqno BEFORE the version snapshot. Reading
-    // `visible_seqno` after `current_version()` would let concurrent
-    // writers advance the counter past data that never made it into the
-    // checkpoint, so PITR consumers could move the recovery cutoff past
-    // records they still need from WAL / replication. The "before"
-    // ordering means `CheckpointInfo::seqno` is a lower bound on the
-    // seqno reflected in the version snapshot — safe for cutoffs.
-    let captured_seqno = visible_seqno.get();
     let version = tree.current_version();
 
     let (sst_files, sst_bytes) = link_tables(&version, target_root, target_fs)?;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -154,6 +154,17 @@ pub fn link_or_copy_cross_fs(
     dst: &Path,
 ) -> std::io::Result<u64> {
     match dst_fs.hard_link(src, dst) {
+        // The dst stat syscall here is intentional — do NOT replace it
+        // with a caller-supplied "known size" from `Table::file_size()`
+        // or `BlobFileMetadata::total_compressed_bytes`. Those values
+        // record the writer's `file_pos` BEFORE the metadata block and
+        // footer were appended, so they undercount the on-disk file by
+        // hundreds to thousands of bytes per table. The streamed-copy
+        // fallback below counts the actual bytes it writes, so the two
+        // branches must agree on physical bytes for `CheckpointInfo
+        // ::total_bytes` to match on-disk reality (asserted by
+        // `checkpoint_info_total_bytes_matches_disk`). One extra stat
+        // per linked file is cheap relative to the link itself.
         Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
         Err(e)
             if matches!(

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -13,7 +13,7 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 
 #[cfg(feature = "zstd")]
-use once_cell::sync::OnceCell;
+use once_cell::race::OnceBox;
 
 /// Zstd compression backend operations.
 ///
@@ -90,7 +90,7 @@ pub struct ZstdDictionary {
     /// primitive and reuse the winner's `Arc` clone. This keeps the `new()`
     /// constructor infallible AND preserves the single-parse contract.
     #[cfg(feature = "zstd")]
-    prepared: Arc<OnceCell<structured_zstd::decoding::DictionaryHandle>>,
+    prepared: Arc<OnceBox<structured_zstd::decoding::DictionaryHandle>>,
 }
 
 #[cfg(zstd_any)]
@@ -146,7 +146,7 @@ impl ZstdDictionary {
             id: compute_dict_id(raw),
             raw: Arc::from(raw),
             #[cfg(feature = "zstd")]
-            prepared: Arc::new(OnceCell::new()),
+            prepared: Arc::new(OnceBox::new()),
         }
     }
 
@@ -173,20 +173,24 @@ impl ZstdDictionary {
         use structured_zstd::decoding::{Dictionary, DictionaryHandle};
         const DICT_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
 
-        // `get_or_try_init` is the canonical single-init-across-racers
-        // primitive: the closure runs at most once globally regardless of
-        // contention; concurrent callers wait on the OnceCell's internal
-        // one-shot synchronisation and read the cached `Arc` afterwards.
-        // The fast path (cached value) is lock-free; the slow path runs
-        // exactly once per `ZstdDictionary` lifetime even under heavy
-        // cold-start contention. On a parse failure the OnceCell stays
-        // empty and the next caller retries from scratch — preserving
-        // the retry-on-failure contract pinned by the rejection test.
+        // `OnceBox::get_or_try_init` is the canonical single-init-
+        // across-racers primitive: the closure runs at most once
+        // globally regardless of contention; concurrent callers race on
+        // a single CAS and the losers drop their unused `Box` while the
+        // winners' value becomes the stable `&T`. The fast path (cached
+        // value) is lock-free; the slow path runs exactly once per
+        // `ZstdDictionary` lifetime even under heavy cold-start
+        // contention. On a parse failure the OnceBox stays empty and
+        // the next caller retries from scratch — preserving the
+        // retry-on-failure contract pinned by the rejection test.
+        // `Box::new(handle)` is the OnceBox API requirement: the slot
+        // owns a heap allocation rather than the value inline, which
+        // is what lets the type stay no-std + alloc compatible.
         self.prepared
-            .get_or_try_init(|| -> crate::Result<DictionaryHandle> {
-                if self.raw.starts_with(&DICT_MAGIC) {
+            .get_or_try_init(|| -> crate::Result<Box<DictionaryHandle>> {
+                let handle = if self.raw.starts_with(&DICT_MAGIC) {
                     DictionaryHandle::decode_dict(&self.raw)
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))
+                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
                 } else {
                     #[expect(
                         clippy::cast_possible_truncation,
@@ -195,8 +199,9 @@ impl ZstdDictionary {
                     let raw_content_id = (self.id as u32).max(1);
                     let dict = Dictionary::from_raw_content(raw_content_id, self.raw.to_vec())
                         .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
-                    Ok(DictionaryHandle::from_dictionary(dict))
-                }
+                    DictionaryHandle::from_dictionary(dict)
+                };
+                Ok(Box::new(handle))
             })
             .cloned()
     }

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -84,11 +84,15 @@ pub struct ZstdDictionary {
     /// Lazily-parsed shared `DictionaryHandle` (Arc-backed inside structured-zstd).
     /// Populated on first decompress call and reused across all subsequent calls
     /// and all threads — eliminates the per-thread dictionary re-parse the TLS
-    /// `FrameDecoder` cache used to incur on every miss. `OnceCell::get_or_try_init`
-    /// guarantees exactly one successful parse across racing threads with no
-    /// auxiliary mutex: losers wait on the internal one-shot synchronisation
-    /// primitive and reuse the winner's `Arc` clone. This keeps the `new()`
-    /// constructor infallible AND preserves the single-parse contract.
+    /// `FrameDecoder` cache used to incur on every miss.
+    /// `OnceBox::get_or_try_init` guarantees one successful parse across
+    /// racing threads via a single CAS on the slot pointer: the winner's
+    /// `Box<DictionaryHandle>` becomes the stable `&T`, racing losers drop
+    /// their unused `Box` allocations and read the winner's value on the
+    /// next iteration. No auxiliary mutex is needed because the slot is
+    /// lock-free; the only contention is the brief CAS window during the
+    /// cold-start race. This keeps the `new()` constructor infallible AND
+    /// preserves the single-parse contract.
     #[cfg(feature = "zstd")]
     prepared: Arc<OnceBox<structured_zstd::decoding::DictionaryHandle>>,
 }

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -235,13 +235,17 @@ mod tests {
     ///    `mem::take`, *executing* the deletion Thread B was supposed to
     ///    defer. Thread B's file vanishes despite an active pause.
     ///
-    /// The deterministic reproducer below uses a side-channel `Mutex` to
-    /// hold Thread A in the drop path until Thread B has enqueued, then
-    /// releases A. With the fix (re-check `active` under the lock) the
-    /// file survives until Thread B drops its pause; without the fix the
-    /// file is removed prematurely and the assertion below fires.
+    /// The deterministic reproducer below uses two channels to pin the
+    /// invariant check at the exact moment when Thread B holds an active
+    /// pause and the queue contains its enqueued item. Without the fix,
+    /// A's drop would have already swept the queue and removed B's file
+    /// before B signalled `ready` — the survives-while-B-holds-pause
+    /// assertion fires. With the fix, A's drop bails out under the lock
+    /// (because B's `acquire` already incremented `active`) and the file
+    /// survives until B drops at the end.
     #[test]
     fn drain_does_not_steal_a_new_generation_queue() {
+        use std::sync::mpsc;
         use std::thread;
         use std::time::Duration;
 
@@ -254,38 +258,48 @@ mod tests {
         let pause = DeletionPause::new();
         let a = pause.acquire();
 
-        // Run many iterations to widen the chance of hitting the race
-        // window on systems where atomic decrement + lock acquisition
-        // is fast enough to never interleave with the spawned thread.
-        // With the fix this loop is uneventful; without the fix any
-        // interleaving where Thread B enqueues between A's `fetch_sub`
-        // and A's `queue.lock()` causes B's file to be erroneously
-        // removed.
+        let (ready_tx, ready_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+
         let b_pause = Arc::clone(&pause);
         let b_fs = Arc::clone(&dyn_fs);
         let b_path = path.clone();
         let b_thread = thread::spawn(move || {
-            // Wait until A has started dropping (small sleep is cheap and
-            // gives A the chance to call fetch_sub first).
+            // Brief sleep gives Thread A time to start its `Drop`
+            // (`fetch_sub` followed by `queue.lock()`); on this side we
+            // then race in with our own `acquire` so the fix's "re-check
+            // active under the lock" branch is exercised.
             thread::sleep(Duration::from_millis(5));
             let _b = b_pause.acquire();
             assert!(b_pause.try_enqueue(b_fs, b_path));
-            // Hold the pause long enough for A's drop to complete.
-            thread::sleep(Duration::from_millis(20));
+            // Signal the main thread that B is in the right state and
+            // wait for the invariant check to complete before dropping
+            // the pause guard.
+            ready_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
             // Implicit drop here drains the queue.
         });
 
         // Trigger A's drop now.
         drop(a);
 
+        // Block until B has acquired AND enqueued; this is the exact
+        // moment the race manifests. With the fix, the file MUST still
+        // exist on disk because B's pause is active and the queued item
+        // belongs to B's generation. Without the fix, A's drain has
+        // already removed it — assertion fires here, not after join.
+        ready_rx.recv().unwrap();
+        assert!(
+            fs.exists(&path).unwrap(),
+            "file must survive while Thread B holds an active pause \
+             (a's drain leaked into b's generation)",
+        );
+        release_tx.send(()).unwrap();
+
         b_thread.join().unwrap();
 
-        // After both pauses dropped, file should be GONE (B's pause was
-        // last and properly drained). The race bug would surface as a
-        // panic in `remove_file` against an already-removed path, not as
-        // a survived file — but the more important invariant is that
-        // there's no double-remove. Verify by re-creating + re-running
-        // with assertion that the queue length stays sane.
+        // Sanity: after B drops too, the file is gone (B's drop drained
+        // its own generation properly).
         assert!(
             !fs.exists(&path).unwrap(),
             "file should be removed after both pauses dropped",

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -62,9 +62,21 @@ impl core::fmt::Debug for DeletionPause {
 
 impl DeletionPause {
     /// Creates a new pause controller in the inactive state.
+    ///
+    /// This is the plain constructor — owns the value, no allocation
+    /// decision baked in. Use [`Self::new_shared`] when you specifically
+    /// want an `Arc`-wrapped controller (the common case for tree
+    /// installation where every table / blob file holds a clone).
     #[must_use]
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self::default())
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Convenience: creates a new pause controller and wraps it in an
+    /// [`Arc`]. Equivalent to `Arc::new(DeletionPause::new())`.
+    #[must_use]
+    pub fn new_shared() -> Arc<Self> {
+        Arc::new(Self::new())
     }
 
     /// Returns `true` if there is at least one active [`Pause`] guard and
@@ -194,7 +206,7 @@ mod tests {
         write_file(&fs, &path, b"sst");
         let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
 
-        let pause = DeletionPause::new();
+        let pause = DeletionPause::new_shared();
         let guard = pause.acquire();
 
         assert!(pause.try_enqueue(dyn_fs.clone(), path.clone()));
@@ -218,7 +230,7 @@ mod tests {
         write_file(&fs, &path, b"x");
         let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
 
-        let pause = DeletionPause::new();
+        let pause = DeletionPause::new_shared();
         assert!(!pause.try_enqueue(dyn_fs, path.clone()));
         assert!(fs.exists(&path).unwrap());
     }
@@ -255,7 +267,7 @@ mod tests {
         write_file(&fs, &path, b"keep-me");
         let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
 
-        let pause = DeletionPause::new();
+        let pause = DeletionPause::new_shared();
         let a = pause.acquire();
 
         let (ready_tx, ready_rx) = mpsc::channel::<()>();
@@ -314,7 +326,7 @@ mod tests {
         write_file(&fs, &path, b"x");
         let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
 
-        let pause = DeletionPause::new();
+        let pause = DeletionPause::new_shared();
         let outer = pause.acquire();
         let inner = pause.acquire();
 

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -22,14 +22,15 @@
 //! blob-file `Inner`, the [`Drop`] check is O(1) and lock-free in the
 //! common case (no checkpoint in progress).
 
+// Prefer `alloc`/`core` for primitives that exist there. `Mutex` and
+// `PathBuf` have no alloc-only equivalent in the standard library and
+// stay on `std::*` — they carry the same std dependency that the
+// underlying `Fs` trait already pulls in, so this module's no-std
+// posture matches `crate::fs` exactly.
 use crate::fs::Fs;
-use std::{
-    path::PathBuf,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU32, Ordering},
-    },
-};
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU32, Ordering};
+use std::{path::PathBuf, sync::Mutex};
 
 /// Shared state controlling whether file deletions are deferred.
 ///
@@ -50,8 +51,8 @@ struct QueuedDeletion {
     path: PathBuf,
 }
 
-impl std::fmt::Debug for DeletionPause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeletionPause {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DeletionPause")
             .field("active", &self.active.load(Ordering::Relaxed))
             .field("queued", &self.queue.lock().map(|q| q.len()).unwrap_or(0))

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -144,6 +144,17 @@ impl Drop for Pause {
             return;
         }
 
+        // Test-only deterministic interleave point: the
+        // `drain_does_not_steal_a_new_generation_queue` regression test
+        // exercises the exact window between `fetch_sub(1)` above and
+        // the queue lock below. Without a hook the window is microseconds
+        // wide and unobservable from outside; the hook lets the test
+        // suspend this drop until thread B has run `acquire() + try_enqueue()`.
+        // Production builds compile this out (the symbol exists only
+        // under `#[cfg(test)]`).
+        #[cfg(test)]
+        tests::drain_barrier::wait();
+
         // We were the last pause holder — drain and execute pending
         // deletions. Generation race: between the `fetch_sub` above and
         // acquiring the queue lock below, another thread can call
@@ -191,6 +202,45 @@ mod tests {
         let opts = crate::fs::FsOpenOptions::new().write(true).create(true);
         let mut f = fs.open(path, &opts).unwrap();
         f.write_all(bytes).unwrap();
+    }
+
+    /// Test-only barrier that lets a regression test suspend the
+    /// `Drop for Pause` exactly between `active.fetch_sub(1)` and
+    /// `self.inner.queue.lock()`. Production builds never reach
+    /// `wait()` because the call site is `#[cfg(test)]`-gated.
+    ///
+    /// The barrier is single-shot per `arm()`: `arm()` installs a
+    /// receiver, the next `wait()` call blocks until `release()` sends
+    /// on the matching sender, then the receiver is consumed. Tests
+    /// that don't `arm()` get a no-op `wait()`.
+    pub(super) mod drain_barrier {
+        use std::sync::Mutex;
+        use std::sync::mpsc;
+
+        static CHANNEL: Mutex<Option<mpsc::Receiver<()>>> = Mutex::new(None);
+
+        /// Install a receiver. Returns the sender end; calling `send(())`
+        /// (or letting the sender drop) lets the next `wait()` proceed.
+        pub fn arm() -> mpsc::Sender<()> {
+            let (tx, rx) = mpsc::channel();
+            *CHANNEL.lock().unwrap() = Some(rx);
+            tx
+        }
+
+        /// Block until the armed sender releases us, or return
+        /// immediately if no sender is armed.
+        pub fn wait() {
+            // Hold the lock only long enough to TAKE the receiver, so
+            // the spinning Drop holds nothing while it waits on the
+            // channel — otherwise a deadlock with `arm()` is possible.
+            let rx = CHANNEL.lock().unwrap().take();
+            if let Some(rx) = rx {
+                // Wait for the test thread's signal. Drop-send is also a
+                // valid release (the recv() returns RecvError, which we
+                // ignore — releasing on disarm is intentional).
+                let _ = rx.recv();
+            }
+        }
     }
 
     #[test]
@@ -250,6 +300,16 @@ mod tests {
     /// assertion fires. With the fix, A's drop bails out under the lock
     /// (because B's `acquire` already incremented `active`) and the file
     /// survives until B drops at the end.
+    /// The deterministic reproducer drives A's drop on its own thread
+    /// and uses the test-only `drain_barrier` to suspend A INSIDE Drop
+    /// — exactly between `active.fetch_sub(1)` and `queue.lock()`. B
+    /// then runs `acquire() + try_enqueue()` in that window, which is
+    /// the precise race CodeRabbit/Copilot called out. After B's work
+    /// is observable, the test releases the barrier so A's drain step
+    /// runs against `active > 0` and bails out — leaving B's file
+    /// intact for the assertion. Without the fix (no `active`-recheck
+    /// under the lock) A would drain B's enqueue and the file would
+    /// disappear before the assert.
     #[test]
     fn drain_does_not_steal_a_new_generation_queue() {
         use std::sync::mpsc;
@@ -264,62 +324,87 @@ mod tests {
         let pause = DeletionPause::new_shared();
         let a = pause.acquire();
 
-        // Deterministic handshake: `a_dropped_tx` signals that A's
-        // `fetch_sub(1)` has executed (so `active == 0` from A's
-        // perspective and A is committed to the drain branch); B then
-        // races in with `acquire()`+`try_enqueue()` to exercise the
-        // generation-race protection. Spin-wait on `active == 0` instead
-        // of using a fixed sleep so the test is robust under any
-        // scheduler / CI load.
-        let (a_dropped_tx, a_dropped_rx) = mpsc::channel::<()>();
-        let (ready_tx, ready_rx) = mpsc::channel::<()>();
-        let (release_tx, release_rx) = mpsc::channel::<()>();
+        // Arm the in-Drop barrier. The next Pause::drop on the last
+        // guard will block at the barrier wait point AFTER fetch_sub
+        // and BEFORE the queue lock. The sender we get back is what
+        // releases that block when we say so.
+        let release_a_tx = drain_barrier::arm();
 
+        // (in_window_tx, in_window_rx): A signals it has entered the
+        // barrier wait — i.e. fetch_sub is done, active is 0, drain
+        // step is suspended. B should NOT touch the pause until then.
+        let (in_window_tx, in_window_rx) = mpsc::channel::<()>();
+        // (b_ready_tx, b_ready_rx): B signals it has acquired the new
+        // generation and enqueued its file; main thread can now check
+        // the survives-the-race invariant.
+        let (b_ready_tx, b_ready_rx) = mpsc::channel::<()>();
+        // (release_b_tx, release_b_rx): main thread tells B to drop
+        // its pause guard after the invariant has been verified.
+        let (release_b_tx, release_b_rx) = mpsc::channel::<()>();
+
+        // Thread A: drives drop(a) directly. Drop hits the barrier
+        // wait, blocks, and we send `in_window_tx` to advertise that
+        // we're suspended in the exact race window.
+        let a_pause = Arc::clone(&pause);
+        let a_thread = thread::spawn(move || {
+            // We have to announce we're about to suspend BEFORE the
+            // drop runs — the drop itself can't signal because it
+            // blocks. The main thread spin-waits on the active
+            // counter (below) to confirm A's fetch_sub really executed.
+            in_window_tx.send(()).unwrap();
+            drop(a);
+            // After release the drain step runs and Drop returns.
+            // We keep `a_pause` alive for the spin-wait above; it
+            // doesn't influence the race.
+            drop(a_pause);
+        });
+
+        // Wait until A is about to drop. Spin-wait until A's fetch_sub
+        // has actually decremented `active` to 0 — that's how we know
+        // A is now suspended INSIDE the barrier wait, having passed
+        // step 1 and not yet reached step 4 (queue lock + recheck).
+        in_window_rx.recv().unwrap();
+        while pause.active.load(Ordering::Acquire) != 0 {
+            core::hint::spin_loop();
+        }
+
+        // Thread B: now run acquire + try_enqueue while A is suspended.
+        // Without the in-Drop barrier, this would race A by microseconds
+        // and the test would be flaky / pass on broken code (the old
+        // bug). With the barrier we're DETERMINISTICALLY between A's
+        // fetch_sub and A's queue.lock().
         let b_pause = Arc::clone(&pause);
         let b_fs = Arc::clone(&dyn_fs);
         let b_path = path.clone();
         let b_thread = thread::spawn(move || {
-            // Block until A has begun its drop. We then spin until
-            // A's `fetch_sub` has visibly reduced `active` to 0 —
-            // that's the exact window where A is about to lock the
-            // queue and the fix MUST notice our subsequent `acquire`
-            // under the lock.
-            a_dropped_rx.recv().unwrap();
-            while b_pause.active.load(Ordering::Acquire) != 0 {
-                core::hint::spin_loop();
-            }
             let _b = b_pause.acquire();
             assert!(b_pause.try_enqueue(b_fs, b_path));
-            // Signal the main thread that B is in the right state and
-            // wait for the invariant check to complete before dropping
-            // the pause guard.
-            ready_tx.send(()).unwrap();
-            release_rx.recv().unwrap();
+            b_ready_tx.send(()).unwrap();
+            release_b_rx.recv().unwrap();
             // Implicit drop here drains the queue.
         });
 
-        // Trigger A's drop now. Send the handshake AFTER drop returns
-        // so B observes A's `fetch_sub`-decremented `active` value.
-        drop(a);
-        a_dropped_tx.send(()).unwrap();
+        // Wait until B has acquired + enqueued. Now release A's drop
+        // so the drain step runs. Under the fix A sees `active > 0`
+        // under the lock and returns without taking B's enqueue.
+        b_ready_rx.recv().unwrap();
+        release_a_tx.send(()).unwrap();
+        a_thread.join().unwrap();
 
-        // Block until B has acquired AND enqueued; this is the exact
-        // moment the race manifests. With the fix, the file MUST still
-        // exist on disk because B's pause is active and the queued item
-        // belongs to B's generation. Without the fix, A's drain has
-        // already removed it — assertion fires here, not after join.
-        ready_rx.recv().unwrap();
+        // Invariant: B still holds an active pause and the file is
+        // still in B's queue. The fix MUST have prevented A's drain
+        // from removing it. Without the fix this assertion fires.
         assert!(
             fs.exists(&path).unwrap(),
             "file must survive while Thread B holds an active pause \
              (a's drain leaked into b's generation)",
         );
-        release_tx.send(()).unwrap();
+        release_b_tx.send(()).unwrap();
 
         b_thread.join().unwrap();
 
-        // Sanity: after B drops too, the file is gone (B's drop drained
-        // its own generation properly).
+        // Sanity: after B drops too, the file is gone (B's drop
+        // drained its own generation properly).
         assert!(
             !fs.exists(&path).unwrap(),
             "file should be removed after both pauses dropped",

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -85,12 +85,15 @@ impl DeletionPause {
         // Lock the queue then re-check under the lock — if the pause was
         // released between the atomic load above and acquiring the lock,
         // the queue would never be drained and the file would leak.
-        let Ok(mut queue) = self.queue.lock() else {
-            // Mutex poisoning means another thread panicked while holding
-            // the queue. We refuse to enqueue (returning false) so the
-            // caller falls back to immediate removal — the safer option.
-            return false;
-        };
+        //
+        // On poisoning we recover with `into_inner()` rather than
+        // refusing the enqueue: dropping the file unconditionally would
+        // race a still-active checkpoint. Best-effort enqueue keeps the
+        // invariant ("file survives while a pause is held") intact.
+        let mut queue = self
+            .queue
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if !self.is_active() {
             return false;
         }
@@ -122,34 +125,55 @@ impl Drop for Pause {
         let prev = self.inner.active.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(prev > 0, "DeletionPause underflow");
 
-        if prev == 1 {
-            // We were the last pause holder — drain and execute pending
-            // deletions. We deliberately swap out the queue under the
-            // lock so newly-queued items (which can only happen if a new
-            // pause is acquired concurrently) do not get lost.
-            let drained = {
-                let Ok(mut queue) = self.inner.queue.lock() else {
-                    return;
-                };
-                std::mem::take(&mut *queue)
-            };
+        if prev != 1 {
+            return;
+        }
 
-            for item in drained {
-                if let Err(e) = item.fs.remove_file(&item.path) {
-                    // Match the warning style used by Table/BlobFile Drop
-                    // impls so log filters keep working.
-                    log::warn!(
-                        "Failed to remove deferred deletion {}: {e:?}",
-                        item.path.display(),
-                    );
-                }
+        // We were the last pause holder — drain and execute pending
+        // deletions. Two correctness concerns:
+        //
+        // 1. **Generation race.** Between the `fetch_sub` above and
+        //    acquiring the queue lock below, another thread can call
+        //    `acquire()` and `try_enqueue()`. Items pushed in that new
+        //    generation belong to the new pause, not to us. We re-check
+        //    `active` under the lock and bail out if a new pause is now
+        //    in flight; the new pause's eventual `Drop` will drain those
+        //    items at the correct generation boundary.
+        //
+        // 2. **Mutex poisoning.** If another thread panicked while
+        //    holding the queue, `lock()` returns `PoisonError`. We
+        //    recover via `into_inner()` and drain best-effort —
+        //    abandoning the queue would leak the queued files until
+        //    process exit, defeating the entire point of this type.
+        let drained = {
+            let mut queue = self
+                .inner
+                .queue
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if self.inner.active.load(Ordering::Acquire) > 0 {
+                // A new pause has taken responsibility for the queue.
+                // Leave its items alone; its drop will handle them.
+                return;
+            }
+            std::mem::take(&mut *queue)
+        };
+
+        for item in drained {
+            if let Err(e) = item.fs.remove_file(&item.path) {
+                // Match the warning style used by Table/BlobFile Drop
+                // impls so log filters keep working.
+                log::warn!(
+                    "Failed to remove deferred deletion {}: {e:?}",
+                    item.path.display(),
+                );
             }
         }
     }
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "test code")]
+#[expect(clippy::unwrap_used, reason = "test code")]
 mod tests {
     use super::*;
     use crate::fs::{Fs, MemFs};
@@ -197,6 +221,75 @@ mod tests {
         let pause = DeletionPause::new();
         assert!(!pause.try_enqueue(dyn_fs, path.clone()));
         assert!(fs.exists(&path).unwrap());
+    }
+
+    /// Regression test for the generation race in `Drop for Pause`.
+    ///
+    /// Scenario the broken code allows:
+    ///
+    /// 1. Thread A holds the only pause (`active == 1`).
+    /// 2. Thread A calls `fetch_sub(1)`, observing `prev == 1` (now `active == 0`).
+    /// 3. Before Thread A locks the queue, Thread B calls `acquire()`
+    ///    (`active == 1`) and `try_enqueue` queues a fresh deletion.
+    /// 4. Thread A finally locks the queue and the original code does
+    ///    `mem::take`, *executing* the deletion Thread B was supposed to
+    ///    defer. Thread B's file vanishes despite an active pause.
+    ///
+    /// The deterministic reproducer below uses a side-channel `Mutex` to
+    /// hold Thread A in the drop path until Thread B has enqueued, then
+    /// releases A. With the fix (re-check `active` under the lock) the
+    /// file survives until Thread B drops its pause; without the fix the
+    /// file is removed prematurely and the assertion below fires.
+    #[test]
+    fn drain_does_not_steal_a_new_generation_queue() {
+        use std::thread;
+        use std::time::Duration;
+
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/d")).unwrap();
+        let path = Path::new("/d/race.sst").to_path_buf();
+        write_file(&fs, &path, b"keep-me");
+        let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
+
+        let pause = DeletionPause::new();
+        let a = pause.acquire();
+
+        // Run many iterations to widen the chance of hitting the race
+        // window on systems where atomic decrement + lock acquisition
+        // is fast enough to never interleave with the spawned thread.
+        // With the fix this loop is uneventful; without the fix any
+        // interleaving where Thread B enqueues between A's `fetch_sub`
+        // and A's `queue.lock()` causes B's file to be erroneously
+        // removed.
+        let b_pause = Arc::clone(&pause);
+        let b_fs = Arc::clone(&dyn_fs);
+        let b_path = path.clone();
+        let b_thread = thread::spawn(move || {
+            // Wait until A has started dropping (small sleep is cheap and
+            // gives A the chance to call fetch_sub first).
+            thread::sleep(Duration::from_millis(5));
+            let _b = b_pause.acquire();
+            assert!(b_pause.try_enqueue(b_fs, b_path));
+            // Hold the pause long enough for A's drop to complete.
+            thread::sleep(Duration::from_millis(20));
+            // Implicit drop here drains the queue.
+        });
+
+        // Trigger A's drop now.
+        drop(a);
+
+        b_thread.join().unwrap();
+
+        // After both pauses dropped, file should be GONE (B's pause was
+        // last and properly drained). The race bug would surface as a
+        // panic in `remove_file` against an already-removed path, not as
+        // a survived file — but the more important invariant is that
+        // there's no double-remove. Verify by re-creating + re-running
+        // with assertion that the queue length stays sane.
+        assert!(
+            !fs.exists(&path).unwrap(),
+            "file should be removed after both pauses dropped",
+        );
     }
 
     #[test]

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -254,7 +254,6 @@ mod tests {
     fn drain_does_not_steal_a_new_generation_queue() {
         use std::sync::mpsc;
         use std::thread;
-        use std::time::Duration;
 
         let fs = MemFs::new();
         fs.create_dir_all(Path::new("/d")).unwrap();
@@ -265,6 +264,14 @@ mod tests {
         let pause = DeletionPause::new_shared();
         let a = pause.acquire();
 
+        // Deterministic handshake: `a_dropped_tx` signals that A's
+        // `fetch_sub(1)` has executed (so `active == 0` from A's
+        // perspective and A is committed to the drain branch); B then
+        // races in with `acquire()`+`try_enqueue()` to exercise the
+        // generation-race protection. Spin-wait on `active == 0` instead
+        // of using a fixed sleep so the test is robust under any
+        // scheduler / CI load.
+        let (a_dropped_tx, a_dropped_rx) = mpsc::channel::<()>();
         let (ready_tx, ready_rx) = mpsc::channel::<()>();
         let (release_tx, release_rx) = mpsc::channel::<()>();
 
@@ -272,11 +279,15 @@ mod tests {
         let b_fs = Arc::clone(&dyn_fs);
         let b_path = path.clone();
         let b_thread = thread::spawn(move || {
-            // Brief sleep gives Thread A time to start its `Drop`
-            // (`fetch_sub` followed by `queue.lock()`); on this side we
-            // then race in with our own `acquire` so the fix's "re-check
-            // active under the lock" branch is exercised.
-            thread::sleep(Duration::from_millis(5));
+            // Block until A has begun its drop. We then spin until
+            // A's `fetch_sub` has visibly reduced `active` to 0 —
+            // that's the exact window where A is about to lock the
+            // queue and the fix MUST notice our subsequent `acquire`
+            // under the lock.
+            a_dropped_rx.recv().unwrap();
+            while b_pause.active.load(Ordering::Acquire) != 0 {
+                core::hint::spin_loop();
+            }
             let _b = b_pause.acquire();
             assert!(b_pause.try_enqueue(b_fs, b_path));
             // Signal the main thread that B is in the right state and
@@ -287,8 +298,10 @@ mod tests {
             // Implicit drop here drains the queue.
         });
 
-        // Trigger A's drop now.
+        // Trigger A's drop now. Send the handshake AFTER drop returns
+        // so B observes A's `fetch_sub`-decremented `active` value.
         drop(a);
+        a_dropped_tx.send(()).unwrap();
 
         // Block until B has acquired AND enqueued; this is the exact
         // moment the race manifests. With the fix, the file MUST still

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -22,15 +22,25 @@
 //! blob-file `Inner`, the [`Drop`] check is O(1) and lock-free in the
 //! common case (no checkpoint in progress).
 
-// Prefer `alloc`/`core` for primitives that exist there. `Mutex` and
-// `PathBuf` have no alloc-only equivalent in the standard library and
-// stay on `std::*` — they carry the same std dependency that the
-// underlying `Fs` trait already pulls in, so this module's no-std
-// posture matches `crate::fs` exactly.
+// Synchronisation comes from `spin::Mutex` (no_std-compatible) rather
+// than `std::sync::Mutex`. The queue is only contended during
+// checkpoint setup/teardown — never on the read path — so spin
+// contention is irrelevant in practice; the benefit is that this
+// module's std footprint is bounded by what the `Fs` trait already
+// requires (path types + I/O) with no extra std-only synchronisation
+// primitive layered on top. `spin::Mutex` also cannot poison, which
+// removes the `PoisonError::into_inner` recovery branches that the
+// std variant required.
+//
+// `PathBuf` has no alloc-only counterpart in the standard library
+// (path types live in `std::path`, not `alloc::path`), so it stays
+// here — the value is unavoidably std-coupled the moment we call
+// `Fs::remove_file(&Path)` anyway.
 use crate::fs::Fs;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicU32, Ordering};
-use std::{path::PathBuf, sync::Mutex};
+use spin::Mutex;
+use std::path::PathBuf;
 
 /// Shared state controlling whether file deletions are deferred.
 ///
@@ -55,7 +65,7 @@ impl core::fmt::Debug for DeletionPause {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DeletionPause")
             .field("active", &self.active.load(Ordering::Relaxed))
-            .field("queued", &self.queue.lock().map(|q| q.len()).unwrap_or(0))
+            .field("queued", &self.queue.lock().len())
             .finish()
     }
 }
@@ -97,15 +107,8 @@ impl DeletionPause {
         // Lock the queue then re-check under the lock — if the pause was
         // released between the atomic load above and acquiring the lock,
         // the queue would never be drained and the file would leak.
-        //
-        // On poisoning we recover with `into_inner()` rather than
-        // refusing the enqueue: dropping the file unconditionally would
-        // race a still-active checkpoint. Best-effort enqueue keeps the
-        // invariant ("file survives while a pause is held") intact.
-        let mut queue = self
-            .queue
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // `spin::Mutex` cannot poison, so no recovery branch is needed.
+        let mut queue = self.queue.lock();
         if !self.is_active() {
             return false;
         }
@@ -142,33 +145,25 @@ impl Drop for Pause {
         }
 
         // We were the last pause holder — drain and execute pending
-        // deletions. Two correctness concerns:
+        // deletions. Generation race: between the `fetch_sub` above and
+        // acquiring the queue lock below, another thread can call
+        // `acquire()` and `try_enqueue()`. Items pushed in that new
+        // generation belong to the new pause, not to us. Re-check
+        // `active` under the lock and bail out if a new pause is now
+        // in flight; the new pause's eventual `Drop` will drain those
+        // items at the correct generation boundary.
         //
-        // 1. **Generation race.** Between the `fetch_sub` above and
-        //    acquiring the queue lock below, another thread can call
-        //    `acquire()` and `try_enqueue()`. Items pushed in that new
-        //    generation belong to the new pause, not to us. We re-check
-        //    `active` under the lock and bail out if a new pause is now
-        //    in flight; the new pause's eventual `Drop` will drain those
-        //    items at the correct generation boundary.
-        //
-        // 2. **Mutex poisoning.** If another thread panicked while
-        //    holding the queue, `lock()` returns `PoisonError`. We
-        //    recover via `into_inner()` and drain best-effort —
-        //    abandoning the queue would leak the queued files until
-        //    process exit, defeating the entire point of this type.
+        // `spin::Mutex` cannot poison, so there is no
+        // `PoisonError`-recovery branch here — `lock()` always returns
+        // a guard.
         let drained = {
-            let mut queue = self
-                .inner
-                .queue
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut queue = self.inner.queue.lock();
             if self.inner.active.load(Ordering::Acquire) > 0 {
                 // A new pause has taken responsibility for the queue.
                 // Leave its items alone; its drop will handle them.
                 return;
             }
-            std::mem::take(&mut *queue)
+            core::mem::take(&mut *queue)
         };
 
         for item in drained {

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Reference-counted file-deletion gate used by checkpoint-style snapshots.
+//!
+//! While a [`DeletionPause`] is *active* (refcount ≥ 1), the [`Drop`]
+//! implementations on tables and blob files do not call
+//! [`Fs::remove_file`](crate::fs::Fs::remove_file) immediately. Instead they
+//! enqueue `(fs, path)` for later removal. Compaction may continue producing
+//! obsolete files; their physical deletion is just deferred.
+//!
+//! When the last [`Pause`] guard is dropped, the queue is drained and every
+//! queued path is unlinked through the original [`crate::fs::Fs`] backend.
+//! This pattern mirrors `RocksDB`'s `DisableFileDeletions` /
+//! `EnableFileDeletions` API used by `Checkpoint::CreateCheckpoint`.
+//!
+//! # Why a queue per pause and not per file?
+//!
+//! Tables and blob files only know their own path + [`crate::fs::Fs`]; they
+//! do not have a back-reference to the tree they belong to. By embedding an
+//! [`Arc<DeletionPause>`] (optional, [`None`] by default) into each table /
+//! blob-file `Inner`, the [`Drop`] check is O(1) and lock-free in the
+//! common case (no checkpoint in progress).
+
+use crate::fs::Fs;
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+
+/// Shared state controlling whether file deletions are deferred.
+///
+/// Cheap to clone: holds an atomic counter plus a `Mutex<Vec<...>>` that is
+/// only contended during checkpoint setup/teardown, never on the read path.
+#[derive(Default)]
+pub struct DeletionPause {
+    /// Number of active [`Pause`] guards. `0` means deletions happen
+    /// immediately; `>0` means they are queued.
+    active: AtomicU32,
+
+    /// Paths queued for removal while at least one pause was active.
+    queue: Mutex<Vec<QueuedDeletion>>,
+}
+
+struct QueuedDeletion {
+    fs: Arc<dyn Fs>,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for DeletionPause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeletionPause")
+            .field("active", &self.active.load(Ordering::Relaxed))
+            .field("queued", &self.queue.lock().map(|q| q.len()).unwrap_or(0))
+            .finish()
+    }
+}
+
+impl DeletionPause {
+    /// Creates a new pause controller in the inactive state.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Returns `true` if there is at least one active [`Pause`] guard and
+    /// deletions should therefore be queued.
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire) > 0
+    }
+
+    /// Tries to enqueue `(fs, path)` for later removal. Returns `true` if
+    /// the deletion was queued (caller must NOT call `remove_file`), or
+    /// `false` if the pause is currently inactive (caller proceeds with
+    /// the deletion as usual).
+    pub fn try_enqueue(&self, fs: Arc<dyn Fs>, path: PathBuf) -> bool {
+        if !self.is_active() {
+            return false;
+        }
+        // Lock the queue then re-check under the lock — if the pause was
+        // released between the atomic load above and acquiring the lock,
+        // the queue would never be drained and the file would leak.
+        let Ok(mut queue) = self.queue.lock() else {
+            // Mutex poisoning means another thread panicked while holding
+            // the queue. We refuse to enqueue (returning false) so the
+            // caller falls back to immediate removal — the safer option.
+            return false;
+        };
+        if !self.is_active() {
+            return false;
+        }
+        queue.push(QueuedDeletion { fs, path });
+        true
+    }
+
+    /// Acquires a pause guard. While at least one guard is alive,
+    /// [`try_enqueue`](Self::try_enqueue) defers deletions.
+    pub fn acquire(self: &Arc<Self>) -> Pause {
+        self.active.fetch_add(1, Ordering::AcqRel);
+        Pause {
+            inner: Arc::clone(self),
+        }
+    }
+}
+
+/// RAII guard that keeps a [`DeletionPause`] active. Dropping the last
+/// guard drains the queue and unlinks every queued file.
+#[must_use = "deletion pause is released when this guard is dropped"]
+pub struct Pause {
+    inner: Arc<DeletionPause>,
+}
+
+impl Drop for Pause {
+    fn drop(&mut self) {
+        // Use AcqRel so the decrement is sequenced with respect to any
+        // queued enqueue calls performed by other threads.
+        let prev = self.inner.active.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(prev > 0, "DeletionPause underflow");
+
+        if prev == 1 {
+            // We were the last pause holder — drain and execute pending
+            // deletions. We deliberately swap out the queue under the
+            // lock so newly-queued items (which can only happen if a new
+            // pause is acquired concurrently) do not get lost.
+            let drained = {
+                let Ok(mut queue) = self.inner.queue.lock() else {
+                    return;
+                };
+                std::mem::take(&mut *queue)
+            };
+
+            for item in drained {
+                if let Err(e) = item.fs.remove_file(&item.path) {
+                    // Match the warning style used by Table/BlobFile Drop
+                    // impls so log filters keep working.
+                    log::warn!(
+                        "Failed to remove deferred deletion {}: {e:?}",
+                        item.path.display(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::fs::{Fs, MemFs};
+    use std::path::Path;
+
+    fn write_file(fs: &MemFs, path: &Path, bytes: &[u8]) {
+        use std::io::Write;
+        let opts = crate::fs::FsOpenOptions::new().write(true).create(true);
+        let mut f = fs.open(path, &opts).unwrap();
+        f.write_all(bytes).unwrap();
+    }
+
+    #[test]
+    fn deletion_pause_defers_then_executes_removal() {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/d")).unwrap();
+        let path = Path::new("/d/file.sst").to_path_buf();
+        write_file(&fs, &path, b"sst");
+        let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
+
+        let pause = DeletionPause::new();
+        let guard = pause.acquire();
+
+        assert!(pause.try_enqueue(dyn_fs.clone(), path.clone()));
+        assert!(
+            fs.exists(&path).unwrap(),
+            "file must still exist while paused"
+        );
+
+        drop(guard);
+        assert!(
+            !fs.exists(&path).unwrap(),
+            "file must be removed after pause released"
+        );
+    }
+
+    #[test]
+    fn enqueue_returns_false_when_inactive() {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/d")).unwrap();
+        let path = Path::new("/d/file.sst").to_path_buf();
+        write_file(&fs, &path, b"x");
+        let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
+
+        let pause = DeletionPause::new();
+        assert!(!pause.try_enqueue(dyn_fs, path.clone()));
+        assert!(fs.exists(&path).unwrap());
+    }
+
+    #[test]
+    fn nested_pauses_only_release_on_last_drop() {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/d")).unwrap();
+        let path = Path::new("/d/file.sst").to_path_buf();
+        write_file(&fs, &path, b"x");
+        let dyn_fs: Arc<dyn Fs> = Arc::new(fs.clone());
+
+        let pause = DeletionPause::new();
+        let outer = pause.acquire();
+        let inner = pause.acquire();
+
+        assert!(pause.try_enqueue(dyn_fs, path.clone()));
+
+        drop(inner);
+        assert!(fs.exists(&path).unwrap(), "still paused by outer guard");
+
+        drop(outer);
+        assert!(
+            !fs.exists(&path).unwrap(),
+            "released after last guard dropped"
+        );
+    }
+}

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -204,6 +204,13 @@ impl Fs for IoUringFs {
     fn exists(&self, path: &Path) -> io::Result<bool> {
         path.try_exists()
     }
+
+    fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+        // Hard linking is a metadata-only operation; io_uring offers no
+        // throughput benefit, so delegate to [`StdFs`] for the EXDEV
+        // fallback logic.
+        super::StdFs.hard_link(src, dst)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -144,6 +144,10 @@ impl Fs for IoUringFs {
         std::fs::create_dir_all(path)
     }
 
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        std::fs::create_dir(path)
+    }
+
     fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
         // Delegate to std::fs — directory listing doesn't benefit from io_uring.
         std::fs::read_dir(path)?

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -215,6 +215,14 @@ impl Fs for IoUringFs {
         // fallback logic.
         super::StdFs.hard_link(src, dst)
     }
+
+    fn backend_id(&self) -> Option<u64> {
+        // `IoUringFs` resolves paths through the host kernel just like
+        // `StdFs`, so it MUST report the same namespace ID — otherwise
+        // the checkpoint driver would needlessly stream-copy between the
+        // two backends.
+        super::StdFs.backend_id()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -620,6 +620,47 @@ impl Fs for MemFs {
         let state = read_state(&self.state)?;
         Ok(state.files.contains_key(path) || state.dirs.contains(path))
     }
+
+    fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+        ensure_non_empty_path(src)?;
+        ensure_non_empty_path(dst)?;
+        let mut state = write_state(&self.state)?;
+
+        ensure_parent_dir(dst, &state)?;
+
+        if state.dirs.contains(dst) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("destination is a directory: {}", dst.display()),
+            ));
+        }
+        if state.files.contains_key(dst) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("destination already exists: {}", dst.display()),
+            ));
+        }
+
+        // MemFs has no inode concept — produce an independent copy so the
+        // destination has the same byte contents but its own backing buffer.
+        // This matches the documented [`Fs::hard_link`] semantics for
+        // in-memory backends.
+        let bytes = {
+            let src_data = state.files.get(src).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("source file not found: {}", src.display()),
+                )
+            })?;
+            let guard = lock(src_data)?;
+            guard.clone()
+        };
+
+        state
+            .files
+            .insert(dst.to_path_buf(), Arc::new(Mutex::new(bytes)));
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1238,6 +1279,64 @@ mod tests {
             .rename(Path::new("/dir/file"), Path::new(""))
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_creates_independent_copy() -> io::Result<()> {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/dir"))?;
+
+        let src = Path::new("/dir/src.bin");
+        let dst = Path::new("/dir/dst.bin");
+        let opts = FsOpenOptions::new().write(true).create(true);
+        let mut file = fs.open(src, &opts)?;
+        file.write_all(b"checkpoint")?;
+        drop(file);
+
+        fs.hard_link(src, dst)?;
+
+        // Both exist and contain the same bytes.
+        let opts = FsOpenOptions::new().read(true);
+        let mut buf = String::new();
+        fs.open(src, &opts)?.read_to_string(&mut buf)?;
+        assert_eq!(buf, "checkpoint");
+        let mut buf = String::new();
+        fs.open(dst, &opts)?.read_to_string(&mut buf)?;
+        assert_eq!(buf, "checkpoint");
+
+        // Removing the source leaves the destination intact.
+        fs.remove_file(src)?;
+        assert!(!fs.exists(src)?);
+        assert!(fs.exists(dst)?);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_rejects_existing_destination() -> io::Result<()> {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/dir"))?;
+
+        let opts = FsOpenOptions::new().write(true).create(true);
+        fs.open(Path::new("/dir/a"), &opts)?;
+        fs.open(Path::new("/dir/b"), &opts)?;
+
+        let err = fs
+            .hard_link(Path::new("/dir/a"), Path::new("/dir/b"))
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_rejects_missing_source() -> io::Result<()> {
+        let fs = MemFs::new();
+        fs.create_dir_all(Path::new("/dir"))?;
+
+        let err = fs
+            .hard_link(Path::new("/dir/missing"), Path::new("/dir/dst"))
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
         Ok(())
     }
 }

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -440,16 +440,11 @@ impl Fs for MemFs {
             ));
         }
 
-        // Parent must exist; we do not recurse.
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-            && !state.dirs.contains(parent)
-        {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("parent directory does not exist: {}", parent.display()),
-            ));
-        }
+        // Parent must exist AND be a directory. Delegating to
+        // `ensure_parent_dir` gives the caller a `NotFound` vs
+        // `parent-is-a-file` diagnostic (matching POSIX `ENOTDIR`),
+        // instead of a single ambiguous `NotFound` for both cases.
+        ensure_parent_dir(path, &state)?;
 
         state.dirs.insert(path.to_path_buf());
         Ok(())

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -427,6 +427,34 @@ impl Fs for MemFs {
         Ok(())
     }
 
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        ensure_non_empty_path(path)?;
+        let mut state = write_state(&self.state)?;
+
+        // Atomic single-leaf create: reject if anything (file OR dir)
+        // already occupies the path. Mirrors POSIX `mkdir(2)` semantics.
+        if state.dirs.contains(path) || state.files.contains_key(path) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("path already exists: {}", path.display()),
+            ));
+        }
+
+        // Parent must exist; we do not recurse.
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+            && !state.dirs.contains(parent)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("parent directory does not exist: {}", parent.display()),
+            ));
+        }
+
+        state.dirs.insert(path.to_path_buf());
+        Ok(())
+    }
+
     fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
         let state = read_state(&self.state)?;
 
@@ -1304,6 +1332,22 @@ mod tests {
         let mut buf = String::new();
         fs.open(dst, &opts)?.read_to_string(&mut buf)?;
         assert_eq!(buf, "checkpoint");
+
+        // Critical invariant: `MemFs::hard_link` returns an *independent*
+        // copy (no `Arc<Mutex<Vec<u8>>>` aliasing). Mutate the source and
+        // verify the destination is unaffected — if the test only relied
+        // on `remove_file` it would pass even with an aliased buffer.
+        let mut writer = fs.open(src, &FsOpenOptions::new().write(true).truncate(true))?;
+        writer.write_all(b"mutated")?;
+        drop(writer);
+
+        let mut after = String::new();
+        fs.open(dst, &FsOpenOptions::new().read(true))?
+            .read_to_string(&mut after)?;
+        assert_eq!(
+            after, "checkpoint",
+            "dst must not see writes to src — buffers must be independent",
+        );
 
         // Removing the source leaves the destination intact.
         fs.remove_file(src)?;

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -69,7 +69,7 @@ impl MemFs {
     }
 }
 
-/// Allocates the next per-instance MemFs namespace ID. Values are
+/// Allocates the next per-instance `MemFs` namespace ID. Values are
 /// process-unique (monotonic atomic counter) so two `MemFs::new()`
 /// values never collide; cloned `MemFs` instances reuse the same ID
 /// because `MemFs` derives `Clone`.

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -41,6 +41,12 @@ use std::sync::{Arc, Mutex, RwLock};
 #[derive(Clone, Debug)]
 pub struct MemFs {
     state: Arc<RwLock<State>>,
+    /// Per-instance namespace ID used by [`Fs::backend_id`]. Cloned
+    /// `MemFs` values share the same `state` Arc AND the same ID — they
+    /// are the same backend by all observable behaviour. Independently
+    /// constructed `MemFs::new()` values get DIFFERENT IDs because they
+    /// have disjoint file trees.
+    namespace_id: u64,
 }
 
 #[derive(Debug, Default)]
@@ -58,8 +64,20 @@ impl MemFs {
         state.dirs.insert(PathBuf::from("/"));
         Self {
             state: Arc::new(RwLock::new(state)),
+            namespace_id: next_mem_fs_namespace_id(),
         }
     }
+}
+
+/// Allocates the next per-instance MemFs namespace ID. Values are
+/// process-unique (monotonic atomic counter) so two `MemFs::new()`
+/// values never collide; cloned `MemFs` instances reuse the same ID
+/// because `MemFs` derives `Clone`.
+fn next_mem_fs_namespace_id() -> u64 {
+    use core::sync::atomic::{AtomicU64, Ordering};
+    // Start at 1 so a future `0` sentinel stays available if needed.
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 impl Default for MemFs {
@@ -683,6 +701,10 @@ impl Fs for MemFs {
             .files
             .insert(dst.to_path_buf(), Arc::new(Mutex::new(bytes)));
         Ok(())
+    }
+
+    fn backend_id(&self) -> Option<u64> {
+        Some(self.namespace_id)
     }
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -247,6 +247,36 @@ pub trait Fs: Send + Sync + 'static {
     /// Returns an I/O error if directory creation fails.
     fn create_dir_all(&self, path: &Path) -> io::Result<()>;
 
+    /// Atomically creates a single directory at `path`.
+    ///
+    /// Unlike [`create_dir_all`](Self::create_dir_all), this method must
+    /// FAIL with [`io::ErrorKind::AlreadyExists`] when `path` already
+    /// exists — it is the POSIX `mkdir(2)` primitive used by
+    /// [`Tree::create_checkpoint`](crate::Tree::create_checkpoint) to
+    /// claim its target directory without a TOCTOU window.
+    ///
+    /// The parent directory must already exist; this method does not
+    /// recurse.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns [`io::ErrorKind::Unsupported`]. Backends that want to be
+    /// usable as a checkpoint target MUST override this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::ErrorKind::AlreadyExists`] if `path` already exists,
+    /// [`io::ErrorKind::NotFound`] if the parent directory does not
+    /// exist, or another I/O error if creation fails for backend-specific
+    /// reasons.
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        let _ = path;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Fs::create_dir is not implemented for this backend",
+        ))
+    }
+
     /// Returns all entries in a directory (order is unspecified).
     ///
     /// Returns a `Vec` rather than a streaming iterator because

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -373,10 +373,14 @@ pub trait Fs: Send + Sync + 'static {
     ///
     /// # Default implementation
     ///
-    /// Returns [`io::ErrorKind::Unsupported`]. Backends that want to
-    /// participate in [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
-    /// MUST override this method; otherwise checkpoint will surface
-    /// `Unsupported` and refuse to snapshot.
+    /// Returns [`io::ErrorKind::Unsupported`]. Backends are free to leave
+    /// this default in place: the checkpoint driver's
+    /// `link_or_copy_cross_fs` helper treats `Unsupported` (and `NotFound`)
+    /// as a signal to fall back to a streamed byte copy, so snapshots
+    /// still succeed — they just lose the O(1) hard-link optimisation
+    /// and pay full-bytes worth of disk on the target volume. Backends
+    /// that DO support real hard links (most kernel filesystems) should
+    /// override this for the inode-sharing benefit.
     ///
     /// # Errors
     ///

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -360,8 +360,12 @@ pub trait Fs: Send + Sync + 'static {
     /// Hard links cannot span filesystems. Implementations that detect a
     /// cross-device situation (Unix `EXDEV`) MUST fall back to a byte copy
     /// so that callers can treat `hard_link` as always-succeeding when the
-    /// destination filesystem is writable. The fallback emits a warning
-    /// via [`log::warn`] so operators can notice unexpected copies.
+    /// destination filesystem is writable. The fallback emits a [`log::debug`]
+    /// trace per call (deliberately not `warn`: a tier-misconfigured
+    /// checkpoint can hit this path thousands of times per snapshot, and
+    /// per-file warnings would drown real signal). Callers that need
+    /// operator-visible notification of unexpected copies are expected
+    /// to aggregate per-checkpoint and emit a single summary warning.
     ///
     /// In-memory backends ([`MemFs`](crate::fs::MemFs)) do not have inodes;
     /// they implement this as a byte copy that produces an independent file

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -394,6 +394,40 @@ pub trait Fs: Send + Sync + 'static {
             "Fs::hard_link is not implemented for this backend",
         ))
     }
+
+    /// Identifies the **path namespace** this backend resolves against.
+    ///
+    /// Two `Fs` values may safely participate in a cross-backend
+    /// [`Fs::hard_link`] call only if their `backend_id()` values are
+    /// both `Some` and equal: that contract states "we resolve paths
+    /// against the same underlying inode table, so a hard link from
+    /// `src` here to `dst` there links the SAME file we'd see by
+    /// reading `src` through `Self`."
+    ///
+    /// Examples of equal backend IDs:
+    /// - All [`crate::fs::StdFs`] instances on the same host (one
+    ///   shared kernel filesystem).
+    /// - A [`crate::fs::IoUringFs`] and a [`crate::fs::StdFs`] on the
+    ///   same host (the uring backend delegates path resolution to the
+    ///   kernel).
+    ///
+    /// Examples of distinct backend IDs:
+    /// - Two independent [`crate::fs::MemFs`] instances (each has its
+    ///   own in-memory tree).
+    /// - A [`crate::fs::MemFs`] vs any kernel-backed backend (a
+    ///   hard-link attempt would resolve `src` against the host
+    ///   filesystem and silently capture an unrelated file if one
+    ///   happens to exist at the same path — a checkpoint correctness
+    ///   bug).
+    ///
+    /// The default returns `None`, meaning "no shared-namespace
+    /// guarantee" — safe-by-default for third-party backends that have
+    /// not opted in. Callers MUST treat `None` as a veto on
+    /// cross-backend [`Fs::hard_link`] and stream-copy instead, even
+    /// when both sides return `None`.
+    fn backend_id(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Opens a section of an sfa archive for buffered reading via the [`Fs`] trait.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -316,6 +316,46 @@ pub trait Fs: Send + Sync + 'static {
     /// Returns an I/O error if the existence of `path` cannot be determined
     /// (for example, due to permission issues or transient backend failures).
     fn exists(&self, path: &Path) -> io::Result<bool>;
+
+    /// Creates a hard link `dst` that refers to the same inode as `src`.
+    ///
+    /// Used by [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+    /// to snapshot SST and blob files in O(1) per file without duplicating
+    /// data on disk. After the link is created, deleting either path leaves
+    /// the other intact; the inode is reclaimed only after the last link
+    /// is removed.
+    ///
+    /// # Cross-filesystem fallback
+    ///
+    /// Hard links cannot span filesystems. Implementations that detect a
+    /// cross-device situation (Unix `EXDEV`) MUST fall back to a byte copy
+    /// so that callers can treat `hard_link` as always-succeeding when the
+    /// destination filesystem is writable. The fallback emits a warning
+    /// via [`log::warn`] so operators can notice unexpected copies.
+    ///
+    /// In-memory backends ([`MemFs`](crate::fs::MemFs)) do not have inodes;
+    /// they implement this as a byte copy that produces an independent file
+    /// with the same contents.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns [`io::ErrorKind::Unsupported`]. Backends that want to
+    /// participate in [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+    /// MUST override this method; otherwise checkpoint will surface
+    /// `Unsupported` and refuse to snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if `src` does not exist, `dst` already exists,
+    /// the destination's parent directory is missing, or the fallback copy
+    /// fails.
+    fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+        let _ = (src, dst);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Fs::hard_link is not implemented for this backend",
+        ))
+    }
 }
 
 /// Opens a section of an sfa archive for buffered reading via the [`Fs`] trait.

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -212,7 +212,17 @@ impl Fs for StdFs {
             Err(e) => Err(e),
         }
     }
+
+    fn backend_id(&self) -> Option<u64> {
+        Some(KERNEL_BACKEND_ID)
+    }
 }
+
+/// Shared by every backend that resolves paths against the host kernel's
+/// filesystem table — currently `StdFs` and `IoUringFs`. Two such backends
+/// can hard-link across instances because `std::fs::hard_link(src, dst)`
+/// resolves both paths through the same kernel namespace.
+pub(crate) const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
 
 /// Detects `EXDEV` (cross-device link) errors across platforms.
 ///

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -188,6 +188,71 @@ impl Fs for StdFs {
     fn exists(&self, path: &Path) -> io::Result<bool> {
         path.try_exists()
     }
+
+    fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+        match std::fs::hard_link(src, dst) {
+            Ok(()) => Ok(()),
+            Err(e) if is_cross_device(&e) => {
+                log::warn!(
+                    "hard_link({}, {}) crossed filesystems — falling back to copy",
+                    src.display(),
+                    dst.display(),
+                );
+                copy_fallback(src, dst)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Detects `EXDEV` (cross-device link) errors across platforms.
+///
+/// Unix exposes the raw `EXDEV` (errno 18 on Linux/macOS/BSDs). Windows
+/// reports the equivalent failure as [`io::ErrorKind::Unsupported`] or
+/// [`io::ErrorKind::PermissionDenied`] depending on the volume layout.
+fn is_cross_device(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        // EXDEV = 18 on Linux/macOS/*BSD.
+        if err.raw_os_error() == Some(18) {
+            return true;
+        }
+    }
+    matches!(
+        err.kind(),
+        io::ErrorKind::CrossesDevices | io::ErrorKind::Unsupported
+    )
+}
+
+/// Byte-copy fallback used when [`hard_link`](Fs::hard_link) cannot create
+/// a true link (cross-device or in-memory FS without inode semantics).
+///
+/// Uses `create_new` semantics so an accidental clobber surfaces as
+/// [`io::ErrorKind::AlreadyExists`] — matching real `hard_link` behaviour.
+fn copy_fallback(src: &Path, dst: &Path) -> io::Result<()> {
+    use std::io::{Read, Write};
+
+    let mut src_file = File::open(src)?;
+    let mut dst_file = OpenOptions::new().write(true).create_new(true).open(dst)?;
+
+    // Heap-allocate the scratch buffer — checkpoint is cold-path I/O, so a
+    // 64 KiB Vec is cheaper than blowing past clippy's stack-array budget.
+    let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
+    loop {
+        let n = match src_file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "n was just produced by read() and bounded by buf.len()"
+        )]
+        dst_file.write_all(&buf[..n])?;
+    }
+    dst_file.sync_all()?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -647,6 +712,122 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let bogus = dir.path().join("nonexistent");
         assert!(!fs.exists(&bogus)?);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_creates_second_path_to_same_inode() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+
+        let src = dir.path().join("src.bin");
+        let dst = dir.path().join("dst.bin");
+        std::fs::write(&src, b"checkpoint payload")?;
+
+        fs.hard_link(&src, &dst)?;
+
+        // Both paths exist and have the same content.
+        assert_eq!(std::fs::read(&dst)?, b"checkpoint payload");
+
+        // Mutating the link changes both views (same inode), proving this
+        // was a true hard link, not a copy. We only check this on Unix —
+        // Windows hard links share content but inode equality is not
+        // exposed through std.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let src_meta = std::fs::metadata(&src)?;
+            let dst_meta = std::fs::metadata(&dst)?;
+            assert_eq!(src_meta.ino(), dst_meta.ino());
+            assert_eq!(src_meta.dev(), dst_meta.dev());
+            assert_eq!(dst_meta.nlink(), 2);
+        }
+
+        // Removing the source leaves the link intact.
+        fs.remove_file(&src)?;
+        assert_eq!(std::fs::read(&dst)?, b"checkpoint payload");
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_rejects_existing_destination() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"src")?;
+        std::fs::write(&dst, b"dst")?;
+
+        let err = fs.hard_link(&src, &dst).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        Ok(())
+    }
+
+    #[test]
+    fn hard_link_rejects_missing_source() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+
+        let err = fs
+            .hard_link(&dir.path().join("missing"), &dir.path().join("dst"))
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        Ok(())
+    }
+
+    /// Forces the EXDEV fallback by calling [`copy_fallback`] directly.
+    /// A real cross-device scenario needs two mounted filesystems which is
+    /// impractical in unit tests, but the fallback path itself is exercised.
+    #[test]
+    fn copy_fallback_copies_bytes_independently() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"payload-for-fallback")?;
+
+        copy_fallback(&src, &dst)?;
+        assert_eq!(std::fs::read(&dst)?, b"payload-for-fallback");
+
+        // Writing to dst must NOT affect src (independent file).
+        std::fs::write(&dst, b"modified")?;
+        assert_eq!(std::fs::read(&src)?, b"payload-for-fallback");
+        Ok(())
+    }
+
+    #[test]
+    fn is_cross_device_detects_exdev_and_kind_variants() {
+        // Synthesise a raw EXDEV error — what Linux/macOS/BSDs return when
+        // hard_link spans devices. `is_cross_device` must accept it so the
+        // fallback copy path kicks in.
+        let exdev = io::Error::from_raw_os_error(18);
+        assert!(is_cross_device(&exdev), "raw EXDEV must be recognised");
+
+        // ErrorKind::CrossesDevices is the modern stable variant (Rust 1.85+).
+        let crosses = io::Error::from(io::ErrorKind::CrossesDevices);
+        assert!(is_cross_device(&crosses));
+
+        // ErrorKind::Unsupported covers Windows / exotic filesystems where
+        // hard links are simply not implemented — also a cue to fall back.
+        let unsupported = io::Error::from(io::ErrorKind::Unsupported);
+        assert!(is_cross_device(&unsupported));
+
+        // A garden-variety NotFound must NOT be misclassified — the caller
+        // needs to surface that error verbatim, not silently copy.
+        let notfound = io::Error::from(io::ErrorKind::NotFound);
+        assert!(!is_cross_device(&notfound));
+    }
+
+    #[test]
+    fn copy_fallback_refuses_to_overwrite() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let src = dir.path().join("src");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"src")?;
+        std::fs::write(&dst, b"dst")?;
+
+        let err = copy_fallback(&src, &dst).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         Ok(())
     }
 }

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -118,6 +118,10 @@ impl Fs for StdFs {
         std::fs::create_dir_all(path)
     }
 
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        std::fs::create_dir(path)
+    }
+
     fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
         // Fail-fast on bad entries is intentional: non-UTF-8 filenames in an
         // lsm-tree data directory indicate filesystem corruption (see FsDirEntry docs).
@@ -207,9 +211,19 @@ impl Fs for StdFs {
 
 /// Detects `EXDEV` (cross-device link) errors across platforms.
 ///
-/// Unix exposes the raw `EXDEV` (errno 18 on Linux/macOS/BSDs). Windows
-/// reports the equivalent failure as [`io::ErrorKind::Unsupported`] or
-/// [`io::ErrorKind::PermissionDenied`] depending on the volume layout.
+/// Unix exposes the raw `EXDEV` (errno 18 on Linux/macOS/BSDs); we also
+/// accept [`io::ErrorKind::CrossesDevices`] (stable since Rust 1.85) and
+/// [`io::ErrorKind::Unsupported`] which Windows surfaces when a volume
+/// configuration disallows hard links altogether.
+///
+/// We deliberately do NOT treat [`io::ErrorKind::PermissionDenied`] as a
+/// cross-device signal even though Windows can sometimes surface
+/// cross-volume link failures that way. Misclassifying genuine ACL /
+/// permission errors as "different filesystem" would silently turn a
+/// "you can't read this" into a full byte copy, hiding real security
+/// misconfigurations. Operators hitting that edge case on Windows can
+/// fix it explicitly (move the target volume, adjust ACLs); the
+/// fall-back is opt-out by design.
 fn is_cross_device(err: &io::Error) -> bool {
     #[cfg(unix)]
     {

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -222,7 +222,7 @@ impl Fs for StdFs {
 /// filesystem table — currently `StdFs` and `IoUringFs`. Two such backends
 /// can hard-link across instances because `std::fs::hard_link(src, dst)`
 /// resolves both paths through the same kernel namespace.
-pub(crate) const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
+pub const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
 
 /// Detects `EXDEV` (cross-device link) errors across platforms.
 ///

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -197,7 +197,12 @@ impl Fs for StdFs {
         match std::fs::hard_link(src, dst) {
             Ok(()) => Ok(()),
             Err(e) if is_cross_device(&e) => {
-                log::warn!(
+                // `debug!`, not `warn!`: a tier-misconfigured checkpoint
+                // can hit this path once per SST + once per blob (potentially
+                // thousands of times). The checkpoint driver is responsible
+                // for emitting a single summary warning if the fallback rate
+                // is excessive; per-file noise here would drown real logs.
+                log::debug!(
                     "hard_link({}, {}) crossed filesystems — falling back to copy",
                     src.display(),
                     dst.display(),
@@ -227,8 +232,15 @@ impl Fs for StdFs {
 fn is_cross_device(err: &io::Error) -> bool {
     #[cfg(unix)]
     {
-        // EXDEV = 18 on Linux/macOS/*BSD.
-        if err.raw_os_error() == Some(18) {
+        // POSIX `EXDEV` ("invalid cross-device link"). The raw value is
+        // 18 on every supported Unix target (Linux, macOS, FreeBSD,
+        // OpenBSD, NetBSD, Android — see `errno.h` on each platform).
+        // We declare it as a named constant rather than depending on
+        // `libc`: the crate deliberately avoids a `libc` dependency
+        // (see the `flock` extern in this file for the same pattern),
+        // and EXDEV's value is locked by ABI compatibility.
+        const EXDEV: i32 = 18;
+        if err.raw_os_error() == Some(EXDEV) {
             return true;
         }
     }
@@ -819,7 +831,9 @@ mod tests {
         // non-Unix targets.
         #[cfg(unix)]
         {
-            let exdev = io::Error::from_raw_os_error(18);
+            // Matches the `EXDEV` constant inside `is_cross_device`.
+            const EXDEV: i32 = 18;
+            let exdev = io::Error::from_raw_os_error(EXDEV);
             assert!(is_cross_device(&exdev), "raw EXDEV must be recognised");
         }
 

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -258,27 +258,42 @@ fn is_cross_device(err: &io::Error) -> bool {
 fn copy_fallback(src: &Path, dst: &Path) -> io::Result<()> {
     use std::io::{Read, Write};
 
-    let mut src_file = File::open(src)?;
-    let mut dst_file = OpenOptions::new().write(true).create_new(true).open(dst)?;
+    // Wrap the copy in an inner closure so any post-`create_new` error
+    // (ENOSPC, EIO, write_all failure, sync_all failure) triggers a
+    // best-effort unlink of the partially-written destination. Without
+    // this, a failed `copy_fallback` leaves a truncated file behind and
+    // the next retry surfaces as `AlreadyExists` — callers would then
+    // see a corrupt file from an operation that already reported error.
+    let res: io::Result<()> = (|| {
+        let mut src_file = File::open(src)?;
+        let mut dst_file = OpenOptions::new().write(true).create_new(true).open(dst)?;
 
-    // Heap-allocate the scratch buffer — checkpoint is cold-path I/O, so a
-    // 64 KiB Vec is cheaper than blowing past clippy's stack-array budget.
-    let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
-    loop {
-        let n = match src_file.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(e),
-        };
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "n was just produced by read() and bounded by buf.len()"
-        )]
-        dst_file.write_all(&buf[..n])?;
+        // Heap-allocated buffer — checkpoint is cold-path I/O, so a
+        // 64 KiB Vec is cheaper than blowing past clippy's stack-array budget.
+        let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
+        loop {
+            let n = match src_file.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            };
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "n was just produced by read() and bounded by buf.len()"
+            )]
+            dst_file.write_all(&buf[..n])?;
+        }
+        dst_file.sync_all()
+    })();
+
+    if res.is_err() {
+        // Best-effort: if cleanup itself fails (permission denied,
+        // already removed by another process), there's nothing more we
+        // can do — the original error is what the caller needs to see.
+        let _ = std::fs::remove_file(dst);
     }
-    dst_file.sync_all()?;
-    Ok(())
+    res
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -813,9 +813,15 @@ mod tests {
     fn is_cross_device_detects_exdev_and_kind_variants() {
         // Synthesise a raw EXDEV error — what Linux/macOS/BSDs return when
         // hard_link spans devices. `is_cross_device` must accept it so the
-        // fallback copy path kicks in.
-        let exdev = io::Error::from_raw_os_error(18);
-        assert!(is_cross_device(&exdev), "raw EXDEV must be recognised");
+        // fallback copy path kicks in. Gated to Unix because errno 18 has
+        // a different meaning on Windows (ERROR_NO_MORE_FILES) and the
+        // `#[cfg(unix)]` branch in `is_cross_device` is never compiled on
+        // non-Unix targets.
+        #[cfg(unix)]
+        {
+            let exdev = io::Error::from_raw_os_error(18);
+            assert!(is_cross_device(&exdev), "raw EXDEV must be recognised");
+        }
 
         // ErrorKind::CrossesDevices is the modern stable variant (Rust 1.85+).
         let crosses = io::Error::from(io::ErrorKind::CrossesDevices);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,11 @@ mod any_tree;
 
 mod abstract_tree;
 
+pub(crate) mod deletion_pause;
+
+#[doc(hidden)]
+pub mod checkpoint;
+
 #[doc(hidden)]
 pub mod blob_tree;
 
@@ -242,7 +247,7 @@ pub use pinnable_slice::PinnableSlice;
 pub use write_batch::WriteBatch;
 
 pub use {
-    abstract_tree::AbstractTree,
+    abstract_tree::{AbstractTree, CheckpointInfo},
     any_tree::AnyTree,
     blob_tree::BlobTree,
     cache::Cache,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,13 @@ mod abstract_tree;
 
 pub(crate) mod deletion_pause;
 
-#[doc(hidden)]
-pub mod checkpoint;
+// `checkpoint` is `pub(crate)`: it contains internal helpers
+// (`link_or_copy_cross_fs`, `prepare_target`, `run_checkpoint`) used by
+// `Tree::create_checkpoint` and `BlobTree::create_checkpoint`. Exposing
+// it via `pub` (even with `#[doc(hidden)]`) would lock the helpers into
+// the stable surface; tests that need to exercise them live inline as
+// unit tests inside `src/checkpoint.rs`.
+pub(crate) mod checkpoint;
 
 #[doc(hidden)]
 pub mod blob_tree;

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -6,6 +6,7 @@
 use crate::metrics::Metrics;
 
 use super::{block_index::BlockIndexImpl, meta::ParsedMeta, regions::ParsedRegions};
+use crate::deletion_pause::DeletionPause;
 use crate::{
     Checksum, GlobalTableId, SeqNo,
     cache::Cache,
@@ -84,6 +85,14 @@ pub struct Inner {
     /// Pre-trained zstd dictionary for dictionary decompression.
     #[cfg(zstd_any)]
     pub(crate) zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+
+    /// Tree-wide file-deletion gate. Installed once by
+    /// [`Table::install_deletion_pause`](super::Table::install_deletion_pause)
+    /// after the table is registered with a tree. When `Some` and active,
+    /// the [`Drop`] impl defers the underlying `remove_file` call so that
+    /// an in-progress [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+    /// can hard-link the file before it disappears.
+    pub(crate) deletion_pause: OnceLock<Arc<DeletionPause>>,
 }
 
 impl Inner {
@@ -117,6 +126,20 @@ impl Drop for Inner {
             // Drop the accessor and block index (releases all Arc<dyn FsFile>).
             drop(file_accessor);
             drop(block_index);
+
+            // If a checkpoint is active, defer the physical deletion so the
+            // file remains hard-linkable until the checkpoint releases its
+            // pause. Falls through to immediate removal when no pause is
+            // installed or the pause is inactive.
+            if let Some(pause) = self.deletion_pause.get()
+                && pause.try_enqueue(Arc::clone(&self.fs), (*self.path).clone())
+            {
+                log::trace!(
+                    "Deferred deletion of table {global_id:?} at {:?} (checkpoint active)",
+                    self.path,
+                );
+                return;
+            }
 
             if let Err(e) = self.fs.remove_file(&self.path) {
                 log::warn!(

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -92,7 +92,13 @@ pub struct Inner {
     /// the [`Drop`] impl defers the underlying `remove_file` call so that
     /// an in-progress [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
     /// can hard-link the file before it disappears.
-    pub(crate) deletion_pause: OnceLock<Arc<DeletionPause>>,
+    // `once_cell::sync::OnceCell` rather than `std::sync::OnceLock`
+    // because once_cell's `get_or_try_init` is stable on our MSRV
+    // (std::sync::OnceLock::get_or_try_init landed in 1.86) and the
+    // dep is already pulled in by other call sites — keeping a single
+    // alloc-friendly primitive across the crate matches the no-std
+    // direction without changing this field's API surface.
+    pub(crate) deletion_pause: once_cell::sync::OnceCell<Arc<DeletionPause>>,
 }
 
 impl Inner {
@@ -131,7 +137,14 @@ impl Drop for Inner {
             // file remains hard-linkable until the checkpoint releases its
             // pause. Falls through to immediate removal when no pause is
             // installed or the pause is inactive.
+            // Short-circuit on the common no-checkpoint path: skip
+            // the Arc<dyn Fs> bump and PathBuf clone unless a pause is
+            // both installed AND currently active. `try_enqueue` still
+            // re-checks `is_active()` under the queue lock to close
+            // the publish-then-release race, so the outer check is a
+            // pure perf gate, not a correctness one.
             if let Some(pause) = self.deletion_pause.get()
+                && pause.is_active()
                 && pause.try_enqueue(Arc::clone(&self.fs), (*self.path).clone())
             {
                 log::trace!(

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -92,13 +92,12 @@ pub struct Inner {
     /// the [`Drop`] impl defers the underlying `remove_file` call so that
     /// an in-progress [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
     /// can hard-link the file before it disappears.
-    // `once_cell::sync::OnceCell` rather than `std::sync::OnceLock`
-    // because once_cell's `get_or_try_init` is stable on our MSRV
-    // (std::sync::OnceLock::get_or_try_init landed in 1.86) and the
-    // dep is already pulled in by other call sites — keeping a single
-    // alloc-friendly primitive across the crate matches the no-std
-    // direction without changing this field's API surface.
-    pub(crate) deletion_pause: once_cell::sync::OnceCell<Arc<DeletionPause>>,
+    // `once_cell::race::OnceBox` rather than `std::sync::OnceLock` so
+    // this field doesn't pin the type to `std` — OnceBox is no-std +
+    // alloc by construction. The slot is set once after recovery /
+    // compaction and read on every Drop; CAS-based race semantics are
+    // fine for this single-publisher, many-reader pattern.
+    pub(crate) deletion_pause: once_cell::race::OnceBox<Arc<DeletionPause>>,
 }
 
 impl Inner {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -845,7 +845,7 @@ impl Table {
             #[cfg(zstd_any)]
             zstd_dictionary,
 
-            deletion_pause: std::sync::OnceLock::new(),
+            deletion_pause: once_cell::sync::OnceCell::new(),
         })))
     }
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -844,7 +844,17 @@ impl Table {
 
             #[cfg(zstd_any)]
             zstd_dictionary,
+
+            deletion_pause: std::sync::OnceLock::new(),
         })))
+    }
+
+    /// Installs the tree-wide deletion pause used by checkpoints.
+    ///
+    /// Idempotent: a second call is a no-op. Called by the owning tree
+    /// after recovery and after compaction registers freshly-built tables.
+    pub(crate) fn install_deletion_pause(&self, pause: Arc<crate::deletion_pause::DeletionPause>) {
+        let _ = self.0.deletion_pause.set(pause);
     }
 
     #[must_use]

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -845,7 +845,7 @@ impl Table {
             #[cfg(zstd_any)]
             zstd_dictionary,
 
-            deletion_pause: once_cell::sync::OnceCell::new(),
+            deletion_pause: once_cell::race::OnceBox::new(),
         })))
     }
 
@@ -854,7 +854,7 @@ impl Table {
     /// Idempotent: a second call is a no-op. Called by the owning tree
     /// after recovery and after compaction registers freshly-built tables.
     pub(crate) fn install_deletion_pause(&self, pause: Arc<crate::deletion_pause::DeletionPause>) {
-        let _ = self.0.deletion_pause.set(pause);
+        let _ = self.0.deletion_pause.set(Box::new(pause));
     }
 
     #[must_use]

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -109,7 +109,7 @@ impl TreeInner {
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
-            deletion_pause: DeletionPause::new(),
+            deletion_pause: DeletionPause::new_shared(),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -6,6 +6,7 @@ use crate::{
     SequenceNumberCounter, TableId,
     compaction::state::CompactionState,
     config::Config,
+    deletion_pause::DeletionPause,
     stop_signal::StopSignal,
     version::{SuperVersions, Version, persist_version},
 };
@@ -65,6 +66,14 @@ pub struct TreeInner {
 
     /// Serializes flush operations.
     pub(crate) flush_lock: Mutex<()>,
+
+    /// Tree-wide gate that defers SST / blob-file deletions while a
+    /// [`Tree::create_checkpoint`](crate::Tree::create_checkpoint) is in
+    /// flight. Acquired by checkpoint code via
+    /// [`DeletionPause::acquire`]; consulted by [`Drop`] impls on
+    /// [`Table`](crate::Table) and [`BlobFile`](crate::BlobFile).
+    pub(crate) deletion_pause: Arc<DeletionPause>,
+
     #[doc(hidden)]
     #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,
@@ -100,6 +109,7 @@ impl TreeInner {
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
+            deletion_pause: DeletionPause::new(),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -172,6 +172,24 @@ impl AbstractTree for Tree {
         0
     }
 
+    fn create_checkpoint(
+        &self,
+        target_path: &std::path::Path,
+    ) -> crate::Result<crate::CheckpointInfo> {
+        crate::checkpoint::run_checkpoint(
+            self,
+            &crate::checkpoint::CheckpointParams {
+                target_root: target_path,
+                target_fs: &self.config.fs,
+                src_root: &self.config.path,
+                src_fs: &self.config.fs,
+                deletion_pause: &self.deletion_pause,
+                visible_seqno: &self.config.visible_seqno,
+                include_blobs: false,
+            },
+        )
+    }
+
     fn print_trace(&self, key: &[u8]) -> crate::Result<()> {
         #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         let super_version = self
@@ -546,6 +564,18 @@ impl AbstractTree for Tree {
             tables.len(),
             blob_files.map(<[BlobFile]>::len).unwrap_or_default(),
         );
+
+        // Wire the tree-wide deletion pause into every fresh table / blob
+        // file so an in-flight checkpoint defers their cleanup if they
+        // later get marked `is_deleted` by compaction.
+        for table in tables {
+            table.install_deletion_pause(Arc::clone(&self.deletion_pause));
+        }
+        if let Some(bfs) = blob_files {
+            for bf in bfs {
+                bf.install_deletion_pause(Arc::clone(&self.deletion_pause));
+            }
+        }
 
         #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         let mut _compaction_state = self.compaction_state.lock().expect("lock is poisoned");
@@ -1878,6 +1908,8 @@ impl Tree {
 
         let comparator = config.comparator.clone();
 
+        let deletion_pause = crate::deletion_pause::DeletionPause::new();
+
         let inner = TreeInner {
             id: tree_id,
             memtable_id_counter: SequenceNumberCounter::new(1),
@@ -1889,10 +1921,35 @@ impl Tree {
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
+            deletion_pause: Arc::clone(&deletion_pause),
 
             #[cfg(feature = "metrics")]
             metrics,
         };
+
+        // Install the pause on every recovered table / blob file so their
+        // Drop impls consult it when a checkpoint is in flight. Snapshot
+        // the Arc handles into owned collections so the read lock is
+        // released before iterating (avoids `significant_drop_tightening`).
+        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+        let (recovered_tables, recovered_blobs): (Vec<Table>, Vec<BlobFile>) = inner
+            .version_history
+            .read()
+            .map(|lock| {
+                let version = &lock.latest_version().version;
+                (
+                    version.iter_tables().cloned().collect(),
+                    version.blob_files.iter().cloned().collect(),
+                )
+            })
+            .expect("lock is poisoned");
+
+        for table in &recovered_tables {
+            table.install_deletion_pause(Arc::clone(&deletion_pause));
+        }
+        for blob_file in &recovered_blobs {
+            blob_file.install_deletion_pause(Arc::clone(&deletion_pause));
+        }
 
         Ok(Self(Arc::new(inner)))
     }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1678,17 +1678,28 @@ impl Tree {
                 // would overwrite the partial state with an empty tree,
                 // turning a recoverable failure into data loss.
                 if has_existing_version_state(&config.path, &*config.fs)? {
-                    log::error!(
-                        "Tree::open: refusing to recover {} — `current` \
-                         pointer is missing but the directory still holds \
-                         version artifacts (tables/, blobs/, or vN). This \
-                         is the on-disk signature of a half-written \
-                         checkpoint or interrupted sealing. Remove the \
-                         partial directory and retry the checkpoint, or \
-                         restore `current` from a backup before reopening.",
+                    // Return Error::Io(InvalidData, ...) rather than
+                    // Error::Unrecoverable so callers that don't read
+                    // logs still get a programmatic surface with the
+                    // path and remediation hint embedded. `log::error!`
+                    // stays for human ops who DO watch logs and want
+                    // the full context at the moment of failure (the
+                    // structured error is what propagates up the call
+                    // chain; the log line records the diagnosis next
+                    // to the timestamp).
+                    let msg = format!(
+                        "Tree::open: refusing to recover {} — `current` pointer is missing \
+                         but the directory still holds version artifacts (tables/, blobs/, \
+                         or vN). This is the on-disk signature of a half-written checkpoint \
+                         or interrupted sealing. Remove the partial directory and retry the \
+                         checkpoint, or restore `current` from a backup before reopening.",
                         config.path.display(),
                     );
-                    return Err(crate::Error::Unrecoverable);
+                    log::error!("{msg}");
+                    return Err(crate::Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        msg,
+                    )));
                 }
                 Self::create_new(config)
             }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     compaction::{CompactionStrategy, drop_range::OwnedBounds, state::CompactionState},
     config::Config,
     format_version::FormatVersion,
+    fs::Fs,
     iter_guard::{IterGuard, IterGuardImpl},
     key::InternalKey,
     manifest::Manifest,
@@ -1670,6 +1671,15 @@ impl Tree {
         let tree = match crate::version::recovery::get_current_version(&config.path, &*config.fs) {
             Ok(_) => Self::recover(config),
             Err(crate::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Missing CURRENT MUST coincide with a directory that
+                // has no version artifacts; otherwise we are looking at
+                // a half-written checkpoint (or other interrupted
+                // sealing). Silently calling `create_new` in that case
+                // would overwrite the partial state with an empty tree,
+                // turning a recoverable failure into data loss.
+                if has_existing_version_state(&config.path, &*config.fs)? {
+                    return Err(crate::Error::Unrecoverable);
+                }
                 Self::create_new(config)
             }
             Err(e) => Err(e),
@@ -2249,4 +2259,26 @@ impl Tree {
 
         Ok(())
     }
+}
+
+/// Returns `true` if the directory contains version-related artifacts
+/// (a `tables/` subdir, a `blobs/` subdir, or any `vN` manifest file).
+///
+/// Used by [`Tree::open`] to distinguish a genuinely fresh directory
+/// (safe to `create_new`) from a half-written checkpoint or other
+/// interrupted sealing (must error rather than silently overwrite).
+fn has_existing_version_state(folder: &Path, fs: &dyn Fs) -> crate::Result<bool> {
+    if fs.exists(&folder.join(crate::file::TABLES_FOLDER))?
+        || fs.exists(&folder.join(crate::file::BLOBS_FOLDER))?
+    {
+        return Ok(true);
+    }
+    for entry in fs.read_dir(folder)? {
+        let name = &entry.file_name;
+        if name.starts_with('v') && name.len() > 1 && name[1..].bytes().all(|c| c.is_ascii_digit())
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2267,13 +2267,22 @@ impl Tree {
 /// Used by [`Tree::open`] to distinguish a genuinely fresh directory
 /// (safe to `create_new`) from a half-written checkpoint or other
 /// interrupted sealing (must error rather than silently overwrite).
+///
+/// A missing parent directory is treated as "no state" — `create_new`
+/// is what creates the directory in the first place, so callers may
+/// invoke `Tree::open` against a path that does not exist yet.
 fn has_existing_version_state(folder: &Path, fs: &dyn Fs) -> crate::Result<bool> {
     if fs.exists(&folder.join(crate::file::TABLES_FOLDER))?
         || fs.exists(&folder.join(crate::file::BLOBS_FOLDER))?
     {
         return Ok(true);
     }
-    for entry in fs.read_dir(folder)? {
+    let entries = match fs.read_dir(folder) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    for entry in entries {
         let name = &entry.file_name;
         if name.starts_with('v') && name.len() > 1 && name[1..].bytes().all(|c| c.is_ascii_digit())
         {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1678,6 +1678,16 @@ impl Tree {
                 // would overwrite the partial state with an empty tree,
                 // turning a recoverable failure into data loss.
                 if has_existing_version_state(&config.path, &*config.fs)? {
+                    log::error!(
+                        "Tree::open: refusing to recover {} — `current` \
+                         pointer is missing but the directory still holds \
+                         version artifacts (tables/, blobs/, or vN). This \
+                         is the on-disk signature of a half-written \
+                         checkpoint or interrupted sealing. Remove the \
+                         partial directory and retry the checkpoint, or \
+                         restore `current` from a backup before reopening.",
+                        config.path.display(),
+                    );
                     return Err(crate::Error::Unrecoverable);
                 }
                 Self::create_new(config)

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1908,7 +1908,7 @@ impl Tree {
 
         let comparator = config.comparator.clone();
 
-        let deletion_pause = crate::deletion_pause::DeletionPause::new();
+        let deletion_pause = crate::deletion_pause::DeletionPause::new_shared();
 
         let inner = TreeInner {
             id: tree_id,

--- a/src/vlog/blob_file/merge.rs
+++ b/src/vlog/blob_file/merge.rs
@@ -4,8 +4,9 @@
 
 use super::scanner::Scanner as BlobFileScanner;
 use crate::vlog::{BlobFileId, blob_file::scanner::ScanEntry};
-use interval_heap::IntervalHeap;
-use std::cmp::Reverse;
+use alloc::collections::BinaryHeap;
+use alloc::vec::Vec;
+use core::cmp::Reverse;
 
 type IteratorIndex = usize;
 
@@ -24,28 +25,33 @@ impl PartialEq for IteratorValue {
 impl Eq for IteratorValue {}
 
 impl PartialOrd for IteratorValue {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for IteratorValue {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         (&self.scan_entry.key, Reverse(&self.scan_entry.seqno))
             .cmp(&(&other.scan_entry.key, Reverse(&other.scan_entry.seqno)))
     }
 }
 
-/// Interleaves multiple blob file readers into a single, sorted stream
+/// Interleaves multiple blob file readers into a single, sorted stream.
+///
+/// Uses `BinaryHeap<Reverse<_>>` for a min-heap. The merger only needs
+/// pop-min + push semantics — the previous `IntervalHeap` (double-ended)
+/// was overkill, and its `compare` transitive dep doesn't declare
+/// `#![no_std]`, blocking the crate's no-std-check job.
 pub struct MergeScanner {
     readers: Vec<BlobFileScanner>,
-    heap: IntervalHeap<IteratorValue>,
+    heap: BinaryHeap<Reverse<IteratorValue>>,
 }
 
 impl MergeScanner {
     /// Initializes a new merging reader
     pub fn new(readers: Vec<BlobFileScanner>) -> Self {
-        let heap = IntervalHeap::with_capacity(readers.len());
+        let heap = BinaryHeap::with_capacity(readers.len());
         Self { readers, heap }
     }
 
@@ -57,11 +63,11 @@ impl MergeScanner {
             let scan_entry = value?;
             let blob_file_id = reader.blob_file_id;
 
-            self.heap.push(IteratorValue {
+            self.heap.push(Reverse(IteratorValue {
                 index: idx,
                 blob_file_id,
                 scan_entry,
-            });
+            }));
         }
 
         Ok(())
@@ -84,7 +90,7 @@ impl Iterator for MergeScanner {
             fail_iter!(self.push_next());
         }
 
-        if let Some(head) = self.heap.pop_min() {
+        if let Some(Reverse(head)) = self.heap.pop() {
             fail_iter!(self.advance_reader(head.index));
             return Some(Ok((head.scan_entry, head.blob_file_id)));
         }

--- a/src/vlog/blob_file/merge.rs
+++ b/src/vlog/blob_file/merge.rs
@@ -17,9 +17,16 @@ struct IteratorValue {
     blob_file_id: BlobFileId,
 }
 
+// PartialEq / Eq are derived from Ord so they STAY consistent: the
+// `Ord` contract requires `a == b` ⇔ `a.cmp(b) == Equal`. Defining
+// Eq on just `key` (the previous impl) violated that, because two
+// entries with the same key + different seqno would test equal but
+// `cmp` would order them. BinaryHeap doesn't call Eq today, but
+// breaking the contract is a latent footgun the moment any caller
+// puts these in a HashSet, BTreeSet, dedup() pass, etc.
 impl PartialEq for IteratorValue {
     fn eq(&self, other: &Self) -> bool {
-        self.scan_entry.key == other.scan_entry.key
+        self.cmp(other) == core::cmp::Ordering::Equal
     }
 }
 impl Eq for IteratorValue {}

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -20,6 +20,13 @@ use std::{
 };
 
 /// A blob file is an immutable, sorted, contiguous file that contains large key-value pairs (blobs)
+//
+// `#[derive(Debug)]` cannot be used because [`Fs`] is not `Debug` (trait
+// objects without an explicit `Debug` bound would require boxing through
+// `dyn Debug`). A manual impl that prints stable identifiers gives the
+// same operational ergonomics as the previous derived `Debug` without
+// pulling `Debug` into the `Fs` trait bound (which would cascade through
+// every backend).
 pub struct Inner {
     /// Blob file ID
     pub id: BlobFileId,
@@ -56,6 +63,21 @@ pub struct Inner {
 impl Inner {
     fn global_id(&self) -> GlobalTableId {
         GlobalTableId::from((self.tree_id, self.id))
+    }
+}
+
+impl core::fmt::Debug for Inner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("blob_file::Inner")
+            .field("id", &self.id)
+            .field("tree_id", &self.tree_id)
+            .field("path", &self.path)
+            .field(
+                "is_deleted",
+                &self.is_deleted.load(std::sync::atomic::Ordering::Relaxed),
+            )
+            .field("meta", &self.meta)
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -57,9 +57,9 @@ pub struct Inner {
     /// with a tree. When `Some` and active, the [`Drop`] impl defers the
     /// underlying `remove_file` so an in-progress checkpoint can hard-link
     /// the file before it disappears.
-    // `once_cell::sync::OnceCell` rather than `std::sync::OnceLock` —
-    // see analogous reasoning on `Table::Inner::deletion_pause`.
-    pub(crate) deletion_pause: once_cell::sync::OnceCell<Arc<DeletionPause>>,
+    // `once_cell::race::OnceBox` — see Table::Inner::deletion_pause
+    // for the rationale (no-std-friendly one-shot slot).
+    pub(crate) deletion_pause: once_cell::race::OnceBox<Arc<DeletionPause>>,
 }
 
 impl Inner {
@@ -166,7 +166,7 @@ impl BlobFile {
     /// Installs the tree-wide deletion pause used by checkpoints.
     /// Idempotent: a second call is a no-op.
     pub(crate) fn install_deletion_pause(&self, pause: Arc<DeletionPause>) {
-        let _ = self.0.deletion_pause.set(pause);
+        let _ = self.0.deletion_pause.set(Box::new(pause));
     }
 
     /// Returns the blob file ID.

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 pub use meta::Metadata;
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock, atomic::AtomicBool},
+    sync::{Arc, atomic::AtomicBool},
 };
 
 /// A blob file is an immutable, sorted, contiguous file that contains large key-value pairs (blobs)
@@ -57,7 +57,9 @@ pub struct Inner {
     /// with a tree. When `Some` and active, the [`Drop`] impl defers the
     /// underlying `remove_file` so an in-progress checkpoint can hard-link
     /// the file before it disappears.
-    pub(crate) deletion_pause: OnceLock<Arc<DeletionPause>>,
+    // `once_cell::sync::OnceCell` rather than `std::sync::OnceLock` —
+    // see analogous reasoning on `Table::Inner::deletion_pause`.
+    pub(crate) deletion_pause: once_cell::sync::OnceCell<Arc<DeletionPause>>,
 }
 
 impl Inner {
@@ -107,12 +109,16 @@ impl Drop for Inner {
 
             // If a checkpoint is active, defer the physical deletion so the
             // file remains hard-linkable until the checkpoint releases its
-            // pause. Falls through to immediate removal when no pause is
-            // installed or the pause is inactive.
-            let deferred = if let Some(pause) = self.deletion_pause.get() {
-                pause.try_enqueue(Arc::clone(&self.fs), self.path.clone())
-            } else {
-                false
+            // pause. Short-circuit on the common no-checkpoint path: skip
+            // the Arc<dyn Fs> bump and PathBuf clone unless a pause is
+            // both installed AND currently active. `try_enqueue` still
+            // re-checks `is_active()` under the queue lock to close the
+            // publish-then-release race, so the outer check is pure perf.
+            let deferred = match self.deletion_pause.get() {
+                Some(pause) if pause.is_active() => {
+                    pause.try_enqueue(Arc::clone(&self.fs), self.path.clone())
+                }
+                _ => false,
             };
 
             if deferred {

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -90,6 +90,21 @@ impl Drop for Inner {
                 self.path.display(),
             );
 
+            // Move the accessor out and drop it FIRST so every pinned
+            // Arc<dyn FsFile> the file_accessor holds is released before
+            // we try to unlink. On Windows (and any other platform where
+            // an open handle blocks unlink) a live handle here would
+            // make remove_file fail silently, leaking the blob file's
+            // disk space — the same hazard already handled in
+            // table::Inner::drop. Eviction from the descriptor table
+            // happens through the same accessor before the drop.
+            let global_id = self.global_id();
+            let file_accessor = std::mem::replace(&mut self.file_accessor, FileAccessor::Closed);
+            file_accessor
+                .as_descriptor_table()
+                .inspect(|d| d.remove_for_blob_file(&global_id));
+            drop(file_accessor);
+
             // If a checkpoint is active, defer the physical deletion so the
             // file remains hard-linkable until the checkpoint releases its
             // pause. Falls through to immediate removal when no pause is
@@ -113,10 +128,6 @@ impl Drop for Inner {
                     self.path.display(),
                 );
             }
-
-            self.file_accessor
-                .as_descriptor_table()
-                .inspect(|d| d.remove_for_blob_file(&self.global_id()));
         }
     }
 }

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -10,17 +10,16 @@ pub mod scanner;
 pub mod writer;
 
 use crate::{
-    Checksum, GlobalTableId, TreeId, blob_tree::FragmentationMap, file_accessor::FileAccessor,
-    vlog::BlobFileId,
+    Checksum, GlobalTableId, TreeId, blob_tree::FragmentationMap, deletion_pause::DeletionPause,
+    file_accessor::FileAccessor, fs::Fs, vlog::BlobFileId,
 };
 pub use meta::Metadata;
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
+    sync::{Arc, OnceLock, atomic::AtomicBool},
 };
 
 /// A blob file is an immutable, sorted, contiguous file that contains large key-value pairs (blobs)
-#[derive(Debug)]
 pub struct Inner {
     /// Blob file ID
     pub id: BlobFileId,
@@ -39,6 +38,19 @@ pub struct Inner {
     pub checksum: Checksum,
 
     pub(crate) file_accessor: FileAccessor,
+
+    /// Filesystem backend used by [`Drop`] for the physical removal.
+    /// Carries the same `Fs` instance the file was opened through so that
+    /// in-memory and routed-tier backends behave consistently with the
+    /// rest of the tree.
+    pub(crate) fs: Arc<dyn Fs>,
+
+    /// Tree-wide file-deletion gate. Installed once by
+    /// [`BlobFile::install_deletion_pause`] after the file is registered
+    /// with a tree. When `Some` and active, the [`Drop`] impl defers the
+    /// underlying `remove_file` so an in-progress checkpoint can hard-link
+    /// the file before it disappears.
+    pub(crate) deletion_pause: OnceLock<Arc<DeletionPause>>,
 }
 
 impl Inner {
@@ -56,7 +68,23 @@ impl Drop for Inner {
                 self.path.display(),
             );
 
-            if let Err(e) = std::fs::remove_file(&*self.path) {
+            // If a checkpoint is active, defer the physical deletion so the
+            // file remains hard-linkable until the checkpoint releases its
+            // pause. Falls through to immediate removal when no pause is
+            // installed or the pause is inactive.
+            let deferred = if let Some(pause) = self.deletion_pause.get() {
+                pause.try_enqueue(Arc::clone(&self.fs), self.path.clone())
+            } else {
+                false
+            };
+
+            if deferred {
+                log::trace!(
+                    "Deferred deletion of blob file {:?} at {} (checkpoint active)",
+                    self.id,
+                    self.path.display(),
+                );
+            } else if let Err(e) = self.fs.remove_file(&self.path) {
                 log::warn!(
                     "Failed to cleanup deleted blob file {:?} at {}: {e:?}",
                     self.id,
@@ -94,6 +122,12 @@ impl BlobFile {
         self.0
             .is_deleted
             .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Installs the tree-wide deletion pause used by checkpoints.
+    /// Idempotent: a second call is a no-op.
+    pub(crate) fn install_deletion_pause(&self, pause: Arc<DeletionPause>) {
+        let _ = self.0.deletion_pause.set(pause);
     }
 
     /// Returns the blob file ID.

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -205,7 +205,7 @@ impl MultiWriter {
                     },
                 },
                 fs: fs.clone(),
-                deletion_pause: once_cell::sync::OnceCell::new(),
+                deletion_pause: once_cell::race::OnceBox::new(),
             }));
 
             Ok(Some(blob_file))

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -204,6 +204,8 @@ impl MultiWriter {
                         passthrough_compression
                     },
                 },
+                fs: fs.clone(),
+                deletion_pause: std::sync::OnceLock::new(),
             }));
 
             Ok(Some(blob_file))

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -205,7 +205,7 @@ impl MultiWriter {
                     },
                 },
                 fs: fs.clone(),
-                deletion_pause: std::sync::OnceLock::new(),
+                deletion_pause: once_cell::sync::OnceCell::new(),
             }));
 
             Ok(Some(blob_file))

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1050,7 +1050,7 @@ mod tests {
             checksum: crate::Checksum::from_raw(0),
             file_accessor: FileAccessor::File(Arc::new(file2)),
             fs: Arc::new(crate::fs::StdFs),
-            deletion_pause: once_cell::sync::OnceCell::new(),
+            deletion_pause: once_cell::race::OnceBox::new(),
         }));
 
         let reader = Reader::new(&blob_file, &file);

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1049,6 +1049,8 @@ mod tests {
             is_deleted: AtomicBool::new(false),
             checksum: crate::Checksum::from_raw(0),
             file_accessor: FileAccessor::File(Arc::new(file2)),
+            fs: Arc::new(crate::fs::StdFs),
+            deletion_pause: std::sync::OnceLock::new(),
         }));
 
         let reader = Reader::new(&blob_file, &file);

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1050,7 +1050,7 @@ mod tests {
             checksum: crate::Checksum::from_raw(0),
             file_accessor: FileAccessor::File(Arc::new(file2)),
             fs: Arc::new(crate::fs::StdFs),
-            deletion_pause: std::sync::OnceLock::new(),
+            deletion_pause: once_cell::sync::OnceCell::new(),
         }));
 
         let reader = Reader::new(&blob_file, &file);

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -136,7 +136,7 @@ pub fn recover_blob_files(
                 file_accessor,
                 tree_id,
                 fs: fs.clone(),
-                deletion_pause: std::sync::OnceLock::new(),
+                deletion_pause: once_cell::sync::OnceCell::new(),
             })));
 
             if idx % progress_mod == 0 {

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -136,7 +136,7 @@ pub fn recover_blob_files(
                 file_accessor,
                 tree_id,
                 fs: fs.clone(),
-                deletion_pause: once_cell::sync::OnceCell::new(),
+                deletion_pause: once_cell::race::OnceBox::new(),
             })));
 
             if idx % progress_mod == 0 {

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -135,6 +135,8 @@ pub fn recover_blob_files(
                 checksum,
                 file_accessor,
                 tree_id,
+                fs: fs.clone(),
+                deletion_pause: std::sync::OnceLock::new(),
             })));
 
             if idx % progress_mod == 0 {

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -671,3 +671,69 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
     assert_eq!(&*val, b"v42");
     Ok(())
 }
+
+/// A checkpoint whose `current` pointer is missing (the crash-recovery
+/// hole described in `write_current_for_version`) MUST be rejected by
+/// `Tree::open` rather than silently treated as fresh-tree state. This
+/// regression test removes the file after a successful checkpoint and
+/// asserts open returns an error.
+#[test_log::test]
+fn checkpoint_open_rejects_missing_current_pointer() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..10 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+    tree.create_checkpoint(&dst_path)?;
+    drop(tree);
+
+    // Tamper: delete the `current` pointer that
+    // `write_current_for_version` writes last during checkpoint sealing.
+    let current = dst_path.join("current");
+    assert!(
+        current.exists(),
+        "checkpoint sealing must have produced a `current` pointer",
+    );
+    std::fs::remove_file(&current)?;
+
+    // Open MUST fail (no fresh-tree fallback) so callers detect the
+    // half-written checkpoint instead of mistaking it for empty data.
+    let open_result = open_tree(&dst_path);
+    assert!(
+        open_result.is_err(),
+        "open_tree on a checkpoint with no `current` must error, got Ok",
+    );
+    Ok(())
+}
+
+/// Same crash-recovery contract as above, but for a `current` file that
+/// exists yet contains garbage instead of a valid version pointer.
+/// `Tree::open` MUST refuse to interpret the directory as a fresh tree.
+#[test_log::test]
+fn checkpoint_open_rejects_corrupt_current_pointer() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..10 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+    tree.create_checkpoint(&dst_path)?;
+    drop(tree);
+
+    let current = dst_path.join("current");
+    std::fs::write(&current, b"this is not a valid version pointer")?;
+
+    let open_result = open_tree(&dst_path);
+    assert!(
+        open_result.is_err(),
+        "open_tree on a checkpoint with corrupt `current` must error, got Ok",
+    );
+    Ok(())
+}

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -363,16 +363,21 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
     let handle = thread::spawn(move || -> lsm_tree::Result<()> {
         let mut announced = false;
         while !compactor_stop.load(Ordering::Acquire) {
+            // Errors from major_compact MUST surface — silently
+            // discarding them would let a checkpoint race that
+            // corrupted compaction state pass the test as green.
+            compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX)?;
+            // Announce AFTER the first compaction completes so the
+            // main thread blocks on `recv()` until the worker has
+            // actually mutated tree state. Signalling before the call
+            // would let a fast scheduler run the checkpoint before
+            // any compaction work began, defeating the race coverage.
             if !announced {
                 started_tx
                     .send(())
                     .expect("checkpoint thread dropped compactor-start receiver");
                 announced = true;
             }
-            // Errors from major_compact MUST surface — silently
-            // discarding them would let a checkpoint race that
-            // corrupted compaction state pass the test as green.
-            compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX)?;
             thread::sleep(Duration::from_millis(5));
         }
         Ok(())

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -170,15 +170,29 @@ fn checkpoint_flattens_level_routes() -> lsm_tree::Result<()> {
     }
     tree.flush_active_memtable(0)?;
 
+    // Verify the routed tier is actually being used BEFORE checkpoint.
+    // Without this guard the test would still pass if `level_routes` were
+    // silently ignored and SSTs landed in the default source directory —
+    // the checkpoint code would just hard-link from the wrong place.
+    let hot_tables = hot_dir.path().join("tables");
+    let hot_entries = std::fs::read_dir(&hot_tables)?.collect::<std::io::Result<Vec<_>>>()?;
+    assert!(
+        !hot_entries.is_empty(),
+        "level_routes route should have produced ≥1 SST in {}",
+        hot_tables.display(),
+    );
+
     let info = tree.create_checkpoint(&dst_path)?;
     assert!(info.sst_files >= 1);
 
     // All checkpoint SSTs live under <dst>/tables/ regardless of where
-    // they were physically stored in the source.
+    // they were physically stored in the source. Errors are propagated
+    // (not silenced with `filter_map(Result::ok)`) so a partial / corrupt
+    // checkpoint surfaces as a failed I/O instead of a smaller count.
     let dst_tables = dst_path.join("tables");
     let entries = std::fs::read_dir(&dst_tables)?
-        .filter_map(Result::ok)
-        .count();
+        .collect::<std::io::Result<Vec<_>>>()?
+        .len();
     assert!(
         entries >= 1,
         "checkpoint tables/ must contain hard-linked SSTs"
@@ -258,7 +272,8 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
 
     let tables_dir = src_dir.path().join("tables");
     let pre_checkpoint_ssts: std::collections::HashSet<_> = std::fs::read_dir(&tables_dir)?
-        .filter_map(Result::ok)
+        .collect::<std::io::Result<Vec<_>>>()?
+        .into_iter()
         .map(|e| e.file_name())
         .collect();
     assert!(
@@ -267,25 +282,51 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
         pre_checkpoint_ssts.len(),
     );
 
+    // RAII guard that stops + joins the compactor thread on every exit
+    // path. Without this, an early-returning `?` would detach the thread
+    // and let it keep mutating the tree behind concurrent tests.
+    struct CompactorGuard {
+        stop: Arc<AtomicBool>,
+        handle: Option<thread::JoinHandle<lsm_tree::Result<()>>>,
+    }
+    impl Drop for CompactorGuard {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Release);
+            if let Some(h) = self.handle.take() {
+                // Best-effort join; panics from the worker thread are
+                // re-raised so test failures are visible.
+                let _ = h.join();
+            }
+        }
+    }
+
     let stop = Arc::new(AtomicBool::new(false));
     let compactor_tree = Arc::clone(&tree);
     let compactor_stop = Arc::clone(&stop);
-    let compactor = thread::spawn(move || -> lsm_tree::Result<()> {
+    let handle = thread::spawn(move || -> lsm_tree::Result<()> {
         while !compactor_stop.load(Ordering::Acquire) {
             let _ = compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX);
             thread::sleep(Duration::from_millis(5));
         }
         Ok(())
     });
+    let _compactor = CompactorGuard {
+        stop: Arc::clone(&stop),
+        handle: Some(handle),
+    };
 
     // Run the checkpoint while compaction is racing. The pause must hold
     // back any compaction-driven removals until our hard-link loop has
-    // captured every SST that existed at checkpoint time.
+    // captured every SST that existed at checkpoint time. If
+    // `create_checkpoint` returns Err, the `?` propagates and
+    // `CompactorGuard::drop` stops + joins the worker cleanly.
     let info = tree.create_checkpoint(&dst_path)?;
-    stop.store(true, Ordering::Release);
-    compactor.join().expect("compactor panicked")?;
+    assert!(
+        info.sst_files >= 1,
+        "checkpoint captured no SSTs despite {} pre-existing on disk",
+        pre_checkpoint_ssts.len(),
+    );
 
-    assert_eq!(info.sst_files, info.sst_files); // sanity
     let restored = open_tree(&dst_path)?;
     for batch in 0u32..5 {
         for i in 0u32..20 {
@@ -335,9 +376,16 @@ fn checkpoint_info_total_bytes_matches_disk() -> lsm_tree::Result<()> {
 
     let info = tree.create_checkpoint(&dst_path)?;
 
-    let actual_bytes: u64 = std::fs::read_dir(dst_path.join("tables"))?
-        .filter_map(Result::ok)
-        .filter_map(|e| e.metadata().ok())
+    // Propagate I/O errors instead of swallowing them with `Result::ok`,
+    // so a corrupted / unreadable entry fails the test instead of being
+    // silently excluded from the byte total.
+    let entries =
+        std::fs::read_dir(dst_path.join("tables"))?.collect::<std::io::Result<Vec<_>>>()?;
+    let actual_bytes: u64 = entries
+        .into_iter()
+        .map(|e| e.metadata())
+        .collect::<std::io::Result<Vec<_>>>()?
+        .into_iter()
         .map(|m| m.len())
         .sum();
     assert_eq!(
@@ -402,13 +450,25 @@ fn cross_fs_link_or_copy_streams_through_trait() -> lsm_tree::Result<()> {
         .read_to_string(&mut buf)?;
     assert_eq!(buf, "cross-fs-payload");
 
-    // And: subsequent writes through MemFs do not affect the source file.
-    let mut f = mem_fs.open(
-        std::path::Path::new("/dst/payload.bin.2"),
-        &FsOpenOptions::new().write(true).create(true),
-    )?;
-    f.write_all(b"unrelated")?;
+    // And: overwriting `dst` itself through MemFs must NOT affect the
+    // source on StdFs. The original test mutated a different file
+    // (`payload.bin.2`) which doesn't actually verify backing-buffer
+    // independence between the two backends.
+    let mut writer = mem_fs.open(dst, &FsOpenOptions::new().write(true).truncate(true))?;
+    writer.write_all(b"mutated-via-mem-fs")?;
+    drop(writer);
+
+    // Source on StdFs is untouched.
     assert_eq!(std::fs::read(&src)?, b"cross-fs-payload");
+
+    // MemFs `dst` reflects the mutation, confirming the two filesystems
+    // really are independent (this is the symmetric assertion missing
+    // from the previous version of this test).
+    let mut after = String::new();
+    mem_fs
+        .open(dst, &FsOpenOptions::new().read(true))?
+        .read_to_string(&mut after)?;
+    assert_eq!(after, "mutated-via-mem-fs");
     Ok(())
 }
 
@@ -419,8 +479,6 @@ fn cross_fs_link_or_copy_streams_through_trait() -> lsm_tree::Result<()> {
 fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
     let src_dir = tempfile::tempdir()?;
     let dst_dir = tempfile::tempdir()?;
-    let dst_path = dst_dir.path().join("checkpoint");
-    std::fs::create_dir_all(&dst_path)?;
 
     let tree = open_tree(src_dir.path())?;
     for i in 0u32..50 {
@@ -428,14 +486,61 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
     }
     tree.flush_active_memtable(0)?;
 
-    let err = tree.create_checkpoint(&dst_path).unwrap_err();
+    // ── (a) Early-reject path: target already exists ─────────────────
+    // Atomic `Fs::create_dir(target)` inside `prepare_target` returns
+    // `AlreadyExists`, so we never enter the link/metadata stage.
+    let early_dst = dst_dir.path().join("early");
+    std::fs::create_dir_all(&early_dst)?;
+    let err = tree.create_checkpoint(&early_dst).unwrap_err();
     let msg = format!("{err:?}");
     assert!(
         msg.contains("already exists") || msg.contains("AlreadyExists"),
-        "expected AlreadyExists error, got {msg}",
+        "expected AlreadyExists on early reject, got {msg}",
+    );
+    // Early reject must NOT damage the pre-existing target (it isn't
+    // ours to clean up).
+    assert!(
+        early_dst.exists(),
+        "early reject must leave the pre-existing target alone",
     );
 
-    // Source tree remains fully readable.
+    // ── (b) Post-prepare failure path ────────────────────────────────
+    // Plant a directory at `<target>/tables/<id>` that collides with the
+    // upcoming hard-link target, forcing `link_tables` to error out
+    // AFTER `prepare_target` succeeded. The `PartialCheckpointGuard`
+    // must then remove the entire partial checkpoint so a retry on the
+    // same path can succeed.
+    let post_dst = dst_dir.path().join("post");
+    // Identify the SST id we just flushed so we can plant a collider.
+    let src_tables_entries =
+        std::fs::read_dir(src_dir.path().join("tables"))?.collect::<std::io::Result<Vec<_>>>()?;
+    let first_sst_name = src_tables_entries
+        .first()
+        .expect("flush should have produced at least one SST")
+        .file_name();
+    // Create just enough scaffolding to trip link_tables. We cannot
+    // pre-create `post_dst` itself because `prepare_target` uses atomic
+    // create_dir — instead we plant a collider INSIDE the eventual
+    // tables/ path using a parent symlink trick: prepare a sibling dir
+    // first and rename it into place between calls.
+    //
+    // Simpler/portable: do NOT pre-create anything. Run the first
+    // checkpoint successfully, then re-run into the same path → it
+    // fails on AlreadyExists. The PartialCheckpointGuard does not fire
+    // here (the failure is in prepare_target, before the guard is
+    // armed) but `remove_dir_all` lets the next attempt work, which
+    // proves the success-side cleanup chain is sound.
+    let _ = first_sst_name; // documents the alternative collider strategy
+    let info1 = tree.create_checkpoint(&post_dst)?;
+    assert!(info1.sst_files >= 1);
+    std::fs::remove_dir_all(&post_dst)?;
+    // Retry into the now-empty path must succeed — proves no stale state
+    // leaked between checkpoints.
+    let info2 = tree.create_checkpoint(&post_dst)?;
+    assert_eq!(info1.sst_files, info2.sst_files);
+    assert_eq!(info1.version_id, info2.version_id);
+
+    // ── Source intact across both failure modes ──────────────────────
     for i in 0u32..50 {
         let key = format!("k{i:03}");
         let val = tree
@@ -445,7 +550,7 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
     }
     drop(tree);
 
-    // And: reopening the source after the failed checkpoint still works.
+    // And: reopening the source after the failed checkpoints still works.
     let reopened = open_tree(src_dir.path())?;
     let val = reopened
         .get(b"k042", lsm_tree::SeqNo::MAX)?

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -751,11 +751,25 @@ fn checkpoint_open_rejects_corrupt_current_pointer() -> lsm_tree::Result<()> {
     let current = dst_path.join("current");
     std::fs::write(&current, b"this is not a valid version pointer")?;
 
-    let open_result = open_tree(&dst_path);
-    assert!(
-        open_result.is_err(),
-        "open_tree on a checkpoint with corrupt `current` must error, got Ok",
-    );
+    // Assert the specific failure mode the parser catches.
+    // `get_current_version` reads `u64 version_id | u128 checksum |
+    // u8 checksum_type` and rejects any checksum_type byte that
+    // isn't 0 (xxh3) with `Error::InvalidTag(("ChecksumType", _))`.
+    // Writing 36 bytes of junk guarantees we hit that branch — checking
+    // for InvalidTag instead of just `is_err()` ensures a future refactor
+    // that masks the corruption behind a different error path fails the
+    // test instead of silently passing.
+    let err = match open_tree(&dst_path) {
+        Ok(_) => panic!("open_tree on a checkpoint with corrupt `current` must error, got Ok"),
+        Err(e) => e,
+    };
+    match err {
+        lsm_tree::Error::InvalidTag((field, _)) => assert_eq!(
+            field, "ChecksumType",
+            "expected ChecksumType InvalidTag from corrupt `current`, got field {field}",
+        ),
+        other => panic!("expected Error::InvalidTag(ChecksumType, _), got {other:?}"),
+    }
     Ok(())
 }
 
@@ -785,15 +799,23 @@ fn checkpoint_survives_concurrent_manifest_gc_of_captured_version() -> lsm_tree:
     }
     tree.flush_active_memtable(0)?;
 
-    // Identify the live version file on disk so we can remove it
-    // without going through the maintenance API (which would also
-    // evict the in-memory entry — defeating the race-reproduction).
-    let live_v = std::fs::read_dir(src_dir.path())?
-        .filter_map(Result::ok)
-        .map(|e| e.file_name())
-        .filter_map(|n| n.into_string().ok())
-        .find(|n| n.starts_with('v') && n.len() > 1 && n[1..].bytes().all(|c| c.is_ascii_digit()))
-        .expect("source tree should have at least one vN file after flush");
+    // Identify the live version file the same way recovery does — read
+    // the version id out of `current` rather than picking the first
+    // matching `vN` from `read_dir`. read_dir's order is unspecified and
+    // multiple vN files may coexist (the previous flush leaves the prior
+    // version around for snapshot readers until manifest GC runs), so a
+    // naive .find() could remove a STALE file and silently turn the
+    // test into a no-op that passes even when the race fix regresses.
+    //
+    // The `current` wire format is `u64 version_id | u128 checksum |
+    // u8 checksum_type` — the first 8 LE bytes give us the live id.
+    let current_bytes = std::fs::read(src_dir.path().join("current"))?;
+    let version_id = u64::from_le_bytes(
+        current_bytes[..8]
+            .try_into()
+            .expect("`current` stores the version id in the first 8 bytes"),
+    );
+    let live_v = format!("v{version_id}");
     std::fs::remove_file(src_dir.path().join(&live_v))?;
 
     // With the fix, the checkpoint serialises the in-memory Version

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -705,11 +705,22 @@ fn checkpoint_open_rejects_missing_current_pointer() -> lsm_tree::Result<()> {
 
     // Open MUST fail (no fresh-tree fallback) so callers detect the
     // half-written checkpoint instead of mistaking it for empty data.
-    let open_result = open_tree(&dst_path);
-    assert!(
-        open_result.is_err(),
-        "open_tree on a checkpoint with no `current` must error, got Ok",
-    );
+    // The error carries the path + remediation hint so a programmatic
+    // caller can surface it without reading logs.
+    let err = match open_tree(&dst_path) {
+        Ok(_) => panic!("open_tree on a checkpoint with no `current` must error, got Ok"),
+        Err(e) => e,
+    };
+    match err {
+        lsm_tree::Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData => {
+            let msg = io_err.to_string();
+            assert!(
+                msg.contains("current") && msg.contains("version artifacts"),
+                "error must explain the half-written-checkpoint condition, got: {msg}",
+            );
+        }
+        other => panic!("expected Io(InvalidData) with diagnostic message, got {other:?}"),
+    }
     Ok(())
 }
 

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -75,10 +75,26 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
     let dst_dir = tempfile::tempdir()?;
     let dst_path = dst_dir.path().join("checkpoint");
 
-    let tree = Arc::new(open_tree(src_dir.path())?);
+    // Use a SHARED visible_seqno generator and fetch_max it past every
+    // inserted record's seqno. Without this, info.seqno (captured from
+    // the visible_seqno generator) stays at whatever value internal
+    // version transitions bumped it to — small, unrelated to the
+    // 0..200 record seqnos this test uses — and the watermark assertion
+    // below becomes vacuous (the `i as u64 <= info.seqno` guard rarely
+    // fires, so checkpoint regressions silently pass).
+    let visible_seqno = SequenceNumberCounter::default();
+    let tree = Arc::new(
+        Config::new(
+            src_dir.path(),
+            SequenceNumberCounter::default(),
+            visible_seqno.clone(),
+        )
+        .open()?,
+    );
 
     for i in 0u32..50 {
         tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+        visible_seqno.fetch_max(u64::from(i) + 1);
     }
     tree.flush_active_memtable(0)?;
 
@@ -89,9 +105,11 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
     // smoke test that does not exercise the concurrency invariant.
     let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
     let writer_tree = Arc::clone(&tree);
+    let writer_seqno = visible_seqno.clone();
     let writer = thread::spawn(move || -> lsm_tree::Result<()> {
         for i in 50u32..200 {
             writer_tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+            writer_seqno.fetch_max(u64::from(i) + 1);
             if i == 50 {
                 started_tx
                     .send(())

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -93,18 +93,32 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
         Ok(())
     });
 
-    let _info = tree.create_checkpoint(&dst_path)?;
+    let info = tree.create_checkpoint(&dst_path)?;
     writer.join().expect("writer thread panicked")?;
 
     // Reopening must succeed regardless of what the writer did.
     let restored = open_tree(&dst_path)?;
-    // Keys 0..50 were flushed before the checkpoint started — their SSTs
-    // must be present in the snapshot. Use SeqNo::MAX since checkpoint
-    // captures the storage state, not the visible-seqno watermark.
-    for i in 0u32..50 {
+
+    // PITR watermark contract: every key with `seqno <= info.seqno` MUST
+    // be present in the checkpoint. The lower-bound watermark guarantee
+    // is what callers rely on for replay cutoffs — verify it explicitly
+    // rather than just checking the pre-flushed 0..50 range.
+    //
+    // Keys are inserted with `seqno = i`, so any key index `i` such that
+    // `i as u64 <= info.seqno` must be readable. We make NO claim about
+    // keys with `i > info.seqno` — those may or may not be in the
+    // snapshot depending on whether the writer thread reached them
+    // before checkpoint sampled the version.
+    for i in 0u32..200 {
         let key = format!("k{i:03}");
-        let val = restored.get(key.as_bytes(), lsm_tree::SeqNo::MAX)?;
-        assert!(val.is_some(), "checkpoint missing pre-existing key {key}");
+        let got = restored.get(key.as_bytes(), lsm_tree::SeqNo::MAX)?;
+        if u64::from(i) <= info.seqno {
+            assert!(
+                got.is_some(),
+                "PITR watermark violated: key {key} (seqno {i}) <= info.seqno ({}) but missing from checkpoint",
+                info.seqno,
+            );
+        }
     }
     Ok(())
 }
@@ -285,6 +299,18 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
     // RAII guard that stops + joins the compactor thread on every exit
     // path. Without this, an early-returning `?` would detach the thread
     // and let it keep mutating the tree behind concurrent tests.
+    //
+    // The Drop impl propagates BOTH panics and Err results:
+    //
+    // - `Err(Box<dyn Any>)` from `join()` means the worker thread
+    //   panicked. We `resume_unwind` so the panic surfaces as a test
+    //   failure instead of being silently dropped.
+    // - `Ok(Err(e))` means the worker returned an error from
+    //   `major_compact` — we `panic!` to fail the test loudly.
+    //
+    // Both branches check `thread::panicking()` first: if the test body
+    // is already unwinding from its own failure, re-panicking would
+    // abort the process instead of letting the original panic propagate.
     struct CompactorGuard {
         stop: Arc<AtomicBool>,
         handle: Option<thread::JoinHandle<lsm_tree::Result<()>>>,
@@ -292,10 +318,21 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
     impl Drop for CompactorGuard {
         fn drop(&mut self) {
             self.stop.store(true, Ordering::Release);
-            if let Some(h) = self.handle.take() {
-                // Best-effort join; panics from the worker thread are
-                // re-raised so test failures are visible.
-                let _ = h.join();
+            let Some(h) = self.handle.take() else {
+                return;
+            };
+            match h.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    if !thread::panicking() {
+                        panic!("compactor thread returned error: {err:?}");
+                    }
+                }
+                Err(payload) => {
+                    if !thread::panicking() {
+                        std::panic::resume_unwind(payload);
+                    }
+                }
             }
         }
     }
@@ -305,7 +342,10 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
     let compactor_stop = Arc::clone(&stop);
     let handle = thread::spawn(move || -> lsm_tree::Result<()> {
         while !compactor_stop.load(Ordering::Acquire) {
-            let _ = compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX);
+            // Errors from major_compact MUST surface — silently
+            // discarding them would let a checkpoint race that
+            // corrupted compaction state pass the test as green.
+            compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX)?;
             thread::sleep(Duration::from_millis(5));
         }
         Ok(())
@@ -504,41 +544,72 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
         "early reject must leave the pre-existing target alone",
     );
 
-    // ── (b) Post-prepare failure path ────────────────────────────────
-    // Plant a directory at `<target>/tables/<id>` that collides with the
-    // upcoming hard-link target, forcing `link_tables` to error out
-    // AFTER `prepare_target` succeeded. The `PartialCheckpointGuard`
-    // must then remove the entire partial checkpoint so a retry on the
-    // same path can succeed.
-    let post_dst = dst_dir.path().join("post");
-    // Identify the SST id we just flushed so we can plant a collider.
-    let src_tables_entries =
-        std::fs::read_dir(src_dir.path().join("tables"))?.collect::<std::io::Result<Vec<_>>>()?;
-    let first_sst_name = src_tables_entries
-        .first()
-        .expect("flush should have produced at least one SST")
-        .file_name();
-    // Create just enough scaffolding to trip link_tables. We cannot
-    // pre-create `post_dst` itself because `prepare_target` uses atomic
-    // create_dir — instead we plant a collider INSIDE the eventual
-    // tables/ path using a parent symlink trick: prepare a sibling dir
-    // first and rename it into place between calls.
-    //
-    // Simpler/portable: do NOT pre-create anything. Run the first
-    // checkpoint successfully, then re-run into the same path → it
-    // fails on AlreadyExists. The PartialCheckpointGuard does not fire
-    // here (the failure is in prepare_target, before the guard is
-    // armed) but `remove_dir_all` lets the next attempt work, which
-    // proves the success-side cleanup chain is sound.
-    let _ = first_sst_name; // documents the alternative collider strategy
-    let info1 = tree.create_checkpoint(&post_dst)?;
-    assert!(info1.sst_files >= 1);
-    std::fs::remove_dir_all(&post_dst)?;
-    // Retry into the now-empty path must succeed — proves no stale state
-    // leaked between checkpoints.
-    let info2 = tree.create_checkpoint(&post_dst)?;
-    assert_eq!(info1.sst_files, info2.sst_files);
-    assert_eq!(info1.version_id, info2.version_id);
+    // ── (b) Post-prepare failure path (Unix-only) ───────────────────
+    // Force `link_tables` to fail by chmod-ing the source SST to 000
+    // AFTER `prepare_target` would normally have succeeded. The outer
+    // `PartialCheckpointGuard` (armed right after prepare_target returns)
+    // must remove the entire partial checkpoint so a retry on the same
+    // path succeeds. Restricted to Unix because Windows has no portable
+    // way to make an open file unreadable from another process.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let post_dst = dst_dir.path().join("post");
+        let src_tables = src_dir.path().join("tables");
+        let orig_perm = std::fs::metadata(&src_tables)?.permissions();
+
+        // Strip read+execute on the SOURCE tables/ directory. We strip
+        // the *directory* not the SST file because `link(2)` does NOT
+        // require read permission on the source file (it just bumps the
+        // inode's link count) — but it DOES require search (x) permission
+        // on every directory component of the source path. Without `x`
+        // on `tables/`, the kernel cannot resolve `tables/<id>` and
+        // `link()` fails with `EACCES`.
+        std::fs::set_permissions(&src_tables, std::fs::Permissions::from_mode(0o000))?;
+
+        let result = tree.create_checkpoint(&post_dst);
+        // Restore perms BEFORE assertions so source remains usable even
+        // if a later assertion fails.
+        std::fs::set_permissions(&src_tables, orig_perm)?;
+
+        let err = result.expect_err("create_checkpoint should fail when src tables/ is unreadable");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("Permission")
+                || msg.contains("denied")
+                || msg.contains("Os")
+                || msg.contains("error"),
+            "expected post-prepare I/O error, got {msg}",
+        );
+
+        // PartialCheckpointGuard must have removed the partial checkpoint.
+        assert!(
+            !post_dst.exists(),
+            "PartialCheckpointGuard must remove partial checkpoint after \
+             post-prepare failure; {} still present",
+            post_dst.display(),
+        );
+
+        // And a retry against the same path now succeeds, proving no
+        // stale state leaked.
+        let info = tree.create_checkpoint(&post_dst)?;
+        assert!(info.sst_files >= 1);
+    }
+
+    // Portable fallback (non-Unix): exercise just the success-then-
+    // cleanup-then-retry chain to verify run_checkpoint is idempotent
+    // against a freshly cleaned target.
+    #[cfg(not(unix))]
+    {
+        let post_dst = dst_dir.path().join("post");
+        let info1 = tree.create_checkpoint(&post_dst)?;
+        assert!(info1.sst_files >= 1);
+        std::fs::remove_dir_all(&post_dst)?;
+        let info2 = tree.create_checkpoint(&post_dst)?;
+        assert_eq!(info1.sst_files, info2.sst_files);
+        assert_eq!(info1.version_id, info2.version_id);
+    }
 
     // ── Source intact across both failure modes ──────────────────────
     for i in 0u32..50 {

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -131,23 +131,28 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
     // Reopening must succeed regardless of what the writer did.
     let restored = open_tree(&dst_path)?;
 
-    // PITR watermark contract: every key with `seqno <= info.seqno` MUST
-    // be present in the checkpoint. The lower-bound watermark guarantee
-    // is what callers rely on for replay cutoffs — verify it explicitly
-    // rather than just checking the pre-flushed 0..50 range.
+    // PITR watermark contract: every key with `seqno < info.seqno` MUST
+    // be present in the checkpoint. visible_seqno is "lowest excluded"
+    // (the next-seqno-to-allocate) — a record with `seqno = N` is
+    // committed/visible iff `visible_seqno >= N + 1`, equivalently
+    // `seqno < visible_seqno`. The strict `<` matters under concurrent
+    // scheduling: writer's `insert(seqno=i)` and `fetch_max(i + 1)` are
+    // NOT atomic, so main can observe `visible_seqno = i` between
+    // those two steps. At that moment record-i may or may not be in
+    // the flushed memtable; only records with seqno strictly less than
+    // the captured watermark are guaranteed committed.
     //
-    // Keys are inserted with `seqno = i`, so any key index `i` such that
-    // `i as u64 <= info.seqno` must be readable. We make NO claim about
-    // keys with `i > info.seqno` — those may or may not be in the
-    // snapshot depending on whether the writer thread reached them
-    // before checkpoint sampled the version.
+    // We make NO claim about keys with `i >= info.seqno` — those may
+    // or may not be in the snapshot depending on whether the writer
+    // had advanced its watermark past `i` before checkpoint sampled
+    // visible_seqno.
     for i in 0u32..200 {
         let key = format!("k{i:03}");
         let got = restored.get(key.as_bytes(), lsm_tree::SeqNo::MAX)?;
-        if u64::from(i) <= info.seqno {
+        if u64::from(i) < info.seqno {
             assert!(
                 got.is_some(),
-                "PITR watermark violated: key {key} (seqno {i}) <= info.seqno ({}) but missing from checkpoint",
+                "PITR watermark violated: key {key} (seqno {i}) < info.seqno ({}) but missing from checkpoint",
                 info.seqno,
             );
         }

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -459,58 +459,9 @@ fn second_checkpoint_into_same_target_rejected() -> lsm_tree::Result<()> {
     Ok(())
 }
 
-/// 6e. Cross-`Fs` link fall-back: when the source tree's `Fs` differs
-///     from the checkpoint target's `Fs` (here: `StdFs` source vs.
-///     `MemFs` target), the checkpoint code must transparently stream
-///     bytes through both trait objects instead of attempting a real
-///     hard link.
-#[test_log::test]
-fn cross_fs_link_or_copy_streams_through_trait() -> lsm_tree::Result<()> {
-    use lsm_tree::checkpoint::link_or_copy_cross_fs;
-    use lsm_tree::fs::{Fs, FsOpenOptions, MemFs, StdFs};
-    use std::io::Write;
-
-    let dir = tempfile::tempdir()?;
-    let src = dir.path().join("payload.bin");
-    std::fs::write(&src, b"cross-fs-payload")?;
-
-    let std_fs: Arc<dyn Fs> = Arc::new(StdFs);
-    let mem_fs: Arc<dyn Fs> = Arc::new(MemFs::new());
-    mem_fs.create_dir_all(std::path::Path::new("/dst"))?;
-
-    let dst = std::path::Path::new("/dst/payload.bin");
-    let bytes = link_or_copy_cross_fs(&std_fs, &src, &mem_fs, dst)?;
-    assert_eq!(bytes, b"cross-fs-payload".len() as u64);
-
-    // Read back through MemFs to confirm the bytes landed.
-    let mut buf = String::new();
-    use std::io::Read;
-    mem_fs
-        .open(dst, &FsOpenOptions::new().read(true))?
-        .read_to_string(&mut buf)?;
-    assert_eq!(buf, "cross-fs-payload");
-
-    // And: overwriting `dst` itself through MemFs must NOT affect the
-    // source on StdFs. The original test mutated a different file
-    // (`payload.bin.2`) which doesn't actually verify backing-buffer
-    // independence between the two backends.
-    let mut writer = mem_fs.open(dst, &FsOpenOptions::new().write(true).truncate(true))?;
-    writer.write_all(b"mutated-via-mem-fs")?;
-    drop(writer);
-
-    // Source on StdFs is untouched.
-    assert_eq!(std::fs::read(&src)?, b"cross-fs-payload");
-
-    // MemFs `dst` reflects the mutation, confirming the two filesystems
-    // really are independent (this is the symmetric assertion missing
-    // from the previous version of this test).
-    let mut after = String::new();
-    mem_fs
-        .open(dst, &FsOpenOptions::new().read(true))?
-        .read_to_string(&mut after)?;
-    assert_eq!(after, "mutated-via-mem-fs");
-    Ok(())
-}
+// 6e. Cross-`Fs` link fall-back is covered by the inline unit test
+// `cross_fs_link_or_copy_streams_through_trait` in `src/checkpoint.rs`
+// (the helper is `pub(crate)`, so the test lives next to it).
 
 /// 7. Crash safety: aborting mid-checkpoint must leave the SOURCE tree
 ///    fully intact and reopenable. We force the failure by pre-creating

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -758,3 +758,60 @@ fn checkpoint_open_rejects_corrupt_current_pointer() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+/// Regression test for the manifest-GC race: a concurrent compaction
+/// can run `SuperVersions::maintenance` between `current_version()`
+/// inside the checkpoint driver and the time `copy_metadata` reaches
+/// the source `v<id>` file. The captured Version still lives in
+/// memory, but the on-disk `v<id>` is gone — the source-file copy
+/// path would fail. The fix serialises the captured Version from
+/// memory into the checkpoint dir, so the race cannot fail the
+/// checkpoint.
+///
+/// We simulate the race by deleting the source `v<id>` AFTER
+/// `current_version()` would have captured it. In this test there is
+/// no concurrent maintenance because we drive the deletion directly;
+/// the in-memory SuperVersions still references the deleted file's
+/// id, exactly as it would mid-race.
+#[test_log::test]
+fn checkpoint_survives_concurrent_manifest_gc_of_captured_version() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..5 {
+        tree.insert(format!("k{i:02}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Identify the live version file on disk so we can remove it
+    // without going through the maintenance API (which would also
+    // evict the in-memory entry — defeating the race-reproduction).
+    let live_v = std::fs::read_dir(src_dir.path())?
+        .filter_map(Result::ok)
+        .map(|e| e.file_name())
+        .filter_map(|n| n.into_string().ok())
+        .find(|n| n.starts_with('v') && n.len() > 1 && n[1..].bytes().all(|c| c.is_ascii_digit()))
+        .expect("source tree should have at least one vN file after flush");
+    std::fs::remove_file(src_dir.path().join(&live_v))?;
+
+    // With the fix, the checkpoint serialises the in-memory Version
+    // into target/v<id> and succeeds. Without the fix, the copy of
+    // the (now missing) source v<id> file fails with NotFound.
+    let info = tree.create_checkpoint(&dst_path)?;
+    assert!(info.sst_files >= 1);
+
+    // The reopened checkpoint must read every pre-deletion key back
+    // — proving the captured version was written into the snapshot
+    // independently of the deleted source file.
+    let restored = open_tree(&dst_path)?;
+    for i in 0u32..5 {
+        let key = format!("k{i:02}");
+        let val = restored
+            .get(key.as_bytes(), lsm_tree::SeqNo::MAX)?
+            .unwrap_or_else(|| panic!("missing key {key} in checkpoint"));
+        assert_eq!(&*val, format!("v{i}").as_bytes());
+    }
+    Ok(())
+}

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -542,11 +542,14 @@ fn second_checkpoint_into_same_target_rejected() -> lsm_tree::Result<()> {
 
     tree.create_checkpoint(&dst_path)?;
     let err = tree.create_checkpoint(&dst_path).unwrap_err();
-    let msg = format!("{err:?}");
-    assert!(
-        msg.contains("already exists") || msg.contains("AlreadyExists"),
-        "expected AlreadyExists on second checkpoint, got {msg}",
-    );
+    // Assert on the structural variant rather than the Debug string,
+    // which is OS-/std-formatter-specific. The second checkpoint must
+    // surface `Io(NotFound | AlreadyExists)`-class refusal so callers
+    // can detect double-target programmatically.
+    match err {
+        lsm_tree::Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::AlreadyExists => {}
+        other => panic!("expected Io(AlreadyExists) on second checkpoint, got {other:?}"),
+    }
     Ok(())
 }
 

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+//
+// End-to-end tests for `Tree::create_checkpoint` and
+// `BlobTree::create_checkpoint` — the point-in-time recovery (PITR) primitive
+// described in https://github.com/structured-world/coordinode-lsm-tree/issues/210.
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, KvSeparationOptions, SequenceNumberCounter, config::LevelRoute,
+};
+use std::sync::Arc;
+
+fn open_tree<P: AsRef<std::path::Path>>(path: P) -> lsm_tree::Result<AnyTree> {
+    Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+}
+
+fn open_blob_tree<P: AsRef<std::path::Path>>(path: P) -> lsm_tree::Result<AnyTree> {
+    Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    .open()
+}
+
+/// 1. Round-trip: write data, checkpoint, reopen the checkpoint as an
+///    independent tree, verify every key is readable.
+#[test_log::test]
+fn checkpoint_roundtrip_reopens_independently() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..100 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let info = tree.create_checkpoint(&dst_path)?;
+    assert!(
+        info.sst_files >= 1,
+        "checkpoint must capture at least one SST"
+    );
+    assert_eq!(info.blob_files, 0);
+    assert!(info.total_bytes > 0);
+
+    // Reopen the checkpoint as a brand-new tree and read every key.
+    let restored = open_tree(&dst_path)?;
+    for i in 0u32..100 {
+        let key = format!("k{i:03}");
+        let val = restored
+            .get(key.as_bytes(), lsm_tree::SeqNo::MAX)?
+            .unwrap_or_else(|| panic!("missing key {key} in checkpoint"));
+        assert_eq!(&*val, format!("v{i}").as_bytes());
+    }
+    Ok(())
+}
+
+/// 2. Concurrent writes: writes interleaved with the checkpoint must not
+///    corrupt the snapshot. After the checkpoint completes, every key
+///    that existed at checkpoint time must be readable from the
+///    re-opened copy.
+#[test_log::test]
+fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
+    use std::thread;
+
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = Arc::new(open_tree(src_dir.path())?);
+
+    for i in 0u32..50 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let writer_tree = Arc::clone(&tree);
+    let writer = thread::spawn(move || -> lsm_tree::Result<()> {
+        for i in 50u32..200 {
+            writer_tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+            if i.is_multiple_of(10) {
+                writer_tree.flush_active_memtable(0)?;
+            }
+        }
+        Ok(())
+    });
+
+    let _info = tree.create_checkpoint(&dst_path)?;
+    writer.join().expect("writer thread panicked")?;
+
+    // Reopening must succeed regardless of what the writer did.
+    let restored = open_tree(&dst_path)?;
+    // Keys 0..50 were flushed before the checkpoint started — their SSTs
+    // must be present in the snapshot. Use SeqNo::MAX since checkpoint
+    // captures the storage state, not the visible-seqno watermark.
+    for i in 0u32..50 {
+        let key = format!("k{i:03}");
+        let val = restored.get(key.as_bytes(), lsm_tree::SeqNo::MAX)?;
+        assert!(val.is_some(), "checkpoint missing pre-existing key {key}");
+    }
+    Ok(())
+}
+
+/// 3. BlobTree: KV-separated values must also be present in the
+///    checkpoint, with both index SSTs and blob files hard-linked.
+#[test_log::test]
+fn blob_tree_checkpoint_captures_blobs() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_blob_tree(src_dir.path())?;
+    let big = b"x".repeat(4096);
+    for i in 0u32..10 {
+        tree.insert(format!("blob{i}"), &big, u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let info = tree.create_checkpoint(&dst_path)?;
+    assert!(info.sst_files >= 1);
+    assert!(
+        info.blob_files >= 1,
+        "BlobTree checkpoint must include blob files"
+    );
+
+    let restored = open_blob_tree(&dst_path)?;
+    for i in 0u32..10 {
+        let key = format!("blob{i}");
+        let val = restored
+            .get(key.as_bytes(), lsm_tree::SeqNo::MAX)?
+            .unwrap_or_else(|| panic!("missing blob {key}"));
+        assert_eq!(&*val, big.as_slice());
+    }
+    Ok(())
+}
+
+/// 4. level_routes (tiered storage): an SST on a routed tier must still be
+///    captured in the checkpoint under the flattened `tables/` folder.
+#[test_log::test]
+fn checkpoint_flattens_level_routes() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let hot_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let routes = vec![LevelRoute {
+        levels: 0..2, // route L0 + L1 to the hot tier
+        path: hot_dir.path().to_path_buf(),
+        fs: Arc::new(lsm_tree::fs::StdFs),
+    }];
+
+    let tree = Config::new(
+        src_dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .level_routes(routes)
+    .open()?;
+
+    for i in 0u32..20 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let info = tree.create_checkpoint(&dst_path)?;
+    assert!(info.sst_files >= 1);
+
+    // All checkpoint SSTs live under <dst>/tables/ regardless of where
+    // they were physically stored in the source.
+    let dst_tables = dst_path.join("tables");
+    let entries = std::fs::read_dir(&dst_tables)?
+        .filter_map(Result::ok)
+        .count();
+    assert!(
+        entries >= 1,
+        "checkpoint tables/ must contain hard-linked SSTs"
+    );
+    Ok(())
+}
+
+/// 5. Reopen-then-mutate isolation: writes against the checkpoint must
+///    NOT bleed back into the source tree (proves hard links share inode
+///    data but the tree state diverges from the checkpoint moment forward).
+#[test_log::test]
+fn checkpoint_and_source_diverge_after_writes() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    tree.insert("shared", "before", 1);
+    tree.flush_active_memtable(0)?;
+
+    tree.create_checkpoint(&dst_path)?;
+
+    // Mutate the source AFTER the checkpoint.
+    tree.insert("shared", "after-src", 2);
+    tree.insert("src-only", "src", 3);
+    tree.flush_active_memtable(0)?;
+    drop(tree);
+
+    let restored = open_tree(&dst_path)?;
+    // Checkpoint must still see the pre-checkpoint value.
+    let v = restored
+        .get(b"shared", lsm_tree::SeqNo::MAX)?
+        .expect("shared key");
+    assert_eq!(&*v, b"before");
+    assert!(
+        restored.get(b"src-only", lsm_tree::SeqNo::MAX)?.is_none(),
+        "post-checkpoint inserts must NOT appear in the checkpoint tree",
+    );
+
+    // And: mutating the checkpoint copy must not affect the source.
+    restored.insert("dst-only", "dst", 7);
+    restored.flush_active_memtable(0)?;
+    drop(restored);
+
+    let src_again = open_tree(src_dir.path())?;
+    assert!(
+        src_again.get(b"dst-only", lsm_tree::SeqNo::MAX)?.is_none(),
+        "writes to the checkpoint must NOT bleed back into the source",
+    );
+    Ok(())
+}
+
+/// 6a. Deferred-deletion invariant: a major compaction that runs while a
+///     checkpoint is taking SSTs in-flight must NOT physically remove any
+///     pre-compaction SST until the checkpoint finishes. This is the core
+///     correctness property of the deletion-pause gate.
+#[test_log::test]
+fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = Arc::new(open_tree(src_dir.path())?);
+
+    // Produce several SSTs so major_compact will actually have work to do.
+    for batch in 0u32..5 {
+        for i in 0u32..20 {
+            let k = format!("k{batch:02}_{i:03}");
+            tree.insert(k, format!("v{batch}.{i}"), u64::from(batch * 100 + i));
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let tables_dir = src_dir.path().join("tables");
+    let pre_checkpoint_ssts: std::collections::HashSet<_> = std::fs::read_dir(&tables_dir)?
+        .filter_map(Result::ok)
+        .map(|e| e.file_name())
+        .collect();
+    assert!(
+        pre_checkpoint_ssts.len() >= 2,
+        "test needs ≥2 SSTs to be meaningful (got {})",
+        pre_checkpoint_ssts.len(),
+    );
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let compactor_tree = Arc::clone(&tree);
+    let compactor_stop = Arc::clone(&stop);
+    let compactor = thread::spawn(move || -> lsm_tree::Result<()> {
+        while !compactor_stop.load(Ordering::Acquire) {
+            let _ = compactor_tree.major_compact(u64::MAX, lsm_tree::SeqNo::MAX);
+            thread::sleep(Duration::from_millis(5));
+        }
+        Ok(())
+    });
+
+    // Run the checkpoint while compaction is racing. The pause must hold
+    // back any compaction-driven removals until our hard-link loop has
+    // captured every SST that existed at checkpoint time.
+    let info = tree.create_checkpoint(&dst_path)?;
+    stop.store(true, Ordering::Release);
+    compactor.join().expect("compactor panicked")?;
+
+    assert_eq!(info.sst_files, info.sst_files); // sanity
+    let restored = open_tree(&dst_path)?;
+    for batch in 0u32..5 {
+        for i in 0u32..20 {
+            let k = format!("k{batch:02}_{i:03}");
+            assert!(
+                restored.get(k.as_bytes(), lsm_tree::SeqNo::MAX)?.is_some(),
+                "checkpoint missing key {k} despite concurrent compaction",
+            );
+        }
+    }
+    Ok(())
+}
+
+/// 6b. Empty tree: checkpointing a freshly-opened, never-written tree
+///     must succeed and produce a checkpoint that opens cleanly with
+///     zero SSTs.
+#[test_log::test]
+fn checkpoint_of_empty_tree() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    let info = tree.create_checkpoint(&dst_path)?;
+    assert_eq!(info.sst_files, 0);
+    assert_eq!(info.blob_files, 0);
+    assert_eq!(info.total_bytes, 0);
+
+    let restored = open_tree(&dst_path)?;
+    assert!(restored.get(b"anything", lsm_tree::SeqNo::MAX)?.is_none());
+    Ok(())
+}
+
+/// 6c. `CheckpointInfo.total_bytes` matches the actual on-disk sum of
+///     the hard-linked SST files in the destination directory.
+#[test_log::test]
+fn checkpoint_info_total_bytes_matches_disk() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..200 {
+        tree.insert(format!("k{i:04}"), b"v".repeat(64), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let info = tree.create_checkpoint(&dst_path)?;
+
+    let actual_bytes: u64 = std::fs::read_dir(dst_path.join("tables"))?
+        .filter_map(Result::ok)
+        .filter_map(|e| e.metadata().ok())
+        .map(|m| m.len())
+        .sum();
+    assert_eq!(
+        info.total_bytes, actual_bytes,
+        "CheckpointInfo.total_bytes ({}) must equal on-disk sum ({actual_bytes})",
+        info.total_bytes,
+    );
+    Ok(())
+}
+
+/// 6d. Re-running a checkpoint into the SAME target after it succeeded
+///     must fail with `AlreadyExists` — the snapshot is not allowed to
+///     overwrite a prior one without explicit caller intervention.
+#[test_log::test]
+fn second_checkpoint_into_same_target_rejected() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    tree.insert("k", "v", 1);
+    tree.flush_active_memtable(0)?;
+
+    tree.create_checkpoint(&dst_path)?;
+    let err = tree.create_checkpoint(&dst_path).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("already exists") || msg.contains("AlreadyExists"),
+        "expected AlreadyExists on second checkpoint, got {msg}",
+    );
+    Ok(())
+}
+
+/// 6e. Cross-`Fs` link fall-back: when the source tree's `Fs` differs
+///     from the checkpoint target's `Fs` (here: `StdFs` source vs.
+///     `MemFs` target), the checkpoint code must transparently stream
+///     bytes through both trait objects instead of attempting a real
+///     hard link.
+#[test_log::test]
+fn cross_fs_link_or_copy_streams_through_trait() -> lsm_tree::Result<()> {
+    use lsm_tree::checkpoint::link_or_copy_cross_fs;
+    use lsm_tree::fs::{Fs, FsOpenOptions, MemFs, StdFs};
+    use std::io::Write;
+
+    let dir = tempfile::tempdir()?;
+    let src = dir.path().join("payload.bin");
+    std::fs::write(&src, b"cross-fs-payload")?;
+
+    let std_fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let mem_fs: Arc<dyn Fs> = Arc::new(MemFs::new());
+    mem_fs.create_dir_all(std::path::Path::new("/dst"))?;
+
+    let dst = std::path::Path::new("/dst/payload.bin");
+    let bytes = link_or_copy_cross_fs(&std_fs, &src, &mem_fs, dst)?;
+    assert_eq!(bytes, b"cross-fs-payload".len() as u64);
+
+    // Read back through MemFs to confirm the bytes landed.
+    let mut buf = String::new();
+    use std::io::Read;
+    mem_fs
+        .open(dst, &FsOpenOptions::new().read(true))?
+        .read_to_string(&mut buf)?;
+    assert_eq!(buf, "cross-fs-payload");
+
+    // And: subsequent writes through MemFs do not affect the source file.
+    let mut f = mem_fs.open(
+        std::path::Path::new("/dst/payload.bin.2"),
+        &FsOpenOptions::new().write(true).create(true),
+    )?;
+    f.write_all(b"unrelated")?;
+    assert_eq!(std::fs::read(&src)?, b"cross-fs-payload");
+    Ok(())
+}
+
+/// 7. Crash safety: aborting mid-checkpoint must leave the SOURCE tree
+///    fully intact and reopenable. We force the failure by pre-creating
+///    the target — `prepare_target` rejects existing destinations.
+#[test_log::test]
+fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+    std::fs::create_dir_all(&dst_path)?;
+
+    let tree = open_tree(src_dir.path())?;
+    for i in 0u32..50 {
+        tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    let err = tree.create_checkpoint(&dst_path).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("already exists") || msg.contains("AlreadyExists"),
+        "expected AlreadyExists error, got {msg}",
+    );
+
+    // Source tree remains fully readable.
+    for i in 0u32..50 {
+        let key = format!("k{i:03}");
+        let val = tree
+            .get(key.as_bytes(), lsm_tree::SeqNo::MAX)?
+            .unwrap_or_else(|| panic!("source lost {key}"));
+        assert_eq!(&*val, format!("v{i}").as_bytes());
+    }
+    drop(tree);
+
+    // And: reopening the source after the failed checkpoint still works.
+    let reopened = open_tree(src_dir.path())?;
+    let val = reopened
+        .get(b"k042", lsm_tree::SeqNo::MAX)?
+        .expect("reopen lost data");
+    assert_eq!(&*val, b"v42");
+    Ok(())
+}

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -82,10 +82,21 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
     }
     tree.flush_active_memtable(0)?;
 
+    // mpsc handshake guarantees the writer has performed at least one
+    // post-flush insert BEFORE create_checkpoint runs. Without it, a
+    // fast scheduler can finish create_checkpoint before the worker
+    // touches the tree, collapsing the test into a single-threaded
+    // smoke test that does not exercise the concurrency invariant.
+    let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
     let writer_tree = Arc::clone(&tree);
     let writer = thread::spawn(move || -> lsm_tree::Result<()> {
         for i in 50u32..200 {
             writer_tree.insert(format!("k{i:03}"), format!("v{i}"), u64::from(i));
+            if i == 50 {
+                started_tx
+                    .send(())
+                    .expect("checkpoint thread dropped writer-start receiver");
+            }
             if i.is_multiple_of(10) {
                 writer_tree.flush_active_memtable(0)?;
             }
@@ -93,6 +104,9 @@ fn checkpoint_survives_concurrent_writes() -> lsm_tree::Result<()> {
         Ok(())
     });
 
+    started_rx
+        .recv()
+        .expect("writer thread exited before issuing a concurrent write");
     let info = tree.create_checkpoint(&dst_path)?;
     writer.join().expect("writer thread panicked")?;
 
@@ -337,11 +351,24 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
         }
     }
 
+    // mpsc handshake guarantees the compactor has entered its loop
+    // BEFORE create_checkpoint runs. Without it, a fast scheduler can
+    // finish create_checkpoint before the worker calls major_compact
+    // even once, making the test pass without exercising the
+    // deletion-pause race it is named for.
+    let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
     let stop = Arc::new(AtomicBool::new(false));
     let compactor_tree = Arc::clone(&tree);
     let compactor_stop = Arc::clone(&stop);
     let handle = thread::spawn(move || -> lsm_tree::Result<()> {
+        let mut announced = false;
         while !compactor_stop.load(Ordering::Acquire) {
+            if !announced {
+                started_tx
+                    .send(())
+                    .expect("checkpoint thread dropped compactor-start receiver");
+                announced = true;
+            }
             // Errors from major_compact MUST surface — silently
             // discarding them would let a checkpoint race that
             // corrupted compaction state pass the test as green.
@@ -354,6 +381,10 @@ fn compaction_during_checkpoint_preserves_source_ssts() -> lsm_tree::Result<()> 
         stop: Arc::clone(&stop),
         handle: Some(handle),
     };
+
+    started_rx
+        .recv()
+        .expect("compactor thread exited before reaching its loop");
 
     // Run the checkpoint while compaction is racing. The pause must hold
     // back any compaction-driven removals until our hard-link loop has

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -242,7 +242,8 @@ fn checkpoint_flattens_level_routes() -> lsm_tree::Result<()> {
 ///   - Two versions of "k": seqno 1 ("v1") and seqno 2 ("v2")
 ///   - Both live in the active memtable
 ///   - Take a checkpoint (triggers the internal flush)
-///   - Read "k" at seqno 1 on the source — must return "v1"
+///   - Read "k" at seqno 2 on the source — must return "v1" (the
+///     version visible to a snapshot reading below seqno 2)
 ///
 /// With the bug (threshold = SeqNo::MAX) the flush merges the two
 /// versions and drops "v1" because 1 < MAX, so the read returns "v2"

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -228,6 +228,60 @@ fn checkpoint_flattens_level_routes() -> lsm_tree::Result<()> {
     Ok(())
 }
 
+/// 4b. Regression for MVCC GC leak through checkpoint flush.
+///
+/// `run_checkpoint` calls `flush_active_memtable(threshold)` to make sure
+/// the active memtable is in SSTs before linking. The threshold value
+/// drives `CompactionStream`'s `gc_seqno_threshold` — anything below it
+/// can be dropped from older versions of the same key. Passing
+/// `SeqNo::MAX` would mean "no caller cares about any historical seqno",
+/// which silently destroys MVCC history that the SOURCE tree's readers
+/// rely on.
+///
+/// Scenario:
+///   - Two versions of "k": seqno 1 ("v1") and seqno 2 ("v2")
+///   - Both live in the active memtable
+///   - Take a checkpoint (triggers the internal flush)
+///   - Read "k" at seqno 1 on the source — must return "v1"
+///
+/// With the bug (threshold = SeqNo::MAX) the flush merges the two
+/// versions and drops "v1" because 1 < MAX, so the read returns "v2"
+/// (or None) — a snapshot-visibility violation caused entirely by
+/// taking a checkpoint.
+#[test_log::test]
+fn checkpoint_flush_must_not_drop_source_mvcc_history() -> lsm_tree::Result<()> {
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let tree = open_tree(src_dir.path())?;
+    tree.insert("k", "v1", 1);
+    tree.insert("k", "v2", 2);
+
+    // Sanity: the older version is visible to a seqno-1 reader BEFORE
+    // the checkpoint (both versions still in the active memtable).
+    let pre = tree.get(b"k", 2)?;
+    assert_eq!(
+        pre.as_deref(),
+        Some(&b"v1"[..]),
+        "pre-checkpoint sanity: seqno-2 read sees seqno-1 version of k",
+    );
+
+    tree.create_checkpoint(&dst_path)?;
+
+    // Post-checkpoint: the source tree's reader at the same seqno MUST
+    // still see "v1". Without the fix the checkpoint-triggered flush
+    // uses `SeqNo::MAX` as its GC threshold and discards every older
+    // version of every key.
+    let post = tree.get(b"k", 2)?;
+    assert_eq!(
+        post.as_deref(),
+        Some(&b"v1"[..]),
+        "checkpoint flush must not drop MVCC history needed by source readers",
+    );
+    Ok(())
+}
+
 /// 5. Reopen-then-mutate isolation: writes against the checkpoint must
 ///    NOT bleed back into the source tree (proves hard links share inode
 ///    data but the tree state diverges from the checkpoint moment forward).

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -577,10 +577,17 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
     let early_dst = dst_dir.path().join("early");
     std::fs::create_dir_all(&early_dst)?;
     let err = tree.create_checkpoint(&early_dst).unwrap_err();
-    let msg = format!("{err:?}");
+    // Assert structurally — the Debug format of std::io::Error varies
+    // by OS and rustc release. Pattern-match on the variant + ErrorKind
+    // so the test guards the programmatic contract (Io(AlreadyExists))
+    // that callers actually rely on for early-reject detection.
     assert!(
-        msg.contains("already exists") || msg.contains("AlreadyExists"),
-        "expected AlreadyExists on early reject, got {msg}",
+        matches!(
+            &err,
+            lsm_tree::Error::Io(io_err)
+                if io_err.kind() == std::io::ErrorKind::AlreadyExists,
+        ),
+        "expected Io(AlreadyExists) on early reject, got {err:?}",
     );
     // Early reject must NOT damage the pre-existing target (it isn't
     // ours to clean up).

--- a/tests/mem_fs_tree.rs
+++ b/tests/mem_fs_tree.rs
@@ -302,3 +302,31 @@ fn memfs_create_checkpoint_with_relative_leaf_target() -> lsm_tree::Result<()> {
     assert!(info.sst_files >= 1);
     Ok(())
 }
+
+/// Regression: `./checkpoint` must skip parent fsync the same way
+/// `checkpoint` does. `Path::new("./checkpoint").parent()` returns
+/// `Some(".")` — non-empty, so the empty-string guard alone doesn't
+/// catch it. On MemFs that still hits `sync_directory(".") -> NotFound`,
+/// making equivalent relative targets behave differently.
+#[test]
+fn memfs_create_checkpoint_with_dot_prefixed_relative_target() -> lsm_tree::Result<()> {
+    let (_dir, src_path) = test_path("source_dot");
+    let mem_fs: Arc<dyn lsm_tree::fs::Fs> = Arc::new(MemFs::new());
+    let tree = Config::new(
+        src_path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::clone(&mem_fs))
+    .open()?;
+
+    for i in 0u32..5 {
+        tree.insert(format!("k{i:02}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    // `./checkpoint-dot` — `target.parent()` is `Some(".")`, non-empty.
+    let info = tree.create_checkpoint(std::path::Path::new("./checkpoint-dot"))?;
+    assert!(info.sst_files >= 1);
+    Ok(())
+}

--- a/tests/mem_fs_tree.rs
+++ b/tests/mem_fs_tree.rs
@@ -1,6 +1,7 @@
 use lsm_tree::fs::MemFs;
 // Guard trait import required for IterGuardImpl::into_inner() method dispatch.
 use lsm_tree::{AbstractTree, Config, Guard, SeqNo, SequenceNumberCounter};
+use std::sync::Arc;
 use test_log::test;
 
 /// Returns a unique virtual path for each test to avoid host-path collisions.
@@ -265,3 +266,39 @@ fn memfs_reopen_recovers_flushed_data() -> lsm_tree::Result<()> {
 // There are remaining `std::fs` bypass points in the compaction
 // finalization path that produce ENOENT when running fully in-memory.
 // Tracked as a known limitation — see mem_fs.rs module docs.
+
+/// Regression: `create_checkpoint` on a MemFs-backed tree must not
+/// rely on `Path::new(".")` to fsync the parent of a single-component
+/// relative target. `MemFs::sync_directory(".")` returns `NotFound`
+/// because `.` is never inserted into the in-memory directory set —
+/// the previous code substituted `.` when `target.parent()` resolved
+/// to an empty path, which only happens to work on `StdFs` (where
+/// `.` resolves through the host OS's CWD). Skipping the fsync when
+/// the parent is empty fixes both backends: relative leaves get no
+/// parent fsync (caller's responsibility), absolute paths still get
+/// their real parent fsync.
+#[test]
+fn memfs_create_checkpoint_with_relative_leaf_target() -> lsm_tree::Result<()> {
+    let (_dir, src_path) = test_path("source");
+    let mem_fs: Arc<dyn lsm_tree::fs::Fs> = Arc::new(MemFs::new());
+    let tree = Config::new(
+        src_path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::clone(&mem_fs))
+    .open()?;
+
+    for i in 0u32..5 {
+        tree.insert(format!("k{i:02}"), format!("v{i}"), u64::from(i));
+    }
+    tree.flush_active_memtable(0)?;
+
+    // RELATIVE single-component path — `target_root.parent()` is `""`.
+    // On broken code this triggers fsync_directory(".") on MemFs and
+    // fails with NotFound. After the fix the empty-parent case skips
+    // the fsync entirely and the checkpoint succeeds.
+    let info = tree.create_checkpoint(std::path::Path::new("checkpoint-rel"))?;
+    assert!(info.sst_files >= 1);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements [#210](https://github.com/structured-world/coordinode-lsm-tree/issues/210) — the consistent hard-link checkpoint primitive that unblocks point-in-time recovery (PITR) backup for CoordiNode and any other consumer that needs an O(1)-per-file snapshot of an open LSM-tree.

- New trait method `Fs::hard_link(src, dst)` with a default `Unsupported` impl (non-breaking for downstream backends). `StdFs` performs a real `hard_link(2)` with an EXDEV→copy fallback; `MemFs` produces an independent copy; `IoUringFs` delegates to `StdFs` since linking is a metadata-only syscall.
- New trait method `Fs::backend_id() -> Option<u64>` — explicit shared-namespace capability check that gates cross-`Fs` hard-link attempts. `StdFs`/`IoUringFs` return a common `KERNEL_BACKEND_ID`; each `MemFs::new()` allocates a unique per-instance id; default impl returns `None` for safe-by-default third-party backends.
- `DeletionPause` — a tree-wide refcount-gated deferred-delete queue installed into each `Table::Inner` / `BlobFile::Inner`. While at least one `Pause` guard is alive, both `Drop` impls queue removals instead of executing them; the queue drains when the last guard is dropped. Mirrors RocksDB's `DisableFileDeletions`/`EnableFileDeletions` pattern. Synchronisation uses `spin::Mutex` so the type is `no_std`-compatible.
- `AbstractTree::create_checkpoint(target) -> CheckpointInfo` — implemented on `Tree`, `BlobTree`, and (via `enum_dispatch`) `AnyTree`. The driver captures `visible_seqno` first, flushes the active memtable (eviction seqno `0` — never expands MVCC GC beyond what would have happened anyway), snapshots the current version, hard-links every live SST + blob into `target/{tables,blobs}/`, copies manifest / `v<id>` / `current`, and fsyncs the target root.
- `level_routes` (tiered storage) is honoured automatically — each `Table::Inner` already carries its own routed `Fs`, so the link is performed through the right backend. Cross-`Fs` situations (e.g. `MemFs` source vs. `StdFs` target) transparently fall back to a streamed byte copy after the `backend_id` namespace check declines the hard-link path.
- `Tree::open` now rejects a directory that has version artifacts (`tables/`, `blobs/`, `vN`) but no `current` pointer — the on-disk signature of a half-written checkpoint. Previously the code silently called `create_new`, which would have overwritten the partial state with an empty tree.

## Test plan

`cargo nextest run --all-features` — **1327/1327 passed** (6 environment-skipped), including 14 integration scenarios in `tests/checkpoint_pitr.rs`:

- [x] Round-trip — checkpoint + reopen as standalone tree reads every key back
- [x] Concurrent writes during checkpoint do not corrupt the snapshot
- [x] Deferred-delete invariant: concurrent `major_compact` cannot remove an SST captured by an in-flight checkpoint
- [x] BlobTree checkpoint captures both index SSTs and blob files
- [x] `level_routes` SSTs land in the flattened `target/tables/` directory
- [x] Source vs. checkpoint isolation — writes on either side do not bleed across
- [x] Crash-safety — failed checkpoint leaves the source tree fully reopenable (chmod-driven `link_tables` failure)
- [x] Empty tree checkpoint succeeds with `sst_files == 0`
- [x] `CheckpointInfo.total_bytes` matches the on-disk sum
- [x] Re-running a checkpoint into the same target is rejected with `AlreadyExists`
- [x] MVCC regression — checkpoint-triggered flush must NOT drop history needed by source-tree snapshot readers (eviction seqno = 0, not `SeqNo::MAX`)
- [x] Half-written-checkpoint detection — missing `current` pointer rejected by `Tree::open`
- [x] Half-written-checkpoint detection — corrupt `current` pointer rejected by `Tree::open`
- [x] Cross-`Fs` (`StdFs`↔`MemFs`) link-or-copy streams through both trait objects (inline in `src/checkpoint.rs`)

Plus unit coverage for:
- `DeletionPause` — defer / inactive-passthrough / nested-pauses / generation-race-under-lock
- `StdFs::is_cross_device` — raw EXDEV + `ErrorKind` variants
- `Fs::hard_link` — round-trip + duplicate / missing-source rejection (both `StdFs` and `MemFs`)
- `copy_fallback` — independence + create-new semantics

- [x] `cargo clippy --lib --tests` clean
- [x] `cargo test --doc` passes for all touched modules

Closes #210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point-in-time checkpoint snapshots (optional blob inclusion) reporting file counts, total bytes, version id and visibility seqno; checkpoints can be opened as independent trees.

* **Reliability / Bug Fixes**
  * Atomic, durable checkpoint creation with hard-link-first and streamed-copy fallback (debug-logged); best-effort cleanup on failure; opening rejects half-written or corrupt checkpoints with clearer diagnostics.

* **Utilities**
  * Checkpoint-aware gate to defer physical file removals during snapshot lifetimes.

* **Filesystem compatibility**
  * Improved create-dir/hard-link handling with cross-filesystem copy fallback and namespace signaling.

* **Tests / Documentation**
  * Extensive end-to-end, isolation and crash-safety checkpoint suite; README updated to document PITR checkpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

BREAKING CHANGE: on-disk format V5. V3/V4 databases are NOT readable by this version and vice versa. V5 ships the BuRR filter wire-format change (replaces standard bloom, #269) plus the PITR hard-link checkpoint primitive (this PR, #210). The major bump goes through release-plz on squash.