### PR TITLE
perf(loser_tree): close N≥16 regression, reduce small-N gap (#283 partial)

### DIFF
--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -116,7 +116,7 @@ where
     }
 
     /// Whether every slot is exhausted (`None`).
-    #[inline]
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.active == 0
     }
@@ -139,7 +139,7 @@ where
     /// Useful for callers (like the LSM merger) that need to know
     /// *which* source produced the current minimum, so the next item
     /// from that source can be pulled in.
-    #[inline]
+    #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
         reason = "tree[0] always exists: cap >= 2 by construction"
@@ -282,6 +282,15 @@ where
 
     /// Replay the tournament path from `leaf`'s position back up to the
     /// root, updating `tree[0]` with the new overall winner. O(log cap).
+    ///
+    /// `#[inline(always)]` — this is the single hot per-step routine
+    /// called from `replace_min` / `pop_min` / `take_slot` on every
+    /// merger step. Forcing inlining lets the caller hoist
+    /// `self.tree.as_ptr()` / `self.cmp` out of the loop and avoids
+    /// the call-site branch-predictor cost; default `#[inline]` is
+    /// only a hint and stops at crate boundaries (benches live in a
+    /// separate compilation unit).
+    #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
         reason = "node traverses 1..cap by construction; tree[0] always exists"
@@ -307,6 +316,12 @@ where
 
     /// Compare leaves by slot index, treating `None` as `+∞`. `None`
     /// always loses to `Some`; `None` vs `None` returns `Equal`.
+    ///
+    /// `#[inline(always)]` — called O(log cap) times per `replay()`
+    /// step, which is itself the hot per-merger-step routine. The
+    /// match-on-Options-tuple is small enough that inlining lets
+    /// LLVM fuse the discriminant checks across consecutive calls.
+    #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
         reason = "callers (build_subtree, replay) only pass slot indices < cap"

--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -36,38 +36,87 @@
 //!
 //! # Sentinel handling
 //!
-//! Each leaf is `Option<E>`. `None` means "this source is exhausted".
-//! `cmp_indices` treats `None` as strictly greater than any `Some`, so
-//! exhausted sources naturally lose every game and drop out of the
-//! tournament. Once every leaf is `None`, `peek_min` returns `None` and
-//! the tree is empty.
+//! Each leaf is logically `Option<E>` — present or sentinel. The
+//! physical representation uses two parallel arrays:
+//! `leaves: Vec<MaybeUninit<E>>` for the values and
+//! `present: Vec<bool>` for the discriminants. This eliminates the
+//! `Option` discriminant branch that LLVM emits inside `cmp_indices`
+//! on every game (called O(log cap) times per merger step); the
+//! present-bit fetch is a single byte load that branch-predicts
+//! perfectly under steady-state merging (where leaves stay present
+//! until exhaustion). `cmp_indices` treats absent leaves as
+//! strictly greater than any present value, so exhausted sources
+//! naturally lose every game.
+//!
+//! All `MaybeUninit::assume_init_*` calls are guarded by a check on
+//! the corresponding `present[i]` bit and never widen the unsafe
+//! contract beyond what the bitmap already guarantees. `Drop`
+//! walks the bitmap and drops in place.
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
+use core::mem::MaybeUninit;
 
 /// A min-tournament tree over `n` input slots.
 ///
 /// The "min" comes from how `cmp` is interpreted: the leaf whose value
 /// is `Ordering::Less` than every other leaf wins. To get max-semantics,
 /// pass a reversed comparator (`|a, b| cmp(a, b).reverse()`).
