### PR TITLE
refactor(table/block/tests): extract write_block_to_tempfile helper (#128 part 1)

### DIFF
--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -738,13 +738,32 @@ mod tests {
     use super::*;
     use test_log::test;
 
+    /// Result of [`write_block_to_tempfile`]. Named struct (not a
+    /// 4-tuple) so call-site destructuring is self-documenting
+    /// and order-independent — tests that only care about `file`
+    /// and `handle` skip `dir` by name instead of by position.
+    /// The internal header is consumed by the helper itself to
+    /// build `handle`; tests don't need it.
+    struct TempBlock {
+        /// Keep bound for the test lifetime — drop reclaims the
+        /// directory and the file inside it. Leading underscore
+        /// at the binding site (`dir: _dir`) is the convention
+        /// for call sites that only need the drop-side effect.
+        dir: tempfile::TempDir,
+        /// Open read-only handle on the persisted block.
+        file: std::fs::File,
+        /// Pre-computed handle: offset 0, length = header +
+        /// payload, ready to pass straight into `Block::from_file`.
+        handle: crate::table::BlockHandle,
+    }
+
     /// Shared scaffold for `Block::from_file` roundtrip tests: writes
-    /// `data` through `Block::write_into` into a fresh tempdir-backed
-    /// file, reopens it read-only, and returns the FD + handle + header
-    /// the caller needs to invoke `Block::from_file`. The `TempDir` is
-    /// returned so the caller can keep it bound for the test lifetime —
-    /// once it drops, the directory (and the file inside it) is
-    /// reclaimed.
+    /// `data` through `Block::write_into` directly into a fresh
+    /// tempdir-backed file, reopens it read-only, and returns the
+    /// FD + handle + header the caller needs to invoke
+    /// `Block::from_file`. The streaming write avoids an
+    /// intermediate `Vec<u8>` — relevant for the 32 KiB
+    /// large-payload encryption test.
     ///
     /// Centralises the ~10× write/sync/reopen/handle boilerplate that
     /// the `from_file` tests below would otherwise duplicate.
@@ -754,44 +773,42 @@ mod tests {
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
-    ) -> crate::Result<(
-        tempfile::TempDir,
-        std::fs::File,
-        crate::table::BlockHandle,
-        Header,
-    )> {
-        use std::io::Write;
-
-        let mut buf = vec![];
-        let header = Block::write_into(
-            &mut buf,
-            data,
-            block_type,
-            compression,
-            encryption,
-            #[cfg(zstd_any)]
-            zstd_dict,
-        )?;
-
+    ) -> crate::Result<TempBlock> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("block");
-        let mut file = std::fs::File::create(&path)?;
-        file.write_all(&buf)?;
-        file.sync_all()?;
-        drop(file);
-
+        // Scope the write-side file handle so the read-side
+        // `File::open` below sees a fully-flushed file. Dropping
+        // closes; sync_all flushes before close.
+        let header = {
+            let mut file = std::fs::File::create(&path)?;
+            let header = Block::write_into(
+                &mut file,
+                data,
+                block_type,
+                compression,
+                encryption,
+                #[cfg(zstd_any)]
+                zstd_dict,
+            )?;
+            file.sync_all()?;
+            header
+        };
         let file = std::fs::File::open(&path)?;
         let handle = crate::table::BlockHandle::new(
             BlockOffset(0),
             header.data_length + Header::serialized_len() as u32,
         );
-        Ok((dir, file, handle, header))
+        Ok(TempBlock { dir, file, handle })
     }
 
     #[test]
     fn block_from_file_roundtrip_uncompressed() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let (_dir, file, handle, _) = write_block_to_tempfile(
+        let TempBlock {
+            dir: _dir,
+            file,
+            handle,
+        } = write_block_to_tempfile(
             data,
             BlockType::Data,
             CompressionType::None,
@@ -815,7 +832,11 @@ mod tests {
     #[cfg(feature = "lz4")]
     fn block_from_file_roundtrip_lz4() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let (_dir, file, handle, _) = write_block_to_tempfile(
+        let TempBlock {
+            dir: _dir,
+            file,
+            handle,
+        } = write_block_to_tempfile(
             data,
             BlockType::Data,
             CompressionType::Lz4,
@@ -839,8 +860,11 @@ mod tests {
     #[cfg(zstd_any)]
     fn block_from_file_roundtrip_zstd() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let (_dir, file, handle, _) =
-            write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
+        let TempBlock {
+            dir: _dir,
+            file,
+            handle,
+        } = write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
         let block = Block::from_file(&file, handle, CompressionType::Zstd(3), None, None)?;
         assert_eq!(data, &*block.data);
         Ok(())
@@ -1461,7 +1485,11 @@ mod tests {
         fn block_from_file_encrypted_uncompressed() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"plaintext block data for from_file encryption test";
-            let (_dir, file, handle, _) = super::write_block_to_tempfile(
+            let super::TempBlock {
+                dir: _dir,
+                file,
+                handle,
+            } = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1486,7 +1514,11 @@ mod tests {
         fn block_from_file_encrypted_lz4() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let (_dir, file, handle, _) = super::write_block_to_tempfile(
+            let super::TempBlock {
+                dir: _dir,
+                file,
+                handle,
+            } = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Lz4,
@@ -1511,7 +1543,11 @@ mod tests {
         fn block_from_file_encrypted_zstd() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let (_dir, file, handle, _) = super::write_block_to_tempfile(
+            let super::TempBlock {
+                dir: _dir,
+                file,
+                handle,
+            } = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Zstd(3),
@@ -1529,7 +1565,11 @@ mod tests {
             let enc_write = test_provider();
             let enc_read = crate::encryption::Aes256GcmProvider::new(&[0x99; 32]);
             let data = b"encrypted block data";
-            let (_dir, file, handle, _) = super::write_block_to_tempfile(
+            let super::TempBlock {
+                dir: _dir,
+                file,
+                handle,
+            } = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1676,7 +1716,11 @@ mod tests {
         fn block_from_file_encrypted_uncompressed_large_payload() -> crate::Result<()> {
             let enc = test_provider();
             let data = vec![0xBB_u8; 32 * 1024]; // 32 KiB
-            let (_dir, file, handle, _) = super::write_block_to_tempfile(
+            let super::TempBlock {
+                dir: _dir,
+                file,
+                handle,
+            } = super::write_block_to_tempfile(
                 &data,
                 BlockType::Data,
                 CompressionType::None,

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -742,27 +742,36 @@ mod tests {
     /// 4-tuple) so call-site destructuring is self-documenting
     /// and order-independent — tests that only care about `file`
     /// and `handle` skip `dir` by name instead of by position.
-    /// The internal header is consumed by the helper itself to
-    /// build `handle`; tests don't need it.
+    ///
+    /// **Field order matters for `Drop`.** Rust drops struct
+    /// fields in declaration order, so `file` and `handle` are
+    /// listed first and `dir` LAST: when the whole `TempBlock`
+    /// goes out of scope as a unit (rather than being
+    /// destructured), the open file handle closes before the
+    /// `TempDir` removes the directory. Windows rejects
+    /// directory removal while a file inside it is still open;
+    /// the order makes the helper portable.
     struct TempBlock {
-        /// Keep bound for the test lifetime — drop reclaims the
-        /// directory and the file inside it. Leading underscore
-        /// at the binding site (`dir: _dir`) is the convention
-        /// for call sites that only need the drop-side effect.
-        dir: tempfile::TempDir,
         /// Open read-only handle on the persisted block.
+        /// Declared first so it drops before `dir`.
         file: std::fs::File,
         /// Pre-computed handle: offset 0, length = header +
         /// payload, ready to pass straight into `Block::from_file`.
         handle: crate::table::BlockHandle,
+        /// Keep bound for the test lifetime — drop reclaims the
+        /// directory and the file inside it. Declared LAST so
+        /// the file handle above closes before this removes the
+        /// directory.
+        dir: tempfile::TempDir,
     }
 
     /// Shared scaffold for `Block::from_file` roundtrip tests: writes
     /// `data` through `Block::write_into` directly into a fresh
-    /// tempdir-backed file, reopens it read-only, and returns the
-    /// FD + handle + header the caller needs to invoke
-    /// `Block::from_file`. The streaming write avoids an
-    /// intermediate `Vec<u8>` — relevant for the 32 KiB
+    /// tempdir-backed file, reopens it read-only, and returns a
+    /// [`TempBlock`] bundling the open file, the pre-computed
+    /// [`crate::table::BlockHandle`], and the owning [`tempfile::TempDir`]
+    /// (kept bound for the test's lifetime). The streaming write
+    /// avoids an intermediate `Vec<u8>` — relevant for the 32 KiB
     /// large-payload encryption test.
     ///
     /// Centralises the ~10× write/sync/reopen/handle boilerplate that
@@ -798,7 +807,7 @@ mod tests {
             BlockOffset(0),
             header.data_length + Header::serialized_len() as u32,
         );
-        Ok(TempBlock { dir, file, handle })
+        Ok(TempBlock { file, handle, dir })
     }
 
     #[test]

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -739,18 +739,42 @@ mod tests {
     use test_log::test;
 
     /// Result of [`write_block_to_tempfile`]. Named struct (not a
-    /// 4-tuple) so call-site destructuring is self-documenting
-    /// and order-independent — tests that only care about `file`
-    /// and `handle` skip `dir` by name instead of by position.
+    /// 4-tuple) so call-site destructuring is self-documenting —
+    /// tests that only care about `file` and `handle` skip `dir`
+    /// by name instead of by position.
     ///
-    /// **Field order matters for `Drop`.** Rust drops struct
-    /// fields in declaration order, so `file` and `handle` are
-    /// listed first and `dir` LAST: when the whole `TempBlock`
-    /// goes out of scope as a unit (rather than being
-    /// destructured), the open file handle closes before the
-    /// `TempDir` removes the directory. Windows rejects
-    /// directory removal while a file inside it is still open;
-    /// the order makes the helper portable.
+    /// **Two separate drop-order constraints apply; both matter
+    /// for Windows portability:**
+    ///
+    /// 1. **Struct field order.** Rust drops struct fields in
+    ///    declaration order, so `file` and `handle` are listed
+    ///    first and `dir` LAST. When a `TempBlock` value goes
+    ///    out of scope as a unit (e.g., bubbled via `?`, returned
+    ///    from a helper, or stored in a `Vec`), the open file
+    ///    handle closes before the `TempDir` removes the
+    ///    directory.
+    ///
+    /// 2. **Local-binding order in destructuring patterns.**
+    ///    Local bindings drop in REVERSE declaration order. So
+    ///    a call site MUST bind `dir` FIRST in its pattern so
+    ///    that the `dir` binding drops LAST:
+    ///
+    ///    ```ignore
+    ///    // CORRECT: dir bound first → drops last
+    ///    let TempBlock { dir: _dir, file, handle } = ...?;
+    ///    ```
+    ///
+    ///    The opposite order would close the directory before
+    ///    the file:
+    ///
+    ///    ```ignore
+    ///    // WRONG on Windows: dir bound last → drops first,
+    ///    // removes directory while `file` is still open.
+    ///    let TempBlock { file, handle, dir: _dir } = ...?;
+    ///    ```
+    ///
+    /// Existing call sites in this module follow constraint #2.
+    /// New callers MUST do the same.
     struct TempBlock {
         /// Open read-only handle on the persisted block.
         /// Declared first so it drops before `dir`.

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -738,43 +738,28 @@ mod tests {
     use super::*;
     use test_log::test;
 
-    /// Result of [`write_block_to_tempfile`]. Named struct (not a
-    /// 4-tuple) so call-site destructuring is self-documenting —
-    /// tests that only care about `file` and `handle` skip `dir`
-    /// by name instead of by position.
+    /// Result of [`write_block_to_tempfile`]. Bundles the open
+    /// file, the pre-computed [`crate::table::BlockHandle`], and
+    /// the owning [`tempfile::TempDir`].
     ///
-    /// **Two separate drop-order constraints apply; both matter
-    /// for Windows portability:**
+    /// **Drop-order safety lives entirely in the struct field
+    /// order** (Windows portability constraint). Rust drops
+    /// struct fields in declaration order, so `file` is first
+    /// and `dir` LAST: when a `TempBlock` value goes out of
+    /// scope, the open file handle closes before the `TempDir`
+    /// removes the directory. Windows rejects directory
+    /// removal while a file inside it is still open.
     ///
-    /// 1. **Struct field order.** Rust drops struct fields in
-    ///    declaration order, so `file` and `handle` are listed
-    ///    first and `dir` LAST. When a `TempBlock` value goes
-    ///    out of scope as a unit (e.g., bubbled via `?`, returned
-    ///    from a helper, or stored in a `Vec`), the open file
-    ///    handle closes before the `TempDir` removes the
-    ///    directory.
-    ///
-    /// 2. **Local-binding order in destructuring patterns.**
-    ///    Local bindings drop in REVERSE declaration order. So
-    ///    a call site MUST bind `dir` FIRST in its pattern so
-    ///    that the `dir` binding drops LAST:
-    ///
-    ///    ```ignore
-    ///    // CORRECT: dir bound first → drops last
-    ///    let TempBlock { dir: _dir, file, handle } = ...?;
-    ///    ```
-    ///
-    ///    The opposite order would close the directory before
-    ///    the file:
-    ///
-    ///    ```ignore
-    ///    // WRONG on Windows: dir bound last → drops first,
-    ///    // removes directory while `file` is still open.
-    ///    let TempBlock { file, handle, dir: _dir } = ...?;
-    ///    ```
-    ///
-    /// Existing call sites in this module follow constraint #2.
-    /// New callers MUST do the same.
+    /// **Callers SHOULD keep the result as a single binding**
+    /// — borrow `&tmp.file` and copy `tmp.handle` (it's `Copy`)
+    /// instead of destructuring. Destructuring opens a
+    /// foot-gun: local bindings drop in REVERSE declaration
+    /// order, so a pattern like
+    /// `let TempBlock { file, handle, dir: _dir } = ...?;`
+    /// would close `dir` before `file` and break the
+    /// invariant. Holding the whole struct as one local
+    /// (`let tmp = ...?;`) makes the struct field order the
+    /// SOLE source of truth — no pattern can break it.
     struct TempBlock {
         /// Open read-only handle on the persisted block.
         /// Declared first so it drops before `dir`.
@@ -785,7 +770,15 @@ mod tests {
         /// Keep bound for the test lifetime — drop reclaims the
         /// directory and the file inside it. Declared LAST so
         /// the file handle above closes before this removes the
-        /// directory.
+        /// directory. The field is never READ — its only purpose
+        /// is its `Drop` side-effect — so the dead-code lint
+        /// would flag it without this `expect`.
+        #[expect(
+            dead_code,
+            reason = "Drop guard for the tempdir; held purely for the \
+                      destructor's side-effect of cleaning up the \
+                      directory + the file inside it"
+        )]
         dir: tempfile::TempDir,
     }
 
@@ -837,11 +830,7 @@ mod tests {
     #[test]
     fn block_from_file_roundtrip_uncompressed() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let TempBlock {
-            dir: _dir,
-            file,
-            handle,
-        } = write_block_to_tempfile(
+        let tmp = write_block_to_tempfile(
             data,
             BlockType::Data,
             CompressionType::None,
@@ -850,8 +839,8 @@ mod tests {
             None,
         )?;
         let block = Block::from_file(
-            &file,
-            handle,
+            &tmp.file,
+            tmp.handle,
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -865,11 +854,7 @@ mod tests {
     #[cfg(feature = "lz4")]
     fn block_from_file_roundtrip_lz4() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let TempBlock {
-            dir: _dir,
-            file,
-            handle,
-        } = write_block_to_tempfile(
+        let tmp = write_block_to_tempfile(
             data,
             BlockType::Data,
             CompressionType::Lz4,
@@ -878,8 +863,8 @@ mod tests {
             None,
         )?;
         let block = Block::from_file(
-            &file,
-            handle,
+            &tmp.file,
+            tmp.handle,
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -893,12 +878,9 @@ mod tests {
     #[cfg(zstd_any)]
     fn block_from_file_roundtrip_zstd() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let TempBlock {
-            dir: _dir,
-            file,
-            handle,
-        } = write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
-        let block = Block::from_file(&file, handle, CompressionType::Zstd(3), None, None)?;
+        let tmp =
+            write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
+        let block = Block::from_file(&tmp.file, tmp.handle, CompressionType::Zstd(3), None, None)?;
         assert_eq!(data, &*block.data);
         Ok(())
     }
@@ -1518,11 +1500,7 @@ mod tests {
         fn block_from_file_encrypted_uncompressed() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"plaintext block data for from_file encryption test";
-            let super::TempBlock {
-                dir: _dir,
-                file,
-                handle,
-            } = super::write_block_to_tempfile(
+            let tmp = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1531,8 +1509,8 @@ mod tests {
                 None,
             )?;
             let block = Block::from_file(
-                &file,
-                handle,
+                &tmp.file,
+                tmp.handle,
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1547,11 +1525,7 @@ mod tests {
         fn block_from_file_encrypted_lz4() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let super::TempBlock {
-                dir: _dir,
-                file,
-                handle,
-            } = super::write_block_to_tempfile(
+            let tmp = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Lz4,
@@ -1560,8 +1534,8 @@ mod tests {
                 None,
             )?;
             let block = Block::from_file(
-                &file,
-                handle,
+                &tmp.file,
+                tmp.handle,
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1576,19 +1550,20 @@ mod tests {
         fn block_from_file_encrypted_zstd() -> crate::Result<()> {
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let super::TempBlock {
-                dir: _dir,
-                file,
-                handle,
-            } = super::write_block_to_tempfile(
+            let tmp = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Zstd(3),
                 Some(&enc),
                 None,
             )?;
-            let block =
-                Block::from_file(&file, handle, CompressionType::Zstd(3), Some(&enc), None)?;
+            let block = Block::from_file(
+                &tmp.file,
+                tmp.handle,
+                CompressionType::Zstd(3),
+                Some(&enc),
+                None,
+            )?;
             assert_eq!(data, &*block.data);
             Ok(())
         }
@@ -1598,11 +1573,7 @@ mod tests {
             let enc_write = test_provider();
             let enc_read = crate::encryption::Aes256GcmProvider::new(&[0x99; 32]);
             let data = b"encrypted block data";
-            let super::TempBlock {
-                dir: _dir,
-                file,
-                handle,
-            } = super::write_block_to_tempfile(
+            let tmp = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1611,8 +1582,8 @@ mod tests {
                 None,
             )?;
             let result = Block::from_file(
-                &file,
-                handle,
+                &tmp.file,
+                tmp.handle,
                 CompressionType::None,
                 Some(&enc_read),
                 #[cfg(zstd_any)]
@@ -1749,11 +1720,7 @@ mod tests {
         fn block_from_file_encrypted_uncompressed_large_payload() -> crate::Result<()> {
             let enc = test_provider();
             let data = vec![0xBB_u8; 32 * 1024]; // 32 KiB
-            let super::TempBlock {
-                dir: _dir,
-                file,
-                handle,
-            } = super::write_block_to_tempfile(
+            let tmp = super::write_block_to_tempfile(
                 &data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1762,8 +1729,8 @@ mod tests {
                 None,
             )?;
             let block = Block::from_file(
-                &file,
-                handle,
+                &tmp.file,
+                tmp.handle,
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -738,20 +738,39 @@ mod tests {
     use super::*;
     use test_log::test;
 
-    #[test]
-    fn block_from_file_roundtrip_uncompressed() -> crate::Result<()> {
+    /// Shared scaffold for `Block::from_file` roundtrip tests: writes
+    /// `data` through `Block::write_into` into a fresh tempdir-backed
+    /// file, reopens it read-only, and returns the FD + handle + header
+    /// the caller needs to invoke `Block::from_file`. The `TempDir` is
+    /// returned so the caller can keep it bound for the test lifetime —
+    /// once it drops, the directory (and the file inside it) is
+    /// reclaimed.
+    ///
+    /// Centralises the ~10× write/sync/reopen/handle boilerplate that
+    /// the `from_file` tests below would otherwise duplicate.
+    fn write_block_to_tempfile(
+        data: &[u8],
+        block_type: BlockType,
+        compression: CompressionType,
+        encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+        #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
+    ) -> crate::Result<(
+        tempfile::TempDir,
+        std::fs::File,
+        crate::table::BlockHandle,
+        Header,
+    )> {
         use std::io::Write;
 
-        let data = b"abcdefabcdefabcdef";
         let mut buf = vec![];
         let header = Block::write_into(
             &mut buf,
             data,
-            BlockType::Data,
-            CompressionType::None,
-            None,
+            block_type,
+            compression,
+            encryption,
             #[cfg(zstd_any)]
-            None,
+            zstd_dict,
         )?;
 
         let dir = tempfile::tempdir()?;
@@ -766,6 +785,20 @@ mod tests {
             BlockOffset(0),
             header.data_length + Header::serialized_len() as u32,
         );
+        Ok((dir, file, handle, header))
+    }
+
+    #[test]
+    fn block_from_file_roundtrip_uncompressed() -> crate::Result<()> {
+        let data = b"abcdefabcdefabcdef";
+        let (_dir, file, handle, _) = write_block_to_tempfile(
+            data,
+            BlockType::Data,
+            CompressionType::None,
+            None,
+            #[cfg(zstd_any)]
+            None,
+        )?;
         let block = Block::from_file(
             &file,
             handle,
@@ -775,19 +808,14 @@ mod tests {
             None,
         )?;
         assert_eq!(data, &*block.data);
-
         Ok(())
     }
 
     #[test]
     #[cfg(feature = "lz4")]
     fn block_from_file_roundtrip_lz4() -> crate::Result<()> {
-        use std::io::Write;
-
         let data = b"abcdefabcdefabcdef";
-        let mut buf = vec![];
-        let header = Block::write_into(
-            &mut buf,
+        let (_dir, file, handle, _) = write_block_to_tempfile(
             data,
             BlockType::Data,
             CompressionType::Lz4,
@@ -795,19 +823,6 @@ mod tests {
             #[cfg(zstd_any)]
             None,
         )?;
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("block");
-        let mut file = std::fs::File::create(&path)?;
-        file.write_all(&buf)?;
-        file.sync_all()?;
-        drop(file);
-
-        let file = std::fs::File::open(&path)?;
-        let handle = crate::table::BlockHandle::new(
-            BlockOffset(0),
-            header.data_length + Header::serialized_len() as u32,
-        );
         let block = Block::from_file(
             &file,
             handle,
@@ -817,41 +832,17 @@ mod tests {
             None,
         )?;
         assert_eq!(data, &*block.data);
-
         Ok(())
     }
 
     #[test]
     #[cfg(zstd_any)]
     fn block_from_file_roundtrip_zstd() -> crate::Result<()> {
-        use std::io::Write;
-
         let data = b"abcdefabcdefabcdef";
-        let mut buf = vec![];
-        let header = Block::write_into(
-            &mut buf,
-            data,
-            BlockType::Data,
-            CompressionType::Zstd(3),
-            None,
-            None,
-        )?;
-
-        let dir = tempfile::tempdir()?;
-        let path = dir.path().join("block");
-        let mut file = std::fs::File::create(&path)?;
-        file.write_all(&buf)?;
-        file.sync_all()?;
-        drop(file);
-
-        let file = std::fs::File::open(&path)?;
-        let handle = crate::table::BlockHandle::new(
-            BlockOffset(0),
-            header.data_length + Header::serialized_len() as u32,
-        );
+        let (_dir, file, handle, _) =
+            write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
         let block = Block::from_file(&file, handle, CompressionType::Zstd(3), None, None)?;
         assert_eq!(data, &*block.data);
-
         Ok(())
     }
 
@@ -1468,13 +1459,9 @@ mod tests {
 
         #[test]
         fn block_from_file_encrypted_uncompressed() -> crate::Result<()> {
-            use std::io::Write;
-
             let enc = test_provider();
             let data = b"plaintext block data for from_file encryption test";
-            let mut buf = vec![];
-            let header = Block::write_into(
-                &mut buf,
+            let (_dir, file, handle, _) = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1482,19 +1469,6 @@ mod tests {
                 #[cfg(zstd_any)]
                 None,
             )?;
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("block");
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(&buf)?;
-            file.sync_all()?;
-            drop(file);
-
-            let file = std::fs::File::open(&path)?;
-            let handle = crate::table::BlockHandle::new(
-                BlockOffset(0),
-                header.data_length + Header::serialized_len() as u32,
-            );
             let block = Block::from_file(
                 &file,
                 handle,
@@ -1510,13 +1484,9 @@ mod tests {
         #[test]
         #[cfg(feature = "lz4")]
         fn block_from_file_encrypted_lz4() -> crate::Result<()> {
-            use std::io::Write;
-
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let mut buf = vec![];
-            let header = Block::write_into(
-                &mut buf,
+            let (_dir, file, handle, _) = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Lz4,
@@ -1524,19 +1494,6 @@ mod tests {
                 #[cfg(zstd_any)]
                 None,
             )?;
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("block");
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(&buf)?;
-            file.sync_all()?;
-            drop(file);
-
-            let file = std::fs::File::open(&path)?;
-            let handle = crate::table::BlockHandle::new(
-                BlockOffset(0),
-                header.data_length + Header::serialized_len() as u32,
-            );
             let block = Block::from_file(
                 &file,
                 handle,
@@ -1552,55 +1509,27 @@ mod tests {
         #[test]
         #[cfg(zstd_any)]
         fn block_from_file_encrypted_zstd() -> crate::Result<()> {
-            use std::io::Write;
-
             let enc = test_provider();
             let data = b"abcdefabcdefabcdef";
-            let mut buf = vec![];
-            let header = Block::write_into(
-                &mut buf,
+            let (_dir, file, handle, _) = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::Zstd(3),
                 Some(&enc),
-                #[cfg(zstd_any)]
                 None,
             )?;
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("block");
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(&buf)?;
-            file.sync_all()?;
-            drop(file);
-
-            let file = std::fs::File::open(&path)?;
-            let handle = crate::table::BlockHandle::new(
-                BlockOffset(0),
-                header.data_length + Header::serialized_len() as u32,
-            );
-            let block = Block::from_file(
-                &file,
-                handle,
-                CompressionType::Zstd(3),
-                Some(&enc),
-                #[cfg(zstd_any)]
-                None,
-            )?;
+            let block =
+                Block::from_file(&file, handle, CompressionType::Zstd(3), Some(&enc), None)?;
             assert_eq!(data, &*block.data);
             Ok(())
         }
 
         #[test]
         fn block_from_file_encrypted_wrong_key_fails() -> crate::Result<()> {
-            use std::io::Write;
-
             let enc_write = test_provider();
             let enc_read = crate::encryption::Aes256GcmProvider::new(&[0x99; 32]);
             let data = b"encrypted block data";
-            let mut buf = vec![];
-            let header = Block::write_into(
-                &mut buf,
+            let (_dir, file, handle, _) = super::write_block_to_tempfile(
                 data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1608,19 +1537,6 @@ mod tests {
                 #[cfg(zstd_any)]
                 None,
             )?;
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("block");
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(&buf)?;
-            file.sync_all()?;
-            drop(file);
-
-            let file = std::fs::File::open(&path)?;
-            let handle = crate::table::BlockHandle::new(
-                BlockOffset(0),
-                header.data_length + Header::serialized_len() as u32,
-            );
             let result = Block::from_file(
                 &file,
                 handle,
@@ -1758,13 +1674,9 @@ mod tests {
 
         #[test]
         fn block_from_file_encrypted_uncompressed_large_payload() -> crate::Result<()> {
-            use std::io::Write;
-
             let enc = test_provider();
             let data = vec![0xBB_u8; 32 * 1024]; // 32 KiB
-            let mut buf = vec![];
-            let header = Block::write_into(
-                &mut buf,
+            let (_dir, file, handle, _) = super::write_block_to_tempfile(
                 &data,
                 BlockType::Data,
                 CompressionType::None,
@@ -1772,19 +1684,6 @@ mod tests {
                 #[cfg(zstd_any)]
                 None,
             )?;
-
-            let dir = tempfile::tempdir()?;
-            let path = dir.path().join("block");
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(&buf)?;
-            file.sync_all()?;
-            drop(file);
-
-            let file = std::fs::File::open(&path)?;
-            let handle = crate::table::BlockHandle::new(
-                BlockOffset(0),
-                header.data_length + Header::serialized_len() as u32,
-            );
             let block = Block::from_file(
                 &file,
                 handle,


### PR DESCRIPTION
## Summary

Part 1 of #128. Extracts the duplicated tempfile/write/reopen/handle scaffold from `Block::from_file` roundtrip tests into a single helper.

## What

```rust
struct TempBlock {
    file: std::fs::File,
    handle: crate::table::BlockHandle,
    dir: tempfile::TempDir, // declared LAST so it drops after `file`
}

fn write_block_to_tempfile(
    data: &[u8],
    block_type: BlockType,
    compression: CompressionType,
    encryption: Option<&dyn EncryptionProvider>,
    #[cfg(zstd_any)] zstd_dict: Option<&ZstdDictionary>,
) -> crate::Result<TempBlock>
```

The struct bundles the open file, the pre-computed `BlockHandle`, and the owning `TempDir`. The `TempDir` field stays bound for the test's lifetime — its `Drop` reclaims the directory and the file inside.

Field order matters for `Drop` (Windows portability): `file` declared first → drops before `dir` removes the directory. Call sites destructure with `let TempBlock { dir: _dir, file, handle } = ...?;` — binding `dir` first means it drops LAST among the locals (local bindings drop in reverse declaration order), preserving the same invariant.

Helper writes directly into the tempfile via `Block::write_into(&mut file, ...)` — no intermediate `Vec<u8>`, relevant for the 32 KiB large-payload encryption test.

## Refactored

| Test | cfg |
|---|---|
| `block_from_file_roundtrip_uncompressed` | — |
| `block_from_file_roundtrip_lz4` | lz4 |
| `block_from_file_roundtrip_zstd` | zstd_any |
| `block_from_file_encrypted_uncompressed` | encryption |
| `block_from_file_encrypted_lz4` | encryption + lz4 |
| `block_from_file_encrypted_zstd` | encryption + zstd_any |
| `block_from_file_encrypted_wrong_key_fails` | encryption |
| `block_from_file_encrypted_uncompressed_large_payload` | encryption |

## Intentionally not refactored

Two `from_file` tests need pre-write byte manipulation that doesn't fit the helper:

- `block_from_file_encrypted_checksum_tamper_detected` — XORs a byte in the encoded buffer before persisting (the helper would have to expose the intermediate buffer)
- `block_from_file_encrypted_undersized_handle_rejected` — writes raw `"tiny"` bytes (not a `Block`-encoded payload) to test undersized-handle rejection

## Test plan

- [x] `cargo clippy --lib --tests --all-features` — clean
- [x] `cargo nextest run --workspace --all-features` — 1509/1509 pass
- [x] Diff: -151 +50 lines, single file (`src/table/block/mod.rs`)

## Out of scope

Part 2 of #128 — the mixed-load encryption stress test — stays open as a separate follow-up.

Part of #128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored the block roundtrip tests by introducing a shared temporary-block helper to centralize write/reopen/handle setup.
  * Updated uncompressed, LZ4, Zstd, and encrypted test cases to use the new helper, removing duplicated filesystem and buffer setup.
  * Consolidated encrypted wrong-key and large-payload tests onto the shared helper.

Note: No user-facing changes; all edits are internal to the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
