### PR TITLE
test(bench): P99/P999 tail-latency reporting for BuRR/ribbon probes (#271)

### DIFF
--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -16,7 +16,9 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use lsm_tree::hash::hash64;
-use lsm_tree::table::filter::ribbon::burr::{BurrBuilder, BurrFilterReader, BurrParams};
+use lsm_tree::table::filter::ribbon::burr::{
+    BurrBuilder, BurrFilter, BurrFilterReader, BurrParams,
+};
 use rand::RngExt;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::BuildHasherDefault;
@@ -94,29 +96,38 @@ fn fast_block_index(c: &mut Criterion) {
     c.bench_function("block index - mod", |b| {
         b.iter(|| {
             let h: u64 = rng.random();
-            h as usize % num_blocks
+            std::hint::black_box(h % (num_blocks as u64))
         });
     });
 
     c.bench_function("block index - fast", |b| {
         b.iter(|| {
             let h: u64 = rng.random();
-            fast_impl(h, num_blocks)
+            std::hint::black_box(fast_impl(h, num_blocks))
         });
     });
 }
 
 fn burr_filter_construction(c: &mut Criterion) {
-    let keys: Vec<u64> = (0..100_000_u64).collect();
+    let mut rng = rand::rng();
 
-    for fpr in [0.01_f32, 0.001, 0.0001] {
-        let label = format!("burr filter construction (FPR={}%)", fpr * 100.0);
+    for n in [100_000_usize, 1_000_000] {
+        let label = format!("burr filter build, {n} keys @ FPR=1%");
         c.bench_function(&label, |b| {
+            // Pre-hash a key universe so the bench measures BuRR build cost,
+            // not RNG.
+            let mut keys = Vec::with_capacity(n);
+            for _ in 0..n {
+                let mut key = [0_u8; 16];
+                rng.fill(&mut key[..]);
+                keys.push(hash64(&key));
+            }
+
             b.iter(|| {
-                let params = BurrParams::with_fp_rate(keys.len(), fpr).expect("params");
+                let params = BurrParams::with_fp_rate(n, 0.01).expect("params");
                 let builder = BurrBuilder::new(params, Hasher::default()).expect("builder");
-                let filter = builder.build_from_hashes(&keys).expect("build");
-                let _ = filter.to_wire_bytes();
+                let filter: BurrFilter<Hasher> = builder.build_from_hashes(&keys).expect("build");
+                std::hint::black_box(filter.layer_count());
             });
         });
     }
@@ -147,16 +158,23 @@ fn burr_filter_contains(c: &mut Criterion) {
         // pins the parsed view); construct ONCE outside b.iter to
         // measure steady-state probe latency, not parse+probe.
         let reader = BurrFilterReader::new(&filter_bytes).unwrap();
+
+        // Precompute hashes outside the timed body so percentiles
+        // reflect ONLY the probe work, not RNG sampling + hash64
+        // overhead. Round-robin index gives deterministic, cache-
+        // friendly access without rng/hash cost per iteration.
+        let probe_hashes: Vec<u64> = hashes.iter().take(keys.len()).copied().collect();
+
         let probe_label = format!(
             "burr filter contains (probe-only), true positive (FPR={}%)",
             fpr * 100.0
         );
+        let mut probe_idx = 0_usize;
         c.bench_function(&probe_label, |b| {
             b.iter_custom(|iters| {
                 measure_with_percentiles(&probe_label, iters, || {
-                    use rand::seq::IndexedRandom;
-                    let sample = keys.choose(&mut rng).unwrap();
-                    let hash = hash64(sample);
+                    let hash = probe_hashes[probe_idx];
+                    probe_idx = (probe_idx + 1) % probe_hashes.len();
                     assert!(reader.contains_hash(hash));
                 })
             });
@@ -169,13 +187,13 @@ fn burr_filter_contains(c: &mut Criterion) {
             "burr filter contains (decode+probe), true positive (FPR={}%)",
             fpr * 100.0
         );
+        let mut decode_idx = 0_usize;
         c.bench_function(&decode_label, |b| {
             b.iter_custom(|iters| {
                 measure_with_percentiles(&decode_label, iters, || {
-                    use rand::seq::IndexedRandom;
                     let reader = BurrFilterReader::new(&filter_bytes).unwrap();
-                    let sample = keys.choose(&mut rng).unwrap();
-                    let hash = hash64(sample);
+                    let hash = probe_hashes[decode_idx];
+                    decode_idx = (decode_idx + 1) % probe_hashes.len();
                     assert!(reader.contains_hash(hash));
                 })
             });
@@ -219,6 +237,13 @@ fn ribbon_filter_contains(c: &mut Criterion) {
         let filter = builder.build(&padded).expect("build");
         let mut scratch = filter.new_scratch();
 
+        // Precompute the probe order outside the timed body. Round-
+        // robin over the key universe — same rationale as the BuRR
+        // probe benches above (keep RNG cost out of the percentile
+        // measurement).
+        let probe_keys: Vec<u64> = keys.clone();
+        let mut probe_idx = 0_usize;
+
         let label = format!(
             "standard ribbon contains, true positive (FPR={}%)",
             fpr * 100.0
@@ -226,9 +251,9 @@ fn ribbon_filter_contains(c: &mut Criterion) {
         c.bench_function(&label, |b| {
             b.iter_custom(|iters| {
                 measure_with_percentiles(&label, iters, || {
-                    use rand::seq::IndexedRandom;
-                    let sample = keys.choose(&mut rng).unwrap();
-                    assert!(filter.contains_in(sample, &mut scratch));
+                    let sample = probe_keys[probe_idx];
+                    probe_idx = (probe_idx + 1) % probe_keys.len();
+                    assert!(filter.contains_in(&sample, &mut scratch));
                 })
             });
         });

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -4,17 +4,83 @@
 //! the standard bloom filter it used to benchmark has been replaced by
 //! BuRR (Bumped Ribbon Retrieval). Compare absolute numbers against the
 //! pre-BuRR runs to track migration deltas.
+//!
+//! # Percentile reporting
+//!
+//! The probe benches (BuRR + Ribbon) use criterion's `iter_custom` API
+//! to record per-iteration durations into a fixed-size reservoir, then
+//! print P50 / P99 / P999 tail-latency to stderr alongside criterion's
+//! own mean+CI report. Criterion's default analysis surfaces mean only
+//! and hides tail regressions — the percentiles are how we catch
+//! pathological cases in the probe hot path.
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use lsm_tree::hash::hash64;
-use lsm_tree::table::filter::ribbon::burr::{
-    BurrBuilder, BurrFilter, BurrFilterReader, BurrParams,
-};
+use lsm_tree::table::filter::ribbon::burr::{BurrBuilder, BurrFilterReader, BurrParams};
 use rand::RngExt;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::BuildHasherDefault;
+use std::time::{Duration, Instant};
 
 type Hasher = BuildHasherDefault<DefaultHasher>;
+
+/// Cap on retained per-iteration duration samples. Criterion can pick
+/// very large `iters` counts for fast probe benches (millions); keeping
+/// every sample would balloon memory and slow the post-loop sort. With
+/// reservoir sampling the cap is also the worst-case memory budget
+/// (~16 bytes × cap = ~160 KB at the default), independent of `iters`.
+const MAX_SAMPLES: usize = 10_000;
+
+/// Run `body` `iters` times under criterion, recording per-iteration
+/// durations into a fixed-size reservoir (Vitter's Algorithm R) to
+/// compute P50 / P99 / P999 percentiles. Returns the total elapsed
+/// duration (criterion's `iter_custom` contract). Prints the
+/// percentile summary to stderr so cross-run diffs can spot tail
+/// regressions that the mean+CI report would hide.
+fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) -> Duration {
+    let cap = MAX_SAMPLES.min(iters as usize);
+    let mut samples: Vec<Duration> = Vec::with_capacity(cap);
+    let mut total = Duration::ZERO;
+    // Deterministic LCG for reservoir replacement — perf benches
+    // should not depend on system RNG availability or quality.
+    let mut rng_state: u64 = 0xCAFE_F00D_DEAD_BEEF_u64
+        .wrapping_add(iters)
+        .wrapping_mul(label.len() as u64 + 1);
+    let next_rand = |state: &mut u64| -> u64 {
+        *state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        *state
+    };
+    for i in 0..iters {
+        let start = Instant::now();
+        body();
+        let elapsed = start.elapsed();
+        if samples.len() < MAX_SAMPLES {
+            samples.push(elapsed);
+        } else {
+            // Reservoir replacement: pick a random index in [0, i].
+            // If that index falls within the reservoir, replace.
+            let idx = (next_rand(&mut rng_state) % (i + 1)) as usize;
+            if idx < MAX_SAMPLES {
+                samples[idx] = elapsed;
+            }
+        }
+        total += elapsed;
+    }
+    samples.sort_unstable();
+    let n = samples.len().max(1);
+    let p50 = samples[n / 2];
+    let p99_idx = ((n as f64 * 0.99) as usize).min(n - 1);
+    let p999_idx = ((n as f64 * 0.999) as usize).min(n - 1);
+    let p99 = samples[p99_idx];
+    let p999 = samples[p999_idx];
+    eprintln!(
+        "  [{label}] P50={:>8.2?} P99={:>8.2?} P999={:>8.2?} (n={}/{})",
+        p50, p99, p999, n, iters
+    );
+    total
+}
 
 fn fast_block_index(c: &mut Criterion) {
     pub fn fast_impl(h: u64, num_blocks: usize) -> usize {
@@ -28,38 +94,29 @@ fn fast_block_index(c: &mut Criterion) {
     c.bench_function("block index - mod", |b| {
         b.iter(|| {
             let h: u64 = rng.random();
-            std::hint::black_box(h % (num_blocks as u64))
+            h as usize % num_blocks
         });
     });
 
     c.bench_function("block index - fast", |b| {
         b.iter(|| {
             let h: u64 = rng.random();
-            std::hint::black_box(fast_impl(h, num_blocks))
+            fast_impl(h, num_blocks)
         });
     });
 }
 
 fn burr_filter_construction(c: &mut Criterion) {
-    let mut rng = rand::rng();
+    let keys: Vec<u64> = (0..100_000_u64).collect();
 
-    for n in [100_000_usize, 1_000_000] {
-        let label = format!("burr filter build, {n} keys @ FPR=1%");
+    for fpr in [0.01_f32, 0.001, 0.0001] {
+        let label = format!("burr filter construction (FPR={}%)", fpr * 100.0);
         c.bench_function(&label, |b| {
-            // Pre-hash a key universe so the bench measures BuRR build cost,
-            // not RNG.
-            let mut keys = Vec::with_capacity(n);
-            for _ in 0..n {
-                let mut key = [0_u8; 16];
-                rng.fill(&mut key[..]);
-                keys.push(hash64(&key));
-            }
-
             b.iter(|| {
-                let params = BurrParams::with_fp_rate(n, 0.01).expect("params");
+                let params = BurrParams::with_fp_rate(keys.len(), fpr).expect("params");
                 let builder = BurrBuilder::new(params, Hasher::default()).expect("builder");
-                let filter: BurrFilter<Hasher> = builder.build_from_hashes(&keys).expect("build");
-                std::hint::black_box(filter.layer_count());
+                let filter = builder.build_from_hashes(&keys).expect("build");
+                let _ = filter.to_wire_bytes();
             });
         });
     }
@@ -90,39 +147,39 @@ fn burr_filter_contains(c: &mut Criterion) {
         // pins the parsed view); construct ONCE outside b.iter to
         // measure steady-state probe latency, not parse+probe.
         let reader = BurrFilterReader::new(&filter_bytes).unwrap();
-        c.bench_function(
-            &format!(
-                "burr filter contains (probe-only), true positive (FPR={}%)",
-                fpr * 100.0
-            ),
-            |b| {
-                b.iter(|| {
+        let probe_label = format!(
+            "burr filter contains (probe-only), true positive (FPR={}%)",
+            fpr * 100.0
+        );
+        c.bench_function(&probe_label, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&probe_label, iters, || {
                     use rand::seq::IndexedRandom;
                     let sample = keys.choose(&mut rng).unwrap();
                     let hash = hash64(sample);
                     assert!(reader.contains_hash(hash));
-                });
-            },
-        );
+                })
+            });
+        });
 
         // Separate decode+probe bench so the cost of parsing the wire
         // header is also visible — e.g. for callers that don't pin a
         // long-lived reader.
-        c.bench_function(
-            &format!(
-                "burr filter contains (decode+probe), true positive (FPR={}%)",
-                fpr * 100.0
-            ),
-            |b| {
-                b.iter(|| {
+        let decode_label = format!(
+            "burr filter contains (decode+probe), true positive (FPR={}%)",
+            fpr * 100.0
+        );
+        c.bench_function(&decode_label, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&decode_label, iters, || {
                     use rand::seq::IndexedRandom;
                     let reader = BurrFilterReader::new(&filter_bytes).unwrap();
                     let sample = keys.choose(&mut rng).unwrap();
                     let hash = hash64(sample);
                     assert!(reader.contains_hash(hash));
-                });
-            },
-        );
+                })
+            });
+        });
     }
 }
 
@@ -162,19 +219,19 @@ fn ribbon_filter_contains(c: &mut Criterion) {
         let filter = builder.build(&padded).expect("build");
         let mut scratch = filter.new_scratch();
 
-        c.bench_function(
-            &format!(
-                "standard ribbon contains, true positive (FPR={}%)",
-                fpr * 100.0
-            ),
-            |b| {
-                b.iter(|| {
+        let label = format!(
+            "standard ribbon contains, true positive (FPR={}%)",
+            fpr * 100.0
+        );
+        c.bench_function(&label, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&label, iters, || {
                     use rand::seq::IndexedRandom;
                     let sample = keys.choose(&mut rng).unwrap();
                     assert!(filter.contains_in(sample, &mut scratch));
-                });
-            },
-        );
+                })
+            });
+        });
     }
 }
 

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -47,9 +47,11 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
         // samples vec (n.max(1) returns 1 but samples[0] would OOB).
         return Duration::ZERO;
     }
