### PR TITLE
feat(fs): FileHint enum + FsFile::hint() primitive for posix_fadvise (#133 Phase 1a)

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -256,10 +256,10 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
     /// Advise the kernel about the expected access pattern for this file.
     ///
     /// Implementations translate the [`FileHint`] to the platform's
-    /// closest primitive (`posix_fadvise` on Linux, `fcntl(F_RDADVISE)`
-    /// on macOS, no-op on Windows / in-memory backends). The default
-    /// trait impl is a no-op so backends that have nothing useful to do
-    /// here don't need to override it.
+    /// closest primitive (`posix_fadvise` on Linux, no-op on macOS /
+    /// Windows / in-memory backends for now). The default trait impl
+    /// is a no-op so backends that have nothing useful to do here
+    /// don't need to override it.
     ///
     /// The hint is advisory — backends may ignore it — and only
     /// influences kernel readahead / page-cache eviction heuristics, not

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -163,6 +163,7 @@ pub struct FsDirEntry {
 /// on cold-path compaction reads and prevents readahead waste on
 /// point-read SST files.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FileHint {
     /// No hint — leave the kernel's default caching / readahead policy in
     /// place. Use when the access pattern is unknown or genuinely mixed.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -149,6 +149,47 @@ pub struct FsDirEntry {
     pub is_dir: bool,
 }
 
+/// Access-pattern hint passed to [`FsFile::hint`].
+///
+/// Backends translate it to the platform's nearest equivalent
+/// (`posix_fadvise` on Linux, no-op on macOS / Windows for now). The
+/// hint is advisory — backends are free to ignore it — and only
+/// influences kernel readahead / page-cache eviction heuristics, not
+/// correctness.
+///
+/// Used at SST/blob open sites to tell the OS what we're about to do
+/// with the file (sequential scan, random point read, write-once-and-
+/// evict, …). Picking the right hint cuts page-cache double-buffering
+/// on cold-path compaction reads and prevents readahead waste on
+/// point-read SST files.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FileHint {
+    /// No hint — leave the kernel's default caching / readahead policy in
+    /// place. Use when the access pattern is unknown or genuinely mixed.
+    #[default]
+    Default,
+
+    /// File will be read mostly forward, in order
+    /// (`POSIX_FADV_SEQUENTIAL`). Tells the kernel to ramp up readahead
+    /// and evict already-read pages aggressively. Use for compaction
+    /// input files and full-range scans.
+    Sequential,
+
+    /// File will be read at scattered offsets with no useful prefetch
+    /// pattern (`POSIX_FADV_RANDOM`). Tells the kernel to disable
+    /// readahead so it doesn't waste bandwidth speculatively loading
+    /// pages we won't touch. Use for SST files opened for point-read
+    /// service.
+    Random,
+
+    /// File is being written and we won't need it cached afterwards —
+    /// drop pages from the page cache when the write completes
+    /// (`POSIX_FADV_DONTNEED`). Use for compaction output and memtable
+    /// flush output to keep them from evicting hot pages of files we're
+    /// still reading from.
+    WriteOnce,
+}
+
 /// Filesystem operations on an open file handle.
 ///
 /// Extends [`Read`] + [`Write`] + [`Seek`] with persistence and
@@ -211,6 +252,29 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
     ///
     /// Returns an I/O error if locking fails or is unsupported.
     fn lock_exclusive(&self) -> io::Result<()>;
+
+    /// Advise the kernel about the expected access pattern for this file.
+    ///
+    /// Implementations translate the [`FileHint`] to the platform's
+    /// closest primitive (`posix_fadvise` on Linux, `fcntl(F_RDADVISE)`
+    /// on macOS, no-op on Windows / in-memory backends). The default
+    /// trait impl is a no-op so backends that have nothing useful to do
+    /// here don't need to override it.
+    ///
+    /// The hint is advisory — backends may ignore it — and only
+    /// influences kernel readahead / page-cache eviction heuristics, not
+    /// correctness.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error only if the underlying syscall fails with a
+    /// non-`EINVAL` error. A backend that doesn't support the requested
+    /// hint should treat the call as a no-op and return `Ok(())` rather
+    /// than fail — the hint is a performance lever, not a correctness
+    /// requirement.
+    fn hint(&self, _hint: FileHint) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Pluggable filesystem abstraction.

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -350,11 +350,8 @@ mod sys {
         }
     }
 
