### PR TITLE
perf(fs): O_DIRECT foundation — AlignedBuf + FsOpenOptions::direct_io (#133 phase 2)

### DIFF
--- a/src/fs/aligned_buf.rs
+++ b/src/fs/aligned_buf.rs
@@ -29,9 +29,13 @@ use core::slice;
 ///
 /// # Invariants
 ///
-/// - `ptr` is always non-null and points to a region of at least
-///   `capacity` bytes allocated via the global allocator with
-///   `Layout::from_size_align(capacity, alignment)`.
+/// - `ptr` is always non-null. When `capacity > 0`, it points to a
+///   region of at least `capacity` bytes allocated via the global
+///   allocator with `Layout::from_size_align(capacity, alignment)`.
+///   When `capacity == 0`, it is a non-dereferenceable dangling
+///   sentinel synthesised from the requested alignment (see
+///   `new_zeroed` for the special-case path) — `len == 0` always
+///   holds in that case, so the sentinel is never dereferenced.
 /// - `len <= capacity`.
 /// - `alignment` is a power of two ≥ 1 and ≤ `isize::MAX as usize`
 ///   (enforced at construction).
@@ -110,10 +114,16 @@ impl AlignedBuf {
         if rounded > (isize::MAX as usize) {
             return None;
         }
-        // 0-byte allocation is undefined for the global allocator;
-        // synthesise a non-null dangling pointer with the requested
-        // alignment instead. Reads / writes through it are bounded
-        // by `len == 0`, so they never touch the dangling address.
+        // `alloc::alloc::alloc(layout)` requires `layout.size() > 0`
+        // — calling it with a zero-size layout is UB per the trait
+        // docs (Layout itself accepts size==0, but the allocator
+        // call does not). Std handles this for `Vec<T>` etc. by
+        // using `NonNull::dangling()` internally; we do the same
+        // here but synthesise the sentinel from the caller's
+        // requested alignment so `as_ptr().addr() % alignment == 0`
+        // still holds for zero-capacity buffers. The sentinel is
+        // never dereferenced — every read/write path is bounded by
+        // `len`, which is 0 here.
         if rounded == 0 {
             // SAFETY: alignment is a power of two ≥ 1, so casting it
             // to a pointer is well-defined and the pointer is non-

--- a/src/fs/aligned_buf.rs
+++ b/src/fs/aligned_buf.rs
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Heap-allocated byte buffer with caller-specified alignment.
+//!
+//! `AlignedBuf` exists for the `O_DIRECT` I/O path: Linux requires
+//! both the file offset and the userspace buffer to be aligned to
+//! the filesystem's logical block size (typically 512 B on legacy
+//! disks, 4 KiB on Advanced Format SSDs). A `Vec<u8>` is aligned
+//! to `align_of::<u8>() = 1`, so an unaligned write to an
+//! `O_DIRECT` file errors with `EINVAL`.
+//!
+//! This wrapper exists exclusively for the `O_DIRECT` pairing
+//! (#133 Phase 2). Normal cached I/O has no alignment requirement
+//! and should keep using `Vec<u8>` / `BytesMut` — using
+//! `AlignedBuf` there would waste the extra alignment slack with
+//! no benefit.
+
+use core::alloc::Layout;
+use core::ptr::NonNull;
+use core::slice;
+
+/// A heap-allocated byte buffer aligned to a caller-specified
+/// boundary.
+///
+/// Used for the `O_DIRECT` I/O path where kernel alignment
+/// requirements (typically 4 KiB) exceed `Vec<u8>`'s default
+/// `align_of::<u8>() = 1`.
+///
+/// # Invariants
+///
+/// - `ptr` is always non-null and points to a region of at least
+///   `capacity` bytes allocated via the global allocator with
+///   `Layout::from_size_align(capacity, alignment)`.
+/// - `len <= capacity`.
+/// - `alignment` is a power of two ≥ 1 and ≤ `isize::MAX as usize`
+///   (enforced at construction).
+/// - `capacity` is a power-of-two multiple of `alignment` (rounded
+///   up at construction).
+///
+/// # `Send` + `Sync`
+///
+/// The raw pointer doesn't carry any cross-thread state; the
+/// buffer's bytes are owned, immobile until `Drop`, and only
+/// reachable via `&self` / `&mut self`. So `Send` + `Sync` are
+/// both safe.
+pub struct AlignedBuf {
+    /// Non-null pointer to the start of the aligned allocation.
+    ptr: NonNull<u8>,
+    /// Number of bytes currently written (`<= capacity`).
+    len: usize,
+    /// Number of bytes allocated.
+    capacity: usize,
+    /// Alignment boundary the allocation satisfies (power of two).
+    alignment: usize,
+}
+
+// SAFETY: AlignedBuf owns its allocation; the raw pointer doesn't
+// alias anything else and is only reachable through &self / &mut
+// self. Sending the buffer to another thread is sound; concurrent
+// shared access through &self is sound (the bytes are immutable
+// behind a shared reference).
+#[expect(
+    unsafe_code,
+    reason = "raw-pointer wrapper; Send/Sync soundness justified"
+)]
+unsafe impl Send for AlignedBuf {}
+#[expect(
+    unsafe_code,
+    reason = "raw-pointer wrapper; Send/Sync soundness justified"
+)]
+unsafe impl Sync for AlignedBuf {}
+
+impl AlignedBuf {
+    /// Allocates a zero-initialised buffer of `capacity` bytes
+    /// aligned to `alignment`. `capacity` is rounded up to the
+    /// next multiple of `alignment` so the trailing slack is
+    /// large enough for aligned writes that consume the whole
+    /// buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if:
+    /// - `alignment` is not a power of two, OR
+    /// - `alignment > isize::MAX as usize`, OR
+    /// - the rounded-up capacity overflows `isize::MAX as usize`, OR
+    /// - the global allocator fails (returns null).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # // ignored: AlignedBuf is pub(crate), not exposed publicly.
+    /// use lsm_tree::fs::AlignedBuf;
+    /// let buf = AlignedBuf::new_zeroed(8192, 4096).unwrap();
+    /// assert_eq!(buf.capacity(), 8192);
+    /// assert_eq!(buf.as_ptr().addr() % 4096, 0);
+    /// ```
+    #[must_use]
+    pub fn new_zeroed(capacity: usize, alignment: usize) -> Option<Self> {
+        if !alignment.is_power_of_two() {
+            return None;
+        }
+        if alignment > (isize::MAX as usize) {
+            return None;
+        }
+        // Round up so the trailing slack is large enough for an
+        // aligned write that consumes the whole capacity.
+        let rounded = capacity.checked_add(alignment - 1)? & !(alignment - 1);
+        if rounded > (isize::MAX as usize) {
+            return None;
+        }
+        // 0-byte allocation is undefined for the global allocator;
+        // synthesise a non-null dangling pointer with the requested
+        // alignment instead. Reads / writes through it are bounded
+        // by `len == 0`, so they never touch the dangling address.
+        if rounded == 0 {
+            // SAFETY: alignment is a power of two ≥ 1, so casting it
+            // to a pointer is well-defined and the pointer is non-
+            // null. We never deref past `len = 0`.
+            let dangling = {
+                #[expect(unsafe_code, reason = "non-null dangling for 0-cap buffer")]
+                unsafe {
+                    NonNull::new_unchecked(alignment as *mut u8)
+                }
+            };
+            return Some(Self {
+                ptr: dangling,
+                len: 0,
+                capacity: 0,
+                alignment,
+            });
+        }
+        let layout = Layout::from_size_align(rounded, alignment).ok()?;
+        // SAFETY: layout was just validated; alloc_zeroed is safe to
+        // call for any valid non-zero layout. Returns null on OOM,
+        // which we surface as None.
+        #[expect(unsafe_code, reason = "global allocator call with validated layout")]
+        let raw = unsafe { alloc::alloc::alloc_zeroed(layout) };
+        let ptr = NonNull::new(raw)?;
+        Some(Self {
+            ptr,
+            len: 0,
+            capacity: rounded,
+            alignment,
+        })
+    }
+
+    /// Number of bytes currently written.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Buffer capacity in bytes (`>= len`, rounded up to a
+    /// multiple of `alignment` at construction time).
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Alignment the allocation was constructed with (power of two).
+    #[must_use]
+    pub const fn alignment(&self) -> usize {
+        self.alignment
+    }
+
+    /// `true` when `len == 0`.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Raw const pointer to the buffer's first byte. Stable across
+    /// the lifetime of `self` (no reallocation). Valid for reads
+    /// of `len` bytes.
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const u8 {
+        self.ptr.as_ptr().cast_const()
+    }
+
+    /// Raw mut pointer to the buffer's first byte. Valid for
+    /// writes of `capacity` bytes.
+    #[must_use]
+    pub const fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    /// Shared slice over the currently-written `len` bytes.
+    #[must_use]
+    pub const fn as_slice(&self) -> &[u8] {
+        // SAFETY: `ptr` is valid for reads of `capacity >= len`
+        // bytes by invariant; the lifetime is tied to `&self`.
+        #[expect(unsafe_code, reason = "slice over owned aligned allocation")]
+        unsafe {
+            slice::from_raw_parts(self.ptr.as_ptr(), self.len)
+        }
+    }
+
+    /// Mut slice over the full `capacity` (NOT just `len`). Caller
+    /// is responsible for updating `len` via [`Self::set_len`]
+    /// after writing.
+    #[must_use]
+    pub const fn spare_capacity_mut(&mut self) -> &mut [u8] {
+        // SAFETY: `ptr` is valid for writes of `capacity` bytes by
+        // invariant; the lifetime is tied to `&mut self`.
+        #[expect(unsafe_code, reason = "mut slice over owned aligned allocation")]
+        unsafe {
+            slice::from_raw_parts_mut(self.ptr.as_ptr(), self.capacity)
+        }
+    }
+
+    /// Updates the written-bytes count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len > capacity`.
+    pub const fn set_len(&mut self, new_len: usize) {
+        assert!(
+            new_len <= self.capacity,
+            "AlignedBuf::set_len exceeds capacity",
+        );
+        self.len = new_len;
+    }
+
+    /// Resets `len` to 0 without touching the allocation.
+    pub const fn clear(&mut self) {
+        self.len = 0;
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        if self.capacity == 0 {
+            // Dangling sentinel from `new_zeroed(0, _)`; nothing to
+            // free.
+            return;
+        }
+        // SAFETY: layout reproduces the one used at allocation;
+        // `ptr` was obtained from the global allocator with that
+        // exact layout and hasn't been freed yet (Drop runs once).
+        // The unwrap_or_else fast-paths the impossible case
+        // (Layout was valid at construction; we never mutate
+        // capacity / alignment after) without panicking — Drop
+        // panics during unwinding would abort the process.
+        let Ok(layout) = Layout::from_size_align(self.capacity, self.alignment) else {
+            // Unreachable: invariants enforced at construction
+            // guarantee Layout::from_size_align succeeds here.
+            // Skipping dealloc leaks `capacity` bytes — preferable
+            // to aborting if the invariant ever drifts.
+            return;
+        };
+        #[expect(unsafe_code, reason = "matched dealloc for owned allocation")]
+        unsafe {
+            alloc::alloc::dealloc(self.ptr.as_ptr(), layout);
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_zeroed_4k_aligned() {
+        let buf = AlignedBuf::new_zeroed(8192, 4096).unwrap();
+        assert_eq!(buf.capacity(), 8192);
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.alignment(), 4096);
+        assert_eq!(buf.as_ptr().addr() % 4096, 0, "pointer not 4 KiB aligned");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn new_zeroed_rounds_capacity_up_to_alignment() {
+        // 5000 bytes requested at 4 KiB alignment → rounded to 8 KiB.
+        let buf = AlignedBuf::new_zeroed(5000, 4096).unwrap();
+        assert_eq!(buf.capacity(), 8192);
+        // Already a multiple → no rounding.
+        let buf = AlignedBuf::new_zeroed(8192, 4096).unwrap();
+        assert_eq!(buf.capacity(), 8192);
+    }
+
+    #[test]
+    fn new_zeroed_returns_zeroed_memory() {
+        let buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        // Spare slice covers the full capacity; every byte must be zero.
+        let slice = unsafe { slice::from_raw_parts(buf.as_ptr(), buf.capacity()) };
+        assert!(slice.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn new_zeroed_rejects_non_power_of_two_alignment() {
+        assert!(AlignedBuf::new_zeroed(4096, 3000).is_none());
+        assert!(AlignedBuf::new_zeroed(4096, 0).is_none());
+    }
+
+    #[test]
+    fn new_zeroed_rejects_excessive_alignment() {
+        // isize::MAX + 1 is a power of two but exceeds the cap.
+        assert!(AlignedBuf::new_zeroed(4096, (isize::MAX as usize) + 1).is_none());
+    }
+
+    #[test]
+    fn new_zeroed_zero_capacity_returns_dangling() {
+        // Zero-byte AlignedBuf is allowed and never touches the
+        // allocator; the dangling sentinel must still satisfy the
+        // alignment promise so callers that pass it to FFI don't
+        // surprise the kernel.
+        let buf = AlignedBuf::new_zeroed(0, 4096).unwrap();
+        assert_eq!(buf.capacity(), 0);
+        assert_eq!(buf.as_ptr().addr() % 4096, 0);
+        assert!(buf.as_slice().is_empty());
+    }
+
+    #[test]
+    fn set_len_grows_visible_slice() {
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        assert_eq!(buf.as_slice().len(), 0);
+        buf.set_len(1024);
+        assert_eq!(buf.as_slice().len(), 1024);
+        assert_eq!(buf.len(), 1024);
+    }
+
+    #[test]
+    #[should_panic(expected = "AlignedBuf::set_len exceeds capacity")]
+    fn set_len_panics_past_capacity() {
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        buf.set_len(buf.capacity() + 1);
+    }
+
+    #[test]
+    fn clear_resets_len_but_preserves_capacity() {
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        buf.set_len(2048);
+        buf.clear();
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.capacity(), 4096);
+    }
+
+    #[test]
+    fn spare_capacity_mut_covers_full_capacity() {
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        let spare = buf.spare_capacity_mut();
+        assert_eq!(spare.len(), 4096);
+        *spare.first_mut().unwrap() = 0xAB;
+        *spare.last_mut().unwrap() = 0xCD;
+        buf.set_len(4096);
+        let slice = buf.as_slice();
+        assert_eq!(slice.first().copied(), Some(0xAB));
+        assert_eq!(slice.last().copied(), Some(0xCD));
+    }
+
+    #[test]
+    fn send_sync_compile_check() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<AlignedBuf>();
+    }
+
+    #[test]
+    fn pointer_stays_stable_across_writes() {
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        let initial = buf.as_ptr();
+        // Write some content + set_len; pointer must not move
+        // (no reallocation: AlignedBuf has no growth API).
+        *buf.spare_capacity_mut().first_mut().unwrap() = 1;
+        buf.set_len(1);
+        assert_eq!(buf.as_ptr(), initial);
+    }
+}

--- a/src/fs/aligned_buf.rs
+++ b/src/fs/aligned_buf.rs
@@ -125,13 +125,18 @@ impl AlignedBuf {
         // never dereferenced — every read/write path is bounded by
         // `len`, which is 0 here.
         if rounded == 0 {
-            // SAFETY: alignment is a power of two ≥ 1, so casting it
-            // to a pointer is well-defined and the pointer is non-
-            // null. We never deref past `len = 0`.
+            // SAFETY: alignment is a power of two ≥ 1, so the
+            // resulting pointer is non-null and properly aligned.
+            // `without_provenance_mut` constructs an address-only
+            // pointer (no provenance, no associated allocation) —
+            // exactly right for a sentinel that must never be
+            // dereferenced. We never deref past `len = 0`. Strict-
+            // provenance-friendly: avoids the integer-to-pointer
+            // cast lint by using the canonical exposed-address API.
             let dangling = {
                 #[expect(unsafe_code, reason = "non-null dangling for 0-cap buffer")]
                 unsafe {
-                    NonNull::new_unchecked(alignment as *mut u8)
+                    NonNull::new_unchecked(core::ptr::without_provenance_mut::<u8>(alignment))
                 }
             };
             return Some(Self {

--- a/src/fs/aligned_buf.rs
+++ b/src/fs/aligned_buf.rs
@@ -207,11 +207,20 @@ impl AlignedBuf {
         }
     }
 
-    /// Mut slice over the full `capacity` (NOT just `len`). Caller
-    /// is responsible for updating `len` via [`Self::set_len`]
-    /// after writing.
+    /// Mut slice over the FULL `capacity` — including bytes already
+    /// in the `0..len` written region.
+    ///
+    /// Named `as_capacity_mut` (not `spare_capacity_mut`) because
+    /// `spare_capacity` in `Vec` / `BytesMut` means the tail
+    /// `len..capacity` only. This method intentionally exposes the
+    /// entire allocation: `O_DIRECT` kernel reads need to overwrite
+    /// already-buffered bytes when refilling a recycled buffer, so
+    /// the right primitive is "full buffer", not "tail beyond len".
+    ///
+    /// Caller is responsible for updating `len` via
+    /// [`Self::set_len`] after writing.
     #[must_use]
-    pub const fn spare_capacity_mut(&mut self) -> &mut [u8] {
+    pub const fn as_capacity_mut(&mut self) -> &mut [u8] {
         // SAFETY: `ptr` is valid for writes of `capacity` bytes by
         // invariant; the lifetime is tied to `&mut self`.
         #[expect(unsafe_code, reason = "mut slice over owned aligned allocation")]
@@ -294,10 +303,11 @@ mod tests {
 
     #[test]
     fn new_zeroed_returns_zeroed_memory() {
-        let buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
-        // Spare slice covers the full capacity; every byte must be zero.
-        let slice = unsafe { slice::from_raw_parts(buf.as_ptr(), buf.capacity()) };
-        assert!(slice.iter().all(|&b| b == 0));
+        let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
+        // `as_capacity_mut` covers the full capacity — safe API,
+        // no need for raw-pointer slicing in tests.
+        let cap = buf.as_capacity_mut();
+        assert!(cap.iter().all(|&b| b == 0));
     }
 
     #[test]
@@ -350,12 +360,12 @@ mod tests {
     }
 
     #[test]
-    fn spare_capacity_mut_covers_full_capacity() {
+    fn as_capacity_mut_covers_full_capacity() {
         let mut buf = AlignedBuf::new_zeroed(4096, 4096).unwrap();
-        let spare = buf.spare_capacity_mut();
-        assert_eq!(spare.len(), 4096);
-        *spare.first_mut().unwrap() = 0xAB;
-        *spare.last_mut().unwrap() = 0xCD;
+        let cap = buf.as_capacity_mut();
+        assert_eq!(cap.len(), 4096);
+        *cap.first_mut().unwrap() = 0xAB;
+        *cap.last_mut().unwrap() = 0xCD;
         buf.set_len(4096);
         let slice = buf.as_slice();
         assert_eq!(slice.first().copied(), Some(0xAB));
@@ -374,7 +384,7 @@ mod tests {
         let initial = buf.as_ptr();
         // Write some content + set_len; pointer must not move
         // (no reallocation: AlignedBuf has no growth API).
-        *buf.spare_capacity_mut().first_mut().unwrap() = 1;
+        *buf.as_capacity_mut().first_mut().unwrap() = 1;
         buf.set_len(1);
         assert_eq!(buf.as_ptr(), initial);
     }

--- a/src/fs/aligned_buf.rs
+++ b/src/fs/aligned_buf.rs
@@ -35,8 +35,10 @@ use core::slice;
 /// - `len <= capacity`.
 /// - `alignment` is a power of two ≥ 1 and ≤ `isize::MAX as usize`
 ///   (enforced at construction).
-/// - `capacity` is a power-of-two multiple of `alignment` (rounded
-///   up at construction).
+/// - `capacity` is an integer multiple of `alignment` (rounded up
+///   at construction from the caller's requested size). The
+///   multiplier itself is NOT required to be a power of two — e.g.
+///   `new_zeroed(9000, 4096)` yields `capacity = 12288 = 3 × 4096`.
 ///
 /// # `Send` + `Sync`
 ///
@@ -88,8 +90,7 @@ impl AlignedBuf {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// # // ignored: AlignedBuf is pub(crate), not exposed publicly.
+    /// ```
     /// use lsm_tree::fs::AlignedBuf;
     /// let buf = AlignedBuf::new_zeroed(8192, 4096).unwrap();
     /// assert_eq!(buf.capacity(), 8192);

--- a/src/fs/direct_io.rs
+++ b/src/fs/direct_io.rs
@@ -15,6 +15,21 @@
 //! the flag is best-effort, may be silently dropped, and correctness
 //! must not depend on it.
 //!
+//! # `std` dependency
+//!
+//! This module touches `std::fs::OpenOptions` directly, so it is
+//! std-only. No `#[cfg(feature = "std")]` gate is added here on
+//! purpose: its sole consumers — [`StdFs`] and [`IoUringFs`] —
+//! are themselves unconditionally std-bound today (the entire
+//! `fs::*` backend builds on `std::fs`). Gating *only* this module
+//! while leaving the consumers ungated would be a no-op — the std
+//! backend would still compile and drag this module in
+//! transitively, then fail. The unit of gating is the whole
+//! `fs::*` std backend; that move is tracked under the no-std
+//! migration epic (issue `#274`), where the
+//! `#[cfg(feature = "std")]` gate will land on `pub mod fs::std_fs`
+//! (and `io_uring_fs`) and this module follows automatically.
+//!
 //! [`StdFs`]: super::StdFs
 //! [`IoUringFs`]: super::IoUringFs
 

--- a/src/fs/direct_io.rs
+++ b/src/fs/direct_io.rs
@@ -10,9 +10,10 @@
 //! diverge if one was updated to support a new arch and the other
 //! wasn't.
 //!
-//! Doc-contract for `direct_io` is on
-//! [`FsOpenOptions::direct_io`](super::FsOpenOptions::direct_io):
-//! the flag is best-effort, may be silently dropped, and correctness
+//! Doc-contract for the `direct_io` flag is on the
+//! [`FsOpenOptions::direct_io`](field@super::FsOpenOptions::direct_io)
+//! field (disambiguated against the same-named builder method): the
+//! flag is best-effort, may be silently dropped, and correctness
 //! must not depend on it.
 //!
 //! # `std` dependency
@@ -82,7 +83,9 @@ mod apply {
     /// need `F_NOCACHE` via `fcntl` post-open, Windows would need
     /// `FILE_FLAG_NO_BUFFERING` at `CreateFile` time, divergent Linux
     /// arches need a different `O_DIRECT` bit — all out of scope per
-    /// the [`super::FsOpenOptions::direct_io`] best-effort contract.
+    /// the [`FsOpenOptions::direct_io`](field@crate::fs::FsOpenOptions::direct_io)
+    /// best-effort contract (disambiguated against the same-named
+    /// builder method).
     pub fn apply_direct_io_flag(_builder: &mut std::fs::OpenOptions, _direct_io: bool) {}
 }
 

--- a/src/fs/direct_io.rs
+++ b/src/fs/direct_io.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 //! `O_DIRECT` flag application shared between [`StdFs`] and
-//! [`IoUringFs`] backends.
+//! `IoUringFs` backends.
 //!
 //! Lives here (rather than inline in each backend's `open()`) so the
 //! arch-gating list and the `O_DIRECT` bit value are defined in
@@ -19,7 +19,7 @@
 //!
 //! This module touches `std::fs::OpenOptions` directly, so it is
 //! std-only. No `#[cfg(feature = "std")]` gate is added here on
-//! purpose: its sole consumers — [`StdFs`] and [`IoUringFs`] —
+//! purpose: its sole consumers — [`StdFs`] and `IoUringFs` —
 //! are themselves unconditionally std-bound today (the entire
 //! `fs::*` backend builds on `std::fs`). Gating *only* this module
 //! while leaving the consumers ungated would be a no-op — the std
@@ -31,7 +31,6 @@
 //! (and `io_uring_fs`) and this module follows automatically.
 //!
 //! [`StdFs`]: super::StdFs
-//! [`IoUringFs`]: super::IoUringFs
 
 #[cfg(all(
     any(target_os = "linux", target_os = "android"),

--- a/src/fs/direct_io.rs
+++ b/src/fs/direct_io.rs
@@ -18,17 +18,19 @@
 //! # `std` dependency
 //!
 //! This module touches `std::fs::OpenOptions` directly, so it is
-//! std-only. No `#[cfg(feature = "std")]` gate is added here on
-//! purpose: its sole consumers — [`StdFs`] and `IoUringFs` —
-//! are themselves unconditionally std-bound today (the entire
-//! `fs::*` backend builds on `std::fs`). Gating *only* this module
-//! while leaving the consumers ungated would be a no-op — the std
-//! backend would still compile and drag this module in
-//! transitively, then fail. The unit of gating is the whole
-//! `fs::*` std backend; that move is tracked under the no-std
-//! migration epic (issue `#274`), where the
-//! `#[cfg(feature = "std")]` gate will land on `pub mod fs::std_fs`
-//! (and `io_uring_fs`) and this module follows automatically.
+//! std-only and the parent `mod direct_io;` declaration in
+//! `fs/mod.rs` is gated behind `#[cfg(feature = "std")]`. That gate
+//! is the first concrete honest step toward the no-std backend
+//! split, but it does NOT by itself unblock a `no_std + alloc`
+//! build: the wider `Fs` / `FsFile` trait surface (`std::io::{Read,
+//! Write, Seek}`, `std::path::Path`) is std-bound at the trait
+//! definition level, so even `MemFs` (alloc-only in its body) can't
+//! compile under `--no-default-features --features alloc`. Porting
+//! the traits off `std::io` / `std::path` is tracked separately
+//! (issue `#311`), as a prerequisite for the rest of `fs::*` to
+//! become honestly feature-gateable. When that lands, this module's
+//! gate becomes load-bearing; until then it's a forward-looking
+//! marker that keeps new std-side helpers honest with the policy.
 //!
 //! [`StdFs`]: super::StdFs
 

--- a/src/fs/direct_io.rs
+++ b/src/fs/direct_io.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! `O_DIRECT` flag application shared between [`StdFs`] and
+//! [`IoUringFs`] backends.
+//!
+//! Lives here (rather than inline in each backend's `open()`) so the
+//! arch-gating list and the `O_DIRECT` bit value are defined in
+//! exactly one place. Two backends with their own copy would silently
+//! diverge if one was updated to support a new arch and the other
+//! wasn't.
+//!
+//! Doc-contract for `direct_io` is on
+//! [`FsOpenOptions::direct_io`](super::FsOpenOptions::direct_io):
+//! the flag is best-effort, may be silently dropped, and correctness
+//! must not depend on it.
+//!
+//! [`StdFs`]: super::StdFs
+//! [`IoUringFs`]: super::IoUringFs
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "s390x",
+    ),
+))]
+mod apply {
+    /// `asm-generic/fcntl.h`: `#define O_DIRECT 00040000`. Authoritative
+    /// on every arch listed in the parent `cfg`. Arches with a
+    /// divergent bit (arm `0o200000`, mips `0o100000`, parisc, sparc)
+    /// are excluded from the `cfg` rather than handled here so we
+    /// never risk passing the wrong bit to `open(2)`.
+    const O_DIRECT: i32 = 0o0_040_000;
+
+    /// Apply the `O_DIRECT` flag to a `std::fs::OpenOptions` builder
+    /// when `direct_io` is requested AND the running target supports
+    /// the authoritative `asm-generic/fcntl.h` value.
+    pub fn apply_direct_io_flag(builder: &mut std::fs::OpenOptions, direct_io: bool) {
+        if direct_io {
+            use std::os::unix::fs::OpenOptionsExt;
+            builder.custom_flags(O_DIRECT);
+        }
+    }
+}
+
+#[cfg(not(all(
+    any(target_os = "linux", target_os = "android"),
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch64",
+        target_arch = "s390x",
+    ),
+)))]
+mod apply {
+    /// No-op outside Linux/Android on a supported arch. macOS would
+    /// need `F_NOCACHE` via `fcntl` post-open, Windows would need
+    /// `FILE_FLAG_NO_BUFFERING` at `CreateFile` time, divergent Linux
+    /// arches need a different `O_DIRECT` bit — all out of scope per
+    /// the [`super::FsOpenOptions::direct_io`] best-effort contract.
+    pub fn apply_direct_io_flag(_builder: &mut std::fs::OpenOptions, _direct_io: bool) {}
+}
+
+pub(super) use apply::apply_direct_io_flag;

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -120,6 +120,18 @@ impl Fs for IoUringFs {
             .truncate(opts.truncate)
             .append(opts.append);
 
+        // Gate matches the `mod direct_io;` declaration in `fs/mod.rs`
+        // — the submodule only exists when `feature = "std"` is on.
+        // The whole `io_uring_fs` module is already gated by
+        // `cfg(all(target_os = "linux", feature = "io-uring"))`, and
+        // the `io-uring` feature transitively enables `std` (see the
+        // feature declaration in Cargo.toml), so this extra
+        // `feature = "std"` predicate is logically redundant here.
+        // Kept for consistency with `StdFs::open` and to make the
+        // dependency on direct_io's gate explicit at the call site,
+        // so feature-gate audits don't have to chase the implication
+        // through Cargo.toml.
+        #[cfg(feature = "std")]
         super::direct_io::apply_direct_io_flag(&mut builder, opts.direct_io);
 
         let file = builder.open(path)?;

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -111,14 +111,35 @@ impl std::fmt::Debug for IoUringFs {
 
 impl Fs for IoUringFs {
     fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
-        let file = OpenOptions::new()
+        let mut builder = OpenOptions::new();
+        builder
             .read(opts.read)
             .write(opts.write)
             .create(opts.create)
             .create_new(opts.create_new)
             .truncate(opts.truncate)
-            .append(opts.append)
-            .open(path)?;
+            .append(opts.append);
+
+        // O_DIRECT: identical arch gating to StdFs::open (see the comment
+        // there for rationale). io_uring is Linux-only, so the os-gate is
+        // implicit, but the arch gate still matters: O_DIRECT's bit value
+        // diverges on arm/mips/parisc/sparc.
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "riscv32",
+            target_arch = "riscv64",
+            target_arch = "loongarch64",
+            target_arch = "s390x",
+        ))]
+        if opts.direct_io {
+            use std::os::unix::fs::OpenOptionsExt;
+            const O_DIRECT: i32 = 0o0_040_000;
+            builder.custom_flags(O_DIRECT);
+        }
+
+        let file = builder.open(path)?;
 
         // When opened in append mode, io_uring writes use an explicit offset
         // so the kernel's O_APPEND semantics don't apply. Initialize the

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -120,24 +120,7 @@ impl Fs for IoUringFs {
             .truncate(opts.truncate)
             .append(opts.append);
 
-        // O_DIRECT: identical arch gating to StdFs::open (see the comment
-        // there for rationale). io_uring is Linux-only, so the os-gate is
-        // implicit, but the arch gate still matters: O_DIRECT's bit value
-        // diverges on arm/mips/parisc/sparc.
-        #[cfg(any(
-            target_arch = "x86",
-            target_arch = "x86_64",
-            target_arch = "aarch64",
-            target_arch = "riscv32",
-            target_arch = "riscv64",
-            target_arch = "loongarch64",
-            target_arch = "s390x",
-        ))]
-        if opts.direct_io {
-            use std::os::unix::fs::OpenOptionsExt;
-            const O_DIRECT: i32 = 0o0_040_000;
-            builder.custom_flags(O_DIRECT);
-        }
+        super::direct_io::apply_direct_io_flag(&mut builder, opts.direct_io);
 
         let file = builder.open(path)?;
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -56,6 +56,7 @@ use std::path::{Path, PathBuf};
     reason = "mirrors std::fs::OpenOptions which uses bool flags for each mode"
 )]
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct FsOpenOptions {
     /// Open for reading.
     pub read: bool,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -23,8 +23,11 @@
 //! - **macOS / BSD**: no batched I/O API exists (`dispatch_io` and `kqueue`
 //!   do not help for storage I/O patterns); [`StdFs`] is the correct choice
 
+pub mod aligned_buf;
 mod mem_fs;
 mod std_fs;
+
+pub use aligned_buf::AlignedBuf;
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 mod io_uring_fs;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -62,6 +62,21 @@ pub struct FsOpenOptions {
     pub truncate: bool,
     /// Open in append mode, so writes go to the end of the file.
     pub append: bool,
+    /// Bypass the kernel page cache for this file (`O_DIRECT` on Linux).
+    ///
+    /// When set, the caller is responsible for issuing reads and writes
+    /// at offsets aligned to the filesystem's logical block size, with
+    /// userspace buffers aligned to the same boundary and lengths that
+    /// are a multiple of that block size. See [`AlignedBuf`] for an
+    /// aligned heap buffer suitable for `O_DIRECT` I/O.
+    ///
+    /// Platforms other than Linux/Android treat this as a no-op: macOS
+    /// has no equivalent flag (use `F_NOCACHE` on the open file descriptor
+    /// instead, which is not yet wired here), and Windows requires
+    /// `FILE_FLAG_NO_BUFFERING` at `CreateFile` time (also not wired).
+    /// Callers should treat `direct_io` as a hint that may be silently
+    /// ignored — correctness must not depend on it.
+    pub direct_io: bool,
 }
 
 impl Default for FsOpenOptions {
@@ -81,6 +96,7 @@ impl FsOpenOptions {
             create_new: false,
             truncate: false,
             append: false,
+            direct_io: false,
         }
     }
 
@@ -123,6 +139,13 @@ impl FsOpenOptions {
     #[must_use]
     pub const fn append(mut self, append: bool) -> Self {
         self.append = append;
+        self
+    }
+
+    /// Sets the `direct_io` flag.
+    #[must_use]
+    pub const fn direct_io(mut self, direct_io: bool) -> Self {
+        self.direct_io = direct_io;
         self
     }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -24,6 +24,7 @@
 //!   do not help for storage I/O patterns); [`StdFs`] is the correct choice
 
 pub mod aligned_buf;
+mod direct_io;
 mod mem_fs;
 mod std_fs;
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -67,15 +67,27 @@ pub struct FsOpenOptions {
     /// When set, the caller is responsible for issuing reads and writes
     /// at offsets aligned to the filesystem's logical block size, with
     /// userspace buffers aligned to the same boundary and lengths that
-    /// are a multiple of that block size. See [`AlignedBuf`] for an
-    /// aligned heap buffer suitable for `O_DIRECT` I/O.
+    /// are a multiple of that block size.
     ///
-    /// Platforms other than Linux/Android treat this as a no-op: macOS
-    /// has no equivalent flag (use `F_NOCACHE` on the open file descriptor
-    /// instead, which is not yet wired here), and Windows requires
-    /// `FILE_FLAG_NO_BUFFERING` at `CreateFile` time (also not wired).
-    /// Callers should treat `direct_io` as a hint that may be silently
-    /// ignored — correctness must not depend on it.
+    /// `direct_io` is a HINT, not a guarantee. The flag is honoured only
+    /// on Linux and Android, and only on architectures where the
+    /// `asm-generic/fcntl.h` value `O_DIRECT = 0o40000` is authoritative
+    /// — `x86`, `x86_64`, `aarch64`, `riscv32`/`riscv64`, `loongarch64`,
+    /// `s390x`. On Linux
+    /// architectures with a divergent `O_DIRECT` bit (arm `0o200000`,
+    /// mips `0o100000`, parisc, sparc) the flag is silently dropped to
+    /// avoid passing the wrong bit to `open(2)`. Other platforms — macOS
+    /// (would need `F_NOCACHE` post-open via `fcntl`, not wired here),
+    /// Windows (would need `FILE_FLAG_NO_BUFFERING` at `CreateFile` time,
+    /// not wired here), other Unixes — also silently drop the flag.
+    ///
+    /// Callers must therefore treat `direct_io` as best-effort:
+    /// correctness must not depend on cache bypass being in effect, and
+    /// any alignment requirements imposed by the kernel only apply when
+    /// the flag is actually honoured (you cannot tell from this API
+    /// alone whether it was). See [`AlignedBuf`] for an aligned heap
+    /// buffer suitable for `O_DIRECT` reads and writes when the flag is
+    /// honoured.
     pub direct_io: bool,
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -25,11 +25,15 @@
 
 mod aligned_buf;
 // `direct_io` is std-only (touches `std::fs::OpenOptions`). It is
-// intentionally not feature-gated here: its sole consumers `std_fs`
-// and `io_uring_fs` are themselves unconditionally std-bound, so the
-// effective unit of gating is the whole `fs::*` backend (tracked
-// under the no-std migration epic, issue #274). See the module
-// header in `direct_io.rs` for the full rationale.
+// gated behind the `std` feature so a `no_std + alloc` build of
+// this crate does not even attempt to compile it. The wider
+// `fs::*` backend (Fs / FsFile traits, std_fs, io_uring_fs)
+// still depends on `std::io::{Read, Write, Seek}` + `std::path::Path`
+// — those have no `core::*` equivalents, so feature-gating just
+// this submodule does not yet make a no-std build work end-to-end.
+// The full backend split is tracked under no-std migration epic
+// (issue #274); this gate is the first step.
+#[cfg(feature = "std")]
 mod direct_io;
 mod mem_fs;
 mod std_fs;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -55,6 +55,13 @@ use std::path::{Path, PathBuf};
     clippy::struct_excessive_bools,
     reason = "mirrors std::fs::OpenOptions which uses bool flags for each mode"
 )]
+// `non_exhaustive` paired with the `direct_io` field landing in the
+// same release. The new field already breaks struct-literal
+// callers; bundling `non_exhaustive` in the same semver-major bump
+// confines the break to one release and lets every future field
+// land as semver-minor. Builder methods (`.read()`, `.write()`, …,
+// `.direct_io()`) cover every field, so callers using the builder
+// API are unaffected.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct FsOpenOptions {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -31,8 +31,9 @@ mod aligned_buf;
 // still depends on `std::io::{Read, Write, Seek}` + `std::path::Path`
 // — those have no `core::*` equivalents, so feature-gating just
 // this submodule does not yet make a no-std build work end-to-end.
-// The full backend split is tracked under no-std migration epic
-// (issue #274); this gate is the first step.
+// Porting the traits off std::io / std::path is tracked as #311
+// (prerequisite); the wider no-std migration epic is #274. This
+// gate is the first concrete step.
 #[cfg(feature = "std")]
 mod direct_io;
 mod mem_fs;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -23,7 +23,7 @@
 //! - **macOS / BSD**: no batched I/O API exists (`dispatch_io` and `kqueue`
 //!   do not help for storage I/O patterns); [`StdFs`] is the correct choice
 
-pub mod aligned_buf;
+mod aligned_buf;
 // `direct_io` is std-only (touches `std::fs::OpenOptions`). It is
 // intentionally not feature-gated here: its sole consumers `std_fs`
 // and `io_uring_fs` are themselves unconditionally std-bound, so the

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -24,6 +24,12 @@
 //!   do not help for storage I/O patterns); [`StdFs`] is the correct choice
 
 pub mod aligned_buf;
+// `direct_io` is std-only (touches `std::fs::OpenOptions`). It is
+// intentionally not feature-gated here: its sole consumers `std_fs`
+// and `io_uring_fs` are themselves unconditionally std-bound, so the
+// effective unit of gating is the whole `fs::*` backend (tracked
+// under the no-std migration epic, issue #274). See the module
+// header in `direct_io.rs` for the full rationale.
 mod direct_io;
 mod mem_fs;
 mod std_fs;

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -112,36 +112,7 @@ impl Fs for StdFs {
             .truncate(opts.truncate)
             .append(opts.append);
 
-        // O_DIRECT on Linux/Android (architectures with `asm-generic/fcntl.h`
-        // value 0o40000: x86, x86_64, aarch64, riscv32/64, loongarch64,
-        // s390x — i.e. every Linux arch we plausibly run on). Architectures
-        // with a divergent O_DIRECT (arm 0o200000, mips 0o100000, parisc,
-        // sparc) are not gated here on purpose: misencoding the flag would
-        // silently pass the wrong bit to open(2). The FsOpenOptions doc
-        // contract permits `direct_io` to be ignored, so divergent archs
-        // simply fall through to a cached open — correctness preserved.
-        //
-        // macOS / Windows / other Unixes: same "may be silently ignored"
-        // contract. macOS has no O_DIRECT (F_NOCACHE via fcntl post-open
-        // is the closest equivalent and is out of scope here).
-        #[cfg(all(
-            any(target_os = "linux", target_os = "android"),
-            any(
-                target_arch = "x86",
-                target_arch = "x86_64",
-                target_arch = "aarch64",
-                target_arch = "riscv32",
-                target_arch = "riscv64",
-                target_arch = "loongarch64",
-                target_arch = "s390x",
-            ),
-        ))]
-        if opts.direct_io {
-            use std::os::unix::fs::OpenOptionsExt;
-            // asm-generic/fcntl.h: #define O_DIRECT 00040000
-            const O_DIRECT: i32 = 0o0_040_000;
-            builder.custom_flags(O_DIRECT);
-        }
+        super::direct_io::apply_direct_io_flag(&mut builder, opts.direct_io);
 
         let file = builder.open(path)?;
         Ok(Box::new(file))

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -116,6 +116,15 @@ impl Fs for StdFs {
             .truncate(opts.truncate)
             .append(opts.append);
 
+        // Gate matches the `mod direct_io;` declaration in `fs/mod.rs`
+        // — the submodule only exists when `feature = "std"` is on.
+        // Without the gate this site would fail to compile under
+        // `--no-default-features --features alloc` even before the
+        // wider std-bound surface of `StdFs` itself hits the trait
+        // signatures; keeping the cfg in sync prevents adding a
+        // resolution-time error on top of the type-checking ones
+        // already tracked under the no-std migration epic.
+        #[cfg(feature = "std")]
         super::direct_io::apply_direct_io_flag(&mut builder, opts.direct_io);
 
         let file = builder.open(path)?;

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -103,14 +103,47 @@ impl FsFile for File {
 
 impl Fs for StdFs {
     fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
-        let file = OpenOptions::new()
+        let mut builder = OpenOptions::new();
+        builder
             .read(opts.read)
             .write(opts.write)
             .create(opts.create)
             .create_new(opts.create_new)
             .truncate(opts.truncate)
-            .append(opts.append)
-            .open(path)?;
+            .append(opts.append);
+
+        // O_DIRECT on Linux/Android (architectures with `asm-generic/fcntl.h`
+        // value 0o40000: x86, x86_64, aarch64, riscv32/64, loongarch64,
+        // s390x — i.e. every Linux arch we plausibly run on). Architectures
+        // with a divergent O_DIRECT (arm 0o200000, mips 0o100000, parisc,
+        // sparc) are not gated here on purpose: misencoding the flag would
+        // silently pass the wrong bit to open(2). The FsOpenOptions doc
+        // contract permits `direct_io` to be ignored, so divergent archs
+        // simply fall through to a cached open — correctness preserved.
+        //
+        // macOS / Windows / other Unixes: same "may be silently ignored"
+        // contract. macOS has no O_DIRECT (F_NOCACHE via fcntl post-open
+        // is the closest equivalent and is out of scope here).
+        #[cfg(all(
+            any(target_os = "linux", target_os = "android"),
+            any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "riscv32",
+                target_arch = "riscv64",
+                target_arch = "loongarch64",
+                target_arch = "s390x",
+            ),
+        ))]
+        if opts.direct_io {
+            use std::os::unix::fs::OpenOptionsExt;
+            // asm-generic/fcntl.h: #define O_DIRECT 00040000
+            const O_DIRECT: i32 = 0o0_040_000;
+            builder.custom_flags(O_DIRECT);
+        }
+
+        let file = builder.open(path)?;
         Ok(Box::new(file))
     }
 
