### PR TITLE
feat(io): local Read/Write/Seek trait surface to lift Fs off std::io (#311)

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -56,13 +56,14 @@ pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 // existing std-backed backends (`std_fs`, `io_uring_fs`) satisfy
 // these bounds without any change to their own impls.
 //
-// `io::{Result, Error, ErrorKind}` are still re-exported from
-// `std::io` here. The trait *bounds* are what blocked no-std for this
-// module; the surrounding `io::Result<T>` return type still uses
+// `io::{Result, Error, ErrorKind}` still come from `std::io` here
+// (no public re-export — `use std::io;` is a local module alias).
+// The trait *bounds* are what blocked no-std for this module; the
+// surrounding `io::Result<T>` return type still resolves to
 // `std::io::Result<T>` and will be migrated to `crate::io::Result<T>`
 // in a follow-up so we keep the diff scoped to what this issue
-// actually unblocks. `std::path::Path` likewise stays for now — the
-// path migration is the second blocker tracked separately.
+// actually unblocks. `std::path::Path` likewise stays for now —
+// the path migration is the second blocker tracked separately.
 use crate::io::{Read, Seek, Write};
 use std::io;
 // `Read::take` is a provided method on the `std::io::Read` trait,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -76,6 +76,13 @@ use std::io;
 // `std::io::Read`. Bring the std trait into scope anonymously here
 // so `take` / `chain` / `bytes` resolve on receivers below.
 use std::io::Read as _;
+// Same supertrait-alias resolution rule applies to `Seek::seek`: the
+// provided method lives on `std::io::Seek`, and `crate::io::Seek` is
+// an empty supertrait alias under `feature = "std"`. Without this
+// import, `file.seek(...)` (e.g. in `open_section_reader`) fails to
+// resolve. Bring `std::io::Seek` into scope anonymously alongside
+// `Read` so receivers below find both provided methods.
+use std::io::Seek as _;
 use std::path::{Path, PathBuf};
 
 /// Options for opening a file through the [`Fs`] trait.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -50,7 +50,28 @@ pub use std_fs::StdFs;
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 
-use std::io::{self, Read, Seek, Write};
+// `Read` / `Write` / `Seek` come from `crate::io`, the local mirror
+// of `std::io` that compiles under `no_std + alloc`. Under `feature =
+// "std"` the blanket impls in `crate::io` forward to `std::io::*`, so
+// existing std-backed backends (`std_fs`, `io_uring_fs`) satisfy
+// these bounds without any change to their own impls.
+//
+// `io::{Result, Error, ErrorKind}` are still re-exported from
+// `std::io` here. The trait *bounds* are what blocked no-std for this
+// module; the surrounding `io::Result<T>` return type still uses
+// `std::io::Result<T>` and will be migrated to `crate::io::Result<T>`
+// in a follow-up so we keep the diff scoped to what this issue
+// actually unblocks. `std::path::Path` likewise stays for now — the
+// path migration is the second blocker tracked separately.
+use crate::io::{Read, Seek, Write};
+use std::io;
+// `Read::take` is an inherent method on `std::io::Read`, not on our
+// supertrait alias. The supertrait relationship lets a value bounded
+// on `crate::io::Read` flow into APIs expecting `std::io::Read`, but
+// the std-specific helper methods (`take`, `chain`, `bytes`) are not
+// re-exported on the alias trait. Bring `std::io::Read` into scope
+// anonymously here so those helpers resolve on receivers below.
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 /// Options for opening a file through the [`Fs`] trait.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -65,12 +65,15 @@ pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 // path migration is the second blocker tracked separately.
 use crate::io::{Read, Seek, Write};
 use std::io;
-// `Read::take` is an inherent method on `std::io::Read`, not on our
-// supertrait alias. The supertrait relationship lets a value bounded
-// on `crate::io::Read` flow into APIs expecting `std::io::Read`, but
-// the std-specific helper methods (`take`, `chain`, `bytes`) are not
-// re-exported on the alias trait. Bring `std::io::Read` into scope
-// anonymously here so those helpers resolve on receivers below.
+// `Read::take` is a provided method on the `std::io::Read` trait,
+// not on our supertrait alias `crate::io::Read`. The supertrait
+// relationship lets a value bounded on `crate::io::Read` flow into
+// APIs expecting `std::io::Read`, but Rust's method-resolution only
+// considers methods from traits that are IN SCOPE at the call site
+// — so without an explicit import of `std::io::Read`, `file.take(N)`
+// fails to resolve even though the receiver does implement
+// `std::io::Read`. Bring the std trait into scope anonymously here
+// so `take` / `chain` / `bytes` resolve on receivers below.
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,356 @@
+// Local I/O trait surface, mirroring `std::io::{Read, Write, Seek}` so the
+// `fs::Fs` / `fs::FsFile` trait definitions compile under
+// `--no-default-features --features alloc`. The signatures match
+// `std::io` exactly, so backends gated behind `#[cfg(feature = "std")]`
+// (such as `std_fs` and `io_uring_fs`) keep using `std::io::*`
+// internally — they just satisfy this crate's traits via the bridge
+// impls below.
+//
+// Why not pull in an external `core_io` / `core2` / `core3` / `embedded-io`
+// crate: those add a maintainer dependency for what is ultimately three
+// stable trait signatures plus an error type. The signatures here have
+// not meaningfully changed since Rust 1.0, so maintenance is near zero,
+// and we keep the no-std contract under our own control.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
+
+/// Specialised `Result` for I/O operations on this crate's traits.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Mirrors [`std::io::ErrorKind`] for the variants this crate actually
+/// constructs. Kept in alphabetical order so additions stay easy to spot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// Entity (file, directory, key, etc.) already exists.
+    AlreadyExists,
+    /// Broken pipe — the other end of a stream is closed.
+    BrokenPipe,
+    /// Operation attempted across distinct devices/filesystems.
+    CrossesDevices,
+    /// Operation was interrupted (`EINTR`-equivalent); usually retriable.
+    Interrupted,
+    /// Data being read does not match the expected format/schema.
+    InvalidData,
+    /// A function argument had an invalid value.
+    InvalidInput,
+    /// Entity was not found.
+    NotFound,
+    /// Catch-all for errors that don't fit any other variant.
+    Other,
+    /// Operation denied due to lack of permissions.
+    PermissionDenied,
+    /// Reader hit end-of-file before satisfying the request.
+    UnexpectedEof,
+    /// Operation is not supported on this platform / backend / build.
+    Unsupported,
+}
+
+impl ErrorKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AlreadyExists => "entity already exists",
+            Self::BrokenPipe => "broken pipe",
+            Self::CrossesDevices => "cross-device link or rename",
+            Self::Interrupted => "operation interrupted",
+            Self::InvalidData => "invalid data",
+            Self::InvalidInput => "invalid input parameter",
+            Self::NotFound => "entity not found",
+            Self::Other => "other error",
+            Self::PermissionDenied => "permission denied",
+            Self::UnexpectedEof => "unexpected end of file",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// I/O error mirroring [`std::io::Error`].
+///
+/// Carries an [`ErrorKind`] plus an optional message string for context.
+/// Under `feature = "std"` the `From<std::io::Error>` bridge below
+/// preserves the original error as the message payload via `Display`,
+/// so callers using `?` see the same human-readable text as the
+/// platform error.
+pub struct Error {
+    kind: ErrorKind,
+    message: Option<Box<str>>,
+}
+
+impl Error {
+    /// Construct an error with the given kind and a context message.
+    /// Matches [`std::io::Error::new`].
+    pub fn new<M: Into<String>>(kind: ErrorKind, message: M) -> Self {
+        Self {
+            kind,
+            message: Some(message.into().into_boxed_str()),
+        }
+    }
+
+    /// Construct an error with only an [`ErrorKind`] (no message).
+    /// Matches [`std::io::Error::from`] for `ErrorKind`.
+    #[must_use]
+    pub const fn from_kind(kind: ErrorKind) -> Self {
+        Self {
+            kind,
+            message: None,
+        }
+    }
+
+    /// Return the [`ErrorKind`] this error carries.
+    #[must_use]
+    pub const fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self::from_kind(kind)
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dbg = f.debug_struct("Error");
+        dbg.field("kind", &self.kind);
+        if let Some(msg) = &self.message {
+            dbg.field("message", &msg);
+        }
+        dbg.finish()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.message {
+            Some(msg) => write!(f, "{}: {msg}", self.kind.as_str()),
+            None => f.write_str(self.kind.as_str()),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+/// Bridge from `std::io::Error`. Preserves the platform error's
+/// `ErrorKind` mapping and its `Display` message so `?` from std-backed
+/// backends propagates the original context.
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        let kind = match err.kind() {
+            std::io::ErrorKind::AlreadyExists => ErrorKind::AlreadyExists,
+            std::io::ErrorKind::BrokenPipe => ErrorKind::BrokenPipe,
+            std::io::ErrorKind::CrossesDevices => ErrorKind::CrossesDevices,
+            std::io::ErrorKind::Interrupted => ErrorKind::Interrupted,
+            std::io::ErrorKind::InvalidData => ErrorKind::InvalidData,
+            std::io::ErrorKind::InvalidInput => ErrorKind::InvalidInput,
+            std::io::ErrorKind::NotFound => ErrorKind::NotFound,
+            std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
+            std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
+            std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            _ => ErrorKind::Other,
+        };
+        // Use Display on the std error so OS-level detail
+        // (errno text, path context) survives the conversion.
+        Self::new(kind, alloc::format!("{err}"))
+    }
+}
+
+/// Bridge back to `std::io::Error` so existing call sites that consume
+/// `std::io::Result<_>` (and where `From` is invoked via `?`) keep
+/// compiling once their input switches to this module.
+#[cfg(feature = "std")]
+impl From<Error> for std::io::Error {
+    fn from(err: Error) -> Self {
+        let kind = match err.kind {
+            ErrorKind::AlreadyExists => std::io::ErrorKind::AlreadyExists,
+            ErrorKind::BrokenPipe => std::io::ErrorKind::BrokenPipe,
+            ErrorKind::CrossesDevices => std::io::ErrorKind::CrossesDevices,
+            ErrorKind::Interrupted => std::io::ErrorKind::Interrupted,
+            ErrorKind::InvalidData => std::io::ErrorKind::InvalidData,
+            ErrorKind::InvalidInput => std::io::ErrorKind::InvalidInput,
+            ErrorKind::NotFound => std::io::ErrorKind::NotFound,
+            ErrorKind::Other => std::io::ErrorKind::Other,
+            ErrorKind::PermissionDenied => std::io::ErrorKind::PermissionDenied,
+            ErrorKind::UnexpectedEof => std::io::ErrorKind::UnexpectedEof,
+            ErrorKind::Unsupported => std::io::ErrorKind::Unsupported,
+        };
+        match err.message {
+            Some(msg) => Self::new(kind, msg.into_string()),
+            None => Self::from(kind),
+        }
+    }
+}
+
+/// Seek target, mirroring [`std::io::SeekFrom`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekFrom {
+    /// Seek to an absolute offset from the start of the stream.
+    Start(u64),
+    /// Seek to an offset relative to the end of the stream.
+    End(i64),
+    /// Seek to an offset relative to the current cursor position.
+    Current(i64),
+}
+
+#[cfg(feature = "std")]
+impl From<SeekFrom> for std::io::SeekFrom {
+    fn from(s: SeekFrom) -> Self {
+        match s {
+            SeekFrom::Start(n) => Self::Start(n),
+            SeekFrom::End(n) => Self::End(n),
+            SeekFrom::Current(n) => Self::Current(n),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::SeekFrom> for SeekFrom {
+    fn from(s: std::io::SeekFrom) -> Self {
+        match s {
+            std::io::SeekFrom::Start(n) => Self::Start(n),
+            std::io::SeekFrom::End(n) => Self::End(n),
+            std::io::SeekFrom::Current(n) => Self::Current(n),
+        }
+    }
+}
+
+// Under `feature = "std"`, the `Read` / `Write` / `Seek` traits in
+// this module are supertrait aliases over `std::io::{Read,Write,
+// Seek}`. Any `T: std::io::Read` automatically implements
+// `crate::io::Read` via the blanket below — AND `T: crate::io::Read`
+// implies `T: std::io::Read` (because std::io::Read is a supertrait).
+// This second direction is what lets `dyn FsFile` (bounded on
+// `crate::io::Read`) flow into `std::io::BufReader`, `byteorder`,
+// and the rest of the std ecosystem without any explicit adapter.
+//
+// Under `--no-default-features --features alloc`, std::io does not
+// exist, so the traits are standalone with their own method bodies
+// returning `crate::io::Result<T>` (the local Error type above).
+// Signatures stay identical between modes so call sites compile in
+// both builds.
+//
+// This dual-shape is the whole reason we own this module instead of
+// depending on `core2` / `core3` / `embedded-io` — none of those let
+// the std-mode trait *be* `std::io::Read` (they're meant to replace
+// std::io, not bridge to it), and bridging the other way needs an
+// adapter shim at every backend boundary.
+
+/// Read trait. Under `std` it's a supertrait alias for
+/// [`std::io::Read`]; under `no_std + alloc` it carries its own
+/// signature mirroring the std contract.
+#[cfg(feature = "std")]
+pub trait Read: std::io::Read {}
+#[cfg(feature = "std")]
+impl<R: std::io::Read + ?Sized> Read for R {}
+
+/// Write trait. Under `std` it's a supertrait alias for
+/// [`std::io::Write`]; under `no_std + alloc` it carries its own
+/// signature mirroring the std contract.
+#[cfg(feature = "std")]
+pub trait Write: std::io::Write {}
+#[cfg(feature = "std")]
+impl<W: std::io::Write + ?Sized> Write for W {}
+
+/// Seek trait. Under `std` it's a supertrait alias for
+/// [`std::io::Seek`]; under `no_std + alloc` it carries its own
+/// signature mirroring the std contract.
+#[cfg(feature = "std")]
+pub trait Seek: std::io::Seek {}
+#[cfg(feature = "std")]
+impl<S: std::io::Seek + ?Sized> Seek for S {}
+
+/// Read trait mirroring [`std::io::Read`]. Only the methods this
+/// crate depends on are surfaced; default implementations follow the
+/// std contract verbatim so behaviour matches.
+#[cfg(not(feature = "std"))]
+pub trait Read {
+    /// Read bytes into `buf`. Returns the number of bytes read. A
+    /// return value of `0` indicates the source has reached EOF.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error encountered by the backing reader.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+
+    /// Read exactly `buf.len()` bytes. Returns
+    /// [`ErrorKind::UnexpectedEof`] if EOF is reached before the
+    /// buffer is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying reader, or
+    /// [`ErrorKind::UnexpectedEof`] on short read.
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.read(buf) {
+                Ok(0) => break,
+                Ok(n) => buf = &mut buf[n..],
+                Err(e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if buf.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::from_kind(ErrorKind::UnexpectedEof))
+        }
+    }
+}
+
+/// Write trait mirroring [`std::io::Write`].
+#[cfg(not(feature = "std"))]
+pub trait Write {
+    /// Write `buf` into the sink. Returns the number of bytes
+    /// accepted by the writer in this call.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying writer.
+    fn write(&mut self, buf: &[u8]) -> Result<usize>;
+
+    /// Flush buffered output to the underlying medium.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying writer.
+    fn flush(&mut self) -> Result<()>;
+
+    /// Write the entire `buf`, retrying on `Interrupted` and
+    /// returning [`ErrorKind::Other`] (matching std's `write_zero`)
+    /// if the writer stops accepting bytes early.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying writer's error, or a synthesised
+    /// `WriteZero`-equivalent error on short write.
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    return Err(Error::new(ErrorKind::Other, "failed to write whole buffer"));
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Seek trait mirroring [`std::io::Seek`].
+#[cfg(not(feature = "std"))]
+pub trait Seek {
+    /// Seek the stream cursor to the offset described by `pos`.
+    /// Returns the resulting absolute byte offset from the start of
+    /// the stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying seeker.
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -100,7 +100,19 @@ pub struct Error {
 
 impl Error {
     /// Construct an error with the given kind and a context message.
-    /// Matches [`std::io::Error::new`].
+    ///
+    /// Analogous to [`std::io::Error::new`] but intentionally
+    /// narrower: this constructor takes a `String`-coercible
+    /// message and stores it verbatim, where std's `new()`
+    /// accepts `E: Into<Box<dyn std::error::Error + Send + Sync>>`
+    /// and carries a chained source via `Error::source()`. This
+    /// crate's error type has no source-chaining surface (and
+    /// can't have one under `no_std + alloc` without an alloc
+    /// dyn-trait shim), so an analogous "wrap an inner error"
+    /// helper would be misleading; callers wanting the source
+    /// payload of a std error use the `From<std::io::Error>`
+    /// bridge below, which renders the std Display into the
+    /// message field.
     pub fn new<M: Into<String>>(kind: ErrorKind, message: M) -> Self {
         Self {
             kind,
@@ -160,36 +172,52 @@ impl std::error::Error for Error {}
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
-        let kind = match err.kind() {
-            std::io::ErrorKind::AlreadyExists => ErrorKind::AlreadyExists,
-            std::io::ErrorKind::BrokenPipe => ErrorKind::BrokenPipe,
-            std::io::ErrorKind::CrossesDevices => ErrorKind::CrossesDevices,
-            std::io::ErrorKind::Interrupted => ErrorKind::Interrupted,
-            std::io::ErrorKind::InvalidData => ErrorKind::InvalidData,
-            std::io::ErrorKind::InvalidInput => ErrorKind::InvalidInput,
-            std::io::ErrorKind::NotFound => ErrorKind::NotFound,
-            std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
-            std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
-            std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
-            std::io::ErrorKind::WriteZero => ErrorKind::WriteZero,
-            _ => ErrorKind::Other,
+        let std_kind = err.kind();
+        let (kind, kind_is_mapped) = match std_kind {
+            std::io::ErrorKind::AlreadyExists => (ErrorKind::AlreadyExists, true),
+            std::io::ErrorKind::BrokenPipe => (ErrorKind::BrokenPipe, true),
+            std::io::ErrorKind::CrossesDevices => (ErrorKind::CrossesDevices, true),
+            std::io::ErrorKind::Interrupted => (ErrorKind::Interrupted, true),
+            std::io::ErrorKind::InvalidData => (ErrorKind::InvalidData, true),
+            std::io::ErrorKind::InvalidInput => (ErrorKind::InvalidInput, true),
+            std::io::ErrorKind::NotFound => (ErrorKind::NotFound, true),
+            std::io::ErrorKind::PermissionDenied => (ErrorKind::PermissionDenied, true),
+            std::io::ErrorKind::UnexpectedEof => (ErrorKind::UnexpectedEof, true),
+            std::io::ErrorKind::Unsupported => (ErrorKind::Unsupported, true),
+            std::io::ErrorKind::WriteZero => (ErrorKind::WriteZero, true),
+            _ => (ErrorKind::Other, false),
         };
-        // If the std error carries actual context (an `errno`, a
-        // path / OS message, or a custom payload), preserve that
-        // Display text as our message so the OS-level detail
-        // survives the conversion. If it's a plain kind-only
-        // error (`std::io::Error::from(ErrorKind::X)`), skip the
-        // message entirely — our `Display` already prefixes the
-        // kind tag, so storing "entity not found" as the message
-        // would produce "entity not found: entity not found" on
-        // render AND burn an unnecessary heap allocation. The
-        // `raw_os_error.is_some() || get_ref().is_some()` check
-        // is the canonical std-side discriminator for "this
-        // error carries more than just a kind".
+        // Message-attachment policy:
+        //
+        // - If the std error carries actual context (an `errno`, a
+        //   path / OS message, or a custom payload, detected by
+        //   `raw_os_error.is_some() || get_ref().is_some()` — the
+        //   canonical std-side discriminator for "this error
+        //   carries more than just a kind"), preserve its Display
+        //   output as our message so the OS-level detail survives.
+        //
+        // - If the std error is a plain kind-only one
+        //   (`std::io::Error::from(ErrorKind::X)`) AND we mapped
+        //   the kind, skip the message — our `Display` already
+        //   prefixes the kind tag, so storing "entity not found"
+        //   as the message would produce
+        //   "entity not found: entity not found" on render AND
+        //   burn an unnecessary heap allocation.
+        //
+        // - If the std error is kind-only but we DIDN'T map the
+        //   kind (`std::io::ErrorKind` is `#[non_exhaustive]`, e.g.
+        //   `OutOfMemory` / `ResourceBusy`), the user-visible
+        //   discriminant is otherwise lost in our `Other` bucket.
+        //   Preserve the std `Display` text in that case so an
+        //   unmapped kind still renders something useful (e.g.
+        //   "other error: out of memory") instead of just
+        //   "other error".
         if err.raw_os_error().is_some() || err.get_ref().is_some() {
             Self::new(kind, alloc::format!("{err}"))
-        } else {
+        } else if kind_is_mapped {
             Self::from_kind(kind)
+        } else {
+            Self::new(kind, alloc::format!("{err}"))
         }
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -174,9 +174,23 @@ impl From<std::io::Error> for Error {
             std::io::ErrorKind::WriteZero => ErrorKind::WriteZero,
             _ => ErrorKind::Other,
         };
-        // Use Display on the std error so OS-level detail
-        // (errno text, path context) survives the conversion.
-        Self::new(kind, alloc::format!("{err}"))
+        // If the std error carries actual context (an `errno`, a
+        // path / OS message, or a custom payload), preserve that
+        // Display text as our message so the OS-level detail
+        // survives the conversion. If it's a plain kind-only
+        // error (`std::io::Error::from(ErrorKind::X)`), skip the
+        // message entirely — our `Display` already prefixes the
+        // kind tag, so storing "entity not found" as the message
+        // would produce "entity not found: entity not found" on
+        // render AND burn an unnecessary heap allocation. The
+        // `raw_os_error.is_some() || get_ref().is_some()` check
+        // is the canonical std-side discriminator for "this
+        // error carries more than just a kind".
+        if err.raw_os_error().is_some() || err.get_ref().is_some() {
+            Self::new(kind, alloc::format!("{err}"))
+        } else {
+            Self::from_kind(kind)
+        }
     }
 }
 
@@ -318,7 +332,14 @@ pub trait Read {
         if buf.is_empty() {
             Ok(())
         } else {
-            Err(Error::from_kind(ErrorKind::UnexpectedEof))
+            // Match the stable message text `std::io::Read::read_exact`
+            // emits on the same short-read condition — callers that
+            // grep diagnostics for "failed to fill whole buffer" keep
+            // working without a feature-conditional branch.
+            Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ))
         }
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -185,9 +185,21 @@ impl fmt::Display for Error {
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-/// Bridge from `std::io::Error`. Preserves the platform error's
-/// `ErrorKind` mapping and its `Display` message so `?` from std-backed
-/// backends propagates the original context.
+/// Bridge from `std::io::Error`. Maps the std `ErrorKind` to
+/// this crate's [`ErrorKind`] when a variant exists for it, and
+/// falls back to [`ErrorKind::Other`] for any std variant we
+/// don't track (the std type is `#[non_exhaustive]`, so the
+/// catch-all is required). The `Display` message is captured via
+/// the tri-state policy documented on [`Error`]: kept for
+/// contextful std errors and for unmapped kinds (so the
+/// discriminant is preserved even in the `Other` bucket),
+/// dropped for plain kind-only errors whose kind we DO map (to
+/// avoid the redundant `"<kind>: <kind>"` render and the heap
+/// allocation). Net effect: `?` from std-backed backends
+/// propagates the original context to operators, but callers
+/// inspecting `err.kind()` after the conversion should be aware
+/// that an unknown std kind now reads as
+/// `ErrorKind::Other` rather than the originating variant.
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,16 +1,26 @@
-// Local I/O trait surface, mirroring `std::io::{Read, Write, Seek}` so the
-// `fs::Fs` / `fs::FsFile` trait definitions compile under
-// `--no-default-features --features alloc`. The signatures match
-// `std::io` exactly, so backends gated behind `#[cfg(feature = "std")]`
-// (such as `std_fs` and `io_uring_fs`) keep using `std::io::*`
-// internally — they just satisfy this crate's traits via the bridge
+// Local I/O trait surface, mirroring `std::io::{Read, Write, Seek}`
+// so that THE BOUNDS on `fs::Fs` / `fs::FsFile` no longer carry
+// `std::io::*` directly. The signatures match `std::io` exactly, so
+// backends gated behind `#[cfg(feature = "std")]` (such as `std_fs`
+// and `io_uring_fs`) keep using `std::io::*` internally — they just
+// satisfy this crate's traits via the supertrait alias + blanket
 // impls below.
 //
-// Why not pull in an external `core_io` / `core2` / `core3` / `embedded-io`
-// crate: those add a maintainer dependency for what is ultimately three
-// stable trait signatures plus an error type. The signatures here have
-// not meaningfully changed since Rust 1.0, so maintenance is near zero,
-// and we keep the no-std contract under our own control.
+// Scope of this module's contribution to the no-std epic (see #311):
+// it removes `std::io::{Read, Write, Seek}` from the trait BOUNDS.
+// The `fs` module still uses `std::io::Result` for return types and
+// `&std::path::Path` for path arguments in `Fs` / `FsFile` method
+// signatures — those migrate to `crate::io::Result<T>` and a
+// `crate::path` equivalent in follow-up commits. Until both follow-
+// ups land, `fs::*` does NOT yet compile under
+// `--no-default-features --features alloc`.
+//
+// Why not pull in an external `core_io` / `core2` / `core3` /
+// `embedded-io` crate: those add a maintainer dependency for what
+// is ultimately three stable trait signatures plus an error type.
+// The signatures here have not meaningfully changed since Rust 1.0,
+// so maintenance is near zero, and we keep the no-std contract
+// under our own control.
 
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -365,4 +375,151 @@ pub trait Seek {
     ///
     /// Returns any I/O error from the underlying seeker.
     fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Type-level check that a value satisfies the supertrait-alias
+    /// bound. Used by the alias-wiring tests to fail the build if a
+    /// future refactor breaks `&[u8]: crate::io::Read` /
+    /// `Vec<u8>: crate::io::Write` propagation.
+    #[cfg(feature = "std")]
+    fn assert_read_alias_bound<R: Read>(_: &R) {}
+
+    #[cfg(feature = "std")]
+    fn assert_write_alias_bound<W: Write>(_: &W) {}
+
+    #[test]
+    fn error_kind_strings_are_distinct() {
+        // Belt-and-suspenders that the `as_str` table stays in
+        // sync with the enum — a forgotten arm would either fail
+        // compilation (exhaustive match) or, if someone collapses
+        // arms into a wildcard later, produce a duplicate message
+        // that this assertion catches.
+        let all = [
+            ErrorKind::AlreadyExists,
+            ErrorKind::BrokenPipe,
+            ErrorKind::CrossesDevices,
+            ErrorKind::Interrupted,
+            ErrorKind::InvalidData,
+            ErrorKind::InvalidInput,
+            ErrorKind::NotFound,
+            ErrorKind::Other,
+            ErrorKind::PermissionDenied,
+            ErrorKind::UnexpectedEof,
+            ErrorKind::Unsupported,
+            ErrorKind::WriteZero,
+        ];
+        for (i, a) in all.iter().enumerate() {
+            for b in all.iter().skip(i + 1) {
+                assert_ne!(
+                    a.as_str(),
+                    b.as_str(),
+                    "duplicate description for {a:?} vs {b:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn error_carries_kind_and_optional_message() {
+        let e = Error::from_kind(ErrorKind::NotFound);
+        assert_eq!(e.kind(), ErrorKind::NotFound);
+        assert_eq!(alloc::format!("{e}"), "entity not found");
+
+        let e = Error::new(ErrorKind::InvalidData, "bad magic");
+        assert_eq!(e.kind(), ErrorKind::InvalidData);
+        assert_eq!(alloc::format!("{e}"), "invalid data: bad magic");
+    }
+
+    #[test]
+    fn error_kind_from_kind_is_const_friendly() {
+        // `Error::from_kind` is `const fn`; this test would fail
+        // to compile if the constness ever regressed.
+        const _E: Error = Error::from_kind(ErrorKind::Interrupted);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn from_std_io_error_preserves_kind_and_message() {
+        let std_err = std::io::Error::new(std::io::ErrorKind::WriteZero, "ran out");
+        let crate_err: Error = std_err.into();
+        assert_eq!(crate_err.kind(), ErrorKind::WriteZero);
+        // Display must carry the original std error's message
+        // (the `From` impl uses `format!("{err}")` on the std side).
+        let rendered = alloc::format!("{crate_err}");
+        assert!(
+            rendered.contains("ran out"),
+            "expected std message to survive in {rendered:?}",
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn from_std_io_error_maps_unknown_to_other() {
+        // `std::io::ErrorKind` is `#[non_exhaustive]`; variants
+        // we don't map explicitly fall through to `Other` so the
+        // bridge stays total.
+        let std_err = std::io::Error::from(std::io::ErrorKind::OutOfMemory);
+        let crate_err: Error = std_err.into();
+        assert_eq!(crate_err.kind(), ErrorKind::Other);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn round_trip_through_std_io_error_preserves_writezero() {
+        // The fix for the inverted From-mapping (PR #347): a
+        // `crate::io::Error { WriteZero }` must round-trip
+        // through `std::io::Error` back to `WriteZero`, NOT
+        // collapse to `Other`.
+        let original = Error::new(ErrorKind::WriteZero, "short write");
+        let as_std: std::io::Error = original.into();
+        assert_eq!(as_std.kind(), std::io::ErrorKind::WriteZero);
+        let back: Error = as_std.into();
+        assert_eq!(back.kind(), ErrorKind::WriteZero);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn seek_from_round_trips_through_std() {
+        // Variant-by-variant round trip — catches a future
+        // refactor that drops or re-orders a discriminant.
+        for case in [SeekFrom::Start(42), SeekFrom::End(-7), SeekFrom::Current(0)] {
+            let std_form: std::io::SeekFrom = case.into();
+            let back: SeekFrom = std_form.into();
+            assert_eq!(case, back);
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn read_exact_via_blanket_impl_on_slice() -> std::io::Result<()> {
+        // `&[u8]` impls `std::io::Read`, and the std-mode supertrait
+        // alias + blanket make it satisfy `crate::io::Read`. Exercise
+        // the resulting `read_exact` path end-to-end so a future
+        // regression in the supertrait wiring fails here. The
+        // `assert_read_alias_bound` helper above enforces the alias
+        // bound at compile time; the runtime portion just checks the
+        // read produces the expected bytes.
+        let mut src: &[u8] = b"\x01\x02\x03\x04";
+        assert_read_alias_bound(&src);
+        let mut buf = [0u8; 4];
+        <&[u8] as std::io::Read>::read_exact(&mut src, &mut buf)?;
+        assert_eq!(buf, [1, 2, 3, 4]);
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn write_all_via_blanket_impl_on_vec() -> std::io::Result<()> {
+        // Same pattern for `Vec<u8>` — `std::io::Write` impl picks
+        // up the supertrait alias and `write_all` flows through.
+        let mut sink: Vec<u8> = Vec::new();
+        assert_write_alias_bound(&sink);
+        <Vec<u8> as std::io::Write>::write_all(&mut sink, b"hello")?;
+        assert_eq!(sink, b"hello");
+        Ok(())
+    }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -167,7 +167,7 @@ impl fmt::Debug for Error {
         let mut dbg = f.debug_struct("Error");
         dbg.field("kind", &self.kind);
         if let Some(msg) = &self.message {
-            dbg.field("message", &msg);
+            dbg.field("message", msg);
         }
         dbg.finish()
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -383,7 +383,17 @@ pub trait Read {
         while !buf.is_empty() {
             match self.read(buf) {
                 Ok(0) => break,
-                Ok(n) => buf = &mut buf[n..],
+                Ok(n) => {
+                    // `split_at_mut(n)` keeps the crate-level
+                    // `#![deny(clippy::indexing_slicing)]` happy
+                    // under `--no-default-features --features
+                    // alloc` clippy: indexing form `buf = &mut
+                    // buf[n..]` would lint-fail on the no-std
+                    // build even though `n` is bounded by the
+                    // `Ok(n)` return contract of `read()`.
+                    let (_, rest) = buf.split_at_mut(n);
+                    buf = rest;
+                }
                 Err(e) if e.kind() == ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
@@ -439,7 +449,15 @@ pub trait Write {
                         "failed to write whole buffer",
                     ));
                 }
-                Ok(n) => buf = &buf[n..],
+                Ok(n) => {
+                    // `split_at(n)` keeps the crate-level
+                    // `#![deny(clippy::indexing_slicing)]` happy
+                    // under `--no-default-features --features
+                    // alloc` clippy: same reasoning as the
+                    // matching `read_exact` default impl above.
+                    let (_, rest) = buf.split_at(n);
+                    buf = rest;
+                }
                 Err(e) if e.kind() == ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -85,14 +85,33 @@ impl ErrorKind {
 /// I/O error mirroring [`std::io::Error`].
 ///
 /// Carries an [`ErrorKind`] plus an optional message string for
-/// context. Under `feature = "std"` the `From<std::io::Error>`
-/// bridge below RETAINS the platform error's `Display` output as
-/// the message payload, so the original text (OS error string,
-/// path context, errno description) survives the conversion and
-/// appears in this error's `Display` after the kind prefix
-/// — the rendered form is `"<kind>: <std-display>"`, which is
-/// the same information as the original `std::io::Error` printed,
-/// just with an explicit kind tag prepended.
+/// context. The rendered `Display` form is `"<kind>"` when no
+/// message is attached, or `"<kind>: <message>"` when one is.
+///
+/// Under `feature = "std"`, the `From<std::io::Error>` bridge
+/// below applies a tri-state message-attachment policy so the
+/// rendered text matches the information density of the input
+/// without paying a heap allocation for plain kind-only inputs:
+///
+/// 1. **std error carries context** (`raw_os_error.is_some()` OR
+///    `get_ref().is_some()` — the canonical std discriminator
+///    for "more than just a kind") — the std `Display` output is
+///    captured as the message. The original OS / errno / path
+///    text survives the conversion and appears after the kind
+///    tag.
+/// 2. **std error is plain kind-only AND we mapped the kind**
+///    (`std::io::Error::from(ErrorKind::NotFound)` etc.) — no
+///    message is attached. The kind tag already conveys the
+///    information; capturing the std `Display` output would just
+///    repeat it (`"entity not found: entity not found"`) and burn
+///    a heap allocation on the hot path.
+/// 3. **std error is plain kind-only but we did NOT map the
+///    kind** (the `#[non_exhaustive]` `std::io::ErrorKind`
+///    catch-all branch — e.g. `OutOfMemory` mapping to our
+///    `ErrorKind::Other`) — the std `Display` output IS captured
+///    so the user-visible discriminant isn't lost in the
+///    `Other` bucket. Renders as `"other error: out of memory"`
+///    rather than just `"other error"`.
 pub struct Error {
     kind: ErrorKind,
     message: Option<Box<str>>,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -46,6 +46,11 @@ pub enum ErrorKind {
     UnexpectedEof,
     /// Operation is not supported on this platform / backend / build.
     Unsupported,
+    /// `write` returned `Ok(0)` while bytes still needed to be
+    /// written. Mirrors [`std::io::ErrorKind::WriteZero`] so callers
+    /// can distinguish a stuck-writer short write from a generic
+    /// [`Other`](Self::Other) failure.
+    WriteZero,
 }
 
 impl ErrorKind {
@@ -62,6 +67,7 @@ impl ErrorKind {
             Self::PermissionDenied => "permission denied",
             Self::UnexpectedEof => "unexpected end of file",
             Self::Unsupported => "unsupported",
+            Self::WriteZero => "write returned 0 bytes",
         }
     }
 }
@@ -151,6 +157,7 @@ impl From<std::io::Error> for Error {
             std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
             std::io::ErrorKind::UnexpectedEof => ErrorKind::UnexpectedEof,
             std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
+            std::io::ErrorKind::WriteZero => ErrorKind::WriteZero,
             _ => ErrorKind::Other,
         };
         // Use Display on the std error so OS-level detail
@@ -177,6 +184,7 @@ impl From<Error> for std::io::Error {
             ErrorKind::PermissionDenied => std::io::ErrorKind::PermissionDenied,
             ErrorKind::UnexpectedEof => std::io::ErrorKind::UnexpectedEof,
             ErrorKind::Unsupported => std::io::ErrorKind::Unsupported,
+            ErrorKind::WriteZero => std::io::ErrorKind::WriteZero,
         };
         match err.message {
             Some(msg) => Self::new(kind, msg.into_string()),
@@ -320,18 +328,22 @@ pub trait Write {
     fn flush(&mut self) -> Result<()>;
 
     /// Write the entire `buf`, retrying on `Interrupted` and
-    /// returning [`ErrorKind::Other`] (matching std's `write_zero`)
-    /// if the writer stops accepting bytes early.
+    /// returning [`ErrorKind::WriteZero`] if the writer stops
+    /// accepting bytes early. Matches the semantics of
+    /// [`std::io::Write::write_all`].
     ///
     /// # Errors
     ///
-    /// Returns the underlying writer's error, or a synthesised
-    /// `WriteZero`-equivalent error on short write.
+    /// Returns the underlying writer's error, or
+    /// [`ErrorKind::WriteZero`] on short write.
     fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
         while !buf.is_empty() {
             match self.write(buf) {
                 Ok(0) => {
-                    return Err(Error::new(ErrorKind::Other, "failed to write whole buffer"));
+                    return Err(Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
                 }
                 Ok(n) => buf = &buf[n..],
                 Err(e) if e.kind() == ErrorKind::Interrupted => {}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -216,6 +216,11 @@ impl From<std::io::Error> for Error {
             std::io::ErrorKind::UnexpectedEof => (ErrorKind::UnexpectedEof, true),
             std::io::ErrorKind::Unsupported => (ErrorKind::Unsupported, true),
             std::io::ErrorKind::WriteZero => (ErrorKind::WriteZero, true),
+            // `Other` is a mapped kind: a kind-only `Other` std error
+            // would otherwise fall through to the unmapped branch and
+            // attach Display ("other error"), producing
+            // "other error: other error" on render plus a heap alloc.
+            std::io::ErrorKind::Other => (ErrorKind::Other, true),
             _ => (ErrorKind::Other, false),
         };
         // Message-attachment policy:
@@ -581,6 +586,29 @@ mod tests {
         assert_eq!(as_std.kind(), std::io::ErrorKind::WriteZero);
         let back: Error = as_std.into();
         assert_eq!(back.kind(), ErrorKind::WriteZero);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn kind_only_other_std_error_skips_message_attachment() {
+        // A kind-only `std::io::Error::from(ErrorKind::Other)` carries
+        // no `raw_os_error` and no `get_ref` payload. Without an
+        // explicit `Other => mapped=true` arm in the `From` impl, it
+        // would fall through to the unmapped branch and attach
+        // Display ("other error") as the message, producing the
+        // doubled render "other error: other error" plus a heap alloc.
+        let std_err = std::io::Error::from(std::io::ErrorKind::Other);
+        let ours: Error = std_err.into();
+        assert_eq!(ours.kind(), ErrorKind::Other);
+        // Display includes the message only when one is attached
+        // ("<kind>: <message>"); a kind-only error renders as just
+        // "<kind>". The doubled "other error: other error" rendering
+        // was the symptom the explicit Other arm fixes.
+        let rendered = alloc::format!("{ours}");
+        assert!(
+            !rendered.contains(':'),
+            "kind-only Other must not attach a message, got: {rendered:?}"
+        );
     }
 
     #[cfg(feature = "std")]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -84,11 +84,15 @@ impl ErrorKind {
 
 /// I/O error mirroring [`std::io::Error`].
 ///
-/// Carries an [`ErrorKind`] plus an optional message string for context.
-/// Under `feature = "std"` the `From<std::io::Error>` bridge below
-/// preserves the original error as the message payload via `Display`,
-/// so callers using `?` see the same human-readable text as the
-/// platform error.
+/// Carries an [`ErrorKind`] plus an optional message string for
+/// context. Under `feature = "std"` the `From<std::io::Error>`
+/// bridge below RETAINS the platform error's `Display` output as
+/// the message payload, so the original text (OS error string,
+/// path context, errno description) survives the conversion and
+/// appears in this error's `Display` after the kind prefix
+/// — the rendered form is `"<kind>: <std-display>"`, which is
+/// the same information as the original `std::io::Error` printed,
+/// just with an explicit kind tag prepended.
 pub struct Error {
     kind: ErrorKind,
     message: Option<Box<str>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,11 +155,22 @@ pub mod hash;
 
 /// Local I/O trait surface mirroring `std::io::{Read, Write, Seek}`.
 ///
-/// Also re-exports `Error` / `ErrorKind` / `SeekFrom`, so traits in
-/// [`fs`] do not depend directly on `std::io` and compile under
-/// `--no-default-features --features alloc`. Under the `std` feature,
-/// blanket impls forward from `std::io` types so existing std-backed
-/// backends satisfy the trait surface automatically.
+/// Provides `Error` / `ErrorKind` / `SeekFrom` plus the three trait
+/// definitions so the bounds on the [`fs`] traits no longer carry
+/// `std::io::*` directly. Under the `std` feature, supertrait
+/// aliases + blanket impls forward to `std::io` types so existing
+/// std-backed backends satisfy the trait surface automatically; the
+/// alias form also propagates BACK to `std::io`, so a `dyn FsFile`
+/// bounded on `crate::io::Read` still flows into `std::io::BufReader`,
+/// `byteorder`, and friends.
+///
+/// Scope: this prerequisite slice (per #311) lifts only
+/// `Read`/`Write`/`Seek` out of the [`fs`] trait bounds. The
+/// `io::Result<T>` return types and `&Path` argument types in
+/// `fs::Fs` / `fs::FsFile` still resolve to `std::io::Result<T>` and
+/// `std::path::Path` and migrate in follow-up commits; the full
+/// `--no-default-features --features alloc` build of the `fs::*`
+/// surface arrives once those two follow-ups land.
 pub mod io;
 
 mod heap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,16 @@ pub mod file;
 pub mod fs;
 
 pub mod hash;
+
+/// Local I/O trait surface mirroring `std::io::{Read, Write, Seek}`.
+///
+/// Also re-exports `Error` / `ErrorKind` / `SeekFrom`, so traits in
+/// [`fs`] do not depend directly on `std::io` and compile under
+/// `--no-default-features --features alloc`. Under the `std` feature,
+/// blanket impls forward from `std::io` types so existing std-backed
+/// backends satisfy the trait surface automatically.
+pub mod io;
+
 mod heap;
 mod ingestion;
 mod iter_guard;


### PR DESCRIPTION
## Summary

Introduce `lsm_tree::io` — a local mirror of `std::io::{Read, Write, Seek}` plus `Error`/`ErrorKind`/`SeekFrom` — and switch `Fs` / `FsFile` trait bounds in `src/fs/mod.rs` to use it. This lifts the direct `std::io::*` dependency out of those trait signatures, which is the prerequisite called out in #311 for compiling `src/fs/` under `--no-default-features --features alloc`.

## Design: dual-shape traits

The crux of the design is that under `feature = \"std\"`, `crate::io::{Read, Write, Seek}` are **supertrait aliases** over the corresponding `std::io` traits:

```rust
#[cfg(feature = \"std\")]
pub trait Read: std::io::Read {}
#[cfg(feature = \"std\")]
impl<R: std::io::Read + ?Sized> Read for R {}
```

That gives us both directions for free:

- Any `T: std::io::Read` automatically implements `crate::io::Read` (forward via blanket)
- `T: crate::io::Read` implies `T: std::io::Read` (backward via supertrait relationship)

So `dyn FsFile` bounded on `crate::io::Read` flows directly into `std::io::BufReader`, `byteorder`, and every other std-shaped consumer — zero adapter code at the backend boundary.

Under `--no-default-features --features alloc`, the traits are standalone, with their own method bodies returning `crate::io::Result<T>` and a local `Error` type derived from `ErrorKind` + optional message. Signatures match `std::io` so call sites compile in both modes.

## Why we own this module (vs. `core2` / `core3` / `embedded-io`)

| Option | Problem |
|--------|---------|
| `core2` 0.4.x | Yanked, abandoned |
| `core3` | Single low-trust maintainer, same yank risk as `core2` |
| `embedded-io` | Doesn't allow std-mode trait to *be* `std::io::Read` — designed to replace, not bridge. Forces adapter shim in every backend |
| Our own module | Three stable trait signatures (haven't moved since Rust 1.0), full control of the bridge direction, zero external maintainer dependency |

Maintenance cost: near zero — these signatures have not meaningfully changed since Rust 1.0. The contract is set by the OS, not by anything we'd evolve.

## Scope (intentionally narrow)

This commit migrates ONLY the trait *bounds*. Specifically:

- ✅ `Fs` / `FsFile` no longer have `std::io::Read + std::io::Write + std::io::Seek` directly in their bounds
- ⏸ `io::Result<T>` return types in trait methods still resolve to `std::io::Result<T>` via `use std::io;` — migration deferred to a follow-up so this diff stays scoped
- ⏸ `&std::path::Path` arguments untouched — path migration is the second blocker called out in #311, deferred to a follow-up

The `StdFs` and `IoUringFs` backends are entirely unchanged. They keep using `std::io::*` internally and satisfy the new trait bounds through the supertrait alias.

## Runtime backend selection: preserved

`is_io_uring_available()` and caller-side fallback to `StdFs` continue to work as-is — there is no new compile-time gate on the runtime path. `IoUringFs` vs `StdFs` is still a runtime decision in the caller. Under no_std + alloc, both backends are unavailable (they require `std`); the consumer brings their own `impl Fs`.

## What's NOT covered by this PR

- **no_std io_uring**: there is no no_std variant of the `io-uring` crate, and we don't ship a raw-syscall driver. Tracked as roadmap issue #346 (P3/future).
- **Backend migration** to use `crate::io::*` internally: backends still use `std::io::*` — they don't need to migrate yet because supertrait alias makes them automatically satisfy our traits.

## Test plan

- [x] `cargo check --lib` (default features) — clean
- [x] `cargo clippy --all-features --lib --tests -- -D warnings` — clean
- [x] `cargo nextest run --lib --all-features` — 1042 passed, 1 skipped
- [ ] CI to confirm across feature matrix

Closes #311 (first slice — Read/Write/Seek bounds). Related: #274 (broader no-std epic), #346 (no_std io_uring driver follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a no_std + alloc-compatible I/O surface with Read/Write/Seek traits, a Result alias, SeekFrom, and std-bridging when available.
  * Introduced Error and ErrorKind types for richer I/O error handling and conversion to/from std errors.

* **Refactor**
  * Filesystem interfaces updated to use the new crate-local I/O traits.

* **Documentation**
  * Added module-level docs describing the new I/O API and migration scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->