-    // POSIX_FADV_* values are stable across glibc / musl / *BSD libc on
-    // every Linux + Android target we ship to. macOS routes through a
-    // separate `fcntl(F_RDADVISE)` path below — declared `not(target_os
-    // = "macos")` so we don't accidentally call posix_fadvise64 on a
-    // libc that doesn't export it.
+    // POSIX_FADV_* values are stable across glibc / musl / *BSD libc.
+    // macOS has no posix_fadvise — routed to a no-op `fadvise` below.
     #[cfg(not(target_os = "macos"))]
     const POSIX_FADV_NORMAL: c_int = 0;
     #[cfg(not(target_os = "macos"))]
@@ -364,11 +361,35 @@ mod sys {
     #[cfg(not(target_os = "macos"))]
     const POSIX_FADV_DONTNEED: c_int = 4;
 
+    // EINVAL == 22 on every Linux / *BSD target we ship to. Used to
+    // map "kernel rejected this hint" to Ok(()) per the FsFile::hint
+    // contract — hints are advisory, EINVAL means "the kernel didn't
+    // like this advice code", not "the file is broken".
     #[cfg(not(target_os = "macos"))]
-    // SAFETY: declaration matches the POSIX `posix_fadvise` ABI on Linux
-    // and BSD targets (off_t is i64 on all 64-bit Linux + BSD targets
-    // and on 32-bit targets via _FILE_OFFSET_BITS=64 which glibc / musl
-    // both default to for new code).
+    const EINVAL: c_int = 22;
+
+    // Use posix_fadvise64 on Linux + Android to keep the off_t-sized
+    // arguments ABI-stable on 32-bit targets (where bare posix_fadvise
+    // uses a 32-bit off_t unless the caller opted into
+    // _FILE_OFFSET_BITS=64 — Rust FFI declarations don't get that
+    // define, so we'd pass 64-bit ints into a 32-bit-off_t syscall
+    // wrapper and corrupt the stack). posix_fadvise64 always takes
+    // int64_t arguments regardless of target pointer width.
+    //
+    // BSD targets (freebsd / netbsd / dragonfly) don't ship a *64
+    // variant, but their off_t is unconditionally 64-bit, so the
+    // plain posix_fadvise is ABI-correct there.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    // SAFETY: matches glibc / musl / bionic posix_fadvise64 ABI.
+    unsafe extern "C" {
+        fn posix_fadvise64(fd: c_int, offset: i64, len: i64, advice: c_int) -> c_int;
+    }
+
+    #[cfg(all(
+        not(target_os = "macos"),
+        not(any(target_os = "linux", target_os = "android"))
+    ))]
+    // SAFETY: matches BSD posix_fadvise ABI (off_t is always 64-bit).
     unsafe extern "C" {
         fn posix_fadvise(fd: c_int, offset: i64, len: i64, advice: c_int) -> c_int;
     }
@@ -381,15 +402,29 @@ mod sys {
             FileHint::Random => POSIX_FADV_RANDOM,
             FileHint::WriteOnce => POSIX_FADV_DONTNEED,
         };
-        // offset=0 + len=0 = "apply to the whole file" per posix_fadvise(2).
-        // posix_fadvise returns the errno DIRECTLY (not via errno; 0 on
-        // success, positive errno on failure).
+        // offset=0 + len=0 = "apply to the whole file" per
+        // posix_fadvise(2). posix_fadvise{,64} returns the errno
+        // DIRECTLY (not via errno; 0 on success, positive errno on
+        // failure).
         let fd = file.as_raw_fd();
         // SAFETY: fd is a valid file descriptor owned by `file`;
