### PR TITLE
feat(table): mirror TLI block near file tail for torn-write safety

### DIFF
--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -910,7 +910,17 @@ impl Table {
             crate::table::block::BlockIdentity {
                 tree_id: 0,
                 table_id,
-                block_offset: *handle.offset(),
+                // Match the writer: both `tli` and `tli_tail` are
+                // emitted with `block_offset: 0` (the partitioned /
+                // full index writers do not currently thread their
+                // SFA section offset through `BlockIndexWriter`).
+                // BlockIdentity is ignored by `Block::from_file`
+                // today, but once #251 wires it into AEAD AAD,
+                // reader and writer MUST encode the same value or
+                // encrypted tables fail to reopen. Threading real
+                // section offsets through is tracked alongside the
+                // BlockIndexWriter::finish surface in #251.
+                block_offset: 0,
                 block_type: BlockType::Index,
                 dict_id: 0,
                 window_log: 0,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -867,15 +867,50 @@ impl Table {
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
     ) -> crate::Result<IndexBlock> {
-        log::trace!("Reading TLI block, with tli_ptr={:?}", regions.tli);
+        // Tail copy first (preferred — if a fresh `tli_tail` exists it
+        // landed after the head `tli`, so it's the most-recently
+        // fsynced copy). On any decode / decrypt / checksum failure
+        // fall back to the head `tli` if present.
+        //
+        // Both copies encode the same handles list (the writer hands
+        // a single `tli_bytes` buffer to both sites), so the resulting
+        // IndexBlock content is identical regardless of which side
+        // wins. Compression / encryption nonce differ per-section,
+        // but the decoded handles match.
+        //
+        // Tables written before the TLI-mirror change have no
+        // `tli_tail`; reader falls straight through to the head copy.
+        if let Some(tail_handle) = regions.tli_tail {
+            log::trace!("Reading TLI tail mirror, with tli_tail_ptr={tail_handle:?}");
+            match Self::read_tli_at(file, tail_handle, table_id, compression, encryption) {
+                Ok(idx) => return Ok(idx),
+                Err(tail_err) => {
+                    log::warn!(
+                        "TLI tail mirror unreadable ({tail_err}); falling back to TLI head copy at {:?}",
+                        regions.tli,
+                    );
+                }
+            }
+        }
 
+        log::trace!("Reading TLI head copy, with tli_ptr={:?}", regions.tli);
+        Self::read_tli_at(file, regions.tli, table_id, compression, encryption)
+    }
+
+    fn read_tli_at(
+        file: &dyn FsFile,
+        handle: BlockHandle,
+        table_id: TableId,
+        compression: CompressionType,
+        encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+    ) -> crate::Result<IndexBlock> {
         let block = Block::from_file(
             file,
-            regions.tli,
+            handle,
             crate::table::block::BlockIdentity {
                 tree_id: 0,
                 table_id,
-                block_offset: *regions.tli.offset(),
+                block_offset: *handle.offset(),
                 block_type: BlockType::Index,
                 dict_id: 0,
                 window_log: 0,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -893,6 +893,28 @@ impl Table {
                         "TLI tail mirror unreadable ({tail_err}); falling back to TLI head copy at {:?}",
                         regions.tli,
                     );
+                    // Match the meta-mirror pattern: when BOTH
+                    // copies fail, surface the original `tail_err`
+                    // (callers care about the authoritative /
+                    // preferred copy's failure mode). The head
+                    // failure goes to the log so it's not silently
+                    // dropped from diagnostics.
+                    log::trace!("Reading TLI head copy, with tli_ptr={:?}", regions.tli);
+                    return match Self::read_tli_at(
+                        file,
+                        regions.tli,
+                        table_id,
+                        compression,
+                        encryption,
+                    ) {
+                        Ok(idx) => Ok(idx),
+                        Err(head_err) => {
+                            log::warn!(
+                                "TLI head copy also unreadable ({head_err}); returning original tail error",
+                            );
+                            Err(tail_err)
+                        }
+                    };
                 }
             }
         }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -867,16 +867,20 @@ impl Table {
         compression: CompressionType,
         encryption: Option<&dyn crate::encryption::EncryptionProvider>,
     ) -> crate::Result<IndexBlock> {
-        // Tail copy first (preferred — if a fresh `tli_tail` exists it
+        // Tail copy first (preferred): if a fresh `tli_tail` exists it
         // landed after the head `tli`, so it's the most-recently
-        // fsynced copy). On any decode / decrypt / checksum failure
+        // fsynced copy. On any decode / decrypt / checksum failure
         // fall back to the head `tli` if present.
         //
         // Both copies encode the same handles list (the writer hands
-        // a single `tli_bytes` buffer to both sites), so the resulting
-        // IndexBlock content is identical regardless of which side
-        // wins. Compression / encryption nonce differ per-section,
-        // but the decoded handles match.
+        // a single `tli_bytes` buffer to both sites) and both are
+        // written under the same `CompressionType`
+        // (`metadata.index_block_compression`); the block header does
+        // not record a compression tag, so this single value decodes
+        // either copy. Encryption nonce differs per copy (fresh per
+        // `Block::write_into`) and the ciphertext therefore differs
+        // byte-for-byte, but both decrypt to the same plaintext
+        // IndexBlock.
         //
         // Tables written before the TLI-mirror change have no
         // `tli_tail`; reader falls straight through to the head copy.

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -26,11 +26,14 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 /// --------------------
 /// |       data       | <- implicitly start at 0
 /// |------------------|
-/// |        tli       | <- head copy
+/// |       index      | <- partitioned only: sub-index blocks
+/// |                  |    (full-index tables emit only `tli` below)
 /// |------------------|
-/// |       index      | <- may not exist (if full block index is used, TLI will be dense)
+/// |        tli       | <- head copy (top-level index)
 /// |------------------|
 /// |      filter      | <- may not exist
+/// |------------------|
+/// |    filter_tli    | <- partitioned filter only
 /// |------------------|
 /// | range_tombstones | <- may not exist
 /// |------------------|
@@ -51,6 +54,13 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 /// |      trailer     | <- fixed size
 /// |------------------|
 /// ```
+///
+/// Writer emission order matches the diagram top-to-bottom. For the
+/// partitioned index path (`PartitionedIndexWriter::finish`) the
+/// `index` section is written first, then `tli`; the full-index
+/// path (`FullIndexWriter::finish`) skips `index` and emits only
+/// `tli`. Same pattern for filters: partitioned writes `filter`
+/// then `filter_tli`, full writes only `filter`.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ParsedRegions {
     pub tli: BlockHandle,

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -22,33 +22,35 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 
 /// The regions block stores offsets to the different table file "regions"
 ///
-/// ----------------
-/// |     data     | <- implicitly start at 0
-/// |--------------|
-/// |      tli     | <- head copy
-/// |--------------|
-/// |     index    | <- may not exist (if full block index is used, TLI will be dense)
-/// |--------------|
-/// |    filter    | <- may not exist
-/// |--------------|
-/// |  `range_tomb`  | <- may not exist
-/// |--------------|
-/// |   `meta_mid`   | <- mirror of meta
-/// |--------------|
-/// | linked blobs | <- may not exist
-/// |--------------|
-/// |table_version |
-/// |--------------|
-/// |meta_separator| <- 4 KiB zero padding
-/// |--------------|
-/// |   tli_tail   | <- mirror of tli
-/// |--------------|
-/// |     meta     |
-/// |--------------|
-/// |     toc      |
-/// |--------------|
-/// |   trailer    | <- fixed size
-/// |--------------|
+/// ```text
+/// --------------------
+/// |       data       | <- implicitly start at 0
+/// |------------------|
+/// |        tli       | <- head copy
+/// |------------------|
+/// |       index      | <- may not exist (if full block index is used, TLI will be dense)
+/// |------------------|
+/// |      filter      | <- may not exist
+/// |------------------|
+/// | range_tombstones | <- may not exist
+/// |------------------|
+/// |     meta_mid     | <- mirror of meta
+/// |------------------|
+/// | linked_blob_files| <- may not exist
+/// |------------------|
+/// |   table_version  |
+/// |------------------|
+/// |  meta_separator  | <- 4 KiB zero padding
+/// |------------------|
+/// |     tli_tail     | <- mirror of tli
+/// |------------------|
+/// |       meta       |
+/// |------------------|
+/// |        toc       |
+/// |------------------|
+/// |      trailer     | <- fixed size
+/// |------------------|
+/// ```
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ParsedRegions {
     pub tli: BlockHandle,

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -65,8 +65,10 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 pub struct ParsedRegions {
     pub tli: BlockHandle,
     /// Tail-side mirror of the TLI block. Head copy lives in the
-    /// `tli` section near the file start (after the data section);
-    /// this copy lives near the file tail, after `meta_separator`
+    /// `tli` section earlier in the file (after `data` and the
+    /// partitioned `index` sub-blocks if any, before `filter` /
+    /// `filter_tli` / `range_tombstones`); this copy lives near the
+    /// file tail, after `meta_separator`
     /// and before `meta`. A torn-write or bad sector at either
     /// position leaves the other copy intact. Reader prefers the
     /// tail copy on open and transparently falls back to the head
@@ -80,10 +82,11 @@ pub struct ParsedRegions {
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
-    /// `data` → `tli` → `index?` → `filter_tli?` → `filter?` →
+    /// `data` → `index?` → `tli` → `filter?` → `filter_tli?` →
     /// `range_tombstones?` → **`meta_mid`** →
     /// `linked_blob_files?` → `table_version` → `meta_separator` →
-    /// `meta`. Absent on tables written before the meta-mirror change.
+    /// `tli_tail` → `meta`. Absent on tables written before the
+    /// meta-mirror change.
     /// Defends against torn-write at the file tail (incomplete fsync):
     /// MID lives several KiB before TAIL, with a 4 KiB
     /// `meta_separator` section between them to guarantee a fresh

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -25,15 +25,23 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 /// ----------------
 /// |     data     | <- implicitly start at 0
 /// |--------------|
-/// |      tli     |
+/// |      tli     | <- head copy
 /// |--------------|
 /// |     index    | <- may not exist (if full block index is used, TLI will be dense)
 /// |--------------|
 /// |    filter    | <- may not exist
 /// |--------------|
-/// |  range_tomb  | <- may not exist
+/// |  `range_tomb`  | <- may not exist
+/// |--------------|
+/// |   `meta_mid`   | <- mirror of meta
 /// |--------------|
 /// | linked blobs | <- may not exist
+/// |--------------|
+/// |table_version |
+/// |--------------|
+/// |meta_separator| <- 4 KiB zero padding
+/// |--------------|
+/// |   tli_tail   | <- mirror of tli
 /// |--------------|
 /// |     meta     |
 /// |--------------|
@@ -44,6 +52,15 @@ fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ParsedRegions {
     pub tli: BlockHandle,
+    /// Tail-side mirror of the TLI block. Head copy lives in the
+    /// `tli` section near the file start (after the data section);
+    /// this copy lives near the file tail, after `meta_separator`
+    /// and before `meta`. A torn-write or bad sector at either
+    /// position leaves the other copy intact. Reader prefers the
+    /// tail copy on open and transparently falls back to the head
+    /// copy on decode/checksum/decrypt failure. Absent on tables
+    /// written before the TLI-mirror change.
+    pub tli_tail: Option<BlockHandle>,
     pub index: Option<BlockHandle>,
     pub filter_tli: Option<BlockHandle>,
     pub filter: Option<BlockHandle>,
@@ -73,6 +90,7 @@ impl ParsedRegions {
                     log::error!("TLI should exist");
                     crate::Error::Unrecoverable
                 })?,
+            tli_tail: toc.section(b"tli_tail").map(toc_entry_to_handle),
             index: toc.section(b"index").map(toc_entry_to_handle),
             filter: toc.section(b"filter").map(toc_entry_to_handle),
             range_tombstones: toc.section(b"range_tombstones").map(toc_entry_to_handle),

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -84,7 +84,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
     fn finish(
         self: Box<Self>,
         file_writer: &mut sfa::Writer<ChecksummedWriter<W>>,
-    ) -> crate::Result<usize> {
+    ) -> crate::Result<(usize, Vec<u8>)> {
         file_writer.start("tli")?;
 
         let mut bytes = vec![];
@@ -132,6 +132,6 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter 
             self.block_handles.len(),
         );
 
-        Ok(1)
+        Ok((1, bytes))
     }
 }

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -20,11 +20,18 @@ pub trait BlockIndexWriter<W: std::io::Write + std::io::Seek> {
 
     /// Writes the block index to a file.
     ///
-    /// Returns the number of index blocks written.
+    /// Returns the number of index blocks written and the raw
+    /// IndexBlock-encoded top-level-index bytes (uncompressed,
+    /// unencrypted). The outer table writer re-encodes these bytes
+    /// into a `tli_tail` mirror section near the file tail so that a
+    /// torn-write or bad sector at the head TLI position is
+    /// recoverable. The buffer reflects post-shift handles (matching
+    /// what `tli` head section encodes), so head and tail decode to
+    /// the same logical TLI.
     fn finish(
         self: Box<Self>,
         file_writer: &mut sfa::Writer<ChecksummedWriter<W>>,
-    ) -> crate::Result<usize>;
+    ) -> crate::Result<(usize, Vec<u8>)>;
 
     fn use_compression(
         self: Box<Self>,

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -137,7 +137,7 @@ impl PartitionedIndexWriter {
         &mut self,
         file_writer: &mut sfa::Writer<ChecksummedWriter<WR>>,
         index_base_offset: BlockOffset,
-    ) -> crate::Result<()> {
+    ) -> crate::Result<Vec<u8>> {
         file_writer.start("tli")?;
 
         for item in &mut self.tli_handles {
@@ -181,7 +181,7 @@ impl PartitionedIndexWriter {
             self.tli_handles.len(),
         );
 
-        Ok(())
+        Ok(bytes)
     }
 }
 
@@ -246,7 +246,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndex
     fn finish(
         mut self: Box<Self>,
         file_writer: &mut sfa::Writer<ChecksummedWriter<W>>,
-    ) -> crate::Result<usize> {
+    ) -> crate::Result<(usize, Vec<u8>)> {
         if self.buffer_size > 0 {
             self.cut_index_block()?;
         }
@@ -257,8 +257,8 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndex
         file_writer.write_all(&self.final_write_buffer)?;
         log::trace!("Concatted index partitions onto blocks file");
 
-        self.write_top_level_index(file_writer, index_base_offset)?;
+        let tli_bytes = self.write_top_level_index(file_writer, index_base_offset)?;
 
-        Ok(self.index_block_count)
+        Ok((self.index_block_count, tli_bytes))
     }
 }

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -768,8 +768,18 @@ impl Writer {
         // copy on open and transparently falls back to the head copy
         // on decode/checksum/decrypt failure. Re-encodes the same
         // `tli_bytes` returned by `index_writer.finish()` so the two
-        // sections decode to the same logical TLI; compression /
-        // encryption nonce can differ per-section, but content matches.
+        // sections decode to the same logical TLI. Both copies MUST
+        // be written with the same `CompressionType` (this call uses
+        // `self.index_block_compression`, identical to what the
+        // partitioned/full index writer used for the head): the block
+        // header does not record the compression tag, so the reader
+        // supplies a single `CompressionType` from table metadata
+        // when decoding either copy. If the two were written under
+        // different codecs, at least one copy would be undecodable.
+        // The encryption nonce differs per `Block::write_into` call,
+        // so the resulting ciphertext differs byte-for-byte across
+        // the two copies, but both decrypt to the same plaintext
+        // IndexBlock.
         // `block_offset` is held at 0 to match the head copy's
         // BlockIdentity (`partitioned::write_top_level_index` /
         // `full::finish` both encode with offset=0); once #251 wires

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -592,7 +592,7 @@ impl Writer {
 
         // Write index
         log::trace!("Finishing index writer");
-        let index_block_count = self.index_writer.finish(&mut self.file_writer)?;
+        let (index_block_count, tli_bytes) = self.index_writer.finish(&mut self.file_writer)?;
 
         // Write filter
         log::trace!("Finishing filter writer");
@@ -759,6 +759,39 @@ impl Writer {
         // sections between them).
         self.file_writer.start("meta_separator")?;
         self.file_writer.write_all(&[0u8; 4096])?;
+
+        // TLI mirror near the file tail. Head copy lives in the `tli`
+        // section near the file start, ~MB earlier (the data section
+        // is between them, so head and tail are always on different
+        // filesystem sectors). A torn-write or bad sector at either
+        // end leaves the other copy intact. Reader prefers the tail
+        // copy on open and transparently falls back to the head copy
+        // on decode/checksum/decrypt failure. Re-encodes the same
+        // `tli_bytes` returned by `index_writer.finish()` so the two
+        // sections decode to the same logical TLI; compression /
+        // encryption nonce can differ per-section, but content matches.
+        // `block_offset` is held at 0 to match the head copy's
+        // BlockIdentity (`partitioned::write_top_level_index` /
+        // `full::finish` both encode with offset=0); once #251 wires
+        // real offsets into AAD this needs to thread the tail SFA
+        // section offset alongside the head one.
+        self.file_writer.start("tli_tail")?;
+        Block::write_into(
+            &mut self.file_writer,
+            &tli_bytes,
+            crate::table::block::BlockIdentity {
+                tree_id: 0,
+                table_id: self.table_id,
+                block_offset: 0,
+                block_type: crate::table::block::BlockType::Index,
+                dict_id: 0,
+                window_log: 0,
+            },
+            self.index_block_compression,
+            self.encryption.as_deref(),
+            #[cfg(zstd_any)]
+            None,
+        )?;
 
         // TAIL meta — the canonical, authoritative copy. `file_size`
         // is the LOGICAL size up to the end of the data blocks

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -760,11 +760,19 @@ impl Writer {
         self.file_writer.start("meta_separator")?;
         self.file_writer.write_all(&[0u8; 4096])?;
 
-        // TLI mirror near the file tail. Head copy lives in the `tli`
-        // section near the file start, ~MB earlier (the data section
-        // is between them, so head and tail are always on different
-        // filesystem sectors). A torn-write or bad sector at either
-        // end leaves the other copy intact. Reader prefers the tail
+        // TLI mirror near the file tail. The head `tli` section was
+        // emitted earlier in `finish()` by `index_writer.finish()` —
+        // after `data` and the partitioned `index` sub-blocks (if any)
+        // but before `filter` / `filter_tli` / `range_tombstones` /
+        // `meta_mid` / `linked_blob_files` / `table_version` /
+        // `meta_separator`. So the head copy lives in the middle of
+        // the file, and `tli_tail` lives after `meta_separator` and
+        // before the canonical `meta` section. Several KiB of
+        // unrelated sections plus the 4 KiB `meta_separator`
+        // guarantee the two copies land in different 4 KiB
+        // filesystem sectors (for any typical table they are
+        // hundreds of KiB to MiB apart). A torn-write or bad sector
+        // at either end leaves the other copy intact. Reader prefers the tail
         // copy on open and transparently falls back to the head copy
         // on decode/checksum/decrypt failure. Re-encodes the same
         // `tli_bytes` returned by `index_writer.finish()` so the two

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -573,14 +573,17 @@ fn scan_sst_blocks(
     // region. Other named sections, in writer order:
     //
     //   - `data`              : block-format (data blocks)
+    //   - `index`             : block-format (partitioned index leaf
+    //                           blocks; absent for full-index tables,
+    //                           emitted before `tli` by
+    //                           `PartitionedIndexWriter::finish`)
     //   - `tli`               : block-format (top-level index, both
     //                           full and partitioned variants)
-    //   - `index`             : block-format (partitioned index leaf
-    //                           blocks; absent for full-index tables)
+    //   - `filter`            : block-format (filter blocks)
     //   - `filter_tli`        : block-format (top-level filter for
     //                           partitioned filters; absent for full
-    //                           filters)
-    //   - `filter`            : block-format (filter blocks)
+    //                           filters, emitted after `filter` by
+    //                           `PartitionedFilterWriter::finish`)
     //   - `range_tombstones`  : block-format (optional)
     //   - `meta_mid`          : block-format (early mirror of `meta`)
     //   - `linked_blob_files` : RAW length-prefixed list of u64s

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -582,9 +582,12 @@ fn scan_sst_blocks(
     //                           filters)
     //   - `filter`            : block-format (filter blocks)
     //   - `range_tombstones`  : block-format (optional)
+    //   - `meta_mid`          : block-format (early mirror of `meta`)
     //   - `linked_blob_files` : RAW length-prefixed list of u64s
     //   - `table_version`     : RAW single byte
-    //   - `meta`              : block-format (metadata)
+    //   - `meta_separator`    : RAW 4 KiB zero padding
+    //   - `tli_tail`          : block-format (tail mirror of `tli`)
+    //   - `meta`              : block-format (metadata, authoritative)
     //
     // Block-format sections are walked block-by-block (each block
     // prefixed with the standard `Header`). Raw-format sections are
@@ -670,7 +673,7 @@ fn scan_sst_blocks(
 /// (i.e. NOT prefixed with the standard `Header`). The scrub skips
 /// these sections — their integrity is covered by the SFA-trailer
 /// checksum verified at table-open time. Every other section
-/// (`data` / `tli` / `index` / `filter_tli` / `filter` /
+/// (`data` / `tli` / `tli_tail` / `index` / `filter_tli` / `filter` /
 /// `range_tombstones` / `meta` / `meta_mid`) is a `Header`-prefixed
 /// block run and gets walked. See `scan_sst_blocks` for the full
 /// section catalogue and the writer-side source of truth.

--- a/tests/tli_mirror.rs
+++ b/tests/tli_mirror.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Integration tests for the TLI-block mirror (head + tail copies,
+//! see writer/mod.rs `Block::write_into` of `tli_tail`). A single
+//! bit-flip or torn-write that takes out one copy must not prevent
+//! table open — the surviving copy is used.
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter, config::PinningPolicy, get_tmp_folder,
+};
+use std::{fs::OpenOptions, io::Write, path::Path};
+use test_log::test;
+
+fn find_table_file(dir: &Path) -> std::path::PathBuf {
+    let tables_dir = dir.join("tables");
+    let search_dir = if tables_dir.exists() {
+        tables_dir
+    } else {
+        dir.to_path_buf()
+    };
+    for entry in std::fs::read_dir(&search_dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_file() {
+            return entry.path();
+        }
+    }
+    panic!("no table file found in {}", search_dir.display());
+}
+
+fn locate_section(path: &Path, name: &[u8]) -> Option<(u64, u64)> {
+    let mut file = std::fs::File::open(path).unwrap();
+    let reader = sfa::Reader::from_reader(&mut file).unwrap();
+    reader
+        .toc()
+        .section(name)
+        .map(|entry| (entry.pos(), entry.len()))
+}
+
+fn corrupt_region(path: &Path, offset: u64, len: u64, byte: u8) {
+    use std::io::Seek;
+    let mut file = OpenOptions::new().write(true).open(path).unwrap();
+    file.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    let buf = vec![byte; len as usize];
+    file.write_all(&buf).unwrap();
+    file.sync_all().unwrap();
+}
+
+/// Build a tree forcing partitioned-index for all levels so the TLI
+/// section is small (a few entries) AND so the recovery path takes
+/// the `read_tli` branch (rather than the volatile-full branch which
+/// bypasses `read_tli` entirely).
+fn build_partitioned_tree(items: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .index_block_partitioning_policy(PinningPolicy::all(true))
+    .open()
+    .unwrap();
+
+    for i in 0..items {
+        tree.insert(format!("key-{i:06}"), b"value", 0);
+    }
+    tree.flush_active_memtable(0).unwrap();
+
+    let sst = find_table_file(dir.path());
+    (dir, sst)
+}
+
+fn reopen_partitioned(dir: &Path) -> lsm_tree::AnyTree {
+    Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .index_block_partitioning_policy(PinningPolicy::all(true))
+    .open()
+    .expect("table open should succeed")
+}
+
+#[test]
+fn tli_mirror_writer_emits_both_copies() {
+    let (_dir, sst) = build_partitioned_tree(2048);
+
+    let head = locate_section(&sst, b"tli");
+    let tail = locate_section(&sst, b"tli_tail");
+
+    assert!(head.is_some(), "head tli section must be present");
+    assert!(
+        tail.is_some(),
+        "tail tli_tail section must be present (mirror)"
+    );
+
+    let (head_off, _head_len) = head.unwrap();
+    let (tail_off, _tail_len) = tail.unwrap();
+
+    // Head is written first (near file start, after the data section);
+    // tail copy sits near the file end after meta_separator.
+    assert!(
+        head_off < tail_off,
+        "head tli at {head_off} should come before tail tli_tail at {tail_off}"
+    );
+}
+
+#[test]
+fn tli_tail_sits_after_meta_separator_and_before_meta() {
+    let (_dir, sst) = build_partitioned_tree(2048);
+
+    let (sep_off, sep_len) =
+        locate_section(&sst, b"meta_separator").expect("meta_separator missing");
+    let (tail_off, tail_len) = locate_section(&sst, b"tli_tail").expect("tli_tail missing");
+    let (meta_off, _meta_len) = locate_section(&sst, b"meta").expect("meta missing");
+
+    let sep_end = sep_off + sep_len;
+    assert!(
+        tail_off >= sep_end,
+        "tli_tail at {tail_off} must come after meta_separator end {sep_end}"
+    );
+    let tail_end = tail_off + tail_len;
+    assert!(
+        tail_end <= meta_off,
+        "tli_tail must end (at {tail_end}) before TAIL meta starts (at {meta_off})"
+    );
+}
+
+#[test]
+fn table_reopens_via_head_when_tail_tli_is_zeroed() {
+    let (dir, sst) = build_partitioned_tree(2048);
+
+    // Wipe the tail TLI copy. XXH3 over zeros won't match the header
+    // checksum, so Block::from_file rejects it and the recovery path
+    // must fall back to the head copy.
+    let (tail_off, tail_len) = locate_section(&sst, b"tli_tail").expect("tail tli missing");
+    corrupt_region(&sst, tail_off, tail_len, 0x00);
+
+    let tree = reopen_partitioned(dir.path());
+
+    let value = tree
+        .get(b"key-000000", lsm_tree::MAX_SEQNO)
+        .expect("get should succeed on table recovered via head TLI")
+        .expect("key should exist");
+    assert_eq!(&*value, b"value");
+}
+
+#[test]
+fn table_reopens_via_tail_when_head_tli_is_zeroed() {
+    let (dir, sst) = build_partitioned_tree(2048);
+
+    // Wipe the head TLI copy. Reader tries tail first, so this is the
+    // path that exercises the tail-first / head-fallback inversion:
+    // head is broken, tail must carry the table.
+    let (head_off, head_len) = locate_section(&sst, b"tli").expect("head tli missing");
+    corrupt_region(&sst, head_off, head_len, 0x00);
+
+    let tree = reopen_partitioned(dir.path());
+
+    let value = tree
+        .get(b"key-000000", lsm_tree::MAX_SEQNO)
+        .expect("get should succeed on table recovered via tail TLI")
+        .expect("key should exist");
+    assert_eq!(&*value, b"value");
+}
+
+#[test]
+fn table_open_fails_when_both_tli_copies_are_zeroed() {
+    let (dir, sst) = build_partitioned_tree(2048);
+
+    let (head_off, head_len) = locate_section(&sst, b"tli").expect("head tli missing");
+    let (tail_off, tail_len) = locate_section(&sst, b"tli_tail").expect("tail tli missing");
+    corrupt_region(&sst, head_off, head_len, 0x00);
+    corrupt_region(&sst, tail_off, tail_len, 0x00);
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .index_block_partitioning_policy(PinningPolicy::all(true))
+    .open();
+
+    assert!(
+        result.is_err(),
+        "open must fail when both TLI copies are unreadable"
+    );
+}


### PR DESCRIPTION
## Summary

Add a tail-side mirror of the top-level index (TLI) block, analogous to the meta-block mirror landed in #295. A torn-write or bad-sector at the head TLI position is now recoverable from the tail copy and vice versa.

## Wire format

New `tli_tail` SFA section written after `meta_separator` and before the authoritative `meta`:

```
... → meta_mid → linked_blob_files → table_version → meta_separator → tli_tail → meta
```

The head `tli` section (near the file start, after `data`) stays where it is. `tli_tail` re-encodes the same `IndexBlock` bytes via a second `Block::write_into` call; both copies are written under the same `CompressionType` (`metadata.index_block_compression`) since the block header does not encode a compression tag and the reader supplies a single value when decoding either copy. Only the encryption nonce differs between the two copies (fresh per `Block::write_into`), so the resulting ciphertext is byte-different but the decoded handles match. Tables written before this change omit `tli_tail` and the reader falls straight through to the head copy (backward compatible).

## Reader fallback (tail-first / head-fallback)

`Table::read_tli` tries `tli_tail` first when present and transparently falls back to `tli` on any decode / checksum / decrypt failure. Both copies decode to the same logical TLI.

The recovery path goes through `read_tli` for the partitioned and pinned-full index branches. The volatile-full branch (small unpinned full-index tables) continues to read head-only on demand; adding fallback there needs handle threading through `VolatileBlockIndex` and is left out of this PR.

## Internal refactor

`BlockIndexWriter::finish` now returns `(usize, Vec<u8>)` so the outer table writer can re-emit the encoded TLI bytes at the tail position without re-shifting handles (which `write_top_level_index` mutates in place). Both `FullIndexWriter` and `PartitionedIndexWriter` implementations updated. The trait module is `pub(crate)` from outside the crate's perspective (parent module `index` is private), so this is not a public API change.

## Tests

`tests/tli_mirror.rs` (5 new tests, all pass):

- writer emits both `tli` and `tli_tail` sections
- `tli_tail` sits after `meta_separator` and before `meta`
- open recovers when tail TLI is zeroed (head fallback)
- open recovers when head TLI is zeroed (tail wins)
- open fails when both copies are zeroed

Forces partitioned-index for all levels so the recovery path takes `read_tli` rather than the volatile-full bypass.

## Test plan

- [x] `cargo nextest run` (1407 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] New mirror tests cover writer emission, ordering, head/tail corruption, and double-corruption

Closes #296
