### PR TITLE
fix(compaction/leveled): tie level-count assertion to config

### DIFF
--- a/src/compaction/leveled/mod.rs
+++ b/src/compaction/leveled/mod.rs
@@ -466,7 +466,18 @@ impl CompactionStrategy for Strategy {
 
     #[expect(clippy::too_many_lines)]
     fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice {
-        assert!(version.level_count() == 7, "should have exactly 7 levels");
+        // Tie the invariant to the caller-supplied `Config::level_count`
+        // rather than a literal so a tree explicitly configured with a
+        // non-default level count does not panic here. The assertion still
+        // fires when a `Version` carries a different count than the
+        // `Config` driving this compactor invocation — that mismatch is a
+        // real bug (Version and Config disagree).
+        assert!(
+            version.level_count() == usize::from(config.level_count),
+            "leveled compaction requires version.level_count() == config.level_count (got version={}, config={})",
+            version.level_count(),
+            config.level_count,
+        );
         let cmp = config.comparator.as_ref();
 
         // Trivial move into Lmax

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -331,21 +331,17 @@ pub fn recover(folder: &Path, fs: &dyn Fs, mode: ManifestRecoveryMode) -> crate:
         // section, so a single bit flip can silently transform it
         // into any other u8 value, and tolerant recovery modes
         // would still produce a `Version` whose `level_count()`
-        // disagrees with the downstream
-        // `assert!(version.level_count() == 7)` in
-        // `src/compaction/leveled/mod.rs`. The architectural fix
-        // is to teach `compaction/leveled` to honour the version's
-        // actual level_count rather than the hardcoded `== 7`;
-        // tracked as a follow-up to this PR's first wave.
-        //
-        // Gating recovery on `level_count == DEFAULT_LEVEL_COUNT`
-        // here would force every fixture that uses sub-default
-        // level counts for compact test manifests to pad to 7
-        // levels even when the test only cares about a single
-        // level's worth of records, which is strictly more
-        // brittleness for no production benefit — real trees
-        // ALWAYS use the default level count, so the hardcoded
-        // downstream assertion only fires on actual corruption.
+        // disagrees with the downstream `assert!` in
+        // `src/compaction/leveled/mod.rs`, which now compares
+        // against `config.level_count` rather than the literal
+        // `7`. Recovery still does not validate the recovered
+        // byte against `DEFAULT_LEVEL_COUNT`: fixtures use sub-
+        // default level counts for compact test manifests, so a
+        // strict gate here would force them to pad to the default
+        // level count even when the test only cares about a single
+        // level's worth of records. The downstream assertion fires
+        // only when a real corruption produces a Version whose
+        // count disagrees with the Config the compactor receives.
 
         'levels: for _ in 0..level_count {
             let mut level = vec![];
@@ -1886,7 +1882,8 @@ mod tests {
     ///    placeholder run with no tables inside".
     /// 3. The number of level SLOTS in `table_ids` must equal the
     ///    persisted `level_count` — downstream code
-    ///    (compaction/leveled asserts `version.level_count() == 7`)
+    ///    (compaction/leveled asserts
+    ///    `version.level_count() == config.level_count`)
     ///    reads `levels.len()` directly and shrinking it crashes
     ///    the tree.
     #[test]


### PR DESCRIPTION
## Summary

- Replace the hardcoded `assert!(version.level_count() == 7, ...)` in `compaction/leveled` with `assert!(version.level_count() == usize::from(config.level_count), ...)` so the invariant tracks the caller-supplied `Config::level_count` instead of a literal.
- Include both numbers in the panic message so a future Version/Config mismatch surfaces with each side visible.
- Update the two doc-comment references in `version/recovery.rs` that quoted the old literal form.

## Why

`Config::level_count` (default `DEFAULT_LEVEL_COUNT = 7`) is respected throughout the codebase except in the leveled compactor, which pinned the check to `7`. Two consequences:

1. A tree configured with a non-default `level_count` would have panicked at compaction time even though the rest of the codebase accepted the value.
2. Manifest recovery cannot validate `level_count` against `DEFAULT_LEVEL_COUNT` without breaking tests that use sub-default level counts for compact fixtures — that strict-mode validation is the follow-up unlocked by this change.

## Testing

- Lint clean with -D warnings on all targets / all features.
- Full workspace nextest run: 1472 passed, 0 failed.
- Doc tests: 43 passed.
- No new tests: this is a hygiene change to an invariant expression. Production `Version::new` still constructs with `DEFAULT_LEVEL_COUNT`, so the default-config path remains exercised by the existing suite (which all 1472 tests now run against `config.level_count` instead of `7`).

Closes #350