-#[derive(Debug)]
 pub struct LoserTree<E, F> {
-    /// Current value per source slot. `None` = exhausted / sentinel.
-    /// Length is `cap` (padded to the next power of two ≥ 2); the
-    /// trailing `cap - n_sources` slots are permanent `None`
-    /// sentinels and never carry a value.
-    leaves: Vec<Option<E>>,
+    /// Current value per source slot, untagged. Only meaningful when
+    /// the matching `present[i]` bit is `true`. Length is `cap`
+    /// (padded to the next power of two ≥ 2); the trailing
+    /// `cap - n_sources` slots are permanent sentinels with
+    /// `present[i] == false`.
+    leaves: Vec<MaybeUninit<E>>,
+    /// Discriminant for `leaves[i]`. `true` ⇒ initialised; `false` ⇒
+    /// uninit (exhausted or padding sentinel). Walking this bitmap
+    /// alongside `leaves` replaces the `Option` discriminant the
+    /// previous layout carried inline.
+    present: Vec<bool>,
     /// Tree of size `cap`. `tree[0]` = winner leaf index; `tree[1..cap]`
     /// = loser leaf index at each internal node.
     tree: Vec<usize>,
     /// Number of source slots originally supplied. Less than or equal
     /// to `leaves.len()` (= `cap`). Exposed via [`Self::slots`].
     n_sources: usize,
-    /// Number of `Some` leaves. When zero the tree is empty.
+    /// Count of present leaves. When zero the tree is empty.
     active: usize,
     /// Comparator. Captures source-order tie-break and any other
     /// merge-precedence rules the caller wants.
     cmp: F,
+}
+
+impl<E: core::fmt::Debug, F> core::fmt::Debug for LoserTree<E, F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Reconstitute the conceptual Vec<Option<&E>> view for Debug
+        // — never expose a MaybeUninit through Debug output.
+        f.debug_struct("LoserTree")
+            .field("n_sources", &self.n_sources)
+            .field("active", &self.active)
+            .field("cap", &self.leaves.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<E, F> Drop for LoserTree<E, F> {
+    fn drop(&mut self) {
+        // Drop each present leaf in place. The MaybeUninit storage
+        // doesn't drop on its own; without this loop, owned values
+        // (Strings, Boxes, Arcs, ...) inside present leaves would
+        // leak when the tree itself is dropped.
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "leaves.len() == present.len() by construction (set in build())"
+        )]
+        for i in 0..self.leaves.len() {
+            if self.present[i] {
+                // SAFETY: `present[i] == true` is the LoserTree
+                // invariant for `leaves[i]` being initialised.
+                unsafe { self.leaves[i].assume_init_drop() };
+            }
+        }
+    }
 }
 
 impl<E, F> LoserTree<E, F>
@@ -85,14 +134,31 @@ where
     pub fn build(initial: Vec<Option<E>>, cmp: F) -> Self {
         let n = initial.len();
         let cap = n.next_power_of_two().max(2);
-        let mut leaves = initial;
-        leaves.resize_with(cap, || None);
 
-        let active = leaves.iter().filter(|x| x.is_some()).count();
+        // Split the Option<E> input into parallel (MaybeUninit, bool)
+        // arrays. Trailing padding past `n` is uninit + absent.
+        let mut leaves: Vec<MaybeUninit<E>> = Vec::with_capacity(cap);
+        let mut present: Vec<bool> = Vec::with_capacity(cap);
+        let mut active = 0_usize;
+        for item in initial {
+            if let Some(v) = item {
+                leaves.push(MaybeUninit::new(v));
+                present.push(true);
+                active += 1;
+            } else {
+                leaves.push(MaybeUninit::uninit());
+                present.push(false);
+            }
+        }
+        while leaves.len() < cap {
+            leaves.push(MaybeUninit::uninit());
+            present.push(false);
+        }
         let tree = alloc::vec![0; cap];
 
         let mut t = Self {
             leaves,
+            present,
             tree,
             n_sources: n,
             active,
@@ -115,7 +181,12 @@ where
         self.n_sources
     }
 
-    /// Whether every slot is exhausted (`None`).
+    /// Whether every slot is exhausted (no present leaves).
+    #[expect(
+        clippy::inline_always,
+        reason = "called from winner_slot() on every merger step; forcing cross-crate inlining \
+                  for the bench compilation unit measurably tightens the hot loop"
+    )]
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.active == 0
@@ -139,6 +210,10 @@ where
     /// Useful for callers (like the LSM merger) that need to know
     /// *which* source produced the current minimum, so the next item
     /// from that source can be pulled in.
+    #[expect(
+        clippy::inline_always,
+        reason = "hot per-step routine; cross-crate inlining for benches"
+    )]
     #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
@@ -169,7 +244,12 @@ where
     )]
     pub fn peek_min(&self) -> Option<&E> {
         let idx = self.winner_slot()?;
-        self.leaves[idx].as_ref()
+        if !self.present[idx] {
+            return None;
+        }
+        // SAFETY: `present[idx] == true` is the LoserTree invariant
+        // for `leaves[idx]` being initialised.
+        Some(unsafe { self.leaves[idx].assume_init_ref() })
     }
 
     /// Replace the value at the winning slot with `new` and return the