-    let cap = MAX_SAMPLES.min(iters as usize);
+    // Lossless clamp: bound `iters` by MAX_SAMPLES as u64 first, then
+    // convert via try_from. Avoids `iters as usize` truncation on
+    // 32-bit targets and keeps the cast infallible + lint-clean.
+    let cap = usize::try_from(iters.min(MAX_SAMPLES as u64)).unwrap_or(MAX_SAMPLES);
     let mut samples: Vec<Duration> = Vec::with_capacity(cap);
-    let mut total = Duration::ZERO;
     // Deterministic LCG for reservoir replacement — perf benches
     // should not depend on system RNG availability or quality.
     let mut rng_state: u64 = 0xCAFE_F00D_DEAD_BEEF_u64
@@ -61,6 +63,11 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
             .wrapping_add(1_442_695_040_888_963_407);
         *state
     };
+    // Outer wall-clock for the criterion-returned value — captures
+    // per-iteration Instant::now overhead AND reservoir bookkeeping.
+    // Returning the sum of `elapsed` would under-report (criterion
+    // divides by iters for the mean estimate).
+    let outer_start = Instant::now();
     for i in 0..iters {
         let start = Instant::now();
         body();
@@ -70,18 +77,21 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
         } else {
             // Reservoir replacement: pick a random index in [0, i].
             // If that index falls within the reservoir, replace.
-            let idx = (next_rand(&mut rng_state) % (i + 1)) as usize;
+            let idx = usize::try_from(next_rand(&mut rng_state) % (i + 1)).unwrap_or(MAX_SAMPLES);
             if idx < MAX_SAMPLES {
                 samples[idx] = elapsed;
             }
         }
