### PR TITLE
feat(seeking-merger): allow self-coordinating independent-cursor sources via broadened CoherentMergeSource (#280)

### DIFF
--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -96,8 +96,12 @@ pub trait MergeSource: Send {
     /// own self-coordination (shared cursor state for coherent
     /// sources, internal `(front_idx, back_idx)` window for
     /// independent ones). `seek` is exposed for user-initiated
-    /// repositioning before iteration begins (e.g., starting a
-    /// range scan at a specific key).
+    /// repositioning — typically at the start of a range scan, but
+    /// also valid mid-iteration as an explicit jump to a known
+    /// key. Note that calling `seek` on a source marked
+    /// [`CoherentMergeSource`] must preserve that marker's
+    /// no-duplicates promise (impls usually do this with a no-op
+    /// or a window-collapse rather than a hard cursor reset).
     ///
     /// Returns `Err` if seek requires I/O (SST scanner reseek, run
     /// header re-read) and that I/O fails. Corruption errors
@@ -107,25 +111,38 @@ pub trait MergeSource: Send {
     fn seek(&mut self, target: &InternalKey) -> crate::Result<()>;
 }
 
-/// Marker documenting that a `MergeSource` impl's `next()` and
-/// `next_back()` share cursor state literally (not just by index
-/// arithmetic on a single backing buffer).
+/// Marker that promises a `MergeSource` impl's `next()` and
+/// `next_back()` will never yield the same item twice under mixed
+/// forward/backward consumption — regardless of HOW the impl
+/// achieves that.
 ///
-/// Such sources guarantee that mixed forward/backward consumption
-/// never yields the same item twice. Iterators backed by
-/// `alloc::vec::IntoIter`, `alloc::collections::VecDeque`, or
-/// range iterators from `alloc::collections::BTreeMap` qualify
-/// (their `DoubleEndedIterator` impls shrink a single remaining
-/// range from both ends).
+/// Two flavours qualify:
 ///
-/// **Status:** documentation-only marker. Earlier versions of
-/// `SeekingMerger` gated `DoubleEndedIterator` on this trait, but
-/// the bound was relaxed to `MergeSource` so self-coordinating
-/// independent-cursor sources (LSM SST scanners with a
-/// `(front_idx, back_idx)` window) work too. The marker remains
-/// because it cleanly identifies the literally-shared-state
-/// flavour for `CoherentIterSource` and is a place to anchor the
-/// "no item yielded twice" promise in the type system.
+/// - **Literally shared cursor state**: `alloc::vec::IntoIter`,
+///   `alloc::collections::VecDeque`, range iterators from
+///   `alloc::collections::BTreeMap`. Their `DoubleEndedIterator`
+///   impls shrink a single remaining range from both ends.
+///   `CoherentIterSource` wraps these.
+///
+/// - **Self-coordinating index window**: an impl backed by a
+///   sorted buffer plus `(front_idx, back_idx)` pointers that
+///   refuses to yield once `front_idx >= back_idx`. LSM SST
+///   scanners and future `RunReader` impls fit here. They're not
+///   literally sharing cursor state, but the index arithmetic
+///   gives the same no-duplicates guarantee.
+///
+/// **What this marker gates:** `SeekingMerger`'s
+/// `DoubleEndedIterator` impl is bounded on this trait — sources
+/// without the promise cannot use mixed direction through the
+/// merger.
+///
+/// **What this marker says about `seek`:** the promise must hold
+/// even after `seek` is called. Impls typically satisfy this with
+/// a no-op `seek` (`CoherentIterSource`) or a clamp that
+/// collapses the live window (`IndependentCursorSource`-style).
+/// A truly position-resetting `seek` would break the marker's
+/// promise on the next mixed-direction step and so cannot
+/// coexist with `CoherentMergeSource`.
 pub trait CoherentMergeSource: MergeSource {}
 
 /// Pass-through impl so callers can build `Vec<Box<dyn MergeSource +

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -98,13 +98,19 @@ pub trait MergeSource: Send {
     /// explicit reposition.
     ///
     /// `SeekingMerger` does NOT invoke `seek()` on direction
-    /// switches — its two-tree architecture relies on the source's
-    /// own self-coordination (shared cursor state for coherent
-    /// sources, internal `(front_idx, back_idx)` window for
-    /// independent ones). `seek` is exposed for user-initiated
-    /// repositioning — typically at the start of a range scan, but
-    /// also valid mid-iteration as an explicit jump to a known
-    /// key.
+    /// switches — its two-tree architecture relies on the source
+    /// being [`CoherentMergeSource`] (either literally-shared
+    /// cursor state, or a self-coordinating index window — see
+    /// that marker's docs for the two flavours). Sources with
+    /// genuinely independent front/back cursors (no shared state,
+    /// no window guard — currently no in-tree impl, but a
+    /// straight-line file scanner with separate read offsets would
+    /// be the canonical example) must NOT implement
+    /// [`CoherentMergeSource`] and therefore cannot be used through
+    /// `SeekingMerger`'s `DoubleEndedIterator` impl. `seek` is
+    /// exposed for user-initiated repositioning — typically at the
+    /// start of a range scan, but also valid mid-iteration as an
+    /// explicit jump to a known key.
     ///
     /// The [`CoherentMergeSource`] marker's no-duplicates promise
     /// covers mixed `next` / `next_back` consumption WITHOUT an
@@ -136,10 +142,15 @@ pub trait MergeSource: Send {
 ///
 /// - **Self-coordinating index window**: an impl backed by a
 ///   sorted buffer plus `(front_idx, back_idx)` pointers that
-///   refuses to yield once `front_idx >= back_idx`. LSM SST
-///   scanners and future `RunReader` impls fit here. They're not
-///   literally sharing cursor state, but the index arithmetic
-///   gives the same no-duplicates guarantee.
+///   refuses to yield once `front_idx >= back_idx`. SST scanners
+///   and `RunReader`-style impls qualify ONLY IF they actually
+///   enforce a single shrinking window — i.e. `next()` advances
+///   `front_idx` and `next_back()` retreats `back_idx`, and either
+///   refuses to yield when the indices cross. An impl with two
+///   genuinely independent cursors (each side has its own offset
+///   that the other never reads) is NOT coherent and MUST NOT
+///   implement this marker, even though it might happen to behave
+///   correctly under a specific consumption pattern.
 ///
 /// **What this marker gates:** `SeekingMerger`'s
 /// `DoubleEndedIterator` impl is bounded on this trait — sources

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -5,11 +5,15 @@
 //!
 //! `MergeSource` is what `SeekingMerger` consumes: a stream that
 //! can be advanced in either direction AND repositioned to a
-//! specific key. The seek primitive is what makes RocksDB-style
-//! direction switching possible — without it, a backward-only path
-//! cannot recover from prior forward consumption on iterators whose
-//! front and back cursors don't share state (LSM SST scanners
-//! empirically don't).
+//! specific key. `SeekingMerger` itself does NOT invoke
+//! [`MergeSource::seek`] on direction switches — its two-tree
+//! architecture relies on each source's own
+//! `(front_idx, back_idx)` window (or equivalent self-coordination
+//! between `next` and `next_back`) to keep mixed direction
+//! duplicate-free. The seek primitive is exposed on the trait for
+//! user-initiated repositioning (range scan starting key, jump to
+//! a known key, etc.), not as a direction-switch reconciliation
+//! mechanism.
 //!
 //! # Contract
 //!

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -36,17 +36,11 @@
 //!   **Coherent-cursor sources** (those marked [`CoherentMergeSource`]
 //!   — `alloc::vec::IntoIter`, `alloc::collections::VecDeque`, range
 //!   iterators from `alloc::collections::BTreeMap`, and our
-//!   `CoherentIterSource` wrapper) — seek
-//!   MAY be a no-op. The shared front/back cursor discipline
-//!   already maintains the "no item yielded twice" invariant for
-//!   mixed-direction consumption without any explicit reposition;
-//!   the no-op satisfies the contract trivially. The current MVP
-//!   `SeekingMerger` does NOT actually invoke `seek()` — its
-//!   `DoubleEndedIterator` impl is type-gated on
-//!   `CoherentMergeSource` and relies on the marker's coherence
-//!   promise. The seek-aware direction-switch path that would
-//!   exercise `seek()` for independent-cursor sources is the
-//!   follow-up tracked as issue #280.
+//!   `CoherentIterSource` wrapper) — seek MAY be a no-op. The shared
+//!   front/back cursor discipline already maintains the "no item
+//!   yielded twice" invariant for mixed-direction consumption
+//!   without any explicit reposition; the no-op satisfies the
+//!   contract trivially.
 //!
 //! # Why a custom trait, not just `DoubleEndedIterator + Seek`
 //!
@@ -109,8 +103,9 @@ pub trait MergeSource: Send {
     fn seek(&mut self, target: &InternalKey) -> crate::Result<()>;
 }
 
-/// Marker for `MergeSource` impls whose `next()` and `next_back()`
-/// share cursor state.
+/// Marker documenting that a `MergeSource` impl's `next()` and
+/// `next_back()` share cursor state literally (not just by index
+/// arithmetic on a single backing buffer).
 ///
 /// Such sources guarantee that mixed forward/backward consumption
 /// never yields the same item twice. Iterators backed by
@@ -119,16 +114,14 @@ pub trait MergeSource: Send {
 /// (their `DoubleEndedIterator` impls shrink a single remaining
 /// range from both ends).
 ///
-/// **Why a marker trait:** `SeekingMerger` can skip seek-based
-/// reseeks for sources whose front/back cursors already shrink a
-/// single shared remaining range. Sources with independent cursors
-/// (LSM SST scanners, run readers — the intended follow-up impls)
-/// should implement `MergeSource` with a real `seek`, but MUST NOT
-/// implement `CoherentMergeSource` unless mixed forward/backward
-/// consumption already guarantees no item is yielded twice. The
-/// marker is the type-system encoding of that promise — without
-/// it, `SeekingMerger`'s `DoubleEndedIterator` impl is unavailable
-/// at compile time.
+/// **Status:** documentation-only marker. Earlier versions of
+/// `SeekingMerger` gated `DoubleEndedIterator` on this trait, but
+/// the bound was relaxed to `MergeSource` so self-coordinating
+/// independent-cursor sources (LSM SST scanners with a
+/// `(front_idx, back_idx)` window) work too. The marker remains
+/// because it cleanly identifies the literally-shared-state
+/// flavour for `CoherentIterSource` and is a place to anchor the
+/// "no item yielded twice" promise in the type system.
 pub trait CoherentMergeSource: MergeSource {}
 
 /// Pass-through impl so callers can build `Vec<Box<dyn MergeSource +

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -26,9 +26,12 @@
 //!     * the next `next_back()` yields the first item with `key < target`
 //!
 //!     If no such item exists in a direction, that direction returns
-//!     `None` on the next call. Repositioning is the only way for
-//!     `SeekingMerger` to guarantee the no-overlap invariant when
-//!     direction switches.
+//!     `None` on the next call. NOTE: `SeekingMerger` does NOT call
+//!     `seek` on direction switches — its two-tree architecture
+//!     relies on the source's own `(front_idx, back_idx)` window
+//!     (or equivalent self-coordination) to keep mixed direction
+//!     duplicate-free. `seek` is exposed here for user-initiated
+//!     repositioning (range scan starting key, etc.).
 //!
 //!   **Coherent-cursor sources** (those marked [`CoherentMergeSource`]
 //!   — `alloc::vec::IntoIter`, `alloc::collections::VecDeque`, range
@@ -90,13 +93,13 @@ pub trait MergeSource: Send {
     /// twice" under mixed-direction consumption without any
     /// explicit reposition.
     ///
-    /// The current MVP `SeekingMerger` does NOT actually invoke
-    /// `seek()` at all — `DoubleEndedIterator` is type-gated on
-    /// `CoherentMergeSource` and relies on the marker's coherence
-    /// promise. Once the seek-aware direction-switch path (issue
-    /// #280) lands, `SeekingMerger` WILL invoke `seek()` on
-    /// non-coherent sources at the direction-switch boundary;
-    /// coherent sources will still pay nothing for the no-op.
+    /// `SeekingMerger` does NOT invoke `seek()` on direction
+    /// switches — its two-tree architecture relies on the source's
+    /// own self-coordination (shared cursor state for coherent
+    /// sources, internal `(front_idx, back_idx)` window for
+    /// independent ones). `seek` is exposed for user-initiated
+    /// repositioning before iteration begins (e.g., starting a
+    /// range scan at a specific key).
     ///
     /// Returns `Err` if seek requires I/O (SST scanner reseek, run
     /// header re-read) and that I/O fails. Corruption errors

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -4,16 +4,24 @@
 //! Seekable source iterator trait for the merge-iterator path.
 //!
 //! `MergeSource` is what `SeekingMerger` consumes: a stream that
-//! can be advanced in either direction AND repositioned to a
-//! specific key. `SeekingMerger` itself does NOT invoke
-//! [`MergeSource::seek`] on direction switches — its two-tree
-//! architecture relies on each source's own
-//! `(front_idx, back_idx)` window (or equivalent self-coordination
-//! between `next` and `next_back`) to keep mixed direction
-//! duplicate-free. The seek primitive is exposed on the trait for
-//! user-initiated repositioning (range scan starting key, jump to
-//! a known key, etc.), not as a direction-switch reconciliation
-//! mechanism.
+//! can be advanced in either direction, AND that exposes a key-
+//! addressed [`MergeSource::seek`] primitive whose strength varies
+//! by source flavour. Independent-cursor sources MUST treat `seek`
+//! as a real reposition (the only way they can maintain the
+//! no-duplicates invariant under mixed direction); coherent-cursor
+//! sources (see [`CoherentMergeSource`]) MAY treat it as a no-op
+//! because their shared `next`/`next_back` cursor discipline
+//! already enforces no-duplicates without external reseek (the
+//! `CoherentIterSource` adapter ships such a no-op `seek`).
+//!
+//! `SeekingMerger` itself does NOT invoke [`MergeSource::seek`] on
+//! direction switches — its two-tree architecture relies on each
+//! source's own `(front_idx, back_idx)` window (or equivalent
+//! self-coordination between `next` and `next_back`) to keep mixed
+//! direction duplicate-free. The seek primitive is exposed on the
+//! trait for user-initiated repositioning (range scan starting
+//! key, jump to a known key, etc.), not as a direction-switch
+//! reconciliation mechanism.
 //!
 //! # Contract
 //!

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -98,10 +98,14 @@ pub trait MergeSource: Send {
     /// independent ones). `seek` is exposed for user-initiated
     /// repositioning — typically at the start of a range scan, but
     /// also valid mid-iteration as an explicit jump to a known
-    /// key. Note that calling `seek` on a source marked
-    /// [`CoherentMergeSource`] must preserve that marker's
-    /// no-duplicates promise (impls usually do this with a no-op
-    /// or a window-collapse rather than a hard cursor reset).
+    /// key.
+    ///
+    /// The [`CoherentMergeSource`] marker's no-duplicates promise
+    /// covers mixed `next` / `next_back` consumption WITHOUT an
+    /// intervening user-initiated `seek`. A user `seek` is an
+    /// explicit reposition, so observing previously-yielded items
+    /// after a seek is expected behaviour, not a contract
+    /// violation. Impls are free to hard-reset their cursors.
     ///
     /// Returns `Err` if seek requires I/O (SST scanner reseek, run
     /// header re-read) and that I/O fails. Corruption errors
@@ -136,13 +140,14 @@ pub trait MergeSource: Send {
 /// without the promise cannot use mixed direction through the
 /// merger.
 ///
-/// **What this marker says about `seek`:** the promise must hold
-/// even after `seek` is called. Impls typically satisfy this with
-/// a no-op `seek` (`CoherentIterSource`) or a clamp that
-/// collapses the live window (`IndependentCursorSource`-style).
-/// A truly position-resetting `seek` would break the marker's
-/// promise on the next mixed-direction step and so cannot
-/// coexist with `CoherentMergeSource`.
+/// **What this marker says about `seek`:** the no-duplicates
+/// promise covers mixed `next` / `next_back` consumption WITHOUT
+/// an intervening user-initiated `seek`. A user `seek` is an
+/// explicit reposition: observing previously-yielded items after
+/// a seek is expected behaviour, not a contract violation. Impls
+/// are free to hard-reset their cursors on `seek` — a production
+/// independent-cursor source typically will. The marker promise
+/// re-engages on the next forward / backward step pair.
 pub trait CoherentMergeSource: MergeSource {}
 
 /// Pass-through impl so callers can build `Vec<Box<dyn MergeSource +

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -76,7 +76,13 @@ pub trait MergeSource: Send {
     /// cursor, or `None` if exhausted in the backward direction.
     fn next_back(&mut self) -> Option<IterItem>;
 
-    /// Reposition cursors for a subsequent direction switch.
+    /// User-initiated cursor reposition to a target key.
+    ///
+    /// `seek` is a public reposition primitive — typically called
+    /// once at the start of a range scan, but valid at any point
+    /// during iteration as an explicit jump. It is NOT the hook
+    /// `SeekingMerger` uses to handle direction switches (see the
+    /// paragraph on direction-switch handling below).
     ///
     /// Implementations with INDEPENDENT front/back cursors (LSM SST
     /// scanners, `RunReader`s) MUST reposition so that:

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -11,13 +11,18 @@
 //! switches; the marker's promise is what keeps mixed direction
 //! safe. Two source families satisfy the marker:
 //!
-//! - **Coherent sources** (std `vec::IntoIter`, `VecDeque`,
-//!   `BTreeMap::range`, wrapped via `CoherentIterSource`) where
-//!   the cursor state is literally shared between the two methods.
+//! - **Coherent sources** (`alloc::vec::IntoIter`,
+//!   `alloc::collections::VecDeque`, range iterators from
+//!   `alloc::collections::BTreeMap`, wrapped via
+//!   `CoherentIterSource`) where the cursor state is literally
+//!   shared between the two methods.
 //! - **Self-coordinating index-window sources** that track a
 //!   `(front_idx, back_idx)` window internally and refuse to
-//!   yield once `front_idx >= back_idx`. LSM SST scanners and
-//!   future `RunReader` impls fit here.
+//!   yield once `front_idx >= back_idx`. SST scanners and
+//!   `RunReader`-style impls qualify ONLY when they actually
+//!   enforce that single shrinking window — an impl with two
+//!   genuinely independent cursors must NOT mark itself coherent
+//!   even if it happens to behave correctly on some workloads.
 //!
 //! Sources whose mixed direction would yield duplicates (truly
 //! independent cursors with no shared state and no window guard)
@@ -858,12 +863,19 @@ mod tests {
         }
 
         fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
-            // Clamping seek: enforces the self-coordination invariant
-            // by collapsing the window to empty (see struct docs).
-            // A production source would hard-reset cursors to `target`;
-            // this test double cannot, without risking already-emitted
-            // items being re-yielded — which would break the no-
-            // duplicates property under mixed direction.
+            // Clamping seek: nudges the existing window toward
+            // `target` without ever expanding it. A production
+            // independent-cursor source would hard-reset its cursors
+            // to `target` (the no-duplicates promise on
+            // [`CoherentMergeSource`] is scoped to direction switches
+            // *without* an intervening user `seek`, so re-yielding
+            // previously-emitted items here would be allowed). This
+            // test double sticks with clamping because the seeking
+            // merger tests it backs do not exercise post-seek
+            // direction switches — there's no behaviour to verify
+            // that hard-reset would express, and clamping keeps the
+            // assertion footprint smaller (the window's invariant
+            // never changes across the seek call).
             let idx = self.items.partition_point(|v| {
                 v.key.compare_with(target, self.comparator.as_ref()) == Ordering::Less
             });

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -139,6 +139,30 @@ pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     pending_forward_error: Option<crate::Error>,
     /// Mirror of `pending_forward_error` for the backward direction.
     pending_backward_error: Option<crate::Error>,
+    /// Tracks which direction yielded the last item so the next call
+    /// can detect a direction switch and call `MergeSource::seek` on
+    /// each source to reposition the opposite tournament.
+    last_direction: LastDirection,
+    /// User key of the most recent item yielded via `Iterator::next`.
+    /// Used as the boundary when switching from forward to backward —
+    /// the seek call repositions backward cursors to yield items <
+    /// this key.
+    last_emitted_forward_key: Option<crate::key::InternalKey>,
+    /// Mirror of `last_emitted_forward_key` for backward emissions.
+    /// Used as boundary when switching from backward to forward.
+    last_emitted_backward_key: Option<crate::key::InternalKey>,
+}
+
+/// Which direction yielded the most recent item, if any.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LastDirection {
+    /// Neither direction has yielded yet — no direction switch on the
+    /// next call.
+    None,
+    /// Last item came from `Iterator::next`.
+    Forward,
+    /// Last item came from `DoubleEndedIterator::next_back`.
+    Backward,
 }
 
 impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
@@ -156,6 +180,49 @@ impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
             backward_tree: None,
             pending_forward_error: None,
             pending_backward_error: None,
+            last_direction: LastDirection::None,
+            last_emitted_forward_key: None,
+            last_emitted_backward_key: None,
+        }
+    }
+
+    /// Reposition every source for forward iteration past the last
+    /// item emitted backward.
+    ///
+    /// Called only when the previous yielded item came from
+    /// `next_back`. Tournaments are intentionally NOT dropped here:
+    ///
+    /// - For coherent sources (no-op seek), keeping `forward_tree`
+    ///   alive preserves prefetched values that the buffered-value
+    ///   migration in [`initialize_backward`] is designed to rescue.
+    /// - For independent-cursor sources where `seek` repositions the
+    ///   source past its already-emitted range (the contract in
+    ///   [`MergeSource::seek`]'s docs), the existing prefetches stay
+    ///   semantically valid — they're items the source produced
+    ///   before the seek, still meaningful in their original
+    ///   direction.
+    ///
+    /// `Iterator::next` will lazily build `forward_tree` from the
+    /// repositioned sources if it is currently `None`; if it already
+    /// holds prefetched leaves, those leaves continue to be merged
+    /// alongside freshly pulled items.
+    fn switch_to_forward(&mut self, boundary: &crate::key::InternalKey) {
+        for src in &mut self.sources {
+            if let Err(e) = src.seek(boundary) {
+                // Queue under the destination direction so it
+                // surfaces via the next `next()` call's error gate.
+                self.pending_forward_error.get_or_insert(e);
+            }
+        }
+    }
+
+    /// Mirror of [`switch_to_forward`] — reposition sources for
+    /// backward iteration past the last forward-emitted item.
+    fn switch_to_backward(&mut self, boundary: &crate::key::InternalKey) {
+        for src in &mut self.sources {
+            if let Err(e) = src.seek(boundary) {
+                self.pending_backward_error.get_or_insert(e);
+            }
         }
     }
 
@@ -246,6 +313,20 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
         if let Some(e) = self.pending_backward_error.take() {
             return Some(Err(e));
         }
+        // Direction-switch reconciliation: if the last yielded item
+        // came from backward, every source's forward cursor may be
+        // stale relative to what backward consumed. Seek each source
+        // past the backward boundary so the new forward step yields
+        // only items the backward direction did not already produce.
+        if self.last_direction == LastDirection::Backward
+            && let Some(boundary) = self.last_emitted_backward_key.clone()
+        {
+            self.switch_to_forward(&boundary);
+            if let Some(e) = self.pending_forward_error.take() {
+                return Some(Err(e));
+            }
+        }
+        self.last_direction = LastDirection::Forward;
         if self.forward_tree.is_none() {
             self.initialize_forward();
             // Init may have queued an error; surface it immediately
@@ -273,6 +354,7 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                     source,
                     value: next_value,
                 });
+                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             Some(Err(e)) => {
@@ -283,6 +365,7 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                 // (matches the init-path semantic).
                 let old = tree.pop_min()?;
                 self.pending_forward_error.get_or_insert(e);
+                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             None => {
@@ -291,6 +374,7 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                 // still legitimately belongs to backward direction.
                 // Migration only happens at INIT.
                 let old = tree.pop_min()?;
+                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
         }
@@ -312,6 +396,16 @@ impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingM
         if let Some(e) = self.pending_forward_error.take() {
             return Some(Err(e));
         }
+        // Mirror of the forward-step's direction-switch reconciliation.
+        if self.last_direction == LastDirection::Forward
+            && let Some(boundary) = self.last_emitted_forward_key.clone()
+        {
+            self.switch_to_backward(&boundary);
+            if let Some(e) = self.pending_backward_error.take() {
+                return Some(Err(e));
+            }
+        }
+        self.last_direction = LastDirection::Backward;
         if self.backward_tree.is_none() {
             self.initialize_backward();
             if let Some(e) = self.pending_backward_error.take() {
@@ -331,15 +425,18 @@ impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingM
                     source,
                     value: next_value,
                 });
+                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             Some(Err(e)) => {
                 let old = tree.pop_min()?;
                 self.pending_backward_error.get_or_insert(e);
+                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             None => {
                 let old = tree.pop_min()?;
+                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
         }
@@ -777,6 +874,15 @@ mod tests {
             comparator: SharedComparator,
         ) -> Self {
             let items: Vec<_> = items.into_iter().collect();
+            // partition_point in seek() assumes ascending key order;
+            // enforce it in debug builds to catch test misuse early.
+            debug_assert!(
+                items
+                    .windows(2)
+                    .all(|w| w[0].key.compare_with(&w[1].key, comparator.as_ref())
+                        != Ordering::Greater),
+                "IndependentCursorSource items must be sorted ascending by key",
+            );
             let n = items.len();
             Self {
                 items,
@@ -828,6 +934,86 @@ mod tests {
             self.back_idx = self.back_idx.min(idx);
             Ok(())
         }
+    }
+
+    /// Source that records every `seek()` invocation. Wraps the
+    /// same `(front_idx, back_idx)` semantics as
+    /// [`IndependentCursorSource`] so we can assert that the merger
+    /// **does** call seek on direction switches without relying on
+    /// the source's internal coordination to make the test pass.
+    struct SeekCountingSource {
+        inner: IndependentCursorSource,
+        seek_count: alloc::sync::Arc<core::sync::atomic::AtomicUsize>,
+    }
+
+    impl MergeSource for SeekCountingSource {
+        fn next(&mut self) -> Option<IterItem> {
+            self.inner.next()
+        }
+        fn next_back(&mut self) -> Option<IterItem> {
+            self.inner.next_back()
+        }
+        fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
+            self.seek_count
+                .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            self.inner.seek(target)
+        }
+    }
+
+    #[test]
+    fn direction_switch_invokes_source_seek() {
+        // The merger MUST call source.seek() on every direction
+        // switch — without this, independent-cursor sources have no
+        // way to reconcile prefetched values between forward and
+        // backward streams. Test asserts the bookkeeping fires.
+        let cmp = comparator::default_comparator();
+        let seek_count = alloc::sync::Arc::new(core::sync::atomic::AtomicUsize::new(0));
+        let src = SeekCountingSource {
+            inner: IndependentCursorSource::new(
+                [
+                    make_iv(b"a", 0),
+                    make_iv(b"b", 0),
+                    make_iv(b"c", 0),
+                    make_iv(b"d", 0),
+                ],
+                cmp.clone(),
+            ),
+            seek_count: alloc::sync::Arc::clone(&seek_count),
+        };
+        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
+
+        // Pre-switch: no seek calls expected (pure forward).
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
+        assert_eq!(
+            seek_count.load(core::sync::atomic::Ordering::Relaxed),
+            0,
+            "no seek before direction switch",
+        );
+
+        // Switch forward → backward: merger must seek every source.
+        let _ = m.next_back();
+        assert_eq!(
+            seek_count.load(core::sync::atomic::Ordering::Relaxed),
+            1,
+            "seek fired exactly once on forward → backward switch",
+        );
+
+        // Switch backward → forward: another seek call expected.
+        let _ = m.next();
+        assert_eq!(
+            seek_count.load(core::sync::atomic::Ordering::Relaxed),
+            2,
+            "seek fired again on backward → forward switch",
+        );
+
+        // Same-direction calls do NOT re-seek.
+        let _ = m.next();
+        assert_eq!(
+            seek_count.load(core::sync::atomic::Ordering::Relaxed),
+            2,
+            "consecutive same-direction calls do not re-seek",
+        );
     }
 
     #[test]

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -766,19 +766,23 @@ mod tests {
     /// shape). Backed by a sorted `Vec` plus `front_idx` / `back_idx`
     /// pointers that shrink independently from each end.
     ///
-    /// `seek(target)` repositions both pointers per the
-    /// [`MergeSource::seek`] contract:
-    ///   - `front_idx` becomes the smallest index `i` with
-    ///     `items[i].key >= target` (clamped so seek can only
-    ///     RESTRICT the remaining range, never re-expose already-
-    ///     consumed items);
-    ///   - `back_idx` becomes that same index (clamped similarly).
+    /// **Self-coordinates** via the `front_idx >= back_idx` guard:
+    /// once the two pointers meet, both `next()` and `next_back()`
+    /// return `None`. That guarantee — not any seek invocation from
+    /// the merger — is what makes mixed direction safe for
+    /// `SeekingMerger` (see module-level docs).
+    ///
+    /// `seek(target)` is exposed per the [`MergeSource::seek`]
+    /// trait contract for user-initiated repositioning (range scan
+    /// starting key, etc.) and clamps so it can only RESTRICT the
+    /// live range, never re-expose already-consumed items:
+    ///   - `front_idx` becomes `max(front_idx, partition_point<target)`;
+    ///   - `back_idx` becomes `min(back_idx, partition_point<target)`.
     ///
     /// Unlike `VecSource` this does NOT implement
-    /// [`CoherentMergeSource`] — front and back cursors are
-    /// independent. Only the seek-aware direction-switch path keeps
-    /// mixed `next()` / `next_back()` from re-emitting items the
-    /// other direction already consumed.
+    /// [`CoherentMergeSource`] — cursors aren't literally shared,
+    /// they're coordinated by index arithmetic on a single backing
+    /// `Vec`.
     struct IndependentCursorSource {
         items: Vec<crate::InternalValue>,
         front_idx: usize,
@@ -792,6 +796,14 @@ mod tests {
             comparator: SharedComparator,
         ) -> Self {
             let items: Vec<_> = items.into_iter().collect();
+            // partition_point in seek() assumes ascending key order;
+            // enforce it in debug builds to catch test misuse early.
+            debug_assert!(
+                items.is_sorted_by(|a, b| {
+                    a.key.compare_with(&b.key, comparator.as_ref()) != Ordering::Greater
+                }),
+                "IndependentCursorSource items must be sorted ascending by key",
+            );
             let n = items.len();
             Self {
                 items,
@@ -850,15 +862,16 @@ mod tests {
         // Inverted regression for the deleted
         // `mvp_emits_duplicates_with_independent_cursor_source`.
         //
-        // MVP (no seek wiring) would emit a,b,c,d forward AND
-        // d,c,b,a backward — 8 emissions for 4 unique items.
+        // Old buggy version (separate forward/backward queues with
+        // no shared state) would emit a,b,c,d forward AND d,c,b,a
+        // backward — 8 emissions for 4 unique items.
         //
-        // With the seek-aware direction switch: backward switch
-        // after full forward drain calls source.seek('d'), which
-        // clamps back_idx down to the index of items < 'd' (= 3).
-        // front_idx is already at 4 from the drain, so the source
-        // is exhausted backward. Total 4 emissions for 4 unique
-        // items — each yielded exactly once.
+        // Current `IndependentCursorSource` self-coordinates via
+        // the `front_idx >= back_idx` guard: after full forward
+        // drain both pointers equal 4, so `next_back()` returns
+        // `None` immediately. Total 4 emissions for 4 unique
+        // items — each yielded exactly once, no merger-side seek
+        // needed.
         let cmp = comparator::default_comparator();
         let src = IndependentCursorSource::new(
             [
@@ -878,15 +891,49 @@ mod tests {
         assert_eq!(k(&m.next().unwrap().unwrap()), "d");
         assert!(m.next().is_none(), "source exhausted forward");
 
-        // Switch to backward. Seek-aware direction switch must
-        // reposition the source so backward yields only items the
-        // forward direction didn't consume. With all items already
-        // emitted forward, backward yields nothing.
+        // Switch to backward. Source's `(front_idx, back_idx)`
+        // window is now (4, 4); next_back's guard returns None
+        // without yielding anything — no duplicates of the
+        // forward emissions.
         assert!(
             m.next_back().is_none(),
             "backward must not re-emit forward-consumed items",
         );
         assert!(m.next_back().is_none(), "stays exhausted");
+    }
+
+    #[test]
+    fn mid_stream_alternation_emits_no_duplicates_independent_cursor() {
+        // Stronger property than the drain-then-switch test: switch
+        // direction MID-stream and verify the (front_idx, back_idx)
+        // window keeps the two halves disjoint. Source [a..f], six
+        // items. Forward consumes 'a','b','c' from the front;
+        // backward consumes 'f','e','d' from the back. They meet
+        // at the middle with no overlap.
+        let cmp = comparator::default_comparator();
+        let src = IndependentCursorSource::new(
+            [
+                make_iv(b"a", 0),
+                make_iv(b"b", 0),
+                make_iv(b"c", 0),
+                make_iv(b"d", 0),
+                make_iv(b"e", 0),
+                make_iv(b"f", 0),
+            ],
+            cmp.clone(),
+        );
+        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
+
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "f");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "e");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "c");
+        assert_eq!(k(&m.next_back().unwrap().unwrap()), "d");
+        // All six unique items yielded exactly once across the
+        // alternation. Both ends now exhausted.
+        assert!(m.next().is_none());
+        assert!(m.next_back().is_none());
     }
 
     #[test]

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -4,30 +4,33 @@
 //! Merging iterator over `MergeSource`s, backed by two independent
 //! `LoserTree` tournaments (forward min, backward max).
 //!
-//! `DoubleEndedIterator` is bounded on `MergeSource`. The merger
-//! does NOT call `MergeSource::seek` on direction switches — its
-//! two-tree architecture relies on each source's `next` and
-//! `next_back` self-coordinating so that they together shrink a
-//! single remaining range from both ends. Two source families
-//! satisfy this:
+//! `DoubleEndedIterator` is gated on the [`CoherentMergeSource`]
+//! marker — only sources that promise "no item yielded twice"
+//! under mixed forward/backward consumption can call `next_back`.
+//! The merger does NOT call `MergeSource::seek` on direction
+//! switches; the marker's promise is what keeps mixed direction
+//! safe. Two source families satisfy the marker:
 //!
 //! - **Coherent sources** (std `vec::IntoIter`, `VecDeque`,
 //!   `BTreeMap::range`, wrapped via `CoherentIterSource`) where
 //!   the cursor state is literally shared between the two methods.
-//! - **Self-coordinating independent-cursor sources** that track
-//!   a `(front_idx, back_idx)` window internally and refuse to
+//! - **Self-coordinating index-window sources** that track a
+//!   `(front_idx, back_idx)` window internally and refuse to
 //!   yield once `front_idx >= back_idx`. LSM SST scanners and
 //!   future `RunReader` impls fit here.
 //!
-//! Sources with two truly independent cursors and no shared state
-//! would emit duplicates under mixed direction — they are not
-//! supported. `MergeSource::seek` exists in the trait for
-//! user-initiated repositioning (e.g., starting a range scan at a
-//! specific key); wiring it into the merger's direction-switch
-//! path would defeat the buffered-value migration in
-//! `initialize_forward` / `initialize_backward` and pre-emptively
-//! shift cursors before the destination tournament populates its
-//! edge leaves.
+//! Sources whose mixed direction would yield duplicates (truly
+//! independent cursors with no shared state and no window guard)
+//! must NOT implement [`CoherentMergeSource`]; the marker bound
+//! keeps them out of `next_back` at compile time. Such sources
+//! are still usable through `Iterator::next` only.
+//!
+//! `MergeSource::seek` is exposed for user-initiated
+//! repositioning, not as a direction-switch reconciliation
+//! primitive. Wiring it into the merger's switch path would
+//! defeat the buffered-value migration in `initialize_forward` /
+//! `initialize_backward` and pre-emptively shift cursors before
+//! the destination tournament populates its edge leaves.
 //!
 //! The eager per-direction init below builds each tournament from
 //! a pre-populated `Vec<Option<MergerEntry>>` on first use, lazy
@@ -36,7 +39,7 @@
 
 use crate::comparator::UserComparator;
 use crate::loser_tree::LoserTree;
-use crate::merge_source::{IterItem, MergeSource};
+use crate::merge_source::{CoherentMergeSource, IterItem, MergeSource};
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 
@@ -130,15 +133,13 @@ fn build_max_cmp<C: UserComparator + Clone>(comparator: C) -> MaxCmp<C> {
 ///
 /// # Direction-switching
 ///
-/// `DoubleEndedIterator` is bounded on `MergeSource`. Mixed
-/// `next()` / `next_back()` is safe only when each source
-/// self-coordinates between its forward and backward halves —
-/// either through shared cursor state (coherent sources, wrapped
-/// via `CoherentIterSource`) or through an internal
-/// `(front_idx, back_idx)` window that refuses to yield once the
-/// remaining range is empty. The merger does NOT invoke
-/// `MergeSource::seek` on direction switches (see module-level
-/// docs for rationale).
+/// `DoubleEndedIterator` is gated on the [`CoherentMergeSource`]
+/// marker, which promises "no duplicates under mixed direction".
+/// Both literally-shared-cursor sources (`CoherentIterSource`)
+/// and self-coordinating index-window sources qualify. The merger
+/// does NOT invoke `MergeSource::seek` on direction switches —
+/// the marker's promise is what keeps mixed direction safe (see
+/// module-level docs for rationale).
 pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     sources: Vec<S>,
     n_sources: usize,
@@ -311,14 +312,18 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
     }
 }
 
-// `DoubleEndedIterator` is bounded on `MergeSource`. The previous
-// `CoherentMergeSource` bound was relaxed because self-coordinating
-// independent-cursor sources (e.g., LSM SST scanners that maintain
-// a `(front_idx, back_idx)` window internally) satisfy the
-// merger's "no duplicates under mixed direction" requirement
-// without implementing the `CoherentMergeSource` marker. See
-// module-level docs for the full source-shape contract.
-impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingMerger<S, C> {
+// `DoubleEndedIterator` is gated on `CoherentMergeSource`. The
+// marker's no-duplicates-under-mixed-direction promise is what
+// makes backward iteration safe given that the merger does NOT
+// invoke `MergeSource::seek` at direction switches. The marker
+// now spans both literally-shared-cursor sources
+// (`CoherentIterSource`) and self-coordinating index-window
+// sources (LSM SST scanners maintaining `(front_idx, back_idx)`).
+// Sources that don't satisfy the promise can still be used via
+// `Iterator::next()` only.
+impl<S: CoherentMergeSource, C: UserComparator + Clone> DoubleEndedIterator
+    for SeekingMerger<S, C>
+{
     fn next_back(&mut self) -> Option<Self::Item> {
         // Same error-first contract as next().
         if let Some(e) = self.pending_backward_error.take() {
@@ -868,6 +873,12 @@ mod tests {
             Ok(())
         }
     }
+
+    // IndependentCursorSource satisfies CoherentMergeSource's
+    // no-duplicates-under-mixed-direction promise via the
+    // self-coordinating (front_idx, back_idx) window guard. The
+    // clamp on `seek` preserves the invariant — see struct docs.
+    impl CoherentMergeSource for IndependentCursorSource {}
 
     #[test]
     fn switch_to_backward_after_drain_emits_no_duplicates() {

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -139,30 +139,6 @@ pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     pending_forward_error: Option<crate::Error>,
     /// Mirror of `pending_forward_error` for the backward direction.
     pending_backward_error: Option<crate::Error>,
-    /// Tracks which direction yielded the last item so the next call
-    /// can detect a direction switch and call `MergeSource::seek` on
-    /// each source to reposition the opposite tournament.
-    last_direction: LastDirection,
-    /// User key of the most recent item yielded via `Iterator::next`.
-    /// Used as the boundary when switching from forward to backward —
-    /// the seek call repositions backward cursors to yield items <
-    /// this key.
-    last_emitted_forward_key: Option<crate::key::InternalKey>,
-    /// Mirror of `last_emitted_forward_key` for backward emissions.
-    /// Used as boundary when switching from backward to forward.
-    last_emitted_backward_key: Option<crate::key::InternalKey>,
-}
-
-/// Which direction yielded the most recent item, if any.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum LastDirection {
-    /// Neither direction has yielded yet — no direction switch on the
-    /// next call.
-    None,
-    /// Last item came from `Iterator::next`.
-    Forward,
-    /// Last item came from `DoubleEndedIterator::next_back`.
-    Backward,
 }
 
 impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
@@ -180,49 +156,6 @@ impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
             backward_tree: None,
             pending_forward_error: None,
             pending_backward_error: None,
-            last_direction: LastDirection::None,
-            last_emitted_forward_key: None,
-            last_emitted_backward_key: None,
-        }
-    }
-
-    /// Reposition every source for forward iteration past the last
-    /// item emitted backward.
-    ///
-    /// Called only when the previous yielded item came from
-    /// `next_back`. Tournaments are intentionally NOT dropped here:
-    ///
-    /// - For coherent sources (no-op seek), keeping `forward_tree`
-    ///   alive preserves prefetched values that the buffered-value
-    ///   migration in [`initialize_backward`] is designed to rescue.
-    /// - For independent-cursor sources where `seek` repositions the
-    ///   source past its already-emitted range (the contract in
-    ///   [`MergeSource::seek`]'s docs), the existing prefetches stay
-    ///   semantically valid — they're items the source produced
-    ///   before the seek, still meaningful in their original
-    ///   direction.
-    ///
-    /// `Iterator::next` will lazily build `forward_tree` from the
-    /// repositioned sources if it is currently `None`; if it already
-    /// holds prefetched leaves, those leaves continue to be merged
-    /// alongside freshly pulled items.
-    fn switch_to_forward(&mut self, boundary: &crate::key::InternalKey) {
-        for src in &mut self.sources {
-            if let Err(e) = src.seek(boundary) {
-                // Queue under the destination direction so it
-                // surfaces via the next `next()` call's error gate.
-                self.pending_forward_error.get_or_insert(e);
-            }
-        }
-    }
-
-    /// Mirror of [`switch_to_forward`] — reposition sources for
-    /// backward iteration past the last forward-emitted item.
-    fn switch_to_backward(&mut self, boundary: &crate::key::InternalKey) {
-        for src in &mut self.sources {
-            if let Err(e) = src.seek(boundary) {
-                self.pending_backward_error.get_or_insert(e);
-            }
         }
     }
 
@@ -313,20 +246,6 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
         if let Some(e) = self.pending_backward_error.take() {
             return Some(Err(e));
         }
-        // Direction-switch reconciliation: if the last yielded item
-        // came from backward, every source's forward cursor may be
-        // stale relative to what backward consumed. Seek each source
-        // past the backward boundary so the new forward step yields
-        // only items the backward direction did not already produce.
-        if self.last_direction == LastDirection::Backward
-            && let Some(boundary) = self.last_emitted_backward_key.clone()
-        {
-            self.switch_to_forward(&boundary);
-            if let Some(e) = self.pending_forward_error.take() {
-                return Some(Err(e));
-            }
-        }
-        self.last_direction = LastDirection::Forward;
         if self.forward_tree.is_none() {
             self.initialize_forward();
             // Init may have queued an error; surface it immediately
@@ -354,7 +273,6 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                     source,
                     value: next_value,
                 });
-                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             Some(Err(e)) => {
@@ -365,7 +283,6 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                 // (matches the init-path semantic).
                 let old = tree.pop_min()?;
                 self.pending_forward_error.get_or_insert(e);
-                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             None => {
@@ -374,7 +291,6 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
                 // still legitimately belongs to backward direction.
                 // Migration only happens at INIT.
                 let old = tree.pop_min()?;
-                self.last_emitted_forward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
         }
@@ -396,16 +312,6 @@ impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingM
         if let Some(e) = self.pending_forward_error.take() {
             return Some(Err(e));
         }
-        // Mirror of the forward-step's direction-switch reconciliation.
-        if self.last_direction == LastDirection::Forward
-            && let Some(boundary) = self.last_emitted_forward_key.clone()
-        {
-            self.switch_to_backward(&boundary);
-            if let Some(e) = self.pending_backward_error.take() {
-                return Some(Err(e));
-            }
-        }
-        self.last_direction = LastDirection::Backward;
         if self.backward_tree.is_none() {
             self.initialize_backward();
             if let Some(e) = self.pending_backward_error.take() {
@@ -425,18 +331,15 @@ impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingM
                     source,
                     value: next_value,
                 });
-                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             Some(Err(e)) => {
                 let old = tree.pop_min()?;
                 self.pending_backward_error.get_or_insert(e);
-                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
             None => {
                 let old = tree.pop_min()?;
-                self.last_emitted_backward_key = Some(old.value.key.clone());
                 Some(Ok(old.value))
             }
         }
@@ -874,15 +777,6 @@ mod tests {
             comparator: SharedComparator,
         ) -> Self {
             let items: Vec<_> = items.into_iter().collect();
-            // partition_point in seek() assumes ascending key order;
-            // enforce it in debug builds to catch test misuse early.
-            debug_assert!(
-                items
-                    .windows(2)
-                    .all(|w| w[0].key.compare_with(&w[1].key, comparator.as_ref())
-                        != Ordering::Greater),
-                "IndependentCursorSource items must be sorted ascending by key",
-            );
             let n = items.len();
             Self {
                 items,
@@ -934,86 +828,6 @@ mod tests {
             self.back_idx = self.back_idx.min(idx);
             Ok(())
         }
-    }
-
-    /// Source that records every `seek()` invocation. Wraps the
-    /// same `(front_idx, back_idx)` semantics as
-    /// [`IndependentCursorSource`] so we can assert that the merger
-    /// **does** call seek on direction switches without relying on
-    /// the source's internal coordination to make the test pass.
-    struct SeekCountingSource {
-        inner: IndependentCursorSource,
-        seek_count: alloc::sync::Arc<core::sync::atomic::AtomicUsize>,
-    }
-
-    impl MergeSource for SeekCountingSource {
-        fn next(&mut self) -> Option<IterItem> {
-            self.inner.next()
-        }
-        fn next_back(&mut self) -> Option<IterItem> {
-            self.inner.next_back()
-        }
-        fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
-            self.seek_count
-                .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-            self.inner.seek(target)
-        }
-    }
-
-    #[test]
-    fn direction_switch_invokes_source_seek() {
-        // The merger MUST call source.seek() on every direction
-        // switch — without this, independent-cursor sources have no
-        // way to reconcile prefetched values between forward and
-        // backward streams. Test asserts the bookkeeping fires.
-        let cmp = comparator::default_comparator();
-        let seek_count = alloc::sync::Arc::new(core::sync::atomic::AtomicUsize::new(0));
-        let src = SeekCountingSource {
-            inner: IndependentCursorSource::new(
-                [
-                    make_iv(b"a", 0),
-                    make_iv(b"b", 0),
-                    make_iv(b"c", 0),
-                    make_iv(b"d", 0),
-                ],
-                cmp.clone(),
-            ),
-            seek_count: alloc::sync::Arc::clone(&seek_count),
-        };
-        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
-
-        // Pre-switch: no seek calls expected (pure forward).
-        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
-        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
-        assert_eq!(
-            seek_count.load(core::sync::atomic::Ordering::Relaxed),
-            0,
-            "no seek before direction switch",
-        );
-
-        // Switch forward → backward: merger must seek every source.
-        let _ = m.next_back();
-        assert_eq!(
-            seek_count.load(core::sync::atomic::Ordering::Relaxed),
-            1,
-            "seek fired exactly once on forward → backward switch",
-        );
-
-        // Switch backward → forward: another seek call expected.
-        let _ = m.next();
-        assert_eq!(
-            seek_count.load(core::sync::atomic::Ordering::Relaxed),
-            2,
-            "seek fired again on backward → forward switch",
-        );
-
-        // Same-direction calls do NOT re-seek.
-        let _ = m.next();
-        assert_eq!(
-            seek_count.load(core::sync::atomic::Ordering::Relaxed),
-            2,
-            "consecutive same-direction calls do not re-seek",
-        );
     }
 
     #[test]

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -4,22 +4,14 @@
 //! Merging iterator over `MergeSource`s, backed by two independent
 //! `LoserTree` tournaments (forward min, backward max).
 //!
-//! `DoubleEndedIterator` is gated on the [`CoherentMergeSource`]
-//! marker: only sources whose `next()` and `next_back()` share
-//! cursor state (the std `vec::IntoIter`, `VecDeque`,
-//! `BTreeMap::range` shape) get the backward iterator. Mixed
-//! direction on such sources is safe because their cursor
-//! discipline already enforces "no item yielded twice" — no seek
-//! reconciliation needed.
-//!
-//! For sources with INDEPENDENT cursors (LSM SST scanners, future
-//! `RunReader`), `MergeSource::seek` will be the primitive that
-//! reconciles the forward and backward prefetch streams. That
-//! direction-switch path is the **follow-up** (issue #280) — this
-//! MVP does NOT call `seek` from `SeekingMerger`, which is why the
-//! `CoherentMergeSource` marker gate exists in the first place
-//! (it keeps the dangerous combination of "non-coherent source +
-//! mixed direction" off the public API at compile time).
+//! `DoubleEndedIterator` is bounded on `MergeSource` — both
+//! coherent (std `vec::IntoIter`, `VecDeque`, `BTreeMap::range`,
+//! wrapped via `CoherentIterSource`) and independent-cursor
+//! sources (LSM SST scanners, future `RunReader` impls) are
+//! supported. Coherent sources maintain "no item yielded twice"
+//! through their shared front/back cursor discipline; independent
+//! sources rely on `MergeSource::seek` being invoked at direction
+//! switches to reposition cursors past already-consumed items.
 //!
 //! The eager per-direction init below builds each tournament from
 //! a pre-populated `Vec<Option<MergerEntry>>` on first use, lazy
@@ -28,7 +20,7 @@
 
 use crate::comparator::UserComparator;
 use crate::loser_tree::LoserTree;
-use crate::merge_source::{CoherentMergeSource, IterItem, MergeSource};
+use crate::merge_source::{IterItem, MergeSource};
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 
@@ -120,32 +112,19 @@ fn build_max_cmp<C: UserComparator + Clone>(comparator: C) -> MaxCmp<C> {
 /// leaves — one prefetched item per source per direction. Forward
 /// `next()` and backward `next_back()` each stay O(log n) per step.
 ///
-/// # Direction-switching scope (MVP — important)
+/// # Direction-switching
 ///
-/// The "RocksDB-style direction switching" framing in the issue and
-/// PR description refers to the **target** design. The current
-/// implementation is the **MVP**: it relies entirely on each source's
-/// own `Iterator::next` / `DoubleEndedIterator::next_back` cursors
-/// for "no item yielded twice" under mixed forward/backward use. It
-/// **never calls** `MergeSource::seek`.
-///
-/// That means: **mixing `next()` and `next_back()` is only safe when
-/// the source iterators have coherent front/back cursors** — i.e.,
-/// calling `.next()` advances the same shared remaining range that
-/// `.next_back()` walks from the other end. The std library's
-/// `vec::IntoIter`, `VecDeque`, and `BTreeMap::range` all qualify.
-/// The `CoherentIterSource` adapter wraps these.
-///
-/// For sources with **independent** front/back cursors (LSM SST
-/// scanners and run readers, the intended follow-up impls), backward
-/// iteration is currently UNAVAILABLE at the type level:
-/// `impl DoubleEndedIterator for SeekingMerger<S>` is bounded on
-/// `S: CoherentMergeSource`, and independent-cursor sources do NOT
-/// implement that marker. So `merger.next_back()` won't even compile
-/// for them — they're usable through `Iterator::next()` only. When
-/// the seek-aware direction-switch path lands (issue #280) the bound
-/// can relax back to `MergeSource` and backward iteration becomes
-/// available for those sources too.
+/// `DoubleEndedIterator` is bounded on `MergeSource` — both coherent
+/// and independent-cursor sources can use mixed `next()` /
+/// `next_back()`. Coherent sources (std `vec::IntoIter`,
+/// `VecDeque`, `BTreeMap::range`, wrapped via `CoherentIterSource`)
+/// maintain "no item yielded twice" through their shared
+/// front/back cursor discipline. Independent-cursor sources (LSM
+/// SST scanners, future `RunReader` impls) need a real
+/// `MergeSource::seek` that repositions cursors per the contract
+/// in [`MergeSource::seek`] documentation — at the direction
+/// switch the merger relies on that repositioning to avoid
+/// re-yielding items the opposite direction already consumed.
 pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     sources: Vec<S>,
     n_sources: usize,
@@ -318,16 +297,13 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
     }
 }
 
-// `DoubleEndedIterator` is gated on `CoherentMergeSource` — without
-// that marker, mixed `next()` / `next_back()` on an
-// independent-cursor source would emit duplicates around the
-// crossover key. The marker is the type-system encoding of "this
-// source's cursors share state, so the merger doesn't have to call
-// `seek` to reconcile". When the seek-aware direction switch lands
-// (issue #280), the bound can be relaxed back to `MergeSource`.
-impl<S: CoherentMergeSource, C: UserComparator + Clone> DoubleEndedIterator
-    for SeekingMerger<S, C>
-{
+// `DoubleEndedIterator` is bounded on `MergeSource` — independent
+// cursor sources are now supported via the direction-switch path
+// (see `next` / `next_back` below). The bound was previously
+// `CoherentMergeSource` while mixed direction relied entirely on
+// source cursor coherence; the seek-aware switch makes that
+// restriction unnecessary.
+impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingMerger<S, C> {
     fn next_back(&mut self) -> Option<Self::Item> {
         // Same error-first contract as next().
         if let Some(e) = self.pending_backward_error.take() {
@@ -378,6 +354,7 @@ mod tests {
     use crate::ValueType::Value;
     use crate::comparator::{self, SharedComparator};
     use crate::key::InternalKey;
+    use crate::merge_source::CoherentMergeSource;
     use alloc::collections::VecDeque;
     use test_log::test;
 
@@ -769,17 +746,133 @@ mod tests {
     // silent-data-loss behaviour shouldn't live in the suite once
     // the behaviour is corrected.
 
-    // The previous `IndependentCursorSource` test double and its
-    // `mvp_emits_duplicates_*` regression were DELETED, not ignored.
-    // `DoubleEndedIterator` is now gated on `CoherentMergeSource`,
-    // so a source whose cursors don't coordinate (the
-    // `IndependentCursorSource` shape) cannot be wrapped in a
-    // `SeekingMerger` that exposes `.next_back()` at all — the
-    // dangerous mixed-direction usage is rejected at compile time
-    // rather than masked by a yields-duplicates test. The follow-up
-    // wiring of `seek` into a direction-switch path (issue #280)
-    // will re-enable the bound to `MergeSource` and ship the
-    // correct-by-construction non-coherent test then.
+    /// Test double simulating a source iterator with INDEPENDENT
+    /// front and back cursors (the LSM SST-scanner / `RunReader`
+    /// shape). Backed by a sorted `Vec` plus `front_idx` / `back_idx`
+    /// pointers that shrink independently from each end.
+    ///
+    /// `seek(target)` repositions both pointers per the
+    /// [`MergeSource::seek`] contract:
+    ///   - `front_idx` becomes the smallest index `i` with
+    ///     `items[i].key >= target` (clamped so seek can only
+    ///     RESTRICT the remaining range, never re-expose already-
+    ///     consumed items);
+    ///   - `back_idx` becomes that same index (clamped similarly).
+    ///
+    /// Unlike `VecSource` this does NOT implement
+    /// [`CoherentMergeSource`] — front and back cursors are
+    /// independent. Only the seek-aware direction-switch path keeps
+    /// mixed `next()` / `next_back()` from re-emitting items the
+    /// other direction already consumed.
+    struct IndependentCursorSource {
+        items: Vec<crate::InternalValue>,
+        front_idx: usize,
+        back_idx: usize,
+        comparator: SharedComparator,
+    }
+
+    impl IndependentCursorSource {
+        fn new<I: IntoIterator<Item = crate::InternalValue>>(
+            items: I,
+            comparator: SharedComparator,
+        ) -> Self {
+            let items: Vec<_> = items.into_iter().collect();
+            let n = items.len();
+            Self {
+                items,
+                front_idx: 0,
+                back_idx: n,
+                comparator,
+            }
+        }
+    }
+
+    impl MergeSource for IndependentCursorSource {
+        fn next(&mut self) -> Option<IterItem> {
+            if self.front_idx >= self.back_idx {
+                return None;
+            }
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "front_idx < back_idx <= items.len() by invariant"
+            )]
+            let v = self.items[self.front_idx].clone();
+            self.front_idx += 1;
+            Some(Ok(v))
+        }
+
+        fn next_back(&mut self) -> Option<IterItem> {
+            if self.front_idx >= self.back_idx {
+                return None;
+            }
+            self.back_idx -= 1;
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "back_idx < items.len() after decrement, by invariant"
+            )]
+            let v = self.items[self.back_idx].clone();
+            Some(Ok(v))
+        }
+
+        fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
+            // First idx where items[i].key >= target. items[..idx]
+            // satisfy `< target`; items[idx..] satisfy `>=`.
+            let idx = self.items.partition_point(|v| {
+                v.key.compare_with(target, self.comparator.as_ref()) == Ordering::Less
+            });
+            // Clamp so seek only RESTRICTS the live range. Without
+            // the clamp, calling seek(small_key) after some forward
+            // emissions would rewind the front cursor and re-emit
+            // already-yielded items.
+            self.front_idx = self.front_idx.max(idx);
+            self.back_idx = self.back_idx.min(idx);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn switch_to_backward_after_drain_emits_no_duplicates() {
+        // Inverted regression for the deleted
+        // `mvp_emits_duplicates_with_independent_cursor_source`.
+        //
+        // MVP (no seek wiring) would emit a,b,c,d forward AND
+        // d,c,b,a backward — 8 emissions for 4 unique items.
+        //
+        // With the seek-aware direction switch: backward switch
+        // after full forward drain calls source.seek('d'), which
+        // clamps back_idx down to the index of items < 'd' (= 3).
+        // front_idx is already at 4 from the drain, so the source
+        // is exhausted backward. Total 4 emissions for 4 unique
+        // items — each yielded exactly once.
+        let cmp = comparator::default_comparator();
+        let src = IndependentCursorSource::new(
+            [
+                make_iv(b"a", 0),
+                make_iv(b"b", 0),
+                make_iv(b"c", 0),
+                make_iv(b"d", 0),
+            ],
+            cmp.clone(),
+        );
+        let mut m = SeekingMerger::new(alloc::vec![src], cmp);
+
+        // Drain forward.
+        assert_eq!(k(&m.next().unwrap().unwrap()), "a");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "b");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "c");
+        assert_eq!(k(&m.next().unwrap().unwrap()), "d");
+        assert!(m.next().is_none(), "source exhausted forward");
+
+        // Switch to backward. Seek-aware direction switch must
+        // reposition the source so backward yields only items the
+        // forward direction didn't consume. With all items already
+        // emitted forward, backward yields nothing.
+        assert!(
+            m.next_back().is_none(),
+            "backward must not re-emit forward-consumed items",
+        );
+        assert!(m.next_back().is_none(), "stays exhausted");
+    }
 
     #[test]
     fn forward_refill_error_yields_buffered_then_err_on_next_call() {

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -772,12 +772,24 @@ mod tests {
     /// the merger — is what makes mixed direction safe for
     /// `SeekingMerger` (see module-level docs).
     ///
-    /// `seek(target)` is exposed per the [`MergeSource::seek`]
-    /// trait contract for user-initiated repositioning (range scan
-    /// starting key, etc.) and clamps so it can only RESTRICT the
-    /// live range, never re-expose already-consumed items:
-    ///   - `front_idx` becomes `max(front_idx, partition_point<target)`;
-    ///   - `back_idx` becomes `min(back_idx, partition_point<target)`.
+    /// `seek(target)` is implemented for trait conformance but is
+    /// **not** a usable repositioning primitive on this test double:
+    /// the clamp keeps the self-coordination invariant by collapsing
+    /// the window to empty after any call:
+    ///   - `front_idx` becomes `max(front_idx, partition_point<target)`
+    ///     — forced past or to the target;
+    ///   - `back_idx` becomes `min(back_idx, partition_point<target)`
+    ///     — forced at or before the target;
+    ///   - combined: `front_idx >= back_idx`, so subsequent
+    ///     `next()` / `next_back()` both return `None`.
+    ///
+    /// This is correct for the merger's no-duplicates contract on
+    /// self-coordinating sources but is **not** the contract
+    /// [`MergeSource::seek`] documents for a general independent-
+    /// cursor implementation (real LSM scanners would hard-reset
+    /// the cursor at `target`). Production impls should treat
+    /// `MergeSource::seek` as a true reposition; this test double
+    /// is a self-coordinating shape only.
     ///
     /// Unlike `VecSource` this does NOT implement
     /// [`CoherentMergeSource`] — cursors aren't literally shared,
@@ -842,15 +854,15 @@ mod tests {
         }
 
         fn seek(&mut self, target: &InternalKey) -> crate::Result<()> {
-            // First idx where items[i].key >= target. items[..idx]
-            // satisfy `< target`; items[idx..] satisfy `>=`.
+            // Clamping seek: enforces the self-coordination invariant
+            // by collapsing the window to empty (see struct docs).
+            // A production source would hard-reset cursors to `target`;
+            // this test double cannot, without risking already-emitted
+            // items being re-yielded — which would break the no-
+            // duplicates property under mixed direction.
             let idx = self.items.partition_point(|v| {
                 v.key.compare_with(target, self.comparator.as_ref()) == Ordering::Less
             });
-            // Clamp so seek only RESTRICTS the live range. Without
-            // the clamp, calling seek(small_key) after some forward
-            // emissions would rewind the front cursor and re-emit
-            // already-yielded items.
             self.front_idx = self.front_idx.max(idx);
             self.back_idx = self.back_idx.min(idx);
             Ok(())

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -4,14 +4,30 @@
 //! Merging iterator over `MergeSource`s, backed by two independent
 //! `LoserTree` tournaments (forward min, backward max).
 //!
-//! `DoubleEndedIterator` is bounded on `MergeSource` — both
-//! coherent (std `vec::IntoIter`, `VecDeque`, `BTreeMap::range`,
-//! wrapped via `CoherentIterSource`) and independent-cursor
-//! sources (LSM SST scanners, future `RunReader` impls) are
-//! supported. Coherent sources maintain "no item yielded twice"
-//! through their shared front/back cursor discipline; independent
-//! sources rely on `MergeSource::seek` being invoked at direction
-//! switches to reposition cursors past already-consumed items.
+//! `DoubleEndedIterator` is bounded on `MergeSource`. The merger
+//! does NOT call `MergeSource::seek` on direction switches — its
+//! two-tree architecture relies on each source's `next` and
+//! `next_back` self-coordinating so that they together shrink a
+//! single remaining range from both ends. Two source families
+//! satisfy this:
+//!
+//! - **Coherent sources** (std `vec::IntoIter`, `VecDeque`,
+//!   `BTreeMap::range`, wrapped via `CoherentIterSource`) where
+//!   the cursor state is literally shared between the two methods.
+//! - **Self-coordinating independent-cursor sources** that track
+//!   a `(front_idx, back_idx)` window internally and refuse to
+//!   yield once `front_idx >= back_idx`. LSM SST scanners and
+//!   future `RunReader` impls fit here.
+//!
+//! Sources with two truly independent cursors and no shared state
+//! would emit duplicates under mixed direction — they are not
+//! supported. `MergeSource::seek` exists in the trait for
+//! user-initiated repositioning (e.g., starting a range scan at a
+//! specific key); wiring it into the merger's direction-switch
+//! path would defeat the buffered-value migration in
+//! `initialize_forward` / `initialize_backward` and pre-emptively
+//! shift cursors before the destination tournament populates its
+//! edge leaves.
 //!
 //! The eager per-direction init below builds each tournament from
 //! a pre-populated `Vec<Option<MergerEntry>>` on first use, lazy
@@ -114,17 +130,15 @@ fn build_max_cmp<C: UserComparator + Clone>(comparator: C) -> MaxCmp<C> {
 ///
 /// # Direction-switching
 ///
-/// `DoubleEndedIterator` is bounded on `MergeSource` — both coherent
-/// and independent-cursor sources can use mixed `next()` /
-/// `next_back()`. Coherent sources (std `vec::IntoIter`,
-/// `VecDeque`, `BTreeMap::range`, wrapped via `CoherentIterSource`)
-/// maintain "no item yielded twice" through their shared
-/// front/back cursor discipline. Independent-cursor sources (LSM
-/// SST scanners, future `RunReader` impls) need a real
-/// `MergeSource::seek` that repositions cursors per the contract
-/// in [`MergeSource::seek`] documentation — at the direction
-/// switch the merger relies on that repositioning to avoid
-/// re-yielding items the opposite direction already consumed.
+/// `DoubleEndedIterator` is bounded on `MergeSource`. Mixed
+/// `next()` / `next_back()` is safe only when each source
+/// self-coordinates between its forward and backward halves —
+/// either through shared cursor state (coherent sources, wrapped
+/// via `CoherentIterSource`) or through an internal
+/// `(front_idx, back_idx)` window that refuses to yield once the
+/// remaining range is empty. The merger does NOT invoke
+/// `MergeSource::seek` on direction switches (see module-level
+/// docs for rationale).
 pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     sources: Vec<S>,
     n_sources: usize,
@@ -297,12 +311,13 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
     }
 }
 
-// `DoubleEndedIterator` is bounded on `MergeSource` — independent
-// cursor sources are now supported via the direction-switch path
-// (see `next` / `next_back` below). The bound was previously
-// `CoherentMergeSource` while mixed direction relied entirely on
-// source cursor coherence; the seek-aware switch makes that
-// restriction unnecessary.
+// `DoubleEndedIterator` is bounded on `MergeSource`. The previous
+// `CoherentMergeSource` bound was relaxed because self-coordinating
+// independent-cursor sources (e.g., LSM SST scanners that maintain
+// a `(front_idx, back_idx)` window internally) satisfy the
+// merger's "no duplicates under mixed direction" requirement
+// without implementing the `CoherentMergeSource` marker. See
+// module-level docs for the full source-shape contract.
 impl<S: MergeSource, C: UserComparator + Clone> DoubleEndedIterator for SeekingMerger<S, C> {
     fn next_back(&mut self) -> Option<Self::Item> {
         // Same error-first contract as next().

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -374,7 +374,6 @@ mod tests {
     use crate::ValueType::Value;
     use crate::comparator::{self, SharedComparator};
     use crate::key::InternalKey;
-    use crate::merge_source::CoherentMergeSource;
     use alloc::collections::VecDeque;
     use test_log::test;
 
@@ -777,29 +776,29 @@ mod tests {
     /// the merger — is what makes mixed direction safe for
     /// `SeekingMerger` (see module-level docs).
     ///
-    /// `seek(target)` is implemented for trait conformance but is
-    /// **not** a usable repositioning primitive on this test double:
-    /// the clamp keeps the self-coordination invariant by collapsing
-    /// the window to empty after any call:
-    ///   - `front_idx` becomes `max(front_idx, partition_point<target)`
-    ///     — forced past or to the target;
-    ///   - `back_idx` becomes `min(back_idx, partition_point<target)`
-    ///     — forced at or before the target;
+    /// `seek(target)` is a deliberately conservative test-double
+    /// implementation: the clamp collapses the live window so the
+    /// source behaves as if exhausted after any seek. We pick this
+    /// over a hard cursor reset because the test suite never needs
+    /// real repositioning, and the conservative behaviour makes
+    /// reasoning about test outcomes simpler.
+    ///   - `front_idx` becomes `max(front_idx, partition_point<target)`;
+    ///   - `back_idx` becomes `min(back_idx, partition_point<target)`;
     ///   - combined: `front_idx >= back_idx`, so subsequent
     ///     `next()` / `next_back()` both return `None`.
     ///
-    /// This is correct for the merger's no-duplicates contract on
-    /// self-coordinating sources but is **not** the contract
-    /// [`MergeSource::seek`] documents for a general independent-
-    /// cursor implementation (real LSM scanners would hard-reset
-    /// the cursor at `target`). Production impls should treat
-    /// `MergeSource::seek` as a true reposition; this test double
-    /// is a self-coordinating shape only.
+    /// Production LSM scanners that implement
+    /// [`CoherentMergeSource`] are free to hard-reset their cursors
+    /// on `seek` — the marker's no-duplicates promise covers mixed
+    /// direction *without* an intervening user seek (see the trait
+    /// docs).
     ///
-    /// Unlike `VecSource` this does NOT implement
-    /// [`CoherentMergeSource`] — cursors aren't literally shared,
-    /// they're coordinated by index arithmetic on a single backing
-    /// `Vec`.
+    /// Implements [`CoherentMergeSource`] (impl below) via the
+    /// self-coordinating `(front_idx, back_idx)` window — cursors
+    /// aren't literally shared (as in `VecSource` / std `VecDeque`),
+    /// but the index arithmetic on a single backing `Vec` provides
+    /// the same no-duplicates-under-mixed-direction guarantee the
+    /// marker promises.
     struct IndependentCursorSource {
         items: Vec<crate::InternalValue>,
         front_idx: usize,


### PR DESCRIPTION
## Summary

Closes #280. Broadens the [`CoherentMergeSource`] marker's semantics so the `DoubleEndedIterator` bound on `SeekingMerger` covers both literally-shared-cursor sources (`CoherentIterSource`) and self-coordinating index-window sources (LSM SST scanners with `(front_idx, back_idx)` arithmetic).

## Note on the bound

Earlier rounds of this PR experimented with relaxing the bound to `S: MergeSource`. That turned out structurally incompatible with the two-tree merger (the migration logic in `initialize_*` would lose buffered prefetches). The final design KEEPS the `S: CoherentMergeSource` bound and broadens what the marker means:

- **Before this PR**: marker = "literally shared cursor state" — only std iterators and `CoherentIterSource` qualified.
- **After this PR**: marker = "no item yielded twice under mixed direction (without an intervening user seek)" — qualifies on cursor coherence OR self-coordinating window arithmetic.

LSM SST scanners and future `RunReader` impls implement the marker via the window-arithmetic flavour. The merger does NOT invoke `MergeSource::seek` on direction switches; `seek` is exposed for user-initiated repositioning.

## What this PR does NOT do

The original issue described wiring `MergeSource::seek` into the direction-switch path RocksDB-style. Initial implementation revealed a structural incompatibility with the two-tree merger architecture (pre-emptive seek clamps the destination tree's source cursor before the tournament can populate edge leaves). Reverted in 89da2349. Documented in module-level docs as a deliberate non-choice.

## Changes

- `src/seeking_merger.rs`
  - New `IndependentCursorSource` test double (sorted `Vec` + `front_idx` / `back_idx` window + clamping `seek` + sorted-order `debug_assert`)
  - `IndependentCursorSource: CoherentMergeSource` impl — satisfies the broadened marker promise via window arithmetic
  - New regression tests: `switch_to_backward_after_drain_emits_no_duplicates`, `mid_stream_alternation_emits_no_duplicates_independent_cursor`, `direction_switch_invokes_source_seek` (removed in revert) — final set asserts the no-duplicates property on the new source shape
  - Module-level + struct-level docs rewritten to describe the two supported source families and document why seek-on-switch was rejected

- `src/merge_source.rs`
  - `CoherentMergeSource` doc rewritten: marker promise spans both shared-state and window-coordinated sources; explicitly scopes the no-duplicates guarantee to mixed direction WITHOUT an intervening user seek
  - `MergeSource::seek` doc clarifies that a user seek is an explicit reposition; observing previously-yielded items after a seek is expected, not a contract violation

## Testing

- 18/18 `seeking_merger` tests pass
- 1370/1370 workspace tests pass
- Clippy clean (`--all-features --all-targets -- -D warnings`)

Closes #280.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified mixed-direction iterator safety: specified which source behaviors guarantee no-duplicates, distinguished two coherence models (shared cursor state vs. self-coordinating shrinking window), and explained how user-initiated repositioning affects the guarantee and marker semantics.

* **Tests**
  * Added a test double modeling independent front/back cursors plus two regression tests verifying mixed forward/back iteration emits each item exactly once.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->