### PR TITLE
feat(config): ManifestRecoveryMode + TolerateCorruptedTailRecords (#299)

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -98,8 +98,14 @@ impl std::fmt::Debug for LevelRoute {
 /// any corrupt record fails the open. Switching to a more permissive
 /// mode is an explicit, informed operator decision: you are trading
 /// "the tree might silently come up with missing tables / blob files"
-/// for "the tree comes up at all". Logged warnings on every dropped
-/// record document exactly what was lost.
+/// for "the tree comes up at all". When a non-default mode drops
+/// records, the recovery path emits a `warn!` summary with the
+/// AGGREGATE dropped count per section (`tables` / `blob_files`) —
+/// individual table IDs / blob-file IDs are NOT enumerated, because
+/// they were never decoded in the first place. Operators wanting a
+/// per-record audit trail should pair tail-tolerant recovery with an
+/// out-of-band integrity scan ([`verify_integrity`](crate::verify::verify_integrity))
+/// of the recovered tree.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum ManifestRecoveryMode {
     /// Production-safe default. Any per-record decode mismatch (bad
@@ -113,11 +119,20 @@ pub enum ManifestRecoveryMode {
     /// over the `tables` / `blob_files` records runs out of bytes
     /// before the declared count is reached (truncated tail), keep
     /// everything that decoded cleanly before the cut and emit a
-    /// `warn!` listing the dropped record counts. Any decode error
-    /// that is NOT a clean tail truncation (bad checksum-type tag,
-    /// declared-count overflow vs section length, etc.) still aborts
-    /// the open — this mode is specifically for "the writer never
-    /// finished" scenarios, not for arbitrary bit-rot.
+    /// `warn!` listing the dropped record counts.
+    ///
+    /// A declared count that exceeds the section's payload capacity
+    /// (e.g. `table_count` claims more entries than the section has
+    /// bytes for) is treated as the same "writer committed a count
+    /// header then truncated the entries" shape — the recovery
+    /// downgrades the original hard fail to a `warn!` and lets the
+    /// per-entry decode loop walk bytes-actually-present until the
+    /// first `UnexpectedEof`.
+    ///
+    /// Any decode error that is NOT a clean tail truncation (bad
+    /// `checksum_type` tag, etc.) still aborts the open — this mode
+    /// is specifically for "the writer never finished" scenarios,
+    /// not for arbitrary bit-rot in already-committed bytes.
     TolerateCorruptedTailRecords,
 
     /// Recover up to the last fully-consistent record group, discard

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1140,10 +1140,13 @@ impl Config {
     /// only choice that's safe for live production: any corrupt record
     /// in the on-disk manifest aborts the open. Switching to a more
     /// permissive mode trades strict correctness for partial
-    /// availability after a disaster — every dropped record is logged
-    /// as `warn!`, but the recovered tree may be missing tables / blob
-    /// files relative to what the operator last fsynced. Always
-    /// pair the non-default modes with an out-of-band integrity scan
+    /// availability after a disaster. The recovery path emits a
+    /// `warn!` summary per affected section (aggregate counts: total
+    /// table records dropped, total blob-file records dropped,
+    /// header truncations) rather than one log line per dropped
+    /// record — the dropped records were never decoded in the first
+    /// place, so no per-record IDs are available. Always pair the
+    /// non-default modes with an out-of-band integrity scan
     /// ([`verify_integrity`](crate::verify::verify_integrity) for
     /// whole-file XXH3 over every SST + blob file, or
     /// [`verify_block_checksums`](crate::verify::verify_block_checksums)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,60 @@ impl std::fmt::Debug for LevelRoute {
     }
 }
 
+/// Policy governing what `Tree::open` does when the on-disk MANIFEST
+/// contains corrupt records.
+///
+/// Mirrors `RocksDB`'s `WALRecoveryMode` semantics, but applied to the
+/// manifest layer (`src/version/recovery.rs`) — lsm-tree itself has no
+/// WAL (durability lives one layer up in the parent fjall/keyspace
+/// crate's `Journal`). The MANIFEST is the equivalent surface where
+/// "loss-tolerance vs strict-consistency" matters at open time.
+///
+/// The default is [`AbsoluteConsistency`](Self::AbsoluteConsistency) —
+/// any corrupt record fails the open. Switching to a more permissive
+/// mode is an explicit, informed operator decision: you are trading
+/// "the tree might silently come up with missing tables / blob files"
+/// for "the tree comes up at all". Logged warnings on every dropped
+/// record document exactly what was lost.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum ManifestRecoveryMode {
+    /// Production-safe default. Any per-record decode mismatch (bad
+    /// XXH3, invalid tag, truncated TOC entry, declared-count overrun)
+    /// aborts the open with the original error. Surfaces every byte
+    /// of corruption; never silently drops data.
+    #[default]
+    AbsoluteConsistency,
+
+    /// Power-loss-at-write-tail salvage. If the per-section iteration
+    /// over the `tables` / `blob_files` records runs out of bytes
+    /// before the declared count is reached (truncated tail), keep
+    /// everything that decoded cleanly before the cut and emit a
+    /// `warn!` listing the dropped record counts. Any decode error
+    /// that is NOT a clean tail truncation (bad checksum-type tag,
+    /// declared-count overflow vs section length, etc.) still aborts
+    /// the open — this mode is specifically for "the writer never
+    /// finished" scenarios, not for arbitrary bit-rot.
+    TolerateCorruptedTailRecords,
+
+    /// Recover up to the last fully-consistent record group, discard
+    /// anything later. Reserved variant: matches `RocksDB`'s
+    /// `kPointInTimeRecovery` semantic, but not yet wired — selecting
+    /// it currently falls back to
+    /// [`AbsoluteConsistency`](Self::AbsoluteConsistency) behaviour.
+    /// Tracked as a follow-up to this issue's first wave.
+    PointInTimeRecovery,
+
+    /// Skip each corrupt record individually, keep all others.
+    /// Maximum-availability, lossy. Reserved variant: matches
+    /// `RocksDB`'s `kSkipAnyCorruptedRecords` semantic, but not yet
+    /// wired — currently falls back to
+    /// [`AbsoluteConsistency`](Self::AbsoluteConsistency) behaviour.
+    /// Intended companion to the `repair_db` tooling tracked as
+    /// `#303`; wiring waits on that PR landing so the two surfaces
+    /// can be reviewed together.
+    SkipAnyCorruptedRecords,
+}
+
 /// LSM-tree type
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TreeType {
@@ -365,6 +419,15 @@ pub struct Config {
     /// using this provider after compression and before checksumming.
     pub(crate) encryption: Option<Arc<dyn EncryptionProvider>>,
 
+    /// Policy governing what `Tree::open` does when the on-disk
+    /// MANIFEST contains corrupt records. Defaults to
+    /// [`ManifestRecoveryMode::AbsoluteConsistency`], the only
+    /// production-safe choice — any corruption aborts the open. Other
+    /// modes trade strict correctness for partial-availability after a
+    /// disaster; see the enum doc for the operational scenarios that
+    /// motivate each mode.
+    pub(crate) manifest_recovery_mode: ManifestRecoveryMode,
+
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
     /// When set together with a [`CompressionType::ZstdDict`] compression
@@ -452,6 +515,7 @@ impl Default for Config {
 
             comparator: comparator::default_comparator(),
             encryption: None,
+            manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
         }
     }
 }
@@ -1052,6 +1116,27 @@ impl Config {
     #[must_use]
     pub fn with_encryption(mut self, encryption: Option<Arc<dyn EncryptionProvider>>) -> Self {
         self.encryption = encryption;
+        self
+    }
+
+    /// Sets the MANIFEST recovery policy for `Tree::open`.
+    ///
+    /// The default ([`ManifestRecoveryMode::AbsoluteConsistency`]) is the
+    /// only choice that's safe for live production: any corrupt record
+    /// in the on-disk manifest aborts the open. Switching to a more
+    /// permissive mode trades strict correctness for partial
+    /// availability after a disaster — every dropped record is logged
+    /// as `warn!`, but the recovered tree may be missing tables / blob
+    /// files relative to what the operator last fsynced. Always
+    /// pair the non-default modes with an out-of-band integrity scan
+    /// ([`verify_integrity`](crate::verify::verify_integrity) and/or
+    /// [`verify_sst_file`](crate::verify::verify_sst_file)) before
+    /// trusting the recovered tree for writes.
+    ///
+    /// See the [`ManifestRecoveryMode`] doc for per-variant semantics.
+    #[must_use]
+    pub fn manifest_recovery_mode(mut self, mode: ManifestRecoveryMode) -> Self {
+        self.manifest_recovery_mode = mode;
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1144,9 +1144,11 @@ impl Config {
     /// as `warn!`, but the recovered tree may be missing tables / blob
     /// files relative to what the operator last fsynced. Always
     /// pair the non-default modes with an out-of-band integrity scan
-    /// ([`verify_integrity`](crate::verify::verify_integrity) and/or
-    /// [`verify_sst_file`](crate::verify::verify_sst_file)) before
-    /// trusting the recovered tree for writes.
+    /// ([`verify_integrity`](crate::verify::verify_integrity) for
+    /// whole-file XXH3 over every SST + blob file, or
+    /// [`verify_block_checksums`](crate::verify::verify_block_checksums)
+    /// for per-block granularity) before trusting the recovered tree
+    /// for writes.
     ///
     /// See the [`ManifestRecoveryMode`] doc for per-variant semantics.
     #[must_use]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2035,7 +2035,7 @@ impl Tree {
 
         let tree_path = tree_path.as_ref();
 
-        let recovery = recover(tree_path, &*config.fs)?;
+        let recovery = recover(tree_path, &*config.fs, config.manifest_recovery_mode)?;
 
         let mut table_map = {
             let mut result: crate::HashMap<TableId, (u8 /* Level index */, Checksum, SeqNo)> =

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -161,7 +161,14 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
             let run_count = match reader.read_u8() {
                 Ok(n) => n,
                 Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    // No runs in this level had a chance to start;
+                    // pushing the empty `level` would be a "zero
+                    // runs at level N" marker which downstream code
+                    // tolerates. Stay consistent with the cut-mid-run
+                    // path below (which DOES push) instead of silently
+                    // dropping the level slot.
                     tables_dropped_to_tail += 1;
+                    levels.push(level);
                     break 'levels;
                 }
                 Err(e) => return Err(e.into()),
@@ -172,7 +179,16 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
                 let table_count = match reader.read_u32::<LittleEndian>() {
                     Ok(n) => n,
                     Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        // Push the partial `level` so any runs that
+                        // were fully decoded earlier in this level
+                        // survive — breaking out of `'levels` without
+                        // this push silently drops the consistent
+                        // prefix, contradicting the tail-tolerant
+                        // contract. The current `run` is empty (we
+                        // failed at the very first byte of its
+                        // record header), so nothing to push for it.
                         tables_dropped_to_tail += 1;
+                        levels.push(level);
                         break 'levels;
                     }
                     Err(e) => return Err(e.into()),
@@ -265,13 +281,34 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
             Err(e) => return Err(e.into()),
         };
 
-        // Same as the `table_count` check: count > section payload means
-        // the count header itself is forged; aborts regardless of mode.
+        // Same as the `table_count` check: count > section payload
+        // is a hard fail under strict mode (the count header is
+        // forged), but a power-loss-during-write that committed the
+        // count then truncated the entries produces exactly this
+        // shape, so tolerant mode must warn and let the per-entry
+        // loop walk bytes-actually-present until the first EOF.
         if u64::from(blob_file_count) > section.len().saturating_sub(4) / 25 {
-            return Err(crate::Error::Unrecoverable);
+            if tolerate_tail {
+                log::warn!(
+                    "blob_files: declared count={blob_file_count} exceeds section \
+                     capacity (~{} entries) in version #{curr_version_id}; \
+                     tail-tolerant mode walks bytes-actually-present and stops at \
+                     the first EOF",
+                    section.len().saturating_sub(4) / 25,
+                );
+            } else {
+                return Err(crate::Error::Unrecoverable);
+            }
         }
 
-        let mut blob_file_ids = Vec::with_capacity(blob_file_count as usize);
+        // Don't allocate full `blob_file_count` capacity when the
+        // count overflows the section — that's a several-GB
+        // Vec::with_capacity allocation on the forged-count branch.
+        // Cap at the section-derived upper bound.
+        let cap_hint =
+            usize::try_from(u64::from(blob_file_count).min(section.len().saturating_sub(4) / 25))
+                .unwrap_or(0);
+        let mut blob_file_ids = Vec::with_capacity(cap_hint);
 
         for _ in 0..blob_file_count {
             match read_one_blob_entry(&mut reader) {
@@ -334,7 +371,7 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::expect_used,
     clippy::indexing_slicing,
     reason = "test assertions"

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -627,4 +627,158 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Writes a `vN` archive with two runs in one level:
+    /// run #0 is a complete entry (declared = actual = 1),
+    /// run #1 declares 3 entries but the section is cut so the
+    /// `table_count` u32 of run #1 reads partially → EOF.
+    /// Exercises the tail-tolerant case where the cut happens mid-RUN
+    /// inside an otherwise-valid level. The consistent prefix (run #0
+    /// of level #0) MUST survive in the recovered Version.
+    fn write_truncated_at_second_run(folder: &Path, id: u64, fs: &dyn Fs) -> crate::Result<()> {
+        let path = folder.join(format!("v{id}"));
+        let file = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        let mut w = sfa::Writer::from_writer(std::io::BufWriter::new(file));
+        w.start("tree_type")?;
+        w.write_u8(0)?;
+        w.start("tables")?;
+        w.write_u8(1)?; // 1 level
+        w.write_u8(2)?; // 2 runs in that level
+        // run #0: declared=1, actual=1 — the consistent prefix.
+        w.write_u32::<LittleEndian>(1)?;
+        w.write_u64::<LittleEndian>(42)?; // id
+        w.write_u8(0)?; // checksum_type
+        w.write_u128::<LittleEndian>(0)?;
+        w.write_u64::<LittleEndian>(0)?;
+        // run #1: only 2 of the 4 bytes of `table_count` are written.
+        // The reader gets `UnexpectedEof` on the u32 read.
+        w.write_u8(0xAA)?;
+        w.write_u8(0xBB)?;
+        w.start("blob_files")?;
+        w.write_u32::<LittleEndian>(0)?;
+        w.start("blob_gc_stats")?;
+        w.write_u32::<LittleEndian>(0)?;
+        w.finish().map_err(|e| match e {
+            sfa::Error::Io(e) => crate::Error::from(e),
+            _ => crate::Error::Unrecoverable,
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn recover_tolerate_tail_keeps_consistent_prefix_within_a_level() -> crate::Result<()> {
+        // Regression: when the EOF cut happens between two runs of
+        // the same level, the tail-tolerant break must push the
+        // partial level into `levels` so the consistent prefix
+        // (run #0 with 1 entry) survives. Earlier behaviour broke
+        // out of `'levels` without pushing, silently dropping the
+        // already-decoded run.
+        let fs = MemFs::new();
+        let folder = Path::new("/tolerate/midlevel");
+        fs.create_dir_all(folder)?;
+
+        write_current(folder, 1, &fs)?;
+        write_truncated_at_second_run(folder, 1, &fs)?;
+
+        let recovery = recover(
+            folder,
+            &fs,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )?;
+        assert_eq!(
+            recovery.table_ids.len(),
+            1,
+            "expected the partially-decoded level to be present, got {} levels",
+            recovery.table_ids.len(),
+        );
+        let level = &recovery.table_ids[0];
+        assert_eq!(
+            level.len(),
+            1,
+            "expected 1 surviving run (the consistent prefix), got {}",
+            level.len(),
+        );
+        assert_eq!(
+            level[0].len(),
+            1,
+            "expected the run to contain its 1 fully-decoded entry",
+        );
+        assert_eq!(level[0][0].id, 42, "wrong entry id recovered");
+        Ok(())
+    }
+
+    /// Writes a `vN` archive whose `blob_files` section declares
+    /// `declared` entries but only writes `actual` complete 25-byte
+    /// records, cutting mid-stream after that. Mirrors the analogous
+    /// `tables` fixture for the blob-files surface.
+    fn write_truncated_blob_tail(
+        folder: &Path,
+        id: u64,
+        declared: u32,
+        actual: u32,
+        fs: &dyn Fs,
+    ) -> crate::Result<()> {
+        assert!(
+            actual < declared,
+            "actual must be < declared for truncation"
+        );
+        let path = folder.join(format!("v{id}"));
+        let file = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        let mut w = sfa::Writer::from_writer(std::io::BufWriter::new(file));
+        w.start("tree_type")?;
+        w.write_u8(0)?;
+        w.start("tables")?;
+        w.write_u8(0)?; // 0 levels
+        w.start("blob_files")?;
+        w.write_u32::<LittleEndian>(declared)?;
+        for entry_id in 0..actual {
+            w.write_u64::<LittleEndian>(u64::from(entry_id))?;
+            w.write_u8(0)?; // checksum_type
+            w.write_u128::<LittleEndian>(0)?; // checksum
+        }
+        w.start("blob_gc_stats")?;
+        w.write_u32::<LittleEndian>(0)?;
+        w.finish().map_err(|e| match e {
+            sfa::Error::Io(e) => crate::Error::from(e),
+            _ => crate::Error::Unrecoverable,
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn recover_tolerate_tail_keeps_consistent_prefix_of_blob_files() -> crate::Result<()> {
+        // Companion to `recover_tolerate_tail_keeps_consistent_prefix_of_tables`
+        // for the blob_files surface. Without this test, a regression
+        // in the blob-files tail-tolerant path would slip through
+        // because the tables-only test already passes.
+        let fs = MemFs::new();
+        let folder = Path::new("/tolerate/blob_tail");
+        fs.create_dir_all(folder)?;
+
+        write_current(folder, 1, &fs)?;
+        write_truncated_blob_tail(folder, 1, 5, 1, &fs)?;
+
+        let recovery = recover(
+            folder,
+            &fs,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )?;
+        assert_eq!(
+            recovery.blob_file_ids.len(),
+            1,
+            "expected 1 surviving blob_file entry (the consistent prefix), got {}",
+            recovery.blob_file_ids.len(),
+        );
+        assert_eq!(
+            recovery.blob_file_ids[0].0, 0,
+            "wrong blob_file id recovered",
+        );
+        Ok(())
+    }
 }

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -818,4 +818,70 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Writes a `vN` archive whose `blob_gc_stats` section is
+    /// truncated to zero bytes. Mimics a power-loss right after the
+    /// `blob_files` section was committed but before the
+    /// `blob_gc_stats` payload landed — `FragmentationMap::decode_from`
+    /// hits `UnexpectedEof` on the first byte.
+    fn write_truncated_blob_gc_stats(folder: &Path, id: u64, fs: &dyn Fs) -> crate::Result<()> {
+        let path = folder.join(format!("v{id}"));
+        let file = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        let mut w = sfa::Writer::from_writer(std::io::BufWriter::new(file));
+        w.start("tree_type")?;
+        w.write_u8(0)?;
+        w.start("tables")?;
+        w.write_u8(0)?; // 0 levels
+        w.start("blob_files")?;
+        w.write_u32::<LittleEndian>(0)?;
+        // blob_gc_stats section started but no payload written —
+        // section.len() == 0, FragmentationMap::decode_from will
+        // surface UnexpectedEof on its first read.
+        w.start("blob_gc_stats")?;
+        w.finish().map_err(|e| match e {
+            sfa::Error::Io(e) => crate::Error::from(e),
+            _ => crate::Error::Unrecoverable,
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn recover_tolerate_tail_handles_truncated_blob_gc_stats() -> crate::Result<()> {
+        // Tail-tolerant mode must extend beyond the record-list
+        // sections (tables / blob_files): a power-loss between the
+        // blob_files commit and the blob_gc_stats payload is the
+        // exact "writer never finished" shape this mode is meant to
+        // salvage. Strict mode still aborts; tolerant mode emits a
+        // warn and uses a default (empty) FragmentationMap.
+        let fs = MemFs::new();
+        let folder = Path::new("/tolerate/gc_stats");
+        fs.create_dir_all(folder)?;
+        write_current(folder, 1, &fs)?;
+        write_truncated_blob_gc_stats(folder, 1, &fs)?;
+
+        // Strict mode: hard fail.
+        let strict = recover(folder, &fs, ManifestRecoveryMode::AbsoluteConsistency);
+        assert!(
+            strict.is_err(),
+            "strict mode must abort on truncated blob_gc_stats; got Ok",
+        );
+
+        // Tolerant mode: succeeds with empty gc_stats. Compare via
+        // `Default` (FragmentationMap implements PartialEq) — the
+        // type does not expose an `is_empty()` accessor.
+        let lenient = recover(
+            folder,
+            &fs,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )?;
+        assert_eq!(
+            lenient.gc_stats,
+            crate::blob_tree::FragmentationMap::default(),
+            "tolerant mode must produce default (empty) gc_stats on truncated section",
+        );
+        Ok(())
+    }
 }

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -126,7 +126,19 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
 
     // // TODO: vvv move into Version::decode vvv
     let mut levels = vec![];
+    // Separate counters for the two distinct tail-truncation shapes
+    // so the summary warnings can report them honestly. Header
+    // truncation = "the writer didn't even finish writing the
+    // count/length byte for this level/run/section"; no per-entry
+    // bytes are missing because no entry was supposed to be there
+    // yet. Record truncation = "the count says N, only K < N
+    // complete entries are present", so N-K entries are actually
+    // missing. Conflating them under one counter (the previous
+    // behaviour) overcounted: a manifest cut between two runs
+    // would log "1 table record dropped" when zero records were
+    // lost — only a header byte.
     let mut tables_dropped_to_tail: u32 = 0;
+    let mut tables_truncated_headers: u32 = 0;
 
     {
         let section = toc
@@ -166,8 +178,12 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
                     // runs at level N" marker which downstream code
                     // tolerates. Stay consistent with the cut-mid-run
                     // path below (which DOES push) instead of silently
-                    // dropping the level slot.
-                    tables_dropped_to_tail += 1;
+                    // dropping the level slot. This is a HEADER
+                    // truncation (the run_count byte didn't land),
+                    // not a record-data loss — count it separately
+                    // so the summary doesn't report nonexistent
+                    // record drops.
+                    tables_truncated_headers += 1;
                     levels.push(level);
                     break 'levels;
                 }
@@ -187,7 +203,9 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
                         // contract. The current `run` is empty (we
                         // failed at the very first byte of its
                         // record header), so nothing to push for it.
-                        tables_dropped_to_tail += 1;
+                        // HEADER truncation — no records were
+                        // supposed to be there yet, count separately.
+                        tables_truncated_headers += 1;
                         levels.push(level);
                         break 'levels;
                     }
@@ -251,10 +269,12 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
         }
     }
 
-    if tables_dropped_to_tail > 0 {
+    if tables_dropped_to_tail > 0 || tables_truncated_headers > 0 {
         log::warn!(
-            "manifest tail truncation dropped {tables_dropped_to_tail} table record(s) \
-             from version #{curr_version_id}; recovered tree may be missing SSTs",
+            "manifest tail truncation in version #{curr_version_id}: \
+             {tables_dropped_to_tail} table record(s) dropped, \
+             {tables_truncated_headers} level/run header(s) truncated; \
+             recovered tree may be missing SSTs",
         );
     }
 
@@ -348,7 +368,26 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
 
         let mut reader = open_section_reader(fs, &version_file_path, section)?;
 
-        crate::blob_tree::FragmentationMap::decode_from(&mut reader)?
+        // Same tail-tolerance contract as the record-list sections:
+        // a power-loss between the `blob_files` commit and the
+        // `blob_gc_stats` payload landing surfaces as
+        // `UnexpectedEof` inside `FragmentationMap::decode_from`.
+        // Strict mode aborts; tolerant mode warns and uses an empty
+        // FragmentationMap (the GC stats are advisory — fragmentation
+        // re-accrues on subsequent compactions, so dropping them is
+        // a "rebuild on next pass" outcome rather than data loss).
+        match crate::blob_tree::FragmentationMap::decode_from(&mut reader) {
+            Ok(m) => m,
+            Err(e) if tolerate_tail && is_clean_tail_truncation(&e) => {
+                log::warn!(
+                    "blob_gc_stats section truncated in version #{curr_version_id}; \
+                     tail-tolerant mode produces an empty FragmentationMap (GC stats \
+                     will rebuild on the next compaction pass)"
+                );
+                crate::blob_tree::FragmentationMap::default()
+            }
+            Err(e) => return Err(e),
+        }
     };
 
     Ok(Recovery {

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -156,8 +156,24 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
         // hits EOF here. Under `TolerateCorruptedTailRecords` that's
         // legitimate "no tables present" — under `AbsoluteConsistency`
         // it's still a hard fail.
+        // Track bytes consumed inside this section so the
+        // overflow guard below can compare against bytes ACTUALLY
+        // remaining at the moment of the check, not the loose
+        // section-total bound. With the total bound, a count
+        // forgery that's still <= section_total/entry_size slips
+        // past the guard, enters the loop, hits EOF after the real
+        // records, and gets reclassified as a clean tail truncation
+        // under tolerant mode — operators see no signal that the
+        // count header was corrupt. The tight bound surfaces the
+        // forgery as an explicit "count exceeds remaining" warn
+        // before the loop runs.
+        let mut tables_bytes_consumed: u64 = 0;
+
         let level_count = match reader.read_u8() {
-            Ok(n) => n,
+            Ok(n) => {
+                tables_bytes_consumed += 1;
+                n
+            }
             Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 log::warn!(
                     "tables section truncated before level_count byte in version \
@@ -171,18 +187,18 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
         'levels: for _ in 0..level_count {
             let mut level = vec![];
             let run_count = match reader.read_u8() {
-                Ok(n) => n,
+                Ok(n) => {
+                    tables_bytes_consumed += 1;
+                    n
+                }
                 Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
                     // No runs in this level had a chance to start;
-                    // pushing the empty `level` would be a "zero
-                    // runs at level N" marker which downstream code
-                    // tolerates. Stay consistent with the cut-mid-run
-                    // path below (which DOES push) instead of silently
-                    // dropping the level slot. This is a HEADER
-                    // truncation (the run_count byte didn't land),
-                    // not a record-data loss — count it separately
-                    // so the summary doesn't report nonexistent
-                    // record drops.
+                    // pushing the empty `level` keeps the level slot
+                    // visible to downstream code (instead of silently
+                    // dropping it) and matches the cut-mid-run path
+                    // below. HEADER truncation — no records were
+                    // dropped (none were supposed to be present yet)
+                    // so count separately from record-drops.
                     tables_truncated_headers += 1;
                     levels.push(level);
                     break 'levels;
@@ -193,18 +209,18 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
             for _ in 0..run_count {
                 let mut run = vec![];
                 let table_count = match reader.read_u32::<LittleEndian>() {
-                    Ok(n) => n,
+                    Ok(n) => {
+                        tables_bytes_consumed += 4;
+                        n
+                    }
                     Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                        // Push the partial `level` so any runs that
-                        // were fully decoded earlier in this level
-                        // survive — breaking out of `'levels` without
-                        // this push silently drops the consistent
-                        // prefix, contradicting the tail-tolerant
-                        // contract. The current `run` is empty (we
-                        // failed at the very first byte of its
-                        // record header), so nothing to push for it.
-                        // HEADER truncation — no records were
-                        // supposed to be there yet, count separately.
+                        // Push the partial `level` so any fully
+                        // decoded runs earlier in this level survive
+                        // — breaking out of `'levels` without this
+                        // push silently drops the consistent prefix.
+                        // The current `run` is empty (failed at the
+                        // very first byte of its header), nothing to
+                        // push for it. HEADER truncation.
                         tables_truncated_headers += 1;
                         levels.push(level);
                         break 'levels;
@@ -212,27 +228,30 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
                     Err(e) => return Err(e.into()),
                 };
 
-                // Bound by total section length (33 bytes per entry). Uses
-                // section.len() because BufReader buffering makes
-                // Take::limit() unreliable for remaining-byte checks.
+                // Tight-bound check: count * entry_size against
+                // bytes_remaining at the current cursor, NOT against
+                // section.len(). The loose bound would let an
+                // in-section forgery (count > remaining but still
+                // <= section_total/entry_size) slip past unnoticed
+                // and get reclassified as a clean tail truncation by
+                // the per-entry EOF arm below. The tight bound
+                // surfaces the same shape as an explicit "count
+                // exceeds remaining" warn before the loop runs.
                 //
-                // Under `AbsoluteConsistency` this is a hard "the count
-                // header was forged / bit-flipped — abort" check. Under
-                // `TolerateCorruptedTailRecords` the same condition
-                // legitimately fires when the writer was interrupted
-                // mid-run (count was committed but the trailing entries
-                // weren't), so it must drop to tail-truncation instead
-                // of aborting. The per-entry decode loop below then
-                // surfaces an `UnexpectedEof` for each missing entry,
-                // which the tail-tolerant match arm catches normally.
-                if u64::from(table_count) > section.len() / 33 {
+                // Under `AbsoluteConsistency` this is a hard "the
+                // count header is forged" abort. Under
+                // `TolerateCorruptedTailRecords` it warns and lets
+                // the loop walk bytes-actually-present.
+                let bytes_remaining = section.len().saturating_sub(tables_bytes_consumed);
+                if u64::from(table_count).saturating_mul(33) > bytes_remaining {
                     if tolerate_tail {
                         log::warn!(
-                            "tables: declared table_count={table_count} exceeds section \
-                             capacity (~{} entries) in version #{curr_version_id}; \
-                             tail-tolerant mode walks bytes-actually-present and stops \
-                             at the first EOF",
-                            section.len() / 33,
+                            "tables: declared table_count={table_count} exceeds \
+                             remaining section payload ({bytes_remaining} bytes, \
+                             ~{} entries) in version #{curr_version_id}; \
+                             tail-tolerant mode walks bytes-actually-present and \
+                             stops at the first EOF",
+                            bytes_remaining / 33,
                         );
                     } else {
                         return Err(crate::Error::Unrecoverable);
@@ -242,15 +261,14 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
                 for _ in 0..table_count {
                     let entry = read_one_table_entry(&mut reader);
                     match entry {
-                        Ok(t) => run.push(t),
+                        Ok(t) => {
+                            tables_bytes_consumed += 33;
+                            run.push(t);
+                        }
                         Err(e) if tolerate_tail && is_clean_tail_truncation(&e) => {
                             // run.len() is bounded by table_count
-                            // (which we read above as u32), so the
-                            // cast cannot truncate in practice. Use
-                            // try_from with a saturating fallback
-                            // anyway to keep clippy happy and to
-                            // avoid an unrelated panic if the bound
-                            // is ever loosened.
+                            // (u32); cast can't truncate in practice
+                            // but try_from for clippy.
                             let recovered = u32::try_from(run.len()).unwrap_or(u32::MAX);
                             tables_dropped_to_tail = tables_dropped_to_tail
                                 .saturating_add(table_count.saturating_sub(recovered));
@@ -307,6 +325,13 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
         // count then truncated the entries produces exactly this
         // shape, so tolerant mode must warn and let the per-entry
         // loop walk bytes-actually-present until the first EOF.
+        //
+        // `section.len().saturating_sub(4)` IS the tight
+        // bytes-remaining bound here — unlike the `tables` section
+        // there are no intermediate header bytes between the count
+        // and the first entry (just the 4-byte count u32 itself),
+        // so this is already the correct "bytes left after the
+        // cursor read" value. No bytes-consumed counter needed.
         if u64::from(blob_file_count) > section.len().saturating_sub(4) / 25 {
             if tolerate_tail {
                 log::warn!(

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -5,6 +5,7 @@
 use crate::{
     Checksum, SeqNo, TableId, TreeType,
     coding::Decode,
+    config::ManifestRecoveryMode,
     file::CURRENT_VERSION_FILE,
     fs::{Fs, FsOpenOptions, open_section_reader},
     version::VersionId,
@@ -12,6 +13,53 @@ use crate::{
 };
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::path::Path;
+
+/// `io::Error::kind` values that we interpret as a clean tail truncation
+/// inside the per-record loop. `UnexpectedEof` is the canonical signal
+/// from `Read::read_exact` / `byteorder::ReadBytesExt` when the reader
+/// runs out of bytes mid-record; any other kind means a different
+/// failure and is not eligible for tail-tolerant recovery.
+fn is_clean_tail_truncation(e: &crate::Error) -> bool {
+    matches!(
+        e,
+        crate::Error::Io(io) if io.kind() == std::io::ErrorKind::UnexpectedEof
+    )
+}
+
+/// Reads one 33-byte table-run entry from a section reader. Each entry:
+/// `id: u64 | checksum_type: u8 | checksum: u128 | global_seqno: u64`.
+/// Tail-tolerance: a partial-read past the section bound surfaces as
+/// `Error::Io(UnexpectedEof)`, which `recover()` recognises as a clean
+/// tail-truncation signal under `TolerateCorruptedTailRecords`. A
+/// non-zero `checksum_type` byte is NOT a tail-truncation case — that's
+/// a forged/corrupt record and aborts regardless of mode.
+fn read_one_table_entry<R: std::io::Read>(reader: &mut R) -> crate::Result<RecoveredTable> {
+    let id = reader.read_u64::<LittleEndian>()?;
+    let checksum_type = reader.read_u8()?;
+    if checksum_type != 0 {
+        return Err(crate::Error::InvalidTag(("ChecksumType", checksum_type)));
+    }
+    let checksum = Checksum::from_raw(reader.read_u128::<LittleEndian>()?);
+    let global_seqno = reader.read_u64::<LittleEndian>()?;
+    Ok(RecoveredTable {
+        id,
+        checksum,
+        global_seqno,
+    })
+}
+
+/// Reads one 25-byte blob-file entry:
+/// `id: u64 | checksum_type: u8 | checksum: u128`. Same
+/// tail-truncation contract as [`read_one_table_entry`].
+fn read_one_blob_entry<R: std::io::Read>(reader: &mut R) -> crate::Result<(BlobFileId, Checksum)> {
+    let id = reader.read_u64::<LittleEndian>()?;
+    let checksum_type = reader.read_u8()?;
+    if checksum_type != 0 {
+        return Err(crate::Error::InvalidTag(("ChecksumType", checksum_type)));
+    }
+    let checksum = Checksum::from_raw(reader.read_u128::<LittleEndian>()?);
+    Ok((id, checksum))
+}
 
 /// Reads and validates the CURRENT version pointer file.
 ///
@@ -39,12 +87,14 @@ pub fn get_current_version(folder: &Path, fs: &dyn Fs) -> crate::Result<VersionI
     Ok(version_id)
 }
 
+#[derive(Debug)]
 pub struct RecoveredTable {
     pub id: TableId,
     pub checksum: Checksum,
     pub global_seqno: SeqNo,
 }
 
+#[derive(Debug)]
 pub struct Recovery {
     pub tree_type: TreeType,
     pub curr_version_id: VersionId,
@@ -53,12 +103,18 @@ pub struct Recovery {
     pub gc_stats: crate::blob_tree::FragmentationMap,
 }
 
-pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
+#[expect(
+    clippy::too_many_lines,
+    reason = "manifest recovery is inherently a long sequential read of multiple SFA \
+              sections; splitting the function would just move the per-mode branching \
+              into helpers without clarifying the flow"
+)]
+pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate::Result<Recovery> {
     let curr_version_id = get_current_version(folder, fs)?;
     let version_file_path = folder.join(format!("v{curr_version_id}"));
 
     log::info!(
-        "Recovering current manifest at {}",
+        "Recovering current manifest at {} (mode={mode:?})",
         version_file_path.display(),
     );
 
@@ -66,8 +122,11 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
     let reader = sfa::Reader::from_reader(&mut file)?;
     let toc = reader.toc();
 
+    let tolerate_tail = matches!(mode, ManifestRecoveryMode::TolerateCorruptedTailRecords);
+
     // // TODO: vvv move into Version::decode vvv
     let mut levels = vec![];
+    let mut tables_dropped_to_tail: u32 = 0;
 
     {
         let section = toc
@@ -79,41 +138,94 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
 
         let mut reader = open_section_reader(fs, &version_file_path, section)?;
 
-        let level_count = reader.read_u8()?;
+        // Wrap the level-count read in tail tolerance too: a manifest
+        // truncated before the first byte of `tables` (or right after
+        // the SFA TOC was committed but before any payload landed)
+        // hits EOF here. Under `TolerateCorruptedTailRecords` that's
+        // legitimate "no tables present" — under `AbsoluteConsistency`
+        // it's still a hard fail.
+        let level_count = match reader.read_u8() {
+            Ok(n) => n,
+            Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                log::warn!(
+                    "tables section truncated before level_count byte in version \
+                     #{curr_version_id}; tail-tolerant mode produces 0 levels"
+                );
+                0
+            }
+            Err(e) => return Err(e.into()),
+        };
 
-        for _ in 0..level_count {
+        'levels: for _ in 0..level_count {
             let mut level = vec![];
-            let run_count = reader.read_u8()?;
+            let run_count = match reader.read_u8() {
+                Ok(n) => n,
+                Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    tables_dropped_to_tail += 1;
+                    break 'levels;
+                }
+                Err(e) => return Err(e.into()),
+            };
 
             for _ in 0..run_count {
                 let mut run = vec![];
-                let table_count = reader.read_u32::<LittleEndian>()?;
+                let table_count = match reader.read_u32::<LittleEndian>() {
+                    Ok(n) => n,
+                    Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        tables_dropped_to_tail += 1;
+                        break 'levels;
+                    }
+                    Err(e) => return Err(e.into()),
+                };
 
                 // Bound by total section length (33 bytes per entry). Uses
                 // section.len() because BufReader buffering makes
                 // Take::limit() unreliable for remaining-byte checks.
+                //
+                // Under `AbsoluteConsistency` this is a hard "the count
+                // header was forged / bit-flipped — abort" check. Under
+                // `TolerateCorruptedTailRecords` the same condition
+                // legitimately fires when the writer was interrupted
+                // mid-run (count was committed but the trailing entries
+                // weren't), so it must drop to tail-truncation instead
+                // of aborting. The per-entry decode loop below then
+                // surfaces an `UnexpectedEof` for each missing entry,
+                // which the tail-tolerant match arm catches normally.
                 if u64::from(table_count) > section.len() / 33 {
-                    return Err(crate::Error::Unrecoverable);
+                    if tolerate_tail {
+                        log::warn!(
+                            "tables: declared table_count={table_count} exceeds section \
+                             capacity (~{} entries) in version #{curr_version_id}; \
+                             tail-tolerant mode walks bytes-actually-present and stops \
+                             at the first EOF",
+                            section.len() / 33,
+                        );
+                    } else {
+                        return Err(crate::Error::Unrecoverable);
+                    }
                 }
 
                 for _ in 0..table_count {
-                    let id = reader.read_u64::<LittleEndian>()?;
-                    let checksum_type = reader.read_u8()?;
-
-                    if checksum_type != 0 {
-                        return Err(crate::Error::InvalidTag(("ChecksumType", checksum_type)));
+                    let entry = read_one_table_entry(&mut reader);
+                    match entry {
+                        Ok(t) => run.push(t),
+                        Err(e) if tolerate_tail && is_clean_tail_truncation(&e) => {
+                            // run.len() is bounded by table_count
+                            // (which we read above as u32), so the
+                            // cast cannot truncate in practice. Use
+                            // try_from with a saturating fallback
+                            // anyway to keep clippy happy and to
+                            // avoid an unrelated panic if the bound
+                            // is ever loosened.
+                            let recovered = u32::try_from(run.len()).unwrap_or(u32::MAX);
+                            tables_dropped_to_tail = tables_dropped_to_tail
+                                .saturating_add(table_count.saturating_sub(recovered));
+                            level.push(run);
+                            levels.push(level);
+                            break 'levels;
+                        }
+                        Err(e) => return Err(e),
                     }
-
-                    let checksum = reader.read_u128::<LittleEndian>()?;
-                    let checksum = Checksum::from_raw(checksum);
-
-                    let global_seqno = reader.read_u64::<LittleEndian>()?;
-
-                    run.push(RecoveredTable {
-                        id,
-                        checksum,
-                        global_seqno,
-                    });
                 }
 
                 level.push(run);
@@ -123,6 +235,14 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
         }
     }
 
+    if tables_dropped_to_tail > 0 {
+        log::warn!(
+            "manifest tail truncation dropped {tables_dropped_to_tail} table record(s) \
+             from version #{curr_version_id}; recovered tree may be missing SSTs",
+        );
+    }
+
+    let mut blob_dropped_to_tail: u32 = 0;
     let blob_file_ids = {
         let section = toc
             .section(b"blob_files")
@@ -133,9 +253,20 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
 
         let mut reader = open_section_reader(fs, &version_file_path, section)?;
 
-        let blob_file_count = reader.read_u32::<LittleEndian>()?;
+        let blob_file_count = match reader.read_u32::<LittleEndian>() {
+            Ok(n) => n,
+            Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                log::warn!(
+                    "blob_files section truncated before count header in version \
+                     #{curr_version_id}; tail-tolerant mode produces 0 blob files"
+                );
+                0
+            }
+            Err(e) => return Err(e.into()),
+        };
 
-        // Bound by section payload (25 bytes per entry, minus 4-byte count header).
+        // Same as the `table_count` check: count > section payload means
+        // the count header itself is forged; aborts regardless of mode.
         if u64::from(blob_file_count) > section.len().saturating_sub(4) / 25 {
             return Err(crate::Error::Unrecoverable);
         }
@@ -143,23 +274,30 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
         let mut blob_file_ids = Vec::with_capacity(blob_file_count as usize);
 
         for _ in 0..blob_file_count {
-            let id = reader.read_u64::<LittleEndian>()?;
-
-            let checksum_type = reader.read_u8()?;
-
-            if checksum_type != 0 {
-                return Err(crate::Error::InvalidTag(("ChecksumType", checksum_type)));
+            match read_one_blob_entry(&mut reader) {
+                Ok(t) => blob_file_ids.push(t),
+                Err(e) if tolerate_tail && is_clean_tail_truncation(&e) => {
+                    // try_from over `as u32` for clippy; the cast is
+                    // safe in practice because blob_file_ids.len() is
+                    // bounded by blob_file_count (u32) via the loop.
+                    let recovered = u32::try_from(blob_file_ids.len()).unwrap_or(u32::MAX);
+                    blob_dropped_to_tail = blob_file_count.saturating_sub(recovered);
+                    break;
+                }
+                Err(e) => return Err(e),
             }
-
-            let checksum = reader.read_u128::<LittleEndian>()?;
-            let checksum = Checksum::from_raw(checksum);
-
-            blob_file_ids.push((id, checksum));
         }
 
         blob_file_ids.sort_by_key(|(id, _)| *id);
         blob_file_ids
     };
+
+    if blob_dropped_to_tail > 0 {
+        log::warn!(
+            "manifest tail truncation dropped {blob_dropped_to_tail} blob-file record(s) \
+             from version #{curr_version_id}; recovered tree may be missing blob files",
+        );
+    }
 
     debug_assert!(blob_file_ids.is_sorted_by_key(|(id, _)| id));
 
@@ -196,6 +334,11 @@ pub fn recover(folder: &Path, fs: &dyn Fs) -> crate::Result<Recovery> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test assertions"
+)]
 mod tests {
     use super::*;
     use crate::fs::{FsOpenOptions, MemFs};
@@ -287,7 +430,7 @@ mod tests {
         write_current(folder, 1, &fs)?;
         write_corrupt_table_count(folder, 1, &fs)?;
 
-        let Err(err) = recover(folder, &fs) else {
+        let Err(err) = recover(folder, &fs, ManifestRecoveryMode::AbsoluteConsistency) else {
             panic!("corrupt table_count should fail");
         };
         assert!(
@@ -307,7 +450,7 @@ mod tests {
         write_current(folder, 1, &fs)?;
         write_corrupt_blob_count(folder, 1, &fs)?;
 
-        let Err(err) = recover(folder, &fs) else {
+        let Err(err) = recover(folder, &fs, ManifestRecoveryMode::AbsoluteConsistency) else {
             panic!("corrupt blob_file_count should fail");
         };
         assert!(
@@ -315,6 +458,173 @@ mod tests {
             "expected Unrecoverable, got: {err:?}"
         );
 
+        Ok(())
+    }
+
+    /// Writes a `vN` archive whose `tables` section claims more table
+    /// entries than are actually present (count says 5, only 1 full
+    /// entry's worth of bytes is written, the next entry's `id: u64`
+    /// is cut off mid-stream). Used to exercise the
+    /// `TolerateCorruptedTailRecords` recovery path.
+    ///
+    /// The `id` parameter selects the version file name; the function
+    /// otherwise produces a deterministic shape: 1 level, 1 run,
+    /// declared count = `declared`, actual full entries = `actual`.
+    fn write_truncated_tables_tail(
+        folder: &Path,
+        id: u64,
+        declared: u32,
+        actual: u32,
+        fs: &dyn Fs,
+    ) -> crate::Result<()> {
+        assert!(
+            actual < declared,
+            "actual must be < declared for truncation"
+        );
+        let path = folder.join(format!("v{id}"));
+        let file = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        let mut w = sfa::Writer::from_writer(std::io::BufWriter::new(file));
+
+        w.start("tree_type")?;
+        w.write_u8(0)?;
+
+        w.start("tables")?;
+        w.write_u8(1)?; // 1 level
+        w.write_u8(1)?; // 1 run
+        w.write_u32::<LittleEndian>(declared)?;
+        // Write `actual` complete 33-byte entries, then stop. SFA will
+        // pad the section length to whatever bytes we wrote — the
+        // truncation surfaces inside the per-entry decode loop, not at
+        // the SFA layer.
+        for entry_id in 0..actual {
+            w.write_u64::<LittleEndian>(u64::from(entry_id))?;
+            w.write_u8(0)?; // checksum_type
+            w.write_u128::<LittleEndian>(0)?; // checksum
+            w.write_u64::<LittleEndian>(0)?; // global_seqno
+        }
+
+        w.start("blob_files")?;
+        w.write_u32::<LittleEndian>(0)?;
+
+        w.start("blob_gc_stats")?;
+        w.write_u32::<LittleEndian>(0)?;
+
+        w.finish().map_err(|e| match e {
+            sfa::Error::Io(e) => crate::Error::from(e),
+            _ => crate::Error::Unrecoverable,
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn recover_absolute_consistency_rejects_truncated_tables_tail() -> crate::Result<()> {
+        let fs = MemFs::new();
+        let folder = Path::new("/absolute/tail");
+        fs.create_dir_all(folder)?;
+
+        write_current(folder, 1, &fs)?;
+        // Section declares 5 entries, only 1 actually written.
+        write_truncated_tables_tail(folder, 1, 5, 1, &fs)?;
+
+        let result = recover(folder, &fs, ManifestRecoveryMode::AbsoluteConsistency);
+        let err = result.expect_err("truncated tail must abort under AbsoluteConsistency");
+        // Either Io(UnexpectedEof) (from the byteorder read) — both are
+        // acceptable strict-mode failures. The contract is: SOMETHING
+        // surfaces, the open does not silently succeed with partial data.
+        assert!(
+            matches!(&err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::UnexpectedEof)
+                || matches!(err, crate::Error::Unrecoverable),
+            "expected UnexpectedEof or Unrecoverable, got: {err:?}",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn recover_tolerate_tail_keeps_consistent_prefix_of_tables() -> crate::Result<()> {
+        let fs = MemFs::new();
+        let folder = Path::new("/tolerate/tail");
+        fs.create_dir_all(folder)?;
+
+        write_current(folder, 1, &fs)?;
+        // Section declares 5 entries, only 1 actually written → expect
+        // 1 entry recovered, 4 silently dropped + warn logged.
+        write_truncated_tables_tail(folder, 1, 5, 1, &fs)?;
+
+        let recovery = recover(
+            folder,
+            &fs,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )?;
+        assert_eq!(
+            recovery.table_ids.len(),
+            1,
+            "expected 1 level, got {}: {:?}",
+            recovery.table_ids.len(),
+            recovery.table_ids.iter().map(Vec::len).collect::<Vec<_>>(),
+        );
+        let level = &recovery.table_ids[0];
+        assert_eq!(level.len(), 1, "expected 1 run in the recovered level");
+        assert_eq!(
+            level[0].len(),
+            1,
+            "expected 1 table record (the consistent prefix); got {}",
+            level[0].len(),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn recover_tolerate_tail_does_not_swallow_invalid_tag() -> crate::Result<()> {
+        // A corrupt non-zero `checksum_type` byte is NOT a clean tail
+        // truncation; the tail-tolerant mode must still abort on it.
+        // Otherwise it'd silently drop the bad record plus everything
+        // after it on bit-rot, which is the opposite of the documented
+        // contract (tail-tolerance is for write-incomplete scenarios,
+        // not for arbitrary corruption).
+        let fs = MemFs::new();
+        let folder = Path::new("/tolerate/bad_tag");
+        fs.create_dir_all(folder)?;
+
+        write_current(folder, 1, &fs)?;
+        let path = folder.join("v1");
+        let file = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        let mut w = sfa::Writer::from_writer(std::io::BufWriter::new(file));
+        w.start("tree_type")?;
+        w.write_u8(0)?;
+        w.start("tables")?;
+        w.write_u8(1)?; // 1 level
+        w.write_u8(1)?; // 1 run
+        w.write_u32::<LittleEndian>(1)?; // 1 entry
+        w.write_u64::<LittleEndian>(0)?; // id
+        w.write_u8(0xFF)?; // corrupt checksum_type — should abort
+        w.write_u128::<LittleEndian>(0)?;
+        w.write_u64::<LittleEndian>(0)?;
+        w.start("blob_files")?;
+        w.write_u32::<LittleEndian>(0)?;
+        w.start("blob_gc_stats")?;
+        w.write_u32::<LittleEndian>(0)?;
+        w.finish().map_err(|e| match e {
+            sfa::Error::Io(e) => crate::Error::from(e),
+            _ => crate::Error::Unrecoverable,
+        })?;
+
+        let result = recover(
+            folder,
+            &fs,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        );
+        let err =
+            result.expect_err("InvalidTag must still abort under TolerateCorruptedTailRecords");
+        assert!(
+            matches!(err, crate::Error::InvalidTag(("ChecksumType", 0xFF))),
+            "expected InvalidTag, got: {err:?}",
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Adds a per-tree policy knob governing what \`Tree::open\` does when the on-disk MANIFEST contains corrupt records. Default \`AbsoluteConsistency\` preserves the current strict behaviour — any corruption aborts the open. New \`TolerateCorruptedTailRecords\` mode salvages a power-loss-during-write scenario: keep everything that decoded cleanly, log warn, drop the truncated tail. Mirrors RocksDB's WALRecoveryMode applied to lsm-tree's manifest layer (lsm-tree itself has no WAL — that lives in the parent fjall crate's Journal).

## Scope

This PR ships the API surface (all 4 variants of the enum) and wires \`AbsoluteConsistency\` + \`TolerateCorruptedTailRecords\` fully. The other two — \`PointInTimeRecovery\`, \`SkipAnyCorruptedRecords\` — are documented as reserved and currently fall through to \`AbsoluteConsistency\` behaviour. They land in follow-up PRs so the recovery semantics for each can be reviewed in isolation (and so \`SkipAnyCorruptedRecords\` can be reviewed alongside the \`repair_db\` tooling in #303).

## What lands

- \`ManifestRecoveryMode\` enum in \`src/config/mod.rs\` (\`#[derive(Default)]\` picks \`AbsoluteConsistency\` so existing consumers see zero behaviour change).
- \`Config::manifest_recovery_mode(mode)\` builder + \`pub(crate)\` field.
- \`recover()\` in \`src/version/recovery.rs\` now takes a \`mode\` parameter. Per-record reads match on \`UnexpectedEof\` and either abort (strict) or drop-to-tail (tolerant). The declared-count > section-capacity guard stays a hard fail under strict, downgrades to a \`warn!\` under tolerant so the per-entry loop can walk what's actually present. Non-tail corruption (bad \`checksum_type\` byte) still aborts under tolerant — the mode is for write-incomplete scenarios, not arbitrary bit-rot. Two top-level \`warn!\` summaries log total dropped record counts.
- \`Tree::open\` plumbs \`config.manifest_recovery_mode\` through to \`recover()\`.
- Three new unit tests in \`src/version/recovery.rs#tests\`:
  - \`recover_absolute_consistency_rejects_truncated_tables_tail\` — strict mode still aborts on the new fixture.
  - \`recover_tolerate_tail_keeps_consistent_prefix_of_tables\` — tolerant mode recovers the consistent prefix (1 entry from a declared-5).
  - \`recover_tolerate_tail_does_not_swallow_invalid_tag\` — tolerant mode still aborts on a corrupt \`checksum_type\` byte.
- \`RecoveredTable\` and \`Recovery\` gain \`#[derive(Debug)]\` (needed by the new \`expect_err\` test assertions).

## Compatibility

- Default behaviour preserved — no on-disk format change, no public API removed. Existing consumers see the same error on the same inputs.
- New mode is fully opt-in via \`Config::manifest_recovery_mode(...)\`.

## Test plan

- [x] Full lsm-tree suite: 1554/1554 pass (1 slow, 1 leaky pre-existing).
- [x] Lint clean: \`cargo clippy --all-targets --all-features -- -D warnings\`.
- [x] Three new recovery tests cover the strict-mode preservation, tail-tolerant happy path, and the not-a-tail-truncation guard.

## Follow-ups (not in this PR)

- Wire \`PointInTimeRecovery\` — recover up to the last fully-consistent record group.
- Wire \`SkipAnyCorruptedRecords\` — skip each corrupt record individually. Best landed alongside #303 (\`repair_db\`) so the two surfaces can be reviewed together.
- README \`recovery\` section describing which mode fits which deployment style.

Part of #299.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable manifest recovery mode to handle corrupt manifest files during database recovery. Users can now choose between strict (default) and tolerant recovery strategies with configurable tradeoffs.

* **Tests**
  * Updated test suite to validate both strict and tolerant manifest recovery behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->