### PR TITLE
ci: always-emit lint/test required checks via path-conditional skip (#348)

### DIFF
--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -67,10 +67,13 @@ jobs:
     # so a missed deadline is the only remaining failure mode and
     # 10 min gives plenty of margin.
     timeout-minutes: 10
-    # Read-only token: we hit the GH REST API for the PR file list /
-    # push compare, never push, never write. Explicit `permissions:`
-    # block scopes the auto-provided GITHUB_TOKEN to exactly what
-    # this job needs, regardless of repo-default permission settings.
+    # Read-only token: the `pull_request` branch of the script
+    # below hits `/pulls/{N}/files`; non-PR events
+    # (`push` to main, `workflow_dispatch`) bypass the API
+    # entirely and just emit `code=true`. Either way, we never
+    # push and never write. Explicit `permissions:` block scopes
+    # the auto-provided GITHUB_TOKEN to exactly what this job
+    # needs, regardless of repo-default permission settings.
     permissions:
       contents: read
       pull-requests: read
@@ -226,17 +229,30 @@ jobs:
 
   test:
     needs: [changes, lint]
-    # `always() && !cancelled()` so the matrix entries (notably
-    # the required `test (stable, ubuntu-latest)`) still emit
-    # their names to the ruleset even if `changes` or `lint`
-    # fails / is skipped — `!cancelled()` alone is NOT enough
-    # because GitHub's default needs-gating skips this job when
-    # a dependency fails. `always()` overrides that gating; the
-    # `!cancelled()` half lets a user-cancelled workflow run
-    # still report cancellation honestly. Empty
-    # `needs.changes.outputs.code` is treated as "run real tests"
-    # via the `!= 'false'` step guards.
-    if: ${{ always() && !cancelled() }}
+    # `always() && !cancelled()` so the matrix entries still
+    # emit their names to the ruleset even if `changes` or
+    # `lint` fails / is skipped — `!cancelled()` alone is NOT
+    # enough because GitHub's default needs-gating skips this
+    # job when a dependency fails. `always()` overrides that
+    # gating; the `!cancelled()` half lets a user-cancelled
+    # workflow run still report cancellation honestly. Empty
+    # `needs.changes.outputs.code` is treated as "run real
+    # tests" via the `!= 'false'` step guards.
+    #
+    # On `code == 'false'` (docs-only PR), the matrix collapses
+    # to ONLY the required entry `test (stable, ubuntu-latest)`
+    # — there's no point scheduling 6 runners just to emit 5
+    # non-required skip notices. The condition reads as: "run
+    # unless cancelled, AND (full matrix if code-touching) OR
+    # (only the required entry if docs-only)". The empty/unset
+    # branch of `code` takes the first half via `!= 'false'`,
+    # matching the same fail-safe-to-running posture as the
+    # step-level guards.
+    if: >-
+      always() && !cancelled() && (
+        needs.changes.outputs.code != 'false'
+        || (matrix.rust == 'stable' && matrix.os == 'ubuntu-latest')
+      )
     timeout-minutes: 20
     strategy:
       fail-fast: true

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -278,7 +278,7 @@ jobs:
 
   test-zstd:
     needs: [changes, lint]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -322,7 +322,7 @@ jobs:
     # `#[cfg(feature = "std")]`); reviewers should request the error count
     # from this job and compare against main.
     needs: [changes, lint]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -371,7 +371,7 @@ jobs:
     # cross-matrix]`) starts immediately rather than waiting for
     # serial chain.
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}
@@ -388,7 +388,7 @@ jobs:
 
   cross:
     needs: [changes, lint, cross-matrix]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -415,7 +415,7 @@ jobs:
 
   codecov:
     needs: [changes, lint]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code != 'false'
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -96,13 +96,39 @@ jobs:
             echo "code=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # For `pull_request` events, GitHub's own PR diff is
+          # `merge-base(base, head)..head`, not `base..head` — diffing
+          # straight from the base tip pulls in any commits that landed
+          # on the base branch AFTER the PR branched, which falsely
+          # flips a docs-only PR to `code=true`. Resolve the merge-base
+          # first so the predicate sees only this PR's own changes.
+          # For `push` events `BASE` is already the previous tip on the
+          # same branch, so the merge-base equals `BASE` itself and the
+          # extra step is a no-op.
+          if MB=$(git merge-base "$BASE" "$HEAD" 2>/dev/null); then
+            DIFF_BASE="$MB"
+          else
+            # Shallow clone / unrelated histories: fall back to BASE
+            # rather than failing — the predicate stays safe because
+            # the `code=true` fallback below is the conservative
+            # default if anything goes wrong.
+            echo "Warning: merge-base($BASE, $HEAD) unavailable — falling back to BASE."
+            DIFF_BASE="$BASE"
+          fi
           # Predicate: anything that affects compile / lint / test
-          # results counts as code. The workflow file is included
-          # so changes to CI logic itself always trigger the full
-          # matrix (avoids self-skipping a CI refactor PR).
-          CODE_RE='^(src/|tests/|benches/|examples/|build\.rs$|Cargo\.toml$|Cargo\.lock$|tools/|\.github/workflows/coordinode-ci\.yml$|rust-toolchain(\.toml)?$|\.cargo/)'
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
-          echo "Changed files between $BASE and $HEAD:"
+          # results counts as code. The workflow file is included so
+          # changes to CI logic itself always trigger the full matrix
+          # (avoids self-skipping a CI refactor PR). The lint/test
+          # config files (`.config/nextest.toml`, `.rustfmt.toml`,
+          # `clippy.toml`) and the in-repo test fixtures
+          # (`test_fixture/`) are included because changes to any of
+          # them can flip the lint/test outcome on otherwise-identical
+          # source code — skipping the real validation on a PR that
+          # touches only those files would defeat the purpose of the
+          # required-check gate.
+          CODE_RE='^(src/|tests/|benches/|examples/|test_fixture/|build\.rs$|Cargo\.toml$|Cargo\.lock$|tools/|\.github/workflows/coordinode-ci\.yml$|rust-toolchain(\.toml)?$|\.cargo/|\.config/nextest\.toml$|\.rustfmt\.toml$|clippy\.toml$)'
+          CHANGED=$(git diff --name-only "$DIFF_BASE" "$HEAD")
+          echo "Changed files between $DIFF_BASE and $HEAD (merge-base of $BASE and $HEAD):"
           echo "$CHANGED" | sed 's/^/  /'
           if echo "$CHANGED" | grep -qE "$CODE_RE"; then
             echo "Result: code paths affected — running real CI."

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -367,8 +367,9 @@ jobs:
     # touch source, doesn't compile, doesn't run lint-sensitive
     # tooling. Running it in parallel with lint shaves ~10s off
     # the PR critical path: the matrix is ready when lint
