### PR TITLE
ci(cross): conditional cross-compile matrix (#158 item 1)

### DIFF
--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -24,9 +24,11 @@ on:
   # Without the input set (default), manual dispatch runs the
   # same reduced 2-target cross matrix that PRs do (aarch64-gnu
   # + i686-gnu) — useful for quick sanity-check re-runs.
-  # workflow_dispatch requires actions:write on the repo, so
-  # only owner / maintainers can fire it — fork PR authors
-  # cannot, full_cross_matrix has no fork-side attack surface.
+  # Triggering workflow_dispatch from the UI / API requires
+  # repository write access (not the workflow-token `actions:write`
+  # scope, which is a different thing). Fork PR authors don't
+  # have write on the upstream repo, so they can't fire this —
+  # full_cross_matrix has no fork-side attack surface.
   workflow_dispatch:
     inputs:
       full_cross_matrix:

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -170,7 +170,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target: ${{ fromJSON(needs.cross-matrix.outputs.targets) }}
+        # Bracket notation REQUIRED on the needs context key here:
+        # the job id `cross-matrix` contains a hyphen, so dot
+        # notation (`needs.cross-matrix.outputs.targets`) is parsed
+        # by the GitHub Actions expression engine as `needs.cross`
+        # minus `matrix.outputs.targets`, breaking the lookup.
+        target: ${{ fromJSON(needs['cross-matrix'].outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -134,18 +134,37 @@ jobs:
       - name: Check (no_std + alloc)
         run: cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc
 
-  cross:
+  # Generates the cross-compile target matrix. Full 5-target sweep
+  # only on push to main; PR / manual-dispatch runs use a reduced
+  # 2-target subset (aarch64-gnu + i686-gnu) that covers the two
+  # canonical mistake-finders — 64-bit aarch64 ABI quirks and 32-bit
+  # x86 pointer-width / endian sensitivity — at ~30% of the CI time
+  # the full sweep costs. The full sweep on main still catches
+  # musl, powerpc64 (BE), and riscv64 (qemu-emulated) regressions
+  # before they ship to users; PR feedback stays under 5 min.
+  cross-matrix:
     needs: lint
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+    steps:
+      - id: set
+        env:
+          IS_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          if [ "$IS_MAIN" = "true" ]; then
+            echo 'targets=["aarch64-unknown-linux-gnu","aarch64-unknown-linux-musl","i686-unknown-linux-gnu","powerpc64-unknown-linux-gnu","riscv64gc-unknown-linux-gnu"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'targets=["aarch64-unknown-linux-gnu","i686-unknown-linux-gnu"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  cross:
+    needs: [lint, cross-matrix]
     timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
-        target:
-          - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
-          - i686-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - riscv64gc-unknown-linux-gnu
+        target: ${{ fromJSON(needs.cross-matrix.outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -163,13 +163,13 @@ jobs:
   #     on a draft branch)
   # Everything else — PR builds + default manual dispatches —
   # uses the reduced 2-target subset (aarch64-gnu + i686-gnu)
-  # that covers the two canonical mistake-finders: 64-bit
-  # aarch64 ABI quirks and 32-bit x86 pointer-width / endian
-  # sensitivity. The reduced run is ~30% of the full-sweep cost
-  # and keeps PR feedback under 5 min while still catching the
-  # majority of cross-platform regressions; musl, powerpc64
-  # (BE), and riscv64 (qemu-emulated) coverage runs on main
-  # before reaching users.
+  # that covers the two canonical pointer-width / ABI mistakes:
+  # 64-bit aarch64 ABI quirks and 32-bit x86 pointer-width.
+  # Both targets are little-endian — endianness coverage (the
+  # big-endian powerpc64 target) is deferred to the full sweep
+  # on main, alongside musl libc differences and the qemu-
+  # emulated riscv64 path. The reduced run is ~30% of the
+  # full-sweep cost and keeps PR feedback under 5 min.
   cross-matrix:
     # No `needs: lint` — this job only inspects github.event_name
     # / github.ref / inputs to emit a JSON target list. It doesn't

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -171,7 +171,13 @@ jobs:
   # (BE), and riscv64 (qemu-emulated) coverage runs on main
   # before reaching users.
   cross-matrix:
-    needs: lint
+    # No `needs: lint` — this job only inspects github.event_name
+    # / github.ref / inputs to emit a JSON target list. It doesn't
+    # touch source, doesn't compile, doesn't run lint-sensitive
+    # tooling. Running it in parallel with lint shaves ~10s off
+    # the PR critical path: the matrix is ready when lint
+    # finishes, and `cross` (which `needs: [lint, cross-matrix]`)
+    # starts immediately rather than waiting for serial chain.
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -13,6 +13,12 @@ on:
   pull_request:
     branches:
       - main
+  # Manual re-run from any branch. Useful for re-triggering after
+  # a flaky cross-compile target, or for maintainers who want a
+  # full CI cycle on a draft branch without opening a PR.
+  # workflow_dispatch requires actions:write on the repo, so only
+  # owner / maintainers can fire it — fork PR authors cannot.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -13,12 +13,27 @@ on:
   pull_request:
     branches:
       - main
-  # Manual re-run from any branch. Useful for re-triggering after
-  # a flaky cross-compile target, or for maintainers who want a
-  # full CI cycle on a draft branch without opening a PR.
-  # workflow_dispatch requires actions:write on the repo, so only
-  # owner / maintainers can fire it — fork PR authors cannot.
+  # Manual re-run from any branch. Two use cases:
+  #   (a) re-trigger a flaky cross-compile target after qemu
+  #       hiccup — needs `full_cross_matrix: true` because the
+  #       flaky ones (powerpc64, riscv64) live ONLY in the full
+  #       matrix, not the PR/dispatch default;
+  #   (b) maintainer wants a full CI cycle on a draft branch
+  #       without opening a PR — also `full_cross_matrix: true`
+  #       to mirror main-branch coverage.
+  # Without the input set (default), manual dispatch runs the
+  # same reduced 2-target cross matrix that PRs do (aarch64-gnu
+  # + i686-gnu) — useful for quick sanity-check re-runs.
+  # workflow_dispatch requires actions:write on the repo, so
+  # only owner / maintainers can fire it — fork PR authors
+  # cannot, full_cross_matrix has no fork-side attack surface.
   workflow_dispatch:
+    inputs:
+      full_cross_matrix:
+        description: "Run the full 5-target cross-compile matrix (aarch64-gnu/musl, i686-gnu, powerpc64-gnu, riscv64gc-gnu) instead of the reduced 2-target subset"
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -140,14 +155,21 @@ jobs:
       - name: Check (no_std + alloc)
         run: cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc
 
-  # Generates the cross-compile target matrix. Full 5-target sweep
-  # only on push to main; PR / manual-dispatch runs use a reduced
-  # 2-target subset (aarch64-gnu + i686-gnu) that covers the two
-  # canonical mistake-finders — 64-bit aarch64 ABI quirks and 32-bit
-  # x86 pointer-width / endian sensitivity — at ~30% of the CI time
-  # the full sweep costs. The full sweep on main still catches
-  # musl, powerpc64 (BE), and riscv64 (qemu-emulated) regressions
-  # before they ship to users; PR feedback stays under 5 min.
+  # Generates the cross-compile target matrix. The full 5-target
+  # sweep runs in either of two cases:
+  #   - push to main (regression coverage on every merged change)
+  #   - workflow_dispatch with `full_cross_matrix: true` (manual
+  #     opt-in for re-testing flaky targets or for full coverage
+  #     on a draft branch)
+  # Everything else — PR builds + default manual dispatches —
+  # uses the reduced 2-target subset (aarch64-gnu + i686-gnu)
+  # that covers the two canonical mistake-finders: 64-bit
+  # aarch64 ABI quirks and 32-bit x86 pointer-width / endian
+  # sensitivity. The reduced run is ~30% of the full-sweep cost
+  # and keeps PR feedback under 5 min while still catching the
+  # majority of cross-platform regressions; musl, powerpc64
+  # (BE), and riscv64 (qemu-emulated) coverage runs on main
+  # before reaching users.
   cross-matrix:
     needs: lint
     runs-on: ubuntu-latest
@@ -156,9 +178,9 @@ jobs:
     steps:
       - id: set
         env:
-          IS_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          IS_FULL: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.full_cross_matrix) }}
         run: |
-          if [ "$IS_MAIN" = "true" ]; then
+          if [ "$IS_FULL" = "true" ]; then
             echo 'targets=["aarch64-unknown-linux-gnu","aarch64-unknown-linux-musl","i686-unknown-linux-gnu","powerpc64-unknown-linux-gnu","riscv64gc-unknown-linux-gnu"]' >> "$GITHUB_OUTPUT"
           else
             echo 'targets=["aarch64-unknown-linux-gnu","i686-unknown-linux-gnu"]' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Splits the cross-compile matrix by trigger: full 5-target sweep on push to main, reduced 2-target subset on PR / manual dispatch.

Addresses item 1 of #158.

## Why

Cross-compile previously ran all 5 targets on every PR:
- aarch64-unknown-linux-gnu
- aarch64-unknown-linux-musl
- i686-unknown-linux-gnu
- powerpc64-unknown-linux-gnu  ← qemu-emulated, slow
- riscv64gc-unknown-linux-gnu  ← qemu-emulated, slow

The two qemu-emulated targets dominate PR feedback time (~5 min sequentially across the matrix). PRs rarely need that coverage — wire-format / ABI regressions on those exotic targets are best caught on merge, not on every push.

## What

Added a small `cross-matrix` prep job (~10s) that emits a JSON target list to a job output:

```yaml
cross-matrix:
  outputs:
    targets: ${{ steps.set.outputs.targets }}
  steps:
    - id: set
      env:
        IS_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
      run: |
        if [ "$IS_MAIN" = "true" ]; then
          echo 'targets=[<full 5>]' >> "$GITHUB_OUTPUT"
        else
          echo 'targets=[<reduced 2>]' >> "$GITHUB_OUTPUT"
        fi
```

The `cross` job then consumes it:

```yaml
cross:
  needs: [lint, cross-matrix]
  strategy:
    matrix:
      target: ${{ fromJSON(needs.cross-matrix.outputs.targets) }}
```

## Trade-off

- **PR feedback** drops from ~8 min → ~5 min (no qemu emulation penalty)
- **Main coverage** unchanged — full 5-target sweep still runs on every merge
- **Reduced subset** covers the two canonical mistake classes: 64-bit aarch64 ABI quirks + 32-bit x86 pointer-width / endian sensitivity. musl, powerpc64 (BE), riscv64 regressions are caught at merge time before they ship to users.

## Out of scope (separate follow-up PRs from #158)

- `PROPTEST_MAX_SHRINK` env var support (item 2)
- Codecov `PROPTEST_CASES=32` verification (item 3 — already verified: codecov job relies on the hardcoded 32 default in `ProptestConfig`, same as test job; comments in the workflow already note this)
- Top-10 slowest-tests profiling (item 4)
- Nextest slow-timeout audit (item 5)

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` clean)
- [ ] First push to a non-main branch should trigger the reduced matrix — visible on this PR's first CI run (only 2 cross targets in the matrix)
- [ ] Next push to main after merge will trigger the full 5-target matrix

Part of #158.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled manual triggering of CI workflows with inline guidance on when to use manual runs.
  * Added an opt-in input to enable a full cross-compile target sweep for manual runs.
  * CI now selects the full target set for main-branch pushes and opted-in manual runs, otherwise uses a reduced set to speed feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->