### PR TITLE
feat(tooling): sst-dump CLI scaffold + verify subcommand (#301)

### DIFF
--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -97,6 +97,16 @@ jobs:
       - name: Check db_bench crate
         working-directory: tools/db_bench
         run: cargo check --all-features
+      - name: Build + test sst-dump crate
+        # Standalone crate (not in workspace), exercise both the bin
+        # build and the integration smoke tests so any drift in the
+        # public verify::verify_sst_file API or the SST writer layout
+        # surfaces here instead of in production. No `--profile ci`:
+        # sst-dump has no .config/nextest.toml of its own and the
+        # parent crate's profile config is not visible from a
+        # non-workspace child.
+        working-directory: tools/sst-dump
+        run: cargo nextest run
 
   test-zstd:
     needs: lint

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ cargo run --release --features flamegraph -- \
 # Render: cargo install inferno && inferno-flamegraph target/flamegraphs/all.folded > flame.svg
 ```
 
+## Operational tools
+
+| Tool | Use |
+|------|-----|
+| [`tools/db_bench`](tools/db_bench) | RocksDB-compatible benchmark suite, also drives the CI perf dashboard. |
+| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band (per-block XXH3 walk). `sst-dump <file> verify` exits non-zero on corruption — usable as a one-shot health check. |
+
 ## Support the project
 
 <div align="center">

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -477,6 +477,61 @@ pub fn verify_block_checksums(tree: &impl crate::AbstractTree) -> BlockVerifyRep
     report
 }
 
+/// Out-of-band variant of [`verify_block_checksums`].
+///
+/// Walks one SST file directly from a filesystem path, without
+/// needing a live `Tree` or the version manifest. Intended for
+/// offline diagnostic tools (`tools/sst-dump verify`, `repair_db`,
+/// forensics CLIs) that operate on a single file in isolation — for
+/// example when the manifest itself is corrupt or the surrounding
+/// tree directory has been moved.
+///
+/// Uses [`StdFs`](crate::fs::StdFs) (the only `Fs` backend that
+/// makes sense for an out-of-band tool — `MemFs` / `IoUring` trees
+/// never produce files at real filesystem paths) and stamps
+/// `table_id = 0` in error reports. The caller's downstream
+/// filtering / logging should refer to the file by path, not by
+/// table id.
+///
+/// AEAD overhead is conservatively assumed to be zero: out-of-band
+/// tools don't carry the per-table encryption provider that would let
+/// them recover the real `max_overhead()`. Encrypted SSTs near the
+/// 256 MiB plaintext ceiling may therefore false-flag as
+/// [`BlockVerifyError::HeaderCorrupted`]. In practice block sizes are
+/// typically a few KiB, so this only matters on artificially-
+/// constructed huge blocks; encrypted-aware verification should go
+/// through [`verify_block_checksums`] on a live tree.
+///
+/// The returned [`BlockVerifyReport`] has `sst_files_scanned == 1`
+/// (always) plus per-block errors collected during the walk.
+#[cfg(feature = "std")]
+#[must_use]
+pub fn verify_sst_file(path: &std::path::Path) -> BlockVerifyReport {
+    use crate::fs::StdFs;
+
+    let fs = StdFs;
+    let mut report = BlockVerifyReport {
+        sst_files_scanned: 1,
+        ..BlockVerifyReport::default()
+    };
+
+    match scan_sst_blocks(&fs, path, 0, 0) {
+        Ok(per_file) => {
+            report.blocks_scanned = per_file.blocks_scanned;
+            report.errors = per_file.errors;
+        }
+        Err(error) => {
+            report.errors.push(BlockVerifyError::SstFileUnreadable {
+                table_id: 0,
+                path: path.to_path_buf(),
+                error,
+            });
+        }
+    }
+
+    report
+}
+
 struct PerFileScan {
     blocks_scanned: usize,
     errors: Vec<BlockVerifyError>,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1045,9 +1045,20 @@ mod block_verify_tests {
     /// pinning the variant routing.
     #[test]
     fn verify_sst_file_missing_file_reports_unreadable() {
-        let missing_path = std::path::Path::new("/this/path/does/not/exist/sst-12345.sst");
+        // Build the missing-file path under a fresh tempdir so it
+        // resolves the same way on Linux / macOS / Windows runners.
+        // A hardcoded Unix-style absolute path would either skip the
+        // test on Windows (no `/this/...` semantics) or risk a flaky
+        // pass if the path happened to exist.
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("does-not-exist-sst-12345.sst");
+        // Sanity: tempdir() guarantees the directory is empty.
+        assert!(
+            !missing_path.exists(),
+            "tempdir entry must be absent for this test to exercise the missing-file branch",
+        );
 
-        let report = verify_sst_file(missing_path);
+        let report = verify_sst_file(&missing_path);
         assert_eq!(
             report.sst_files_scanned, 1,
             "wrapper stamps sst_files_scanned = 1 even on file-open failure \
@@ -1068,7 +1079,7 @@ mod block_verify_tests {
             matches!(
                 err,
                 BlockVerifyError::SstFileUnreadable { table_id: 0, path, .. }
-                    if path == missing_path,
+                    if path == &missing_path,
             ),
             "expected SstFileUnreadable for {}, got {err:?}",
             missing_path.display(),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1009,4 +1009,69 @@ mod block_verify_tests {
             report.errors,
         );
     }
+
+    /// Exercises the out-of-band wrapper on a real clean SST file.
+    /// `verify_sst_file` is the entry point sst-dump calls; this pins
+    /// that it stamps `sst_files_scanned = 1`, reports no errors on a
+    /// healthy file, and propagates the block count through the
+    /// `StdFs` -> `scan_sst_blocks` -> `BlockVerifyReport` path.
+    #[test]
+    fn verify_sst_file_clean_file_has_no_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        populate_tree(dir.path(), 1_000);
+        let sst_path = pick_first_sst_path(dir.path());
+
+        let report = verify_sst_file(&sst_path);
+        assert!(
+            report.is_ok(),
+            "expected clean SST to verify with zero errors, got {:?}",
+            report.errors,
+        );
+        assert_eq!(
+            report.sst_files_scanned, 1,
+            "wrapper must always stamp sst_files_scanned = 1",
+        );
+        assert!(
+            report.blocks_scanned > 0,
+            "expected at least one block scanned in a populated SST",
+        );
+    }
+
+    /// Exercises the file-open failure branch (the only path through
+    /// `verify_sst_file` that converts an underlying `io::Error` into
+    /// a `BlockVerifyError::SstFileUnreadable`). A missing file is the
+    /// simplest trigger; an unreadable-due-to-permissions trigger
+    /// would require root or chmod-induced state and is overkill for
+    /// pinning the variant routing.
+    #[test]
+    fn verify_sst_file_missing_file_reports_unreadable() {
+        let missing_path = std::path::Path::new("/this/path/does/not/exist/sst-12345.sst");
+
+        let report = verify_sst_file(missing_path);
+        assert_eq!(
+            report.sst_files_scanned, 1,
+            "wrapper stamps sst_files_scanned = 1 even on file-open failure \
+             so callers see the attempt was made",
+        );
+        assert_eq!(
+            report.blocks_scanned, 0,
+            "no blocks could be walked because the file couldn't be opened",
+        );
+        assert_eq!(
+            report.errors.len(),
+            1,
+            "expected exactly one error, got {:?}",
+            report.errors,
+        );
+        let err = report.errors.first().unwrap();
+        assert!(
+            matches!(
+                err,
+                BlockVerifyError::SstFileUnreadable { table_id: 0, path, .. }
+                    if path == missing_path,
+            ),
+            "expected SstFileUnreadable for {}, got {err:?}",
+            missing_path.display(),
+        );
+    }
 }

--- a/tools/sst-dump/Cargo.toml
+++ b/tools/sst-dump/Cargo.toml
@@ -1,0 +1,34 @@
+# Standalone diagnostic tool for inspecting / verifying a single SST
+# file out-of-band. Not part of the main coordinode-lsm-tree crate.
+# Build with: cd tools/sst-dump && cargo build --release
+#
+# Use cases:
+#   - Verify a single SST's per-block XXH3 checksums (corruption forensics)
+#   - Future subcommands: dump KV entries, dump TLI structure, filter stats
+#
+# Modeled after RocksDB's sst_dump utility; follows the tools/db_bench
+# layout convention (separate Cargo crate, path dep on the main lib).
+[package]
+name = "sst-dump"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "sst-dump"
+path = "src/main.rs"
+
+[dependencies]
+# Path dep on the main lib so the binary picks up the public API
+# (verify_sst_file, ParsedMeta-style helpers as they are added).
+# `lz4` + `zstd` features enabled because real production SSTs are
+# usually compressed; without them the tool refuses to walk
+# compressed blocks.
+lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["lz4", "zstd"] }
+clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+# Integration smoke tests in tests/ build a real SST through the
+# lsm-tree public API, then drive the compiled sst-dump binary
+# against it.
+tempfile = "3"

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! `sst-dump` — operational diagnostic CLI for a single SST file.
+//!
+//! Mirrors RocksDB's `sst_dump` utility. Used to inspect / verify an
+//! SST out-of-band, without spinning up a `Tree` or recovering the
+//! manifest. This is the tool reached for when a production read
+//! starts failing and the question becomes "is this file corrupt? what
+//! does it actually contain?".
+
+use clap::{Parser, Subcommand};
+use lsm_tree::verify::{BlockVerifyError, verify_sst_file};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sst-dump",
+    about = "Inspect / verify a single coordinode-lsm-tree SST file",
+    version
+)]
+struct Cli {
+    /// Path to the SST file (typically `<dir>/tables/<id>`).
+    file: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Walk every block in the file, verify per-block XXH3 checksums,
+    /// print a summary. Exits non-zero if any block or section is
+    /// corrupt.
+    Verify {
+        /// Print every per-block error individually instead of just a
+        /// count + the first three.
+        #[arg(long)]
+        verbose: bool,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Verify { verbose } => run_verify(&cli.file, verbose),
+    }
+}
+
+fn run_verify(path: &std::path::Path, verbose: bool) -> ExitCode {
+    let report = verify_sst_file(path);
+
+    println!("file:           {}", path.display());
+    println!("blocks scanned: {}", report.blocks_scanned);
+    println!("errors:         {}", report.errors.len());
+
+    if report.is_ok() {
+        println!("status:         OK");
+        return ExitCode::SUCCESS;
+    }
+
+    println!("status:         CORRUPT");
+    println!();
+
+    let to_show: usize = if verbose { report.errors.len() } else { 3 };
+    for (idx, err) in report.errors.iter().take(to_show).enumerate() {
+        // Show each error with its variant tag so consumers grep'ing
+        // for a specific failure mode (HeaderCorrupted, DataCorrupted,
+        // DataReadError, TocCorrupted, SstFileUnreadable) get a stable
+        // anchor. The Display impl includes file path + offset + a
+        // human reason.
+        let kind = match err {
+            BlockVerifyError::SstFileUnreadable { .. } => "SstFileUnreadable",
+            BlockVerifyError::HeaderCorrupted { .. } => "HeaderCorrupted",
+            BlockVerifyError::DataCorrupted { .. } => "DataCorrupted",
+            BlockVerifyError::DataReadError { .. } => "DataReadError",
+            BlockVerifyError::TocCorrupted { .. } => "TocCorrupted",
+            // `BlockVerifyError` is `#[non_exhaustive]` upstream — a
+            // future lib release can add new variants without bumping
+            // the tool's major version. Unknown variants fall back to
+            // their `Display` impl with a generic tag.
+            _ => "Unknown",
+        };
+        println!("  [{idx}] {kind}: {err}");
+    }
+
+    if !verbose && report.errors.len() > to_show {
+        println!(
+            "  ... {} more (use --verbose to see all)",
+            report.errors.len() - to_show
+        );
+    }
+
+    ExitCode::FAILURE
+}