-    # finishes, and `cross` (which `needs: [lint, cross-matrix]`)
-    # starts immediately rather than waiting for serial chain.
+    # finishes, and `cross` (which `needs: [changes, lint,
+    # cross-matrix]`) starts immediately rather than waiting for
+    # serial chain.
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -249,11 +249,7 @@ jobs:
     # branch of `code` takes the first half via `!= 'false'`,
     # matching the same fail-safe-to-running posture as the
     # step-level guards.
-    if: >-
-      always() && !cancelled() && (
-        needs.changes.outputs.code != 'false'
-        || (matrix.rust == 'stable' && matrix.os == 'ubuntu-latest')
-      )
+    if: ${{ always() && !cancelled() && (needs.changes.outputs.code != 'false' || (matrix.rust == 'stable' && matrix.os == 'ubuntu-latest')) }}
     timeout-minutes: 20
     strategy:
       fail-fast: true

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -158,12 +158,18 @@ jobs:
 
   lint:
     needs: changes
-    # `!cancelled()` so the required `lint` check still runs (and
-    # emits its name to the ruleset) even if `changes` errors out
-    # for an infra reason — empty `needs.changes.outputs.code` is
-    # caught below by the `!= 'false'` step guards, which default
-    # to running the real lint work (safe fallback).
-    if: ${{ !cancelled() }}
+    # `always() && !cancelled()` so the required `lint` check
+    # still runs (and emits its name to the ruleset) even if
+    # `changes` itself fails / is skipped — `!cancelled()` alone
+    # is NOT enough because GitHub's default needs-gating skips
+    # this job when a dependency fails. `always()` overrides that
+    # gating; the `!cancelled()` half lets a user-cancelled
+    # workflow run still report cancellation honestly. Empty
+    # `needs.changes.outputs.code` (changes job failed before
+    # emitting output) is caught below by the `!= 'false'` step
+    # guards, which default to running the real lint work (safe
+    # fallback).
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -196,12 +202,17 @@ jobs:
 
   test:
     needs: [changes, lint]
-    # `!cancelled()` so the matrix entries (notably the required
-    # `test (stable, ubuntu-latest)`) still emit their names to the
-    # ruleset even if `changes` or `lint` fails for an infra reason.
-    # Empty `needs.changes.outputs.code` is treated as "run real
-    # tests" via the `!= 'false'` step guards.
-    if: ${{ !cancelled() }}
+    # `always() && !cancelled()` so the matrix entries (notably
+    # the required `test (stable, ubuntu-latest)`) still emit
+    # their names to the ruleset even if `changes` or `lint`
+    # fails / is skipped — `!cancelled()` alone is NOT enough
+    # because GitHub's default needs-gating skips this job when
+    # a dependency fails. `always()` overrides that gating; the
+    # `!cancelled()` half lets a user-cancelled workflow run
+    # still report cancellation honestly. Empty
+    # `needs.changes.outputs.code` is treated as "run real tests"
+    # via the `!= 'false'` step guards.
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 20
     strategy:
       fail-fast: true

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -124,17 +124,17 @@ jobs:
               emit_and_exit "true" "REST /pulls/$PR_NUMBER/files failed, defaulting to full CI"
             fi
           else
