### PR TITLE
feat(sst-dump): index-dump subcommand + public inspect facade extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo run --release --features flamegraph -- \
 | Tool | Use |
 |------|-----|
 | [`tools/db_bench`](tools/db_bench) | RocksDB-compatible benchmark suite, also drives the CI perf dashboard. |
-| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `properties` (print the SST's stored metadata: id, key range, KV / tombstone counts, block counts, compression, timestamp), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`). |
+| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `properties` (print the SST's stored metadata: id, key range, KV / tombstone counts, block counts, compression, timestamp), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`), `index-dump` (print TLI entries: end_key + offset + size + seqno per pointed-at block; useful for diagnosing range-read fan-out). |
 
 ## Support the project
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -179,3 +179,177 @@ pub fn read_table_properties(path: &Path) -> crate::Result<TableProperties> {
         created_at_nanos: *meta.created_at,
     })
 }
+
+/// One entry parsed from an SST's top-level index (TLI) block.
+///
+/// What this points at depends on the index layout, recoverable from
+/// [`TableProperties`]:
+/// - **Full-index tables** (`TableProperties.index_block_count == 1`):
+///   the TLI directly contains data-block handles. Each `IndexEntry`
+///   here corresponds to one data block in the SST.
+/// - **Partitioned-index tables** (`index_block_count > 1`): the TLI
+///   contains handles pointing at the partitioned sub-index leaf
+///   blocks (the `index` SFA section). Each `IndexEntry` here points
+///   at one leaf, not a data block; walking the leaves to enumerate
+///   individual data blocks is a separate operation.
+///
+/// `#[non_exhaustive]` so new fields can be added in a minor version
+/// bump.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct IndexEntry {
+    /// Last user-key covered by the pointed-at block. For binary
+    /// search the TLI is searched on `end_key`, so this is the
+    /// authoritative sort key for the entry.
+    pub end_key: Vec<u8>,
+    /// Highest seqno of any item in the pointed-at block. Used by
+    /// the read path to decide whether a snapshot can skip the
+    /// block entirely.
+    pub seqno: u64,
+    /// On-disk byte offset of the pointed-at block (data-block start
+    /// for full-index tables, sub-index-block start for partitioned).
+    pub offset: u64,
+    /// On-disk size of the pointed-at block in bytes, including the
+    /// block `Header` prefix.
+    pub size: u32,
+}
+
+/// Reads `path` and returns the parsed entries of its top-level index
+/// (TLI) block.
+///
+/// Same out-of-band path-based open semantics as
+/// [`read_table_properties`] (uses [`StdFs`], no encryption provider).
+/// Recovery semantics mirror [`Table::read_tli`](crate::Table)'s
+/// TAIL-first / HEAD-fallback path from #296: the tail `tli_tail`
+/// mirror section is attempted first when present; on
+/// decode / decrypt / checksum failure the canonical head `tli`
+/// section is tried; both copies failing returns the original tail
+/// error. Tables written before the TLI-mirror change have no
+/// `tli_tail` section and fall straight through to the head copy.
+///
+/// The function returns owned `IndexEntry` records — the inner
+/// `IndexBlock` and its underlying `Slice` are dropped on return, so
+/// the caller does not need to keep the file mapping alive. Memory
+/// cost is `O(entries × end_key.len())`.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - the file cannot be opened or read (`std::io::Error`),
+/// - the SFA trailer is missing / malformed and cannot be parsed,
+/// - the `meta` block fails to decode (needed to determine
+///   `index_block_compression`),
+/// - both the head `tli` and the tail `tli_tail` (if present) fail
+///   to decode (block header / XXH3 / structural mismatch). In the
+///   both-copies-fail case the original tail error is returned,
+/// - the TLI block trailer is malformed (e.g. `restart_interval == 0`),
+/// - the table is encrypted: this function does not take an
+///   encryption provider, so the AEAD-protected blocks fail to
+///   decode and the failure surfaces as a regular decrypt error.
+#[cfg(feature = "std")]
+pub fn read_top_level_index_entries(path: &Path) -> crate::Result<Vec<IndexEntry>> {
+    use crate::table::block_index::iter::OwnedIndexBlockIter;
+    use crate::table::{IndexBlock, KeyedBlockHandle};
+
+    let fs = StdFs;
+    let mut file = fs.open(path, &FsOpenOptions::new().read(true))?;
+
+    let sfa_reader = sfa::Reader::from_reader(&mut file)?;
+    let toc = sfa_reader.toc();
+    let regions = ParsedRegions::parse_from_toc(toc)?;
+
+    // Load meta to know the index block's compression codec. Same
+    // TAIL-first / MID-fallback as `read_table_properties` above —
+    // factored together so this function gives identical recovery
+    // behaviour on a meta-corrupted SST.
+    let meta = match ParsedMeta::load_with_handle(&*file, &regions.metadata, None) {
+        Ok(m) => m,
+        Err(tail_err) => {
+            if let Some(mid_handle) = regions.metadata_mid {
+                match ParsedMeta::load_with_handle(&*file, &mid_handle, None) {
+                    Ok(mid) => mid,
+                    Err(_) => return Err(tail_err),
+                }
+            } else {
+                return Err(tail_err);
+            }
+        }
+    };
+    let index_compression = meta.index_block_compression;
+    let table_id = meta.id;
+
+    // TLI tail mirror tried first when present (most-recently fsynced
+    // copy); on failure fall back to the head copy. Mirrors
+    // `Table::read_tli` so a partially-corrupted TLI behaves the
+    // same here as in a live open.
+    let tli_block = if let Some(tail_handle) = regions.tli_tail {
+        match load_index_block(&*file, tail_handle, table_id, index_compression) {
+            Ok(b) => b,
+            Err(tail_err) => {
+                match load_index_block(&*file, regions.tli, table_id, index_compression) {
+                    Ok(b) => b,
+                    Err(_) => return Err(tail_err),
+                }
+            }
+        }
+    } else {
+        load_index_block(&*file, regions.tli, table_id, index_compression)?
+    };
+
+    let block = IndexBlock::new(tli_block);
+    let iter = OwnedIndexBlockIter::from_block(block, crate::comparator::default_comparator())?;
+
+    let entries = iter
+        .map(|h: KeyedBlockHandle| IndexEntry {
+            end_key: h.end_key().to_vec(),
+            seqno: h.seqno(),
+            offset: *h.offset(),
+            size: h.size(),
+        })
+        .collect();
+
+    Ok(entries)
+}
+
+/// Helper: load and validate a single index block from disk. Shared
+/// between the tail and head TLI load sites so both paths produce the
+/// same error shape on a malformed block.
+#[cfg(feature = "std")]
+fn load_index_block(
+    file: &dyn crate::fs::FsFile,
+    handle: crate::table::BlockHandle,
+    table_id: crate::table::TableId,
+    compression: CompressionType,
+) -> crate::Result<crate::table::Block> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+
+    let block = Block::from_file(
+        file,
+        handle,
+        BlockIdentity {
+            tree_id: 0,
+            table_id,
+            // Match the writer: index blocks are emitted with
+            // `block_offset: 0` (see `Table::read_tli`'s comment for
+            // the writer-side rationale). When #251 wires real
+            // offsets into AAD this needs the SFA section offset.
+            block_offset: 0,
+            block_type: BlockType::Index,
+            dict_id: 0,
+            window_log: 0,
+        },
+        compression,
+        None,
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    if block.header.block_type != BlockType::Index {
+        return Err(crate::Error::InvalidTag((
+            "BlockType",
+            block.header.block_type.into(),
+        )));
+    }
+
+    Ok(block)
+}

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -182,16 +182,24 @@ pub fn read_table_properties(path: &Path) -> crate::Result<TableProperties> {
 
 /// One entry parsed from an SST's top-level index (TLI) block.
 ///
-/// What this points at depends on the index layout, recoverable from
-/// [`TableProperties`]:
-/// - **Full-index tables** (`TableProperties.index_block_count == 1`):
-///   the TLI directly contains data-block handles. Each `IndexEntry`
-///   here corresponds to one data block in the SST.
-/// - **Partitioned-index tables** (`index_block_count > 1`): the TLI
-///   contains handles pointing at the partitioned sub-index leaf
-///   blocks (the `index` SFA section). Each `IndexEntry` here points
-///   at one leaf, not a data block; walking the leaves to enumerate
+/// What this points at depends on the SST's index layout:
+///
+/// - **Full-index tables**: the SST has no separate `index` SFA
+///   section. The TLI directly carries data-block handles, so each
+///   `IndexEntry` corresponds to one data block in the SST.
+/// - **Partitioned-index tables**: the SST has an `index` SFA section
+///   containing sub-index leaf blocks. The TLI carries handles
+///   pointing at those leaves, so each `IndexEntry` corresponds to
+///   one leaf, NOT a data block; walking the leaves to enumerate
 ///   individual data blocks is a separate operation.
+///
+/// The distinction is not derivable from `TableProperties` fields
+/// alone — in particular `TableProperties.index_block_count == 1`
+/// can mean either a full-index table OR a partitioned-index table
+/// with a single leaf partition. The authoritative signal is the
+/// presence of an `index` SFA section in the SFA TOC; this facade
+/// does not currently expose that signal. Callers needing to
+/// classify the layout should consult the SST file's TOC directly.
 ///
 /// `#[non_exhaustive]` so new fields can be added in a minor version
 /// bump.

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -361,11 +361,12 @@ fn run_index_dump(path: &std::path::Path) -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    // Header row. Columns are left-aligned; widths chosen so a
-    // 64-bit offset (up to 20 digits) and u32 size (up to 10) line
-    // up against a typical key prefix without crowding. Keys can be
-    // arbitrarily long; place `end_key` last so wrap-around doesn't
-    // mis-align the numeric columns.
+    // Header row. Numeric columns are right-aligned (`{:>...}`) so
+    // u64 / u32 values stack cleanly under their headers; widths
+    // chosen so a 64-bit offset (up to 20 digits) and u32 size (up
+    // to 10) line up against a typical key prefix without crowding.
+    // Keys can be arbitrarily long; place `end_key` last so
+    // wrap-around doesn't mis-align the numeric columns.
     println!(
         "{:>5}  {:>20}  {:>10}  {:>20}  end_key",
         "#", "offset", "size", "seqno",

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -11,7 +11,7 @@
 
 use clap::{Parser, Subcommand};
 use lsm_tree::coding::Decode;
-use lsm_tree::inspect::read_table_properties;
+use lsm_tree::inspect::{read_table_properties, read_top_level_index_entries};
 use lsm_tree::table::block::Header;
 use lsm_tree::verify::{BlockVerifyError, verify_sst_file};
 use std::fs::File;
@@ -88,6 +88,17 @@ enum Command {
     /// directly (with MID-mirror fallback per #295); does not open a
     /// live `Tree` or touch the manifest.
     Properties,
+
+    /// Print the SST's top-level index (TLI) entries: one row per
+    /// pointed-at block with its `end_key`, file `offset`, on-disk
+    /// `size`, and the highest `seqno` it covers. For full-index
+    /// tables each row corresponds to a data block; for
+    /// partitioned-index tables each row corresponds to a sub-index
+    /// leaf block (one further indirection from data blocks). Useful
+    /// for diagnosing range-read fan-out and verifying the TLI
+    /// matches what `verify` walked. Reads the TLI directly (with
+    /// tail-mirror fallback per #296); does not open a live `Tree`.
+    IndexDump,
 }
 
 fn main() -> ExitCode {
@@ -101,6 +112,7 @@ fn main() -> ExitCode {
             no_header,
         } => run_hex(&cli.file, offset, len, no_header),
         Command::Properties => run_properties(&cli.file),
+        Command::IndexDump => run_index_dump(&cli.file),
     }
 }
 
@@ -328,6 +340,46 @@ fn run_properties(path: &std::path::Path) -> ExitCode {
     println!("index_block_count:   {}", props.index_block_count);
     println!("data_compression:    {:?}", props.data_block_compression,);
     println!("index_compression:   {:?}", props.index_block_compression,);
+
+    ExitCode::SUCCESS
+}
+
+fn run_index_dump(path: &std::path::Path) -> ExitCode {
+    let entries = match read_top_level_index_entries(path) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: read TLI of {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("file:                {}", path.display());
+    println!("tli_entry_count:     {}", entries.len());
+    println!();
+
+    if entries.is_empty() {
+        return ExitCode::SUCCESS;
+    }
+
+    // Header row. Columns are left-aligned; widths chosen so a
+    // 64-bit offset (up to 20 digits) and u32 size (up to 10) line
+    // up against a typical key prefix without crowding. Keys can be
+    // arbitrarily long; place `end_key` last so wrap-around doesn't
+    // mis-align the numeric columns.
+    println!(
+        "{:>5}  {:>20}  {:>10}  {:>20}  end_key",
+        "#", "offset", "size", "seqno",
+    );
+    for (i, e) in entries.iter().enumerate() {
+        println!(
+            "{:>5}  {:>20}  {:>10}  {:>20}  {}",
+            i,
+            e.offset,
+            e.size,
+            e.seqno,
+            format_key(&e.end_key),
+        );
+    }
 
     ExitCode::SUCCESS
 }

--- a/tools/sst-dump/tests/index_dump_smoke.rs
+++ b/tools/sst-dump/tests/index_dump_smoke.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test for the `index-dump` subcommand: build a
+//! real SST, then drive `sst-dump index-dump` against it and check
+//! the structure of the printed table.
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter, compression::CompressionType,
+    config::CompressionPolicy,
+};
+use std::process::Command;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+fn build_one_sst(item_count: u64) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()
+    .expect("open tree");
+
+    for i in 0..item_count {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+    (dir, sst)
+}
+
+fn line_value(text: &str, label: &str) -> Option<String> {
+    let prefix = format!("{label}:");
+    text.lines().find_map(|line| {
+        line.strip_prefix(&prefix)
+            .map(|rest| rest.trim().to_owned())
+    })
+}
+
+#[test]
+fn index_dump_prints_header_row_and_entries() {
+    let (_dir, sst) = build_one_sst(200);
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("index-dump")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0, got {:?}; stdout:\n{stdout}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Entry count line is present and matches a non-zero parse.
+    let entry_count: u64 = line_value(&stdout, "tli_entry_count")
+        .and_then(|s| s.parse().ok())
+        .expect("tli_entry_count parses");
+    assert!(
+        entry_count >= 1,
+        "expected >= 1 TLI entries (single-block SSTs still emit one row); got {entry_count}",
+    );
+
+    // Header row of the table is present.
+    assert!(
+        stdout.contains("#"),
+        "expected header row in output; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("end_key"),
+        "expected `end_key` column header; got:\n{stdout}",
+    );
+
+    // The last entry's end_key must be the largest key we inserted
+    // ("key-000199"), because TLI is sorted and the final row's
+    // end_key covers the highest key in the SST. Use the quoted
+    // form to anchor against the format_key wrapping.
+    assert!(
+        stdout.contains("\"key-000199\""),
+        "expected the largest inserted key 'key-000199' in output; got:\n{stdout}",
+    );
+}
+
+#[test]
+fn index_dump_fails_on_missing_file() {
+    let bogus = tempfile::tempdir().expect("tempdir");
+    let nonexistent = bogus.path().join("does-not-exist");
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&nonexistent)
+        .arg("index-dump")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on missing file",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("error:"),
+        "expected `error:` line in stderr; got:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

Third subcommand from the remaining-three list in #324. `sst-dump <file> index-dump` prints the SST's top-level-index (TLI) entries: one row per pointed-at block.

For full-index tables each row corresponds to a data block; for partitioned-index tables each row corresponds to a sub-index leaf block (one further indirection from data blocks).

## Library API

Extends `lsm_tree::inspect`:

\`\`\`rust
#[non_exhaustive]
pub struct IndexEntry {
    pub end_key: Vec<u8>,
    pub seqno: u64,
    pub offset: u64,
    pub size: u32,
}

pub fn read_top_level_index_entries(path: &Path) -> Result<Vec<IndexEntry>>;
\`\`\`

Owned `end_key: Vec<u8>` decouples the public API from the crate-internal `KeyedBlockHandle` / `UserKey` aliases under `#[doc(hidden)]`, same pattern as `TableProperties`'s `min_key` / `max_key`.

Recovery mirrors \`Table::read_tli\` (PR #296): tail \`tli_tail\` mirror first, head \`tli\` fallback on decode failure, original tail error returned if both copies fail. Tables without \`tli_tail\` (pre-mirror SSTs) fall straight through to the head copy.

The meta block load uses the same TAIL-first / MID-fallback as \`read_table_properties\` — needed because \`index_block_compression\` lives in the meta block and is required to decode the TLI's compressed bytes.

## CLI output

\`\`\`
$ sst-dump table-0 index-dump
file:                table-0
tli_entry_count:     1

    #                offset        size                 seqno  end_key
    0                     0        4115                   200  \"key-000199\"
\`\`\`

Numeric columns are right-aligned; \`end_key\` is last so a long key doesn't mis-align the offset / size columns. Keys rendered via the existing \`format_key\` helper (printable ASCII verbatim, \`\"\` / \`\\\` escaped, others as \`\\xNN\`).

## Tests

\`tools/sst-dump/tests/index_dump_smoke.rs\` (2 new):

- \`index_dump_prints_header_row_and_entries\` — builds a 200-item SST, asserts \`tli_entry_count >= 1\`, header row contains the \`end_key\` column label, and the last entry's \`end_key\` equals the largest inserted key (\`key-000199\`).
- \`index_dump_fails_on_missing_file\` — exits non-zero with \`error:\` in stderr.

## Test plan

- [x] \`cargo nextest run\` in \`tools/sst-dump/\` (10 tests pass: 2 new \`index_dump_smoke\` + 4 \`hex_smoke\` + 2 \`properties_smoke\` + 2 \`verify_smoke\`)
- [x] \`cargo nextest run\` main suite (1413 pass)
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean on both crates
- [x] README \`Operational tools\` row updated

Part of #324. Remaining subcommands after this: \`dump\` (streaming KV entries) and \`filter-stats\` (BuRR/Ribbon sizing + FPR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `index-dump` subcommand to `sst-dump` to print top-level index entries from an SST file as a formatted table (offset, size, seqno, end key) and report total entry count.

* **Documentation**
  * Updated README to document the `index-dump` subcommand and its diagnostic behavior.

* **Tests**
  * Added end-to-end smoke tests covering successful output and failure-on-missing-file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->