### PR TITLE
feat(sst-dump): hex subcommand for raw block-region dump with header decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo run --release --features flamegraph -- \
 | Tool | Use |
 |------|-----|
 | [`tools/db_bench`](tools/db_bench) | RocksDB-compatible benchmark suite, also drives the CI perf dashboard. |
-| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band (per-block XXH3 walk). `sst-dump <file> verify` exits non-zero on corruption — usable as a one-shot health check. |
+| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`). |
 
 ## Support the project
 

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -10,9 +10,22 @@
 //! does it actually contain?".
 
 use clap::{Parser, Subcommand};
+use lsm_tree::coding::Decode;
+use lsm_tree::table::block::Header;
 use lsm_tree::verify::{BlockVerifyError, verify_sst_file};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::process::ExitCode;
+
+/// Default number of bytes the `hex` subcommand prints when the
+/// caller does not supply `--len`. Chosen to cover one `Header`
+/// (currently 25 bytes) plus a few payload lines worth of context.
+const HEX_DEFAULT_LEN: u64 = 256;
+/// Hard ceiling on the user-requestable `hex` length so a typo
+/// (`--len 4294967295`) can't allocate a 4 GiB buffer. 1 MiB
+/// already overshoots any plausible single-block diagnostic dump.
+const HEX_MAX_LEN: u64 = 1024 * 1024;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -39,6 +52,31 @@ enum Command {
         #[arg(long)]
         verbose: bool,
     },
+
+    /// Raw hex dump of a region of the file. If the region starts on
+    /// a `Header`-prefixed block boundary (as reported by `verify` or
+    /// derived from a TOC offset), the header is decoded and printed
+    /// before the hex bytes for context. Useful for inspecting a
+    /// specific block flagged as `HeaderCorrupted` / `DataCorrupted`
+    /// without spinning up a `Tree`.
+    Hex {
+        /// Byte offset into the file where the dump starts. Typically
+        /// a value reported by `verify --verbose` or a TOC section
+        /// start position.
+        offset: u64,
+
+        /// How many bytes to dump (max 1 MiB). Defaults to 256, which
+        /// covers a `Header` plus a few payload lines worth of
+        /// context.
+        #[arg(long, default_value_t = HEX_DEFAULT_LEN)]
+        len: u64,
+
+        /// Skip the `Header` decode attempt and print only the raw
+        /// hex. Use when the offset is known not to be a block
+        /// boundary (e.g. mid-payload, raw-format section).
+        #[arg(long)]
+        no_header: bool,
+    },
 }
 
 fn main() -> ExitCode {
@@ -46,6 +84,11 @@ fn main() -> ExitCode {
 
     match cli.command {
         Command::Verify { verbose } => run_verify(&cli.file, verbose),
+        Command::Hex {
+            offset,
+            len,
+            no_header,
+        } => run_hex(&cli.file, offset, len, no_header),
     }
 }
 
@@ -94,4 +137,147 @@ fn run_verify(path: &std::path::Path, verbose: bool) -> ExitCode {
     }
 
     ExitCode::FAILURE
+}
+
+fn run_hex(path: &std::path::Path, offset: u64, len: u64, no_header: bool) -> ExitCode {
+    if len == 0 {
+        eprintln!("error: --len must be > 0");
+        return ExitCode::FAILURE;
+    }
+    if len > HEX_MAX_LEN {
+        eprintln!("error: --len {len} exceeds maximum of {HEX_MAX_LEN} bytes (1 MiB)");
+        return ExitCode::FAILURE;
+    }
+
+    let mut file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: open {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let file_size = match file.metadata().map(|m| m.len()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: stat {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if offset >= file_size {
+        eprintln!(
+            "error: offset {offset} is past end of file ({file_size} bytes); nothing to dump"
+        );
+        return ExitCode::FAILURE;
+    }
+
+    // Clamp the requested length to bytes-actually-available so a
+    // `--len 256` at the file tail dumps the partial tail rather
+    // than EOF-erroring out. The caller sees the actual byte count
+    // in the header line below.
+    let available = file_size - offset;
+    let read_len = len.min(available);
+
+    if let Err(e) = file.seek(SeekFrom::Start(offset)) {
+        eprintln!("error: seek to {offset}: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    // `read_len` is bounded by `HEX_MAX_LEN` (1 MiB) above, so the
+    // `usize` cast is safe on any platform we target. Pre-allocate
+    // the exact size instead of `read_to_end` so a truncated read
+    // still produces a well-sized buffer for the dump.
+    let mut buf = vec![0u8; read_len as usize];
+    if let Err(e) = file.read_exact(&mut buf) {
+        eprintln!("error: read {read_len} bytes at {offset}: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    println!("file:           {}", path.display());
+    println!("file size:      {file_size} bytes");
+    println!("offset:         {offset} (0x{offset:08x})");
+    println!("dumped:         {read_len} bytes (requested {len})");
+
+    // Attempt header decode unless the caller asked us to skip it
+    // (offset known not to be a block boundary) or the buffer is
+    // shorter than a serialized header.
+    if !no_header && read_len as usize >= Header::serialized_len() {
+        let mut header_reader = &buf[..];
+        match Header::decode_from(&mut header_reader) {
+            Ok(header) => {
+                println!("header:");
+                println!("  block_type:          {:?}", header.block_type);
+                println!("  data_length:         {} bytes", header.data_length,);
+                println!(
+                    "  uncompressed_length: {} bytes",
+                    header.uncompressed_length,
+                );
+                println!("  checksum (XXH3):     {:?}", header.checksum);
+            }
+            Err(e) => {
+                // Decode failure is informational — the caller may be
+                // dumping a non-header byte range deliberately. Print
+                // the error so the operator knows the structural
+                // shape didn't match, then continue with the raw hex.
+                println!("header:         decode failed ({e}); printing raw bytes only");
+            }
+        }
+    } else if no_header {
+        println!("header:         skipped (--no-header)");
+    } else {
+        println!(
+            "header:         skipped (only {read_len} bytes available, header is {} bytes)",
+            Header::serialized_len(),
+        );
+    }
+
+    println!();
+    hex_dump(offset, &buf);
+
+    ExitCode::SUCCESS
+}
+
+/// Prints a classic xxd-style hex+ASCII dump of `buf`, with each
+/// line annotated with the absolute file offset (= `base_offset`
+/// plus the line's index within `buf`).
+fn hex_dump(base_offset: u64, buf: &[u8]) {
+    const BYTES_PER_LINE: usize = 16;
+
+    for (i, chunk) in buf.chunks(BYTES_PER_LINE).enumerate() {
+        // Per-line absolute file offset. `i * BYTES_PER_LINE` cannot
+        // overflow because `buf.len()` is bounded by `HEX_MAX_LEN`
+        // (1 MiB) by the caller's clamp above.
+        let line_offset = base_offset + (i * BYTES_PER_LINE) as u64;
+        print!("{line_offset:08x}  ");
+
+        // Hex bytes, padded to keep the ASCII column aligned even on
+        // the final short line.
+        for j in 0..BYTES_PER_LINE {
+            if let Some(b) = chunk.get(j) {
+                print!("{b:02x} ");
+            } else {
+                print!("   ");
+            }
+            if j == 7 {
+                // Extra space at the half-line to match `xxd`'s
+                // convention and make 8-byte alignment visible.
+                print!(" ");
+            }
+        }
+
+        // ASCII gutter: printable ASCII or `.` for everything else
+        // (including the high-bit-set range, which is rarely useful
+        // and clutters output).
+        print!(" |");
+        for b in chunk {
+            let c = if (0x20..0x7f).contains(b) {
+                *b as char
+            } else {
+                '.'
+            };
+            print!("{c}");
+        }
+        println!("|");
+    }
 }

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -20,7 +20,10 @@ use std::process::ExitCode;
 
 /// Default number of bytes the `hex` subcommand prints when the
 /// caller does not supply `--len`. Chosen to cover one `Header`
-/// (currently 25 bytes) plus a few payload lines worth of context.
+/// (currently 33 bytes: 4 B magic + 1 B block_type + 16 B
+/// XXH3-128 checksum + 4 B data_length + 4 B uncompressed_length +
+/// 4 B trailing checksum tag — see `Header::serialized_len()`)
+/// plus a few payload lines worth of context.
 const HEX_DEFAULT_LEN: u64 = 256;
 /// Hard ceiling on the user-requestable `hex` length so a typo
 /// (`--len 4294967295`) can't allocate a 4 GiB buffer. 1 MiB
@@ -185,9 +188,14 @@ fn run_hex(path: &std::path::Path, offset: u64, len: u64, no_header: bool) -> Ex
     }
 
     // `read_len` is bounded by `HEX_MAX_LEN` (1 MiB) above, so the
-    // `usize` cast is safe on any platform we target. Pre-allocate
-    // the exact size instead of `read_to_end` so a truncated read
-    // still produces a well-sized buffer for the dump.
+    // `usize` cast is safe on any platform we target. `read_exact`
+    // is strict: a short read fails the call, and we exit non-zero
+    // without dumping anything. Short reads are not possible on the
+    // happy path because `read_len = min(len, file_size - offset)`
+    // is already bounded by bytes-actually-on-disk above, so the
+    // only way `read_exact` can short-read is mid-call truncation
+    // of the file by another process or a real I/O error — both
+    // are reportable failures, not partial-dump scenarios.
     let mut buf = vec![0u8; read_len as usize];
     if let Err(e) = file.read_exact(&mut buf) {
         eprintln!("error: read {read_len} bytes at {offset}: {e}");

--- a/tools/sst-dump/tests/hex_smoke.rs
+++ b/tools/sst-dump/tests/hex_smoke.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test for the `hex` subcommand: build a real SST
+//! via `lsm-tree`, then drive the `sst-dump hex` binary against
+//! known offsets and check both the success path (block header
+//! decodes, dump body produced) and the documented error paths
+//! (offset past EOF, oversized `--len`).
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter, compression::CompressionType,
+    config::CompressionPolicy,
+};
+use std::process::Command;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+/// Builds a small populated SST in a tempdir, flushes it to disk,
+/// drops the tree, returns the path to the first SST file.
+fn build_one_sst() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()
+    .expect("open tree");
+
+    for i in 0u64..200 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+    (dir, sst)
+}
+
+fn line_value(text: &str, label: &str) -> Option<String> {
+    let prefix = format!("{label}:");
+    text.lines().find_map(|line| {
+        line.strip_prefix(&prefix)
+            .map(|rest| rest.trim().to_owned())
+    })
+}
+
+#[test]
+fn hex_at_first_block_decodes_header_and_prints_dump() {
+    let (_dir, sst) = build_one_sst();
+
+    // Offset 0 is the start of the very first `data` block. The SST
+    // writer emits a `Header`-prefixed block here, so `hex 0` should
+    // both decode the header successfully and produce a dump body.
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("hex")
+        .arg("0")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0, got {:?}; stdout:\n{stdout}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    assert_eq!(
+        line_value(&stdout, "offset"),
+        Some("0 (0x00000000)".to_owned()),
+        "expected offset=0 with hex annotation; got:\n{stdout}",
+    );
+
+    // Header section: the writer wrote a real block at offset 0, so
+    // the decode must succeed (= the section prints `header:` with
+    // sub-lines, NOT `header: decode failed`).
+    assert!(
+        stdout.contains("header:\n"),
+        "expected a populated `header:` section; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("block_type:"),
+        "expected decoded `block_type` line; got:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("decode failed"),
+        "header decode unexpectedly failed at offset 0; got:\n{stdout}",
+    );
+
+    // Hex dump body: at least one xxd-style line starting with the
+    // 8-digit hex offset.
+    assert!(
+        stdout.contains("00000000  "),
+        "expected an xxd-style line for offset 0; got:\n{stdout}",
+    );
+}
+
+#[test]
+fn hex_with_no_header_flag_skips_decode_section() {
+    let (_dir, sst) = build_one_sst();
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("hex")
+        .arg("0")
+        .arg("--no-header")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "expected exit 0; got:\n{stdout}");
+    assert!(
+        stdout.contains("header:         skipped (--no-header)"),
+        "expected the skip-header notice; got:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("block_type:"),
+        "header decode should NOT have run under --no-header; got:\n{stdout}",
+    );
+}
+
+#[test]
+fn hex_past_eof_exits_nonzero() {
+    let (_dir, sst) = build_one_sst();
+    let file_size = std::fs::metadata(&sst).unwrap().len();
+
+    let past_eof = file_size + 1;
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("hex")
+        .arg(past_eof.to_string())
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit when offset is past EOF; got success",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("past end of file"),
+        "expected past-EOF error in stderr; got:\n{stderr}",
+    );
+}
+
+#[test]
+fn hex_oversized_len_is_rejected() {
+    let (_dir, sst) = build_one_sst();
+
+    // Caller-supplied `--len` above the 1 MiB ceiling is a typo
+    // guard, not a clamp — the tool should refuse rather than
+    // silently shrinking the request.
+    let oversized = (1024 * 1024) + 1;
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("hex")
+        .arg("0")
+        .arg("--len")
+        .arg(oversized.to_string())
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(!out.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("exceeds maximum"),
+        "expected len-exceeds-max error in stderr; got:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

Adds `sst-dump <file> hex <offset> [--len N] [--no-header]` — one of the five subcommands still missing from #324 after the `verify` scaffold landed in #316.

## Behaviour

- Reads `--len` bytes (default 256, max 1 MiB; the ceiling guards against typos like `--len 4294967295` rather than clamping silently).
- Offset past EOF: exits non-zero with a precise error. Region extending past EOF: clamped to bytes-available; the actual read length is reported alongside the requested length.
- Header decode: if the buffer is at least `Header::serialized_len()` bytes and `--no-header` is not passed, runs `Header::decode_from` at the requested offset and prints decoded `block_type` / `data_length` / `uncompressed_length` / `checksum`. Decode failure is informational, hex body still prints.
- Hex body: `xxd`-style — 8-digit absolute-offset prefix, 16 bytes per line in two 8-byte groups, ASCII gutter for printable bytes.

## Example

```
$ sst-dump table-0 hex 0
file:           table-0
file size:      8729 bytes
offset:         0 (0x00000000)
dumped:         256 bytes (requested 256)
header:
  block_type:          Data
  data_length:         1834 bytes
  uncompressed_length: 1834 bytes
  checksum (XXH3):     Checksum(...)

00000000  ff ff ff ff fc fb fd fe  00 4a 07 00 00 4a 07 00  |.........J...J..|
00000010  00 5c d7 9c 09 6c 0d 0f  3c c8 c3 ac 6f 4d ae a6  |.\...l..<...oM..|
...
```

## Tests

`tools/sst-dump/tests/hex_smoke.rs` (4 new tests):

- `hex_at_first_block_decodes_header_and_prints_dump` — happy path: build a real SST through the public API, dump offset 0, assert both decoded header section AND xxd-style line for offset 0.
- `hex_with_no_header_flag_skips_decode_section` — `--no-header` suppresses the decode attempt.
- `hex_past_eof_exits_nonzero` — offset past file size errors out cleanly.
- `hex_oversized_len_is_rejected` — `--len > 1 MiB` is refused, not silently clamped.

## Test plan

- [x] `cargo nextest run` in `tools/sst-dump/` (6 tests pass: 4 new + 2 existing `verify_smoke`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Main crate `cargo nextest run` (1405 pass)
- [x] README `Operational tools` table row updated to list the new subcommand

Part of #324.