-            # `push` event: list files between BEFORE and AFTER via
-            # the compare endpoint. First push of a new branch reports
-            # the all-zeros sentinel as `before` — no baseline to diff
-            # against, assume code changed (safe default).
-            if [ -z "${PUSH_BEFORE:-}" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              emit_and_exit "true" "new branch / first push, no baseline"
-            fi
-            echo "Fetching compare $PUSH_BEFORE...$PUSH_AFTER via REST API..."
-            if ! CHANGED=$(gh api "repos/$REPO/compare/$PUSH_BEFORE...$PUSH_AFTER" --jq '.files[].filename' 2>&1); then
-              emit_and_exit "true" "REST /compare failed, defaulting to full CI"
-            fi
+            # `push` event: per the workflow trigger this only fires
+            # on push to `main`, which is the merge-commit landing
+            # surface. ALWAYS run full CI on merges to main — the
+            # path-filter optimisation exists for developer iteration
+            # on PR branches, not for post-merge validation of what
+            # actually ships. Skipping CI on a "docs-only" push to
+            # main would also be unsafe given the compare API's
+            # known 300-entry `.files` truncation cap on large
+            # diffs: a large code-changing merge could be misclassified
+            # as `code=false` and silently skip validation.
+            emit_and_exit "true" "push to main — always run full CI (no path filter on merges)"
           fi
           echo "Changed files:"
           printf '%s\n' "$CHANGED" | sed 's/^/  /'

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -91,7 +91,7 @@ jobs:
       # always emit `code=true` — see the inline rationale below.
       - name: Detect code-touching changes
         id: filter
-        # Override the runner's default `bash -eo pipefail` shell.
+        # Override the runner's default `-eo pipefail` flags.
         # GitHub Actions invokes the default `bash` step with
         # `bash --noprofile --norc -eo pipefail {0}`, so a script
         # that just adds `set -u` STILL inherits `-e` + pipefail
@@ -100,10 +100,11 @@ jobs:
         # (they `needs: changes`); any non-zero exit cascades to
         # "required check never reports" and blocks merges, which
         # is exactly the failure mode we built the safe-default
-        # output for. Drop down to a plain `bash {0}` so the
-        # implicit `-e` / `-o pipefail` doesn't second-guess the
-        # explicit failure-path handling in the script body.
-        shell: bash {0}
+        # output for. Keep `--noprofile --norc` so we still match
+        # the runner's clean-env defaults (no inherited dotfiles
+        # from a self-hosted runner with profile.d / bashrc) —
+        # we only drop the `-eo pipefail` half deliberately.
+        shell: bash --noprofile --norc {0}
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -317,7 +317,7 @@ jobs:
 
   test-zstd:
     needs: [changes, lint]
-    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
+    if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -361,7 +361,7 @@ jobs:
     # `#[cfg(feature = "std")]`); reviewers should request the error count
     # from this job and compare against main.
     needs: [changes, lint]
-    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
+    if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -410,6 +410,15 @@ jobs:
     # cross-matrix]`) starts immediately rather than waiting for
     # serial chain.
     needs: changes
+    # cross-matrix doesn't depend on `lint` (it's a pure
+    # github.event_name / inputs lookup that emits a JSON target
+    # list), so the `needs.lint.result` gate the other downstream
+    # jobs carry doesn't apply here — the matrix-generation work
+    # is cheap (~2 s) and independent of lint passing. The
+    # `always() && !cancelled()` half still applies so a `changes`
+    # infra-failure doesn't silently skip the matrix generator
+    # (which would cascade into `cross` skipping for the wrong
+    # reason).
     if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     outputs:
@@ -427,7 +436,7 @@ jobs:
 
   cross:
     needs: [changes, lint, cross-matrix]
-    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
+    if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -454,7 +463,7 @@ jobs:
 
   codecov:
     needs: [changes, lint]
-    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
+    if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -232,24 +232,26 @@ jobs:
     needs: [changes, lint]
     # `always() && !cancelled()` so the matrix entries still
     # emit their names to the ruleset even if `changes` or
-    # `lint` fails / is skipped — `!cancelled()` alone is NOT
+    # `lint` fails / is skipped. `!cancelled()` alone is NOT
     # enough because GitHub's default needs-gating skips this
-    # job when a dependency fails. `always()` overrides that
-    # gating; the `!cancelled()` half lets a user-cancelled
+    # job when a dependency fails; `always()` overrides that
+    # gating, the `!cancelled()` half lets a user-cancelled
     # workflow run still report cancellation honestly. Empty
     # `needs.changes.outputs.code` is treated as "run real
     # tests" via the `!= 'false'` step guards.
     #
-    # On `code == 'false'` (docs-only PR), the matrix collapses
-    # to ONLY the required entry `test (stable, ubuntu-latest)`
-    # — there's no point scheduling 6 runners just to emit 5
-    # non-required skip notices. The condition reads as: "run
-    # unless cancelled, AND (full matrix if code-touching) OR
-    # (only the required entry if docs-only)". The empty/unset
-    # branch of `code` takes the first half via `!= 'false'`,
-    # matching the same fail-safe-to-running posture as the
-    # step-level guards.
-    if: ${{ always() && !cancelled() && (needs.changes.outputs.code != 'false' || (matrix.rust == 'stable' && matrix.os == 'ubuntu-latest')) }}
+    # Matrix-aware skip (run only the required entry on docs-
+    # only PRs) was attempted via a job-level
+    # `matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'`
+    # branch in this `if:`, but the `matrix` context is NOT
+    # available at job-level expression evaluation — only at
+    # step-level and in job names. All 6 matrix entries run on
+    # docs-only PRs and emit the skip notice from their own
+    # step-level guards; if optimising runner-minute waste is
+    # later required, the right shape is a dynamic matrix via
+    # `fromJSON(needs.changes.outputs.matrix)` (with `changes`
+    # emitting two pre-baked JSON values), not job-level `if:`.
+    if: ${{ always() && !cancelled() }}
     timeout-minutes: 20
     strategy:
       fail-fast: true

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -264,29 +264,39 @@ jobs:
       # entries emit their job name regardless of whether the inner
       # steps ran, so `test (stable, ubuntu-latest)` — the entry
       # listed in the branch ruleset as a required check — is
-      # always satisfied on docs-only PRs without paying the full
-      # test cost. The skip notice only fires on the explicit
-      # `code=false` signal; empty/unset falls through to real work.
+      # always satisfied on docs-only PRs / lint-failed PRs
+      # without paying the full test cost.
+      #
+      # Three step-level cases for the inner work:
+      #   - code == 'false'                            → skip notice (docs-only PR)
+      #   - lint.result != 'success'                   → skip notice (lint broken; running tests adds noise on an already-failed PR)
+      #   - code != 'false' AND lint.result == 'success' → real work
+      # The job-level `if: always() && !cancelled()` keeps the
+      # required check name surfacing in all three cases.
       - name: Path-conditional skip notice
         if: needs.changes.outputs.code == 'false'
         run: |
           echo "::notice::No code paths changed — skipping nextest + doc tests + tools/. Required-check name still emitted as success."
+      - name: Lint-failed skip notice
+        if: needs.changes.outputs.code != 'false' && needs.lint.result != 'success'
+        run: |
+          echo "::notice::Lint failed (result=${{ needs.lint.result }}) — skipping test work to avoid duplicate noise on an already-failed PR. Required-check name still emitted; fix the lint failure to unblock real test runs."
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         with:
           prefix-key: ${{ runner.os }}-cargo
       - uses: taiki-e/install-action@1ef5c5f58e85d25baaaa1704478fdd6c2921f2b5  # nextest
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
       - name: Run tests
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         # tools/db_bench is a standalone crate, not in workspace — built separately
         env:
           # 32 cases is plenty for CI; PROPTEST_MAX_SHRINK trims the
@@ -297,14 +307,14 @@ jobs:
           PROPTEST_MAX_SHRINK: "100"
         run: cargo nextest run --profile ci --all-features
       - name: Run doc tests
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         run: cargo test --doc --features lz4
       - name: Check db_bench crate
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         working-directory: tools/db_bench
         run: cargo check --all-features
       - name: Build + test sst-dump crate
-        if: needs.changes.outputs.code != 'false'
+        if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         # Standalone crate (not in workspace), exercise both the bin
         # build and the integration smoke tests so any drift in the
         # public verify::verify_sst_file API or the SST writer layout

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -45,25 +45,105 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
-    timeout-minutes: 10
+  # Detect whether the change set touches code we want to validate.
+  # Used to gate the inner steps of `lint` and `test (stable,
+  # ubuntu-latest)` — both of which are REQUIRED checks in the
+  # branch ruleset — so their job names always surface to GitHub
+  # (satisfying the ruleset) while heavy work is skipped on
+  # docs-only / repo-meta-only PRs. Non-required downstream jobs
+  # (`test-zstd`, `no-std-check`, `cross-matrix`, `cross`,
+  # `codecov`) gate at the job level via `if:` and skip outright
+  # when no code changes — they aren't required so a "skipped"
+  # status is fine for them, but a required check that reports
+  # "skipped" is treated as "not yet satisfied" by the ruleset
+  # engine, hence the in-job conditional pattern below for the
+  # two required jobs.
+  changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+          # Full history so the diff against the PR base or the
+          # previous push commit always resolves, regardless of how
+          # many commits the push or PR contains.
+          fetch-depth: 0
+      - name: Detect code-touching changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$BASE_SHA"
+            HEAD="$HEAD_SHA"
+          else
+            BASE="$PUSH_BEFORE"
+            HEAD="$PUSH_AFTER"
+          fi
+          # First push of a new branch reports the all-zeros sentinel
+          # as `before`; with no base to diff against, assume code
+          # changed (safe default — runs the full pipeline).
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No baseline commit available (new branch / first push) — assuming code changed."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Predicate: anything that affects compile / lint / test
+          # results counts as code. The workflow file is included
+          # so changes to CI logic itself always trigger the full
+          # matrix (avoids self-skipping a CI refactor PR).
+          CODE_RE='^(src/|tests/|benches/|examples/|build\.rs$|Cargo\.toml$|Cargo\.lock$|tools/|\.github/workflows/coordinode-ci\.yml$|rust-toolchain(\.toml)?$|\.cargo/)'
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          echo "Changed files between $BASE and $HEAD:"
+          echo "$CHANGED" | sed 's/^/  /'
+          if echo "$CHANGED" | grep -qE "$CODE_RE"; then
+            echo "Result: code paths affected — running real CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Result: no code paths affected — emitting fast success for required checks."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint:
+    needs: changes
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      # Surfaces a notice in the run log + summary so docs-only PRs
+      # leave an obvious trail explaining why the check passed
+      # without doing real work.
+      - name: Path-conditional skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: |
+          echo "::notice::No code paths changed — skipping format + clippy. Required-check name still emitted as success."
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        if: needs.changes.outputs.code == 'true'
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        if: needs.changes.outputs.code == 'true'
         with:
           toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        if: needs.changes.outputs.code == 'true'
       - name: Format
+        if: needs.changes.outputs.code == 'true'
         run: cargo fmt --all -- --check
       - name: Clippy (strict)
+        if: needs.changes.outputs.code == 'true'
         run: cargo clippy --all-features -- -D warnings
 
   test:
-    needs: lint
+    needs: [changes, lint]
     timeout-minutes: 20
     strategy:
       fail-fast: true
@@ -72,17 +152,32 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # Same path-conditional skip pattern as `lint`. ALL matrix
+      # entries emit their job name regardless of whether the inner
+      # steps ran, so `test (stable, ubuntu-latest)` — the entry
+      # listed in the branch ruleset as a required check — is
+      # always satisfied on docs-only PRs without paying the full
+      # test cost.
+      - name: Path-conditional skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: |
+          echo "::notice::No code paths changed — skipping nextest + doc tests + tools/. Required-check name still emitted as success."
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        if: needs.changes.outputs.code == 'true'
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        if: needs.changes.outputs.code == 'true'
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        if: needs.changes.outputs.code == 'true'
         with:
           prefix-key: ${{ runner.os }}-cargo
       - uses: taiki-e/install-action@1ef5c5f58e85d25baaaa1704478fdd6c2921f2b5  # nextest
+        if: needs.changes.outputs.code == 'true'
       - name: Run tests
+        if: needs.changes.outputs.code == 'true'
         # tools/db_bench is a standalone crate, not in workspace — built separately
         env:
           # 32 cases is plenty for CI; PROPTEST_MAX_SHRINK trims the
@@ -93,11 +188,14 @@ jobs:
           PROPTEST_MAX_SHRINK: "100"
         run: cargo nextest run --profile ci --all-features
       - name: Run doc tests
+        if: needs.changes.outputs.code == 'true'
         run: cargo test --doc --features lz4
       - name: Check db_bench crate
+        if: needs.changes.outputs.code == 'true'
         working-directory: tools/db_bench
         run: cargo check --all-features
       - name: Build + test sst-dump crate
+        if: needs.changes.outputs.code == 'true'
         # Standalone crate (not in workspace), exercise both the bin
         # build and the integration smoke tests so any drift in the
         # public verify::verify_sst_file API or the SST writer layout
@@ -109,7 +207,8 @@ jobs:
         run: cargo nextest run
 
   test-zstd:
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -152,7 +251,8 @@ jobs:
     # no-std-friendly (prefer `core::*` / `alloc::*`, gate std-only behind
     # `#[cfg(feature = "std")]`); reviewers should request the error count
     # from this job and compare against main.
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -199,6 +299,8 @@ jobs:
     # the PR critical path: the matrix is ready when lint
     # finishes, and `cross` (which `needs: [lint, cross-matrix]`)
     # starts immediately rather than waiting for serial chain.
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}
@@ -214,7 +316,8 @@ jobs:
           fi
 
   cross:
