### PR TITLE
feat(sst-dump): filter-stats subcommand + public inspect::read_filter_stats facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo run --release --features flamegraph -- \
 | Tool | Use |
 |------|-----|
 | [`tools/db_bench`](tools/db_bench) | RocksDB-compatible benchmark suite, also drives the CI perf dashboard. |
-| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `properties` (print the SST's stored metadata: id, key range, KV / tombstone counts, block counts, compression, timestamp), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`), `index-dump` (print TLI entries: end_key + offset + size + seqno per pointed-at block; useful for diagnosing range-read fan-out). |
+| [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `properties` (print the SST's stored metadata: id, key range, KV / tombstone counts, block counts, compression, timestamp), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`), `index-dump` (print TLI entries: end_key + offset + size + seqno per pointed-at block; useful for diagnosing range-read fan-out), `filter-stats` (print BuRR filter sizing: section bytes, layer count, item count, approximate bits-per-key; single-block filters only, partitioned filters not yet supported). |
 
 ## Manifest recovery modes
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,6 +137,16 @@ pub enum Error {
         /// Number of tables actually found across all configured routes.
         found: usize,
     },
+
+    /// Valid on-disk layout that this build does not yet know how to
+    /// process. Distinct from [`Error::Unrecoverable`] (which signals
+    /// corruption) and from [`Error::Io`] with `ErrorKind::Unsupported`
+    /// (which can also surface from platform / backend limits); the
+    /// `&'static str` payload names the specific layout marker that
+    /// triggered the rejection (e.g. `"filter_tli"` for a partitioned
+    /// filter SFA section) so the caller can route the diagnostic
+    /// without parsing message strings.
+    FeatureUnsupported(&'static str),
 }
 
 impl std::fmt::Display for Error {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -437,12 +437,22 @@ pub struct FilterStats {
 /// - the `BuRR` wire format cannot be parsed (magic mismatch,
 ///   unsupported version, structurally invalid header).
 ///
-/// Returns `Ok(None)` when the SST simply has no `filter` SFA
-/// section. That is a valid layout: a tree configured with
+/// Returns `Ok(None)` for both on-disk shapes of "no filter
+/// installed":
+///
+/// 1. the SST has no `filter` SFA section at all, or
+/// 2. the section is present but carries a zero-byte payload (the
+///    [`crate::table::filter::block::FilterBlock`] sentinel for "no
+///    filter"; the writer emits it when the filter policy resolves
+///    to no usable filter at flush time, which is structurally
+///    equivalent to the absent-section case).
+///
+/// A tree configured with
 /// [`FilterPolicy::disabled`](crate::config::FilterPolicy::disabled)
 /// (or any policy whose per-level entry is
 /// [`FilterPolicyEntry::None`](crate::config::FilterPolicyEntry::None))
-/// produces filter-less SSTs.
+/// produces filter-less SSTs that take one of these two shapes;
+/// either way callers see the same `Ok(None)` result.
 #[cfg(feature = "std")]
 pub fn read_filter_stats(path: &Path) -> crate::Result<Option<FilterStats>> {
     use crate::table::block::{Block, BlockIdentity, BlockType};

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -383,8 +383,10 @@ pub struct FilterStats {
     pub filter_section_bytes: u64,
     /// Number of `BuRR` / Ribbon "layers" the writer emitted. Each
     /// layer is a Bumped-Ribbon-Retrieval pass; more layers means a
-    /// larger filter at a given key count but tighter FPR.
-    pub layer_count: usize,
+    /// larger filter at a given key count but tighter FPR. Fixed-width
+    /// `u64` so the public layout doesn't vary between 32-bit and
+    /// 64-bit targets, matching the rest of the inspect facade.
+    pub layer_count: u64,
     /// Number of keys the meta block reports for the table. Used as
     /// the denominator for `bits_per_key`; sourced from
     /// `TableProperties.item_count` and copied here so callers can
@@ -538,10 +540,14 @@ pub fn read_filter_stats(path: &Path) -> crate::Result<Option<FilterStats>> {
     // that case; `bits_per_key` still follows the documented
     // formula below (block header bytes / item_count), so the
     // field semantics stay consistent with `FilterStats`'s doc.
-    let layer_count = if block.data.is_empty() {
+    let layer_count: u64 = if block.data.is_empty() {
         0
     } else {
-        BurrFilterReader::new(&block.data)?.layer_count()
+        // BurrFilterReader::layer_count returns usize; widen to u64 at
+        // the public-API boundary. usize -> u64 is lossless on every
+        // target Rust supports (u64 is at least as wide as usize on
+        // 32-bit and identical on 64-bit).
+        BurrFilterReader::new(&block.data)?.layer_count() as u64
     };
 
     // `item_count` is `u64`; cast to `f64` is lossy for values above

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -429,7 +429,10 @@ pub struct FilterStats {
 /// - the SFA trailer is missing / malformed,
 /// - the `meta` block fails to decode (needed for `item_count`),
 /// - the table has a `filter_tli` SFA section (partitioned filter,
-///   not supported by this facade — see Scope above),
+///   not supported by this facade): returned as
+///   returned as `Error::FeatureUnsupported("filter_tli")` (see
+///   [`crate::Error::FeatureUnsupported`]) so callers can match the
+///   typed variant instead of parsing message strings,
 /// - the `filter` block header / payload is malformed,
 /// - the `BuRR` wire format cannot be parsed (magic mismatch,
 ///   unsupported version, structurally invalid header).
@@ -455,20 +458,13 @@ pub fn read_filter_stats(path: &Path) -> crate::Result<Option<FilterStats>> {
     if regions.filter_tli.is_some() {
         // Partitioned filter: a `filter_tli` SFA section is present
         // alongside `filter`, and the contents of `filter` are a
-        // concatenation of per-partition `BuRR` payloads — not a single
-        // parseable wire buffer. Surface this as
-        // `io::ErrorKind::Unsupported` (NOT `Unrecoverable`) so the
-        // caller can distinguish "valid but unsupported layout" from
-        // "corrupted SST" via `Error::source` / `kind()`. The message
-        // tells the operator how to identify the case ("filter_tli
-        // section present") so they can route to a partitioned-aware
-        // inspector once one exists.
-        return Err(crate::Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "partitioned filter (filter_tli section present) is not yet supported \
-             by read_filter_stats; per-partition stats need a separate API surface \
-             that walks the TLI and reports aggregate or per-partition metrics",
-        )));
+        // concatenation of per-partition `BuRR` payloads, not a
+        // single parseable wire buffer. Surface this as the typed
+        // `Error::FeatureUnsupported("filter_tli")` so callers can
+        // match on the marker without parsing message strings; the
+        // payload literal is the SFA section name an operator can
+        // confirm via the TOC.
+        return Err(crate::Error::FeatureUnsupported("filter_tli"));
     }
 
     let Some(filter_handle) = regions.filter else {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -430,7 +430,7 @@ pub struct FilterStats {
 /// - the `meta` block fails to decode (needed for `item_count`),
 /// - the table has a `filter_tli` SFA section (partitioned filter,
 ///   not supported by this facade): returned as
-///   returned as `Error::FeatureUnsupported("filter_tli")` (see
+///   `Error::FeatureUnsupported("filter_tli")` (see
 ///   [`crate::Error::FeatureUnsupported`]) so callers can match the
 ///   typed variant instead of parsing message strings,
 /// - the `filter` block header / payload is malformed,

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -361,3 +361,210 @@ fn load_index_block(
 
     Ok(block)
 }
+
+/// Read-only stats for a single-block (full) `BuRR` / Ribbon filter
+/// section.
+///
+/// Returned by [`read_filter_stats`]. For partitioned-filter tables
+/// (those with a `filter_tli` SFA section) this struct is not
+/// populated — see `read_filter_stats` for the contract. Stats are
+/// derived from the public
+/// [`BurrFilterReader`](crate::table::filter::ribbon::burr::BurrFilterReader)
+/// surface plus the SFA section size; no internal filter bits are
+/// exposed here.
+///
+/// `#[non_exhaustive]` so new fields can be added in a minor version
+/// bump.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FilterStats {
+    /// On-disk size of the `filter` SFA section in bytes, including
+    /// the block `Header` prefix.
+    pub filter_section_bytes: u64,
+    /// Number of `BuRR` / Ribbon "layers" the writer emitted. Each
+    /// layer is a Bumped-Ribbon-Retrieval pass; more layers means a
+    /// larger filter at a given key count but tighter FPR.
+    pub layer_count: usize,
+    /// Number of keys the meta block reports for the table. Used as
+    /// the denominator for `bits_per_key`; sourced from
+    /// `TableProperties.item_count` and copied here so callers can
+    /// compute the rate without a second `read_table_properties`
+    /// call.
+    pub item_count: u64,
+    /// Approximate average bits-per-key the filter consumes:
+    /// `filter_section_bytes * 8 / max(item_count, 1)`. This is a
+    /// SIZE metric, not the true theoretical `BuRR` overhead — it
+    /// includes the block `Header`, the `BuRR` wire-format header,
+    /// per-layer payload framing, and any zero-padding bits at the
+    /// end of each layer's storage word array. Treat it as an
+    /// upper bound on the actual ribbon parameter `bits_per_key`.
+    pub bits_per_key: f64,
+}
+
+/// Reads `path` and returns `BuRR` filter sizing stats for the SST's
+/// `filter` section, or `Ok(None)` if the SST has no filter section
+/// at all (filter-less table).
+///
+/// **Scope:** only the single-block (full) filter layout is
+/// supported by this facade. SSTs with a `filter_tli` SFA section
+/// (partitioned filter) return an error — per-partition stats need
+/// a different surface that walks the TLI and reports a
+/// `Vec<FilterStats>` or aggregate metrics, and that is a separate
+/// public-API decision not yet made.
+///
+/// Same out-of-band path-based open semantics as
+/// [`read_table_properties`]: uses [`StdFs`], no encryption provider.
+/// Recovery for the meta block (needed to source `item_count`)
+/// mirrors the TAIL-first / MID-fallback pattern from #295. The
+/// filter block itself is written uncompressed (see
+/// `FullFilterWriter::finish`), so no compression-codec dependency on
+/// the read path here.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - the file cannot be opened or read,
+/// - the SFA trailer is missing / malformed,
+/// - the `meta` block fails to decode (needed for `item_count`),
+/// - the table has a `filter_tli` SFA section (partitioned filter,
+///   not supported by this facade — see Scope above),
+/// - the `filter` block header / payload is malformed,
+/// - the `BuRR` wire format cannot be parsed (magic mismatch,
+///   unsupported version, structurally invalid header).
+///
+/// Returns `Ok(None)` when the SST simply has no `filter` SFA
+/// section. That is a valid layout: a tree configured with
+/// [`FilterPolicy::disabled`](crate::config::FilterPolicy::disabled)
+/// (or any policy whose per-level entry is
+/// [`FilterPolicyEntry::None`](crate::config::FilterPolicyEntry::None))
+/// produces filter-less SSTs.
+#[cfg(feature = "std")]
+pub fn read_filter_stats(path: &Path) -> crate::Result<Option<FilterStats>> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+    use crate::table::filter::ribbon::burr::BurrFilterReader;
+
+    let fs = StdFs;
+    let mut file = fs.open(path, &FsOpenOptions::new().read(true))?;
+
+    let sfa_reader = sfa::Reader::from_reader(&mut file)?;
+    let toc = sfa_reader.toc();
+    let regions = ParsedRegions::parse_from_toc(toc)?;
+
+    if regions.filter_tli.is_some() {
+        // Partitioned filter: a `filter_tli` SFA section is present
+        // alongside `filter`, and the contents of `filter` are a
+        // concatenation of per-partition `BuRR` payloads — not a single
+        // parseable wire buffer. Surface this as
+        // `io::ErrorKind::Unsupported` (NOT `Unrecoverable`) so the
+        // caller can distinguish "valid but unsupported layout" from
+        // "corrupted SST" via `Error::source` / `kind()`. The message
+        // tells the operator how to identify the case ("filter_tli
+        // section present") so they can route to a partitioned-aware
+        // inspector once one exists.
+        return Err(crate::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "partitioned filter (filter_tli section present) is not yet supported \
+             by read_filter_stats; per-partition stats need a separate API surface \
+             that walks the TLI and reports aggregate or per-partition metrics",
+        )));
+    }
+
+    let Some(filter_handle) = regions.filter else {
+        return Ok(None);
+    };
+    let filter_section_bytes = u64::from(filter_handle.size());
+
+    // Meta block carries `item_count`. Same TAIL-first / MID-fallback
+    // as `read_table_properties` so a partially-corrupted meta still
+    // yields stats from the surviving copy.
+    let meta = match ParsedMeta::load_with_handle(&*file, &regions.metadata, None) {
+        Ok(m) => m,
+        Err(tail_err) => {
+            if let Some(mid_handle) = regions.metadata_mid {
+                match ParsedMeta::load_with_handle(&*file, &mid_handle, None) {
+                    Ok(mid) => mid,
+                    Err(_) => return Err(tail_err),
+                }
+            } else {
+                return Err(tail_err);
+            }
+        }
+    };
+    let item_count = meta.item_count;
+    let table_id = meta.id;
+
+    // Filter blocks are written uncompressed by `FullFilterWriter`
+    // (see `src/table/writer/filter/full.rs::finish` — it passes
+    // `CompressionType::None`). No compression-codec lookup needed
+    // on the read path.
+    //
+    // `block_offset` is held at 0 here even though
+    // `filter_handle.offset()` carries the real on-disk position,
+    // because the writer
+    // (`src/table/writer/filter/full.rs::finish`) emits the filter
+    // block with `BlockIdentity { block_offset: 0, ... }`. Reader
+    // and writer must agree on BlockIdentity for AEAD verification
+    // once #251 wires it into AAD; switching only this side to
+    // `filter_handle.offset()` would break that agreement.
+    // Threading real offsets through both sides is a coordinated
+    // change tracked alongside #251.
+    let block = Block::from_file(
+        &*file,
+        filter_handle,
+        BlockIdentity {
+            tree_id: 0,
+            table_id,
+            block_offset: 0,
+            block_type: BlockType::Filter,
+            dict_id: 0,
+            window_log: 0,
+        },
+        CompressionType::None,
+        None,
+        #[cfg(zstd_any)]
+        None,
+    )?;
+    if block.header.block_type != BlockType::Filter {
+        return Err(crate::Error::InvalidTag((
+            "BlockType",
+            block.header.block_type.into(),
+        )));
+    }
+
+    // Empty data slice is the "no filter installed" sentinel
+    // (see `FilterBlock::maybe_contains_hash`); `BurrFilterReader::new`
+    // would reject it with `InvalidHeader` (magic mismatch on the
+    // empty buffer), so route around it. `layer_count` is 0 in
+    // that case; `bits_per_key` still follows the documented
+    // formula below (block header bytes / item_count), so the
+    // field semantics stay consistent with `FilterStats`'s doc.
+    let layer_count = if block.data.is_empty() {
+        0
+    } else {
+        BurrFilterReader::new(&block.data)?.layer_count()
+    };
+
+    // `item_count` is `u64`; cast to `f64` is lossy for values above
+    // 2^53 (~9 quadrillion), which is well past anything a real SST
+    // holds. The lossy cast is the standard pattern for size
+    // statistics here — clippy's `cast_precision_loss` lint is
+    // already allowed crate-wide for this kind of arithmetic.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "filter stats are diagnostic; precision loss above 2^53 keys is irrelevant"
+    )]
+    let denom = item_count.max(1) as f64;
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "filter stats are diagnostic; precision loss above 2^53 bytes is irrelevant"
+    )]
+    let bits = (filter_section_bytes * 8) as f64;
+    let bits_per_key = bits / denom;
+
+    Ok(Some(FilterStats {
+        filter_section_bytes,
+        layer_count,
+        item_count,
+        bits_per_key,
+    }))
+}

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -529,22 +529,25 @@ pub fn read_filter_stats(path: &Path) -> crate::Result<Option<FilterStats>> {
         )));
     }
 