@@ -197,9 +277,17 @@ where
         let slot = self
             .winner_slot()
             .expect("replace_min called on empty LoserTree");
-        let old = self.leaves[slot]
-            .replace(new)
-            .expect("LoserTree winner slot must hold Some");
+        debug_assert!(
+            self.present[slot],
+            "LoserTree winner slot must be present when winner_slot() returns Some"
+        );
+        // SAFETY: `present[slot] == true` (asserted by winner_slot
+        // returning Some plus the LoserTree invariant). The old
+        // value is read out and the new is written in its place;
+        // `present[slot]` stays `true` so no bitmap update needed.
+        let old = unsafe {
+            core::mem::replace(&mut self.leaves[slot], MaybeUninit::new(new)).assume_init()
+        };
         self.replay(slot);
         old
     }
@@ -213,14 +301,22 @@ where
     )]
     pub fn pop_min(&mut self) -> Option<E> {
         let slot = self.winner_slot()?;
-        let old = self.leaves[slot].take();
         debug_assert!(
-            old.is_some(),
-            "LoserTree winner slot must hold Some when winner_slot() returns Some"
+            self.present[slot],
+            "LoserTree winner slot must be present when winner_slot() returns Some"
         );
+        // SAFETY: present[slot] == true (LoserTree invariant for the
+        // winner slot). Reading via `replace(_, uninit)` returns the
+        // initialised value and leaves the slot as MaybeUninit::uninit;
+        // we then flip the bitmap so subsequent code (cmp_indices,
+        // peek_min, Drop) sees it as absent.
+        let old = unsafe {
+            core::mem::replace(&mut self.leaves[slot], MaybeUninit::uninit()).assume_init()
+        };
+        self.present[slot] = false;
         self.active -= 1;
         self.replay(slot);
-        old
+        Some(old)
     }
 
     /// Take the value at a specific slot (regardless of winner status)
@@ -238,10 +334,14 @@ where
         reason = "slot is checked < self.leaves.len() before indexing"
     )]
     pub fn take_slot(&mut self, slot: usize) -> Option<E> {
-        if slot >= self.leaves.len() {
+        if slot >= self.leaves.len() || !self.present[slot] {
             return None;
         }
-        let taken = self.leaves[slot].take()?;
+        // SAFETY: present[slot] == true (just checked above).
+        let taken = unsafe {
+            core::mem::replace(&mut self.leaves[slot], MaybeUninit::uninit()).assume_init()
+        };
+        self.present[slot] = false;
         self.active -= 1;
         self.replay(slot);
         Some(taken)
@@ -290,6 +390,10 @@ where
     /// the call-site branch-predictor cost; default `#[inline]` is
     /// only a hint and stops at crate boundaries (benches live in a
     /// separate compilation unit).
+    #[expect(
+        clippy::inline_always,
+        reason = "the single hot per-merger-step routine; cross-crate inlining for benches"
+    )]
     #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
@@ -314,24 +418,38 @@ where
         self.tree[0] = winner;
     }
 
-    /// Compare leaves by slot index, treating `None` as `+∞`. `None`
-    /// always loses to `Some`; `None` vs `None` returns `Equal`.
+    /// Compare leaves by slot index, treating absent slots as `+∞`.
+    /// Absent always loses to present; absent vs absent returns
+    /// `Equal`.
     ///
     /// `#[inline(always)]` — called O(log cap) times per `replay()`
     /// step, which is itself the hot per-merger-step routine. The
-    /// match-on-Options-tuple is small enough that inlining lets
-    /// LLVM fuse the discriminant checks across consecutive calls.
+    /// present-bit branch is a single byte load + predictable
+    /// compare; inlining lets LLVM fuse consecutive checks across
+    /// the replay loop.
+    #[expect(
+        clippy::inline_always,
+        reason = "called O(log cap) per replay; cross-crate inlining for benches"
+    )]
     #[inline(always)]
     #[expect(
         clippy::indexing_slicing,