@@ -617,6 +650,7 @@ mod tests {
         assert!(!opts.create_new);
         assert!(!opts.truncate);
         assert!(!opts.append);
+        assert!(!opts.direct_io);
     }
 
     #[test]
@@ -627,13 +661,15 @@ mod tests {
             .create(true)
             .create_new(false)
             .truncate(true)
-            .append(false);
+            .append(false)
+            .direct_io(true);
         assert!(opts.read);
         assert!(opts.write);
         assert!(opts.create);
         assert!(!opts.create_new);
         assert!(opts.truncate);
         assert!(!opts.append);
+        assert!(opts.direct_io);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Foundation layer for `O_DIRECT` cache-bypass I/O. Two pieces:

1. **`AlignedBuf`** (`src/fs/aligned_buf.rs`) — heap-allocated byte buffer with caller-specified alignment. `Vec<u8>` defaults to `align_of::<u8>() = 1`, which violates `O_DIRECT`'s typical 4 KiB userspace-buffer alignment (EINVAL on unaligned write/read). `AlignedBuf` allocates via `Layout::from_size_align`, rounds capacity up to a multiple of alignment, and exposes a `Vec`-like surface (`len`/`capacity`/`as_slice`/`as_capacity_mut`/`set_len`/`clear`) + raw ptr accessors for kernel handoff.

2. **`FsOpenOptions::direct_io`** — new `bool` field + builder method. On Linux/Android (arches where `asm-generic/fcntl.h`'s `O_DIRECT = 0o40000` is the authoritative value: x86, x86_64, aarch64, riscv32/64, loongarch64, s390x) the flag becomes a `custom_flags(O_DIRECT)` on the std `OpenOptions` builder, in both `StdFs::open` and `IoUringFs::open`.

`O_DIRECT` is declared as a named constant rather than pulling in `libc` — matches the existing `EXDEV` / `flock` pattern in `std_fs.rs`. Architectures with a divergent `O_DIRECT` bit (arm `0o200000`, mips `0o100000`, parisc, sparc) are not gated on purpose: emitting the wrong bit silently would be worse than honouring the documented "`direct_io` may be ignored" contract. macOS / Windows / other Unix targets fall through to a cached open for the same reason — `F_NOCACHE` / `FILE_FLAG_NO_BUFFERING` each need their own opt-in plumbing.

## Design choices (explicit so review does not re-raise)

- **`FsOpenOptions` is `#[non_exhaustive]`.** This is breaking (struct-literal callers + exhaustive pattern matches stop compiling) but only relative to the same release that introduces the new `direct_io` field — which is already breaking for the same callers. Bundling both changes in one release confines the break to a single semver-major bump (v5.0.0, queued in PR #272) and lets every future field land as semver-minor. Builder methods (`.read()`, `.write()`, … `.direct_io()`) cover every field, so non-struct-literal callers are unaffected.

- **`fs::direct_io` submodule IS gated behind `#[cfg(feature = "std")]`.** It uses `std::fs::OpenOptions` and is therefore std-only. The gate is the first concrete step toward honestly feature-gating the std backend per crate policy. However, it does NOT by itself unblock a `no_std + alloc` build: the rest of the `fs::*` backend — the `Fs`/`FsFile` trait *definitions* and all impls (`std_fs`, `io_uring_fs`, even `MemFs`) — still references `std::io::{Read, Write, Seek}` + `std::path::Path` directly, and those have no `core::*` equivalents. Porting the trait surface off `std::io` / `std::path` is a structural prerequisite tracked as a separate prerequisite issue (#311), itself part of the no-std migration epic (#274). The `no-std-check` CI job is `continue-on-error` for exactly this reason — net error count is not changed by this PR.

## What's NOT in this PR

The Tree-level `Config::direct_io` knob and compaction-writer integration are deferred to a follow-up. The current SST writer uses `Vec<u8>` buffers and unaligned block sizes; wiring `direct_io` into `Config` without an alignment-aware writer would EINVAL on first write. Foundation lands here so the writer refactor can build on it.

## Test plan

- [x] 12 unit tests for `AlignedBuf` (alignment verification, capacity rounding, zero init, rejects non-power-of-two / excessive alignment, zero-capacity dangling sentinel, `set_len` growth + panic, `clear`, `as_capacity_mut` writes, `Send`/`Sync` compile check, pointer stability)
- [x] `fs_open_options_default` + `fs_open_options_builders` updated to cover the new field
- [x] Full nextest suite: 1542 tests pass (1 slow), 6 skipped
- [x] cargo clippy all-features all-targets with -D warnings — clean
- [x] Doctest for `AlignedBuf::new_zeroed` example compiles and passes

## Related

- #311 — port `Fs`/`FsFile` traits off `std::io` + `std::path` (prerequisite for the rest of `fs::*` to become honestly feature-gateable)
- #274 — no-std migration epic (parent)
- #272 — release-plz v5.0.0 (semver-major bump that ships the breaking changes here)

Part of #133