-    // Empty data slice is the "no filter installed" sentinel
-    // (see `FilterBlock::maybe_contains_hash`); `BurrFilterReader::new`
-    // would reject it with `InvalidHeader` (magic mismatch on the
-    // empty buffer), so route around it. `layer_count` is 0 in
-    // that case; `bits_per_key` still follows the documented
-    // formula below (block header bytes / item_count), so the
-    // field semantics stay consistent with `FilterStats`'s doc.
-    let layer_count: u64 = if block.data.is_empty() {
-        0
-    } else {
-        // BurrFilterReader::layer_count returns usize; widen to u64 at
-        // the public-API boundary. usize -> u64 is lossless on every
-        // target Rust supports (u64 is at least as wide as usize on
-        // 32-bit and identical on 64-bit).
-        BurrFilterReader::new(&block.data)?.layer_count() as u64
-    };
+    // Empty data slice is the "no filter installed" sentinel (see
+    // `FilterBlock::maybe_contains_hash`). The on-disk shape of "no
+    // filter present" can be either the section absent entirely
+    // OR the section present with a zero-byte payload; both mean
+    // the same thing semantically. Collapse the empty-payload case
+    // to the same `Ok(None)` result the section-absent branch
+    // above returns, so the CLI prints the documented
+    // "no filter section installed" line for either shape and the
+    // public API stays consistent with the FilterBlock sentinel
+    // contract.
+    if block.data.is_empty() {
+        return Ok(None);
+    }
+
+    // BurrFilterReader::layer_count returns usize; widen to u64 at
+    // the public-API boundary. usize -> u64 is lossless on every
+    // target Rust supports (u64 is at least as wide as usize on
+    // 32-bit and identical on 64-bit).
+    let layer_count: u64 = BurrFilterReader::new(&block.data)?.layer_count() as u64;
 
     // `item_count` is `u64`; cast to `f64` is lossy for values above
     // 2^53 (~9 quadrillion), which is well past anything a real SST