--- a/tools/sst-dump/tests/verify_smoke.rs
+++ b/tools/sst-dump/tests/verify_smoke.rs
@@ -66,14 +66,32 @@ fn verify_clean_sst_exits_zero_with_ok() {
         out.status,
         String::from_utf8_lossy(&out.stderr),
     );
-    assert!(
-        stdout.contains("status:         OK"),
-        "expected OK status in output; got:\n{stdout}",
+    // Parse `<label>: <value>` lines by trimming around the colon
+    // rather than hard-coding column alignment. Robust against
+    // future formatting tweaks in sst-dump's output (column-width
+    // changes, switching to tab-separated, etc.).
+    assert_eq!(
+        line_value(&stdout, "status"),
+        Some("OK".to_owned()),
+        "expected status=OK in output; got:\n{stdout}",
     );
-    assert!(
-        stdout.contains("errors:         0"),
-        "expected zero errors line; got:\n{stdout}",
+    assert_eq!(
+        line_value(&stdout, "errors"),
+        Some("0".to_owned()),
+        "expected errors=0 in output; got:\n{stdout}",
     );
+}
+
+/// Returns the trimmed value after the first `<label>:` line in
+/// `text`, or `None` if no such line exists. Whitespace around the
+/// value is normalised so callers don't have to encode the exact
+/// column alignment sst-dump uses (which is implementation detail).
+fn line_value(text: &str, label: &str) -> Option<String> {
+    let prefix = format!("{label}:");
+    text.lines().find_map(|line| {
+        line.strip_prefix(&prefix)
+            .map(|rest| rest.trim().to_owned())
+    })
 }
 
 #[test]
@@ -109,12 +127,28 @@ fn verify_tampered_sst_exits_nonzero_with_corrupt() {
         !out.status.success(),
         "expected non-zero exit on corruption; stdout:\n{stdout}",
     );
-    assert!(
-        stdout.contains("status:         CORRUPT"),
-        "expected CORRUPT status in output; got:\n{stdout}",
+    assert_eq!(
+        line_value(&stdout, "status"),
+        Some("CORRUPT".to_owned()),
+        "expected status=CORRUPT in output; got:\n{stdout}",
     );
+    // The behaviour under test is "corruption is detected and
+    // reported", not the specific variant. A future writer-layout
+    // change could move the byte-flipped region from a data block
+    // into the TOC region or end up surfacing as SstFileUnreadable
+    // / TocCorrupted / DataReadError instead — all of those are
+    // valid "corruption detected" outcomes. Accept any of the five
+    // variant tags sst-dump prints.
+    const VARIANT_TAGS: &[&str] = &[
+        "SstFileUnreadable",
+        "HeaderCorrupted",
+        "DataCorrupted",
+        "DataReadError",
+        "TocCorrupted",
+    ];
+    let saw_variant = VARIANT_TAGS.iter().any(|tag| stdout.contains(tag));
     assert!(
-        stdout.contains("DataCorrupted") || stdout.contains("HeaderCorrupted"),
-        "expected DataCorrupted or HeaderCorrupted in output; got:\n{stdout}",
+        saw_variant,
+        "expected one of {VARIANT_TAGS:?} in output; got:\n{stdout}",
     );
 }

--- a/tools/sst-dump/tests/verify_smoke.rs
+++ b/tools/sst-dump/tests/verify_smoke.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test: build a real SST via `lsm-tree`, then drive
+//! the `sst-dump verify` binary against the file and assert the
+//! exit code + output. The clean case must exit 0 with `OK`; a
+//! tampered file must exit 1 with `CORRUPT` plus at least one
+//! per-block error line.
+//!
+//! Uses the cargo-built binary at `target/{debug,release}/sst-dump`
+//! resolved via `CARGO_BIN_EXE_sst-dump` — the env var cargo
+//! provides to integration tests for the crate's own binaries.
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter, compression::CompressionType,
+    config::CompressionPolicy,
+};
+use std::process::Command;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+/// Builds a small populated SST in a tempdir, flushes it to disk,
+/// drops the tree, returns the path to the first SST file.
+fn build_one_sst() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()
+    .expect("open tree");
+
+    for i in 0u64..200 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    // Tables/ subdir, take the first entry — single SST after one flush.
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+    (dir, sst)
+}
+
+#[test]
+fn verify_clean_sst_exits_zero_with_ok() {
+    let (_dir, sst) = build_one_sst();
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("verify")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0, got {:?}; stdout:\n{stdout}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stdout.contains("status:         OK"),
+        "expected OK status in output; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("errors:         0"),
+        "expected zero errors line; got:\n{stdout}",
+    );
+}
+
+#[test]
+fn verify_tampered_sst_exits_nonzero_with_corrupt() {
+    let (_dir, sst) = build_one_sst();
+
+    // Flip a byte inside the first data block's payload. Offset 64
+    // lands inside the encrypted/plain payload (past the 33-byte
+    // Header), so the header's own XXH3 still verifies but the
+    // payload XXH3 mismatches → DataCorrupted.
+    let mut bytes = std::fs::read(&sst).expect("read sst");
+    bytes[64] ^= 0xFF;
+    std::fs::write(&sst, &bytes).expect("write tampered sst");
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("verify")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on corruption; stdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("status:         CORRUPT"),
+        "expected CORRUPT status in output; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("DataCorrupted") || stdout.contains("HeaderCorrupted"),
+        "expected DataCorrupted or HeaderCorrupted in output; got:\n{stdout}",
+    );
+}