-        reason = "callers (build_subtree, replay) only pass slot indices < cap"
+        reason = "callers (build_subtree, replay) only pass slot indices < cap; \
+                  present.len() == leaves.len() == cap by construction"
     )]
     fn cmp_indices(&self, a: usize, b: usize) -> Ordering {
-        match (&self.leaves[a], &self.leaves[b]) {
-            (Some(x), Some(y)) => (self.cmp)(x, y),
-            (Some(_), None) => Ordering::Less,
-            (None, Some(_)) => Ordering::Greater,
-            (None, None) => Ordering::Equal,
+        match (self.present[a], self.present[b]) {
+            (true, true) => {
+                // SAFETY: both bits set ⇒ both leaves initialised
+                // (LoserTree invariant maintained by build/replace/
+                // pop/take_slot).
+                let va = unsafe { self.leaves[a].assume_init_ref() };
+                let vb = unsafe { self.leaves[b].assume_init_ref() };
+                (self.cmp)(va, vb)
+            }
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            (false, false) => Ordering::Equal,
         }
     }
 }

--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -42,11 +42,14 @@
 //! `present: Vec<bool>` for the discriminants. This eliminates the
 //! `Option` discriminant branch that LLVM emits inside `cmp_indices`
 //! on every game (called O(log cap) times per merger step); the
-//! present-bit fetch is a single byte load that branch-predicts
-//! perfectly under steady-state merging (where leaves stay present
-//! until exhaustion). `cmp_indices` treats absent leaves as
-//! strictly greater than any present value, so exhausted sources
-//! naturally lose every game.
+//! present-bit fetch is a single byte load (in Rust's stdlib
+//! `Vec<bool>` is NOT bit-packed — each `bool` occupies one byte
+//! with valid bit-pattern `0u8`/`1u8`, so `present[i]` lowers to a
+//! single-byte read + zero-compare, not a bit-test) that
+//! branch-predicts perfectly under steady-state merging (where
+//! leaves stay present until exhaustion). `cmp_indices` treats
+//! absent leaves as strictly greater than any present value, so
+//! exhausted sources naturally lose every game.
 //!
 //! All `MaybeUninit::assume_init_*` calls are guarded by a check on
 //! the corresponding `present[i]` bit and never widen the unsafe

--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -39,22 +39,25 @@
 //! Each leaf is logically `Option<E>` — present or sentinel. The
 //! physical representation uses two parallel arrays:
 //! `leaves: Vec<MaybeUninit<E>>` for the values and
-//! `present: Vec<bool>` for the discriminants. This eliminates the
-//! `Option` discriminant branch that LLVM emits inside `cmp_indices`
-//! on every game (called O(log cap) times per merger step); the
-//! present-bit fetch is a single byte load (in Rust's stdlib
-//! `Vec<bool>` is NOT bit-packed — each `bool` occupies one byte
-//! with valid bit-pattern `0u8`/`1u8`, so `present[i]` lowers to a
-//! single-byte read + zero-compare, not a bit-test) that
-//! branch-predicts perfectly under steady-state merging (where
-//! leaves stay present until exhaustion). `cmp_indices` treats
-//! absent leaves as strictly greater than any present value, so
+//! `present: Vec<u8>` for the discriminants (one byte per slot,
+//! `1` = present, `0` = absent). `Vec<u8>` is used over `Vec<bool>`
+//! to make the byte-per-element layout self-evident from the type
+//! and avoid any ambiguity about discriminant packing — the array
+//! is a flat byte map by design.
+//!
+//! This eliminates the `Option` discriminant branch that LLVM
+//! emits inside `cmp_indices` on every game (called O(log cap)
+//! times per merger step); the present-byte fetch is a single
+//! contiguous load + zero-compare that branch-predicts perfectly
+//! under steady-state merging (where leaves stay present until
+//! exhaustion). `cmp_indices` treats absent leaves (`present[i]
+//! == 0`) as strictly greater than any present value, so
 //! exhausted sources naturally lose every game.
 //!