--- a/tools/sst-dump/Cargo.toml
+++ b/tools/sst-dump/Cargo.toml
@@ -32,3 +32,7 @@ clap = { version = "4", features = ["derive"] }
 # lsm-tree public API, then drive the compiled sst-dump binary
 # against it.
 tempfile = "3"
+# Tests inspect the SFA TOC directly to confirm on-disk shape
+# (e.g. `filter_tli` section presence) before driving the CLI.
+# Matches the version pinned by the main crate.
+sfa = "~1.0.0"

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -11,7 +11,7 @@
 
 use clap::{Parser, Subcommand};
 use lsm_tree::coding::Decode;
-use lsm_tree::inspect::{read_table_properties, read_top_level_index_entries};
+use lsm_tree::inspect::{read_filter_stats, read_table_properties, read_top_level_index_entries};
 use lsm_tree::table::block::Header;
 use lsm_tree::verify::{BlockVerifyError, verify_sst_file};
 use std::fs::File;
@@ -99,6 +99,15 @@ enum Command {
     /// matches what `verify` walked. Reads the TLI directly (with
     /// tail-mirror fallback per #296); does not open a live `Tree`.
     IndexDump,
+
+    /// Print sizing stats for the SST's BuRR filter: on-disk filter
+    /// section bytes, BuRR layer count, item count from meta, and
+    /// approximate bits-per-key. Only single-block (full) filters
+    /// are supported by this subcommand; partitioned-filter tables
+    /// (`filter_tli` SFA section present) exit non-zero with a
+    /// "not supported" error. Filter-less tables (no `filter`
+    /// section at all) exit 0 with a "no filter installed" notice.
+    FilterStats,
 }
 
 fn main() -> ExitCode {
@@ -113,6 +122,7 @@ fn main() -> ExitCode {
         } => run_hex(&cli.file, offset, len, no_header),
         Command::Properties => run_properties(&cli.file),
         Command::IndexDump => run_index_dump(&cli.file),
+        Command::FilterStats => run_filter_stats(&cli.file),
     }
 }
 