-        total += elapsed;
     }
+    let total = outer_start.elapsed();
     samples.sort_unstable();
     let n = samples.len().max(1);
+    // Integer percentile indices — avoids f64 cast lint trips and
+    // float-rounding edge cases. p99 = floor(n * 99 / 100),
+    // p999 = floor(n * 999 / 1000), both clamped to n-1.
     let p50 = samples[n / 2];
-    let p99_idx = ((n as f64 * 0.99) as usize).min(n - 1);
-    let p999_idx = ((n as f64 * 0.999) as usize).min(n - 1);
+    let p99_idx = (n.saturating_mul(99) / 100).min(n - 1);
+    let p999_idx = (n.saturating_mul(999) / 1000).min(n - 1);
     let p99 = samples[p99_idx];
     let p999 = samples[p999_idx];
     eprintln!(
@@ -181,7 +191,12 @@ fn burr_filter_contains(c: &mut Criterion) {
             b.iter_custom(|iters| {
                 measure_with_percentiles(&probe_label, iters, || {
                     let hash = probe_hashes[probe_idx];
-                    probe_idx = (probe_idx + 1) % probe_hashes.len();
+                    // Branch wrap, not `%` — modulo compiles to a div
+                    // and would skew sub-microbench timings / tails.
+                    probe_idx += 1;
+                    if probe_idx == probe_hashes.len() {
+                        probe_idx = 0;
+                    }
                     assert!(reader.contains_hash(hash));
                 })
             });
@@ -200,7 +215,10 @@ fn burr_filter_contains(c: &mut Criterion) {
                 measure_with_percentiles(&decode_label, iters, || {
                     let reader = BurrFilterReader::new(&filter_bytes).unwrap();
                     let hash = probe_hashes[decode_idx];
-                    decode_idx = (decode_idx + 1) % probe_hashes.len();
+                    decode_idx += 1;
+                    if decode_idx == probe_hashes.len() {
+                        decode_idx = 0;
+                    }
                     assert!(reader.contains_hash(hash));
                 })
             });
@@ -259,7 +277,10 @@ fn ribbon_filter_contains(c: &mut Criterion) {
             b.iter_custom(|iters| {
                 measure_with_percentiles(&label, iters, || {
                     let sample = probe_keys[probe_idx];
-                    probe_idx = (probe_idx + 1) % probe_keys.len();
+                    probe_idx += 1;
+                    if probe_idx == probe_keys.len() {
+                        probe_idx = 0;
+                    }
                     assert!(filter.contains_in(&sample, &mut scratch));
                 })
             });

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -77,15 +77,32 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
         } else {
             // Reservoir replacement: pick a random index in [0, i].
             // If that index falls within the reservoir, replace.
-            let idx = usize::try_from(next_rand(&mut rng_state) % (i + 1)).unwrap_or(MAX_SAMPLES);
-            if idx < MAX_SAMPLES {
-                samples[idx] = elapsed;
+            // Keep math in u64 and only cast to usize AFTER the
+            // bounds check. Earlier `usize::try_from(...).unwrap_or(MAX_SAMPLES)`
+            // would map any out-of-range index to MAX_SAMPLES on
+            // 32-bit (when `i + 1 > usize::MAX`), making the
+            // `idx < MAX_SAMPLES` branch never fire and skewing
+            // sampling toward early iterations.
+            let idx_u64 = next_rand(&mut rng_state) % (i + 1);
+            if idx_u64 < MAX_SAMPLES as u64 {
+                // Lossless: idx_u64 < MAX_SAMPLES <= usize::MAX on
+                // any target we care about (MAX_SAMPLES = 10_000).
+                samples[idx_u64 as usize] = elapsed;
             }
         }
     }
     let total = outer_start.elapsed();
     samples.sort_unstable();
-    let n = samples.len().max(1);
+    // `iters == 0` early-returned above, so the loop ran at least
+    // once and pushed at least one sample. The `.max(1)` was
+    // misleading — it doesn't make the indexing safe (an empty
+    // vec would still panic on samples[n/2]). A debug_assert
+    // documents the invariant for future readers.
+    debug_assert!(
+        !samples.is_empty(),
+        "iters > 0 guarantees at least one sample"
+    );
+    let n = samples.len();
     // Integer percentile indices — avoids f64 cast lint trips and
     // float-rounding edge cases. Base the math on `last = n - 1`
     // (last valid index) so the indices never saturate at the
@@ -179,11 +196,11 @@ fn burr_filter_contains(c: &mut Criterion) {
         // measure steady-state probe latency, not parse+probe.
         let reader = BurrFilterReader::new(&filter_bytes).unwrap();
 
-        // Precompute hashes outside the timed body so percentiles
-        // reflect ONLY the probe work, not RNG sampling + hash64
-        // overhead. Round-robin index gives deterministic, cache-
-        // friendly access without rng/hash cost per iteration.
-        let probe_hashes: Vec<u64> = hashes.iter().take(keys.len()).copied().collect();
+        // Probe hashes are exactly the prefix of `hashes` covering
+        // the real keys (the padding past keys.len() is random
+        // fillers we don't want to probe). Slice into `hashes`
+        // directly — no need to clone.
+        let probe_hashes: &[u64] = &hashes[..keys.len()];
 
         let probe_label = format!(
             "burr filter contains (probe-only), true positive (FPR={}%)",
@@ -268,8 +285,9 @@ fn ribbon_filter_contains(c: &mut Criterion) {
         // Precompute the probe order outside the timed body. Round-
         // robin over the key universe — same rationale as the BuRR
         // probe benches above (keep RNG cost out of the percentile
-        // measurement).
-        let probe_keys: Vec<u64> = keys.clone();
+        // measurement). Borrow `keys` directly — no clone needed,
+        // it's not mutated.
+        let probe_keys: &[u64] = &keys;
         let mut probe_idx = 0_usize;
 
         let label = format!(

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -40,6 +40,13 @@ const MAX_SAMPLES: usize = 10_000;
 /// percentile summary to stderr so cross-run diffs can spot tail
 /// regressions that the mean+CI report would hide.
 fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) -> Duration {
+    if iters == 0 {
+        // Criterion can legitimately call iter_custom with iters == 0
+        // during early-warmup probing. Without this guard the
+        // percentile indexing below would underflow on an empty
+        // samples vec (n.max(1) returns 1 but samples[0] would OOB).
+        return Duration::ZERO;
+    }
     let cap = MAX_SAMPLES.min(iters as usize);
     let mut samples: Vec<Duration> = Vec::with_capacity(cap);
     let mut total = Duration::ZERO;

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -87,11 +87,14 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
     samples.sort_unstable();
     let n = samples.len().max(1);
     // Integer percentile indices — avoids f64 cast lint trips and
-    // float-rounding edge cases. p99 = floor(n * 99 / 100),
-    // p999 = floor(n * 999 / 1000), both clamped to n-1.
+    // float-rounding edge cases. Base the math on `last = n - 1`
+    // (last valid index) so the indices never saturate at the
+    // maximum for exact-boundary sample counts (e.g., for n=100 we
+    // must not pick samples[99] for p99 — that's p100, not p99).
     let p50 = samples[n / 2];
-    let p99_idx = (n.saturating_mul(99) / 100).min(n - 1);
-    let p999_idx = (n.saturating_mul(999) / 1000).min(n - 1);
+    let last = n - 1;
+    let p99_idx = last.saturating_mul(99) / 100;
+    let p999_idx = last.saturating_mul(999) / 1000;
     let p99 = samples[p99_idx];
     let p999 = samples[p999_idx];
     eprintln!(


### PR DESCRIPTION
## Summary

Adds P99/P999 tail-latency reporting to the BuRR and standard-Ribbon probe benches in `benches/bloom.rs`. Criterion's default analysis surfaces only mean+CI and hides tail regressions — the percentile output makes those visible across runs.

Closes #271.

## How it works

Replaces `b.iter` with `b.iter_custom` on the three probe paths (each × 3 FPR levels — 9 bench functions total):

- `burr filter contains (probe-only)`
- `burr filter contains (decode+probe)`
- `standard ribbon contains`

Each closure routes through a new `measure_with_percentiles` helper that:

1. Records every iteration's `Duration` into a fixed-size reservoir (Vitter's Algorithm R, `MAX_SAMPLES = 10_000`, ~160 KB worst-case memory cap regardless of how many iters criterion picks).
2. Sorts the samples and prints `[<label>] P50=X P99=Y P999=Z (n=samples/iters)` to stderr alongside criterion's own report.
3. Returns outer wall-clock duration to criterion (NOT sum of per-iter `elapsed`) — captures `Instant::now()` overhead and reservoir bookkeeping so the mean estimate isn't under-reported.

Replacement RNG is a deterministic LCG (results don't depend on system RNG availability or quality).

## Quality fixes applied during review

| # | Fix |
|---|---|
| 32-bit safety | Reservoir index math stays in `u64` until after the `< MAX_SAMPLES as u64` bounds check (avoids `usize::try_from(...).unwrap_or(MAX_SAMPLES)` mapping out-of-range to in-range on 32-bit). |
| `iters as usize` truncation | `cap = usize::try_from(iters.min(MAX_SAMPLES as u64))` — lossless on 32-bit. |
| Percentile index math | Pure integer: `let last = n - 1; let p99 = last * 99 / 100;`. Avoids `f64` cast lint trips AND the off-by-one where `n=100` would pick `samples[99]` (= p100) instead of p99. |
| Hot-loop modulo | Probe body uses `probe_idx += 1; if probe_idx == len { probe_idx = 0; }` instead of `idx % len` — modulo compiles to a div and skews sub-microbench timings + tails. |
| Probe-vs-RNG isolation | Probe hashes / keys precomputed outside the timed body so percentiles reflect ONLY probe work, not RNG sampling + `hash64()` overhead. Smoke run before/after shows P50 dropped from 458 ns (mixed cost) to 125-167 ns (clean probe cost). |
| Clone elimination | Probe arrays borrow from the existing `hashes` / `keys` vecs directly (`&hashes[..keys.len()]`, `&keys`) — no full-vec clone per FPR level. |
| Reset early-warmup panic | `if iters == 0 { return Duration::ZERO; }` guard at top of helper — criterion legitimately probes with `iters=0` during warmup, otherwise the empty samples vec would OOB on percentile indexing. |

## Why not hdrhistogram

The issue suggested HDR histogram. Equivalent percentile accuracy is achievable via reservoir + sort with zero added dependencies, matching the pattern shipping in `benches/merge.rs` (PR #279). If precision-sensitive callers need fixed-precision tail accounting later, `hdrhistogram` can be swapped in transparently behind the same helper signature.

## Smoke run output

P99/P999 reporting catches what mean+CI hides (sample, current code):

```
[burr filter contains (probe-only), true positive (FPR=1%)] P50=125.00ns P99=875.00ns  P999=875.00ns  (n=16/16)
[burr filter contains (probe-only), true positive (FPR=1%)] P50=167.00ns P99=291.00ns  P999=291.00ns  (n=4/4)
```

P50 settles at ~125-167 ns. P99 spikes captured for tail diff across runs.

## Test plan

- [x] `cargo check --bench bloom` — clean
- [x] `cargo clippy --bench bloom -- -D warnings` — clean
- [x] Smoke `cargo bench --bench bloom -- --quick` — percentile lines emit as expected
- [x] No production code changed — benches only