-    needs: [lint, cross-matrix]
+    needs: [changes, lint, cross-matrix]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -240,7 +343,8 @@ jobs:
         run: cross test -r --features lz4 --target ${{ matrix.target }}
 
   codecov:
-    needs: lint
+    needs: [changes, lint]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -78,29 +78,34 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       # No `actions/checkout` step on purpose: the change predicate
-      # uses GitHub's REST API to list affected files
-      # (`/pulls/{N}/files` for PRs, `/compare/{before}...{after}`
-      # for pushes). That avoids the `actions/checkout@v6 +
-      # fetch-depth: 0 + persist-credentials: false` 403 we hit on
-      # the first attempt, and skips the clone cost entirely for a
-      # job that only needs path names.
+      # uses GitHub's REST API to list affected files via
+      # `/pulls/{N}/files` for the `pull_request` event. That
+      # avoids the `actions/checkout@v6 + fetch-depth: 0 +
+      # persist-credentials: false` 403 we hit on the first
+      # attempt, and skips the clone cost entirely for a job that
+      # only needs path names. Non-PR events (`push` to main,
+      # `workflow_dispatch`) bypass the path filter entirely and
+      # always emit `code=true` — see the inline rationale below.
       - name: Detect code-touching changes
         id: filter
+        # Override the runner's default `bash -eo pipefail` shell.
+        # GitHub Actions invokes the default `bash` step with
+        # `bash --noprofile --norc -eo pipefail {0}`, so a script
+        # that just adds `set -u` STILL inherits `-e` + pipefail
+        # from the runner. This job is a hard dependency of the
+        # required `lint` + `test (stable, ubuntu-latest)` checks
+        # (they `needs: changes`); any non-zero exit cascades to
+        # "required check never reports" and blocks merges, which
+        # is exactly the failure mode we built the safe-default
+        # output for. Drop down to a plain `bash {0}` so the
+        # implicit `-e` / `-o pipefail` doesn't second-guess the
+        # explicit failure-path handling in the script body.
+        shell: bash {0}
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PUSH_BEFORE: ${{ github.event.before }}
-          PUSH_AFTER: ${{ github.sha }}
-        # Intentionally NOT `set -euo pipefail`. This job is a hard
-        # dependency of the required `lint` + `test (stable,
-        # ubuntu-latest)` checks (they `needs: changes`), so any
-        # failure here cascades to "required check never reports"
-        # and blocks merges. Instead, every failure path below
-        # explicitly emits `code=true` (safe default — runs the
-        # real pipeline) and exits 0. The job's exit status is
-        # always 0 unless GitHub Actions itself kills the runner.
         run: |
           set -u
           # Helper: emit a `code` output, log a reason, and exit 0
