### PR TITLE
test(table): pin global-seqno translation on Table::get return path (#321)

### DIFF
--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -1535,6 +1535,72 @@ fn table_global_seqno() -> crate::Result<()> {
     Ok(())
 }
 
+/// Pins `Table::get` returning items with **global** seqno coordinates
+/// even when the on-disk block carries `seqno = 0`. Mirrors the upstream
+/// regression test for the equivalent fix in fjall-rs/lsm-tree (commit
+/// bad4fe0a). Our fork's structural fix lives at the `Table::get` /
+/// `get_with_block` / `batch_get` boundary (each call site adds
+/// `global_seqno` back via `saturating_add` after the table-local
+/// `point_read`), rather than inside `point_read` itself, but the
+/// caller-observable contract is the same: a recovered ingested item
+/// is returned with its effective global seqno, not the on-disk
+/// table-local seqno.
+///
+/// A regression that drops the `saturating_add(global_seqno)` step
+/// (e.g. a refactor that flattens `point_read` directly into `get`
+/// without re-applying the offset) would fail this test by returning
+/// `seqno = 0` instead of `seqno = SEQNO`.
+#[test]
+#[expect(clippy::unwrap_used, reason = "test assertions")]
+fn table_return_global_seqno() -> crate::Result<()> {
+    use crate::ValueType::Value;
+    use crate::fs::StdFs;
+
+    const SEQNO: SeqNo = 15;
+
+    let items = [InternalValue::from_components("abc", "abc", 0, Value)];
+
+    let dir = tempfile::tempdir()?;
+    let file = dir.path().join("table_fuzz");
+
+    let mut writer = crate::table::Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+
+    for item in items {
+        writer.write(item)?;
+    }
+
+    let _trailer = writer.finish()?;
+
+    let table = crate::Table::recover(
+        file,
+        crate::Checksum::from_raw(0),
+        SEQNO,
+        0,
+        Arc::new(crate::Cache::with_capacity_bytes(0)),
+        Some(Arc::new(crate::DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        true,
+        true,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::default(),
+    )?;
+
+    // On disk: seqno = 0. Effective global seqno: 0 + SEQNO = SEQNO.
+    // Snapshot = 2 * SEQNO is above the effective seqno, so the read sees the item.
+    // Returned value MUST carry the effective global seqno (= SEQNO),
+    // not the table-local seqno (= 0) it has on disk.
+    assert_eq!(
+        InternalValue::from_components("abc", "abc", SEQNO, Value),
+        table.get(b"abc", 2 * SEQNO, hash64(b"abc"))?.unwrap(),
+    );
+
+    Ok(())
+}
+
 /// Build a [`Block`] from raw bytes for `decode_range_tombstones` tests.
 #[expect(
     clippy::expect_used,


### PR DESCRIPTION
## Summary

Issue #321 reported an upstream-sync delta (18 new commits in fjall-rs/lsm-tree since the last sync). Audit of the two bug fixes among them:

- **`db394880` fix: `clear()` corrupting blob trees (upstream #286)** — already fixed in our fork (commit `07b26588`, regression test in `tests/blob_tree_clear_reopen.rs` from `a485c3cf`). Our `BlobTree::clear` at `src/blob_tree/mod.rs:368-388` does the full version-history upgrade with the correct `tree_type()` derived from `kv_separation_opts`. No action needed.
- **`bad4fe0a` fix: seqno of ingested items on point-read** — fix is **already in our code** (commit `431e9759`), but our fix is structurally different from upstream's, and we have no regression test pinning it. This PR adds that test.

## What this PR does

Adds `table_return_global_seqno` to `src/table/tests.rs` (1561/1561 tests pass). The test:

1. Writes a single item with on-disk `seqno = 0`.
2. Recovers the table with `global_seqno = SEQNO` (= 15).
3. Calls `Table::get` with snapshot `2 * SEQNO`.
4. Asserts the returned `InternalValue` has `seqno == SEQNO` (the effective global seqno), NOT `seqno == 0` (the on-disk table-local seqno).

This mirrors the upstream `table_return_global_seqno` test from fjall-rs/lsm-tree (the regression test attached to fix `bad4fe0a`), adapted to our `Table::recover` signature.

## Why our fix is in a different place than upstream

Upstream put the `seqno += self.global_seqno()` adjustment **inside `Table::point_read`**, after each `block.point_read()` hit. Our fork puts the same adjustment at the public-API boundary: `Table::get` / `get_with_block` / `batch_get` each apply it via `saturating_add` after the table-local `point_read` returns. Both designs produce the same caller-observable contract (returned items carry effective global seqno). Our placement covers more entry points (`get_with_block`, `batch_get`); upstream covers only what flows through their `point_read`.

The test is design-agnostic, asserting the public contract rather than the implementation location, so it pins our fork's correctness regardless of where future refactors put the adjustment.

## Test plan

- All checks green locally: new test passes in 0.023 s; full suite 1561/1561 pass; clippy with -D warnings clean across all targets and features
- Code audit confirms our existing fix at `src/table/mod.rs:362` (where `iv.key.seqno = iv.key.seqno.saturating_add(global_seqno)`) is exercised by this test path

Closes #321