### PR TITLE
perf(table/scanner): bump compaction readahead 32 KiB → 2 MiB (#133 Phase 1c)

### DIFF
--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -51,8 +51,18 @@ impl Scanner {
         comparator: SharedComparator,
         table_id: crate::TableId,
     ) -> crate::Result<Self> {
-        // TODO: a larger buffer size may be better for HDD, maybe make this configurable
-        let mut reader = BufReader::with_capacity(8 * 4_096, File::open(path)?);
+        // 2 MiB buffer matches RocksDB's `compaction_readahead_size`
+        // default and is large enough that the kernel can fold the
+        // sequential-scan readahead heuristic into a single big
+        // userspace fill per ~500 typical (4 KiB) data blocks instead
+        // of one syscall every 8 blocks. Picked to dominate any
+        // pre-#133-Phase1c micro-cost: the loss is at most a few MB
+        // of allocator overhead per concurrent compaction, and
+        // compaction concurrency is bounded by the scheduler. HDD-
+        // tuning beyond this would benefit from a configurable knob,
+        // tracked as the configurable-readahead follow-up under #133.
+        const SCANNER_READAHEAD_BYTES: usize = 2 * 1024 * 1024;
+        let mut reader = BufReader::with_capacity(SCANNER_READAHEAD_BYTES, File::open(path)?);
 
         let block = Self::fetch_next_block(
             &mut reader,


### PR DESCRIPTION
## Summary

Phase 1c of #133 (I/O performance epic). One-line bump of the sequential-scan `BufReader` capacity in `Scanner::new`.

## Context

The original fjall default was 32 KiB (`8 * 4_096`), causing one read syscall every ~8 typical 4 KiB data blocks during full-table scans (compaction input, range scans spanning whole SSTs).

2 MiB matches RocksDB's default `compaction_readahead_size` and is large enough that the kernel folds the sequential-scan readahead heuristic into a single big userspace fill per ~500 blocks instead of one syscall every 8.

## Trade-offs

- **Memory**: +~2 MB per concurrent `Scanner`. Compaction concurrency is bounded by the scheduler, so the working-set cost is small and predictable.
- **HDD tuning**: 2 MiB is a reasonable middle ground for SSD/NVMe. A configurable knob for HDD-heavy workloads is tracked as a follow-up under #133 (alongside other I/O knobs in the epic).
- **Phase 1a primitive interaction**: This is orthogonal to the `FileHint` primitive added in #307. That one is the *kernel* readahead hint via `posix_fadvise`; this is the *userspace* prefetch buffer. They compose — Phase 1b (call-site wiring) will apply `Sequential` hints to the same Scanner-opened files.

## Testing

- `cargo nextest run --workspace` — 1368/1368 pass.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.

Refs #133.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized readahead buffer configuration for table scanning operations to improve data reading performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->