### PR TITLE
feat(config): runtime-toggleable RuntimeConfig foundation (#352)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "src/lib.rs"
 # std-only primitives behind `#[cfg(feature = "std")]`, and pick external
 # crates that support no-std.
 default = ["std"]
-std = []
+std = ["dep:arc-swap"]
 # `alloc` is the minimal hard requirement — the crate uses `Arc`,
 # `Vec`, `Box` everywhere. Listed explicitly so consumers can pick it up
 # without enabling `std` once the no-std migration completes per-module.
@@ -99,11 +99,12 @@ bytes = { version = "1", optional = true }
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
 # Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
-# std-bound — the `RuntimeConfigHandle` wrapper is gated behind feature
-# `std`. Types in `runtime_config::types` stay alloc-friendly so
-# downstream no_std consumers (block decoders, format constants) can
-# reach them without pulling the handle.
-arc-swap = "1.9"
+# std-bound — `RuntimeConfigHandle` is gated behind the `std` feature,
+# and so is this dep. Without `std`, only `runtime_config::types`
+# (alloc-friendly POD data) compiles, keeping the no-std-check job
+# from regressing on this crate's behalf. Types stay reachable from
+# downstream no_std consumers (block decoders, format constants).
+arc-swap = { version = "1.9", optional = true }
 enum_dispatch = "0.3.13"
 log = "0.4.27"
 # `spin` provides a no_std-compatible Mutex. Used by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,12 @@ ribbon-serde = ["dep:serde"]
 bytes = { version = "1", optional = true }
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 byteview = "~0.10.1"
+# Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
+# std-bound — the `RuntimeConfigHandle` wrapper is gated behind feature
+# `std`. Types in `runtime_config::types` stay alloc-friendly so
+# downstream no_std consumers (block decoders, format constants) can
+# reach them without pulling the handle.
+arc-swap = "1.9"
 enum_dispatch = "0.3.13"
 log = "0.4.27"
 # `spin` provides a no_std-compatible Mutex. Used by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,9 @@ mod prefix;
 #[doc(hidden)]
 pub mod range;
 
+/// Runtime-toggleable configuration (`RuntimeConfig` + atomic-swap handle).
+pub mod runtime_config;
+
 pub(crate) mod active_tombstone_set;
 pub(crate) mod range_tombstone;
 pub(crate) mod range_tombstone_filter;

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! `RuntimeConfigHandle` — atomic snapshot wrapper around
+//! [`RuntimeConfig`].
+//!
+//! Std-bound because `arc_swap::ArcSwap` depends on std-side
+//! primitives (the `experimental-thread-local` `no_std` mode is
+//! out of scope for now).
+//!
+//! Hot-path semantics:
+//! - Read: `load()` returns a `Guard<Arc<RuntimeConfig>>` via a
+//!   single atomic load. No locks, no allocation, no syscall.
+//!   Cheap enough to call on every block write / manifest commit.
+//! - Update: `update(|cfg| ...)` clones the current snapshot,
+//!   applies the caller's mutator, and atomically swaps the new
+//!   snapshot in. Single-writer; concurrent readers may observe
+//!   either the old or the new snapshot, never a torn one.
+
+use super::types::RuntimeConfig;
+use arc_swap::ArcSwap;
+use std::sync::Arc;
+
+/// Lockless atomic snapshot of [`RuntimeConfig`].
+///
+/// Constructed once at `Tree::open()`, lives for the lifetime of
+/// the Tree. Cloned snapshots from `load()` outlive the handle if
+/// caller holds the returned `Arc` past handle drop.
+pub struct RuntimeConfigHandle {
+    inner: ArcSwap<RuntimeConfig>,
+}
+
+impl RuntimeConfigHandle {
+    /// Build a handle wrapping the given initial config.
+    #[must_use]
+    pub fn new(initial: RuntimeConfig) -> Self {
+        Self {
+            inner: ArcSwap::from_pointee(initial),
+        }
+    }
+
+    /// Load the current snapshot — lockless single atomic load.
+    /// The returned guard is cheap to drop; for longer-lived
+    /// references use [`Self::load_full`] which returns an
+    /// owned `Arc<RuntimeConfig>`.
+    pub fn load(&self) -> arc_swap::Guard<Arc<RuntimeConfig>> {
+        self.inner.load()
+    }
+
+    /// Load the current snapshot as an owned `Arc`.
+    /// Slightly more expensive than [`Self::load`] (one atomic
+    /// increment) but the result outlives the handle.
+    #[must_use]
+    pub fn load_full(&self) -> Arc<RuntimeConfig> {
+        self.inner.load_full()
+    }
+
+    /// Apply `mutator` to a clone of the current snapshot, then
+    /// atomically swap the new snapshot in. Concurrent readers
+    /// observe either the old or the new snapshot — never a torn
+    /// intermediate state.
+    ///
+    /// If multiple writers race, the final state is whichever
+    /// `store` won the race; intermediate updates are NOT lost
+    /// because each mutator operates on its own clone before the
+    /// swap, but cross-writer ordering is not preserved. Callers
+    /// that need ordered updates should serialize at the caller
+    /// layer.
+    pub fn update<F>(&self, mutator: F)
+    where
+        F: FnOnce(&mut RuntimeConfig),
+    {
+        let current = self.inner.load_full();
+        let mut next = (*current).clone();
+        mutator(&mut next);
+        self.inner.store(Arc::new(next));
+    }
+}
+
+impl core::fmt::Debug for RuntimeConfigHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RuntimeConfigHandle")
+            .field("inner", &*self.load())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::ChecksumAlgorithm;
+    use super::*;
+    use std::sync::Barrier;
+    use std::thread;
+
+    // Stress-test parameters for the torn-read test.
+    const STRESS_READERS: usize = 8;
+    const STRESS_READS_PER_THREAD: usize = 5_000;
+
+    #[test]
+    fn load_returns_initial_config() {
+        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+        let snap = handle.load();
+        assert_eq!(snap.block_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+    }
+
+    #[test]
+    fn update_applies_mutation_visible_on_next_load() {
+        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+        handle.update(|cfg| {
+            cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+        });
+        let snap = handle.load();
+        assert_eq!(snap.block_checksum_algo, ChecksumAlgorithm::Crc32c);
+    }
+
+    #[test]
+    fn snapshot_held_during_update_is_unchanged() {
+        // A snapshot captured before update() must remain at the
+        // old value — Arc semantics: snapshot owns its clone, the
+        // swap only affects subsequent loads. This is the
+        // load-old-then-act-old guarantee that compaction-as-
+        // migration relies on (in-flight compaction finishes with
+        // its starting snapshot; next compaction picks up new
+        // config).
+        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+        let snap_before = handle.load_full();
+
+        handle.update(|cfg| {
+            cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+        });
+
+        // The old snapshot still observes the original algo.
+        assert_eq!(snap_before.block_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+        // A fresh load sees the new algo.
+        assert_eq!(handle.load().block_checksum_algo, ChecksumAlgorithm::Crc32c,);
+    }
+
+    #[test]
+    fn concurrent_reads_during_single_update_observe_consistent_snapshot() {
+        // Stress test torn-read guarantee: many reader threads
+        // continuously load() while one writer thread swaps the
+        // snapshot. Every observed snapshot must be one of the
+        // two valid states (initial or post-update) — never a
+        // half-updated combination.
+        //
+        // RuntimeConfig only has two fields right now, so torn
+        // reads would manifest as a snapshot where block_checksum
+        // is post-update but kv_checksum is pre-update. ArcSwap
+        // makes this impossible (swap is single-pointer atomic
+        // and clone preserves field correlation), but the test
+        // locks the invariant so future field additions don't
+        // accidentally break it.
+        let handle = Arc::new(RuntimeConfigHandle::new(RuntimeConfig {
+            block_checksum_algo: ChecksumAlgorithm::Xxh3_64,
+            kv_checksum_algo: ChecksumAlgorithm::Xxh3_64,
+        }));
+
+        let barrier = Arc::new(Barrier::new(STRESS_READERS + 1));
+
+        let reader_handles: Vec<_> = (0..STRESS_READERS)
+            .map(|_| {
+                let handle = Arc::clone(&handle);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    for _ in 0..STRESS_READS_PER_THREAD {
+                        let snap = handle.load();
+                        // Valid states: both Xxh3_64 (initial) or
+                        // both Crc32c (post-update). Any other
+                        // pairing means a torn read.
+                        let (a, b) = (snap.block_checksum_algo, snap.kv_checksum_algo);
+                        let initial =
+                            a == ChecksumAlgorithm::Xxh3_64 && b == ChecksumAlgorithm::Xxh3_64;
+                        let updated =
+                            a == ChecksumAlgorithm::Crc32c && b == ChecksumAlgorithm::Crc32c;
+                        assert!(initial || updated, "torn read: block={a:?}, kv={b:?}",);
+                    }
+                })
+            })
+            .collect();
+
+        // Writer waits at the barrier with the readers, then
+        // performs the swap once.
+        barrier.wait();
+        handle.update(|cfg| {
+            cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+            cfg.kv_checksum_algo = ChecksumAlgorithm::Crc32c;
+        });
+
+        for h in reader_handles {
+            // Propagate panics from reader threads as a join failure.
+            // Using assert! avoids clippy::expect_used in test code.
+            assert!(h.join().is_ok(), "reader thread panicked");
+        }
+    }
+
+    #[test]
+    fn multiple_back_to_back_updates_final_state_observable() {
+        // Three back-to-back updates from a single writer — the
+        // final load must observe the last-written value, no
+        // updates lost in the middle.
+        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+
+        handle.update(|cfg| cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c);
+        handle.update(|cfg| cfg.kv_checksum_algo = ChecksumAlgorithm::Xxh3Low32);
+        handle.update(|cfg| cfg.block_checksum_algo = ChecksumAlgorithm::Xxh3Low32);
+
+        let snap = handle.load();
+        assert_eq!(snap.block_checksum_algo, ChecksumAlgorithm::Xxh3Low32);
+        assert_eq!(snap.kv_checksum_algo, ChecksumAlgorithm::Xxh3Low32);
+    }
+}

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -24,8 +24,13 @@ use std::sync::Arc;
 /// Lockless atomic snapshot of [`RuntimeConfig`].
 ///
 /// Constructed once at `Tree::open()`, lives for the lifetime of
