### PR TITLE
perf(table/scanner): apply FileHint::Sequential at scanner open (#133 Phase 1b — Scanner site)

### DIFF
--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -7,6 +7,7 @@ use crate::{
     CompressionType, InternalValue, SeqNo,
     comparator::SharedComparator,
     encryption::EncryptionProvider,
+    fs::{FileHint, FsFile},
     table::{block::BlockType, iter::OwnedDataBlockIter},
 };
 use std::{fs::File, io::BufReader, path::Path, sync::Arc};
@@ -52,7 +53,15 @@ impl Scanner {
         table_id: crate::TableId,
     ) -> crate::Result<Self> {
         // TODO: a larger buffer size may be better for HDD, maybe make this configurable
-        let mut reader = BufReader::with_capacity(8 * 4_096, File::open(path)?);
+        let file = File::open(path)?;
+        // The scanner walks every block in order — tell the kernel so
+        // it can ramp readahead aggressively and evict already-read
+        // pages instead of pinning them. Best-effort: hint() is
+        // advisory and any failure here would just leave the kernel
+        // on the default heuristic, so drop the error rather than
+        // failing the open.
+        let _ = file.hint(FileHint::Sequential);
+        let mut reader = BufReader::with_capacity(8 * 4_096, file);
 
         let block = Self::fetch_next_block(
             &mut reader,


### PR DESCRIPTION
## Summary

Phase 1b of #133, first call site. Stacks on #307 (FileHint primitive).

\`Scanner::new\` reads the SST sequentially block-by-block — compaction input, full range scans. Apply \`FileHint::Sequential\` right after open so the kernel ramps readahead aggressively and evicts already-read pages instead of pinning them.

Best-effort: \`FsFile::hint\` is advisory; any failure here would just leave the kernel on the default heuristic, so the error is dropped rather than failing the open.

## Composition with sibling PRs

| PR | Layer | Effect |
|---|---|---|
| #307 (Phase 1a) | trait primitive | \`FileHint\` enum + \`FsFile::hint\` method + Linux posix_fadvise impl |
| #308 (Phase 1c) | userspace prefetch | \`Scanner\`'s \`BufReader\` capacity 32 KiB → 2 MiB |
| this (Phase 1b — Scanner site) | kernel hint | \`posix_fadvise(SEQUENTIAL)\` on the Scanner-opened file |

The kernel hint + userspace buffer compose: posix_fadvise ramps readahead pages, the 2 MiB BufReader keeps userspace fill cost amortised.

Other Phase 1b call sites (compaction output / flush output WriteOnce, point-read SST Random) are tracked as follow-ups so each call-site PR stays reviewable.

## Base branch

This PR targets \`perf/#133-filehint\` (#307's branch). Will be rebased onto main automatically when #307 merges.

## Testing

- \`cargo nextest run --workspace\` — 1369/1369 pass.
- \`cargo clippy --all-features --all-targets -- -D warnings\` — clean.

Refs #133.