### PR TITLE
build(deps): bump structured-zstd to 0.0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ log = "0.4.27"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.21", optional = true, default-features = false, features = ["std"] }
+structured-zstd = { version = "0.0.23", optional = true, default-features = false, features = ["std"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is


### PR DESCRIPTION
## Summary

Bump our maintained pure-Rust zstd fork: 0.0.21 → 0.0.23. Two patch-level releases from upstream — semver-compatible, no API changes for consumers.

Other transitive patch updates pulled at the same time via `cargo update` (autocfg 1.5.0→1.5.1, bumpalo 3.20.2→3.20.3, ctr 0.10.0→0.10.1, either 1.15.0→1.16.0, serde_json 1.0.149→1.0.150, js-sys / wasm-bindgen / web-sys patch line). None of these are pinned in `Cargo.toml` (this is a library crate; `Cargo.lock` is `.gitignored`) — they will be picked up by downstream `cargo update` runs.

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings`: clean
- [x] `cargo nextest run --all-features`: 1530 tests pass (1 slow), 6 skipped