### PR TITLE
build(deps): bump structured-zstd 0.0.23 → 0.0.25, spin 0.9 → 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,12 +82,12 @@ byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
 enum_dispatch = "0.3.13"
 log = "0.4.27"
-# `spin = "0.9"` provides a no_std-compatible Mutex. Used by
+# `spin` provides a no_std-compatible Mutex. Used by
 # `deletion_pause` so that module's only std footprint comes from the
 # `Fs` trait it interacts with, not from its own synchronisation.
-spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
+spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.23", optional = true, default-features = false, features = ["std"] }
+structured-zstd = { version = "0.0.25", optional = true, default-features = false, features = ["std"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is


### PR DESCRIPTION
## Summary

Two dependency bumps:

- **structured-zstd 0.0.23 → 0.0.25** — lands the two API surfaces #251 (AAD-bound block encoder/decoder, CP1 in roadmap #215) was blocked on:
  - typed `SkippableFrame` API behind the `lsm` feature (tracked as `structured-zstd#171`)
  - `expect_dict_id` + `expect_window_descriptor` setters on `FrameDecoder` (tracked as `structured-zstd#177`)

  v0.0.24 (also in this bump) shipped decode-path performance work (HUF table layout as u16, 4-stream burst-gate collapse, lazy-band `target_len` alignment with donor `clevels.h` table[0]). Picked up for free.

- **spin 0.9 → 0.12** — major bump. The only surface we use (`Mutex` / `spin_mutex` in `src/deletion_pause.rs`) is mechanically identical between the two versions: full test suite and clippy pass without any source changes.

## Roadmap impact

#251 (CP1 — AAD wire-format encoder/decoder) moves from "blocked by structured-zstd#171, #177" to "unblocked". After this PR merges the roadmap #215 should be updated to reflect that.

## Test plan

- [x] `cargo build` clean on the lsm-tree crate
- [x] `cargo build` clean on `tools/sst-dump/`
- [x] `cargo nextest run` — 1410 main tests + 6 sst-dump tests green
- [x] `cargo clippy --all-features -- -D warnings` clean on both crates
- [x] `Cargo.toml` updated; comment that hardcoded `"0.9"` literal cleaned up so it doesn't bitrot

Closes #330