--- a/tools/sst-dump/tests/verify_smoke.rs
+++ b/tools/sst-dump/tests/verify_smoke.rs
@@ -81,11 +81,21 @@ fn verify_tampered_sst_exits_nonzero_with_corrupt() {
     let (_dir, sst) = build_one_sst();
 
     // Flip a byte inside the first data block's payload. Offset 64
-    // lands inside the encrypted/plain payload (past the 33-byte
-    // Header), so the header's own XXH3 still verifies but the
-    // payload XXH3 mismatches → DataCorrupted.
+    // lands inside the plain payload (past the 33-byte Header), so
+    // the header's own XXH3 still verifies but the payload XXH3
+    // mismatches → DataCorrupted. Bounds-check via `get_mut` so a
+    // future writer-layout change that produces a sub-65-byte SST
+    // fails the test with a clear message instead of an index panic.
+    const TAMPER_OFFSET: usize = 64;
     let mut bytes = std::fs::read(&sst).expect("read sst");
-    bytes[64] ^= 0xFF;
+    let len = bytes.len();
+    let byte = bytes.get_mut(TAMPER_OFFSET).unwrap_or_else(|| {
+        panic!(
+            "SST file is {len} bytes long, smaller than tamper offset {TAMPER_OFFSET} — \
+             writer layout changed or fixture is too small",
+        )
+    });
+    *byte ^= 0xFF;
     std::fs::write(&sst, &bytes).expect("write tampered sst");
 
     let out = Command::new(SST_DUMP_BIN)


### PR DESCRIPTION
## Summary

New `tools/sst-dump` standalone binary modeled on RocksDB's `sst_dump`. First subcommand `verify` walks every block in the SST, checks per-block XXH3, and exits 0 on a clean file / 1 on corruption. Lays the scaffolding for the remaining subcommands listed in #301 (properties, dump, index-dump, filter-stats, hex), which can be added incrementally without restructuring the binary or the test harness.

## What lands

- `tools/sst-dump/` standalone Cargo crate (path dep on the main lib, mirrors the `tools/db_bench` layout).
- New public API `lsm_tree::verify::verify_sst_file(&Path) -> BlockVerifyReport`. Wraps the existing internal `scan_sst_blocks` with `StdFs`, `table_id=0` and `max_enc_overhead=0`. Std-feature-gated, `#[must_use]`. Doc comment spells out the encryption-overhead caveat (encrypted blocks near the 256 MiB plaintext ceiling may false-flag — encryption-aware verification still goes through `verify_block_checksums` on a live tree).
- `sst-dump <file> verify [--verbose]` CLI:
  - Prints file path, block count, error count, status (`OK` / `CORRUPT`).
  - Shows the first 3 errors by default; `--verbose` shows all.
  - Each error line is prefixed with its variant tag (`SstFileUnreadable` / `HeaderCorrupted` / `DataCorrupted` / `DataReadError` / `TocCorrupted`) for stable log scraping.
  - Exit code: 0 on clean, 1 on any per-block or file-level error.
- Two integration smoke tests in `tools/sst-dump/tests/verify_smoke.rs`:
  - Clean SST → exit 0, output contains `status: OK` + `errors: 0`.
  - Single-byte tamper inside first data block payload → exit 1, output contains `status: CORRUPT` + `DataCorrupted` (or `HeaderCorrupted`) error line.
- README ``Operational tools`` table covering both `db_bench` and `sst-dump`.

## Compatibility

- Pure additive: no changes to existing API or on-disk format.
- New `verify_sst_file` is std-only (gated behind the `std` feature, same as the rest of `verify::*`).

## Test plan

- [x] Standalone build: `cargo build` in `tools/sst-dump` finishes clean.
- [x] Manual smoke: `sst-dump /tmp/nonexistent verify` → exit 1, output `SstFileUnreadable: ... No such file or directory`.
- [x] Manual smoke: `sst-dump --help` shows usage + subcommand summary.
- [x] Integration tests: 2/2 pass via `cargo nextest run`.
- [x] Full lsm-tree suite: 1545/1545 pass after the new `pub fn` is added.
- [x] Lint clean on both crates: `cargo clippy --all-targets --all-features -- -D warnings` in lib root and in `tools/sst-dump`.

## Follow-up (not in this PR)

Remaining subcommands from #301 — `properties` (meta-block dump), `dump --from/--to/--keys-only/--max=N` (KV iteration), `index-dump` (TLI structure), `filter-stats` (Bloom / Ribbon FPR estimate), `hex` (raw block dump). Each requires exposing more of the internal table machinery (`ParsedMeta`, `ParsedRegions`, `DataBlock` decode); held back here to keep the API-surface change minimal and reviewable.

Part of #301.