### PR TITLE
feat(range): wire SeekingMerger into Tree::range read path (#222)

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -4,14 +4,16 @@
 
 use crate::{
     BoxedIterator, InternalValue,
+    comparator::SharedComparator,
     key::InternalKey,
     memtable::Memtable,
-    merge::Merger,
     merge_operator::MergeOperator,
+    merge_source::{CoherentIterSource, CoherentMergeSource},
     mvcc_stream::MvccStream,
     range_tombstone::RangeTombstone,
     range_tombstone_filter::RangeTombstoneFilter,
     run_reader::RunReader,
+    seeking_merger::SeekingMerger,
     value::{SeqNo, UserKey},
     version::{Run, SuperVersion},
 };
@@ -24,6 +26,30 @@ use std::{
 #[must_use]
 pub fn seqno_filter(item_seqno: SeqNo, seqno: SeqNo) -> bool {
     item_seqno < seqno
+}
+
+/// Wrap a vector of boxed double-ended source iterators into a
+/// `SeekingMerger`, the loser-tree-based merging iterator that
+/// replaces the legacy `Merger` (sorted-vector heap) on the read
+/// path. The `BoxedIterator`s become `MergeSource`s via the
+/// `CoherentIterSource` adapter — its coherent-cursor contract
+/// is satisfied by every memtable / run / table iter we feed in
+/// here (they all share a single front/back cursor over the
+/// remaining range).
+///
+/// The compaction merge path still uses the legacy `Merger`
+/// because compaction `Scanner`s are forward-only (`Iterator`,
+/// not `DoubleEndedIterator`) and `MergeSource` requires
+/// `next_back`. That swap is a separate refactor.
+fn build_seeking<'a>(
+    iters: Vec<BoxedIterator<'a>>,
+    comparator: SharedComparator,
+) -> SeekingMerger<Box<dyn CoherentMergeSource + 'a>, SharedComparator> {
+    let sources: Vec<Box<dyn CoherentMergeSource + 'a>> = iters
+        .into_iter()
+        .map(|it| Box::new(CoherentIterSource::new(it)) as Box<dyn CoherentMergeSource + 'a>)
+        .collect();
+    SeekingMerger::new(sources, comparator)
 }
 
 /// Calculates the prefix's upper range.
@@ -392,7 +418,7 @@ impl TreeIter {
                 ));
             }
 
