### PR TITLE
fix(table): mirror meta block at mid-file for tail-corruption resilience (#295)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,12 @@ rand = "0.10.1"
 # Used by the vendored ribbon-filter's #[cfg(feature = "ribbon-serde")]
 # round-trip tests. Dev-only; production code does not depend on it.
 serde_json = "1"
+# Pulled in as a dev-dep (in addition to the lib dep) so integration
+# tests can parse the SFA trailer + TOC directly to find absolute
+# offsets of named sections (used by the meta-mirror corruption tests
+# to target the TAIL or MID meta region without depending on writer
+# layout heuristics).
+sfa = "~1.0.0"
 strum = { version = "0.28.0", features = ["derive"] }
 test-log = "0.2.18"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,12 +137,6 @@ rand = "0.10.1"
 # Used by the vendored ribbon-filter's #[cfg(feature = "ribbon-serde")]
 # round-trip tests. Dev-only; production code does not depend on it.
 serde_json = "1"
-# Pulled in as a dev-dep (in addition to the lib dep) so integration
-# tests can parse the SFA trailer + TOC directly to find absolute
-# offsets of named sections (used by the meta-mirror corruption tests
-# to target the TAIL or MID meta region without depending on writer
-# layout heuristics).
-sfa = "~1.0.0"
 strum = { version = "0.28.0", features = ["derive"] }
 test-log = "0.2.18"
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -951,15 +951,31 @@ impl Table {
                         "TAIL meta block unreadable for {} ({tail_err}); falling back to MID copy",
                         file_path.display(),
                     );
-                    let mut mid =
-                        ParsedMeta::load_with_handle(&*file, &mid_handle, encryption.as_deref())?;
-                    // MID writes file_size as a 0 sentinel because the
-                    // file isn't done growing when the section is
-                    // emitted. Recover the real on-disk size now.
-                    if mid.file_size == 0 {
-                        mid.file_size = std::fs::metadata(&*file_path)?.len();
+                    // Match the PR contract: when BOTH copies fail,
+                    // surface the original TAIL error (callers care
+                    // about the authoritative copy's failure mode).
+                    // The MID failure goes to the log so it's not
+                    // silently dropped from diagnostics.
+                    match ParsedMeta::load_with_handle(&*file, &mid_handle, encryption.as_deref()) {
+                        Ok(mut mid) => {
+                            // MID writes file_size as a 0 sentinel because
+                            // the file isn't done growing when the section
+                            // is emitted. Recover the real on-disk size
+                            // now.
+                            if mid.file_size == 0 {
+                                mid.file_size = std::fs::metadata(&*file_path)?.len();
+                            }
+                            mid
+                        }
+                        Err(mid_err) => {
+                            log::warn!(
+                                "MID meta block also unreadable for {}: {mid_err}; \
+                                 returning original TAIL error",
+                                file_path.display(),
+                            );
+                            return Err(tail_err);
+                        }
                     }
-                    mid
                 } else {
                     return Err(tail_err);
                 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -956,12 +956,14 @@ impl Table {
                     // about the authoritative copy's failure mode).
                     // The MID failure goes to the log so it's not
                     // silently dropped from diagnostics.
-                    // MID encodes the same `file_size` value as TAIL
-                    // (the writer takes one snapshot of
-                    // `self.meta.file_pos` and stamps both copies with
-                    // it), so the MID payload is usable directly — no
-                    // patching, no `std::fs::metadata` (which would
-                    // also bypass the pluggable `Fs` backend).
+                    // MID and TAIL are byte-identical: same `file_size`
+                    // (= `*self.meta.file_pos`, only bumped inside
+                    // `spill_block`, unchanged between the two writes),
+                    // same `created_at` (snapshotted once in
+                    // `finish()`), same KV map. MID payload is usable
+                    // directly — no sentinel patching, no
+                    // `std::fs::metadata` (which would also bypass the
+                    // pluggable `Fs` backend).
                     match ParsedMeta::load_with_handle(&*file, &mid_handle, encryption.as_deref()) {
                         Ok(mid) => mid,
                         Err(mid_err) => {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -934,8 +934,37 @@ impl Table {
         let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
 
         log::trace!("Reading meta block, with meta_ptr={:?}", regions.metadata);
-        let metadata =
-            ParsedMeta::load_with_handle(&*file, &regions.metadata, encryption.as_deref())?;
+        // TAIL first (authoritative copy with the real file_size).
+        // On any decode/decrypt/checksum failure fall back to the MID
+        // copy if present — it contains the same fields except a
+        // sentinel file_size==0, which the load path patches up from
+        // the on-disk file length.
+        let metadata = match ParsedMeta::load_with_handle(
+            &*file,
+            &regions.metadata,
+            encryption.as_deref(),
+        ) {
+            Ok(m) => m,
+            Err(tail_err) => {
+                if let Some(mid_handle) = regions.metadata_mid {
+                    log::warn!(
+                        "TAIL meta block unreadable for {} ({tail_err}); falling back to MID copy",
+                        file_path.display(),
+                    );
+                    let mut mid =
+                        ParsedMeta::load_with_handle(&*file, &mid_handle, encryption.as_deref())?;
+                    // MID writes file_size as a 0 sentinel because the
+                    // file isn't done growing when the section is
+                    // emitted. Recover the real on-disk size now.
+                    if mid.file_size == 0 {
+                        mid.file_size = std::fs::metadata(&*file_path)?.len();
+                    }
+                    mid
+                } else {
+                    return Err(tail_err);
+                }
+            }
+        };
 
         // Fail-fast: if this table was written with dictionary compression,
         // verify the caller provided the matching dictionary. Without this

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -934,11 +934,11 @@ impl Table {
         let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
 
         log::trace!("Reading meta block, with meta_ptr={:?}", regions.metadata);
-        // TAIL first (authoritative copy with the real file_size).
-        // On any decode/decrypt/checksum failure fall back to the MID
-        // copy if present — it contains the same fields except a
-        // sentinel file_size==0, which the load path patches up from
-        // the on-disk file length.
+        // TAIL first (authoritative copy by convention; physically
+        // identical content to MID — same `file_size`, same
+        // `created_at`, same KV map — the only difference is which
+        // SFA section is loaded). On any decode/decrypt/checksum
+        // failure fall back to the MID copy if present.
         let metadata = match ParsedMeta::load_with_handle(
             &*file,
             &regions.metadata,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -956,17 +956,14 @@ impl Table {
                     // about the authoritative copy's failure mode).
                     // The MID failure goes to the log so it's not
                     // silently dropped from diagnostics.
+                    // MID encodes the same `file_size` value as TAIL
+                    // (the writer takes one snapshot of
+                    // `self.meta.file_pos` and stamps both copies with
+                    // it), so the MID payload is usable directly — no
+                    // patching, no `std::fs::metadata` (which would
+                    // also bypass the pluggable `Fs` backend).
                     match ParsedMeta::load_with_handle(&*file, &mid_handle, encryption.as_deref()) {
-                        Ok(mut mid) => {
-                            // MID writes file_size as a 0 sentinel because
-                            // the file isn't done growing when the section
-                            // is emitted. Recover the real on-disk size
-                            // now.
-                            if mid.file_size == 0 {
-                                mid.file_size = std::fs::metadata(&*file_path)?.len();
-                            }
-                            mid
-                        }
+                        Ok(mid) => mid,
                         Err(mid_err) => {
                             log::warn!(
                                 "MID meta block also unreadable for {}: {mid_err}; \

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -50,10 +50,15 @@ pub struct ParsedRegions {
     pub range_tombstones: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
-    /// Mid-file backup of the meta block, written between the filter
-    /// region and `linked_blob_files`. Absent on tables written before
-    /// the meta-mirror change; defends against torn-write at the file
-    /// tail because it lives at ~95% of the eventual file position.
+    /// Mid-file backup of the meta block. Writer order:
+    /// `data` → `tli` → `index?` → `filter_tli?` → `filter?` →
+    /// `range_tombstones?` → **`meta_mid`** →
+    /// `linked_blob_files?` → `table_version` → `meta_separator` →
+    /// `meta`. Absent on tables written before the meta-mirror change.
+    /// Defends against torn-write at the file tail (incomplete fsync):
+    /// MID lives several KiB before TAIL, with a 4 KiB
+    /// `meta_separator` section between them to guarantee a fresh
+    /// filesystem sector boundary.
     pub metadata_mid: Option<BlockHandle>,
 }
 

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -50,6 +50,11 @@ pub struct ParsedRegions {
     pub range_tombstones: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
+    /// Mid-file backup of the meta block, written between the filter
+    /// region and `linked_blob_files`. Absent on tables written before
+    /// the meta-mirror change; defends against torn-write at the file
+    /// tail because it lives at ~95% of the eventual file position.
+    pub metadata_mid: Option<BlockHandle>,
 }
 
 impl ParsedRegions {
@@ -74,6 +79,7 @@ impl ParsedRegions {
                     log::error!("Metadata should exist");
                     crate::Error::Unrecoverable
                 })?,
+            metadata_mid: toc.section(b"meta_mid").map(toc_entry_to_handle),
         })
     }
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2052,6 +2052,74 @@ fn meta_mid_and_tail_have_identical_created_at() -> crate::Result<()> {
     Ok(())
 }
 
+/// `meta_mid` and `meta` (TAIL) must encode the SAME `file_size`. The
+/// writer was stamping MID with a 0 sentinel and the reader was
+/// patching the value with `std::fs::metadata(path).len()` on MID
+/// fallback — that path (a) bypasses the pluggable `Fs` backend (so
+/// `Table::recover` would fail on MemFs / io_uring trees the moment it
+/// touched the MID fallback branch), and (b) reported the entire
+/// physical file length (including TOC, trailer, and the TAIL meta
+/// block itself), while TAIL stores `self.meta.file_pos` taken before
+/// any of those tail sections were written. Recovered tables therefore
+/// reported wildly different sizes depending on which meta copy survived.
+///
+/// `self.meta.file_pos` is only ever incremented inside `spill_block()`
+/// (data-block writes). The index/tli/filter/range-tombstone writes,
+/// the MID meta block itself, the linked_blob_files / table_version /
+/// meta_separator raw sections, and the TAIL meta block all leave it
+/// unchanged. So the value is identical at MID and TAIL write time —
+/// MID can encode it directly, no recovery-time patching, no
+/// `std::fs::metadata` call.
+#[test]
+fn meta_mid_and_tail_have_identical_file_size() -> crate::Result<()> {
+    use super::meta::ParsedMeta;
+    use super::regions::ParsedRegions;
+
+    let dir = tempfile::tempdir()?;
+    let file = dir.path().join("table");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    for (i, key) in (b'a'..=b'e').enumerate() {
+        writer.write(InternalValue::from_components(
+            [key],
+            b"val",
+            (i as u64) + 1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    #[expect(
+        clippy::unwrap_used,
+        reason = "finish() returns Some after writing data items"
+    )]
+    let _ = writer.finish()?.unwrap();
+
+    let mut f = std::fs::File::open(&file)?;
+    let trailer = sfa::Reader::from_reader(&mut f)?;
+    let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
+
+    let tail = ParsedMeta::load_with_handle(&f, &regions.metadata, None)?;
+    let mid_handle = regions
+        .metadata_mid
+        .expect("writer must emit meta_mid alongside meta");
+    let mid = ParsedMeta::load_with_handle(&f, &mid_handle, None)?;
+
+    assert_eq!(
+        tail.file_size, mid.file_size,
+        "MID and TAIL meta copies must store an identical file_size \
+         (both observe the same `self.meta.file_pos` because no \
+         post-data section bumps it); observed tail={} mid={}",
+        tail.file_size, mid.file_size,
+    );
+    assert_ne!(
+        mid.file_size, 0,
+        "MID file_size must not be the legacy 0 sentinel — that pushed \
+         the recovery path through std::fs::metadata, which bypasses \
+         the pluggable Fs backend"
+    );
+
+    Ok(())
+}
+
 /// `bloom_may_contain_key` with full (non-partitioned) filter delegates to
 /// `bloom_may_contain_hash`. Both methods agree for full filters.
 #[test]

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2001,6 +2001,57 @@ fn meta_seqno_kv_max_corruption_returns_invalid_data() -> crate::Result<()> {
     Ok(())
 }
 
+/// `meta_mid` and `meta` (TAIL) must encode the SAME `created_at`. The
+/// writer was generating `unix_timestamp()` independently inside each
+/// `write_meta_section` call, so MID and TAIL would observe slightly
+/// different wall-clock values. After recovery via MID the table would
+/// report a different creation time than after recovery via TAIL,
+/// which silently shifts TTL / FIFO ordering depending on which copy
+/// the reader fell back to.
+#[test]
+fn meta_mid_and_tail_have_identical_created_at() -> crate::Result<()> {
+    use super::meta::ParsedMeta;
+    use super::regions::ParsedRegions;
+
+    let dir = tempfile::tempdir()?;
+    let file = dir.path().join("table");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    for (i, key) in (b'a'..=b'e').enumerate() {
+        writer.write(InternalValue::from_components(
+            [key],
+            b"val",
+            (i as u64) + 1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    #[expect(
+        clippy::unwrap_used,
+        reason = "finish() returns Some after writing data items"
+    )]
+    let _ = writer.finish()?.unwrap();
+
+    let mut f = std::fs::File::open(&file)?;
+    let trailer = sfa::Reader::from_reader(&mut f)?;
+    let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
+
+    let tail = ParsedMeta::load_with_handle(&f, &regions.metadata, None)?;
+    let mid_handle = regions
+        .metadata_mid
+        .expect("writer must emit meta_mid alongside meta");
+    let mid = ParsedMeta::load_with_handle(&f, &mid_handle, None)?;
+
+    assert_eq!(
+        tail.created_at, mid.created_at,
+        "MID and TAIL meta copies must share an identical created_at \
+         (writer must snapshot the timestamp once and pass it to both \
+         write_meta_section calls; observed tail={:?} mid={:?})",
+        tail.created_at, mid.created_at,
+    );
+
+    Ok(())
+}
+
 /// `bloom_may_contain_key` with full (non-partitioned) filter delegates to
 /// `bloom_may_contain_hash`. Both methods agree for full filters.
 #[test]

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -666,7 +666,13 @@ impl Writer {
             section_name: "meta_mid",
             index_block_count,
             filter_block_count,
-            file_size: 0, // sentinel; reader recovers actual size from fs metadata
+            // MID and TAIL must encode the SAME file_size — recovery
+            // falls back transparently and downstream consumers
+            // (compaction window picking, etc.) read it as if it were
+            // authoritative. `self.meta.file_pos` is only ever bumped
+            // inside spill_block, so its value is identical at MID
+            // and TAIL write time.
+            file_size: *self.meta.file_pos,
             table_id: self.table_id,
             data_block_count: self.meta.data_block_count as u64,
             item_count: self.meta.item_count as u64,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -646,9 +646,14 @@ impl Writer {
         }
 
         // Snapshot all meta fields once — reused for both MID and TAIL
-        // copies. Borrowing the keys from `self.meta` here is fine
-        // because `self.range_tombstones` is the only field consumed
-        // before the TAIL write, and we capture only its `.len()`.
+        // copies. Borrowing `first_key` / `last_key` from `self.meta`
+        // here is fine because neither the MID write nor any of the
+        // intermediate tail sections (`linked_blob_files`,
+        // `table_version`, `meta_separator`) touch `self.meta`'s key
+        // buffers — those stay owned by `self` through to the TAIL
+        // write. Note that `self.index_writer` and `self.filter_writer`
+        // are already moved by the `.finish()` calls above; we don't
+        // touch them again here.
         #[expect(clippy::expect_used, reason = "non-empty table guaranteed earlier")]
         let first_key = self
             .meta
@@ -708,11 +713,15 @@ impl Writer {
         };
 
         // MID meta copy — defends against torn-write at the file tail
-        // (incomplete fsync). MID sits at ~95% of the eventual file
-        // position, far from the tail's last-write region. `file_size`
-        // is `*self.meta.file_pos` so MID and TAIL encode identical
-        // values: `file_pos` is only ever bumped inside `spill_block`,
-        // so it doesn't change between the two writes.
+        // (incomplete fsync). Written at the current writer cursor,
+        // after `range_tombstones` and before
+        // `linked_blob_files` / `table_version` / `meta_separator` /
+        // `meta`. The 4 KiB `meta_separator` between MID and TAIL
+        // guarantees the two copies land on different filesystem
+        // sectors. `file_size` is `*self.meta.file_pos` so MID and
+        // TAIL encode identical values: `file_pos` is only ever bumped
+        // inside `spill_block`, so it doesn't change between the two
+        // writes.
         write_meta_section(
             &mut self.file_writer,
             &mut self.block_buffer,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -693,6 +693,16 @@ impl Writer {
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
             range_tombstone_count,
+            // `block_offset` here feeds `BlockIdentity` which today is
+            // unused (`let _ = identity;` in `Block::write_into` /
+            // `Block::from_file`). Once AAD is wired in #251 the read
+            // side will derive this from `*handle.offset()` (the SFA
+            // TOC section offset, distinct for MID vs TAIL), so this
+            // shared `*self.meta.file_pos` value will need to be
+            // replaced with each section's actual file position at
+            // write time. Tracked as part of the #251 AAD-wiring
+            // surface — the writer here will need to query the SFA
+            // writer's current file position per section.
             block_offset: *self.meta.file_pos,
             created_at_nanos,
         };
@@ -700,8 +710,9 @@ impl Writer {
         // MID meta copy — defends against torn-write at the file tail
         // (incomplete fsync). MID sits at ~95% of the eventual file
         // position, far from the tail's last-write region. `file_size`
-        // is 0 because the file isn't done growing yet; reader treats
-        // 0 as "use std::fs::metadata().len() instead".
+        // is `*self.meta.file_pos` so MID and TAIL encode identical
+        // values: `file_pos` is only ever bumped inside `spill_block`,
+        // so it doesn't change between the two writes.
         write_meta_section(
             &mut self.file_writer,
             &mut self.block_buffer,
@@ -740,11 +751,22 @@ impl Writer {
         self.file_writer.start("meta_separator")?;
         self.file_writer.write_all(&[0u8; 4096])?;
 
-        // TAIL meta — the canonical, authoritative copy. Contains the
-        // real `file_size` (= `self.meta.file_pos` snapshot taken just
-        // before this block is written, i.e. the offset where this
-        // block itself starts).
+        // TAIL meta — the canonical, authoritative copy. `file_size`
+        // is the LOGICAL size up to the end of the data blocks
+        // (`self.meta.file_pos`), NOT the on-disk offset of this
+        // block. `file_pos` is bumped only inside `spill_block`, so
+        // it does not track the absolute file cursor here; the value
+        // is the same one MID encoded above, which is the contract
+        // downstream consumers (`Table::file_size`, compaction window
+        // picking, checkpoint sizing — see the comment in
+        // `checkpoint.rs:170-185`) read.
         meta_params.section_name = "meta";
+        // file_size and block_offset already carry `*self.meta.file_pos`
+        // from the MID write; `file_pos` hasn't moved since (no
+        // intermediate write touches it), so re-assigning is a
+        // no-op. Kept explicit for readability — if someone later
+        // adds a Block::write_into call before TAIL that DOES bump
+        // file_pos, this line will need to re-snapshot.
         meta_params.file_size = *self.meta.file_pos;
         meta_params.block_offset = *self.meta.file_pos;
         write_meta_section(

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -802,6 +802,10 @@ struct MetaSectionParams<'a> {
     block_offset: u64,
 }
 
+fn meta_kv(key: &str, value: &[u8]) -> InternalValue {
+    InternalValue::from_components(key, value, 0, crate::ValueType::Value)
+}
+
 fn write_meta_section<W: std::io::Write + std::io::Seek>(
     file_writer: &mut sfa::Writer<ChecksummedWriter<W>>,
     block_buffer: &mut Vec<u8>,
@@ -810,10 +814,7 @@ fn write_meta_section<W: std::io::Write + std::io::Seek>(
 ) -> crate::Result<()> {
     file_writer.start(p.section_name)?;
 
-    fn meta(key: &str, value: &[u8]) -> InternalValue {
-        InternalValue::from_components(key, value, 0, crate::ValueType::Value)
-    }
-
+    let meta = meta_kv;
     let meta_items = [
         meta("block_count#data", &p.data_block_count.to_le_bytes()),
         meta(

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -658,6 +658,10 @@ impl Writer {
         #[expect(clippy::expect_used, reason = "non-empty table guaranteed earlier")]
         let last_key = self.meta.last_key.as_ref().expect("last_key should exist");
         let range_tombstone_count = self.range_tombstones.len() as u64;
+        // Snapshot the wall-clock once — both MID and TAIL copies
+        // must report the SAME created_at so MID-fallback recovery
+        // produces the same timestamp as a clean TAIL recovery.
+        let created_at_nanos = unix_timestamp().as_nanos();
         let mut meta_params = MetaSectionParams {
             section_name: "meta_mid",
             index_block_count,
@@ -684,6 +688,7 @@ impl Writer {
             initial_level: self.initial_level,
             range_tombstone_count,
             block_offset: *self.meta.file_pos,
+            created_at_nanos,
         };
 
         // MID meta copy — defends against torn-write at the file tail
@@ -800,6 +805,12 @@ struct MetaSectionParams<'a> {
     initial_level: u8,
     range_tombstone_count: u64,
     block_offset: u64,
+    /// `created_at` snapshot taken once in `finish()`. Both MID and
+    /// TAIL writes consume this same value; generating it inside
+    /// `write_meta_section` per call would stamp the two copies with
+    /// different wall-clock readings and shift TTL/FIFO ordering on
+    /// MID-fallback recovery.
+    created_at_nanos: u128,
 }
 
 fn meta_kv(key: &str, value: &[u8]) -> InternalValue {
@@ -835,7 +846,7 @@ fn write_meta_section<W: std::io::Write + std::io::Seek>(
             &p.index_block_compression.encode_into_vec(),
         ),
         meta("crate_version", env!("CARGO_PKG_VERSION").as_bytes()),
-        meta("created_at", &unix_timestamp().as_nanos().to_le_bytes()),
+        meta("created_at", &p.created_at_nanos.to_le_bytes()),
         meta(
             "data_block_hash_ratio",
             &p.data_block_hash_ratio.to_le_bytes(),

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -645,6 +645,59 @@ impl Writer {
             )?;
         }
 
+        // Snapshot all meta fields once — reused for both MID and TAIL
+        // copies. Borrowing the keys from `self.meta` here is fine
+        // because `self.range_tombstones` is the only field consumed
+        // before the TAIL write, and we capture only its `.len()`.
+        #[expect(clippy::expect_used, reason = "non-empty table guaranteed earlier")]
+        let first_key = self
+            .meta
+            .first_key
+            .as_ref()
+            .expect("first_key should exist");
+        #[expect(clippy::expect_used, reason = "non-empty table guaranteed earlier")]
+        let last_key = self.meta.last_key.as_ref().expect("last_key should exist");
+        let range_tombstone_count = self.range_tombstones.len() as u64;
+        let mut meta_params = MetaSectionParams {
+            section_name: "meta_mid",
+            index_block_count,
+            filter_block_count,
+            file_size: 0, // sentinel; reader recovers actual size from fs metadata
+            table_id: self.table_id,
+            data_block_count: self.meta.data_block_count as u64,
+            item_count: self.meta.item_count as u64,
+            tombstone_count: self.meta.tombstone_count as u64,
+            weak_tombstone_count: self.meta.weak_tombstone_count as u64,
+            weak_tombstone_reclaimable: self.meta.weak_tombstone_reclaimable_count as u64,
+            key_count: self.meta.key_count as u64,
+            uncompressed_size: self.meta.uncompressed_size,
+            first_key,
+            last_key,
+            lowest_seqno: self.meta.lowest_seqno,
+            highest_seqno: self.meta.highest_seqno,
+            highest_kv_seqno: self.meta.highest_kv_seqno,
+            data_block_compression: self.data_block_compression,
+            index_block_compression: self.index_block_compression,
+            data_block_hash_ratio: self.data_block_hash_ratio,
+            data_block_restart_interval: self.data_block_restart_interval,
+            index_block_restart_interval: self.index_block_restart_interval,
+            initial_level: self.initial_level,
+            range_tombstone_count,
+            block_offset: *self.meta.file_pos,
+        };
+
+        // MID meta copy — defends against torn-write at the file tail
+        // (incomplete fsync). MID sits at ~95% of the eventual file
+        // position, far from the tail's last-write region. `file_size`
+        // is 0 because the file isn't done growing yet; reader treats
+        // 0 as "use std::fs::metadata().len() instead".
+        write_meta_section(
+            &mut self.file_writer,
+            &mut self.block_buffer,
+            self.encryption.as_deref(),
+            &meta_params,
+        )?;
+
         if !self.linked_blob_files.is_empty() {
             use byteorder::{LE, WriteBytesExt};
 
@@ -657,7 +710,7 @@ impl Writer {
             self.file_writer
                 .write_u32::<LE>(self.linked_blob_files.len() as u32)?;
 
-            for file in self.linked_blob_files {
+            for file in &self.linked_blob_files {
                 self.file_writer.write_u64::<LE>(file.blob_file_id)?;
                 self.file_writer.write_u64::<LE>(file.len as u64)?;
                 self.file_writer.write_u64::<LE>(file.bytes)?;
@@ -668,131 +721,27 @@ impl Writer {
         self.file_writer.start("table_version")?;
         self.file_writer.write_all(&[0x3])?;
 
-        // Write metadata
-        self.file_writer.start("meta")?;
+        // 4 KiB padding section so MID copy and TAIL copy live on
+        // different 4 KiB filesystem sectors. Without this, a single
+        // bad sector at the tail could take out both copies (only
+        // ~tens of bytes separate the linked_blob_files / table_version
+        // sections between them).
+        self.file_writer.start("meta_separator")?;
+        self.file_writer.write_all(&[0u8; 4096])?;
 
-        {
-            fn meta(key: &str, value: &[u8]) -> InternalValue {
-                InternalValue::from_components(key, value, 0, crate::ValueType::Value)
-            }
-
-            let meta_items = [
-                meta(
-                    "block_count#data",
-                    &(self.meta.data_block_count as u64).to_le_bytes(),
-                ),
-                meta(
-                    "block_count#filter",
-                    &(filter_block_count as u64).to_le_bytes(),
-                ),
-                meta(
-                    "block_count#index",
-                    &(index_block_count as u64).to_le_bytes(),
-                ),
-                meta("checksum_type", &[u8::from(ChecksumType::Xxh3)]),
-                meta(
-                    "compression#data",
-                    &self.data_block_compression.encode_into_vec(),
-                ),
-                meta(
-                    "compression#index",
-                    &self.index_block_compression.encode_into_vec(),
-                ),
-                meta("crate_version", env!("CARGO_PKG_VERSION").as_bytes()),
-                meta("created_at", &unix_timestamp().as_nanos().to_le_bytes()),
-                meta(
-                    "data_block_hash_ratio",
-                    &self.data_block_hash_ratio.to_le_bytes(),
-                ),
-                meta("file_size", &self.meta.file_pos.to_le_bytes()),
-                meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
-                meta("index_keys_have_seqno", &[0x1]),
-                meta("initial_level", &self.initial_level.to_le_bytes()),
-                meta("item_count", &(self.meta.item_count as u64).to_le_bytes()),
-                meta(
-                    "key#max",
-                    // NOTE: At the beginning we check that we have written at least 1 item, so last_key must exist
-                    #[expect(clippy::expect_used)]
-                    self.meta.last_key.as_ref().expect("should exist"),
-                ),
-                meta(
-                    "key#min",
-                    // NOTE: At the beginning we check that we have written at least 1 item, so first_key must exist
-                    #[expect(clippy::expect_used)]
-                    self.meta.first_key.as_ref().expect("should exist"),
-                ),
-                meta("key_count", &(self.meta.key_count as u64).to_le_bytes()),
-                meta("prefix_truncation#data", &[1]), // NOTE: currently prefix truncation can not be disabled
-                meta("prefix_truncation#index", &[1]), // NOTE: currently prefix truncation can not be disabled
-                meta(
-                    "range_tombstone_count",
-                    &(self.range_tombstones.len() as u64).to_le_bytes(),
-                ),
-                meta(
-                    "restart_interval#data",
-                    &self.data_block_restart_interval.to_le_bytes(),
-                ),
-                meta(
-                    "restart_interval#index",
-                    &self.index_block_restart_interval.to_le_bytes(),
-                ),
-                meta("seqno#kv_max", &self.meta.highest_kv_seqno.to_le_bytes()),
-                meta("seqno#max", &self.meta.highest_seqno.to_le_bytes()),
-                meta("seqno#min", &self.meta.lowest_seqno.to_le_bytes()),
-                meta("table_id", &self.table_id.to_le_bytes()),
-                meta("table_version", &[3u8]),
-                meta(
-                    "tombstone_count",
-                    &(self.meta.tombstone_count as u64).to_le_bytes(),
-                ),
-                meta("user_data_size", &self.meta.uncompressed_size.to_le_bytes()),
-                meta(
-                    "weak_tombstone_count",
-                    &(self.meta.weak_tombstone_count as u64).to_le_bytes(),
-                ),
-                meta(
-                    "weak_tombstone_reclaimable",
-                    &(self.meta.weak_tombstone_reclaimable_count as u64).to_le_bytes(),
-                ),
-            ];
-
-            // NOTE: Just to make sure the items are definitely sorted
-            #[cfg(debug_assertions)]
-            {
-                let is_sorted = meta_items.iter().is_sorted_by_key(|kv| &kv.key);
-                assert!(is_sorted, "meta items not sorted correctly");
-            }
-
-            self.block_buffer.clear();
-
-            // TODO: disable binary index: https://github.com/fjall-rs/lsm-tree/issues/185
-            DataBlock::encode_into(&mut self.block_buffer, &meta_items, 1, 0.0)?;
-
-            Block::write_into(
-                &mut self.file_writer,
-                &self.block_buffer,
-                crate::table::block::BlockIdentity {
-                    tree_id: 0,
-                    // Meta is read via ParsedMeta::load_with_handle
-                    // BEFORE the reader knows the table id — the
-                    // table id IS what meta itself carries.
-                    // Writer mirrors that with table_id: 0 so write
-                    // and read sides agree on the AAD discriminator
-                    // once #251 wires AAD; otherwise table-open
-                    // would fail AEAD verification on the very
-                    // first block read.
-                    table_id: 0,
-                    block_offset: *self.meta.file_pos,
-                    block_type: crate::table::block::BlockType::Meta,
-                    dict_id: 0,
-                    window_log: 0,
-                },
-                CompressionType::None,
-                self.encryption.as_deref(),
-                #[cfg(zstd_any)]
-                None,
-            )?;
-        };
+        // TAIL meta — the canonical, authoritative copy. Contains the
+        // real `file_size` (= `self.meta.file_pos` snapshot taken just
+        // before this block is written, i.e. the offset where this
+        // block itself starts).
+        meta_params.section_name = "meta";
+        meta_params.file_size = *self.meta.file_pos;
+        meta_params.block_offset = *self.meta.file_pos;
+        write_meta_section(
+            &mut self.file_writer,
+            &mut self.block_buffer,
+            self.encryption.as_deref(),
+            &meta_params,
+        )?;
 
         // Write fixed-size trailer
         // and flush & fsync the table file
@@ -818,6 +767,149 @@ impl Writer {
 
         Ok(Some((self.table_id, checksum)))
     }
+}
+
+/// Parameters bundle for [`write_meta_section`]. Free-standing struct
+/// (not a `Writer` method) because `finish()` calls this AFTER
+/// `index_writer.finish()` / `filter_writer.finish()` have consumed
+/// those two fields by-value, leaving `self` partially-moved and so
+/// unable to dispatch through `&mut self` methods.
+struct MetaSectionParams<'a> {
+    section_name: &'static str,
+    index_block_count: usize,
+    filter_block_count: usize,
+    file_size: u64,
+    table_id: TableId,
+    data_block_count: u64,
+    item_count: u64,
+    tombstone_count: u64,
+    weak_tombstone_count: u64,
+    weak_tombstone_reclaimable: u64,
+    key_count: u64,
+    uncompressed_size: u64,
+    first_key: &'a [u8],
+    last_key: &'a [u8],
+    lowest_seqno: crate::SeqNo,
+    highest_seqno: crate::SeqNo,
+    highest_kv_seqno: crate::SeqNo,
+    data_block_compression: CompressionType,
+    index_block_compression: CompressionType,
+    data_block_hash_ratio: f32,
+    data_block_restart_interval: u8,
+    index_block_restart_interval: u8,
+    initial_level: u8,
+    range_tombstone_count: u64,
+    block_offset: u64,
+}
+
+fn write_meta_section<W: std::io::Write + std::io::Seek>(
+    file_writer: &mut sfa::Writer<ChecksummedWriter<W>>,
+    block_buffer: &mut Vec<u8>,
+    encryption: Option<&dyn EncryptionProvider>,
+    p: &MetaSectionParams<'_>,
+) -> crate::Result<()> {
+    file_writer.start(p.section_name)?;
+
+    fn meta(key: &str, value: &[u8]) -> InternalValue {
+        InternalValue::from_components(key, value, 0, crate::ValueType::Value)
+    }
+
+    let meta_items = [
+        meta("block_count#data", &p.data_block_count.to_le_bytes()),
+        meta(
+            "block_count#filter",
+            &(p.filter_block_count as u64).to_le_bytes(),
+        ),
+        meta(
+            "block_count#index",
+            &(p.index_block_count as u64).to_le_bytes(),
+        ),
+        meta("checksum_type", &[u8::from(ChecksumType::Xxh3)]),
+        meta(
+            "compression#data",
+            &p.data_block_compression.encode_into_vec(),
+        ),
+        meta(
+            "compression#index",
+            &p.index_block_compression.encode_into_vec(),
+        ),
+        meta("crate_version", env!("CARGO_PKG_VERSION").as_bytes()),
+        meta("created_at", &unix_timestamp().as_nanos().to_le_bytes()),
+        meta(
+            "data_block_hash_ratio",
+            &p.data_block_hash_ratio.to_le_bytes(),
+        ),
+        meta("file_size", &p.file_size.to_le_bytes()),
+        meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
+        meta("index_keys_have_seqno", &[0x1]),
+        meta("initial_level", &p.initial_level.to_le_bytes()),
+        meta("item_count", &p.item_count.to_le_bytes()),
+        meta("key#max", p.last_key),
+        meta("key#min", p.first_key),
+        meta("key_count", &p.key_count.to_le_bytes()),
+        meta("prefix_truncation#data", &[1]),
+        meta("prefix_truncation#index", &[1]),
+        meta(
+            "range_tombstone_count",
+            &p.range_tombstone_count.to_le_bytes(),
+        ),
+        meta(
+            "restart_interval#data",
+            &p.data_block_restart_interval.to_le_bytes(),
+        ),
+        meta(
+            "restart_interval#index",
+            &p.index_block_restart_interval.to_le_bytes(),
+        ),
+        meta("seqno#kv_max", &p.highest_kv_seqno.to_le_bytes()),
+        meta("seqno#max", &p.highest_seqno.to_le_bytes()),
+        meta("seqno#min", &p.lowest_seqno.to_le_bytes()),
+        meta("table_id", &p.table_id.to_le_bytes()),
+        meta("table_version", &[3u8]),
+        meta("tombstone_count", &p.tombstone_count.to_le_bytes()),
+        meta("user_data_size", &p.uncompressed_size.to_le_bytes()),
+        meta(
+            "weak_tombstone_count",
+            &p.weak_tombstone_count.to_le_bytes(),
+        ),
+        meta(
+            "weak_tombstone_reclaimable",
+            &p.weak_tombstone_reclaimable.to_le_bytes(),
+        ),
+    ];
+
+    #[cfg(debug_assertions)]
+    {
+        let is_sorted = meta_items.iter().is_sorted_by_key(|kv| &kv.key);
+        assert!(is_sorted, "meta items not sorted correctly");
+    }
+
+    block_buffer.clear();
+    DataBlock::encode_into(block_buffer, &meta_items, 1, 0.0)?;
+
+    Block::write_into(
+        file_writer,
+        block_buffer,
+        crate::table::block::BlockIdentity {
+            tree_id: 0,
+            // Meta is read FIRST during table open, BEFORE the reader
+            // knows the table_id (the table_id is what meta itself
+            // carries). Writer mirrors that with table_id=0 so write
+            // and read sides agree on the AAD discriminator once
+            // #251 wires AAD.
+            table_id: 0,
+            block_offset: p.block_offset,
+            block_type: crate::table::block::BlockType::Meta,
+            dict_id: 0,
+            window_log: 0,
+        },
+        CompressionType::None,
+        encryption,
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -616,10 +616,17 @@ fn scan_sst_blocks(
 /// these sections — their integrity is covered by the SFA-trailer
 /// checksum verified at table-open time. Every other section
 /// (`data` / `tli` / `index` / `filter_tli` / `filter` /
-/// `range_tombstones` / `meta`) is a `Header`-prefixed block run and
-/// gets walked. See `scan_sst_blocks` for the full section catalogue
-/// and the writer-side source of truth.
-const RAW_FORMAT_SECTIONS: &[&[u8]] = &[b"linked_blob_files", b"table_version"];
+/// `range_tombstones` / `meta` / `meta_mid`) is a `Header`-prefixed
+/// block run and gets walked. See `scan_sst_blocks` for the full
+/// section catalogue and the writer-side source of truth.
+///
+/// `meta_separator` is the 4 KiB zero-padding section the writer
+/// emits between the MID and TAIL meta blocks so a single bad
+/// filesystem sector cannot take out both copies — it carries no
+/// blocks and must be skipped here, otherwise the walker would try
+/// to decode zeros as a `Header` and report a spurious
+/// `HeaderCorrupted` on every clean SST.
+const RAW_FORMAT_SECTIONS: &[&[u8]] = &[b"linked_blob_files", b"table_version", b"meta_separator"];
 
 /// Plaintext upper bound on a single block's on-disk data segment
 /// length, mirroring `table::block::MAX_DECOMPRESSION_SIZE` (256 MiB).

--- a/tests/encryption_roundtrip.rs
+++ b/tests/encryption_roundtrip.rs
@@ -171,8 +171,10 @@ mod encrypted {
 
         // Flip bytes inside the first data block. The SFA writer puts
         // the data section as the very first section at file offset 0;
-        // a data block starts with a 16-byte `Header`, then encrypted
-        // payload. Offset 64 lands well inside the payload of the
+        // a data block starts with a `Header` (33 bytes, exposed as
+        // `Header::serialized_len()`: magic[4] + type[1] + checksum[16]
+        // + lengths[8] + CRC[4]), then encrypted payload. Offset 64
+        // lands well inside the payload of the
         // first (and for this tiny one-KV table, only) data block,
         // regardless of meta-block layout near the tail. Picking a
         // layout-independent offset avoids re-introducing this test

--- a/tests/encryption_roundtrip.rs
+++ b/tests/encryption_roundtrip.rs
@@ -169,14 +169,23 @@ mod encrypted {
         let sst_path = find_table_file(dir.path());
         let mut sst_bytes = std::fs::read(&sst_path)?;
 
-        // Flip bytes in the middle of the data section (after the header)
-        let tamper_offset = sst_bytes.len() / 2;
+        // Flip bytes inside the first data block. The SFA writer puts
+        // the data section as the very first section at file offset 0;
+        // a data block starts with a 16-byte `Header`, then encrypted
+        // payload. Offset 64 lands well inside the payload of the
+        // first (and for this tiny one-KV table, only) data block,
+        // regardless of meta-block layout near the tail. Picking a
+        // layout-independent offset avoids re-introducing this test
+        // every time the writer grows a new tail section.
+        let tamper_offset: usize = 64;
+        assert!(
+            tamper_offset + 8 < sst_bytes.len(),
+            "SST too small for tamper test"
+        );
         for i in 0..8 {
-            if tamper_offset + i < sst_bytes.len() {
-                #[expect(clippy::indexing_slicing, reason = "bounds checked")]
-                {
-                    sst_bytes[tamper_offset + i] ^= 0xFF;
-                }
+            #[expect(clippy::indexing_slicing, reason = "bounds checked above")]
+            {
+                sst_bytes[tamper_offset + i] ^= 0xFF;
             }
         }
         std::fs::write(&sst_path, &sst_bytes)?;

--- a/tests/meta_mirror.rs
+++ b/tests/meta_mirror.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Integration tests for the meta-block mirror (TAIL + MID copies,
+//! see writer/mod.rs `write_meta_section`). A single bit-flip or
+//! torn-write that takes out one copy must not prevent table open —
+//! the surviving copy is used.
+
+use lsm_tree::{AbstractTree, Config, SequenceNumberCounter, get_tmp_folder};
+use std::{fs::OpenOptions, io::Write, path::Path};
+use test_log::test;
+
+fn find_table_file(dir: &Path) -> std::path::PathBuf {
+    let tables_dir = dir.join("tables");
+    let search_dir = if tables_dir.exists() {
+        tables_dir
+    } else {
+        dir.to_path_buf()
+    };
+    for entry in std::fs::read_dir(&search_dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_file() {
+            return entry.path();
+        }
+    }
+    panic!("no table file found in {}", search_dir.display());
+}
+
+/// Reads the SFA TOC of `path` and returns `(offset, length)` of the
+/// named section, or `None` if the section is absent.
+fn locate_section(path: &Path, name: &[u8]) -> Option<(u64, u64)> {
+    let mut file = std::fs::File::open(path).unwrap();
+    let reader = sfa::Reader::from_reader(&mut file).unwrap();
+    reader
+        .toc()
+        .section(name)
+        .map(|entry| (entry.pos(), entry.len()))
+}
+
+/// Overwrites `len` bytes at `offset` in `path` with the given byte.
+/// Used to simulate localised corruption (bad sector, bit flip storm).
+fn corrupt_region(path: &Path, offset: u64, len: u64, byte: u8) {
+    use std::io::Seek;
+    let mut file = OpenOptions::new().write(true).open(path).unwrap();
+    file.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    let buf = vec![byte; len as usize];
+    file.write_all(&buf).unwrap();
+    file.sync_all().unwrap();
+}
+
+fn build_tree_with_items(items: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .unwrap();
+
+    for i in 0..items {
+        tree.insert(format!("key-{i:06}"), b"value", 0);
+    }
+    tree.flush_active_memtable(0).unwrap();
+
+    let sst = find_table_file(dir.path());
+    (dir, sst)
+}
+
+#[test]
+fn meta_mirror_writer_emits_both_copies() {
+    let (_dir, sst) = build_tree_with_items(64);
+
+    let tail = locate_section(&sst, b"meta");
+    let mid = locate_section(&sst, b"meta_mid");
+
+    assert!(tail.is_some(), "TAIL meta section must be present");
+    assert!(
+        mid.is_some(),
+        "MID meta_mid section must be present (mirror)"
+    );
+
+    let (tail_off, _) = tail.unwrap();
+    let (mid_off, _) = mid.unwrap();
+    // MID is written before TAIL — its offset must be smaller, and
+    // there must be at least one 4 KiB filesystem sector between
+    // them (meta_separator section enforces this).
+    assert!(
+        mid_off < tail_off,
+        "MID at offset {mid_off} should come before TAIL at {tail_off}"
+    );
+    assert!(
+        tail_off - mid_off >= 4096,
+        "MID..TAIL gap of {} bytes is below 4 KiB sector separation",
+        tail_off - mid_off,
+    );
+}
+
+#[test]
+fn table_reopens_via_mid_when_tail_meta_is_zeroed() {
+    let (dir, sst) = build_tree_with_items(64);
+
+    // Wipe the entire TAIL meta region with zeros — XXH3 over zeros
+    // will not match the header checksum, so Block::from_file rejects
+    // it and the recovery path must fall back to MID.
+    let (tail_off, tail_len) = locate_section(&sst, b"meta").expect("TAIL meta missing");
+    corrupt_region(&sst, tail_off, tail_len, 0x00);
+
+    // Reopen — should succeed via MID.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("table open should succeed using MID meta fallback");
+
+    // Sanity: the recovered table is usable.
+    let value = tree
+        .get(b"key-000000", lsm_tree::MAX_SEQNO)
+        .expect("get should succeed on table recovered via MID")
+        .expect("key should exist");
+    assert_eq!(&*value, b"value");
+}
+
+#[test]
+fn table_reopens_via_tail_when_mid_meta_is_zeroed() {
+    let (dir, sst) = build_tree_with_items(64);
+
+    // Wipe MID — TAIL is still authoritative, so this should be a
+    // no-op as far as the open path is concerned (TAIL is tried first
+    // and succeeds).
+    let (mid_off, mid_len) = locate_section(&sst, b"meta_mid").expect("MID meta missing");
+    corrupt_region(&sst, mid_off, mid_len, 0x00);
+
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("table open should still succeed when only MID is corrupt");
+
+    let value = tree
+        .get(b"key-000000", lsm_tree::MAX_SEQNO)
+        .expect("get should succeed")
+        .expect("key should exist");
+    assert_eq!(&*value, b"value");
+}
+
+#[test]
+fn table_open_fails_when_both_meta_copies_are_zeroed() {
+    let (dir, sst) = build_tree_with_items(64);
+
+    let (tail_off, tail_len) = locate_section(&sst, b"meta").expect("TAIL meta missing");
+    let (mid_off, mid_len) = locate_section(&sst, b"meta_mid").expect("MID meta missing");
+    corrupt_region(&sst, tail_off, tail_len, 0x00);
+    corrupt_region(&sst, mid_off, mid_len, 0x00);
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open();
+
+    assert!(
+        result.is_err(),
+        "open must fail when both meta copies are unreadable",
+    );
+}

--- a/tests/meta_mirror.rs
+++ b/tests/meta_mirror.rs
@@ -75,26 +75,56 @@ fn meta_mirror_writer_emits_both_copies() {
 
     let tail = locate_section(&sst, b"meta");
     let mid = locate_section(&sst, b"meta_mid");
+    let sep = locate_section(&sst, b"meta_separator");
 
     assert!(tail.is_some(), "TAIL meta section must be present");
     assert!(
         mid.is_some(),
         "MID meta_mid section must be present (mirror)"
     );
+    assert!(
+        sep.is_some(),
+        "meta_separator section must be present (sector isolation)"
+    );
 
-    let (tail_off, _) = tail.unwrap();
-    let (mid_off, _) = mid.unwrap();
-    // MID is written before TAIL — its offset must be smaller, and
-    // there must be at least one 4 KiB filesystem sector between
-    // them (meta_separator section enforces this).
+    let (tail_off, _tail_len) = tail.unwrap();
+    let (mid_off, mid_len) = mid.unwrap();
+    let (sep_off, sep_len) = sep.unwrap();
+
+    // MID is written before TAIL — its offset must be smaller.
     assert!(
         mid_off < tail_off,
         "MID at offset {mid_off} should come before TAIL at {tail_off}"
     );
+
+    // The intended invariant is that MID and TAIL cannot share a
+    // 4 KiB filesystem sector. Measure the actual byte gap from the
+    // END of MID to the START of TAIL (start-to-start would be
+    // inflated by mid_len and could pass even when the real gap is
+    // < 4 KiB).
+    let mid_end = mid_off + mid_len;
     assert!(
-        tail_off - mid_off >= 4096,
-        "MID..TAIL gap of {} bytes is below 4 KiB sector separation",
-        tail_off - mid_off,
+        mid_end <= tail_off,
+        "MID ends at {mid_end} but TAIL starts at {tail_off} (overlap)"
+    );
+    let real_gap = tail_off - mid_end;
+    assert!(
+        real_gap >= 4096,
+        "real MID-end..TAIL-start gap is {real_gap} bytes, below 4 KiB sector separation",
+    );
+
+    // The separator itself must be the documented 4 KiB and must
+    // actually sit between MID and TAIL — not somewhere harmless
+    // like before MID or after TAIL where it would not isolate them.
+    assert_eq!(
+        sep_len, 4096,
+        "meta_separator must be exactly 4096 bytes; got {sep_len}"
+    );
+    assert!(
+        sep_off >= mid_end && sep_off + sep_len <= tail_off,
+        "meta_separator at {sep_off}..{} must lie strictly between \
+         MID end {mid_end} and TAIL start {tail_off}",
+        sep_off + sep_len,
     );
 }
 


### PR DESCRIPTION
## Summary

Implements the mid-file half of #295: a second copy of the meta block lives several KiB before the file tail so that **a torn-write at the file tail (incomplete fsync) or a bit-flip / bad sector that takes out the TAIL meta** does not make the SST unopenable.

The HEAD-prefix half of the originally-proposed design (option D) was descoped after a deeper trade-off analysis: `table_id` is already encoded in the SST filename (`tables/<id>`), `table_version` is currently a constant, and `created_at` was the only marginal field a HEAD section would surface. The protections HEAD would add (table-id diagnostics when both body copies are dead) are already available via filename inspection. The Writer-side restructure required to write the HEAD section after `use_encryption(...)` plumbing was not justified by that marginal value. May be revisited as a follow-up if real-world incident analysis surfaces a torn-write-plus-MID-loss scenario.

## What lands

- New SFA section `meta_mid` written after `range_tombstones` and before `linked_blob_files` / `table_version` / `meta_separator` / `meta`. **Same byte-identical content as TAIL**: same `file_size` (= `*self.meta.file_pos`, which is only bumped inside `spill_block`, so it doesn't change between the two writes), same `created_at` (snapshotted once in `finish()`), same KV map.
- New SFA section `meta_separator` (4 KiB of zeros) between `table_version` and TAIL meta, so a single bad filesystem sector cannot cover both MID and TAIL. The block-level scrub (`verify::verify_block_checksums`) skips `meta_separator` the same way it skips `linked_blob_files` / `table_version`.
- `ParsedRegions::parse_from_toc` reads the optional `meta_mid` entry. Old tables without the mirror leave the field `None` and behave exactly as before.
- `Table::recover` tries TAIL first (authoritative by convention; physically identical to MID), falls back to MID on any decode / decrypt / checksum failure. No `std::fs::metadata` call, no on-disk size patching — MID is loaded as-is. If MID is also unreadable, the original TAIL error is surfaced so callers see the actual failure mode.
- Encoding refactor: meta-KV encoding moved out of `finish()` into a free `write_meta_section` function (free function rather than method because `finish()` runs after `index_writer`/`filter_writer.finish()` consume those fields by-value, leaving `self` partially-moved and unable to dispatch through `&mut self` methods).

## Compatibility

- Format-compatible: old SSTs lack `meta_mid` / `meta_separator` — read path treats both as optional and runs through the existing TAIL path unchanged.
- No disk format version bump. Wire-format only adds new optional named TOC sections.

## Test plan

- [x] Writer emits both `meta` and `meta_mid`, with end-to-start gap ≥ 4 KiB (enforced by `meta_separator`, asserted by inspecting the TOC).
- [x] Internal regression test (`meta_mid_and_tail_have_identical_file_size`) loads both copies via `ParsedMeta::load_with_handle` and asserts byte-for-byte equality of `file_size`.
- [x] Internal regression test (`meta_mid_and_tail_have_identical_created_at`) does the same for the timestamp.
- [x] Zero TAIL meta region: table reopens via MID, `get()` returns correct value.
- [x] Zero MID region: no observable change (TAIL still authoritative).
- [x] Zero both copies: open fails as expected.
- [x] Existing `encrypted_data_tamper_fails` updated to tamper at a layout-independent offset inside the first data block; previous `file.len() / 2` heuristic now lands inside the zero-filled separator and would no-op silently — a fragility surfaced by this change rather than caused by it.
- [x] `verify::verify_block_checksums` updated to skip `meta_separator` (it isn't a `Header`-prefixed block run).
- [x] Full test suite: 1551/1551 pass (6 skipped, 1 slow).
- [x] Lint clean on all-targets all-features with deny-warnings.

Closes #295.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table recovery with redundant metadata storage, enabling automatic fallback when primary metadata is corrupted.
  * Improved table opening and reopen resilience through dual metadata copies with protective sector isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->