-/// the Tree. Cloned snapshots from `load()` outlive the handle if
-/// caller holds the returned `Arc` past handle drop.
+/// the Tree. For snapshots that must outlive the handle borrow,
+/// use [`Self::load_full`] — it returns an owned
+/// `Arc<RuntimeConfig>` that the caller can hold across the handle
+/// being dropped. [`Self::load`] returns a borrow-bound
+/// `arc_swap::Guard` and cannot outlive the handle; callers who
+/// need an owned reference from a `Guard` can clone the inner
+/// `Arc` out of it via `Arc::clone(&*guard)`.
 pub struct RuntimeConfigHandle {
     inner: ArcSwap<RuntimeConfig>,
 }

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -60,12 +60,16 @@ impl RuntimeConfigHandle {
     /// observe either the old or the new snapshot — never a torn
     /// intermediate state.
     ///
-    /// If multiple writers race, the final state is whichever
-    /// `store` won the race; intermediate updates are NOT lost
-    /// because each mutator operates on its own clone before the
-    /// swap, but cross-writer ordering is not preserved. Callers
-    /// that need ordered updates should serialize at the caller
-    /// layer.
+    /// Concurrent writers race **last-writer-wins**: each `update`
+    /// loads the current snapshot, mutates a clone, then `store`s
+    /// the new pointer. If two writers `load` the same starting
+    /// snapshot, the second `store` overwrites the first
+    /// outright — the first writer's mutation is lost. There is
+    /// no CAS / RCU merge here. Callers that need lost-update
+    /// avoidance (e.g. two threads concurrently toggling
+    /// different fields) MUST serialize their updates at the
+    /// caller layer, typically via a `Mutex` around the
+    /// `update` call site.
     pub fn update<F>(&self, mutator: F)
     where
         F: FnOnce(&mut RuntimeConfig),

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -14,8 +14,13 @@
 //!   Cheap enough to call on every block write / manifest commit.
 //! - Update: `update(|cfg| ...)` clones the current snapshot,
 //!   applies the caller's mutator, and atomically swaps the new
-//!   snapshot in. Single-writer; concurrent readers may observe
-//!   either the old or the new snapshot, never a torn one.
+//!   snapshot in. Concurrent readers always observe either the old
+//!   or the new snapshot, never a torn one. Concurrent *writers*
+//!   are allowed but race **last-writer-wins** — two `update` calls
+//!   that load the same starting snapshot will see the second
+//!   `store` overwrite the first, losing the first writer's
+//!   mutation. Callers needing lost-update avoidance must serialize
+//!   at the call site (see [`RuntimeConfigHandle::update`]).
 
 use super::types::RuntimeConfig;
 use arc_swap::ArcSwap;

--- a/src/runtime_config/mod.rs
+++ b/src/runtime_config/mod.rs
@@ -14,9 +14,15 @@
 //!
 //! [`RuntimeConfig`] and its companion enums are POD data with no
 //! I/O dependencies — they live in this module and compile under
-//! `no_std + alloc`. The mutable handle [`RuntimeConfigHandle`]
-//! lives in the `handle` submodule behind `#[cfg(feature = "std")]`
-//! because its `ArcSwap` backing requires std-side primitives.
+//! `no_std + alloc`. The mutable handle (crate-internal type
+//! `handle::RuntimeConfigHandle`) lives in a `pub(crate)` submodule
+//! behind `#[cfg(feature = "std")]` because its `ArcSwap` backing
+//! requires std-side primitives. The handle is deliberately NOT
+//! re-exported: the stable public surface is
+//! [`crate::Tree::runtime_config`] /
+//! [`crate::Tree::update_runtime_config`], which return / accept
+//! [`RuntimeConfig`] only, so `arc-swap` stays an implementation
+//! detail and is not part of the crate's semver contract.
 //!
 //! Downstream no_std consumers (block decoders, format constants,
 //! sst-dump-style tooling) can reach the type definitions without
@@ -25,8 +31,8 @@
 //! ## Compaction-as-migration semantic (designed, wired by V5 features)
 //!
 //! This module ships the snapshot + atomic-swap mechanism only. No
-//! write/compaction/manifest code in the current crate consults
-//! `RuntimeConfigHandle` yet — only the public Tree API
+//! write/compaction/manifest code in the current crate consults the
+//! handle yet — only the public Tree API
 //! ([`crate::Tree::runtime_config`] /
 //! [`crate::Tree::update_runtime_config`]) reads and updates it.
 //! The wiring lands with the V5-batch format features (manifest
@@ -36,8 +42,8 @@
 //!
 //! Once wired, the intended semantics are:
 //!
-//! - Every write path loads the current snapshot via
-//!   [`RuntimeConfigHandle::load`] at start. Reads are
+//! - Every write path loads the current snapshot via a lockless
+//!   atomic load on the crate-internal handle. Reads are
 //!   config-independent — each block / manifest is self-describing
 //!   via its own header.
 //! - A toggle on a running Tree affects subsequent writes; existing
@@ -51,9 +57,6 @@
 pub mod types;
 
 #[cfg(feature = "std")]
-pub mod handle;
+pub(crate) mod handle;
 
 pub use types::{ChecksumAlgorithm, RuntimeConfig};
-
-#[cfg(feature = "std")]
-pub use handle::RuntimeConfigHandle;

--- a/src/runtime_config/mod.rs
+++ b/src/runtime_config/mod.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Runtime-toggleable configuration.
+//!
+//! `RuntimeConfig` carries settings that callers want to change
+//! while a `Tree` is open — without restart, without breaking
+//! existing on-disk data. Toggleable fields cover format-affecting
+//! choices (block checksum algorithm, ECC, encryption, per-KV
+//! protection, etc.) that other competing storage engines seal at
+//! open time.
+//!
+//! ## Layered tier separation
+//!
+//! [`RuntimeConfig`] and its companion enums are POD data with no
+//! I/O dependencies — they live in this module and compile under
+//! `no_std + alloc`. The mutable handle [`RuntimeConfigHandle`]
+//! lives in the `handle` submodule behind `#[cfg(feature = "std")]`
+//! because its `ArcSwap` backing requires std-side primitives.
+//!
+//! Downstream no_std consumers (block decoders, format constants,
+//! sst-dump-style tooling) can reach the type definitions without
+//! pulling the mutation machinery.
+//!
+//! ## Compaction-as-migration semantic
+//!
+//! Every write path (block write, manifest write, compaction
+//! output) loads the current snapshot via `RuntimeConfigHandle::load`
+//! at start. Reads are config-independent — each block / manifest
+//! is self-describing via its own header. So a toggle on a running
+//! Tree affects subsequent writes; existing on-disk data stays in
+//! its original format and reads transparently. Compaction acts as
+//! the live-migration mechanism: rewriting source blocks per the
+//! current snapshot, so over time all data converges to the
+//! current settings without stop-the-world coordination.
+
+pub mod types;
+
+#[cfg(feature = "std")]
+pub mod handle;
+
+pub use types::{ChecksumAlgorithm, RuntimeConfig};
+
+#[cfg(feature = "std")]
+pub use handle::RuntimeConfigHandle;

--- a/src/runtime_config/mod.rs
+++ b/src/runtime_config/mod.rs
@@ -22,17 +22,31 @@
 //! sst-dump-style tooling) can reach the type definitions without
 //! pulling the mutation machinery.
 //!
-//! ## Compaction-as-migration semantic
+//! ## Compaction-as-migration semantic (designed, wired by V5 features)
 //!
-//! Every write path (block write, manifest write, compaction
-//! output) loads the current snapshot via `RuntimeConfigHandle::load`
-//! at start. Reads are config-independent — each block / manifest
-//! is self-describing via its own header. So a toggle on a running
-//! Tree affects subsequent writes; existing on-disk data stays in
-//! its original format and reads transparently. Compaction acts as
-//! the live-migration mechanism: rewriting source blocks per the
-//! current snapshot, so over time all data converges to the
-//! current settings without stop-the-world coordination.
+//! This module ships the snapshot + atomic-swap mechanism only. No
+//! write/compaction/manifest code in the current crate consults
+//! `RuntimeConfigHandle` yet — only the public Tree API
+//! ([`crate::Tree::runtime_config`] /
+//! [`crate::Tree::update_runtime_config`]) reads and updates it.
+//! The wiring lands with the V5-batch format features (manifest
+//! hardening, per-KV protection, scan-since-seqno), which extend
+//! [`RuntimeConfig`] with their own fields and load the snapshot at
+//! block write / manifest commit / compaction boundaries.
+//!
+//! Once wired, the intended semantics are:
+//!
+//! - Every write path loads the current snapshot via
+//!   [`RuntimeConfigHandle::load`] at start. Reads are
+//!   config-independent — each block / manifest is self-describing
+//!   via its own header.
+//! - A toggle on a running Tree affects subsequent writes; existing
+//!   on-disk data stays in its original format and reads
+//!   transparently.
+//! - Compaction acts as the live-migration mechanism: rewriting
+//!   source blocks per the current snapshot, so over time all data
+//!   converges to the current settings without stop-the-world
+//!   coordination.
 
 pub mod types;
 

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! `RuntimeConfig` POD types — alloc-friendly (no std dependency).
+//!
+//! Lives in `runtime_config::types` so `no_std` consumers (block
+//! decoders, format constants) can read configuration values
+//! without pulling the `ArcSwap`-based handle in
+//! `runtime_config::handle`.
+
+/// Algorithm used for integrity checksums (block-level and per-KV).
+///
+/// Default: [`Self::Xxh3_64`] — fastest on modern SIMD hardware,
+/// 64-bit collision space. Single primitive used across the crate
+/// keeps the audit surface small.
+///
+/// [`Self::Crc32c`] is provided for callers who prefer the
+/// mathematically-proven burst-error detection guarantees of CRC32C
+/// (100% detection of 1-bit, 2-bit-in-32-bit-window, odd-count, and
+/// burst ≤ 32-bit errors) — at the cost of slightly slower compute
+/// on bulk paths and pulling a second hash dependency.
+///
+/// [`Self::Xxh3Low32`] truncates `XXH3-64` to its low 32 bits —
+/// same compute cost as [`Self::Xxh3_64`], half the storage. Suited
+/// for per-entry checksums where space matters more than collision
+/// resistance.
+///
+/// Live migration semantic: changing the configured algorithm
+/// affects subsequent writes only. Existing blocks self-describe
+/// via their own `checksum_type` byte (added by downstream PR
+/// landing the `BlockHeader` extension), so readers handle mixed
+/// algorithms in the same Tree transparently. Compaction rewrites
+/// source blocks per the current algorithm.
+//
+// no-std: pure data type — compiles under `--no-default-features --features alloc`.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub enum ChecksumAlgorithm {
+    /// XXH3-64. 8 bytes. ~50-100 GB/s on AVX2 / NEON. Default.
+    #[default]
+    Xxh3_64,
+
+    /// Low 32 bits of XXH3-64. 4 bytes. Same compute as
+    /// [`Self::Xxh3_64`], half the storage. Per-entry use case.
+    Xxh3Low32,
+
+    /// CRC32C (Castagnoli polynomial). 4 bytes. HW-accelerated on
+    /// x86 (SSE 4.2 `_mm_crc32_*`) and ARM (CRC32 instructions),
+    /// ~30 GB/s. Mathematically-proven burst-error detection.
+    Crc32c,
+}
+
+impl ChecksumAlgorithm {
+    /// Size in bytes of the stored digest for this algorithm.
+    #[must_use]
+    pub const fn digest_size(self) -> usize {
+        match self {
+            Self::Xxh3_64 => 8,
+            Self::Xxh3Low32 | Self::Crc32c => 4,
+        }
+    }
+
+    /// On-disk discriminator byte. Stable across format versions —
+    /// new variants take fresh values; existing variants never
+    /// change. Downstream `BlockHeader` extension (per #297 / #298
+    /// design) carries this byte to dispatch verify on read.
+    #[must_use]
+    pub const fn wire_tag(self) -> u8 {
+        match self {
+            Self::Xxh3_64 => 0,
+            Self::Xxh3Low32 => 1,
+            Self::Crc32c => 2,
+        }
+    }
+
+    /// Recover algorithm from the on-disk discriminator byte.
+    /// Returns `None` for unknown tags so callers can reject
+    /// forward-incompatible blocks explicitly rather than
+    /// silently misinterpreting.
+    #[must_use]
+    pub const fn from_wire_tag(tag: u8) -> Option<Self> {
+        match tag {
+            0 => Some(Self::Xxh3_64),
+            1 => Some(Self::Xxh3Low32),
+            2 => Some(Self::Crc32c),
+            _ => None,
+        }
+    }
+}
+
+/// Runtime-toggleable configuration.
+///
+/// Fields here can change while the Tree is open via
+/// [`crate::Tree::update_runtime_config`]. Each field documents
+/// when its change takes effect (next write vs next compaction vs
+/// next manifest commit). Read paths are config-independent — each
+/// block / manifest self-describes via its own header, so existing
+/// on-disk data stays in its original format and reads
+/// transparently regardless of current `RuntimeConfig`.
+///
+/// Downstream features (#297 manifest hardening, #298 per-KV
+/// protection, #224 `scan_since_seqno`) extend this struct with
+/// their own fields. The fields listed below are the minimal
+/// foundation set; future PRs add fields additively.
+///
+/// `#[non_exhaustive]` so adding fields downstream is not a
+/// breaking change to struct-literal construction — callers use
+/// [`Self::default`] + builder-style updates.
+//
+// no-std: pure data — compiles under `--no-default-features --features alloc`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RuntimeConfig {
+    /// Algorithm for Block-level integrity (the checksum in
+    /// `BlockHeader`). Default: [`ChecksumAlgorithm::Xxh3_64`].
+    ///
+    /// Toggle takes effect on the next block write. Existing blocks
+    /// carry their own `checksum_type` byte (added by downstream
+    /// `BlockHeader` extension PR) so readers dispatch per-block.
+    /// Compaction rewrites source blocks per the current algorithm.
+    pub block_checksum_algo: ChecksumAlgorithm,
+
+    /// Algorithm for per-KV checksums inside `DataKvChecked` /
+    /// `FilterKvChecked` blocks (added by #298 implementation).
+    /// Independent from [`Self::block_checksum_algo`]. Default:
+    /// [`ChecksumAlgorithm::Xxh3_64`].
+    pub kv_checksum_algo: ChecksumAlgorithm,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            block_checksum_algo: ChecksumAlgorithm::Xxh3_64,
+            kv_checksum_algo: ChecksumAlgorithm::Xxh3_64,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checksum_algorithm_default_is_xxh3_64() {
+        // Default chosen for speed on modern SIMD hardware and
+        // codebase consistency (every other hash site uses XXH3).
+        // Locked here so a regression switching the default to
+        // something slower (e.g. CRC32C) lights up the test.
+        assert_eq!(ChecksumAlgorithm::default(), ChecksumAlgorithm::Xxh3_64);
+    }
+
+    #[test]
+    fn checksum_algorithm_digest_sizes_match_spec() {
+        // Per design (#298 Q5): Xxh3_64 stores 8 bytes; Xxh3Low32
+        // and Crc32c store 4 bytes. Wire format depends on this
+        // — wrong value would silently mis-frame downstream blocks.
+        assert_eq!(ChecksumAlgorithm::Xxh3_64.digest_size(), 8);
+        assert_eq!(ChecksumAlgorithm::Xxh3Low32.digest_size(), 4);
+        assert_eq!(ChecksumAlgorithm::Crc32c.digest_size(), 4);
+    }
+
+    #[test]
+    fn checksum_algorithm_wire_tag_roundtrip() {
+        // Every variant must roundtrip through its on-disk
+        // discriminator. If we ever add a new variant without
+        // wiring it into both directions, this catches the gap
+        // before it ships as a corrupt-looking block on disk.
+        for algo in [
+            ChecksumAlgorithm::Xxh3_64,
+            ChecksumAlgorithm::Xxh3Low32,
+            ChecksumAlgorithm::Crc32c,
+        ] {
+            let tag = algo.wire_tag();
+            assert_eq!(ChecksumAlgorithm::from_wire_tag(tag), Some(algo));
+        }
+    }
+
+    #[test]
+    fn checksum_algorithm_wire_tag_rejects_unknown() {
+        // Forward-incompatible blocks (newer writer, older reader)
+        // must surface as a parse failure rather than be silently
+        // misinterpreted as a known algorithm.
+        assert_eq!(ChecksumAlgorithm::from_wire_tag(255), None);
+        assert_eq!(ChecksumAlgorithm::from_wire_tag(3), None);
+    }
+
+    #[test]
+    fn runtime_config_default_uses_xxh3_64_everywhere() {
+        // Default RuntimeConfig must match RocksDB-like baseline
+        // for benchmark symmetry (#353): block-level checksum on,
+        // no per-KV machinery configured yet (downstream PRs add
+        // policy fields). Both algo slots default to Xxh3_64.
+        let cfg = RuntimeConfig::default();
+        assert_eq!(cfg.block_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+        assert_eq!(cfg.kv_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+    }
+}

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -42,6 +42,13 @@
 /// without re-litigating the value assignment.
 //
 // no-std: pure data type — compiles under `--no-default-features --features alloc`.
+//
+// Naming: `Xxh3_64` keeps the underscore between the algorithm
+// family (`Xxh3`) and the digest-bit-width suffix (`64`). This
+// matches the upstream xxhash crate (`Xxh3_64Hasher`) and reads as
+// "XXH3-64" rather than "version 364". `non_camel_case_types`
+// allows underscores between digit groups, so this passes
+// `clippy ... -D warnings` cleanly.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub enum ChecksumAlgorithm {
     /// XXH3-64. 8 bytes. ~50-100 GB/s on AVX2 / NEON. Default.

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -25,12 +25,21 @@
 /// for per-entry checksums where space matters more than collision
 /// resistance.
 ///
-/// Live migration semantic: changing the configured algorithm
-/// affects subsequent writes only. Existing blocks self-describe
-/// via their own `checksum_type` byte (added by downstream PR
-/// landing the `BlockHeader` extension), so readers handle mixed
-/// algorithms in the same Tree transparently. Compaction rewrites
-/// source blocks per the current algorithm.
+/// **Intended live-migration semantic (effective once downstream
+/// format PRs wire this into block I/O):** changing the configured
+/// algorithm will affect subsequent writes only. Existing blocks
+/// will self-describe via their own `checksum_type` byte (the
+/// `BlockHeader` extension lands with the V5-batch per-KV /
+/// manifest hardening PRs), so readers will handle mixed
+/// algorithms in the same Tree transparently. Compaction will
+/// rewrite source blocks per the current algorithm.
+///
+/// In this PR the algorithm is purely a configuration value —
+/// existing block I/O still uses the current hardcoded path; no
+/// `checksum_type` byte is written to disk yet. The discriminator
+/// API ([`Self::wire_tag`] / [`Self::from_wire_tag`]) is provided
+/// here so downstream wire-format PRs can encode the choice
+/// without re-litigating the value assignment.
 //
 // no-std: pure data type — compiles under `--no-default-features --features alloc`.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -7,7 +7,7 @@ use crate::{
     compaction::state::CompactionState,
     config::Config,
     deletion_pause::DeletionPause,
-    runtime_config::{RuntimeConfig, RuntimeConfigHandle},
+    runtime_config::{RuntimeConfig, handle::RuntimeConfigHandle},
     stop_signal::StopSignal,
     version::{SuperVersions, Version, persist_version},
 };

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -7,6 +7,7 @@ use crate::{
     compaction::state::CompactionState,
     config::Config,
     deletion_pause::DeletionPause,
+    runtime_config::{RuntimeConfig, RuntimeConfigHandle},
     stop_signal::StopSignal,
     version::{SuperVersions, Version, persist_version},
 };