@@ -381,6 +391,48 @@ fn run_index_dump(path: &std::path::Path) -> ExitCode {
             format_key(&e.end_key),
         );
     }
+
+    ExitCode::SUCCESS
+}
+
+fn run_filter_stats(path: &std::path::Path) -> ExitCode {
+    let stats = match read_filter_stats(path) {
+        Ok(s) => s,
+        Err(lsm_tree::Error::Io(io_err)) if io_err.kind() == std::io::ErrorKind::Unsupported => {
+            // Partitioned-filter SSTs surface here. Match the inner
+            // `io::ErrorKind::Unsupported` so the CLI prints a
+            // user-facing "not supported" line instead of the
+            // bare-Display of the inner error; mention the
+            // distinguishing on-disk signal (`filter_tli` SFA section)
+            // so an operator can confirm the diagnosis with `verify
+            // --verbose` or a hex dump of the SFA TOC.
+            eprintln!(
+                "error: filter-stats not supported for {}: {io_err} \
+                 (look for a `filter_tli` section in the SFA TOC to confirm)",
+                path.display(),
+            );
+            return ExitCode::FAILURE;
+        }
+        Err(e) => {
+            eprintln!("error: read filter stats of {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("file:                {}", path.display());
+    let Some(stats) = stats else {
+        println!("filter:              no filter section installed");
+        return ExitCode::SUCCESS;
+    };
+
+    println!("filter_section_size: {} bytes", stats.filter_section_bytes);
+    println!("layer_count:         {}", stats.layer_count);
+    println!("item_count:          {}", stats.item_count);
+    // Three decimals is enough resolution for diagnostic use without
+    // implying false precision; bits-per-key for production filters
+    // is typically in the 5-15 range, occasionally up to ~30 with
+    // tight FPR targets, so the integer part is always small.
+    println!("bits_per_key:        {:.3}", stats.bits_per_key);
 
     ExitCode::SUCCESS
 }

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -398,14 +398,20 @@ fn run_index_dump(path: &std::path::Path) -> ExitCode {
 fn run_filter_stats(path: &std::path::Path) -> ExitCode {
     let stats = match read_filter_stats(path) {
         Ok(s) => s,
-        Err(lsm_tree::Error::Io(io_err)) if io_err.kind() == std::io::ErrorKind::Unsupported => {
-            // Partitioned-filter SSTs surface here. Match the inner
-            // `io::ErrorKind::Unsupported` so the CLI prints a
-            // user-facing "not supported" line instead of the
-            // bare-Display of the inner error; mention the
-            // distinguishing on-disk signal (`filter_tli` SFA section)
-            // so an operator can confirm the diagnosis with `verify
-            // --verbose` or a hex dump of the SFA TOC.
+        Err(lsm_tree::Error::Io(io_err))
+            if io_err.kind() == std::io::ErrorKind::Unsupported
+                && io_err.to_string().contains("filter_tli") =>
+        {
+            // Partitioned-filter SSTs surface here. Match BOTH the
+            // `io::ErrorKind::Unsupported` discriminant AND the
+            // `filter_tli` substring in the message so an unrelated
+            // platform-level Unsupported (e.g. an `FsFile::read_at`
+            // backend that doesn't implement positional reads on a
+            // non-mainstream target) doesn't get mis-attributed as
+            // a partitioned-filter layout. The substring is what
+            // `read_filter_stats` writes deliberately when it detects
+            // a `filter_tli` SFA section; the kind alone is too
+            // coarse to be a reliable discriminator.
             eprintln!(
                 "error: filter-stats not supported for {}: {io_err} \
                  (look for a `filter_tli` section in the SFA TOC to confirm)",

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -398,23 +398,16 @@ fn run_index_dump(path: &std::path::Path) -> ExitCode {
 fn run_filter_stats(path: &std::path::Path) -> ExitCode {
     let stats = match read_filter_stats(path) {
         Ok(s) => s,
-        Err(lsm_tree::Error::Io(io_err))
-            if io_err.kind() == std::io::ErrorKind::Unsupported
-                && io_err.to_string().contains("filter_tli") =>
-        {
-            // Partitioned-filter SSTs surface here. Match BOTH the
-            // `io::ErrorKind::Unsupported` discriminant AND the
-            // `filter_tli` substring in the message so an unrelated
-            // platform-level Unsupported (e.g. an `FsFile::read_at`
-            // backend that doesn't implement positional reads on a
-            // non-mainstream target) doesn't get mis-attributed as
-            // a partitioned-filter layout. The substring is what
-            // `read_filter_stats` writes deliberately when it detects
-            // a `filter_tli` SFA section; the kind alone is too
-            // coarse to be a reliable discriminator.
+        Err(lsm_tree::Error::FeatureUnsupported(marker)) => {
+            // Partitioned-filter SSTs surface here. Match the typed
+            // `FeatureUnsupported` variant directly so control flow
+            // doesn't depend on a message-string substring; the
+            // `marker` payload is the SFA section name the operator
+            // can confirm via the TOC.
             eprintln!(
-                "error: filter-stats not supported for {}: {io_err} \
-                 (look for a `filter_tli` section in the SFA TOC to confirm)",
+                "error: filter-stats not supported for {}: \
+                 valid-but-unsupported layout (look for a `{marker}` \
+                 section in the SFA TOC to confirm)",
                 path.display(),
             );
             return ExitCode::FAILURE;

--- a/tools/sst-dump/tests/filter_stats_smoke.rs
+++ b/tools/sst-dump/tests/filter_stats_smoke.rs
@@ -6,8 +6,11 @@
 //! filter-stats` against it and check the printed metrics.
 
 use lsm_tree::{
-    AbstractTree, Config, SequenceNumberCounter, compression::CompressionType,
-    config::CompressionPolicy,
+    AbstractTree, Config, SequenceNumberCounter,
+    compression::CompressionType,
+    config::{
+        BloomConstructionPolicy, CompressionPolicy, FilterPolicy, FilterPolicyEntry, PinningPolicy,
+    },
 };
 use std::process::Command;
 
@@ -15,12 +18,22 @@ const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
 
 fn build_one_sst(item_count: u64) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempfile::tempdir().expect("tempdir");
+    // Pin the filter policy explicitly instead of relying on the
+    // crate's default. The default ships with BuRR-on-every-level
+    // today, but a future refactor (default tweak, level-0 carve-out,
+    // dynamic policy) could turn filters off for the level our
+    // single-flush SST lands in, and this test would then fail for
+    // reasons unrelated to filter-stats itself. Explicit pin keeps
+    // the smoke test stable.
     let tree = Config::new(
         dir.path(),
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
     .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .filter_policy(FilterPolicy::all(FilterPolicyEntry::Bloom(
+        BloomConstructionPolicy::BitsPerKey(10.0),
+    )))
     .open()
     .expect("open tree");
 
@@ -97,6 +110,82 @@ fn filter_stats_prints_expected_fields() {
         .and_then(|s| s.parse().ok())
         .expect("bits_per_key parses as float");
     assert!(bpk > 0.0, "expected bits_per_key > 0; got {bpk}");
+}
+
+#[test]
+fn filter_stats_rejects_partitioned_filter_with_not_supported_message() {
+    // Build an SST with the filter partitioning policy turned on for
+    // every level. The writer emits both `filter` and `filter_tli`
+    // SFA sections, which is exactly the layout this subcommand
+    // refuses to handle today (the partitioned `filter` section is a
+    // concatenation of per-partition BuRR payloads, not a single
+    // parseable wire buffer).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .filter_policy(FilterPolicy::all(FilterPolicyEntry::Bloom(
+        BloomConstructionPolicy::BitsPerKey(10.0),
+    )))
+    .filter_block_partitioning_policy(PinningPolicy::all(true))
+    .open()
+    .expect("open tree");
+
+    // Enough keys to actually produce multiple filter partitions:
+    // a tiny SST with one partition collapses back to the full case
+    // on some configurations.
+    for i in 0..2048u64 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+
+    // Sanity-check the on-disk shape before driving the CLI: if the
+    // writer didn't actually emit `filter_tli` for this fixture
+    // (e.g. because the keyset shrank below the partitioning
+    // threshold on some platform), the assertions below would test
+    // the wrong code path.
+    let has_filter_tli = {
+        let mut file = std::fs::File::open(&sst).expect("open sst for toc inspection");
+        let reader = sfa::Reader::from_reader(&mut file).expect("sfa trailer parse");
+        reader.toc().section(b"filter_tli").is_some()
+    };
+    assert!(
+        has_filter_tli,
+        "test fixture must produce a `filter_tli` section; \
+         filter partitioning policy may have failed to take effect",
+    );
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("filter-stats")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on partitioned-filter SST; got success",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not supported"),
+        "expected `not supported` in stderr; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("filter_tli"),
+        "expected error message to name `filter_tli` so operators can confirm; got:\n{stderr}",
+    );
 }
 
 #[test]

--- a/tools/sst-dump/tests/filter_stats_smoke.rs
+++ b/tools/sst-dump/tests/filter_stats_smoke.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test for the `filter-stats` subcommand: build a
+//! real SST with a full BuRR filter, then drive `sst-dump
+//! filter-stats` against it and check the printed metrics.
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter, compression::CompressionType,
+    config::CompressionPolicy,
+};
+use std::process::Command;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+fn build_one_sst(item_count: u64) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()
+    .expect("open tree");
+
+    for i in 0..item_count {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+    (dir, sst)
+}
+
+fn line_value(text: &str, label: &str) -> Option<String> {
+    let prefix = format!("{label}:");
+    text.lines().find_map(|line| {
+        line.strip_prefix(&prefix)
+            .map(|rest| rest.trim().to_owned())
+    })
+}
+
+#[test]
+fn filter_stats_prints_expected_fields() {
+    const ITEM_COUNT: u64 = 200;
+    let (_dir, sst) = build_one_sst(ITEM_COUNT);
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("filter-stats")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0, got {:?}; stdout:\n{stdout}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Default Config builds a full BuRR filter for this fixture
+    // (filter policy is on by default; we did not call any
+    // filter-disabling builder). So all four fields must be
+    // populated with non-zero values.
+    assert_eq!(
+        line_value(&stdout, "item_count"),
+        Some(ITEM_COUNT.to_string()),
+        "expected item_count={ITEM_COUNT}; got:\n{stdout}",
+    );
+
+    let filter_bytes: u64 = line_value(&stdout, "filter_section_size")
+        .and_then(|s| s.strip_suffix(" bytes").map(str::to_owned))
+        .and_then(|s| s.parse().ok())
+        .expect("filter_section_size parses as `<n> bytes`");
+    assert!(
+        filter_bytes > 0,
+        "expected filter_section_size > 0 (default filter is on); got 0",
+    );
+
+    let layers: u64 = line_value(&stdout, "layer_count")
+        .and_then(|s| s.parse().ok())
+        .expect("layer_count parses");
+    assert!(layers >= 1, "expected at least 1 BuRR layer; got {layers}",);
+
+    // bits_per_key prints to three decimals; just check it parses
+    // and is positive.
+    let bpk: f64 = line_value(&stdout, "bits_per_key")
+        .and_then(|s| s.parse().ok())
+        .expect("bits_per_key parses as float");
+    assert!(bpk > 0.0, "expected bits_per_key > 0; got {bpk}");
+}
+
+#[test]
+fn filter_stats_fails_on_missing_file() {
+    let bogus = tempfile::tempdir().expect("tempdir");
+    let nonexistent = bogus.path().join("does-not-exist");
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&nonexistent)
+        .arg("filter-stats")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on missing file",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("error:"),
+        "expected `error:` line in stderr; got:\n{stderr}",
+    );
+}

--- a/tools/sst-dump/tests/filter_stats_smoke.rs
+++ b/tools/sst-dump/tests/filter_stats_smoke.rs
@@ -80,10 +80,10 @@ fn filter_stats_prints_expected_fields() {
         String::from_utf8_lossy(&out.stderr),
     );
 
-    // Default Config builds a full BuRR filter for this fixture
-    // (filter policy is on by default; we did not call any
-    // filter-disabling builder). So all four fields must be
-    // populated with non-zero values.
+    // The fixture pins `filter_policy = Bloom(BitsPerKey(10.0))`
+    // at every level explicitly (see `build_one_sst`), so the
+    // writer emits a full BuRR filter section. All four printed
+    // fields must therefore be populated with non-zero values.
     assert_eq!(
         line_value(&stdout, "item_count"),
         Some(ITEM_COUNT.to_string()),

--- a/tools/sst-dump/tests/filter_stats_smoke.rs
+++ b/tools/sst-dump/tests/filter_stats_smoke.rs
@@ -189,6 +189,60 @@ fn filter_stats_rejects_partitioned_filter_with_not_supported_message() {
 }
 
 #[test]
+fn filter_stats_filter_less_sst_prints_no_filter_section_installed_notice() {
+    // SST written with FilterPolicy::disabled() produces no `filter`
+    // SFA section at all (or a zero-byte one), which `read_filter_stats`
+    // collapses to `Ok(None)`. The CLI surface for that is the
+    // "no filter section installed" notice + exit 0. Pin both so a
+    // future regression that flips the `Ok(None)` branch to
+    // `Some(FilterStats { layer_count: 0, ... })` (printing
+    // bytes/bits-per-key for what is effectively no filter) is
+    // caught here.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .filter_policy(FilterPolicy::disabled())
+    .open()
+    .expect("open tree");
+
+    for i in 0..50u64 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("filter-stats")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected exit 0 on filter-less SST; got {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        out.status,
+    );
+    assert!(
+        stdout.contains("no filter section installed"),
+        "expected `no filter section installed` notice on stdout; got:\n{stdout}",
+    );
+}
+
+#[test]
 fn filter_stats_fails_on_missing_file() {
     let bogus = tempfile::tempdir().expect("tempdir");
     let nonexistent = bogus.path().join("does-not-exist");


### PR DESCRIPTION
## Summary

Fourth subcommand from #324. `sst-dump <file> filter-stats` prints BuRR filter sizing for the SST's `filter` SFA section.

After this lands, only one subcommand remains in #324: `dump` (streaming KV entries).

## Library API

New public surface in `lsm_tree::inspect`:

\`\`\`rust
#[non_exhaustive]
pub struct FilterStats {
    pub filter_section_bytes: u64,
    pub layer_count: u64,
    pub item_count: u64,
    pub bits_per_key: f64,
}

pub fn read_filter_stats(path: &Path) -> Result<Option<FilterStats>>;
\`\`\`

`Ok(None)` when the SST has no `filter` SFA section (filter-less table, valid layout under `FilterPolicy::Off`).

`bits_per_key` is `filter_section_bytes * 8 / max(item_count, 1)` and is documented as an UPPER BOUND on the true theoretical BuRR overhead — it includes the block `Header`, the BuRR wire-format header, per-layer payload framing, and any zero-padding bits, not just the ribbon storage proper.

## Scope

Only single-block (full) filters are supported. SSTs with a \`filter_tli\` SFA section (partitioned filter) return an error: per-partition stats need a different surface that walks the TLI and reports either a \`Vec<FilterStats>\` or aggregate metrics, and that public-API shape is not yet decided. Partitioned-filter support is left as a follow-up.

## CLI output

\`\`\`
$ sst-dump table-0 filter-stats
file:                table-0
filter_section_size: 195 bytes
layer_count:         2
item_count:          200
bits_per_key:        7.800
\`\`\`

Filter-less SSTs print \"filter: no filter section installed\" and exit 0. Missing files exit non-zero with an \`error:\` stderr line. Partitioned-filter tables exit non-zero with a precise error.

## Tests

\`tools/sst-dump/tests/filter_stats_smoke.rs\` (2 new):

- \`filter_stats_prints_expected_fields\` — builds a 200-item SST with default config (BuRR filter on), asserts \`item_count=200\`, \`filter_section_size > 0\`, \`layer_count >= 1\`, \`bits_per_key > 0\`.
- \`filter_stats_fails_on_missing_file\` — exits non-zero with \`error:\` in stderr.

## Test plan

- [x] \`cargo nextest run\` in \`tools/sst-dump/\` (10 tests pass: 2 new \`filter_stats_smoke\` + 4 \`hex_smoke\` + 2 \`properties_smoke\` + 2 \`verify_smoke\`)
- [x] \`cargo nextest run\` main suite (1413 pass)
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean on both crates
- [x] README \`Operational tools\` row updated

Part of #324.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `filter-stats` subcommand to `sst-dump` to report BuRR filter diagnostics: filter section size, layer count, item count, and bits-per-key (single-block filters only).
  * Emits a clear "not supported" message and non-zero exit for partitioned/unsupported filters.

* **Documentation**
  * README updated to document the new `filter-stats` subcommand and its single-block limitation.

* **Tests**
  * Added end-to-end smoke tests validating normal output, partitioned-filter rejection, absence-of-filter notice, and missing-file error handling.

* **Chores**
  * Test dev-dependency added to support on-disk inspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