@@ -117,24 +122,43 @@ jobs:
             # exactly what we want, without resolving merge-base
             # ourselves. Paginated to handle PRs touching >100 files
             # (the API caps each page at 100, more pages auto-fetch).
+            # stdout / stderr are captured into SEPARATE variables:
+            # stdout (filename list) goes into CHANGED, stderr (any
+            # warnings or rate-limit messages) is preserved in
+            # API_ERR for the error notice. Mixing the two streams
+            # would let stderr noise leak into the CODE_RE predicate
+            # below and possibly mis-classify the run.
             echo "Fetching PR #$PR_NUMBER file list via REST API..."
-            if ! CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>&1); then
+            API_ERR_FILE=$(mktemp)
+            if ! CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>"$API_ERR_FILE"); then
               # API/auth/rate-limit failure: don't cascade. Default
               # to `code=true` so the real lint/test runs anyway.
-              emit_and_exit "true" "REST /pulls/$PR_NUMBER/files failed, defaulting to full CI"
+              # Surface the underlying error message in the notice
+              # so an operator debugging a flake sees what GitHub
+              # actually returned.
+              api_err=$(cat "$API_ERR_FILE" | tr '\n' ' ' | head -c 200)
+              rm -f "$API_ERR_FILE"
+              emit_and_exit "true" "REST /pulls/$PR_NUMBER/files failed (${api_err:-no stderr}), defaulting to full CI"
             fi
+            rm -f "$API_ERR_FILE"
           else
-            # `push` event: per the workflow trigger this only fires
-            # on push to `main`, which is the merge-commit landing
-            # surface. ALWAYS run full CI on merges to main — the
-            # path-filter optimisation exists for developer iteration
-            # on PR branches, not for post-merge validation of what
-            # actually ships. Skipping CI on a "docs-only" push to
-            # main would also be unsafe given the compare API's
-            # known 300-entry `.files` truncation cap on large
-            # diffs: a large code-changing merge could be misclassified
-            # as `code=false` and silently skip validation.
-            emit_and_exit "true" "push to main — always run full CI (no path filter on merges)"
+            # Any non-`pull_request` event (push to main per the
+            # workflow trigger, plus `workflow_dispatch` for manual
+            # re-runs) bypasses the path filter and runs full CI.
+            #
+            # Rationale: the path-filter optimisation exists for
+            # developer iteration on PR branches (typical PR is
+            # N small commits, fast feedback matters). Merges to
+            # main are integration events validating what ships;
+            # manual workflow dispatches are operator-initiated and
+            # are by definition non-routine. Neither has an
+            # iteration loop to optimise. Skipping CI on a
+            # "docs-only" push to main would ALSO be structurally
+            # unsafe given the compare API's known 300-entry
+            # `.files` truncation cap — a large code-changing merge
+            # could be misclassified as `code=false` and silently
+            # skip validation.
+            emit_and_exit "true" "$EVENT_NAME event — always run full CI (no path filter outside PRs)"
           fi
           echo "Changed files:"
           printf '%s\n' "$CHANGED" | sed 's/^/  /'

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -319,7 +319,7 @@ jobs:
 
   test-zstd:
     needs: [changes, lint]
-    if: needs.changes.outputs.code != 'false'
+    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -363,7 +363,7 @@ jobs:
     # `#[cfg(feature = "std")]`); reviewers should request the error count
     # from this job and compare against main.
     needs: [changes, lint]