@@ -74,6 +75,17 @@ pub struct TreeInner {
     /// [`Table`](crate::Table) and [`BlobFile`](crate::BlobFile).
     pub(crate) deletion_pause: Arc<DeletionPause>,
 
+    /// Runtime-toggleable configuration. Lockless atomic snapshot;
+    /// loaded by write paths (block write, manifest commit, compaction)
+    /// to pick up live config changes without coordination. Read paths
+    /// are config-independent — each block / manifest self-describes
+    /// via its own header.
+    //
+    // no-std: Tree itself is std-bound. For no_std consumers needing
+    // runtime-toggleable config, use spin::RwLock<RuntimeConfig> as
+    // alternative (slower hot path, but compiles under alloc-only).
+    pub(crate) runtime_config: RuntimeConfigHandle,
+
     #[doc(hidden)]
     #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,
@@ -110,6 +122,7 @@ impl TreeInner {
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: DeletionPause::new_shared(),
+            runtime_config: RuntimeConfigHandle::new(RuntimeConfig::default()),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -75,11 +75,16 @@ pub struct TreeInner {
     /// [`Table`](crate::Table) and [`BlobFile`](crate::BlobFile).
     pub(crate) deletion_pause: Arc<DeletionPause>,
 
-    /// Runtime-toggleable configuration. Lockless atomic snapshot;
-    /// loaded by write paths (block write, manifest commit, compaction)
-    /// to pick up live config changes without coordination. Read paths
-    /// are config-independent — each block / manifest self-describes
-    /// via its own header.
+    /// Runtime-toggleable configuration. Lockless atomic snapshot.
+    ///
+    /// In this crate it is only reachable through the public Tree API
+    /// ([`crate::Tree::runtime_config`] /
+    /// [`crate::Tree::update_runtime_config`]); no write path consults
+    /// it yet. Intended to be loaded by write paths (block write,
+    /// manifest commit, compaction) once the V5-batch format features
+    /// wire them in, so that live config changes are picked up without
+    /// coordination. Read paths remain config-independent — each block
+    /// / manifest self-describes via its own header.
     //
     // no-std: Tree itself is std-bound. For no_std consumers needing
     // runtime-toggleable config, use spin::RwLock<RuntimeConfig> as

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2016,7 +2016,7 @@ impl Tree {
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: Arc::clone(&deletion_pause),
-            runtime_config: crate::runtime_config::RuntimeConfigHandle::new(
+            runtime_config: crate::runtime_config::handle::RuntimeConfigHandle::new(
                 crate::runtime_config::RuntimeConfig::default(),
             ),
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -981,19 +981,43 @@ impl Tree {
     /// Update the live [`crate::runtime_config::RuntimeConfig`].
     ///
     /// Mutator runs on a clone of the current snapshot; the new snapshot
-    /// is then atomically swapped in. Subsequent write paths (block write,
-    /// manifest commit, compaction) pick up the change on their next
-    /// `runtime_config()` load. Existing on-disk data remains in its
-    /// original format and reads transparently — every block / manifest
-    /// is self-describing via its own header.
+    /// is then atomically swapped in. Subsequent calls to
+    /// [`Self::runtime_config`] observe the new snapshot.
     ///
-    /// Compaction acts as the live-migration mechanism: once a feature
-    /// is toggled, compaction rewrites source blocks per the new snapshot
-    /// over subsequent cycles, so all data converges to the current
-    /// settings without stop-the-world coordination.
+    /// ## Current scope
     ///
-    /// Atomicity: concurrent readers observe either the old or the new
-    /// snapshot, never a torn one.
+    /// This API ships the snapshot + atomic-swap mechanism. No write
+    /// path in the current tree consults `runtime_config` yet — that
+    /// wiring lands with the V5-batch format features (manifest
+    /// hardening, per-KV protection, scan-since-seqno) which extend
+    /// [`RuntimeConfig`](crate::runtime_config::RuntimeConfig) with
+    /// their own fields and read it at block write / manifest commit /
+    /// compaction boundaries.
+    ///
+    /// ## Designed semantics (effective once wired by V5 features)
+    ///
+    /// - Subsequent write paths load the new snapshot lockless on their
+    ///   next operation.
+    /// - Existing on-disk data remains in its original format and reads
+    ///   transparently — every block / manifest is self-describing via
+    ///   its own header.
+    /// - Compaction acts as the live-migration mechanism: source blocks
+    ///   are rewritten per the current snapshot over subsequent cycles,
+    ///   so all data converges to the current settings without
+    ///   stop-the-world coordination.
+    ///
+    /// ## Concurrency
+    ///
+    /// **Reader atomicity:** concurrent readers observe either the old
+    /// or the new snapshot, never a torn intermediate state.
+    ///
+    /// **Writer semantics: last-writer-wins.** Two `update` calls racing
+    /// from the same starting snapshot will have the second `store`
+    /// overwrite the first — the first writer's mutation is lost. There
+    /// is no CAS / RCU merge. Callers that need lost-update avoidance
+    /// (e.g. two threads concurrently toggling different fields) MUST
+    /// serialize their `update_runtime_config` calls, typically via a
+    /// `Mutex` around the call site.
     pub fn update_runtime_config<F>(&self, mutator: F)
     where
         F: FnOnce(&mut crate::runtime_config::RuntimeConfig),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -978,6 +978,36 @@ impl AbstractTree for Tree {
 }
 
 impl Tree {
+    /// Update the live [`crate::runtime_config::RuntimeConfig`].
+    ///
+    /// Mutator runs on a clone of the current snapshot; the new snapshot
+    /// is then atomically swapped in. Subsequent write paths (block write,
+    /// manifest commit, compaction) pick up the change on their next
+    /// `runtime_config()` load. Existing on-disk data remains in its
+    /// original format and reads transparently — every block / manifest
+    /// is self-describing via its own header.
+    ///
+    /// Compaction acts as the live-migration mechanism: once a feature
+    /// is toggled, compaction rewrites source blocks per the new snapshot
+    /// over subsequent cycles, so all data converges to the current
+    /// settings without stop-the-world coordination.
+    ///
+    /// Atomicity: concurrent readers observe either the old or the new
+    /// snapshot, never a torn one.
+    pub fn update_runtime_config<F>(&self, mutator: F)
+    where
+        F: FnOnce(&mut crate::runtime_config::RuntimeConfig),
+    {
+        self.0.runtime_config.update(mutator);
+    }
+
+    /// Snapshot of the current runtime config. Cheap atomic load —
+    /// safe to call on hot paths.
+    #[must_use]
+    pub fn runtime_config(&self) -> Arc<crate::runtime_config::RuntimeConfig> {
+        self.0.runtime_config.load_full()
+    }
+
     /// Shared point-read logic for `get()` and `multi_get()`: finds the newest
     /// entry, applies merge resolution or RT suppression, and returns the value.
     fn resolve_or_passthrough(
@@ -1962,6 +1992,9 @@ impl Tree {
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: Arc::clone(&deletion_pause),
+            runtime_config: crate::runtime_config::RuntimeConfigHandle::new(
+                crate::runtime_config::RuntimeConfig::default(),
+            ),
 
             #[cfg(feature = "metrics")]
             metrics,

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -82,7 +82,7 @@ fn tree_snapshot_outlives_update_with_pre_update_state() {
 }
 
 #[test]
-fn tree_runtime_config_survives_reopen_to_default() {
+fn tree_runtime_config_resets_to_default_on_reopen() {
     // The runtime config is process-state, not persisted. After Tree
     // close + reopen, the snapshot resets to defaults — caller is
     // responsible for re-applying their desired runtime overrides on

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end Tree-level integration of the runtime-config foundation
+//! (#352): `Tree::update_runtime_config` swaps the live snapshot
+//! atomically, `Tree::runtime_config` returns the current snapshot,
+//! and a snapshot captured before an update reflects the pre-update
+//! state (load-old-then-act-old guarantee that compaction-as-migration
+//! relies on).
+
+use lsm_tree::{
+    AnyTree, Config, SequenceNumberCounter, get_tmp_folder,
+    runtime_config::{ChecksumAlgorithm, RuntimeConfig},
+};
+use std::sync::Arc;
+use test_log::test;
+
+fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("Tree open should succeed");
+
+    match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree, got Blob"),
+    }
+}
+
+#[test]
+fn tree_runtime_config_starts_at_default() {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    let cfg = tree.runtime_config();
+    assert_eq!(cfg.block_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+    assert_eq!(cfg.kv_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+}
+
+#[test]
+fn tree_update_runtime_config_visible_on_next_load() {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.update_runtime_config(|cfg| {
+        cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+    });
+
+    let after = tree.runtime_config();
+    assert_eq!(after.block_checksum_algo, ChecksumAlgorithm::Crc32c);
+    // kv_checksum_algo stays at default — partial updates don't bleed
+    // across fields.
+    assert_eq!(after.kv_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+}
+
+#[test]
+fn tree_snapshot_outlives_update_with_pre_update_state() {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Capture the snapshot BEFORE the update — simulates an in-flight
+    // compaction that loaded its config at start.
+    let snap_before: Arc<RuntimeConfig> = tree.runtime_config();
+
+    tree.update_runtime_config(|cfg| {
+        cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+        cfg.kv_checksum_algo = ChecksumAlgorithm::Xxh3Low32;
+    });
+
+    // Pre-update snapshot still observes original values — the swap
+    // doesn't reach into Arcs already in caller hands.
+    assert_eq!(snap_before.block_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+    assert_eq!(snap_before.kv_checksum_algo, ChecksumAlgorithm::Xxh3_64);
+
+    // Fresh load sees the updated state.
+    let snap_after = tree.runtime_config();
+    assert_eq!(snap_after.block_checksum_algo, ChecksumAlgorithm::Crc32c);
+    assert_eq!(snap_after.kv_checksum_algo, ChecksumAlgorithm::Xxh3Low32);
+}
+
+#[test]
+fn tree_runtime_config_survives_reopen_to_default() {
+    // The runtime config is process-state, not persisted. After Tree
+    // close + reopen, the snapshot resets to defaults — caller is
+    // responsible for re-applying their desired runtime overrides on
+    // open. Pin this contract so a future "persist runtime config to
+    // manifest" change doesn't break the documented expectation
+    // silently.
+    let folder = get_tmp_folder();
+
+    {
+        let tree = open_tree(folder.path());
+        tree.update_runtime_config(|cfg| {
+            cfg.block_checksum_algo = ChecksumAlgorithm::Crc32c;
+        });
+        assert_eq!(
+            tree.runtime_config().block_checksum_algo,
+            ChecksumAlgorithm::Crc32c,
+        );
+    }
+
+    let tree = open_tree(folder.path());
+    assert_eq!(
+        tree.runtime_config().block_checksum_algo,
+        ChecksumAlgorithm::Xxh3_64,
+        "runtime config must reset to default on reopen — \
+         not persisted to manifest by design"
+    );
+}


### PR DESCRIPTION
## Summary

V5-1 of the V5 release batch — foundation for live-toggleable configuration that downstream V5 features (#297 manifest hardening, #298 per-KV protection, #224 scan_since_seqno) build on. Caller updates settings via `Tree::update_runtime_config`; subsequent write paths load the new snapshot lockless. Existing on-disk data stays in its original format and reads transparently via per-block self-description. Compaction acts as the live migration mechanism — source blocks rewritten per the current snapshot over subsequent cycles, all data converges without stop-the-world coordination.

Closes #352.

## Layered tier separation (no_std-aware)

| Module | Tier | Why |
|--------|------|-----|
| `runtime_config::types` | `alloc` (compiles on no_std + alloc) | Pure data: `RuntimeConfig` + `ChecksumAlgorithm`. Reachable from no_std consumers (block decoders, format constants). |
| `runtime_config::handle` | std-bound (`#[cfg(feature = "std")]`) | `ArcSwap`-based snapshot. `load()` = single atomic load; `update(fn)` = clone, mutate, atomic swap. |

## Public API

```rust
impl Tree {
    pub fn runtime_config(&self) -> Arc<RuntimeConfig>;
    pub fn update_runtime_config<F: FnOnce(&mut RuntimeConfig)>(&self, mutator: F);
}
```

## ChecksumAlgorithm

Used by downstream V5 features (#297, #298, #300) for block-level and per-KV checksums. Stable `wire_tag()` / `from_wire_tag()` for on-disk self-description so each block can dispatch verify per its own recorded algorithm.

| Variant | Bytes | Speed | Notes |
|---------|-------|-------|-------|
| `Xxh3_64` (default) | 8 | ~50-100 GB/s SIMD | Default — matches crate-wide XXH3 convention |
| `Xxh3Low32` | 4 | same as `Xxh3_64` | Per-entry use case where space matters |
| `Crc32c` | 4 | ~30 GB/s HW | Mathematically-proven burst-error detection |

## Tests

- **10 unit tests** in `runtime_config::types` + `runtime_config::handle`:
  - digest sizes, wire-tag roundtrip, atomic swap visibility
  - snapshot held during update is unchanged (compaction-as-migration prerequisite)
  - concurrent-reads-during-update consistent state (no torn reads under stress)
  - multiple back-to-back updates: final-state observable
- **4 integration tests** in `tests/runtime_config_integration.rs`:
  - Tree starts at default
  - update visible on next load
  - snapshot outlives update with pre-update state
  - runtime config resets to default on reopen (by design — caller re-applies)

**Workspace: 1664/1664 tests pass** (+24 new vs prior baseline). Lints clean across all-features lib + tests. Doc tests pass (43).

## Test plan

- [x] strict lints clean across all-features lib + tests
- [x] full nextest workspace: 1664/1664 pass
- [x] doc tests pass (43)
- [x] runtime_config unit tests pass (10/10)
- [x] runtime_config integration tests pass (4/4)
- [x] concurrent torn-read stress test passes (8 readers × 5000 reads + writer)

## Dependency

`arc-swap = "1.9"` (std-bound; the `experimental-thread-local` no_std mode is out of scope for now). Handle behind `#[cfg(feature = "std")]`; future no_std consumers can use `spin::RwLock<RuntimeConfig>` as alternative documented in code.

## V5 batch coordination

This is V5-1. After merge, V5-2 (#297), V5-3 (#298), V5-4 (#224) can land in parallel worktrees consuming this foundation. release-plz PR #272 stays held until full V5 batch lands — then v5.0.0 ships with the complete integrity stack as one coherent release. See #215 ROADMAP for full V5 plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-configurable checksum algorithms for block and key-value integrity checks.
  * New lockless, live configuration API to update and read runtime settings without restarts.
  * Configuration changes are isolated per tree session and reset to defaults upon tree reopen.

* **Tests**
  * Added integration and unit tests validating runtime configuration updates, atomic snapshot semantics, and persistence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->