### PR TITLE
feat(merge): SeekingMerger — RocksDB-style dual loser trees (#222)

### DIFF
--- a/benches/merge.rs
+++ b/benches/merge.rs
@@ -16,6 +16,14 @@ use std::time::{Duration, Instant};
 /// memory budget (~16 bytes × cap = ~160 KB at the default cap),
 /// which is independent of the criterion iteration count.
 const MAX_SAMPLES: usize = 10_000;
+/// `MAX_SAMPLES` re-typed as `u64` so reservoir math can stay
+/// fully in `u64` and only narrow to `usize` after a bounds check
+/// via `usize::try_from`. Declared as a raw literal (not `as u64`
+/// from MAX_SAMPLES) to avoid the boundary cast entirely. A
+/// `const_assert!` would be ideal but adds a dev-dep; the values
+/// must stay equal — keep both lines in sync if MAX_SAMPLES
+/// changes.
+const MAX_SAMPLES_U64: u64 = 10_000;
 
 /// Run `body` repeatedly under criterion, recording per-iteration
 /// durations into a fixed-size reservoir (Vitter's Algorithm R) to
@@ -29,16 +37,20 @@ fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) ->
         // samples vec (n.max(1) returns 1 but samples[0] would OOB).
         return Duration::ZERO;
     }
-    // Lossless clamp: bound `iters` by MAX_SAMPLES as u64 first,
-    // then convert via try_from — avoids `iters as usize`
-    // truncation on 32-bit targets, lint-clean.
-    let cap = usize::try_from(iters.min(MAX_SAMPLES as u64)).unwrap_or(MAX_SAMPLES);
+    // Lossless clamp: bound `iters` by MAX_SAMPLES_U64 first, then
+    // convert via try_from — avoids `iters as usize` truncation on
+    // 32-bit targets, lint-clean.
+    let cap = usize::try_from(iters.min(MAX_SAMPLES_U64)).unwrap_or(MAX_SAMPLES);
     let mut samples: Vec<Duration> = Vec::with_capacity(cap);
     // Deterministic LCG for reservoir replacement — perf benches
     // should not depend on system RNG availability/quality.
+    // label.len() → u64 via try_from per the project conversion
+    // rule. saturating_add(1) keeps the multiplier non-zero even
+    // for the impossible case of label.len() == u64::MAX.
+    let label_len_u64 = u64::try_from(label.len()).unwrap_or(u64::MAX);
     let mut rng_state: u64 = 0xCAFE_F00D_DEAD_BEEF_u64
         .wrapping_add(iters)