-        // offset/len/advice are all valid posix_fadvise inputs.
+        // offset / len / advice are all valid inputs.
         #[expect(unsafe_code, reason = "posix_fadvise FFI call with valid fd")]
-        let ret = unsafe { posix_fadvise(fd, 0, 0, advice) };
-        if ret == 0 {
+        let ret = unsafe {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            {
+                posix_fadvise64(fd, 0, 0, advice)
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            {
+                posix_fadvise(fd, 0, 0, advice)
+            }
+        };
+        // EINVAL = kernel doesn't recognise this advice code (or the
+        // fd isn't a regular file — e.g. pipe / socket / character
+        // device). Hints are advisory; treat as a no-op per the
+        // FsFile::hint contract.
+        if ret == 0 || ret == EINVAL {
             Ok(())
         } else {
             Err(io::Error::from_raw_os_error(ret))

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use super::{Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
+use super::{FileHint, Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::Path;
@@ -94,6 +94,10 @@ impl FsFile for File {
 
     fn lock_exclusive(&self) -> io::Result<()> {
         sys::lock_exclusive(self)
+    }
+
+    fn hint(&self, hint: FileHint) -> io::Result<()> {
+        sys::fadvise(self, hint)
     }
 }
 
@@ -312,6 +316,7 @@ fn copy_fallback(src: &Path, dst: &Path) -> io::Result<()> {
 
 #[cfg(unix)]
 mod sys {
+    use super::FileHint;
     use std::ffi::c_int;
     use std::fs::File;
     use std::io;
@@ -344,13 +349,90 @@ mod sys {
             return Err(err);
         }
     }
+
+    // POSIX_FADV_* values are stable across glibc / musl / *BSD libc on
+    // every Linux + Android target we ship to. macOS routes through a
+    // separate `fcntl(F_RDADVISE)` path below — declared `not(target_os
+    // = "macos")` so we don't accidentally call posix_fadvise64 on a
+    // libc that doesn't export it.
+    #[cfg(not(target_os = "macos"))]
+    const POSIX_FADV_NORMAL: c_int = 0;
+    #[cfg(not(target_os = "macos"))]
+    const POSIX_FADV_RANDOM: c_int = 1;
+    #[cfg(not(target_os = "macos"))]
+    const POSIX_FADV_SEQUENTIAL: c_int = 2;
+    #[cfg(not(target_os = "macos"))]
+    const POSIX_FADV_DONTNEED: c_int = 4;
+
+    #[cfg(not(target_os = "macos"))]
+    // SAFETY: declaration matches the POSIX `posix_fadvise` ABI on Linux
+    // and BSD targets (off_t is i64 on all 64-bit Linux + BSD targets
+    // and on 32-bit targets via _FILE_OFFSET_BITS=64 which glibc / musl
+    // both default to for new code).
+    unsafe extern "C" {
+        fn posix_fadvise(fd: c_int, offset: i64, len: i64, advice: c_int) -> c_int;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub(super) fn fadvise(file: &File, hint: FileHint) -> io::Result<()> {
+        let advice = match hint {
+            FileHint::Default => POSIX_FADV_NORMAL,
+            FileHint::Sequential => POSIX_FADV_SEQUENTIAL,
+            FileHint::Random => POSIX_FADV_RANDOM,
+            FileHint::WriteOnce => POSIX_FADV_DONTNEED,
+        };
+        // offset=0 + len=0 = "apply to the whole file" per posix_fadvise(2).
+        // posix_fadvise returns the errno DIRECTLY (not via errno; 0 on
+        // success, positive errno on failure).
+        let fd = file.as_raw_fd();
+        // SAFETY: fd is a valid file descriptor owned by `file`;
+        // offset/len/advice are all valid posix_fadvise inputs.
+        #[expect(unsafe_code, reason = "posix_fadvise FFI call with valid fd")]
+        let ret = unsafe { posix_fadvise(fd, 0, 0, advice) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::from_raw_os_error(ret))
+        }
+    }
+
+    // macOS has no posix_fadvise. The closest primitives are
+    // `fcntl(F_RDADVISE)` (sequential prefetch hint, requires a byte
+    // range — not useful for the whole-file hints we want) and
+    // `fcntl(F_NOCACHE)` (toggle uncached I/O — too blunt for our use
+    // case). Treat as a no-op for now; the performance benefit on
+    // macOS is small enough that wiring a half-equivalent isn't worth
+    // the complexity.
+    #[cfg(target_os = "macos")]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "FsFile::hint signature requires io::Result<()>; macOS branch is a no-op until we wire fcntl(F_RDADVISE)"
+    )]
+    pub(super) fn fadvise(_file: &File, _hint: FileHint) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
 mod sys {
+    use super::FileHint;
     use std::fs::File;
     use std::io;
     use std::os::windows::io::AsRawHandle;
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "FsFile::hint signature requires io::Result<()>; Windows branch is a no-op until we thread the hint through FsOpenOptions for CreateFile flags"
+    )]
+    pub(super) fn fadvise(_file: &File, _hint: FileHint) -> io::Result<()> {
+        // Windows has no direct posix_fadvise equivalent. The closest
+        // primitive (`FILE_FLAG_SEQUENTIAL_SCAN` / `_RANDOM_ACCESS`)
+        // must be set at CreateFile time and can't be changed for an
+        // already-open handle. Treat as a no-op — if Windows
+        // performance becomes a concern we'd thread the hint through
+        // FsOpenOptions instead and set the flag at open time.
+        Ok(())
+    }
 
     pub(super) fn lock_exclusive(file: &File) -> io::Result<()> {
         use std::ptr;
@@ -411,6 +493,7 @@ mod sys {
 
 #[cfg(not(any(unix, windows)))]
 mod sys {
+    use super::FileHint;
     use std::fs::File;
     use std::io;
 
@@ -419,6 +502,15 @@ mod sys {
             io::ErrorKind::Unsupported,
             "file locking is not supported on this platform",
         ))
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "FsFile::hint signature requires io::Result<()>; unsupported platforms have no fallible path"
+    )]
+    pub(super) fn fadvise(_file: &File, _hint: FileHint) -> io::Result<()> {
+        // Unsupported platform — silently ignore. Hints are advisory.
+        Ok(())
     }
 }
 
@@ -887,6 +979,41 @@ mod tests {
 
         let err = copy_fallback(&src, &dst).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        Ok(())
+    }
+
+    #[test]
+    fn fadvise_accepts_every_hint_variant() -> io::Result<()> {
+        // Smoke test: every FileHint variant produces Ok on every
+        // platform our CI builds for. Linux exercises the real
+        // posix_fadvise syscall; macOS / Windows fall through the
+        // no-op branches. Failure of any variant is a regression in
+        // the platform-specific glue, not in the hint contract
+        // itself (which is advisory).
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+        let path = dir.path().join("hint_smoke.bin");
+
+        // Write some content so posix_fadvise has a non-empty file
+        // to act on (POSIX_FADV_DONTNEED is a no-op on 0-byte files
+        // on every kernel I've tested, but checking with content
+        // catches more potential regressions).
+        let opts = FsOpenOptions::new().write(true).create_new(true);
+        let mut file = fs.open(&path, &opts)?;
+        file.write_all(&vec![0u8; 64 * 1024])?;
+        file.sync_all()?;
+        drop(file);
+
+        let opts = FsOpenOptions::new().read(true);
+        let file = fs.open(&path, &opts)?;
+        for hint in [
+            FileHint::Default,
+            FileHint::Sequential,
+            FileHint::Random,
+            FileHint::WriteOnce,
+        ] {
+            file.hint(hint)?;
+        }
         Ok(())
     }
 }

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -368,28 +368,47 @@ mod sys {
     #[cfg(not(target_os = "macos"))]
     const EINVAL: c_int = 22;
 
-    // Use posix_fadvise64 on Linux + Android to keep the off_t-sized
-    // arguments ABI-stable on 32-bit targets (where bare posix_fadvise
-    // uses a 32-bit off_t unless the caller opted into
-    // _FILE_OFFSET_BITS=64 — Rust FFI declarations don't get that
-    // define, so we'd pass 64-bit ints into a 32-bit-off_t syscall
-    // wrapper and corrupt the stack). posix_fadvise64 always takes
-    // int64_t arguments regardless of target pointer width.
+    // libc symbol selection (the 32-bit glibc trap):
     //
-    // BSD targets (freebsd / netbsd / dragonfly) don't ship a *64
-    // variant, but their off_t is unconditionally 64-bit, so the
-    // plain posix_fadvise is ABI-correct there.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    // SAFETY: matches glibc / musl / bionic posix_fadvise64 ABI.
+    // Plain `posix_fadvise` on 32-bit glibc takes a 32-bit off_t
+    // unless the caller opts into `_FILE_OFFSET_BITS=64` — and Rust
+    // FFI declarations don't get that define. Passing i64 args into
+    // a 32-bit-off_t syscall wrapper corrupts the stack.
+    //
+    // `posix_fadvise64` always takes int64_t but is a glibc-only
+    // symbol; musl doesn't export it (the kernel sees the same
+    // syscall, but musl has no userspace wrapper). bionic (Android)
+    // does export it.
+    //
+    // Resolution by target:
+    // - 32-bit glibc Linux + 32-bit Android: posix_fadvise64
+    //   (otherwise stack corruption)
+    // - musl on any pointer width: posix_fadvise (musl is sane on
+    //   32-bit too — its plain wrapper takes 64-bit off_t)
+    // - 64-bit Linux/Android: posix_fadvise (off_t is always 64-bit)
+    // - BSDs (freebsd/netbsd/dragonfly): posix_fadvise (off_t is
+    //   always 64-bit, no *64 variant exists)
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_pointer_width = "32",
+        any(target_env = "gnu", target_env = "")
+    ))]
+    // SAFETY: matches glibc / bionic posix_fadvise64 ABI on 32-bit.
     unsafe extern "C" {
         fn posix_fadvise64(fd: c_int, offset: i64, len: i64, advice: c_int) -> c_int;
     }
 
     #[cfg(all(
         not(target_os = "macos"),