-//! All `MaybeUninit::assume_init_*` calls are guarded by a check on
-//! the corresponding `present[i]` bit and never widen the unsafe
-//! contract beyond what the bitmap already guarantees. `Drop`
-//! walks the bitmap and drops in place.
+//! All `MaybeUninit::assume_init_*` calls are guarded by a check
+//! on the corresponding `present[i]` byte and never widen the
+//! unsafe contract beyond what the byte-map already guarantees.
+//! `Drop` walks the byte-map and drops in place.
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
@@ -66,17 +69,19 @@ use core::mem::MaybeUninit;
 /// is `Ordering::Less` than every other leaf wins. To get max-semantics,
 /// pass a reversed comparator (`|a, b| cmp(a, b).reverse()`).
 pub struct LoserTree<E, F> {
-    /// Current value per source slot, untagged. Only meaningful when
-    /// the matching `present[i]` bit is `true`. Length is `cap`
-    /// (padded to the next power of two ≥ 2); the trailing
+    /// Current value per source slot, untagged. Only meaningful
+    /// when the matching `present[i]` byte is non-zero. Length is
+    /// `cap` (padded to the next power of two ≥ 2); the trailing
     /// `cap - n_sources` slots are permanent sentinels with
-    /// `present[i] == false`.
+    /// `present[i] == 0`.
     leaves: Vec<MaybeUninit<E>>,
-    /// Discriminant for `leaves[i]`. `true` ⇒ initialised; `false` ⇒
-    /// uninit (exhausted or padding sentinel). Walking this bitmap
-    /// alongside `leaves` replaces the `Option` discriminant the
-    /// previous layout carried inline.
-    present: Vec<bool>,
+    /// Discriminant byte for `leaves[i]`. `1` ⇒ initialised; `0` ⇒
+    /// uninit (exhausted or padding sentinel). Walking this
+    /// contiguous byte-map alongside `leaves` replaces the
+    /// `Option` discriminant the previous layout carried inline.
+    /// `u8` (not `bool`) is chosen so the byte-per-slot layout
+    /// is unambiguous from the type itself.
+    present: Vec<u8>,
     /// Tree of size `cap`. `tree[0]` = winner leaf index; `tree[1..cap]`
     /// = loser leaf index at each internal node.
     tree: Vec<usize>,
@@ -92,8 +97,12 @@ pub struct LoserTree<E, F> {
 
 impl<E: core::fmt::Debug, F> core::fmt::Debug for LoserTree<E, F> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Reconstitute the conceptual Vec<Option<&E>> view for Debug
-        // — never expose a MaybeUninit through Debug output.
+        // Print only the structural shape — never expose leaf
+        // bytes through Debug, since they sit behind MaybeUninit
+        // and may be uninitialised at any given moment. The
+        // `E: Debug` bound stays on the impl so this type can be
+        // nested inside other `#[derive(Debug)]` structs without
+        // breaking their derive expansion; we just don't use it.
         f.debug_struct("LoserTree")
             .field("n_sources", &self.n_sources)
             .field("active", &self.active)
@@ -113,8 +122,8 @@ impl<E, F> Drop for LoserTree<E, F> {
             reason = "leaves.len() == present.len() by construction (set in build())"
         )]
         for i in 0..self.leaves.len() {
-            if self.present[i] {
-                // SAFETY: `present[i] == true` is the LoserTree
+            if self.present[i] != 0 {
+                // SAFETY: `present[i] != 0` is the LoserTree
                 // invariant for `leaves[i]` being initialised.
                 unsafe { self.leaves[i].assume_init_drop() };
             }
@@ -141,21 +150,21 @@ where
         // Split the Option<E> input into parallel (MaybeUninit, bool)
         // arrays. Trailing padding past `n` is uninit + absent.
         let mut leaves: Vec<MaybeUninit<E>> = Vec::with_capacity(cap);
-        let mut present: Vec<bool> = Vec::with_capacity(cap);
+        let mut present: Vec<u8> = Vec::with_capacity(cap);
         let mut active = 0_usize;
         for item in initial {
             if let Some(v) = item {
                 leaves.push(MaybeUninit::new(v));
-                present.push(true);
+                present.push(1);
                 active += 1;
             } else {
                 leaves.push(MaybeUninit::uninit());
-                present.push(false);
+                present.push(0);
             }
         }
         while leaves.len() < cap {
             leaves.push(MaybeUninit::uninit());
-            present.push(false);
+            present.push(0);
         }
         let tree = alloc::vec![0; cap];
 
@@ -247,10 +256,10 @@ where
     )]
     pub fn peek_min(&self) -> Option<&E> {
         let idx = self.winner_slot()?;
-        if !self.present[idx] {
+        if self.present[idx] == 0 {
             return None;
         }
-        // SAFETY: `present[idx] == true` is the LoserTree invariant
+        // SAFETY: `present[idx] != 0` is the LoserTree invariant
         // for `leaves[idx]` being initialised.
         Some(unsafe { self.leaves[idx].assume_init_ref() })
     }
@@ -281,13 +290,14 @@ where
             .winner_slot()
             .expect("replace_min called on empty LoserTree");
         debug_assert!(
-            self.present[slot],
+            self.present[slot] != 0,
             "LoserTree winner slot must be present when winner_slot() returns Some"
         );
-        // SAFETY: `present[slot] == true` (asserted by winner_slot
+        // SAFETY: `present[slot] != 0` (asserted by winner_slot
         // returning Some plus the LoserTree invariant). The old
         // value is read out and the new is written in its place;
-        // `present[slot]` stays `true` so no bitmap update needed.
+        // `present[slot]` stays non-zero so no byte-map update
+        // needed.
         let old = unsafe {
             core::mem::replace(&mut self.leaves[slot], MaybeUninit::new(new)).assume_init()
         };
@@ -305,18 +315,19 @@ where
     pub fn pop_min(&mut self) -> Option<E> {
         let slot = self.winner_slot()?;
         debug_assert!(
-            self.present[slot],
+            self.present[slot] != 0,
             "LoserTree winner slot must be present when winner_slot() returns Some"
         );
-        // SAFETY: present[slot] == true (LoserTree invariant for the
-        // winner slot). Reading via `replace(_, uninit)` returns the
-        // initialised value and leaves the slot as MaybeUninit::uninit;
-        // we then flip the bitmap so subsequent code (cmp_indices,
-        // peek_min, Drop) sees it as absent.
+        // SAFETY: present[slot] != 0 (LoserTree invariant for the
+        // winner slot). Reading via `replace(_, uninit)` returns
+        // the initialised value and leaves the slot as
+        // MaybeUninit::uninit; we then flip the byte-map so
+        // subsequent code (cmp_indices, peek_min, Drop) sees it
+        // as absent.
         let old = unsafe {
             core::mem::replace(&mut self.leaves[slot], MaybeUninit::uninit()).assume_init()
         };
-        self.present[slot] = false;
+        self.present[slot] = 0;
         self.active -= 1;
         self.replay(slot);
         Some(old)
@@ -337,14 +348,14 @@ where
         reason = "slot is checked < self.leaves.len() before indexing"
     )]
     pub fn take_slot(&mut self, slot: usize) -> Option<E> {
-        if slot >= self.leaves.len() || !self.present[slot] {
+        if slot >= self.leaves.len() || self.present[slot] == 0 {
             return None;
         }
-        // SAFETY: present[slot] == true (just checked above).
+        // SAFETY: present[slot] != 0 (just checked above).
         let taken = unsafe {
             core::mem::replace(&mut self.leaves[slot], MaybeUninit::uninit()).assume_init()
         };
-        self.present[slot] = false;
+        self.present[slot] = 0;
         self.active -= 1;
         self.replay(slot);
         Some(taken)
@@ -441,11 +452,11 @@ where
                   present.len() == leaves.len() == cap by construction"
     )]
     fn cmp_indices(&self, a: usize, b: usize) -> Ordering {
-        match (self.present[a], self.present[b]) {
+        match (self.present[a] != 0, self.present[b] != 0) {
             (true, true) => {
-                // SAFETY: both bits set ⇒ both leaves initialised
-                // (LoserTree invariant maintained by build/replace/
-                // pop/take_slot).
+                // SAFETY: both bytes non-zero ⇒ both leaves
+                // initialised (LoserTree invariant maintained by
+                // build/replace/pop/take_slot).
                 let va = unsafe { self.leaves[a].assume_init_ref() };
                 let vb = unsafe { self.leaves[b].assume_init_ref() };
                 (self.cmp)(va, vb)


### PR DESCRIPTION
## Summary

Closes #283 partially — the N ≥ 16 regression is **fully closed**, and the small-N gap is **substantially reduced** but not yet inside the +5% hard requirement at N=2. Two commits land independent, bisectable wins per the issue's methodology.

| N | MergeHeap | SeekingMerger (before) | SeekingMerger (now) | Δ before | Δ now |
|--:|--:|--:|--:|--:|--:|
| 2 | 15.6 µs | ~19.9 µs | **17.3 µs** | +19% | **+11%** |
| 4 | 37.5 µs | ~46.6 µs | **40.0 µs** | +17% | **+6.7%** |
| 8 | 88.0 µs | ~107.5 µs | **92.7 µs** | +11% | **+5.3%** |
| 16 | 228.2 µs | ~262 µs | **228.3 µs** | +5% | **~0%** ✓ |
| 30 | 583.2 µs | ~569 µs | **491.6 µs** | -7% | **-15.7%** ✓ |

(`cargo bench --bench merge`, release, full sample collection. The earlier `--quick` numbers in issue #283 had high run-to-run variance; the table above is from non-quick runs that converged.)

## Commits

### 1. `perf(loser_tree): force inline replay / winner_slot / cmp_indices / is_empty`

Promoted the hot per-step helpers to `#[inline(always)]`. The bench (`benches/merge.rs`) lives in a separate compilation unit from `src/loser_tree.rs`; without explicit force-inlining, cross-crate inlining was not happening reliably and the merger's tight per-step loop ate a real function-call cost. **Inlining alone did not close the gap** (initial `--quick` reading suggested otherwise but was sample-count noise) — it stays as a baseline hardening that the next step can build on without re-fighting the inlining variable.

### 2. `perf(loser_tree): drop Option wrapping — MaybeUninit + present bitmap`

Replaced `Vec<Option<E>>` leaf storage with parallel `Vec<MaybeUninit<E>>` + `Vec<bool>` arrays. The previous layout paid two costs on every `cmp_indices` call:

1. The `Option` discriminant byte sat inline with every leaf, bloating the array and reducing how many leaves fit per cache line.
2. `match (&Option, &Option)` four-arm dispatch couldn't be fused by LLVM across the O(log cap) replay loop because the discriminant lived inside each leaf.

Splitting moves discriminants into a contiguous bitmap (branch-predictor-friendly under steady-state merging) and lets the leaves array stay densely packed. Every `assume_init_*` is guarded by a check on the matching `present[i]` bit; the unsafe contract doesn't widen beyond what the bitmap already guarantees. `Drop` walks the bitmap and `assume_init_drop`s each present leaf so owned values inside `InternalValue` don't leak. Manual `core::fmt::Debug` impl replaces the derive (which `MaybeUninit` deliberately doesn't support).

**This is the bulk of the win** — closed +19% → +11% at N=2, +17% → +6.7% at N=4, +5% → ~0% at N=16, and flipped N=30 from -7% to **-15.7% faster**.

## Acceptance status

| N | Hard requirement (≤+5%) | Goal (≤ MergeHeap) | Status |
|--:|:-:|:-:|---|
| 2 | ❌ (+11%) | ❌ | needs more work |
| 4 | ❌ (+6.7%) | ❌ | needs more work |
| 8 | ❌ (+5.3%) | ❌ | right at the bar |
| 16 | ✓ (~0%) | ✓ | **meets goal** |
| 30 | ✓ (-15.7%) | ✓ | **meets goal** |

## What's left for the remaining N≤8 gap

The remaining ~5-11% is concentrated in `cmp_indices` comparator dispatch: `EntryCmp = Box<dyn Fn(&MergerEntry, &MergerEntry) -> Ordering>` is one indirect call, and inside that closure `SharedComparator = Arc<dyn UserComparator>` is a second indirect call. Two dispatch layers on the merger's hottest path.

Closing that requires either:

- monomorphizing `SeekingMerger` over the comparator's concrete type (infects the struct's type signature — every caller has to thread the type or use `impl Trait`), or
- replacing the `Fn` bound on `LoserTree` with a domain-specific `LeafCmp` trait that lets `SeekingMerger` pass a concrete callable struct (defines a new trait, changes the `LoserTree` generic surface).

Both are more invasive than what this PR took on. I think they're best as a separate follow-up (own scope, own bench delta) rather than absorbed here. Happy to do that next.

## Test plan

- [x] 27/27 `loser_tree::tests::` + `seeking_merger::tests::` pass
- [x] 1362/1362 full workspace `cargo nextest run` pass — no regression to existing callers (`Slice`-backed `InternalValue` drops cleanly through the new `Drop` impl; existing `Tree` / `BlobTree` / `Merger` paths untouched)
- [x] `cargo clippy --lib --tests --benches` — clean
- [x] Bench runs as documented above

## Related

- #222 — the original SeekingMerger PR whose small-N regression this addresses
- #283 — this issue, partial close (large-N done, small-N reduced)
- Possible follow-up: comparator-dispatch optimization for the remaining N≤8 gap (see "What's left" above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Optimization**
  * Reduced memory overhead and faster hot-path comparisons in core merging/selection, improving throughput on large inputs.
* **Reliability / Bug Fixes**
  * More predictable and robust handling of missing or absent inputs during selection, replacement, and removal.
  * Safer cleanup and debug output to reduce edge-case failures and improve diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->