### PR TITLE
fix(table/index): default partitioned index ON at every level (#329)

### DIFF
--- a/benches/index_block.rs
+++ b/benches/index_block.rs
@@ -80,6 +80,10 @@ struct BenchTable {
 }
 
 fn build_table_for_point_read(restart_interval: u8) -> BenchTable {
+    build_table_for_point_read_inner(restart_interval, false)
+}
+
+fn build_table_for_point_read_inner(restart_interval: u8, partitioned: bool) -> BenchTable {
     let dir = tempfile::tempdir().expect("tempdir should be created");
     let path = dir.path().join("table.sst");
 
@@ -87,6 +91,9 @@ fn build_table_for_point_read(restart_interval: u8) -> BenchTable {
         .expect("writer should be created")
         .use_data_block_size(256)
         .use_index_block_restart_interval(restart_interval);
+    if partitioned {
+        writer = writer.use_partitioned_index();
+    }
 
     for i in 0..4096u32 {
         let key = format!("adj:out:vertex-0001:edge-{i:04}:target-0001");
@@ -158,5 +165,35 @@ fn bench_table_point_read(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_index_block_seek, bench_table_point_read);
+fn bench_table_point_read_index_layout(c: &mut Criterion) {
+    let mut group = c.benchmark_group("table_point_read_index_layout");
+
+    for &partitioned in &[false, true] {
+        let label = if partitioned { "partitioned" } else { "full" };
+        let bench_table = build_table_for_point_read_inner(1, partitioned);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(label),
+            &bench_table,
+            |b, bench_table| {
+                b.iter(|| {
+                    let value = bench_table
+                        .table
+                        .get(&bench_table.key, SeqNo::MAX, bench_table.key_hash)
+                        .expect("point read should succeed");
+                    assert!(value.is_some());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_index_block_seek,
+    bench_table_point_read,
+    bench_table_point_read_index_layout
+);
 criterion_main!(benches);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -493,7 +493,23 @@ impl Default for Config {
             top_level_index_block_pinning_policy: PinningPolicy::all(true), // TODO: implement
             top_level_filter_block_pinning_policy: PinningPolicy::all(true), // TODO: implement
 
-            index_block_partitioning_policy: PinningPolicy::new([false, false, false, true]),
+            // Partitioned at every level so a bit-flip inside one
+            // sub-index block only takes out the keys covered by that
+            // partition, not the entire SST. A full-index SST has no
+            // within-block redundancy: one corrupt byte in the single
+            // index block makes every data block in the table
+            // unreachable. See tests/partitioned_index_blast_radius.rs
+            // for the isolation property this default relies on.
+            index_block_partitioning_policy: PinningPolicy::all(true),
+            // Filter-block default intentionally left at the pre-#329
+            // shape (L3+ only). A corrupt filter block can produce a
+            // false negative (filter says "not present" → read short-
+            // circuits → caller misses an existing key), which is a
+            // correctness hazard distinct from index corruption (where
+            // the read fails loudly). Flipping this default is tracked
+            // as a separate decision pending a filter blast-radius /
+            // false-negative analysis; symmetry with index is not
+            // sufficient justification on its own.
             filter_block_partitioning_policy: PinningPolicy::new([false, false, false, true]),
 
             index_block_partition_size_policy: BlockSizePolicy::all(4_096), // TODO: implement

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Integration test for partitioned-index blast-radius isolation.
+//!
+//! When the index is partitioned, each sub-index block carries its own
+//! header / checksum. A bit-flip inside one sub-index partition must
+//! make ONLY that partition's data unreachable; reads against keys
+//! covered by OTHER sub-index partitions must still succeed.
+//!
+//! This is the test #296's acceptance matrix deferred and that
+//! justifies flipping the partitioned-index default ON for every
+//! level: blast radius shrinks from "whole SST unreadable" to "one
+//! partition unreadable".
+
+use lsm_tree::{
+    AbstractTree, Config, SequenceNumberCounter,
+    config::{BlockSizePolicy, PinningPolicy},
+    get_tmp_folder,
+    inspect::{IndexEntry, read_top_level_index_entries},
+};
+use std::{fs::OpenOptions, io::Write, path::Path};
+use test_log::test;
+
+fn find_table_file(dir: &Path) -> std::path::PathBuf {
+    let tables_dir = dir.join("tables");
+    let search_dir = if tables_dir.exists() {
+        tables_dir
+    } else {
+        dir.to_path_buf()
+    };
+    for entry in std::fs::read_dir(&search_dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_file() {
+            return entry.path();
+        }
+    }
+    panic!("no table file found in {}", search_dir.display());
+}
+
+fn corrupt_region(path: &Path, offset: u64, len: u64, byte: u8) {
+    use std::io::Seek;
+    let mut file = OpenOptions::new().write(true).open(path).unwrap();
+    file.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    let buf = vec![byte; len as usize];
+    file.write_all(&buf).unwrap();
+    file.sync_all().unwrap();
+}
+
+fn key_for(i: usize) -> String {
+    format!("key-{i:08}")
+}
+
+/// Builds a single-SST tree with a partitioned index that has many
+/// sub-index partitions, returns (dir, sst_path, total_items).
+fn build_partitioned_tree() -> (tempfile::TempDir, std::path::PathBuf, usize) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+
+    // Small data blocks → many data blocks → many index handles →
+    // many sub-index partitions (the partition-size budget is the
+    // hardcoded 4 KiB in the writer; we shrink the data block side
+    // to fit dozens of partitions in a reasonable corpus).
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .index_block_partitioning_policy(PinningPolicy::all(true))
+    .data_block_size_policy(BlockSizePolicy::all(256))
+    .open()
+    .unwrap();
+
+    let n = 30_000;
+    for i in 0..n {
+        tree.insert(key_for(i), b"value", 0);
+    }
+    tree.flush_active_memtable(0).unwrap();
+
+    let sst = find_table_file(dir.path());
+    (dir, sst, n)
+}
+
+fn reopen_partitioned(dir: &Path) -> lsm_tree::AnyTree {
+    Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .index_block_partitioning_policy(PinningPolicy::all(true))
+    .data_block_size_policy(BlockSizePolicy::all(256))
+    .open()
+    .expect("table reopen should succeed")
+}
+
+#[test]
+fn partitioned_index_corrupting_one_sub_block_only_affects_its_keys() {
+    let (dir, sst, n) = build_partitioned_tree();
+
+    let tli: Vec<IndexEntry> = read_top_level_index_entries(&sst).expect("read tli");
+    assert!(
+        tli.len() >= 3,
+        "test expects multiple sub-index partitions (got {})",
+        tli.len()
+    );
+
+    // Pick a middle sub-index partition — neither first nor last — so
+    // we exercise the case where a partition with intact neighbours on
+    // both sides is corrupted.
+    let victim_idx = tli.len() / 2;
+    let victim = &tli[victim_idx];
+    let safe_low = &tli[victim_idx - 1];
+    let safe_high = &tli[victim_idx + 1];
+
+    // Establish coverage anchors before corruption: the TLI entry's
+    // `end_key` is the LAST user-key covered by the pointed-at block,
+    // so it is the most-likely-to-route-here key for that partition.
+    let victim_last_key = victim.end_key.clone();
+    let safe_low_last_key = safe_low.end_key.clone();
+    let safe_high_last_key = safe_high.end_key.clone();
+
+    // Sanity: the three keys are distinct.
+    assert_ne!(victim_last_key, safe_low_last_key);
+    assert_ne!(victim_last_key, safe_high_last_key);
+
+    // Zero the victim sub-index block's bytes. `size` already
+    // includes the BlockHeader prefix, so this nukes both header and
+    // payload — header checksum will not match XXH3(zeros).
+    corrupt_region(&sst, victim.offset, u64::from(victim.size), 0x00);
+
+    let tree = reopen_partitioned(dir.path());
+
+    // Keys whose data block is referenced by an UN-CORRUPTED sub-index
+    // partition must still be readable. Use the partition's own
+    // `end_key` so the read path routes to that intact partition.
+    let v_low = tree
+        .get(&safe_low_last_key, lsm_tree::MAX_SEQNO)
+        .expect("read against intact lower partition must succeed");
+    assert_eq!(
+        v_low.as_deref(),
+        Some(&b"value"[..]),
+        "intact lower partition: expected value, got {v_low:?}"
+    );
+
+    let v_high = tree
+        .get(&safe_high_last_key, lsm_tree::MAX_SEQNO)
+        .expect("read against intact upper partition must succeed");
+    assert_eq!(
+        v_high.as_deref(),
+        Some(&b"value"[..]),
+        "intact upper partition: expected value, got {v_high:?}"
+    );
+
+    // The read that routes through the corrupted sub-index partition
+    // must surface the corruption as an error, NOT silently return
+    // None / wrong data. Either a block-header XXH3 failure or a
+    // ChecksumMismatch is acceptable.
+    let v_victim = tree.get(&victim_last_key, lsm_tree::MAX_SEQNO);
+    assert!(
+        v_victim.is_err(),
+        "read against corrupted sub-index partition must return an Err (got {v_victim:?})"
+    );
+
+    // Sanity: very-early and very-late keys (covered by partitions
+    // far from the victim) read OK — corruption is not collateral.
+    let first = tree
+        .get(key_for(0).as_bytes(), lsm_tree::MAX_SEQNO)
+        .expect("first key read must succeed");
+    assert_eq!(first.as_deref(), Some(&b"value"[..]));
+
+    let last = tree
+        .get(key_for(n - 1).as_bytes(), lsm_tree::MAX_SEQNO)
+        .expect("last key read must succeed");
+    assert_eq!(last.as_deref(), Some(&b"value"[..]));
+}


### PR DESCRIPTION
## Summary

Closes #329 (the Part 1 follow-up to #296 — PR #325 shipped Part 2 / TLI head+tail mirror; this is the within-index blast-radius half).

- Flips `Config::default().index_block_partitioning_policy` from `PinningPolicy::new([false, false, false, true])` to `PinningPolicy::all(true)`. Every level now emits a partitioned index, so a bit flip inside one sub-index block only takes out the keys covered by that partition, not the entire SST.
- Adds the integration test deferred from #296's acceptance matrix: write a partitioned-index SST, walk the TLI, zero one middle sub-index block, verify intact partitions still read end-to-end and the corrupted one surfaces as an `Err` (not a silent miss).
- Leaves `filter_block_partitioning_policy` at the pre-#329 shape on purpose. A corrupt filter block produces a false negative (read short-circuits, caller misses an existing key) — a different hazard class from index corruption (which fails loudly). Flipping that default needs its own filter blast-radius / false-negative analysis; symmetry with index is not sufficient justification on its own. Rationale recorded in the inline `Config::default()` docstring.

## Bench result

`cargo bench --bench index_block -- table_point_read_index_layout` on the same data shape (4096 keys, 256 B data blocks, restart-interval 1):

| Layout | Point-read time |
|--------|-----------------|
| full   | 6.6963 us / 6.7466 us / 6.8256 us |
| partitioned | 3.8549 us / 3.8655 us / 3.8767 us |

Partitioned is ~43% **faster**, not slower. The TLI is smaller (only handles to partitions, not to every data block), and the sub-partition loaded for the actual lookup is smaller, so the two-stage binary search beats the single-stage search over a large full index. Well within the <5% regression gate from #329.

## Test plan

- [x] `cargo nextest run --workspace` — 1426 / 1426 passing
- [x] cargo clippy all-features all-targets -D warnings — clean
- [x] `cargo test --doc` — 43 / 43 passing
- [x] New `tests/partitioned_index_blast_radius.rs` exercises the within-SST isolation property the default flip relies on
- [x] Bench captured above; default flip is an improvement, not a regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to validate corruption isolation in partitioned index blocks, ensuring failed reads are limited to affected partitions while adjacent partitions remain accessible.

* **Chores**
  * Refactored benchmark code to support performance comparison across different index block layouts.
  * Updated default index block partitioning configuration and expanded related documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->