### PR TITLE
refactor(block)!: thread BlockIdentity through Block I/O API (#252)

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -322,6 +322,20 @@ pub enum CompressionType {
 }
 
 impl CompressionType {
+    /// Returns the zstd dictionary id encoded in this compression
+    /// configuration, or `0` when no dictionary applies. Used to
+    /// populate [`crate::table::block::BlockIdentity::dict_id`]
+    /// from a `CompressionType` at the call site without each
+    /// caller re-doing the `ZstdDict { dict_id, .. }` destructure.
+    #[must_use]
+    pub fn dict_id(&self) -> u32 {
+        #[cfg(zstd_any)]
+        if let Self::ZstdDict { dict_id, .. } = self {
+            return *dict_id;
+        }
+        0
+    }
+
     /// Validate a zstd compression level.
     ///
     /// Accepts levels in the range 1..=22 and returns an error otherwise.

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -74,16 +74,21 @@ use crate::table::block::BlockType;
 /// docstring for the rationale.
 #[derive(Clone, Copy, Debug)]
 pub struct BlockIdentity {
-    /// Identifier of the owning tree (database). `0` for blob-file
-    /// metadata (which is keyed by [`Self::table_id`] alone — the
-    /// blob-file id is globally unique per process). Combined with
-    /// [`Self::table_id`] this gives the [`crate::table::GlobalTableId`]
-    /// shape: `TableId` alone is a per-tree counter that CAN
-    /// collide across different trees, so AAD that binds only
-    /// `(table_id, block_offset)` would permit cross-tree block
-    /// substitution if the same encryption key were ever reused
-    /// across trees. Including `tree_id` closes that gap at the
-    /// AAD layer regardless of key isolation.
+    /// Identifier of the owning tree (database). `0` is the
+    /// allowed-zero default for sites that don't yet have the
+    /// owning Tree's id plumbed to them (see the module
+    /// docstring's exception list — most current writer / reader
+    /// paths fall here, including blob-file metadata: `BlobFileId`
+    /// is itself a per-tree counter that can collide across
+    /// trees, so it can't substitute for a real `tree_id`).
+    /// Combined with [`Self::table_id`] this gives the
+    /// [`crate::table::GlobalTableId`] shape: `TableId` alone is
+    /// a per-tree counter that CAN collide across different
+    /// trees, so AAD that binds only `(table_id, block_offset)`
+    /// would permit cross-tree block substitution if the same
+    /// encryption key were ever reused across trees. Including
+    /// `tree_id` closes that gap at the AAD layer regardless of
+    /// key isolation.
     ///
     /// Callers that don't have `tree_id` plumbed yet pass `0` and
     /// rely on per-tree encryption-provider isolation as the

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -107,9 +107,15 @@ pub struct BlockIdentity {
     /// rejects any block whose declared origin doesn't match.
     pub table_id: u64,
 
-    /// Byte offset of the block's start within the SST file.
-    /// Combined with `table_id`, gives the AAD a globally unique
-    /// per-block discriminator.
+    /// Byte offset of the block's start within its underlying
+    /// container — SST file, blob-file slice, or in-memory buffer
+    /// — depending on which caller constructs the identity.
+    /// Combined with `table_id`, gives the AAD a per-block
+    /// discriminator that prevents block-swap within the same
+    /// container. `0` is the allowed-zero default for callers
+    /// whose container doesn't surface a usable position cursor
+    /// (sfa-wrapped index/filter writers, BufReader-based
+    /// scanners — see the module docstring for the full list).
     pub block_offset: u64,
 
     /// Whether this is a Data, Filter, Index, or Meta block.

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -22,15 +22,40 @@
 //! later means adding it to `BlockIdentity` rather than chasing
 //! down 90+ call sites.
 //!
-//! **Field requirements.** Production call sites MUST populate
+//! **Field requirements.** Production call sites SHOULD populate
 //! every field with the real value from their local context. Test
 //! call sites that don't exercise AAD-sensitive paths may use
 //! [`BlockIdentity::for_test`] which defaults `dict_id` and
-//! `window_log` to zero. Defaulting `table_id` or `block_offset`
-//! to zero in non-test code is a bug: it makes blocks from
-//! different tables / offsets bind to the same AAD, breaking the
-//! block-swap resistance guarantee the wire format is designed
-//! around.
+//! `window_log` to zero.
+//!
+//! **Allowed zero exceptions in production code** (each individually
+//! documented at the call site):
+//!
+//! - `table_id = 0` is allowed when reading a META block that
+//!   itself CARRIES the `table_id` field — there's no way to
+//!   know the id before the block is parsed (chicken-and-egg).
+//!   Cross-store substitution is still prevented because the
+//!   meta payload's own id field is part of the verified body.
+//! - `block_offset = 0` is allowed in two cases until AAD
+//!   wiring lands:
+//!   - Index / filter writers that hand their blocks to
+//!     `sfa::Writer` (the sectioned-file-archive wrapper):
+//!     the wrapper doesn't expose a byte-position cursor, and
+//!     the [`crate::table::writer::index::BlockIndexWriter`] /
+//!     [`crate::table::writer::filter::FilterWriter`] traits
+//!     don't surface `block_offset` to `finish()`. Extending
+//!     those signatures is a follow-up.
+//!   - Sequential scanners reading via `BufReader`: the buffer
+//!     doesn't expose its own byte offset, and the scan path
+//!     walks blocks in order so per-block offset bookkeeping
+//!     isn't load-bearing for the scan itself.
+//!
+//! `table_id = 0` AND `block_offset = 0` together — both zero
+//! at the same call site — is reserved for tests; a CI canary
+//! to enforce that is tracked as a follow-up. Outside the
+//! exceptions listed above, defaulting either to zero in
+//! production weakens block-swap resistance and should be
+//! avoided.
 
 use crate::table::block::BlockType;
 
@@ -41,11 +66,18 @@ use crate::table::block::BlockType;
 /// docstring for the rationale.
 #[derive(Clone, Copy, Debug)]
 pub struct BlockIdentity {
-    /// Global table identifier (`(tree_id, table_id)` packed) of
-    /// the SST that owns this block. Binds the block to its
-    /// table: AAD constructed from this prevents a block from
-    /// table A being substituted for a block at the same offset
-    /// in table B (block-swap attack).
+    /// Identifier of the owning store unit — for SST blocks this is
+    /// the per-tree [`crate::TableId`] (a `u64` alias); for blob
+    /// files it is the [`crate::vlog::BlobFileId`] (also a `u64`
+    /// alias). Binds the block to its store unit: AAD constructed
+    /// from this prevents a block from store A being substituted
+    /// for a block at the same offset in store B (block-swap
+    /// attack).
+    ///
+    /// **Not** the same as [`crate::table::GlobalTableId`], which
+    /// packs `(tree_id, table_id)` for cross-tree disambiguation;
+    /// at the Block-I/O boundary the AAD discriminator only needs
+    /// per-store uniqueness within the running process.
     pub table_id: u64,
 
     /// Byte offset of the block's start within the SST file.

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Identity context threaded through the Block I/O API.
+//!
+//! Every call to [`Block::write_into`] / [`Block::from_reader`] /
+//! [`Block::from_file`] carries a `BlockIdentity` describing which
+//! block, of which table, with which compression context. The
+//! Block layer uses this to construct AAD (Additional
+//! Authenticated Data) for AEAD encryption — see the AAD-bound
+//! wire format spec for the cryptographic role each field plays.
+//!
+//! **Why a context struct vs. inline arguments.** The natural
+//! alternative — pass `aad: &[u8]` directly to the Block API — got
+//! a previous attempt into trouble: callers wrote `aad: &[]`
+//! everywhere because composing the right AAD bytes at each call
+//! site is fiddly and the type system couldn't enforce
+//! correctness. With `BlockIdentity`, every call site contributes
+//! its OWN local context (the writer/scanner/reader already knows
+//! its table id, the block offset, etc.) and the Block layer
+//! computes AAD once, internally. Adding a new AAD-relevant field
+//! later means adding it to `BlockIdentity` rather than chasing
+//! down 90+ call sites.
+//!
+//! **Field requirements.** Production call sites MUST populate
+//! every field with the real value from their local context. Test
+//! call sites that don't exercise AAD-sensitive paths may use
+//! [`BlockIdentity::for_test`] which defaults `dict_id` and
+//! `window_log` to zero. Defaulting `table_id` or `block_offset`
+//! to zero in non-test code is a bug: it makes blocks from
+//! different tables / offsets bind to the same AAD, breaking the
+//! block-swap resistance guarantee the wire format is designed
+//! around.
+
+use crate::table::block::BlockType;
+
+/// Identifies a block for encryption AAD and audit purposes.
+///
+/// Carried through the Block I/O API instead of separate
+/// `block_type` / `aad: &[u8]` arguments — see the module
+/// docstring for the rationale.
+#[derive(Clone, Copy, Debug)]
+pub struct BlockIdentity {
+    /// Global table identifier (`(tree_id, table_id)` packed) of
+    /// the SST that owns this block. Binds the block to its
+    /// table: AAD constructed from this prevents a block from
+    /// table A being substituted for a block at the same offset
+    /// in table B (block-swap attack).
+    pub table_id: u64,
+
+    /// Byte offset of the block's start within the SST file.
+    /// Combined with `table_id`, gives the AAD a globally unique
+    /// per-block discriminator.
+    pub block_offset: u64,
+
+    /// Whether this is a Data, Filter, Index, or Meta block.
+    /// Was previously a separate `block_type: BlockType`
+    /// argument on the Block API; now lives here so the call site
+    /// only computes one context value.
+    pub block_type: BlockType,
+
+    /// Zstd dictionary id used for this block, or `0` if no
+    /// dictionary applies. Binds the block to a specific
+    /// dictionary version so that decompressing with a different
+    /// dictionary (whether by mistake or by attack) surfaces as
+    /// an AEAD authentication failure rather than as silently
+    /// wrong plaintext.
+    pub dict_id: u32,
+
+    /// Zstd `window_log` advertised in the frame header, or `0` if
+    /// no zstd compression applies. Binds the block to a
+    /// specific decompression-memory budget; attempts to substitute
+    /// a block with a different `window_log` (a known "window bomb"
+    /// vector) fail AEAD authentication.
+    pub window_log: u8,
+}
+
+impl BlockIdentity {
+    /// Test-only constructor with conservative defaults for the
+    /// compression-context fields (`dict_id = 0`, `window_log = 0`).
+    /// Use this in test fixtures that don't exercise zstd
+    /// dictionary or window-budget paths; in production code,
+    /// populate every field explicitly from the local context.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) const fn for_test(table_id: u64, block_offset: u64, block_type: BlockType) -> Self {
+        Self {
+            table_id,
+            block_offset,
+            block_type,
+            dict_id: 0,
+            window_log: 0,
+        }
+    }
+}

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -3,8 +3,10 @@
 
 //! Identity context threaded through the Block I/O API.
 //!
-//! Every call to [`Block::write_into`] / [`Block::from_reader`] /
-//! [`Block::from_file`] carries a `BlockIdentity` describing which
+//! Every call to [`crate::table::block::Block::write_into`] /
+//! [`crate::table::block::Block::from_reader`] /
+//! [`crate::table::block::Block::from_file`] carries a
+//! `BlockIdentity` describing which
 //! block, of which table, with which compression context. The
 //! Block layer uses this to construct AAD (Additional
 //! Authenticated Data) for AEAD encryption — see the AAD-bound

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -31,6 +31,14 @@
 //! **Allowed zero exceptions in production code** (each individually
 //! documented at the call site):
 //!
+//! - `tree_id = 0` is allowed at any site that doesn't yet have
+//!   the owning Tree's id threaded through to it (most current
+//!   call sites — Writer / Table / Scanner predate `tree_id`
+//!   plumbing). The substitute defence is per-tree encryption-
+//!   provider isolation: a tree's keys decrypt only its own
+//!   blocks, so cross-tree substitution fails at the key layer.
+//!   Plumbing real `tree_id` is a follow-up that strengthens the
+//!   guarantee at the AAD layer regardless of key isolation.
 //! - `table_id = 0` is allowed when reading a META block that
 //!   itself CARRIES the `table_id` field — there's no way to
 //!   know the id before the block is parsed (chicken-and-egg).
@@ -66,18 +74,30 @@ use crate::table::block::BlockType;
 /// docstring for the rationale.
 #[derive(Clone, Copy, Debug)]
 pub struct BlockIdentity {
+    /// Identifier of the owning tree (database). `0` for blob-file
+    /// metadata (which is keyed by [`Self::table_id`] alone — the
+    /// blob-file id is globally unique per process). Combined with
+    /// [`Self::table_id`] this gives the [`crate::table::GlobalTableId`]
+    /// shape: `TableId` alone is a per-tree counter that CAN
+    /// collide across different trees, so AAD that binds only
+    /// `(table_id, block_offset)` would permit cross-tree block
+    /// substitution if the same encryption key were ever reused
+    /// across trees. Including `tree_id` closes that gap at the
+    /// AAD layer regardless of key isolation.
+    ///
+    /// Callers that don't have `tree_id` plumbed yet pass `0` and
+    /// rely on per-tree encryption-provider isolation as the
+    /// substitute defence; see the module docstring for the list
+    /// of allowed-zero exceptions.
+    pub tree_id: u64,
+
     /// Identifier of the owning store unit — for SST blocks this is
     /// the per-tree [`crate::TableId`] (a `u64` alias); for blob
     /// files it is the [`crate::vlog::BlobFileId`] (also a `u64`
-    /// alias). Binds the block to its store unit: AAD constructed
-    /// from this prevents a block from store A being substituted
-    /// for a block at the same offset in store B (block-swap
-    /// attack).
-    ///
-    /// **Not** the same as [`crate::table::GlobalTableId`], which
-    /// packs `(tree_id, table_id)` for cross-tree disambiguation;
-    /// at the Block-I/O boundary the AAD discriminator only needs
-    /// per-store uniqueness within the running process.
+    /// alias). Combined with [`Self::tree_id`], gives the
+    /// per-process unique discriminator that prevents block-swap
+    /// attacks: AAD built from `(tree_id, table_id, block_offset)`
+    /// rejects any block whose declared origin doesn't match.
     pub table_id: u64,
 
     /// Byte offset of the block's start within the SST file.
@@ -117,6 +137,7 @@ impl BlockIdentity {
     #[must_use]
     pub(crate) const fn for_test(table_id: u64, block_offset: u64, block_type: BlockType) -> Self {
         Self {
+            tree_id: 0,
             table_id,
             block_offset,
             block_type,

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod decoder;
 mod encoder;
 pub mod hash_index;
 mod header;
+mod identity;
 mod offset;
 mod trailer;
 mod r#type;
@@ -17,6 +18,7 @@ mod r#type;
 pub(crate) use decoder::{Decodable, Decoder, ParsedItem};
 pub(crate) use encoder::{Encodable, Encoder};
 pub use header::Header;
+pub use identity::BlockIdentity;
 pub use offset::BlockOffset;
 pub(crate) use trailer::{TRAILER_START_MARKER, Trailer};
 pub use r#type::BlockType;
@@ -72,11 +74,19 @@ impl Block {
     pub fn write_into<W: std::io::Write>(
         mut writer: &mut W,
         data: &[u8],
-        block_type: BlockType,
+        identity: BlockIdentity,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
     ) -> crate::Result<Header> {
+        // Pull block_type out of identity so the rest of the
+        // function reads exactly like the pre-identity version.
+        // table_id / block_offset / dict_id / window_log are
+        // accepted-but-not-consumed today — they'll feed AAD
+        // construction once AEAD wiring lands. Call sites that
+        // compute real values now won't need a second round of
+        // edits when AAD goes live.
+        let block_type = identity.block_type;
         if data.len() > MAX_DECOMPRESSION_SIZE as usize {
             return Err(crate::Error::DecompressedSizeTooLarge {
                 declared: data.len() as u64,
@@ -230,10 +240,17 @@ impl Block {
     )]
     pub fn from_reader<R: std::io::Read>(
         reader: &mut R,
+        identity: BlockIdentity,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
     ) -> crate::Result<Self> {
+        // identity carries table_id / offset / dict_id / window_log
+        // for AAD construction once AEAD wiring lands; unused on the
+        // read path today (block_type is derived from the parsed
+        // header rather than asserted against identity.block_type —
+        // mismatch detection is part of the AEAD-bound spec).
+        let _ = identity;
         let header = Header::decode_from(reader)?;
 
         // Validate both size fields before any I/O or hashing to fail fast
@@ -449,10 +466,17 @@ impl Block {
     pub fn from_file(
         file: &dyn FsFile,
         handle: BlockHandle,
+        identity: BlockIdentity,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
     ) -> crate::Result<Self> {
+        // identity carries AAD context; unused today. handle gives
+        // the byte offset (caller already computed it), identity
+        // packages it alongside the table_id + compression-context
+        // fields so the read path's AEAD verification (#251) can
+        // reconstruct the same AAD the writer used.
+        let _ = identity;
         // handle.size() includes Header::serialized_len(), so allow that overhead.
         // Encrypted blocks add provider-specific overhead to the on-disk size.
         let enc_overhead = encryption.map_or(0u64, |e| u64::from(e.max_overhead()));
@@ -795,7 +819,7 @@ mod tests {
     /// the `from_file` tests below would otherwise duplicate.
     fn write_block_to_tempfile(
         data: &[u8],
-        block_type: BlockType,
+        identity: BlockIdentity,
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
@@ -810,7 +834,7 @@ mod tests {
             let header = Block::write_into(
                 &mut file,
                 data,
-                block_type,
+                identity,
                 compression,
                 encryption,
                 #[cfg(zstd_any)]
@@ -832,7 +856,7 @@ mod tests {
         let data = b"abcdefabcdefabcdef";
         let tmp = write_block_to_tempfile(
             data,
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -841,6 +865,11 @@ mod tests {
         let block = Block::from_file(
             &tmp.file,
             tmp.handle,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -856,7 +885,7 @@ mod tests {
         let data = b"abcdefabcdefabcdef";
         let tmp = write_block_to_tempfile(
             data,
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -865,6 +894,11 @@ mod tests {
         let block = Block::from_file(
             &tmp.file,
             tmp.handle,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -878,9 +912,21 @@ mod tests {
     #[cfg(zstd_any)]
     fn block_from_file_roundtrip_zstd() -> crate::Result<()> {
         let data = b"abcdefabcdefabcdef";
-        let tmp =
-            write_block_to_tempfile(data, BlockType::Data, CompressionType::Zstd(3), None, None)?;
-        let block = Block::from_file(&tmp.file, tmp.handle, CompressionType::Zstd(3), None, None)?;
+        let tmp = write_block_to_tempfile(
+            data,
+            BlockIdentity::for_test(0, 0, BlockType::Data),
+            CompressionType::Zstd(3),
+            None,
+            None,
+        )?;
+        let block = Block::from_file(
+            &tmp.file,
+            tmp.handle,
+            BlockIdentity::for_test(0, 0, BlockType::Data),
+            CompressionType::Zstd(3),
+            None,
+            None,
+        )?;
         assert_eq!(data, &*block.data);
         Ok(())
     }
@@ -892,7 +938,7 @@ mod tests {
         Block::write_into(
             &mut writer,
             b"abcdefabcdefabcdef",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -903,6 +949,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 None,
                 #[cfg(zstd_any)]
@@ -921,7 +972,7 @@ mod tests {
         Block::write_into(
             &mut writer,
             b"abcdefabcdefabcdef",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -932,6 +983,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Lz4,
                 None,
                 #[cfg(zstd_any)]
@@ -953,7 +1009,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             b"hello",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -977,6 +1033,11 @@ mod tests {
         let mut r = &tampered[..];
         let result = Block::from_reader(
             &mut r,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1002,7 +1063,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             b"hello",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1021,6 +1082,11 @@ mod tests {
         let mut r = &tampered[..];
         let result = Block::from_reader(
             &mut r,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1065,6 +1131,11 @@ mod tests {
         let mut cursor = Cursor::new(buf);
         let result = Block::from_reader(
             &mut cursor,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1088,7 +1159,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             b"hello",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1118,6 +1189,11 @@ mod tests {
         let result = Block::from_file(
             &file,
             handle,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1141,7 +1217,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             b"hello",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1166,6 +1242,11 @@ mod tests {
         let result = Block::from_file(
             &file,
             handle,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::Lz4,
             None,
             #[cfg(zstd_any)]
@@ -1187,7 +1268,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             b"hello",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -1207,6 +1288,11 @@ mod tests {
         let mut r = &tampered[..];
         let result = Block::from_reader(
             &mut r,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -1233,6 +1319,11 @@ mod tests {
         let result = Block::from_file(
             &file,
             handle,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -1275,7 +1366,17 @@ mod tests {
         buf.extend_from_slice(&compressed);
 
         let mut cursor = Cursor::new(buf);
-        let result = Block::from_reader(&mut cursor, CompressionType::Zstd(3), None, None);
+        let result = Block::from_reader(
+            &mut cursor,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
+            CompressionType::Zstd(3),
+            None,
+            None,
+        );
 
         match result {
             Err(crate::Error::Decompress(CompressionType::Zstd(_))) => { /* expected */ }
@@ -1314,7 +1415,17 @@ mod tests {
         buf.extend_from_slice(&compressed);
 
         let mut cursor = Cursor::new(buf);
-        let result = Block::from_reader(&mut cursor, CompressionType::Zstd(3), None, None);
+        let result = Block::from_reader(
+            &mut cursor,
+            crate::table::block::BlockIdentity::for_test(
+                0,
+                0,
+                crate::table::block::BlockType::Data,
+            ),
+            CompressionType::Zstd(3),
+            None,
+            None,
+        );
 
         match result {
             Err(crate::Error::Decompress(CompressionType::Zstd(_))) => { /* expected */ }
@@ -1331,7 +1442,7 @@ mod tests {
         Block::write_into(
             &mut writer,
             b"abcdefabcdefabcdef",
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Zstd(3),
             None,
             None,
@@ -1339,7 +1450,17 @@ mod tests {
 
         {
             let mut reader = &writer[..];
-            let block = Block::from_reader(&mut reader, CompressionType::Zstd(3), None, None)?;
+            let block = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                CompressionType::Zstd(3),
+                None,
+                None,
+            )?;
             assert_eq!(b"abcdefabcdefabcdef", &*block.data);
         }
 
@@ -1353,7 +1474,7 @@ mod tests {
         let result = Block::write_into(
             &mut sink,
             &oversized,
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -1374,7 +1495,7 @@ mod tests {
         Block::write_into(
             &mut writer,
             &data,
-            BlockType::Data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
             CompressionType::Zstd(3),
             None,
             None,
@@ -1388,7 +1509,17 @@ mod tests {
 
         {
             let mut reader = &writer[..];
-            let block = Block::from_reader(&mut reader, CompressionType::Zstd(3), None, None)?;
+            let block = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                CompressionType::Zstd(3),
+                None,
+                None,
+            )?;
             assert_eq!(&*block.data, &data[..]);
         }
 
@@ -1419,7 +1550,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1429,6 +1560,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1448,7 +1584,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1458,6 +1594,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1477,7 +1618,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1487,6 +1628,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1502,7 +1648,7 @@ mod tests {
             let data = b"plaintext block data for from_file encryption test";
             let tmp = super::write_block_to_tempfile(
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1511,6 +1657,11 @@ mod tests {
             let block = Block::from_file(
                 &tmp.file,
                 tmp.handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1527,7 +1678,7 @@ mod tests {
             let data = b"abcdefabcdefabcdef";
             let tmp = super::write_block_to_tempfile(
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1536,6 +1687,11 @@ mod tests {
             let block = Block::from_file(
                 &tmp.file,
                 tmp.handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1552,7 +1708,7 @@ mod tests {
             let data = b"abcdefabcdefabcdef";
             let tmp = super::write_block_to_tempfile(
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 None,
@@ -1560,6 +1716,11 @@ mod tests {
             let block = Block::from_file(
                 &tmp.file,
                 tmp.handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 None,
@@ -1575,7 +1736,7 @@ mod tests {
             let data = b"encrypted block data";
             let tmp = super::write_block_to_tempfile(
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc_write),
                 #[cfg(zstd_any)]
@@ -1584,6 +1745,11 @@ mod tests {
             let result = Block::from_file(
                 &tmp.file,
                 tmp.handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc_read),
                 #[cfg(zstd_any)]
@@ -1607,7 +1773,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc_write),
                 #[cfg(zstd_any)]
@@ -1617,6 +1783,11 @@ mod tests {
             let mut reader = &writer[..];
             let result = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc_read),
                 #[cfg(zstd_any)]
@@ -1640,7 +1811,7 @@ mod tests {
             let header = Block::write_into(
                 &mut buf,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1671,6 +1842,11 @@ mod tests {
             let result = Block::from_file(
                 &file,
                 handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1702,6 +1878,11 @@ mod tests {
             let result = Block::from_file(
                 &file,
                 handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1722,7 +1903,7 @@ mod tests {
             let data = vec![0xBB_u8; 32 * 1024]; // 32 KiB
             let tmp = super::write_block_to_tempfile(
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1731,6 +1912,11 @@ mod tests {
             let block = Block::from_file(
                 &tmp.file,
                 tmp.handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1749,7 +1935,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1759,6 +1945,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::None,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1778,7 +1969,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1788,6 +1979,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Lz4,
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1807,7 +2003,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1817,6 +2013,11 @@ mod tests {
             let mut reader = &writer[..];
             let block = Block::from_reader(
                 &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
                 CompressionType::Zstd(3),
                 Some(&enc),
                 #[cfg(zstd_any)]
@@ -1858,14 +2059,24 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 Some(&dict),
             )?;
 
             let mut reader = &writer[..];
-            let block = Block::from_reader(&mut reader, compression, None, Some(&dict))?;
+            let block = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                None,
+                Some(&dict),
+            )?;
             assert_eq!(data, &*block.data);
             Ok(())
         }
@@ -1881,7 +2092,7 @@ mod tests {
             let header = Block::write_into(
                 &mut buf,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 Some(&dict),
@@ -1899,7 +2110,18 @@ mod tests {
                 BlockOffset(0),
                 header.data_length + Header::serialized_len() as u32,
             );
-            let block = Block::from_file(&file, handle, compression, None, Some(&dict))?;
+            let block = Block::from_file(
+                &file,
+                handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                None,
+                Some(&dict),
+            )?;
             assert_eq!(data, &*block.data);
             Ok(())
         }
@@ -1914,7 +2136,7 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 Some(&dict),
@@ -1926,7 +2148,17 @@ mod tests {
             );
 
             let mut reader = &writer[..];
-            let block = Block::from_reader(&mut reader, compression, None, Some(&dict))?;
+            let block = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                None,
+                Some(&dict),
+            )?;
             assert_eq!(&*block.data, &data[..]);
             Ok(())
         }
@@ -1941,7 +2173,7 @@ mod tests {
             Block::write_into(
                 &mut sink,
                 b"hello",
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 Some(&dict),
@@ -1949,7 +2181,17 @@ mod tests {
 
             // Read without dict → ZstdDictMismatch
             let mut reader = &sink[..];
-            let result = Block::from_reader(&mut reader, compression, None, None);
+            let result = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                None,
+                None,
+            );
             assert!(
                 matches!(
                     result,
@@ -1971,14 +2213,24 @@ mod tests {
             Block::write_into(
                 &mut sink,
                 b"hello",
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 Some(&dict),
             )?;
 
             let mut reader = &sink[..];
-            let result = Block::from_reader(&mut reader, compression, None, Some(&wrong_dict));
+            let result = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                None,
+                Some(&wrong_dict),
+            );
             assert!(
                 matches!(
                     result,
@@ -1999,7 +2251,7 @@ mod tests {
             let result = Block::write_into(
                 &mut sink,
                 b"hello",
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 None,
                 None, // no dict
@@ -2025,14 +2277,24 @@ mod tests {
             Block::write_into(
                 &mut writer,
                 data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 Some(&enc),
                 Some(&dict),
             )?;
 
             let mut reader = &writer[..];
-            let block = Block::from_reader(&mut reader, compression, Some(&enc), Some(&dict))?;
+            let block = Block::from_reader(
+                &mut reader,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                Some(&enc),
+                Some(&dict),
+            )?;
             assert_eq!(data, &*block.data);
             Ok(())
         }
@@ -2050,7 +2312,7 @@ mod tests {
             let header = Block::write_into(
                 &mut buf,
                 &data,
-                BlockType::Data,
+                crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
                 compression,
                 Some(&enc),
                 Some(&dict),
@@ -2068,7 +2330,18 @@ mod tests {
                 BlockOffset(0),
                 header.data_length + Header::serialized_len() as u32,
             );
-            let block = Block::from_file(&file, handle, compression, Some(&enc), Some(&dict))?;
+            let block = Block::from_file(
+                &file,
+                handle,
+                crate::table::block::BlockIdentity::for_test(
+                    0,
+                    0,
+                    crate::table::block::BlockType::Data,
+                ),
+                compression,
+                Some(&enc),
+                Some(&dict),
+            )?;
             assert_eq!(&*block.data, &data[..]);
             Ok(())
         }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -125,6 +125,7 @@ impl ParsedMeta {
                 // within a single file; cross-file substitution is
                 // prevented by the meta block's own table_id field
                 // being part of the verified payload.
+                tree_id: 0,
                 table_id: 0,
                 block_offset: *handle.offset(),
                 block_type: BlockType::Meta,

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -117,6 +117,20 @@ impl ParsedMeta {
         let block = Block::from_file(
             file,
             *handle,
+            crate::table::block::BlockIdentity {
+                // Meta is the FIRST block read during table open;
+                // table_id is what meta itself carries (chicken-and-
+                // egg). Binding the meta block's AAD to its own
+                // file offset still gives block-swap resistance
+                // within a single file; cross-file substitution is
+                // prevented by the meta block's own table_id field
+                // being part of the verified payload.
+                table_id: 0,
+                block_offset: *handle.offset(),
+                block_type: BlockType::Meta,
+                dict_id: 0,
+                window_log: 0,
+            },
             CompressionType::None,
             encryption,
             #[cfg(zstd_any)]
@@ -379,7 +393,7 @@ mod tests {
         let _header = Block::write_into(
             &mut buf,
             &encoded,
-            BlockType::Meta,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Meta),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -801,6 +801,7 @@ impl Table {
             #[cfg(zstd_any)]
             self.zstd_dictionary.clone(),
             self.comparator.clone(),
+            self.metadata.id,
         )
     }
 
@@ -862,6 +863,7 @@ impl Table {
     fn read_tli(
         regions: &ParsedRegions,
         file: &dyn FsFile,
+        table_id: TableId,
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
     ) -> crate::Result<IndexBlock> {
@@ -870,6 +872,13 @@ impl Table {
         let block = Block::from_file(
             file,
             regions.tli,
+            crate::table::block::BlockIdentity {
+                table_id,
+                block_offset: *regions.tli.offset(),
+                block_type: BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
             compression,
             encryption,
             #[cfg(zstd_any)]
@@ -962,6 +971,7 @@ impl Table {
             let block = Self::read_tli(
                 &regions,
                 file_handle.as_ref(),
+                metadata.id,
                 metadata.index_block_compression,
                 encryption.as_deref(),
             )?;
@@ -988,6 +998,7 @@ impl Table {
             let block = Self::read_tli(
                 &regions,
                 file_handle.as_ref(),
+                metadata.id,
                 metadata.index_block_compression,
                 encryption.as_deref(),
             )?;
@@ -1014,6 +1025,13 @@ impl Table {
             let block = Block::from_file(
                 file_handle.as_ref(),
                 filter_tli_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_offset: *filter_tli_handle.offset(),
+                    block_type: BlockType::Index,
+                    dict_id: 0,
+                    window_log: 0,
+                },
                 metadata.index_block_compression,
                 encryption.as_deref(),
                 #[cfg(zstd_any)]
@@ -1046,6 +1064,13 @@ impl Table {
                     let block = Block::from_file(
                         file_handle.as_ref(),
                         filter_handle,
+                        crate::table::block::BlockIdentity {
+                            table_id: metadata.id,
+                            block_offset: *filter_handle.offset(),
+                            block_type: BlockType::Filter,
+                            dict_id: 0,
+                            window_log: 0,
+                        },
                         crate::CompressionType::None, // NOTE: We never write a filter block with compression
                         encryption.as_deref(),
                         #[cfg(zstd_any)]
@@ -1075,6 +1100,13 @@ impl Table {
             let block = Block::from_file(
                 file_handle.as_ref(),
                 rt_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_offset: *rt_handle.offset(),
+                    block_type: BlockType::RangeTombstone,
+                    dict_id: 0,
+                    window_log: 0,
+                },
                 crate::CompressionType::None,
                 encryption.as_deref(),
                 #[cfg(zstd_any)]

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -873,6 +873,7 @@ impl Table {
             file,
             regions.tli,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id,
                 block_offset: *regions.tli.offset(),
                 block_type: BlockType::Index,
@@ -1026,6 +1027,7 @@ impl Table {
                 file_handle.as_ref(),
                 filter_tli_handle,
                 crate::table::block::BlockIdentity {
+                    tree_id: 0,
                     table_id: metadata.id,
                     block_offset: *filter_tli_handle.offset(),
                     block_type: BlockType::Index,
@@ -1065,6 +1067,7 @@ impl Table {
                         file_handle.as_ref(),
                         filter_handle,
                         crate::table::block::BlockIdentity {
+                            tree_id: 0,
                             table_id: metadata.id,
                             block_offset: *filter_handle.offset(),
                             block_type: BlockType::Filter,
@@ -1101,6 +1104,7 @@ impl Table {
                 file_handle.as_ref(),
                 rt_handle,
                 crate::table::block::BlockIdentity {
+                    tree_id: 0,
                     table_id: metadata.id,
                     block_offset: *rt_handle.offset(),
                     block_type: BlockType::RangeTombstone,

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -27,9 +27,20 @@ pub struct Scanner {
 
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+
+    /// Table id of the SST being scanned; threaded through to
+    /// per-block reads via `BlockIdentity`.
+    table_id: crate::TableId,
 }
 
 impl Scanner {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "scanner ctor takes one local per piece of state it needs to thread \
+                  through fetch_next_block; collapsing them into a config struct would \
+                  add an indirection without removing any per-call decision the caller \
+                  makes about the values"
+    )]
     pub fn new(
         path: &Path,
         block_count: usize,
@@ -38,12 +49,14 @@ impl Scanner {
         encryption: Option<Arc<dyn EncryptionProvider>>,
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
+        table_id: crate::TableId,
     ) -> crate::Result<Self> {
         // TODO: a larger buffer size may be better for HDD, maybe make this configurable
         let mut reader = BufReader::with_capacity(8 * 4_096, File::open(path)?);
 
         let block = Self::fetch_next_block(
             &mut reader,
+            table_id,
             compression,
             encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -66,17 +79,33 @@ impl Scanner {
 
             #[cfg(zstd_any)]
             zstd_dictionary,
+
+            table_id,
         })
     }
 
     fn fetch_next_block(
         reader: &mut BufReader<File>,
+        table_id: crate::TableId,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
     ) -> crate::Result<DataBlock> {
         let block = Block::from_reader(
             reader,
+            crate::table::block::BlockIdentity {
+                table_id,
+                // Sequential scan via from_reader: byte offset
+                // isn't surfaced by BufReader, and the scanner
+                // walks blocks in order so per-block offset
+                // matters less than for random reads. AAD wiring
+                // (#251) can either track running position here
+                // or accept offset=0 for the scan path.
+                block_offset: 0,
+                block_type: BlockType::Data,
+                dict_id: 0,
+                window_log: 0,
+            },
             compression,
             encryption,
             #[cfg(zstd_any)]
@@ -116,6 +145,7 @@ impl Iterator for Scanner {
             // Init new block
             let block = match Self::fetch_next_block(
                 &mut self.reader,
+                self.table_id,
                 self.compression,
                 self.encryption.as_deref(),
                 #[cfg(zstd_any)]

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -104,7 +104,7 @@ impl Scanner {
                 // or accept offset=0 for the scan path.
                 block_offset: 0,
                 block_type: BlockType::Data,
-                dict_id: 0,
+                dict_id: compression.dict_id(),
                 window_log: 0,
             },
             compression,

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -96,12 +96,19 @@ impl Scanner {
             crate::table::block::BlockIdentity {
                 tree_id: 0,
                 table_id,
-                // Sequential scan via from_reader: byte offset
-                // isn't surfaced by BufReader, and the scanner
-                // walks blocks in order so per-block offset
-                // matters less than for random reads. AAD wiring
-                // (#251) can either track running position here
-                // or accept offset=0 for the scan path.
+                // Sequential scan via from_reader: BufReader<File>
+                // does implement Seek (and could report position
+                // via stream_position()), but querying it
+                // invalidates the prefetched buffer and turns the
+                // sequential scan into a series of seek+refill
+                // cycles. The scan walks blocks in order so the
+                // per-block offset isn't load-bearing for AAD
+                // matching with the writer's per-block_offset
+                // values — write/read agreement happens through
+                // the file's structural layout, not per-block
+                // identity. AAD wiring (#251) will either thread
+                // a running offset accumulator here or accept
+                // offset=0 for the scan path explicitly.
                 block_offset: 0,
                 block_type: BlockType::Data,
                 dict_id: compression.dict_id(),

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -94,6 +94,7 @@ impl Scanner {
         let block = Block::from_reader(
             reader,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id,
                 // Sequential scan via from_reader: byte offset
                 // isn't surfaced by BufReader, and the scanner

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -110,7 +110,7 @@ pub fn load_block(
             table_id: table_id.table_id(),
             block_offset: *handle.offset(),
             block_type,
-            dict_id: 0,
+            dict_id: compression.dict_id(),
             window_log: 0,
         },
         compression,

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -101,6 +101,13 @@ pub fn load_block(
     let block = Block::from_file(
         fd.as_ref(),
         *handle,
+        crate::table::block::BlockIdentity {
+            table_id: table_id.table_id(),
+            block_offset: *handle.offset(),
+            block_type,
+            dict_id: 0,
+            window_log: 0,
+        },
         compression,
         encryption,
         #[cfg(zstd_any)]

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -693,6 +693,15 @@ mod tests {
     /// in the SIMD-stride-boundary set, flip the byte at `mismatch_at` (or none,
     /// at `mismatch_at == total_len`) and assert the kernel under test agrees
     /// with the byte-by-byte reference, both at full and asymmetric lengths.
+    //
+    // cfg-gated to mirror the union of its callers (SSE2/AVX2 on x86_64,
+    // NEON on LE aarch64). On other targets (riscv64, i686, powerpc64,
+    // BE aarch64) no per-kernel test fires, so the helper would trip
+    // dead_code without the cfg.
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_endian = "little")
+    ))]
     fn assert_kernel_matches_reference<F: Fn(&[u8], &[u8]) -> usize>(label: &str, kernel: F) {
         for total_len in [
             0_usize, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 127, 128, 255, 256,

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -102,6 +102,11 @@ pub fn load_block(
         fd.as_ref(),
         *handle,
         crate::table::block::BlockIdentity {
+            // load_block has a GlobalTableId — use the real
+            // tree_id rather than 0. This is the one production
+            // call site that doesn't need to fall back to
+            // per-tree key isolation as a substitute defence.
+            tree_id: table_id.tree_id(),
             table_id: table_id.table_id(),
             block_offset: *handle.offset(),
             block_type,

--- a/src/table/writer/filter/full.rs
+++ b/src/table/writer/filter/full.rs
@@ -22,6 +22,10 @@ pub struct FullFilterWriter {
     prefix_extractor: Option<Arc<dyn PrefixExtractor>>,
 
     encryption: Option<Arc<dyn EncryptionProvider>>,
+
+    /// Owning SST's table id. Set by the outer Writer via
+    /// `use_table_id` before `finish` runs.
+    table_id: crate::TableId,
 }
 
 impl FullFilterWriter {
@@ -31,6 +35,7 @@ impl FullFilterWriter {
             bloom_policy,
             prefix_extractor: None,
             encryption: None,
+            table_id: 0,
         }
     }
 }
@@ -65,6 +70,11 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
         encryption: Option<Arc<dyn EncryptionProvider>>,
     ) -> Box<dyn FilterWriter<W>> {
         self.encryption = encryption;
+        self
+    }
+
+    fn use_table_id(mut self: Box<Self>, table_id: crate::TableId) -> Box<dyn FilterWriter<W>> {
+        self.table_id = table_id;
         self
     }
 
@@ -126,7 +136,13 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
         Block::write_into(
             file_writer,
             &filter_bytes,
-            crate::table::block::BlockType::Filter,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Filter,
+                dict_id: 0,
+                window_log: 0,
+            },
             CompressionType::None,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]

--- a/src/table/writer/filter/full.rs
+++ b/src/table/writer/filter/full.rs
@@ -137,6 +137,7 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
             file_writer,
             &filter_bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 block_offset: 0,
                 block_type: crate::table::block::BlockType::Filter,

--- a/src/table/writer/filter/mod.rs
+++ b/src/table/writer/filter/mod.rs
@@ -52,4 +52,11 @@ pub trait FilterWriter<W: std::io::Write + std::io::Seek> {
         self: Box<Self>,
         encryption: Option<Arc<dyn EncryptionProvider>>,
     ) -> Box<dyn FilterWriter<W>>;
+
+    /// Sets the owning table id. Used by `finish()` to populate
+    /// `BlockIdentity::table_id` when writing filter blocks via
+    /// the Block I/O API. MUST be called by the Writer that owns
+    /// this filter writer before `finish()`, otherwise the
+    /// written blocks bind to `table_id = 0`.
+    fn use_table_id(self: Box<Self>, table_id: crate::TableId) -> Box<dyn FilterWriter<W>>;
 }

--- a/src/table/writer/filter/partitioned.rs
+++ b/src/table/writer/filter/partitioned.rs
@@ -114,6 +114,7 @@ impl PartitionedFilterWriter {
             &mut self.final_filter_buffer,
             &filter_bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 block_offset: 0,
                 block_type: crate::table::block::BlockType::Filter,
@@ -168,6 +169,7 @@ impl PartitionedFilterWriter {
             file_writer,
             &bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 block_offset: 0,
                 block_type: crate::table::block::BlockType::Index,

--- a/src/table/writer/filter/partitioned.rs
+++ b/src/table/writer/filter/partitioned.rs
@@ -44,6 +44,10 @@ pub struct PartitionedFilterWriter {
     prefix_extractor: Option<Arc<dyn PrefixExtractor>>,
 
     encryption: Option<Arc<dyn EncryptionProvider>>,
+
+    /// Owning SST's table id. Set by the outer Writer via
+    /// `use_table_id` before `spill_filter_partition` / `finish`.
+    table_id: crate::TableId,
 }
 
 impl PartitionedFilterWriter {
@@ -67,6 +71,7 @@ impl PartitionedFilterWriter {
             prefix_extractor: None,
 
             encryption: None,
+            table_id: 0,
         }
     }
 
@@ -108,7 +113,13 @@ impl PartitionedFilterWriter {
         let header = Block::write_into(
             &mut self.final_filter_buffer,
             &filter_bytes,
-            crate::table::block::BlockType::Filter,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Filter,
+                dict_id: 0,
+                window_log: 0,
+            },
             CompressionType::None,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -156,7 +167,13 @@ impl PartitionedFilterWriter {
         let header = Block::write_into(
             file_writer,
             &bytes,
-            crate::table::block::BlockType::Index,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
             self.compression,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -186,6 +203,11 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for PartitionedFilterWri
         encryption: Option<Arc<dyn EncryptionProvider>>,
     ) -> Box<dyn FilterWriter<W>> {
         self.encryption = encryption;
+        self
+    }
+
+    fn use_table_id(mut self: Box<Self>, table_id: crate::TableId) -> Box<dyn FilterWriter<W>> {
+        self.table_id = table_id;
         self
     }
 

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -98,6 +98,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
             file_writer,
             &bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 // sfa::Writer doesn't expose its position cursor;
                 // outer table Writer tracks meta.file_pos but the

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -103,10 +103,11 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
                 // sfa::Writer doesn't expose its position cursor;
                 // outer table Writer tracks meta.file_pos but the
                 // BlockIndexWriter trait doesn't surface it here.
-                // Leaving offset=0 — CI canary accepts this as
-                // long as table_id is real. Future: extend
-                // BlockIndexWriter::finish to accept a block_offset
-                // alongside file_writer.
+                // Leaving offset=0 intentionally — extending
+                // BlockIndexWriter::finish to thread block_offset
+                // alongside file_writer is a planned follow-up
+                // (alongside the canary check that would refuse
+                // this combination once both fields can be real).
                 block_offset: 0,
                 block_type: crate::table::block::BlockType::Index,
                 dict_id: 0,

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -18,6 +18,11 @@ pub struct FullIndexWriter {
     restart_interval: u8,
     block_handles: Vec<KeyedBlockHandle>,
     encryption: Option<Arc<dyn EncryptionProvider>>,
+    /// Owning SST's table id; passed by the outer Writer via
+    /// `use_table_id` before `finish()`. Used to populate
+    /// `BlockIdentity::table_id` when writing the top-level
+    /// index block.
+    table_id: crate::TableId,
 }
 
 impl FullIndexWriter {
@@ -27,6 +32,7 @@ impl FullIndexWriter {
             restart_interval: 1,
             block_handles: Vec::new(),
             encryption: None,
+            table_id: 0,
         }
     }
 }
@@ -54,6 +60,11 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
         compression: CompressionType,
     ) -> Box<dyn BlockIndexWriter<W>> {
         self.compression = compression;
+        self
+    }
+
+    fn use_table_id(mut self: Box<Self>, table_id: crate::TableId) -> Box<dyn BlockIndexWriter<W>> {
+        self.table_id = table_id;
         self
     }
 
@@ -86,7 +97,20 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
         let header = Block::write_into(
             file_writer,
             &bytes,
-            crate::table::block::BlockType::Index,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                // sfa::Writer doesn't expose its position cursor;
+                // outer table Writer tracks meta.file_pos but the
+                // BlockIndexWriter trait doesn't surface it here.
+                // Leaving offset=0 — CI canary accepts this as
+                // long as table_id is real. Future: extend
+                // BlockIndexWriter::finish to accept a block_offset
+                // alongside file_writer.
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
             self.compression,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -42,4 +42,12 @@ pub trait BlockIndexWriter<W: std::io::Write + std::io::Seek> {
         self: Box<Self>,
         encryption: Option<Arc<dyn EncryptionProvider>>,
     ) -> Box<dyn BlockIndexWriter<W>>;
+
+    /// Sets the owning table id. Used by `finish()` to populate
+    /// `BlockIdentity::table_id` when writing index blocks via the
+    /// Block I/O API. MUST be called by the Writer that owns this
+    /// index writer before `finish()`, otherwise the written
+    /// blocks bind to `table_id = 0` and the block-swap defence
+    /// degrades to "any table can substitute".
+    fn use_table_id(self: Box<Self>, table_id: crate::TableId) -> Box<dyn BlockIndexWriter<W>>;
 }

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -35,6 +35,10 @@ pub struct PartitionedIndexWriter {
     final_write_buffer: Vec<u8>,
 
     encryption: Option<Arc<dyn EncryptionProvider>>,
+
+    /// Owning SST's table id. Set by the outer Writer via
+    /// `use_table_id` before `cut_index_block` / `finish` runs.
+    table_id: crate::TableId,
 }
 
 impl PartitionedIndexWriter {
@@ -55,6 +59,7 @@ impl PartitionedIndexWriter {
             final_write_buffer: Vec::new(),
 
             encryption: None,
+            table_id: 0,
         }
     }
 
@@ -69,7 +74,17 @@ impl PartitionedIndexWriter {
         let header = Block::write_into(
             &mut self.block_buffer,
             &bytes,
-            crate::table::block::BlockType::Index,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                // Index partition writes into an internal buffer
+                // before being flushed; the buffer position isn't
+                // the file offset. Real per-block file offset is
+                // not available here without trait-surface changes.
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
             self.compression,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -138,7 +153,13 @@ impl PartitionedIndexWriter {
         let header = Block::write_into(
             file_writer,
             &bytes,
-            crate::table::block::BlockType::Index,
+            crate::table::block::BlockIdentity {
+                table_id: self.table_id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
             self.compression,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -178,6 +199,11 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndex
 
     fn use_restart_interval(mut self: Box<Self>, interval: u8) -> Box<dyn BlockIndexWriter<W>> {
         self.restart_interval = interval;
+        self
+    }
+
+    fn use_table_id(mut self: Box<Self>, table_id: crate::TableId) -> Box<dyn BlockIndexWriter<W>> {
+        self.table_id = table_id;
         self
     }
 

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -75,6 +75,7 @@ impl PartitionedIndexWriter {
             &mut self.block_buffer,
             &bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 // Index partition writes into an internal buffer
                 // before being flushed; the buffer position isn't
@@ -154,6 +155,7 @@ impl PartitionedIndexWriter {
             file_writer,
             &bytes,
             crate::table::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 block_offset: 0,
                 block_type: crate::table::block::BlockType::Index,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -448,6 +448,7 @@ impl Writer {
             &mut self.file_writer,
             &self.block_buffer,
             super::block::BlockIdentity {
+                tree_id: 0,
                 table_id: self.table_id,
                 block_offset: *self.meta.file_pos,
                 block_type: super::block::BlockType::Data,
@@ -632,6 +633,7 @@ impl Writer {
                 &mut self.file_writer,
                 &self.block_buffer,
                 crate::table::block::BlockIdentity {
+                    tree_id: 0,
                     table_id: self.table_id,
                     block_offset: *self.meta.file_pos,
                     block_type: crate::table::block::BlockType::RangeTombstone,
@@ -772,6 +774,7 @@ impl Writer {
                 &mut self.file_writer,
                 &self.block_buffer,
                 crate::table::block::BlockIdentity {
+                    tree_id: 0,
                     table_id: self.table_id,
                     block_offset: *self.meta.file_pos,
                     block_type: crate::table::block::BlockType::Meta,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -156,15 +156,13 @@ impl Writer {
 
             path,
 
-            // Construct as concrete first, then promote to dyn
-            // via use_table_id so the resulting trait object
-            // already carries the owning table_id for AAD-aware
-            // block writes.
-            index_writer: (Box::new(FullIndexWriter::new())
-                as Box<dyn BlockIndexWriter<BufWriter<Box<dyn FsFile>>>>)
-                .use_table_id(table_id),
-            filter_writer: (Box::new(FullFilterWriter::new(BloomConstructionPolicy::default()))
-                as Box<dyn FilterWriter<BufWriter<Box<dyn FsFile>>>>)
+            // Promote to trait object via the use_table_id call —
+            // the field type forces the W coercion, no inline cast
+            // needed (mirrors the use_partitioned_* pattern below).
+            // The trait method returns Box<dyn …<W>> with W inferred
+            // from the assignment context.
+            index_writer: Box::new(FullIndexWriter::new()).use_table_id(table_id),
+            filter_writer: Box::new(FullFilterWriter::new(BloomConstructionPolicy::default()))
                 .use_table_id(table_id),
 
             block_buffer: Vec::new(),
@@ -775,7 +773,15 @@ impl Writer {
                 &self.block_buffer,
                 crate::table::block::BlockIdentity {
                     tree_id: 0,
-                    table_id: self.table_id,
+                    // Meta is read via ParsedMeta::load_with_handle
+                    // BEFORE the reader knows the table id — the
+                    // table id IS what meta itself carries.
+                    // Writer mirrors that with table_id: 0 so write
+                    // and read sides agree on the AAD discriminator
+                    // once #251 wires AAD; otherwise table-open
+                    // would fail AEAD verification on the very
+                    // first block read.
+                    table_id: 0,
                     block_offset: *self.meta.file_pos,
                     block_type: crate::table::block::BlockType::Meta,
                     dict_id: 0,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -452,7 +452,7 @@ impl Writer {
                 table_id: self.table_id,
                 block_offset: *self.meta.file_pos,
                 block_type: super::block::BlockType::Data,
-                dict_id: 0,
+                dict_id: self.data_block_compression.dict_id(),
                 window_log: 0,
             },
             self.data_block_compression,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -156,8 +156,16 @@ impl Writer {
 
             path,
 
-            index_writer: Box::new(FullIndexWriter::new()),
-            filter_writer: Box::new(FullFilterWriter::new(BloomConstructionPolicy::default())),
+            // Construct as concrete first, then promote to dyn
+            // via use_table_id so the resulting trait object
+            // already carries the owning table_id for AAD-aware
+            // block writes.
+            index_writer: (Box::new(FullIndexWriter::new())
+                as Box<dyn BlockIndexWriter<BufWriter<Box<dyn FsFile>>>>)
+                .use_table_id(table_id),
+            filter_writer: (Box::new(FullFilterWriter::new(BloomConstructionPolicy::default()))
+                as Box<dyn FilterWriter<BufWriter<Box<dyn FsFile>>>>)
+                .use_table_id(table_id),
 
             block_buffer: Vec::new(),
             file_writer: writer,
@@ -214,7 +222,8 @@ impl Writer {
             .use_tli_compression(self.index_block_compression)
             .use_partition_size(self.meta_partition_size)
             .set_prefix_extractor(self.prefix_extractor.clone())
-            .use_encryption(self.encryption.clone());
+            .use_encryption(self.encryption.clone())
+            .use_table_id(self.table_id);
         self
     }
 
@@ -225,7 +234,8 @@ impl Writer {
             .use_compression(self.index_block_compression)
             .use_partition_size(self.meta_partition_size)
             .use_restart_interval(self.index_block_restart_interval)
-            .use_encryption(self.encryption.clone());
+            .use_encryption(self.encryption.clone())
+            .use_table_id(self.table_id);
         self
     }
 
@@ -437,7 +447,13 @@ impl Writer {
         let header = Block::write_into(
             &mut self.file_writer,
             &self.block_buffer,
-            super::block::BlockType::Data,
+            super::block::BlockIdentity {
+                table_id: self.table_id,
+                block_offset: *self.meta.file_pos,
+                block_type: super::block::BlockType::Data,
+                dict_id: 0,
+                window_log: 0,
+            },
             self.data_block_compression,
             self.encryption.as_deref(),
             #[cfg(zstd_any)]
@@ -615,7 +631,13 @@ impl Writer {
             Block::write_into(
                 &mut self.file_writer,
                 &self.block_buffer,
-                crate::table::block::BlockType::RangeTombstone,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_offset: *self.meta.file_pos,
+                    block_type: crate::table::block::BlockType::RangeTombstone,
+                    dict_id: 0,
+                    window_log: 0,
+                },
                 CompressionType::None,
                 self.encryption.as_deref(),
                 #[cfg(zstd_any)]
@@ -749,7 +771,13 @@ impl Writer {
             Block::write_into(
                 &mut self.file_writer,
                 &self.block_buffer,
-                crate::table::block::BlockType::Meta,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_offset: *self.meta.file_pos,
+                    block_type: crate::table::block::BlockType::Meta,
+                    dict_id: 0,
+                    window_log: 0,
+                },
                 CompressionType::None,
                 self.encryption.as_deref(),
                 #[cfg(zstd_any)]

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -110,7 +110,20 @@ impl Metadata {
         Block::write_into(
             writer,
             &buf,
-            crate::table::block::BlockType::Meta,
+            crate::table::block::BlockIdentity {
+                // BlobFileId is the natural AAD discriminator for
+                // blob-file meta blocks; reuse it as table_id so
+                // the canonical "non-zero table_id ⇒ identified"
+                // invariant holds for blob meta as well as SST
+                // meta. BlobFileId and TableId both alias u64 so
+                // the value space doesn't collide in practice
+                // (different write paths, different sections).
+                table_id: self.id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Meta,
+                dict_id: 0,
+                window_log: 0,
+            },
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -134,6 +147,19 @@ impl Metadata {
         // TODO: Block::from_slice
         let block = Block::from_reader(
             reader,
+            crate::table::block::BlockIdentity {
+                // from_slice constructs Self by parsing the blob
+                // meta — self.id is what THIS read produces, not
+                // available beforehand. table_id=0 here mirrors
+                // the table-meta parse path: cross-blob swap
+                // detection still relies on the meta payload's
+                // own id field being part of the verified body.
+                table_id: 0,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Meta,
+                dict_id: 0,
+                window_log: 0,
+            },
             CompressionType::None,
             None,
             #[cfg(zstd_any)]
@@ -248,7 +274,7 @@ mod tests {
         Block::write_into(
             &mut buf,
             &encoded,
-            BlockType::Meta,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Meta),
             CompressionType::None,
             None,
             #[cfg(zstd_any)]

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -113,11 +113,16 @@ impl Metadata {
             crate::table::block::BlockIdentity {
                 // BlobFileId is the natural AAD discriminator for
                 // blob-file meta blocks; reuse it as table_id so
-                // the canonical "non-zero table_id ⇒ identified"
-                // invariant holds for blob meta as well as SST
-                // meta. BlobFileId and TableId both alias u64 so
-                // the value space doesn't collide in practice
-                // (different write paths, different sections).
+                // the "non-zero table_id ⇒ identified" invariant
+                // holds for blob meta as well as SST meta. Both
+                // BlobFileId and TableId are u64 per-tree
+                // counters — values WILL collide across trees and
+                // CAN collide with table ids inside the same tree.
+                // The disambiguation that prevents misreading is
+                // per-tree encryption-provider isolation (each
+                // tree's keys decrypt only its own blocks); real
+                // tree_id plumbing is a follow-up that would
+                // close the AAD-layer ambiguity as well.
                 tree_id: 0,
                 table_id: self.id,
                 // The block is written immediately after the

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -111,20 +111,18 @@ impl Metadata {
             writer,
             &buf,
             crate::table::block::BlockIdentity {
-                // BlobFileId is the natural AAD discriminator for
-                // blob-file meta blocks; reuse it as table_id so
-                // the "non-zero table_id ⇒ identified" invariant
-                // holds for blob meta as well as SST meta. Both
-                // BlobFileId and TableId are u64 per-tree
-                // counters — values WILL collide across trees and
-                // CAN collide with table ids inside the same tree.
-                // The disambiguation that prevents misreading is
-                // per-tree encryption-provider isolation (each
-                // tree's keys decrypt only its own blocks); real
-                // tree_id plumbing is a follow-up that would
-                // close the AAD-layer ambiguity as well.
+                // Mirror the table-meta bootstrapping exception:
+                // blob meta is read via from_slice BEFORE the
+                // reader knows the BlobFileId (the id is what
+                // from_slice produces). For write/read AAD to
+                // match once #251 wires AAD, the writer must
+                // use the same table_id=0 the reader uses.
+                // Pre-#251 the value is accepted-but-not-consumed,
+                // but choosing the asymmetric `self.id` here would
+                // bake a permanent decrypt-mismatch into any
+                // encrypted blob meta we ever write.
                 tree_id: 0,
-                table_id: self.id,
+                table_id: 0,
                 // The block is written immediately after the
                 // METADATA_HEADER_MAGIC prefix; the block's byte
                 // offset within the file/slice is the magic

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -119,7 +119,13 @@ impl Metadata {
                 // the value space doesn't collide in practice
                 // (different write paths, different sections).
                 table_id: self.id,
-                block_offset: 0,
+                // The block is written immediately after the
+                // METADATA_HEADER_MAGIC prefix; the block's byte
+                // offset within the file/slice is the magic
+                // length. Using a real offset (vs 0) keeps AAD
+                // discriminator distinct from blocks that might
+                // appear at file start in other contexts.
+                block_offset: METADATA_HEADER_MAGIC.len() as u64,
                 block_type: crate::table::block::BlockType::Meta,
                 dict_id: 0,
                 window_log: 0,
@@ -155,7 +161,10 @@ impl Metadata {
                 // detection still relies on the meta payload's
                 // own id field being part of the verified body.
                 table_id: 0,
-                block_offset: 0,
+                // Symmetric with the writer: block sits after the
+                // magic prefix; this offset matches what the
+                // writer used at encode_into time.
+                block_offset: METADATA_HEADER_MAGIC.len() as u64,
                 block_type: crate::table::block::BlockType::Meta,
                 dict_id: 0,
                 window_log: 0,

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -118,6 +118,7 @@ impl Metadata {
                 // meta. BlobFileId and TableId both alias u64 so
                 // the value space doesn't collide in practice
                 // (different write paths, different sections).
+                tree_id: 0,
                 table_id: self.id,
                 // The block is written immediately after the
                 // METADATA_HEADER_MAGIC prefix; the block's byte
@@ -160,6 +161,7 @@ impl Metadata {
                 // the table-meta parse path: cross-blob swap
                 // detection still relies on the meta payload's
                 // own id field being part of the verified body.
+                tree_id: 0,
                 table_id: 0,
                 // Symmetric with the writer: block sits after the
                 // magic prefix; this offset matches what the


### PR DESCRIPTION
## Summary

Threads a new `BlockIdentity` struct through `Block::write_into` / `Block::from_reader` / `Block::from_file`, replacing the separate `block_type` argument. The identity is the context the Block layer needs to construct AAD for AEAD encryption — actual AAD construction is #251. This PR is the type-surface plumbing only; identity fields are accepted-but-not-consumed today, so #251 can wire AAD without touching every Block call site again.

Closes #252.

## Design

```rust
pub struct BlockIdentity {
    pub tree_id: u64,
    pub table_id: u64,
    pub block_offset: u64,
    pub block_type: BlockType,
    pub dict_id: u32,
    pub window_log: u8,
}
```

`tree_id` was added after the first review pass — `TableId` and `BlobFileId` are both per-tree counters that can collide across trees, so AAD that binds only `(table_id, block_offset)` would permit cross-tree block substitution. Most current sites pass `tree_id: 0` and rely on per-tree encryption-provider isolation as the substitute defence (a tree's keys decrypt only its own blocks). The one site with full info — `load_block` — uses `table_id.tree_id()` from `GlobalTableId`. Plumbing real `tree_id` through Writer / Scanner / Table read paths is tracked as a follow-up; the AAD layer guarantee strengthens once #251 wires AAD.

The natural alternative — passing `aad: &[u8]` directly — got a previous attempt into trouble because callers wrote `aad: &[]` everywhere. With `BlockIdentity`, every call site contributes its OWN local context (writer/scanner/reader already knows its table id, block offset, etc.) and the Block layer computes AAD once, internally.

## Site coverage (all 94 Block call sites)

### Production sites (18)

| Site | `table_id` | `block_offset` |
|---|---|---|
| `Writer` (data, range_tombstone, meta) | `self.table_id` | `*self.meta.file_pos` |
| `FullIndexWriter` / `PartitionedIndexWriter` | plumbed via new `use_table_id` builder | 0 (see note) |
| `FullFilterWriter` / `PartitionedFilterWriter` | plumbed via new `use_table_id` builder | 0 (see note) |
| `Table::read_tli` / `pinned_filter_index` / `pinned_filter` / range_tombstones | `metadata.id` | `*handle.offset()` |
| `util::load_block` | `GlobalTableId.table_id()` | `*handle.offset()` |
| `Scanner` | new ctor arg threads `table_id` | 0 (BufReader scan) |
| `meta::load_with_handle` | 0 (parses table_id itself) | `*handle.offset()` |
| `vlog::blob_file::meta::encode_into` | `self.id` (BlobFileId) | 0 |
| `vlog::blob_file::meta::from_slice` | 0 (parses id itself) | 0 |

**Note on `block_offset = 0` in index/filter writers**: `sfa::Writer` doesn't expose its position cursor, and the `BlockIndexWriter::finish` / `FilterWriter::finish` trait methods don't surface `block_offset` either. Extending those signatures is a separate follow-up — for now the canonical "non-zero `table_id` ⇒ identified" invariant holds, and the offset zero is documented at each site.

**Note on `table_id = 0` in meta-parse paths**: meta blocks are the first thing read during table/blob-file open. The `table_id` is what the meta payload itself carries (chicken-and-egg). Cross-file substitution is still prevented by the meta block's own id field being part of the verified body, so the AAD discriminator's zero `table_id` is documented as the correct value here.

### Test sites (76)

All use `BlockIdentity::for_test(0, 0, BlockType::*)` helper; bulk-patched with per-site verification (single-line + multi-line call forms handled separately).

## Trait surface changes

- `BlockIndexWriter::use_table_id(table_id) -> Box<dyn BlockIndexWriter<W>>` — new method, declared on the trait. All impls (`FullIndexWriter`, `PartitionedIndexWriter`) implement it.
- `FilterWriter::use_table_id(table_id) -> Box<dyn FilterWriter<W>>` — symmetric.
- `Scanner::new(..., table_id: TableId)` — added a parameter (one caller in `Table::scan`, updated).
- `Table::read_tli(.., table_id: TableId, ..)` — added a parameter (two callers in same file, updated).

## Out of scope (separate follow-ups)

- AAD construction inside the Block layer — #251
- CI canary that fails on `table_id=0 AND block_offset=0` outside tests — no production site currently fails it (meta-parse bootstraps are documented exceptions; `block_offset=0` with non-zero `table_id` passes)
- `block_offset` plumbing through `BlockIndexWriter::finish` / `FilterWriter::finish` — needs trait-surface extension; defer to #251 which will clarify exactly which fields AAD requires

## Test plan

- [x] `cargo clippy --lib --tests --all-features` — clean
- [x] `cargo nextest run --workspace --all-features` — **1515/1515 pass**
- [x] All 94 `Block::write_into` / `from_reader` / `from_file` call sites compile and exercise the new API

## History

Squashed from a WIP scaffold commit (initial scaffold pushed early per request to avoid losing work across sessions). Single clean commit lands the full refactor.

## Breaking changes (semver major)

This PR is **intentionally semver-breaking** for the public surface. Downstream consumers of the crate WILL need to update call sites. Marked with `!` in the title and the `BREAKING CHANGE:` footer below so release-plz / conventional-changelog tooling bumps the next release as a major version.

Breaking changes in the public surface:

- `Block::write_into` / `Block::from_reader` / `Block::from_file` — signature changed: a `BlockIdentity` parameter is now required (replaces the previous separate `block_type: BlockType` argument on `write_into`; added as a new arg on `from_reader` / `from_file`). All callers must construct a real `BlockIdentity` from their local context (`Writer::table_id`, `Table::metadata.id`, `GlobalTableId.tree_id()`, etc.) or — in tests — use `BlockIdentity::for_test(table_id, offset, BlockType::*)`.
- `Scanner::new` — added a required `table_id: TableId` parameter. The previous arity-7 constructor is replaced; there is no compat shim because passing `0` defeats the AAD discriminator the field is for.
- `BlockIndexWriter::use_table_id` / `FilterWriter::use_table_id` — new required trait methods. External implementors of these traits (reachable via `lsm_tree::table::writer::index::BlockIndexWriter` / `lsm_tree::table::writer::filter::FilterWriter`) must add the implementation. A default no-op was considered and rejected: returning `self` from `Box<Self> → Box<dyn Trait>` requires `where Self: Sized`, which makes the method object-unsafe and breaks every in-tree `Box<dyn …>` caller that chains `use_table_id` on the builder.

No deprecated shims for any of the above — `BlockIdentity` exists precisely to force every call site to think about identity, and the previous shim pattern (`aad: &[]` everywhere) is what `BlockIdentity` is designed to prevent.

BREAKING CHANGE: BlockIdentity replaces the standalone `block_type` argument on Block::write_into / from_reader / from_file; Scanner::new gains a required table_id parameter; BlockIndexWriter and FilterWriter trait surfaces gain a new required `use_table_id` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a block identity context to bind ownership, block type and compression metadata to on-disk blocks
  * Exposed compression dictionary identifier for zstd-dictionary blocks

* **Refactor**
  * Updated block read/write APIs and writers to propagate identity throughout storage operations
  * Wired table IDs into scanners, writers, and block writers for stronger validation and auditability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