-        not(any(target_os = "linux", target_os = "android"))
+        not(all(
+            any(target_os = "linux", target_os = "android"),
+            target_pointer_width = "32",
+            any(target_env = "gnu", target_env = "")
+        ))
     ))]
-    // SAFETY: matches BSD posix_fadvise ABI (off_t is always 64-bit).
+    // SAFETY: matches POSIX posix_fadvise ABI (off_t is 64-bit on
+    // 64-bit Linux/Android, BSD, and on musl regardless of pointer
+    // width).
     unsafe extern "C" {
         fn posix_fadvise(fd: c_int, offset: i64, len: i64, advice: c_int) -> c_int;
     }
@@ -411,11 +430,19 @@ mod sys {
         // offset / len / advice are all valid inputs.
         #[expect(unsafe_code, reason = "posix_fadvise FFI call with valid fd")]
         let ret = unsafe {
-            #[cfg(any(target_os = "linux", target_os = "android"))]
+            #[cfg(all(
+                any(target_os = "linux", target_os = "android"),
+                target_pointer_width = "32",
+                any(target_env = "gnu", target_env = "")
+            ))]
             {
                 posix_fadvise64(fd, 0, 0, advice)
             }
-            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            #[cfg(not(all(
+                any(target_os = "linux", target_os = "android"),
+                target_pointer_width = "32",
+                any(target_env = "gnu", target_env = "")
+            )))]
             {
                 posix_fadvise(fd, 0, 0, advice)
             }

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -7,6 +7,7 @@ use crate::{
     CompressionType, InternalValue, SeqNo,
     comparator::SharedComparator,
     encryption::EncryptionProvider,
+    fs::{FileHint, FsFile},
     table::{block::BlockType, iter::OwnedDataBlockIter},
 };
 use std::{fs::File, io::BufReader, path::Path, sync::Arc};