-            let merged = Merger::new(iters, lock.comparator.clone());
+            let merged = build_seeking(iters, lock.comparator.clone());
             // Clone is cheap: point-read RT sets are typically 0-2 entries.
             // An Arc would add indirection overhead that exceeds the clone cost.
             let iter = MvccStream::new_with_comparator(
@@ -753,7 +779,7 @@ impl TreeIter {
                 iters.push(iter);
             }
 
-            let merged = Merger::new(iters, lock.comparator.clone());
+            let merged = build_seeking(iters, lock.comparator.clone());
             // Clone needed: MvccStream uses the RT set for merge suppression,
             // while RangeTombstoneFilter below consumes it for post-merge
             // filtering. An Arc<[_]> could avoid the copy if RT sets grow large.

--- a/src/range.rs
+++ b/src/range.rs
@@ -8,7 +8,7 @@ use crate::{
     key::InternalKey,
     memtable::Memtable,
     merge_operator::MergeOperator,
-    merge_source::{CoherentIterSource, CoherentMergeSource},
+    merge_source::CoherentIterSource,
     mvcc_stream::MvccStream,
     range_tombstone::RangeTombstone,
     range_tombstone_filter::RangeTombstoneFilter,
@@ -37,6 +37,15 @@ pub fn seqno_filter(item_seqno: SeqNo, seqno: SeqNo) -> bool {
 /// here (they all share a single front/back cursor over the
 /// remaining range).
 ///
+/// The source type stays concrete (`CoherentIterSource<BoxedIterator<'a>>`)
+/// rather than being re-boxed behind a `dyn MergeSource` trait
+/// object: `BoxedIterator` is itself already a heap-allocated
+/// trait object, so wrapping it in another `Box<dyn ...>` would
+/// cost an extra allocation per source AND an extra vtable
+/// dispatch on every `next`/`next_back`. With the concrete
+/// adapter type, only the inner `BoxedIterator`'s vtable
+/// remains — exactly one indirect call per per-step source pull.
+///
 /// The compaction merge path still uses the legacy `Merger`
 /// because compaction `Scanner`s are forward-only (`Iterator`,
 /// not `DoubleEndedIterator`) and `MergeSource` requires
@@ -44,11 +53,9 @@ pub fn seqno_filter(item_seqno: SeqNo, seqno: SeqNo) -> bool {
 fn build_seeking<'a>(
     iters: Vec<BoxedIterator<'a>>,
     comparator: SharedComparator,
-) -> SeekingMerger<Box<dyn CoherentMergeSource + 'a>, SharedComparator> {
-    let sources: Vec<Box<dyn CoherentMergeSource + 'a>> = iters
-        .into_iter()
-        .map(|it| Box::new(CoherentIterSource::new(it)) as Box<dyn CoherentMergeSource + 'a>)
-        .collect();
+) -> SeekingMerger<CoherentIterSource<BoxedIterator<'a>>, SharedComparator> {
+    let sources: Vec<CoherentIterSource<BoxedIterator<'a>>> =
+        iters.into_iter().map(CoherentIterSource::new).collect();
     SeekingMerger::new(sources, comparator)
 }
 


### PR DESCRIPTION
## Summary

Closes #222.

PRs #284 / #286 / #287 built and optimised `SeekingMerger` (loser-tree-based merging iterator) end-to-end. The bench delta against `MergeHeap`-backed `Merger`:

| N | MergeHeap (prev prod) | SeekingMerger (now prod) | Δ |
|---:|---:|---:|---:|
| 2 | 16.4 µs | **15.3 µs** | **-6.7%** |
| 4 | 39.1 µs | **37.6 µs** | **-3.8%** |
| 8 | 91.7 µs | **89.2 µs** | **-2.7%** |
| 16 | 241.4 µs | **213.8 µs** | **-11.4%** |
| 30 | 570.7 µs | **455.7 µs** | **-20.2%** |

Until now those wins lived only in the bench — production read paths in `range.rs` were still going through `Merger::new(...)`. This PR replaces both call sites with a new `build_seeking(...)` helper that wraps each `Vec<BoxedIterator<'a>>` (boxed double-ended source iters from memtables / runs / tables) into a `SeekingMerger<Box<dyn CoherentMergeSource + 'a>, SharedComparator>` via the `CoherentIterSource` adapter. The adapter's coherent-cursor contract is satisfied by every iterator we feed in (each shares a single front/back cursor over its remaining range — std vec/btree style).

## Scope

**Switched to SeekingMerger:**

- `range.rs:395` — point-read range merge (single-key range, used by `Tree::get`-via-range pipeline + MVCC + RT suppression)
- `range.rs:756` — `create_range` path (the main `Tree::range` iterator)

**Left on legacy `Merger` (out of scope):**

- `abstract_tree.rs:213` — flush merger. Output goes to `CompactionStream` which only needs forward `Iterator`; flush is not a read-path hotspot, and switching it would require additional verification of the write path.
- `compaction/worker.rs:202` — compaction merger. Compaction `Scanner`s are forward-only (`CompactionReader = Box<dyn Iterator<...>>`), and `MergeSource` requires `next_back`. Replacing compaction's merger is a separate refactor (either drop `next_back` from `MergeSource`, or build a forward-only `SeekingMerger` variant).

## Why the helper

The conversion `Vec<BoxedIterator<'a>>` → `Vec<Box<dyn CoherentMergeSource + 'a>>` is identical at both call sites, and the trait-object cast (`as Box<dyn CoherentMergeSource + 'a>`) is annoyingly verbose inline. Factoring into `build_seeking` keeps the call sites a single line each and centralises the "we promise these iterators are coherent" rationale in one place (the helper's doc comment).

The helper signature deliberately fixes `C = SharedComparator` (= `Arc<dyn UserComparator>`): `range.rs` already holds the canonical shared comparator, and the blanket `impl UserComparator for Arc<T>` from PR #287 makes it satisfy `C: UserComparator + Clone` without any API change. Production callers don't get the full monomorphisation win that the bench shows for `DefaultUserComparator` (the Arc indirection stays), but they DO get:

- Loser-tree's K-1-comparison structural advantage
- Closure-in-a-box dispatch removed
- Per-cmp direction branch removed (`MinCmp` vs `MaxCmp`)
- `MaybeUninit + present byte-map` cache-friendly leaf layout

— i.e. everything from the #283 work series except the inner-`UserComparator`-vtable removal.

## Test plan

- [x] `cargo nextest run --workspace` — **1362/1362 pass.** Tree::range / point-read range / RT suppression all exercise the new merger; no regression to any existing behaviour
- [x] `cargo clippy --lib --tests --benches` — clean
- [x] `cargo bench --bench merge` micro-bench (PR #287) continues to gate any regression on the `SeekingMerger` itself; wiring it in surfaces the bench delta to the production read path without re-running the same micro-bench

Closes #222.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal refactor of range iteration and merging used in read operations, replacing prior merging implementation with an updated merging pathway.
  * No changes to exported/public interfaces; end-user behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->