-    if: needs.changes.outputs.code != 'false'
+    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -412,7 +412,7 @@ jobs:
     # cross-matrix]`) starts immediately rather than waiting for
     # serial chain.
     needs: changes
-    if: needs.changes.outputs.code != 'false'
+    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}
@@ -429,7 +429,7 @@ jobs:
 
   cross:
     needs: [changes, lint, cross-matrix]
-    if: needs.changes.outputs.code != 'false'
+    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
@@ -456,7 +456,7 @@ jobs:
 
   codecov:
     needs: [changes, lint]
-    if: needs.changes.outputs.code != 'false'
+    if: ${{ always() && !cancelled() && needs.changes.outputs.code != 'false' }}
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -60,7 +60,13 @@ jobs:
   # two required jobs.
   changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    # Bumped from the original 2 min — generous timeout so a slow
+    # `/pulls/{N}/files` page on a large PR can't run us into a
+    # hard wall. The job is also designed to NEVER fail (every
+    # path below resolves to a `code` output, even on API errors)
+    # so a missed deadline is the only remaining failure mode and
+    # 10 min gives plenty of margin.
+    timeout-minutes: 10
     # Read-only token: we hit the GH REST API for the PR file list /
     # push compare, never push, never write. Explicit `permissions:`
     # block scopes the auto-provided GITHUB_TOKEN to exactly what
@@ -87,30 +93,51 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_AFTER: ${{ github.sha }}
+        # Intentionally NOT `set -euo pipefail`. This job is a hard
+        # dependency of the required `lint` + `test (stable,
+        # ubuntu-latest)` checks (they `needs: changes`), so any
+        # failure here cascades to "required check never reports"
+        # and blocks merges. Instead, every failure path below
+        # explicitly emits `code=true` (safe default — runs the
+        # real pipeline) and exits 0. The job's exit status is
+        # always 0 unless GitHub Actions itself kills the runner.
         run: |
-          set -euo pipefail
+          set -u
+          # Helper: emit a `code` output, log a reason, and exit 0
+          # so dependent jobs always have a valid value to consume.
+          emit_and_exit() {
+            local code_value="$1"
+            local reason="$2"
+            echo "::notice::changes job: code=$code_value ($reason)"
+            echo "code=$code_value" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
           if [ "$EVENT_NAME" = "pull_request" ]; then
             # GitHub's own PR file list is the merge-base diff —
             # exactly what we want, without resolving merge-base
             # ourselves. Paginated to handle PRs touching >100 files
             # (the API caps each page at 100, more pages auto-fetch).
             echo "Fetching PR #$PR_NUMBER file list via REST API..."
-            CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+            if ! CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>&1); then
+              # API/auth/rate-limit failure: don't cascade. Default
+              # to `code=true` so the real lint/test runs anyway.
+              emit_and_exit "true" "REST /pulls/$PR_NUMBER/files failed, defaulting to full CI"
+            fi
           else
             # `push` event: list files between BEFORE and AFTER via
             # the compare endpoint. First push of a new branch reports
             # the all-zeros sentinel as `before` — no baseline to diff
             # against, assume code changed (safe default).