@@ -62,7 +63,15 @@ impl Scanner {
         // tuning beyond this would benefit from a configurable knob,
         // tracked as the configurable-readahead follow-up under #133.
         const SCANNER_READAHEAD_BYTES: usize = 2 * 1024 * 1024;
-        let mut reader = BufReader::with_capacity(SCANNER_READAHEAD_BYTES, File::open(path)?);
+        let file = File::open(path)?;
+        // The scanner walks every block in order — tell the kernel so
+        // it can ramp readahead aggressively and evict already-read
+        // pages instead of pinning them. Best-effort: hint() is
+        // advisory and any failure here would just leave the kernel
+        // on the default heuristic, so drop the error rather than
+        // failing the open.
+        let _ = file.hint(FileHint::Sequential);
+        let mut reader = BufReader::with_capacity(SCANNER_READAHEAD_BYTES, file);
 
         let block = Self::fetch_next_block(
             &mut reader,


### PR DESCRIPTION
## Summary

Phases 1a + 1b of #133 (I/O performance epic). Adds the access-pattern hint primitive on the `FsFile` trait AND the first call site that uses it.

## Scope

#133 is split into 4 phases per the issue body (FileHint + posix_fadvise, O_DIRECT + AlignedBuf, adaptive block prefetching, compaction I/O rate limiter). Phase 1 was further split during implementation:

- **Phase 1a — primitive** (commit `55de003b`): `FileHint` enum + `FsFile::hint()` trait method + platform glue (Linux/BSD route through `posix_fadvise`, macOS/Windows no-op for now).
- **Phase 1a follow-up — ABI safety** (commits `363bb065`, `feda0611`): 32-bit `posix_fadvise` ABI fix (route to `posix_fadvise64` on 32-bit glibc only — musl doesn't export the `64` symbol), `EINVAL → Ok(())` mapping per trait contract.
- **Phase 1b — Scanner call site** (commit `b14324e`, merged here as nested PR #309): `Scanner::new` calls `hint(FileHint::Sequential)` on the underlying file handle when opening a table for a forward iteration. Compaction inputs and flush outputs are not yet wired (deferred to Phase 1b-cont).
- **Phase 1c (separate PR #308)** — compaction readahead buffer bump from 32 KiB → 2 MiB default.

Original split intent was "Phase 1a primitive-only PR, Phase 1b call sites separate". The Scanner site is small enough (one `hint()` call at table open) that it landed on top of 1a rather than going through a second 5-line PR. Compaction sites are still pending and will land separately because they touch the writer path more substantially.

## Changes

- `src/fs/mod.rs` — new `FileHint` enum (`Default` / `Sequential` / `Random` / `WriteOnce`) + `FsFile::hint()` trait method with default `Ok(())` impl so backends that have nothing useful to do here don't need to override it.
- `src/fs/std_fs.rs` — Linux / BSD route through `posix_fadvise` (no `libc` dep added — declared the syscall directly, matches the existing `flock` pattern); 32-bit glibc routes through `posix_fadvise64` so the off_t / len arguments match the kernel ABI; macOS is a no-op (no `posix_fadvise`; `fcntl(F_RDADVISE)` needs a byte range and isn't a good fit for whole-file hints); Windows is a no-op (the equivalent `FILE_FLAG_SEQUENTIAL_SCAN` / `_RANDOM_ACCESS` flags must be set at `CreateFile` time, so we'd need to thread the hint through `FsOpenOptions` instead — deferred until Windows performance becomes a concern).
- `src/table/scanner.rs` — `Scanner::new` issues `FileHint::Sequential` to the kernel after opening the SST for read. Failures are non-fatal (the hint is best-effort; a kernel that returns `EINVAL` for the advice value falls through to default caching behaviour).
- Smoke test exercising every `FileHint` variant against a real 64-KiB file — catches any platform-specific glue regression.

## Testing

- `cargo nextest run --lib --all-features fs::std_fs` — pass (incl. `fadvise_accepts_every_hint_variant`).
- `cargo nextest run --workspace` — full pass.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.

Refs #133.