### PR TITLE
test(table/index): tighten blast-radius assertion to corruption variants

### DIFF
--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -153,8 +153,9 @@ fn partitioned_index_corrupting_one_sub_block_only_affects_its_keys() {
 
     // The read that routes through the corrupted sub-index partition
     // must surface the corruption as an error, NOT silently return
-    // None / wrong data. Either a block-header XXH3 failure or a
-    // ChecksumMismatch is acceptable.
+    // None / wrong data. The block-header decode produces one of two
+    // specific Error variants for a zeroed sub-index block — both
+    // are checked in the `matches!` arm below.
     let v_victim = tree.get(&victim_last_key, lsm_tree::MAX_SEQNO);
     // A zeroed sub-index block fails block-header validation: either
     // the header's stored XXH3 disagrees with XXH3(zeros)

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -156,9 +156,19 @@ fn partitioned_index_corrupting_one_sub_block_only_affects_its_keys() {
     // None / wrong data. Either a block-header XXH3 failure or a
     // ChecksumMismatch is acceptable.
     let v_victim = tree.get(&victim_last_key, lsm_tree::MAX_SEQNO);
+    // A zeroed sub-index block fails block-header validation: either
+    // the header's stored XXH3 disagrees with XXH3(zeros)
+    // (`ChecksumMismatch`), or the all-zero header fails structural
+    // checks first (`InvalidHeader`). Both are corruption signals — a
+    // generic `is_err()` would also accept unrelated failures (I/O
+    // error mid-test, an unrelated `Unrecoverable`, etc.) and weaken
+    // the blast-radius assertion.
     assert!(
-        v_victim.is_err(),
-        "read against corrupted sub-index partition must return an Err (got {v_victim:?})"
+        matches!(
+            v_victim,
+            Err(lsm_tree::Error::ChecksumMismatch { .. }) | Err(lsm_tree::Error::InvalidHeader(_))
+        ),
+        "read against corrupted sub-index partition must surface as block-header corruption (ChecksumMismatch or InvalidHeader); got {v_victim:?}"
     );
 
     // Sanity: very-early and very-late keys (covered by partitions

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -164,8 +164,8 @@ fn partitioned_index_corrupting_one_sub_block_only_affects_its_keys() {
     // `Unrecoverable`, etc.) and weaken the blast-radius assertion.
     let v_victim = tree.get(&victim_last_key, lsm_tree::MAX_SEQNO);
     assert!(
-        matches!(v_victim, Err(lsm_tree::Error::InvalidHeader(_))),
-        "read against corrupted sub-index partition must surface as block-header InvalidHeader (zeroed magic short-circuits before XXH3 check); got {v_victim:?}"
+        matches!(v_victim, Err(lsm_tree::Error::InvalidHeader("Block"))),
+        "read against corrupted sub-index partition must surface as block-header InvalidHeader(\"Block\") (zeroed magic short-circuits before XXH3 check); got {v_victim:?}"
     );
 
     // Sanity: very-early and very-late keys (covered by partitions

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -153,23 +153,19 @@ fn partitioned_index_corrupting_one_sub_block_only_affects_its_keys() {
 
     // The read that routes through the corrupted sub-index partition
     // must surface the corruption as an error, NOT silently return
-    // None / wrong data. The block-header decode produces one of two
-    // specific Error variants for a zeroed sub-index block — both
-    // are checked in the `matches!` arm below.
+    // None / wrong data. With the corruption method we use (the whole
+    // sub-index block zeroed, header + payload), `Header::decode_from`
+    // hits the `MAGIC_BYTES` check first and returns
+    // `Error::InvalidHeader("Block")` deterministically — the
+    // following XXH3 header-checksum comparison never runs because
+    // magic mismatch short-circuits the decode. So the test pins the
+    // single expected variant; a generic `is_err()` would also accept
+    // unrelated failures (I/O error mid-test, an unrelated
+    // `Unrecoverable`, etc.) and weaken the blast-radius assertion.
     let v_victim = tree.get(&victim_last_key, lsm_tree::MAX_SEQNO);
-    // A zeroed sub-index block fails block-header validation: either
-    // the header's stored XXH3 disagrees with XXH3(zeros)
-    // (`ChecksumMismatch`), or the all-zero header fails structural
-    // checks first (`InvalidHeader`). Both are corruption signals — a
-    // generic `is_err()` would also accept unrelated failures (I/O
-    // error mid-test, an unrelated `Unrecoverable`, etc.) and weaken
-    // the blast-radius assertion.
     assert!(
-        matches!(
-            v_victim,
-            Err(lsm_tree::Error::ChecksumMismatch { .. }) | Err(lsm_tree::Error::InvalidHeader(_))
-        ),
-        "read against corrupted sub-index partition must surface as block-header corruption (ChecksumMismatch or InvalidHeader); got {v_victim:?}"
+        matches!(v_victim, Err(lsm_tree::Error::InvalidHeader(_))),
+        "read against corrupted sub-index partition must surface as block-header InvalidHeader (zeroed magic short-circuits before XXH3 check); got {v_victim:?}"
     );
 
     // Sanity: very-early and very-late keys (covered by partitions


### PR DESCRIPTION
## Summary

Follow-up to PR #340 (merged). CodeRabbit flagged the new `partitioned_index_corrupting_one_sub_block_only_affects_its_keys` test as using a bare `v_victim.is_err()` for the corrupted-partition read, which is too permissive: any unrelated failure (an I/O error mid-test, an unrelated `Error::Unrecoverable`, etc.) would also satisfy the assertion and the test would silently stop validating the actual blast-radius property.

Tightened to the **single** variant the block-header decode deterministically returns for the corruption method we apply (whole sub-index block zeroed, header + payload):

- `Error::InvalidHeader("Block")` — `Header::decode_from` runs the `MAGIC_BYTES` check first, and an all-zero header short-circuits there before the trailing XXH3 header-checksum comparison gets a chance to run. So `ChecksumMismatch` cannot fire on this code path with this corruption method.

The matches arm pins the literal tag (`"Block"`) so the assertion is bound to the exact decode site the corruption exercises. Inline comment records the short-circuit rationale; a future corruption method that preserves `MAGIC_BYTES` and bit-flips only the payload would exercise the `ChecksumMismatch` path and would want its own dedicated test with its own pinning.

## Test plan

- [x] `cargo nextest run --test partitioned_index_blast_radius` — passes with the tightened assertion