-        .wrapping_mul(label.len() as u64 + 1);
+        .wrapping_mul(label_len_u64.saturating_add(1));
     let next_rand = |state: &mut u64| -> u64 {
         *state = state
             .wrapping_mul(6364136223846793005)
@@ -155,7 +167,7 @@ fn mvcc_stream(c: &mut Criterion) {
                     table.insert(InternalValue::from_components(
                         key.to_string(),
                         vec![],
-                        num as u64,
+                        u64::try_from(num).unwrap_or(u64::MAX),
                         lsm_tree::ValueType::Value,
                     ));
                 }

--- a/benches/merge.rs
+++ b/benches/merge.rs
@@ -1,43 +1,144 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use lsm_tree::merge::{BoxedIterator, Merger};
+use lsm_tree::merge_source::{CoherentIterSource, MergeSource};
+use lsm_tree::seeking_merger::SeekingMerger;
 use lsm_tree::{
     DefaultUserComparator, InternalValue, Memtable, SharedComparator, mvcc_stream::MvccStream,
 };
 use nanoid::nanoid;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Maximum number of duration samples we retain for P99/P999
+/// computation. Criterion can pick very large `iters` counts; storing
+/// one `Duration` per iteration would balloon memory and slow the
+/// sort. With reservoir sampling the cap is also the worst-case
+/// memory budget (~16 bytes × cap = ~160 KB at the default cap),
+/// which is independent of the criterion iteration count.
+const MAX_SAMPLES: usize = 10_000;
+
+/// Run `body` repeatedly under criterion, recording per-iteration
+/// durations into a fixed-size reservoir (Vitter's Algorithm R) to
+/// compute P50/P99/P999 tail latency. Returns the total duration
+/// (criterion's iter_custom contract).
+fn measure_with_percentiles<F: FnMut()>(label: &str, iters: u64, mut body: F) -> Duration {
+    if iters == 0 {
+        // Criterion can legitimately call iter_custom with iters == 0
+        // during early-warmup probing. Without this guard the
+        // percentile indexing below would underflow on an empty
+        // samples vec (n.max(1) returns 1 but samples[0] would OOB).
+        return Duration::ZERO;
+    }
+    // Lossless clamp: bound `iters` by MAX_SAMPLES as u64 first,
+    // then convert via try_from — avoids `iters as usize`
+    // truncation on 32-bit targets, lint-clean.
+    let cap = usize::try_from(iters.min(MAX_SAMPLES as u64)).unwrap_or(MAX_SAMPLES);
+    let mut samples: Vec<Duration> = Vec::with_capacity(cap);
+    // Deterministic LCG for reservoir replacement — perf benches
+    // should not depend on system RNG availability/quality.
+    let mut rng_state: u64 = 0xCAFE_F00D_DEAD_BEEF_u64
+        .wrapping_add(iters)
+        .wrapping_mul(label.len() as u64 + 1);
+    let next_rand = |state: &mut u64| -> u64 {
+        *state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        *state
+    };
+    // Outer wall-clock for the value returned to criterion — this
+    // is what `b.iter` would have observed. Includes per-iteration
+    // `Instant::now()` overhead AND reservoir bookkeeping
+    // (push / LCG / replace). The sum of `elapsed` would
+    // under-report by exactly those amounts and skew criterion's
+    // mean estimate.
+    let outer_start = Instant::now();
+    for i in 0..iters {
+        let start = Instant::now();
+        body();
+        let elapsed = start.elapsed();
+        if samples.len() < MAX_SAMPLES {
+            samples.push(elapsed);
+        } else {
+            // Reservoir replacement: pick a random index in [0, i].
+            // If that index falls within the reservoir, replace.
+            let idx = usize::try_from(next_rand(&mut rng_state) % (i + 1)).unwrap_or(MAX_SAMPLES);
+            if idx < MAX_SAMPLES {
+                samples[idx] = elapsed;
+            }
+        }
+    }
+    let total = outer_start.elapsed();
+    samples.sort_unstable();
+    let n = samples.len().max(1);
+    let p50 = samples[n / 2];
+    // Integer percentile indices — avoids f64 cast lint trips and
+    // float-rounding edge cases. Base the math on `last = n - 1`
+    // (last valid index) so the indices never saturate at the
+    // maximum for exact-boundary sample counts (e.g., for n=100 we
+    // must not pick samples[99] for p99 — that's p100, not p99).
+    let last = n - 1;
+    let p99_idx = last.saturating_mul(99) / 100;
+    let p999_idx = last.saturating_mul(999) / 1000;
+    let p99 = samples[p99_idx];
+    let p999 = samples[p999_idx];
+    // Print tail-latency summary so perf comparisons can be done by
+    // diffing bench output across runs. Criterion's own report only
+    // surfaces mean+CI which hides tail regressions.
+    eprintln!(
+        "  [{label}] P50={:>8.2?} P99={:>8.2?} P999={:>8.2?} (n={}/{})",
+        p50, p99, p999, n, iters
+    );
+    total
+}
 
 fn merger(c: &mut Criterion) {
     let cmp: SharedComparator = Arc::new(DefaultUserComparator);
 
-    for num in [2, 4, 8, 16, 30] {
-        c.bench_function(&format!("Merge {num}"), |b| {
-            let memtables = (0..num)
-                .map(|_| {
-                    let table = Memtable::new(0, cmp.clone());
+    for num in [2_usize, 4, 8, 16, 30] {
+        let memtables = (0..num)
+            .map(|_| {
+                let table = Memtable::new(0, cmp.clone());
+                for _ in 0..100 {
+                    table.insert(InternalValue::from_components(
+                        nanoid!(),
+                        vec![],
+                        0,
+                        lsm_tree::ValueType::Value,
+                    ));
+                }
+                table
+            })
+            .collect::<Vec<_>>();
 
-                    for _ in 0..100 {
-                        table.insert(InternalValue::from_components(
-                            nanoid!(),
-                            vec![],
-                            0,
-                            lsm_tree::ValueType::Value,
-                        ));
-                    }
-
-                    table
+        let label_heap = format!("Merge {num} (MergeHeap)");
+        c.bench_function(&label_heap, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&label_heap, iters, || {
+                    let iters_v = memtables
+                        .iter()
+                        .map(|x| x.iter().map(Ok))
+                        .map(|x| Box::new(x) as BoxedIterator<'_>)
+                        .collect();
+                    let merger = Merger::new(iters_v, cmp.clone());
+                    assert_eq!(num * 100, merger.count());
                 })
-                .collect::<Vec<_>>();
+            })
+        });
 
-            b.iter_with_large_drop(|| {
-                let iters = memtables
-                    .iter()
-                    .map(|x| x.iter().map(Ok))
-                    .map(|x| Box::new(x) as BoxedIterator<'_>)
-                    .collect();
-
-                let merger = Merger::new(iters, cmp.clone());
-
-                assert_eq!(num * 100, merger.count());
+        let label_seeking = format!("Merge {num} (SeekingMerger)");
+        c.bench_function(&label_seeking, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&label_seeking, iters, || {
+                    let sources: Vec<Box<dyn MergeSource + '_>> = memtables
+                        .iter()
+                        .map(|x| {
+                            let iter = x.iter().map(Ok);
+                            Box::new(CoherentIterSource::new(iter)) as Box<dyn MergeSource + '_>
+                        })
+                        .collect();
+                    let merger = SeekingMerger::new(sources, cmp.clone());
+                    assert_eq!(num * 100, merger.count());
+                })
             })
         });
     }
@@ -46,35 +147,34 @@ fn merger(c: &mut Criterion) {
 fn mvcc_stream(c: &mut Criterion) {
     let cmp: SharedComparator = Arc::new(DefaultUserComparator);
 
-    for num in [2, 4, 8, 16, 30] {
-        c.bench_function(&format!("MVCC stream {num} versions"), |b| {
-            let memtables = (0..num)
-                .map(|_| {
-                    let table = Memtable::new(0, cmp.clone());
+    for num in [2_usize, 4, 8, 16, 30] {
+        let memtables = (0..num)
+            .map(|_| {
+                let table = Memtable::new(0, cmp.clone());
+                for key in 'a'..='z' {
+                    table.insert(InternalValue::from_components(
+                        key.to_string(),
+                        vec![],
+                        num as u64,
+                        lsm_tree::ValueType::Value,
+                    ));
+                }
+                table
+            })
+            .collect::<Vec<_>>();
 
-                    for key in 'a'..='z' {
-                        table.insert(InternalValue::from_components(
-                            key.to_string(),
-                            vec![],
-                            num,
-                            lsm_tree::ValueType::Value,
-                        ));
-                    }
-
-                    table
+        let label = format!("MVCC stream {num} versions (MergeHeap)");
+        c.bench_function(&label, |b| {
+            b.iter_custom(|iters| {
+                measure_with_percentiles(&label, iters, || {
+                    let iters_v = memtables
+                        .iter()
+                        .map(|x| x.iter().map(Ok))
+                        .map(|x| Box::new(x) as BoxedIterator<'_>)
+                        .collect();
+                    let merger = MvccStream::new(Merger::new(iters_v, cmp.clone()), None);
+                    assert_eq!(26, merger.count());
                 })
-                .collect::<Vec<_>>();
-
-            b.iter_with_large_drop(|| {
-                let iters = memtables
-                    .iter()
-                    .map(|x| x.iter().map(Ok))
-                    .map(|x| Box::new(x) as BoxedIterator<'_>)
-                    .collect();
-
-                let merger = MvccStream::new(Merger::new(iters, cmp.clone()), None);
-
-                assert_eq!(26, merger.count());
             })
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ mod ingestion;
 mod iter_guard;
 mod key;
 mod key_range;
+mod loser_tree;
 mod manifest;
 mod memtable;
 mod merge_operator;
@@ -165,6 +166,11 @@ mod run_scanner;
 
 #[doc(hidden)]
 pub mod merge;
+
+#[doc(hidden)]
+pub mod merge_source;
+#[doc(hidden)]
+pub mod seeking_merger;
 
 #[cfg(feature = "metrics")]
 pub(crate) mod metrics;

--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Knuth tournament (loser) tree for `k`-way merge.
+//!
+//! A loser tree solves the same problem as a binary heap for merging
+//! sorted inputs, but with one fewer comparison per `replace_min` and
+//! a cache-friendlier memory layout. The winner sits at the root
+//! (`tree[0]`); each internal node stores the **loser** of the game
+//! played at that node. To replace the winner, only the path from its
+//! leaf back up to the root needs to be replayed — `log₂(n)` comparisons
+//! instead of the `2 log₂(n)` a binary heap would need (one per level,
+//! comparing against the loser already stored there rather than against
+//! both children).
+//!
+//! This module's `LoserTree<E, F>` is generic over the element type and
+//! the comparator function (no `Arc<dyn Trait>` indirection — the
+//! comparator is monomorphised per use site for zero-cost dispatch).
+//!
+//! # Layout
+//!
+//! `leaves[0..cap]` holds the current value for each input slot. `cap`
+//! is `n.next_power_of_two().max(2)`, so the tournament always has a
+//! complete binary tree above it. Slots beyond `n` are permanently
+//! `None`, acting as `+∞` sentinels that never win.
+//!
+//! `tree[0]` stores the index (into `leaves`) of the overall winner.
+//! `tree[1..cap]` stores the loser index at each internal node. The
+//! conventional `2cap`-sized embedded-tree layout maps to our `cap`-sized
+//! `tree` like this:
+//!
+//! - leaf `L`'s first internal-node parent lives at index `(cap + L) / 2`
+//! - each parent's parent is `idx >> 1`
+//! - the loop terminates at `idx == 1` (root); the final winner is
+//!   stored at `tree[0]`
+//!
+//! # Sentinel handling
+//!
+//! Each leaf is `Option<E>`. `None` means "this source is exhausted".
+//! `cmp_indices` treats `None` as strictly greater than any `Some`, so
+//! exhausted sources naturally lose every game and drop out of the
+//! tournament. Once every leaf is `None`, `peek_min` returns `None` and
+//! the tree is empty.
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+/// A min-tournament tree over `n` input slots.
+///
+/// The "min" comes from how `cmp` is interpreted: the leaf whose value
+/// is `Ordering::Less` than every other leaf wins. To get max-semantics,
+/// pass a reversed comparator (`|a, b| cmp(a, b).reverse()`).
+#[derive(Debug)]
+pub struct LoserTree<E, F> {
+    /// Current value per source slot. `None` = exhausted / sentinel.
+    /// Length is `cap` (padded to the next power of two ≥ 2); the
+    /// trailing `cap - n_sources` slots are permanent `None`
+    /// sentinels and never carry a value.
+    leaves: Vec<Option<E>>,
+    /// Tree of size `cap`. `tree[0]` = winner leaf index; `tree[1..cap]`
+    /// = loser leaf index at each internal node.
+    tree: Vec<usize>,
+    /// Number of source slots originally supplied. Less than or equal
+    /// to `leaves.len()` (= `cap`). Exposed via [`Self::slots`].
+    n_sources: usize,
+    /// Number of `Some` leaves. When zero the tree is empty.
+    active: usize,
+    /// Comparator. Captures source-order tie-break and any other
+    /// merge-precedence rules the caller wants.
+    cmp: F,
+}
+
+impl<E, F> LoserTree<E, F>
+where
+    F: Fn(&E, &E) -> Ordering,
+{
+    /// Build a tournament over `initial` (one entry per source slot).
+    ///
+    /// `None` entries are treated as exhausted/sentinel. After
+    /// construction, `peek_min()` returns the smallest `Some` value
+    /// across all slots.
+    ///
+    /// O(n) work: each internal node is visited exactly once during
+    /// the bottom-up build.
+    pub fn build(initial: Vec<Option<E>>, cmp: F) -> Self {
+        let n = initial.len();
+        let cap = n.next_power_of_two().max(2);
+        let mut leaves = initial;
+        leaves.resize_with(cap, || None);
+
+        let active = leaves.iter().filter(|x| x.is_some()).count();
+        let tree = alloc::vec![0; cap];
+
+        let mut t = Self {
+            leaves,
+            tree,
+            n_sources: n,
+            active,
+            cmp,
+        };
+        t.build_subtree(1, 0, cap);
+        t
+    }
+
+    /// Number of source slots `n` originally supplied (not `cap`).
+    ///
+    /// Reflects the *capacity* of the tournament; some slots may be
+    /// exhausted (`None`) at any given moment.
+    #[inline]
+    #[expect(
+        dead_code,
+        reason = "part of the slot-set protocol, used by future callers"
+    )]
+    pub fn slots(&self) -> usize {
+        self.n_sources
+    }
+
+    /// Whether every slot is exhausted (`None`).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.active == 0
+    }
+
+    /// Number of slots still holding a value.
+    #[inline]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "diagnostic accessor used by unit tests and future callers"
+        )
+    )]
+    pub fn active_count(&self) -> usize {
+        self.active
+    }
+
+    /// Slot index of the current overall winner, or `None` if empty.
+    ///
+    /// Useful for callers (like the LSM merger) that need to know
+    /// *which* source produced the current minimum, so the next item
+    /// from that source can be pulled in.
+    #[inline]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "tree[0] always exists: cap >= 2 by construction"
+    )]
+    pub fn winner_slot(&self) -> Option<usize> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.tree[0])
+        }
+    }
+
+    /// Borrow the current overall minimum, or `None` if empty.
+    #[inline]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "idx from winner_slot() is always < leaves.len()"
+    )]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "exposed for callers that want to inspect the winner without popping; \
+                      seeking_merger reads the winner via winner_slot() since the slot index \
+                      equals the source index by construction"
+        )
+    )]
+    pub fn peek_min(&self) -> Option<&E> {
+        let idx = self.winner_slot()?;
+        self.leaves[idx].as_ref()
+    }
+
+    /// Replace the value at the winning slot with `new` and return the
+    /// previous winner. Replays `log₂(cap)` games up the path from the
+    /// winning leaf to the root.
+    ///
+    /// Caller-side contract: `new` must come from the **same source
+    /// iterator** that produced the previous winner. Mixing slots
+    /// breaks the merger's invariant that each slot reflects its own
+    /// source's current item.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tree is empty (`peek_min().is_none()`). Callers
+    /// must check `is_empty()` first or use [`Self::pop_min`] semantics.
+    #[expect(
+        clippy::expect_used,
+        reason = "empty-tree panic is the documented contract"
+    )]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "slot from winner_slot() is always < leaves.len()"
+    )]
+    pub fn replace_min(&mut self, new: E) -> E {
+        let slot = self
+            .winner_slot()
+            .expect("replace_min called on empty LoserTree");
+        let old = self.leaves[slot]
+            .replace(new)
+            .expect("LoserTree winner slot must hold Some");
+        self.replay(slot);
+        old
+    }
+
+    /// Pop the winning value and mark its slot exhausted. The next
+    /// `peek_min()` will reflect the new winner (or `None` if this
+    /// drained the last slot). O(log cap).
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "slot from winner_slot() is always < leaves.len()"
+    )]
+    pub fn pop_min(&mut self) -> Option<E> {
+        let slot = self.winner_slot()?;
+        let old = self.leaves[slot].take();
+        debug_assert!(
+            old.is_some(),
+            "LoserTree winner slot must hold Some when winner_slot() returns Some"
+        );
+        self.active -= 1;
+        self.replay(slot);
+        old
+    }
+
+    /// Take the value at a specific slot (regardless of winner status)
+    /// and mark the slot exhausted. The next `peek_min` reflects the
+    /// updated tournament. Returns the taken value, or `None` if the
+    /// slot was already exhausted (or out of range).
+    ///
+    /// This exists for the seeking-merger's cross-direction migration:
+    /// when one tournament's source has run out but the OPPOSITE
+    /// tournament still holds a buffered leaf for that source, the
+    /// active direction takes it via this API rather than dropping
+    /// it on the floor. O(log cap).
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "slot is checked < self.leaves.len() before indexing"
+    )]
+    pub fn take_slot(&mut self, slot: usize) -> Option<E> {
+        if slot >= self.leaves.len() {
+            return None;
+        }
+        let taken = self.leaves[slot].take()?;
+        self.active -= 1;
+        self.replay(slot);
+        Some(taken)
+    }
+
+    // ---------- internals ----------
+
+    /// Recursive bottom-up build. Each internal node at array index
+    /// `node` covers leaves `[leaf_lo, leaf_hi)`. The function returns
+    /// the slot index of the subtree's winner; the loser of the final
+    /// game at `node` is stored in `self.tree[node]`.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "node is always in 1..cap by recursive construction; tree[0] always in bounds"
+    )]
+    fn build_subtree(&mut self, node: usize, leaf_lo: usize, leaf_hi: usize) -> usize {
+        if leaf_hi - leaf_lo == 1 {
+            // Base case: single leaf, no internal node game here.
+            // (`node` corresponds to a leaf "position" in the conceptual
+            // 2*cap-array; we don't write to tree[] for leaves.)
+            return leaf_lo;
+        }
+        let mid = usize::midpoint(leaf_lo, leaf_hi);
+        let left_winner = self.build_subtree(2 * node, leaf_lo, mid);
+        let right_winner = self.build_subtree(2 * node + 1, mid, leaf_hi);
+
+        let (winner, loser) = match self.cmp_indices(left_winner, right_winner) {
+            Ordering::Less | Ordering::Equal => (left_winner, right_winner),
+            Ordering::Greater => (right_winner, left_winner),
+        };
+        self.tree[node] = loser;
+        if node == 1 {
+            // Root subtree finished — store the overall winner.
+            self.tree[0] = winner;
+        }
+        winner
+    }
+
+    /// Replay the tournament path from `leaf`'s position back up to the
+    /// root, updating `tree[0]` with the new overall winner. O(log cap).
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "node traverses 1..cap by construction; tree[0] always exists"
+    )]
+    fn replay(&mut self, leaf: usize) {
+        let mut winner = leaf;
+        // Parent index in the conceptual 2*cap array: (cap + leaf) / 2.
+        // Use midpoint to avoid potential overflow on 32-bit targets.
+        let mut node = usize::midpoint(self.leaves.len(), leaf);
+        while node >= 1 {
+            let other = self.tree[node];
+            // Smaller wins. If the stored loser is actually smaller
+            // than our running winner, swap them: the running winner
+            // becomes the new loser stored at this node.
+            if self.cmp_indices(other, winner) == Ordering::Less {
+                self.tree[node] = winner;
+                winner = other;
+            }
+            node >>= 1;
+        }
+        self.tree[0] = winner;
+    }
+
+    /// Compare leaves by slot index, treating `None` as `+∞`. `None`
+    /// always loses to `Some`; `None` vs `None` returns `Equal`.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "callers (build_subtree, replay) only pass slot indices < cap"
+    )]
+    fn cmp_indices(&self, a: usize, b: usize) -> Ordering {
+        match (&self.leaves[a], &self.leaves[b]) {
+            (Some(x), Some(y)) => (self.cmp)(x, y),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => Ordering::Equal,
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "cmp_u32 signature mirrors the Fn(&E, &E) -> Ordering trait"
+)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "test sizes are small (n <= 33)"
+)]
+mod tests {
+    // Test names below are short forms (e.g. `empty_tree`,
+    // `drain_in_order`) — the project convention requires
+    // `<what>_<condition>_<expected>` for top-level tests, OR
+    // short names inside a descriptively-named submodule. The
+    // descriptively-named submodule path is what's exercised
+    // here: `loser_tree::tests::<short_name>` reads as "loser
+    // tree's <short_name> test", which gives the short forms the
+    // missing `<what>` context.
+    use super::*;
+    use test_log::test;
+
+    fn cmp_u32(a: &u32, b: &u32) -> Ordering {
+        a.cmp(b)
+    }
+
+    fn collect<F: Fn(&u32, &u32) -> Ordering>(mut t: LoserTree<u32, F>) -> Vec<u32> {
+        let mut out = Vec::new();
+        while let Some(v) = t.pop_min() {
+            out.push(v);
+        }
+        out
+    }
+
+    #[test]
+    fn empty_tree() {
+        let t: LoserTree<u32, fn(&u32, &u32) -> Ordering> =
+            LoserTree::build(alloc::vec![None, None, None], cmp_u32);
+        assert!(t.is_empty());
+        assert_eq!(t.active_count(), 0);
+        assert_eq!(t.peek_min(), None);
+        assert_eq!(t.winner_slot(), None);
+    }
+
+    #[test]
+    fn single_slot() {
+        let mut t = LoserTree::build(alloc::vec![Some(42_u32)], cmp_u32);
+        assert!(!t.is_empty());
+        assert_eq!(t.peek_min(), Some(&42));
+        assert_eq!(t.pop_min(), Some(42));
+        assert!(t.is_empty());
+        assert_eq!(t.pop_min(), None);
+    }
+
+    #[test]
+    fn drain_in_order() {
+        // 4 sources, each with a distinct value.
+        let t = LoserTree::build(alloc::vec![Some(3_u32), Some(1), Some(4), Some(2)], cmp_u32);
+        assert_eq!(collect(t), [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn non_pow2_padding() {
+        // 5 slots → cap = 8. Sentinels must not affect winner.
+        let t = LoserTree::build(
+            alloc::vec![Some(50_u32), Some(10), Some(40), Some(20), Some(30)],
+            cmp_u32,
+        );
+        assert_eq!(collect(t), [10, 20, 30, 40, 50]);
+    }
+
+    #[test]
+    fn replace_min_stays_winner_when_still_smallest() {
+        // Slot 0 keeps yielding monotonically increasing values that
+        // are still below everyone else.
+        let mut t = LoserTree::build(
+            alloc::vec![Some(1_u32), Some(100), Some(200), Some(300)],
+            cmp_u32,
+        );
+        assert_eq!(t.replace_min(2), 1);
+        assert_eq!(t.peek_min(), Some(&2));
+        assert_eq!(t.winner_slot(), Some(0));
+        assert_eq!(t.replace_min(3), 2);
+        assert_eq!(t.peek_min(), Some(&3));
+        assert_eq!(t.winner_slot(), Some(0));
+    }
+
+    #[test]
+    fn replace_min_changes_winner() {
+        let mut t = LoserTree::build(alloc::vec![Some(1_u32), Some(5), Some(3), Some(7)], cmp_u32);
+        assert_eq!(t.winner_slot(), Some(0));
+        // Replace slot 0's value with something larger than slot 2 (3)
+        // but smaller than slot 1 (5).
+        assert_eq!(t.replace_min(4), 1);
+        assert_eq!(t.peek_min(), Some(&3)); // slot 2 wins now
+        assert_eq!(t.winner_slot(), Some(2));
+        assert_eq!(t.replace_min(6), 3);
+        assert_eq!(t.peek_min(), Some(&4)); // slot 0 wins again with 4
+        assert_eq!(t.winner_slot(), Some(0));
+    }
+
+    #[test]
+    fn pop_min_then_drain() {
+        let mut t = LoserTree::build(
+            alloc::vec![Some(10_u32), Some(20), Some(5), Some(15)],
+            cmp_u32,
+        );
+        assert_eq!(t.pop_min(), Some(5));
+        assert_eq!(t.active_count(), 3);
+        assert_eq!(t.peek_min(), Some(&10));
+        assert_eq!(collect(t), [10, 15, 20]);
+    }
+
+    #[test]
+    fn mixed_replace_and_pop() {
+        // Drain interleaved: simulates a real merge where some sources
+        // get exhausted partway through.
+        let mut t = LoserTree::build(alloc::vec![Some(1_u32), Some(2), Some(3), Some(4)], cmp_u32);
+        assert_eq!(t.replace_min(5), 1); // slot 0 now 5
+        assert_eq!(t.replace_min(6), 2); // slot 1 now 6
+        // Order should now be 3, 4, 5, 6.
+        assert_eq!(t.pop_min(), Some(3));
+        assert_eq!(t.pop_min(), Some(4));
+        assert_eq!(t.pop_min(), Some(5));
+        assert_eq!(t.pop_min(), Some(6));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn reverse_comparator_gives_max_tree() {
+        // Same data, max-tree semantics via reversed cmp.
+        let cmp = |a: &u32, b: &u32| b.cmp(a);
+        let mut t = LoserTree::build(alloc::vec![Some(1_u32), Some(4), Some(2), Some(3)], cmp);
+        assert_eq!(t.peek_min(), Some(&4)); // "min" under reversed cmp = max
+        assert_eq!(t.pop_min(), Some(4));
+        assert_eq!(t.pop_min(), Some(3));
+        assert_eq!(t.pop_min(), Some(2));
+        assert_eq!(t.pop_min(), Some(1));
+    }
+
+    #[test]
+    fn deterministic_tiebreak_by_cmp() {
+        // Ties go to whichever the comparator picks; we encode source
+        // index via tuple so equal values resolve deterministically.
+        let cmp = |a: &(u32, usize), b: &(u32, usize)| (a.0, a.1).cmp(&(b.0, b.1));
+        let mut t = LoserTree::build(
+            alloc::vec![Some((5_u32, 0)), Some((5, 1)), Some((5, 2)), Some((5, 3)),],
+            cmp,
+        );
+        // All same key → slot 0 wins on tiebreak.
+        assert_eq!(t.winner_slot(), Some(0));
+        let mut order = Vec::new();
+        while let Some((_, idx)) = t.pop_min() {
+            order.push(idx);
+        }
+        assert_eq!(order, [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn random_inputs_match_sorted_reference() {
+        // Property-style: random multi-source data must drain in the
+        // same order a sorted concatenation produces.
+        use rand::SeedableRng;
+        use rand::seq::SliceRandom;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0DE_F00D);
+        for n in [1_usize, 2, 3, 7, 8, 9, 31, 32, 33] {
+            for trial in 0..32 {
+                let mut all: Vec<u32> = (0..(n as u32 * 4)).collect();
+                all.shuffle(&mut rng);
+                // Round-robin distribute into n buckets.
+                let mut buckets: Vec<Vec<u32>> = (0..n).map(|_| Vec::new()).collect();
+                for (i, v) in all.iter().enumerate() {
+                    #[expect(clippy::indexing_slicing, reason = "i % n always < n")]
+                    buckets[i % n].push(*v);
+                }
+                // Each bucket must be individually sorted (loser tree
+                // assumes per-source sortedness, just like a merger).
+                for b in &mut buckets {
+                    b.sort_unstable();
+                }
+                // Snapshot the sorted reference before consuming buckets.
+                let mut reference = all.clone();
+                reference.sort_unstable();
+                // Build tree from the first item of each bucket;
+                // simulate refilling via replace_min until all drained.
+                let mut iters: Vec<std::vec::IntoIter<u32>> =
+                    buckets.into_iter().map(IntoIterator::into_iter).collect();
+                let initial: Vec<Option<u32>> = iters.iter_mut().map(Iterator::next).collect();
+                let mut t = LoserTree::build(initial, cmp_u32);
+                let mut out = Vec::with_capacity(reference.len());
+                while let Some(slot) = t.winner_slot() {
+                    #[expect(clippy::indexing_slicing, reason = "slot < n by construction")]
+                    if let Some(next_val) = iters[slot].next() {
+                        out.push(t.replace_min(next_val));
+                    } else {
+                        out.push(t.pop_min().unwrap());
+                    }
+                }
+                assert_eq!(out, reference, "n={n} trial={trial}");
+            }
+        }
+    }
+}

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -88,10 +88,15 @@ pub trait MergeSource: Send {
     /// remaining range from both ends — MAY treat seek as a no-op.
     /// Their cursor discipline already guarantees "no item yielded
     /// twice" under mixed-direction consumption without any
-    /// explicit reposition. `SeekingMerger` only invokes seek on
-    /// the direction-switch path that needs it (i.e., on sources
-    /// without the marker), so coherent sources pay nothing for
-    /// the no-op.
+    /// explicit reposition.
+    ///
+    /// The current MVP `SeekingMerger` does NOT actually invoke
+    /// `seek()` at all — `DoubleEndedIterator` is type-gated on
+    /// `CoherentMergeSource` and relies on the marker's coherence
+    /// promise. Once the seek-aware direction-switch path (issue
+    /// #280) lands, `SeekingMerger` WILL invoke `seek()` on
+    /// non-coherent sources at the direction-switch boundary;
+    /// coherent sources will still pay nothing for the no-op.
     ///
     /// Returns `Err` if seek requires I/O (SST scanner reseek, run
     /// header re-read) and that I/O fails. Corruption errors

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Seekable source iterator trait for the merge-iterator path.
+//!
+//! `MergeSource` is what `SeekingMerger` consumes: a stream that
+//! can be advanced in either direction AND repositioned to a
+//! specific key. The seek primitive is what makes RocksDB-style
+//! direction switching possible — without it, a backward-only path
+//! cannot recover from prior forward consumption on iterators whose
+//! front and back cursors don't share state (LSM SST scanners
+//! empirically don't).
+//!
+//! # Contract
+//!
+//! - [`Self::next`] yields items in ascending `InternalKey` order
+//!   from the source's "front" cursor.
+//! - [`Self::next_back`] yields items in descending order from the
+//!   source's "back" cursor.
+//! - [`Self::seek`] guarantees depend on the source's cursor model:
+//!
+//!   **Independent-cursor sources** (LSM SST scanners, `RunReader`s,
+//!   where calling `next` repeatedly does NOT advance the back
+//!   cursor and vice versa) — seek MUST reposition so that:
+//!     * the next `next()` yields the first item with `key >= target`
+//!     * the next `next_back()` yields the first item with `key < target`
+//!
+//!     If no such item exists in a direction, that direction returns
+//!     `None` on the next call. Repositioning is the only way for
+//!     `SeekingMerger` to guarantee the no-overlap invariant when
+//!     direction switches.
+//!
+//!   **Coherent-cursor sources** (those marked [`CoherentMergeSource`]
+//!   — `alloc::vec::IntoIter`, `alloc::collections::VecDeque`, range
+//!   iterators from `alloc::collections::BTreeMap`, and our
+//!   `CoherentIterSource` wrapper) — seek
+//!   MAY be a no-op. The shared front/back cursor discipline
+//!   already maintains the "no item yielded twice" invariant for
+//!   mixed-direction consumption without any explicit reposition;
+//!   the no-op satisfies the contract trivially. The current MVP
+//!   `SeekingMerger` does NOT actually invoke `seek()` — its
+//!   `DoubleEndedIterator` impl is type-gated on
+//!   `CoherentMergeSource` and relies on the marker's coherence
+//!   promise. The seek-aware direction-switch path that would
+//!   exercise `seek()` for independent-cursor sources is the
+//!   follow-up tracked as issue #280.
+//!
+//! # Why a custom trait, not just `DoubleEndedIterator + Seek`
+//!
+//! Rust's standard library has no `Seek` trait for iterators
+//! (`io::Seek` is for byte streams). We need a domain-specific
+//! seek that targets an `InternalKey`. Combining this with
+//! `DoubleEndedIterator` would over-constrain the trait: not every
+//! `MergeSource` impl needs the full `DoubleEndedIterator` API
+//! surface, and adapter wrappers (filter, map) need their own
+//! seek handling. Keeping `next` / `next_back` / `seek` as three
+//! distinct methods on one trait keeps the wrapper story simple.
+
+use crate::{InternalValue, key::InternalKey};
+use alloc::boxed::Box;
+
+/// What every merge source yields.
+pub type IterItem = crate::Result<InternalValue>;
+
+/// A source iterator consumable from either end, repositionable by
+/// key. Used by `SeekingMerger` (RocksDB-style merging iterator with
+/// O(n log shard) direction switches and O(log n) per-step
+/// `replace_*`).
+pub trait MergeSource: Send {
+    /// Yield the next item in ascending key order from the front
+    /// cursor, or `None` if exhausted in the forward direction.
+    fn next(&mut self) -> Option<IterItem>;
+
+    /// Yield the next item in descending key order from the back
+    /// cursor, or `None` if exhausted in the backward direction.
+    fn next_back(&mut self) -> Option<IterItem>;
+
+    /// Reposition cursors for a subsequent direction switch.
+    ///
+    /// Implementations with INDEPENDENT front/back cursors (LSM SST
+    /// scanners, `RunReader`s) MUST reposition so that:
+    ///
+    /// - the next `next()` yields the first item with `key >= target`, and
+    /// - the next `next_back()` yields the first item with `key < target`.
+    ///
+    /// Implementations marked [`CoherentMergeSource`] — whose
+    /// `next()` / `next_back()` already shrink a single shared
+    /// remaining range from both ends — MAY treat seek as a no-op.
+    /// Their cursor discipline already guarantees "no item yielded
+    /// twice" under mixed-direction consumption without any
+    /// explicit reposition. `SeekingMerger` only invokes seek on
+    /// the direction-switch path that needs it (i.e., on sources
+    /// without the marker), so coherent sources pay nothing for
+    /// the no-op.
+    ///
+    /// Returns `Err` if seek requires I/O (SST scanner reseek, run
+    /// header re-read) and that I/O fails. Corruption errors
+    /// surface here rather than being stashed for a later
+    /// `next()` / `next_back()` call, so the caller knows
+    /// precisely when the failure happened.
+    fn seek(&mut self, target: &InternalKey) -> crate::Result<()>;
+}
+
+/// Marker for `MergeSource` impls whose `next()` and `next_back()`
+/// share cursor state.
+///
+/// Such sources guarantee that mixed forward/backward consumption
+/// never yields the same item twice. Iterators backed by
+/// `alloc::vec::IntoIter`, `alloc::collections::VecDeque`, or
+/// range iterators from `alloc::collections::BTreeMap` qualify
+/// (their `DoubleEndedIterator` impls shrink a single remaining
+/// range from both ends).
+///
+/// **Why a marker trait:** `SeekingMerger` can skip seek-based
+/// reseeks for sources whose front/back cursors already shrink a
+/// single shared remaining range. Sources with independent cursors
+/// (LSM SST scanners, run readers — the intended follow-up impls)
+/// should implement `MergeSource` with a real `seek`, but MUST NOT
+/// implement `CoherentMergeSource` unless mixed forward/backward
+/// consumption already guarantees no item is yielded twice. The
+/// marker is the type-system encoding of that promise — without
+/// it, `SeekingMerger`'s `DoubleEndedIterator` impl is unavailable
+/// at compile time.
+pub trait CoherentMergeSource: MergeSource {}
+
+/// Pass-through impl so callers can build `Vec<Box<dyn MergeSource +
+/// 'a>>` and pass that to `SeekingMerger`. Each method just
+/// dispatches to the inner trait object.
+impl<S: MergeSource + ?Sized> MergeSource for Box<S> {
+    fn next(&mut self) -> Option<IterItem> {
+        (**self).next()
+    }
+    fn next_back(&mut self) -> Option<IterItem> {
+        (**self).next_back()
+    }
+    fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
+        (**self).seek(target)
+    }
+}
+
+/// Adapter that wraps any `DoubleEndedIterator<Item = IterItem>` as
+/// a `MergeSource` with a no-op `seek`.
+///
+/// Useful for source iterators whose front and back cursors share
+/// state natively (`alloc::vec::IntoIter`,
+/// `alloc::collections::VecDeque`, range iterators from
+/// `alloc::collections::BTreeMap`)
+/// — those don't need seek to maintain the "no item yielded twice"
+/// invariant under mixed forward/backward consumption.
+///
+/// For source iterators with independent front/back cursors (LSM
+/// SST scanners), use a dedicated `MergeSource` impl that uses
+/// real `seek` instead of this adapter.
+pub struct CoherentIterSource<I> {
+    iter: I,
+}
+
+impl<I> CoherentIterSource<I> {
+    pub fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<I> CoherentMergeSource for CoherentIterSource<I> where
+    I: DoubleEndedIterator<Item = IterItem> + Send
+{
+}
+
+impl<S: CoherentMergeSource + ?Sized> CoherentMergeSource for Box<S> {}
+
+impl<I> MergeSource for CoherentIterSource<I>
+where
+    I: DoubleEndedIterator<Item = IterItem> + Send,
+{
+    fn next(&mut self) -> Option<IterItem> {
+        Iterator::next(&mut self.iter)
+    }
+    fn next_back(&mut self) -> Option<IterItem> {
+        DoubleEndedIterator::next_back(&mut self.iter)
+    }
+    fn seek(&mut self, _target: &InternalKey) -> crate::Result<()> {
+        // No-op: callers using this adapter promise the iterator's
+        // cursors are coherent (e.g., std vec/btree iters). Direction
+        // switching relies on the iterator's own front/back cursor
+        // discipline, not on a seek call. Always Ok — there's no I/O
+        // to fail.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::ValueType::Value;
+    use crate::comparator::default_comparator;
+    use alloc::vec;
+    use test_log::test;
+
+    fn make_iv(key: &[u8], seqno: u64) -> InternalValue {
+        InternalValue::from_components(key, b"", seqno, Value)
+    }
+
+    #[test]
+    fn coherent_iter_source_forward_and_backward() {
+        let items: Vec<IterItem> = vec![
+            Ok(make_iv(b"a", 0)),
+            Ok(make_iv(b"b", 0)),
+            Ok(make_iv(b"c", 0)),
+        ];
+        let mut src = CoherentIterSource::new(items.into_iter());
+        // Forward + backward interleave correctly via std::vec::IntoIter's
+        // shared front/back cursors.
+        assert_eq!(src.next().unwrap().unwrap().key.user_key.as_ref(), b"a");
+        assert_eq!(
+            src.next_back().unwrap().unwrap().key.user_key.as_ref(),
+            b"c"
+        );
+        assert_eq!(src.next().unwrap().unwrap().key.user_key.as_ref(), b"b");
+        assert!(src.next().is_none());
+        assert!(src.next_back().is_none());
+    }
+
+    #[test]
+    fn coherent_iter_source_seek_is_no_op() {
+        // seek() does not advance or rewind; the iter keeps its
+        // original position.
+        let items: Vec<IterItem> = vec![Ok(make_iv(b"a", 0)), Ok(make_iv(b"b", 0))];
+        let mut src = CoherentIterSource::new(items.into_iter());
+        let target = make_iv(b"zzz", 0);
+        src.seek(&target.key).unwrap();
+        // Still yields from the start.
+        assert_eq!(src.next().unwrap().unwrap().key.user_key.as_ref(), b"a");
+    }
+
+    #[test]
+    fn boxed_merge_source_dispatches_through_blanket_impl() {
+        // Build a Box<dyn MergeSource> via the blanket impl and
+        // exercise all three trait methods.
+        let items: Vec<IterItem> = vec![Ok(make_iv(b"x", 0)), Ok(make_iv(b"y", 0))];
+        let mut boxed: Box<dyn MergeSource> = Box::new(CoherentIterSource::new(items.into_iter()));
+        // .next() through the box
+        assert_eq!(
+            MergeSource::next(&mut boxed)
+                .unwrap()
+                .unwrap()
+                .key
+                .user_key
+                .as_ref(),
+            b"x"
+        );
+        // .seek() through the box (no-op on the underlying)
+        let target = make_iv(b"target", 0);
+        MergeSource::seek(&mut boxed, &target.key).unwrap();
+        // .next_back() through the box
+        assert_eq!(
+            MergeSource::next_back(&mut boxed)
+                .unwrap()
+                .unwrap()
+                .key
+                .user_key
+                .as_ref(),
+            b"y"
+        );
+        assert!(MergeSource::next(&mut boxed).is_none());
+    }
+
+    #[test]
+    fn coherent_iter_source_propagates_errors() {
+        // Test that error items pass through both forward and backward.
+        let items: Vec<IterItem> = vec![Ok(make_iv(b"a", 0)), Err(crate::Error::Unrecoverable)];
+        let mut src = CoherentIterSource::new(items.into_iter());
+        assert!(src.next().unwrap().is_ok());
+        assert!(src.next().unwrap().is_err());
+        assert!(src.next().is_none());
+        // Sanity: comparator import works in the test
+        let _ = default_comparator();
+    }
+
+    #[test]
+    fn empty_coherent_iter_source() {
+        let items: Vec<IterItem> = vec![];
+        let mut src = CoherentIterSource::new(items.into_iter());
+        assert!(src.next().is_none());
+        assert!(src.next_back().is_none());
+        let target = make_iv(b"k", 0);
+        src.seek(&target.key).unwrap(); // no panic on empty
+    }
+}

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -1,0 +1,773 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Merging iterator over `MergeSource`s, backed by two independent
+//! `LoserTree` tournaments (forward min, backward max).
+//!
+//! `DoubleEndedIterator` is gated on the [`CoherentMergeSource`]
+//! marker: only sources whose `next()` and `next_back()` share
+//! cursor state (the std `vec::IntoIter`, `VecDeque`,
+//! `BTreeMap::range` shape) get the backward iterator. Mixed
+//! direction on such sources is safe because their cursor
+//! discipline already enforces "no item yielded twice" — no seek
+//! reconciliation needed.
+//!
+//! For sources with INDEPENDENT cursors (LSM SST scanners, future
+//! `RunReader`), `MergeSource::seek` will be the primitive that
+//! reconciles the forward and backward prefetch streams. That
+//! direction-switch path is the **follow-up** (issue #280) — this
+//! MVP does NOT call `seek` from `SeekingMerger`, which is why the
+//! `CoherentMergeSource` marker gate exists in the first place
+//! (it keeps the dangerous combination of "non-coherent source +
+//! mixed direction" off the public API at compile time).
+//!
+//! The eager per-direction init below builds each tournament from
+//! a pre-populated `Vec<Option<MergerEntry>>` on first use, lazy
+//! per direction, independent of the other (mirrors the legacy
+//! `MergeHeap` `init_lo` / `init_hi` pattern).
+
+use crate::comparator::SharedComparator;
+use crate::loser_tree::LoserTree;
+use crate::merge_source::{CoherentMergeSource, IterItem, MergeSource};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+/// One leaf of the merge tournament. Carries the source index
+/// alongside the value so the refill path knows which iterator to
+/// pull from.
+struct MergerEntry {
+    source: usize,
+    value: crate::InternalValue,
+}
+
+/// Boxed comparator. `Box<dyn Fn>` keeps `SeekingMerger`'s type
+/// signature simple at the cost of one indirect call per
+/// comparison. If profiling shows this dominates (the old
+/// `MergeHeap` had identical dispatch through `Arc<dyn
+/// UserComparator>`, so it's a wash relative to the prior baseline),
+/// the comparator can later be parameterised generically through
+/// the merger.
+type EntryCmp = Box<dyn Fn(&MergerEntry, &MergerEntry) -> Ordering + Send + Sync>;
+
+fn build_min_cmp(comparator: SharedComparator) -> EntryCmp {
+    Box::new(move |a, b| {
+        a.value
+            .key
+            .compare_with(&b.value.key, comparator.as_ref())
+            .then_with(|| a.source.cmp(&b.source))
+    })
+}
+
+fn build_max_cmp(comparator: SharedComparator) -> EntryCmp {
+    // Reversed key comparison + reversed source-order tiebreak. The
+    // key reversal elects the LARGEST key as winner under the loser
+    // tree's "smaller wins" semantics. The source-index reversal
+    // keeps next_back()'s tie-break opposite of next()'s, matching
+    // the legacy MergeHeap behaviour (forward picks lower source
+    // index on key+seqno tie; backward picks higher source index).
+    Box::new(move |a, b| {
+        b.value
+            .key
+            .compare_with(&a.value.key, comparator.as_ref())
+            .then_with(|| b.source.cmp(&a.source))
+    })
+}
+
+/// Merging iterator over `MergeSource`s, backed by two independent
+/// `LoserTree` tournaments.
+///
+/// Uses one min-tree for forward iteration and one max-tree (via a
+/// reversed comparator) for backward iteration. Each tree holds `n`
+/// leaves — one prefetched item per source per direction. Forward
+/// `next()` and backward `next_back()` each stay O(log n) per step.
+///
+/// # Direction-switching scope (MVP — important)
+///
+/// The "RocksDB-style direction switching" framing in the issue and
+/// PR description refers to the **target** design. The current
+/// implementation is the **MVP**: it relies entirely on each source's
+/// own `Iterator::next` / `DoubleEndedIterator::next_back` cursors
+/// for "no item yielded twice" under mixed forward/backward use. It
+/// **never calls** `MergeSource::seek`.
+///
+/// That means: **mixing `next()` and `next_back()` is only safe when
+/// the source iterators have coherent front/back cursors** — i.e.,
+/// calling `.next()` advances the same shared remaining range that
+/// `.next_back()` walks from the other end. The std library's
+/// `vec::IntoIter`, `VecDeque`, and `BTreeMap::range` all qualify.
+/// The `CoherentIterSource` adapter wraps these.
+///
+/// For sources with **independent** front/back cursors (LSM SST
+/// scanners and run readers, the intended follow-up impls), backward
+/// iteration is currently UNAVAILABLE at the type level:
+/// `impl DoubleEndedIterator for SeekingMerger<S>` is bounded on
+/// `S: CoherentMergeSource`, and independent-cursor sources do NOT
+/// implement that marker. So `merger.next_back()` won't even compile
+/// for them — they're usable through `Iterator::next()` only. When
+/// the seek-aware direction-switch path lands (issue #280) the bound
+/// can relax back to `MergeSource` and backward iteration becomes
+/// available for those sources too.
+pub struct SeekingMerger<S: MergeSource> {
+    sources: Vec<S>,
+    n_sources: usize,
+    comparator: SharedComparator,
+    forward_tree: Option<LoserTree<MergerEntry, EntryCmp>>,
+    backward_tree: Option<LoserTree<MergerEntry, EntryCmp>>,
+    /// Refill error queued during the previous forward step. When
+    /// a source's `.next()` fails AFTER a value was already buffered
+    /// in the tournament, we yield the buffered value first and stash
+    /// the error here so the NEXT call to [`Iterator::next`] surfaces
+    /// it. Avoids silent data loss of the prefetched value.
+    pending_forward_error: Option<crate::Error>,
+    /// Mirror of `pending_forward_error` for the backward direction.
+    pending_backward_error: Option<crate::Error>,
+}
+
+impl<S: MergeSource> SeekingMerger<S> {
+    /// Construct an empty merger ready to consume from `sources`.
+    /// Tournaments are not built yet; both directions populate
+    /// lazily on first use.
+    #[must_use]
+    pub fn new(sources: Vec<S>, comparator: SharedComparator) -> Self {
+        let n = sources.len();
+        Self {
+            sources,
+            n_sources: n,
+            comparator,
+            forward_tree: None,
+            backward_tree: None,
+            pending_forward_error: None,
+            pending_backward_error: None,
+        }
+    }
+
+    fn initialize_forward(&mut self) {
+        let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(self.n_sources);
+        for i in 0..self.n_sources {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "i < n_sources by construction; sources len == n_sources"
+            )]
+            let pulled = MergeSource::next(&mut self.sources[i]);
+            let slot = match pulled {
+                Some(Ok(value)) => Some(MergerEntry { source: i, value }),
+                Some(Err(e)) => {
+                    // Don't drop earlier prefetched values: keep the
+                    // erroring slot empty and queue the error so it
+                    // surfaces AFTER any buffered prefetches are
+                    // consumed. Same contract as the refill paths.
+                    // get_or_insert preserves the FIRST queued error.
+                    self.pending_forward_error.get_or_insert(e);
+                    None
+                }
+                None => {
+                    // Source exhausted forward. If backward_tree
+                    // still holds a buffered leaf for this source
+                    // (the OPPOSITE direction pulled it earlier and
+                    // hasn't yielded it yet), MIGRATE it into the
+                    // forward tournament — otherwise that value
+                    // would be silently lost when the user iterates
+                    // forward after some backward consumption.
+                    self.backward_tree.as_mut().and_then(|bt| bt.take_slot(i))
+                }
+            };
+            initial.push(slot);
+        }
+        let cmp = build_min_cmp(self.comparator.clone());
+        self.forward_tree = Some(LoserTree::build(initial, cmp));
+    }
+
+    fn initialize_backward(&mut self) {
+        let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(self.n_sources);
+        for i in 0..self.n_sources {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "i < n_sources by construction; sources len == n_sources"
+            )]
+            let pulled = MergeSource::next_back(&mut self.sources[i]);
+            let slot = match pulled {
+                Some(Ok(value)) => Some(MergerEntry { source: i, value }),
+                Some(Err(e)) => {
+                    // Mirror of initialize_forward: keep prefetched
+                    // backward values, queue the FIRST error for a
+                    // later call (get_or_insert preserves it).
+                    self.pending_backward_error.get_or_insert(e);
+                    None
+                }
+                None => {
+                    // Source exhausted backward. If forward_tree
+                    // still holds a buffered leaf for this source
+                    // (the OPPOSITE direction pulled it earlier and
+                    // hasn't yielded it yet), MIGRATE it into the
+                    // backward tournament. CodeRabbit's data-loss
+                    // bug (single-source `[a, z]` returning None on
+                    // post-forward next_back) is exactly this case.
+                    self.forward_tree.as_mut().and_then(|ft| ft.take_slot(i))
+                }
+            };
+            initial.push(slot);
+        }
+        let cmp = build_max_cmp(self.comparator.clone());
+        self.backward_tree = Some(LoserTree::build(initial, cmp));
+    }
+}
+
+impl<S: MergeSource> Iterator for SeekingMerger<S> {
+    type Item = IterItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Surface ANY queued error (this direction's OR the opposite
+        // direction's) at the top of every call. Errors are signals
+        // and should NOT be buffered behind unrelated yielded items
+        // from other sources — that hides I/O / corruption failures
+        // until the end of iteration. Cold path: two `Option::take`
+        // calls are near-free when both are None.
+        if let Some(e) = self.pending_forward_error.take() {
+            return Some(Err(e));
+        }
+        if let Some(e) = self.pending_backward_error.take() {
+            return Some(Err(e));
+        }
+        if self.forward_tree.is_none() {
+            self.initialize_forward();
+            // Init may have queued an error; surface it immediately
+            // (same rationale as the top check — errors first).
+            if let Some(e) = self.pending_forward_error.take() {
+                return Some(Err(e));
+            }
+        }
+        // Single mut borrow on the tree field — split-borrow with
+        // self.sources is OK because they're disjoint struct fields.
+        let tree = self.forward_tree.as_mut()?;
+        // winner_slot returns the source index directly (by
+        // construction every MergerEntry's `source` field equals
+        // its slot index). Avoids a separate peek_min call. None
+        // means the tournament is exhausted.
+        let source = tree.winner_slot()?;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "source index < n_sources by construction"
+        )]
+        let next_pull = MergeSource::next(&mut self.sources[source]);
+        match next_pull {
+            Some(Ok(next_value)) => {
+                let old = tree.replace_min(MergerEntry {
+                    source,
+                    value: next_value,
+                });
+                Some(Ok(old.value))
+            }
+            Some(Err(e)) => {
+                // Refill failed AFTER the slot's prefetched value
+                // was already in the tournament. Yield that value
+                // and queue the error for the next call.
+                // get_or_insert preserves the FIRST queued error
+                // (matches the init-path semantic).
+                let old = tree.pop_min()?;
+                self.pending_forward_error.get_or_insert(e);
+                Some(Ok(old.value))
+            }
+            None => {
+                // Source exhausted forward. Do NOT migrate from
+                // backward_tree here — the buffered backward value
+                // still legitimately belongs to backward direction.
+                // Migration only happens at INIT.
+                let old = tree.pop_min()?;
+                Some(Ok(old.value))
+            }
+        }
+    }
+}
+
+// `DoubleEndedIterator` is gated on `CoherentMergeSource` — without
+// that marker, mixed `next()` / `next_back()` on an
+// independent-cursor source would emit duplicates around the
+// crossover key. The marker is the type-system encoding of "this
+// source's cursors share state, so the merger doesn't have to call
+// `seek` to reconcile". When the seek-aware direction switch lands
+// (issue #280), the bound can be relaxed back to `MergeSource`.
+impl<S: CoherentMergeSource> DoubleEndedIterator for SeekingMerger<S> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // Same error-first contract as next().
+        if let Some(e) = self.pending_backward_error.take() {
+            return Some(Err(e));
+        }
+        if let Some(e) = self.pending_forward_error.take() {
+            return Some(Err(e));
+        }
+        if self.backward_tree.is_none() {
+            self.initialize_backward();
+            if let Some(e) = self.pending_backward_error.take() {
+                return Some(Err(e));
+            }
+        }
+        let tree = self.backward_tree.as_mut()?;
+        let source = tree.winner_slot()?;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "source index < n_sources by construction"
+        )]
+        let next_pull = MergeSource::next_back(&mut self.sources[source]);
+        match next_pull {
+            Some(Ok(next_value)) => {
+                let old = tree.replace_min(MergerEntry {
+                    source,
+                    value: next_value,
+                });
+                Some(Ok(old.value))
+            }
+            Some(Err(e)) => {
+                let old = tree.pop_min()?;
+                self.pending_backward_error.get_or_insert(e);
+                Some(Ok(old.value))
+            }
+            None => {
+                let old = tree.pop_min()?;
+                Some(Ok(old.value))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use crate::InternalValue;
+    use crate::ValueType::Value;
+    use crate::comparator::{self, SharedComparator};
+    use crate::key::InternalKey;
+    use alloc::collections::VecDeque;
+    use test_log::test;
+
+    /// Trivial `MergeSource` over a `VecDeque<InternalValue>` for
+    /// unit tests. `next` pops from the front, `next_back` from the
+    /// back, `seek` is a linear skip-while-front-is-less primitive.
+    struct VecSource {
+        items: VecDeque<InternalValue>,
+        comparator: SharedComparator,
+    }
+
+    impl VecSource {
+        fn new<I: IntoIterator<Item = InternalValue>>(
+            items: I,
+            comparator: SharedComparator,
+        ) -> Self {
+            Self {
+                items: items.into_iter().collect(),
+                comparator,
+            }
+        }
+    }
+
+    impl MergeSource for VecSource {
+        fn next(&mut self) -> Option<IterItem> {
+            self.items.pop_front().map(Ok)
+        }
+
+        fn next_back(&mut self) -> Option<IterItem> {
+            self.items.pop_back().map(Ok)
+        }
+
+        fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
+            // `VecSource` is a `CoherentMergeSource` (shared
+            // front/back cursors via `VecDeque`), so seek is a hint
+            // that the trait permits to be a no-op for this class
+            // of source — the cursor discipline already enforces
+            // "no item yielded twice" under mixed direction. We
+            // still drop items strictly less than target from the
+            // front as a courtesy (matches what a partially-seek-
+            // aware implementation would do), since a single
+            // coherent queue cannot simultaneously satisfy both
+            // halves of the contract without re-ordering and
+            // breaking the merger's monotonic-yield expectation.
+            while let Some(front) = self.items.front() {
+                if front.key.compare_with(target, self.comparator.as_ref()) == Ordering::Less {
+                    self.items.pop_front();
+                } else {
+                    break;
+                }
+            }
+            Ok(())
+        }
+    }
+    impl CoherentMergeSource for VecSource {}
+
+    fn make_iv(key: &[u8], seqno: u64) -> InternalValue {
+        InternalValue::from_components(key, b"", seqno, Value)
+    }
+
+    fn k(v: &InternalValue) -> String {
+        String::from_utf8_lossy(&v.key.user_key).to_string()
+    }
+
+    #[test]
+    fn forward_only() {
+        let cmp = comparator::default_comparator();
+        let a = VecSource::new([make_iv(b"a", 0), make_iv(b"c", 0)], cmp.clone());
+        let b = VecSource::new([make_iv(b"b", 0), make_iv(b"d", 0)], cmp.clone());
+        let mut m = SeekingMerger::new(alloc::vec![a, b], cmp);
+        let keys: Vec<String> = (&mut m).map(|r| k(&r.unwrap())).collect();
+        assert_eq!(keys, ["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn backward_only() {
+        let cmp = comparator::default_comparator();
+        let a = VecSource::new([make_iv(b"a", 0), make_iv(b"c", 0)], cmp.clone());
+        let b = VecSource::new([make_iv(b"b", 0), make_iv(b"d", 0)], cmp.clone());
+        let mut iter = SeekingMerger::new(alloc::vec![a, b], cmp);
+        let mut keys: Vec<String> = Vec::new();
+        while let Some(item) = iter.next_back() {
+            keys.push(k(&item.unwrap()));
+        }
+        assert_eq!(keys, ["d", "c", "b", "a"]);
+    }
+
+    #[test]
+    fn mixed_direction() {
+        // Sources have shared front/back cursors (VecDeque), so
+        // forward + backward interleave correctly without seek.
+        let cmp = comparator::default_comparator();
+        let a = VecSource::new(
+            [make_iv(b"a", 0), make_iv(b"c", 0), make_iv(b"e", 0)],
+            cmp.clone(),
+        );
+        let b = VecSource::new(
+            [make_iv(b"b", 0), make_iv(b"d", 0), make_iv(b"f", 0)],
+            cmp.clone(),
+        );
+        let mut m = SeekingMerger::new(alloc::vec![a, b], cmp);
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "f");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "e");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "c");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "d");
+        assert!(m.next().is_none());
+        assert!(m.next_back().is_none());
+    }
+
+    #[test]
+    fn empty_sources() {
+        let cmp = comparator::default_comparator();
+        let mut m: SeekingMerger<VecSource> = SeekingMerger::new(alloc::vec![], cmp);
+        assert!(Iterator::next(&mut m).is_none());
+        assert!(m.next_back().is_none());
+    }
+
+    #[test]
+    fn next_back_after_forward_exhausted_migrates_buffered_value() {
+        // CodeRabbit thread #38 regression: with one coherent source
+        // [a, z], next() yields `a` and prefetches `z` into
+        // forward_tree. next_back() initializes from an already-
+        // exhausted source — without migration the buffered `z`
+        // would be silently lost (init pulls None from src, no
+        // value in backward_tree, returns None even though `z` is
+        // sitting in forward_tree).
+        //
+        // The fix is init-time migration: initialize_backward
+        // detects the empty source AND a Some leaf in the
+        // forward_tree, and takes that leaf into the backward
+        // initial vec.
+        let cmp = comparator::default_comparator();
+        let src = VecSource::new([make_iv(b"a", 0), make_iv(b"z", 0)], cmp.clone());
+        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(
+            k(&m.next_back().unwrap().unwrap()),
+            "z",
+            "migration must rescue `z` buffered in forward_tree",
+        );
+        assert!(m.next().is_none());
+        assert!(m.next_back().is_none());
+    }
+
+    #[test]
+    fn next_after_backward_exhausted_migrates_buffered_value() {
+        // Mirror of next_back_after_forward_exhausted: backward
+        // direction prefetched `a` (after yielding `z`), then
+        // user switches to next() with the source already
+        // exhausted. initialize_forward must migrate from
+        // backward_tree.
+        let cmp = comparator::default_comparator();
+        let src = VecSource::new([make_iv(b"a", 0), make_iv(b"z", 0)], cmp.clone());
+        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "z");
+        assert_eq!(
+            k(&m.next().unwrap().unwrap()),
+            "a",
+            "migration must rescue `a` buffered in backward_tree",
+        );
+        assert!(m.next().is_none());
+        assert!(m.next_back().is_none());
+    }
+
+    #[test]
+    fn single_source_drain_both_directions() {
+        let cmp = comparator::default_comparator();
+        let a = VecSource::new(
+            [make_iv(b"a", 0), make_iv(b"b", 0), make_iv(b"c", 0)],
+            cmp.clone(),
+        );
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "c");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
+        assert!(m.next().is_none());
+        assert!(m.next_back().is_none());
+    }
+
+    /// `MergeSource` impl that yields a controlled `Err` on the
+    /// first `next()` call. Used to assert error propagation through
+    /// the merger.
+    struct ErrSource {
+        emit_forward_error: bool,
+        emit_backward_error: bool,
+    }
+
+    impl MergeSource for ErrSource {
+        fn next(&mut self) -> Option<IterItem> {
+            if self.emit_forward_error {
+                self.emit_forward_error = false;
+                Some(Err(crate::Error::Unrecoverable))
+            } else {
+                None
+            }
+        }
+        fn next_back(&mut self) -> Option<IterItem> {
+            if self.emit_backward_error {
+                self.emit_backward_error = false;
+                Some(Err(crate::Error::Unrecoverable))
+            } else {
+                None
+            }
+        }
+        fn seek(&mut self, _target: &InternalKey) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+    impl CoherentMergeSource for ErrSource {}
+
+    #[test]
+    fn forward_init_propagates_error() {
+        // initialize_forward sees the error during the per-source
+        // pull and returns it as the first yielded item.
+        let cmp = comparator::default_comparator();
+        let a = ErrSource {
+            emit_forward_error: true,
+            emit_backward_error: false,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        assert!(m.next().unwrap().is_err());
+        // Subsequent next() returns None (init done, tournament empty).
+        assert!(m.next().is_none());
+    }
+
+    #[test]
+    fn backward_init_propagates_error() {
+        let cmp = comparator::default_comparator();
+        let a = ErrSource {
+            emit_forward_error: false,
+            emit_backward_error: true,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        assert!(m.next_back().unwrap().is_err());
+        assert!(m.next_back().is_none());
+    }
+
+    #[test]
+    fn forward_init_keeps_earlier_prefetched_when_later_source_errs() {
+        // Regression for the silent-data-loss case CodeRabbit
+        // flagged: before the fix, when sources[i] returned Err
+        // during init, sources[0..i]'s already-prefetched values
+        // were dropped (early-return discarded the `initial` vec).
+        // The fix queues the error AND keeps the prefetched
+        // values; the error surfaces on the very next call (errors
+        // are signals and surface ASAP, not buffered behind
+        // unrelated yields).
+        let cmp = comparator::default_comparator();
+        let good: Box<dyn CoherentMergeSource> = Box::new(VecSource::new(
+            [make_iv(b"good_a", 0), make_iv(b"good_b", 0)],
+            cmp.clone(),
+        ));
+        let bad: Box<dyn CoherentMergeSource> = Box::new(ErrSource {
+            emit_forward_error: true,
+            emit_backward_error: false,
+        });
+        let mut m = SeekingMerger::new(alloc::vec![good, bad], cmp);
+        // Call 1: init queued bad's error AND prefetched good_a.
+        // Error-first contract: error surfaces immediately.
+        assert!(m.next().unwrap().is_err());
+        // Call 2+: good prefetches drain in sorted order — neither
+        // was lost despite the init-time error.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "good_a");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "good_b");
+        assert!(m.next().is_none());
+    }
+
+    #[test]
+    fn refill_err_surfaces_before_unrelated_source_yields() {
+        // Copilot thread #39 regression: with multiple sources, a
+        // refill error on one source must surface on the very next
+        // call after the buffered value is yielded — NOT after the
+        // entire tree drains. Otherwise I/O / corruption failures
+        // hide behind potentially many unrelated yields.
+        let cmp = comparator::default_comparator();
+        let bad: Box<dyn CoherentMergeSource> = Box::new(LateErrSource {
+            first_value: Some(make_iv(b"x_bad", 0)),
+            already_errored: false,
+        });
+        let good: Box<dyn CoherentMergeSource> = Box::new(VecSource::new(
+            [
+                make_iv(b"y_good_1", 0),
+                make_iv(b"y_good_2", 0),
+                make_iv(b"y_good_3", 0),
+            ],
+            cmp.clone(),
+        ));
+        let mut m = SeekingMerger::new(alloc::vec![bad, good], cmp);
+        // Call 1: bad's x_bad wins (lex 'x' < 'y'). Yield, refill
+        // bad → err queued.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "x_bad");
+        // Call 2: error MUST surface here, not after draining
+        // y_good_1, y_good_2, y_good_3.
+        assert!(m.next().unwrap().is_err());
+        // Call 3+: the unrelated good values now drain normally.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "y_good_1");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "y_good_2");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "y_good_3");
+        assert!(m.next().is_none());
+    }
+
+    #[test]
+    fn cross_direction_surface_forward_pending_in_next_back() {
+        // CodeRabbit thread #33: a forward refill error must NOT
+        // be sidestepped by switching to next_back(). The pending
+        // forward error surfaces at the next call regardless of
+        // direction.
+        let cmp = comparator::default_comparator();
+        let a = LateErrSource {
+            first_value: Some(make_iv(b"only", 0)),
+            already_errored: false,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        // Forward: yields "only", queues forward refill err.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "only");
+        // Switch to backward — the queued forward err must still
+        // surface, NOT be lost.
+        assert!(m.next_back().unwrap().is_err());
+    }
+
+    #[test]
+    fn cross_direction_surface_backward_pending_in_next() {
+        // Mirror of the above: backward refill error must surface
+        // on a subsequent next() call.
+        let cmp = comparator::default_comparator();
+        let a = LateErrSource {
+            first_value: Some(make_iv(b"only", 0)),
+            already_errored: false,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "only");
+        assert!(m.next().unwrap().is_err());
+    }
+
+    #[test]
+    fn backward_init_keeps_earlier_prefetched_when_later_source_errs() {
+        let cmp = comparator::default_comparator();
+        let good: Box<dyn CoherentMergeSource> = Box::new(VecSource::new(
+            [make_iv(b"good_a", 0), make_iv(b"good_b", 0)],
+            cmp.clone(),
+        ));
+        let bad: Box<dyn CoherentMergeSource> = Box::new(ErrSource {
+            emit_forward_error: false,
+            emit_backward_error: true,
+        });
+        let mut m = SeekingMerger::new(alloc::vec![good, bad], cmp);
+        // Error-first contract: surfaces immediately, then the
+        // prefetched good values drain in descending order.
+        assert!(m.next_back().unwrap().is_err());
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "good_b");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "good_a");
+        assert!(m.next_back().is_none());
+    }
+
+    /// `MergeSource` impl that yields a successful value first, then
+    /// an error on the second pull. Exercises the error path AFTER
+    /// init (during the per-step refill).
+    struct LateErrSource {
+        first_value: Option<InternalValue>,
+        already_errored: bool,
+    }
+
+    impl MergeSource for LateErrSource {
+        fn next(&mut self) -> Option<IterItem> {
+            if let Some(v) = self.first_value.take() {
+                Some(Ok(v))
+            } else if !self.already_errored {
+                self.already_errored = true;
+                Some(Err(crate::Error::Unrecoverable))
+            } else {
+                None
+            }
+        }
+        fn next_back(&mut self) -> Option<IterItem> {
+            self.next()
+        }
+        fn seek(&mut self, _target: &InternalKey) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+    impl CoherentMergeSource for LateErrSource {}
+
+    // The previous "drops prefetched" tests were removed —
+    // SeekingMerger now yields the buffered value first and queues
+    // the refill error for the following call (see tests below).
+    // Removing the old tests is intentional: a test that pins
+    // silent-data-loss behaviour shouldn't live in the suite once
+    // the behaviour is corrected.
+
+    // The previous `IndependentCursorSource` test double and its
+    // `mvp_emits_duplicates_*` regression were DELETED, not ignored.
+    // `DoubleEndedIterator` is now gated on `CoherentMergeSource`,
+    // so a source whose cursors don't coordinate (the
+    // `IndependentCursorSource` shape) cannot be wrapped in a
+    // `SeekingMerger` that exposes `.next_back()` at all — the
+    // dangerous mixed-direction usage is rejected at compile time
+    // rather than masked by a yields-duplicates test. The follow-up
+    // wiring of `seek` into a direction-switch path (issue #280)
+    // will re-enable the bound to `MergeSource` and ship the
+    // correct-by-construction non-coherent test then.
+
+    #[test]
+    fn forward_refill_error_yields_buffered_then_err_on_next_call() {
+        let cmp = comparator::default_comparator();
+        let a = LateErrSource {
+            first_value: Some(make_iv(b"first", 0)),
+            already_errored: false,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        // First call: returns the buffered "first", the refill Err
+        // is queued.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "first");
+        // Second call: surfaces the queued Err.
+        assert!(m.next().unwrap().is_err());
+        // Third call: source fully drained.
+        assert!(m.next().is_none());
+    }
+
+    #[test]
+    fn backward_refill_error_yields_buffered_then_err_on_next_call() {
+        let cmp = comparator::default_comparator();
+        let a = LateErrSource {
+            first_value: Some(make_iv(b"first", 0)),
+            already_errored: false,
+        };
+        let mut m = SeekingMerger::new(alloc::vec![a], cmp);
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "first");
+        assert!(m.next_back().unwrap().is_err());
+        assert!(m.next_back().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Implements RocksDB-style merging iterator (**Option A** from #222 design exploration). Two independent `LoserTree` instances (forward min + backward max) over `MergeSource` — a new seekable-iter trait — for bidirectional iteration with init-time cross-direction migration. Refs #222.

This PR ships the **primitive layer**. Wiring `seek()` into the direction-switch path for sources with independent front/back cursors (LSM SST scanners, run readers) is the follow-up #280. Closing the small-fan-in perf regression vs `BinaryHeap` is the follow-up #283.

## Architecture

```
SeekingMerger<S: MergeSource>
  ├── forward_tree:  LoserTree<MergerEntry, EntryCmp>   (min, lazy-init)
  ├── backward_tree: LoserTree<MergerEntry, EntryCmp>   (max via reversed cmp, lazy-init)
  ├── sources: Vec<S>
  └── pending_forward_error / pending_backward_error: Option<Error>

MergeSource trait
  ├── fn next(&mut self) -> Option<IterItem>
  ├── fn next_back(&mut self) -> Option<IterItem>
  └── fn seek(&mut self, target: &InternalKey) -> Result<()>

CoherentMergeSource: MergeSource {}   // marker for shared-cursor sources
```

### Contracts that ship

| Surface | Semantic |
|---|---|
| `MergeSource::seek` | Independent-cursor sources MUST reposition both cursors per the per-method doc. Coherent-cursor sources (`CoherentMergeSource` marker) MAY no-op — their shared front/back cursor already enforces "no item yielded twice". |
| `DoubleEndedIterator for SeekingMerger<S>` | Type-bounded on `S: CoherentMergeSource`. Independent-cursor sources are type-system-rejected from `next_back()` calls at compile time until #280 wires seek into the switch path. |
| Init data preservation | If a source errors during init, sources that successfully prefetched earlier are NOT lost — their values stay in the tournament. The error is queued and surfaces on the next call. |
| Init cross-direction migration | If one direction's init pulls `None` from an already-exhausted source while the OPPOSITE tree still holds a buffered leaf for that source, the leaf is migrated (via `LoserTree::take_slot`) into the init-vec. Prevents silent data loss for cases like single source `[a, z]` (`next` yields `a` and prefetches `z`; `next_back` would otherwise return `None`). |
| Error-first contract | Queued errors (from init OR refill, either direction) surface at the top of the very next `next()` / `next_back()` call — they're not buried behind unrelated yields from other sources. |
| First-error-wins | `pending_*_error` is single-slot (`get_or_insert`). Multiple errors collapse to the first; the rest are discarded. |
| Cross-direction surfacing | A forward refill error surfaces on the next `next_back()` call too (and vice versa) so a caller can't sidestep it by switching direction. |

## Bench (criterion --quick, release)

```
N    MergeHeap   SeekingMerger    Δ
─────────────────────────────────────────
 2   17.7 µs     21.0 µs          +18% slower
 4   42.4 µs     49.5 µs          +17% slower
 8   99.2 µs     114.2 µs         +15% slower
16   247.4 µs    262.3 µs         +6%  slower
30   610.0 µs    569.0 µs         -7%  FASTER
```

Crossover at N≈20. SeekingMerger wins on large fan-in (compaction, level merges); BinaryHeap wins on small fan-in (typical L0 read). The remaining small-N gap is structural (LoserTree per-step constants > BinaryHeap on tight loops) and tracked as **#283** with concrete avenues (aggressive inlining, drop `Option` wrap via parallel `present` bitmap, SoA leaf layout, SIMD comparator).

Bench now reports P50/P99/P999 tail latency via `b.iter_custom` alongside criterion's mean+CI report.

## What ships

- `src/loser_tree.rs` — generic `LoserTree<E, F>` (Knuth tournament tree) with `build` / `peek_min` / `replace_min` / `pop_min` / `take_slot` / `winner_slot` / `slots` / `active_count` / `is_empty`. 11 unit tests. `take_slot(i)` is the migration primitive — O(log cap) removal of an arbitrary leaf with tournament replay.
- `src/merge_source.rs` — `MergeSource` trait + `CoherentMergeSource: MergeSource` marker + `Box<dyn>` blanket impl + `CoherentIterSource` adapter (no-op seek for `alloc::vec::IntoIter`, `VecDeque`, `BTreeMap::range`). 5 unit tests.
- `src/seeking_merger.rs` — `SeekingMerger<S: MergeSource>` with 16 unit tests covering forward / backward / mixed / empty / single-source / init-error / refill-error / cross-direction-error / init-migration / error-first-ordering scenarios.
- `benches/merge.rs` — side-by-side `Merge {N} (MergeHeap)` vs `Merge {N} (SeekingMerger)` for `N ∈ {2, 4, 8, 16, 30}` with P50/P99/P999 reporting and zero-based percentile math.

`src/merge.rs` (`Merger` / `MergeHeap`-based) ships unchanged. SeekingMerger is an opt-in alternative until production callers migrate.

## Test plan

- [x] 16/16 SeekingMerger unit tests pass
- [x] 11/11 LoserTree unit tests pass
- [x] 5/5 MergeSource unit tests pass
- [x] Full workspace `cargo nextest run` clean — no regression to existing `Merger`
- [x] `cargo clippy --lib --tests --benches -- -D warnings` clean
- [x] Bench: SeekingMerger faster at N=30 (compaction), regression on N≤16 tracked separately as #283

## Follow-up work for #222 closure

Migrating production callers (`range.rs`, compaction, mvcc_stream) needs `MergeSource` impls for:

- `table::iter::Iter` (SST scanner — already has `seek_lower_inclusive` / `seek_upper_inclusive`)
- `RunReader` (multi-table run iterator)
- Memtable `range_internal().filter().map(Ok)` chain (needs a seekable filter adapter or push the filter into the source)

Plus closing #283 perf regression so SeekingMerger can be the unconditional default. Each piece is bounded; the algorithmic primitives are all there. Next PR.

## Related

- #222 — design exploration that selected this approach
- #280 — wire `MergeSource::seek` into SeekingMerger's direction-switch path
- #283 — close the small-N perf regression vs `BinaryHeap`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bidirectional merge iteration and an alternative merge strategy variant for more flexible merging behavior.

* **Performance**
  * Benchmarks enhanced to report tail-latency percentiles (P50/P99/P999) for better visibility into merge performance.

* **Tests**
  * Comprehensive unit tests added to validate merge behavior, edge cases, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->