-            if [ -z "$PUSH_BEFORE" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              echo "No baseline commit available (new branch / first push) — assuming code changed."
-              echo "code=true" >> "$GITHUB_OUTPUT"
-              exit 0
+            if [ -z "${PUSH_BEFORE:-}" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              emit_and_exit "true" "new branch / first push, no baseline"
             fi
             echo "Fetching compare $PUSH_BEFORE...$PUSH_AFTER via REST API..."
-            CHANGED=$(gh api "repos/$REPO/compare/$PUSH_BEFORE...$PUSH_AFTER" --jq '.files[].filename')
+            if ! CHANGED=$(gh api "repos/$REPO/compare/$PUSH_BEFORE...$PUSH_AFTER" --jq '.files[].filename' 2>&1); then
+              emit_and_exit "true" "REST /compare failed, defaulting to full CI"
+            fi
           fi
           echo "Changed files:"
-          echo "$CHANGED" | sed 's/^/  /'
+          printf '%s\n' "$CHANGED" | sed 's/^/  /'
           # Predicate: anything that affects compile / lint / test
           # results counts as code. The workflow file is included so
           # changes to CI logic itself always trigger the full matrix
@@ -123,46 +150,58 @@ jobs:
           # touches only those files would defeat the purpose of the
           # required-check gate.
           CODE_RE='^(src/|tests/|benches/|examples/|test_fixture/|build\.rs$|Cargo\.toml$|Cargo\.lock$|tools/|\.github/workflows/coordinode-ci\.yml$|rust-toolchain(\.toml)?$|\.cargo/|\.config/nextest\.toml$|\.rustfmt\.toml$|clippy\.toml$)'
-          if echo "$CHANGED" | grep -qE "$CODE_RE"; then
-            echo "Result: code paths affected — running real CI."
-            echo "code=true" >> "$GITHUB_OUTPUT"
+          if printf '%s\n' "$CHANGED" | grep -qE "$CODE_RE"; then
+            emit_and_exit "true" "code paths affected — running real CI"
           else
-            echo "Result: no code paths affected — emitting fast success for required checks."
-            echo "code=false" >> "$GITHUB_OUTPUT"
+            emit_and_exit "false" "no code paths affected — fast success"
           fi
 
   lint:
     needs: changes
+    # `!cancelled()` so the required `lint` check still runs (and
+    # emits its name to the ruleset) even if `changes` errors out
+    # for an infra reason — empty `needs.changes.outputs.code` is
+    # caught below by the `!= 'false'` step guards, which default
+    # to running the real lint work (safe fallback).
+    if: ${{ !cancelled() }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       # Surfaces a notice in the run log + summary so docs-only PRs
       # leave an obvious trail explaining why the check passed
-      # without doing real work.
+      # without doing real work. Only fires on the explicit
+      # `code=false` signal — empty/unset (changes job failed)
+      # falls through to the real lint work below.
       - name: Path-conditional skip notice
-        if: needs.changes.outputs.code != 'true'
+        if: needs.changes.outputs.code == 'false'
         run: |
           echo "::notice::No code paths changed — skipping format + clippy. Required-check name still emitted as success."
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         with:
           toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
       - name: Format
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         run: cargo fmt --all -- --check
       - name: Clippy (strict)
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         run: cargo clippy --all-features -- -D warnings
 
   test:
     needs: [changes, lint]
+    # `!cancelled()` so the matrix entries (notably the required
+    # `test (stable, ubuntu-latest)`) still emit their names to the
+    # ruleset even if `changes` or `lint` fails for an infra reason.
+    # Empty `needs.changes.outputs.code` is treated as "run real
+    # tests" via the `!= 'false'` step guards.
+    if: ${{ !cancelled() }}
     timeout-minutes: 20
     strategy:
       fail-fast: true
@@ -176,27 +215,28 @@ jobs:
       # steps ran, so `test (stable, ubuntu-latest)` — the entry
       # listed in the branch ruleset as a required check — is
       # always satisfied on docs-only PRs without paying the full
-      # test cost.
+      # test cost. The skip notice only fires on the explicit
+      # `code=false` signal; empty/unset falls through to real work.
       - name: Path-conditional skip notice
-        if: needs.changes.outputs.code != 'true'
+        if: needs.changes.outputs.code == 'false'
         run: |
           echo "::notice::No code paths changed — skipping nextest + doc tests + tools/. Required-check name still emitted as success."
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         with:
           prefix-key: ${{ runner.os }}-cargo
       - uses: taiki-e/install-action@1ef5c5f58e85d25baaaa1704478fdd6c2921f2b5  # nextest
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
       - name: Run tests
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         # tools/db_bench is a standalone crate, not in workspace — built separately
         env:
           # 32 cases is plenty for CI; PROPTEST_MAX_SHRINK trims the
@@ -207,14 +247,14 @@ jobs:
           PROPTEST_MAX_SHRINK: "100"
         run: cargo nextest run --profile ci --all-features
       - name: Run doc tests
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         run: cargo test --doc --features lz4
       - name: Check db_bench crate
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         working-directory: tools/db_bench
         run: cargo check --all-features
       - name: Build + test sst-dump crate
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code != 'false'
         # Standalone crate (not in workspace), exercise both the bin
         # build and the integration smoke tests so any drift in the
         # public verify::verify_sst_file API or the SST writer layout

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -61,60 +61,56 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # Read-only token: we hit the GH REST API for the PR file list /
+    # push compare, never push, never write. Explicit `permissions:`
+    # block scopes the auto-provided GITHUB_TOKEN to exactly what
+    # this job needs, regardless of repo-default permission settings.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-          # Full history so the diff against the PR base or the
-          # previous push commit always resolves, regardless of how
-          # many commits the push or PR contains.
-          fetch-depth: 0
+      # No `actions/checkout` step on purpose: the change predicate
+      # uses GitHub's REST API to list affected files
+      # (`/pulls/{N}/files` for PRs, `/compare/{before}...{after}`
+      # for pushes). That avoids the `actions/checkout@v6 +
+      # fetch-depth: 0 + persist-credentials: false` 403 we hit on
+      # the first attempt, and skips the clone cost entirely for a
+      # job that only needs path names.
       - name: Detect code-touching changes
         id: filter
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_AFTER: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            BASE="$BASE_SHA"
-            HEAD="$HEAD_SHA"
+            # GitHub's own PR file list is the merge-base diff —
+            # exactly what we want, without resolving merge-base
+            # ourselves. Paginated to handle PRs touching >100 files
+            # (the API caps each page at 100, more pages auto-fetch).
+            echo "Fetching PR #$PR_NUMBER file list via REST API..."
+            CHANGED=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
           else
-            BASE="$PUSH_BEFORE"
-            HEAD="$PUSH_AFTER"
+            # `push` event: list files between BEFORE and AFTER via
+            # the compare endpoint. First push of a new branch reports
+            # the all-zeros sentinel as `before` — no baseline to diff
+            # against, assume code changed (safe default).
+            if [ -z "$PUSH_BEFORE" ] || [ "$PUSH_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              echo "No baseline commit available (new branch / first push) — assuming code changed."
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Fetching compare $PUSH_BEFORE...$PUSH_AFTER via REST API..."
+            CHANGED=$(gh api "repos/$REPO/compare/$PUSH_BEFORE...$PUSH_AFTER" --jq '.files[].filename')
           fi
-          # First push of a new branch reports the all-zeros sentinel
-          # as `before`; with no base to diff against, assume code
-          # changed (safe default — runs the full pipeline).
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "No baseline commit available (new branch / first push) — assuming code changed."
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # For `pull_request` events, GitHub's own PR diff is
-          # `merge-base(base, head)..head`, not `base..head` — diffing
-          # straight from the base tip pulls in any commits that landed
-          # on the base branch AFTER the PR branched, which falsely
-          # flips a docs-only PR to `code=true`. Resolve the merge-base
-          # first so the predicate sees only this PR's own changes.
-          # For `push` events `BASE` is already the previous tip on the
-          # same branch, so the merge-base equals `BASE` itself and the
-          # extra step is a no-op.
-          if MB=$(git merge-base "$BASE" "$HEAD" 2>/dev/null); then
-            DIFF_BASE="$MB"
-          else
-            # Shallow clone / unrelated histories: fall back to BASE
-            # rather than failing — the predicate stays safe because
-            # the `code=true` fallback below is the conservative
-            # default if anything goes wrong.
-            echo "Warning: merge-base($BASE, $HEAD) unavailable — falling back to BASE."
-            DIFF_BASE="$BASE"
-          fi
+          echo "Changed files:"
+          echo "$CHANGED" | sed 's/^/  /'
           # Predicate: anything that affects compile / lint / test
           # results counts as code. The workflow file is included so
           # changes to CI logic itself always trigger the full matrix
@@ -127,9 +123,6 @@ jobs:
           # touches only those files would defeat the purpose of the
           # required-check gate.
           CODE_RE='^(src/|tests/|benches/|examples/|test_fixture/|build\.rs$|Cargo\.toml$|Cargo\.lock$|tools/|\.github/workflows/coordinode-ci\.yml$|rust-toolchain(\.toml)?$|\.cargo/|\.config/nextest\.toml$|\.rustfmt\.toml$|clippy\.toml$)'
-          CHANGED=$(git diff --name-only "$DIFF_BASE" "$HEAD")
-          echo "Changed files between $DIFF_BASE and $HEAD (merge-base of $BASE and $HEAD):"
-          echo "$CHANGED" | sed 's/^/  /'
           if echo "$CHANGED" | grep -qE "$CODE_RE"; then
             echo "Result: code paths affected — running real CI."
             echo "code=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The branch ruleset on `main` (`main: require PR + Copilot review`) requires two status checks before merge:

- `lint`
- `test (stable, ubuntu-latest)`

Both come from `.github/workflows/coordinode-ci.yml` and previously ran unconditionally on every PR. That created two failure modes — see #348 for the full analysis and the PR #344 incident that motivated the fix.

This PR keeps the workflow trigger unconditional, but introduces an in-job **path-conditional skip pattern** for the two required jobs so the required check NAMES always surface to GitHub (satisfying the ruleset) while heavy work is skipped on docs-only / repo-meta-only PRs and on PRs whose lint failed.

## What changed

1. **New `changes` job** — runs unconditionally, decides whether the PR diff touches code-relevant paths, emits `code=true|false` via `$GITHUB_OUTPUT`. Path predicate (current `CODE_RE`):

   ```
   ^(src/|tests/|benches/|examples/|test_fixture/|build\.rs$
     |Cargo\.toml$|Cargo\.lock$|tools/
     |\.github/workflows/coordinode-ci\.yml$
     |rust-toolchain(\.toml)?$|\.cargo/
     |\.config/nextest\.toml$|\.rustfmt\.toml$|clippy\.toml$)
   ```

   Lint/test config files (`.config/nextest.toml`, `.rustfmt.toml`, `clippy.toml`) and the in-repo `test_fixture/` are included because changes to any of them can flip lint/test outcomes on otherwise-identical source. Edits to the CI workflow itself also count so a CI-refactor PR can never skip its own validation.

   Event handling:
   - `pull_request` — calls `gh api --paginate repos/.../pulls/{N}/files`, splits stdout (filename list) from stderr (surfaced only in the failure notice), runs CODE_RE.
   - `push` to main / `workflow_dispatch` — bypasses the API entirely and emits `code=true` (these are integration / operator-initiated events with no iteration loop to optimise; the compare API would also be unsafe here due to its `.files` truncation cap).

   Fail-safe behaviour: every error path (REST flake, unknown event, runner kill) defaults to `code=true` so the real pipeline still runs on infrastructure flakes; the `changes` job's shell is explicitly `bash --noprofile --norc {0}` to override the runner's default `-eo pipefail` and let the script's explicit emit-and-exit-0 logic stay authoritative.

2. **`lint` job** — `needs: changes`. `if: ${{ always() && !cancelled() }}` to override needs-gating skip on dependency failure. Every inner step guarded by `if: needs.changes.outputs.code != 'false'`; on docs-only PRs the job emits a `::notice::` and exits success in seconds.

3. **`test` job** — `needs: [changes, lint]`. Same `always() && !cancelled()` job-level condition. Three step-level cases for the inner work:

   - `code == 'false'`                                → Path-conditional skip notice (docs-only PR)
   - `code != 'false' AND lint.result != 'success'`   → Lint-failed skip notice (don't add test noise to an already-failed PR)
   - `code != 'false' AND lint.result == 'success'`   → real test work

   The matrix is statically 2×3 (rust × os) — all 6 entries run their above pattern. The matrix-conditional `if:` to skip non-required entries on docs-only PRs was attempted earlier in this PR but reverted: the `matrix` context is NOT available at job-level expression evaluation, only at step-level. A dynamic matrix via `fromJSON(needs.changes.outputs.matrix)` is the correct shape for that optimisation and is documented inline for the next attempt.

4. **Non-required downstream jobs** (`test-zstd`, `no-std-check`, `cross`, `codecov`) — gate at the JOB level via `if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}`. They run on code-touching PRs WHERE LINT PASSED (no point spinning up test-zstd if lint is broken), and skip on docs-only PRs OR lint-failed PRs. `always() && !cancelled()` is needed to override default needs-gating when `changes` itself fails (infra flake), keeping the fail-safe-to-running posture.

   `cross-matrix` is the one downstream job that legitimately does NOT depend on lint (its rationale comment explicitly calls out the parallelism it gets from running alongside lint, shaving ~10s off the PR critical path). It keeps the simpler `always() && !cancelled() && needs.changes.outputs.code != 'false'` condition.

## What this does NOT fix

- **Webhook glitch root cause** (failure mode (A) in #348). When GitHub Actions doesn't fire the workflow at all for a particular push (PR #344's experience on 2026-05-26), no run is created and no required check ever appears. This PR doesn't address that — recovery still requires a manual re-trigger via `workflow_dispatch`, an empty commit, or re-push.

## Test plan

- [ ] Open a docs-only PR (touching only `*.md` / `LICENSE`) — confirm `lint` and `test (stable, ubuntu-latest)` report success in seconds with the skip notice; ruleset accepts the PR. All 6 test matrix entries still run (they just exit early with the skip notice — runner allocation overhead remains; future fix via dynamic matrix).
- [ ] Open a code-only PR — confirm both required jobs run the real work end to end.
- [ ] Open a code PR with a broken lint — confirm `lint` reports failure, `test` matrix entries emit the lint-failed notice without running real tests, non-required jobs skip entirely.
- [ ] Re-run this PR's own CI on this branch and verify both required jobs run (workflow file itself is in the code predicate, so the CI on this very PR must run the full work).

Closes #348.