### PR TITLE
docs(format_version): document on-disk version bump policy

### DIFF
--- a/src/format_version.rs
+++ b/src/format_version.rs
@@ -2,7 +2,56 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-/// Disk format version
+/// Block / SST disk format version.
+///
+/// This enum tracks the on-disk layout of Blocks and SST files: block
+/// header layout, filter wire format, range-tombstone encoding, ECC
+/// trailer geometry. It is the version persisted in the manifest's
+/// `format_version` section and gated at `Tree::open`.
+///
+/// ## Relationship to the manifest layout version
+///
+/// `FormatVersion` and [`crate::manifest_blocks::MANIFEST_LAYOUT_VERSION_V1`]
+/// evolve at **independent cadences**:
+///
+/// | Concept | Type | Tracks |
+/// |---------|------|--------|
+/// | `FormatVersion` | This enum (V1..V5) | Block / SST on-disk layout |
+/// | `manifest_layout_version` | `u8` in manifest Footer Block | Manifest file structure (footer fields, TOC encoding, head-mirror geometry) |
+///
+/// A block format bump does NOT force a manifest layout bump and
+/// vice versa. The CURRENT pointer's canonical digest binds the
+/// manifest layout version (so a manifest-only break is detected
+/// at recovery), and the manifest's `format_version` section binds
+/// this enum (so a block-format-only break is detected at
+/// `Tree::open`).
+///
+/// ## Amendment policy
+///
+/// Once a value is **published to crates.io** (any released binary
+/// writes that value to disk), **any** subsequent change to the
+/// on-disk bytes under that value is a breaking change that MUST
+/// bump to a new variant. This applies regardless of whether the
+/// change is otherwise additive: a reader running the old code is
+/// not free to interpret unknown bytes.
+///
+/// The amendment window is the **pre-release period**: while a
+/// `FormatVersion` is being actively developed and no published
+/// binary writes it, the on-disk bytes under that version MAY be
+/// amended in place (no enum bump required). The release that
+/// crystallises the variant ends this window.
+///
+/// Same rule applies to `manifest_layout_version` independently:
+/// pre-publication amendments are free; post-publication changes
+/// require a new layout-version constant.
+///
+/// **Practical checklist for any PR that touches on-disk bytes:**
+///
+/// 1. Identify which layer the change touches (Block/SST → this
+///    enum; manifest framing → `manifest_layout_version`).
+/// 2. If that layer's current value has shipped to crates.io,
+///    add a new variant / constant instead of amending in place.
+/// 3. The OTHER layer's value stays unless its layer also changed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FormatVersion {
     /// Version for 1.x.x releases

--- a/src/manifest_blocks/mod.rs
+++ b/src/manifest_blocks/mod.rs
@@ -48,6 +48,18 @@ pub mod writer;
 /// (footer fields, TOC encoding, head-mirror geometry); decoupled
 /// from the crate-level [`crate::FormatVersion`] which tracks
 /// block / SST layout.
+///
+/// ## Amendment policy (same rule as [`crate::FormatVersion`])
+///
+/// Pre-release amendments are free: while no published binary
+/// writes this value, the on-disk bytes under it MAY be amended
+/// in place. Once the value ships to crates.io, **any** subsequent
+/// change to the on-disk manifest layout under it is breaking and
+/// MUST introduce a new `MANIFEST_LAYOUT_VERSION_V{N+1}` constant
+/// — even if the change is otherwise additive. The CURRENT
+/// pointer's canonical digest binds this value, so a layout-only
+/// break is detected at recovery without requiring a
+/// [`crate::FormatVersion`] bump.
 pub const MANIFEST_LAYOUT_VERSION_V1: u8 = 1;
 
 /// Fixed-size reservation at file offset 0 for the head footer mirror.

--- a/src/manifest_blocks/mod.rs
+++ b/src/manifest_blocks/mod.rs
@@ -55,8 +55,10 @@ pub mod writer;
 /// writes this value, the on-disk bytes under it MAY be amended
 /// in place. Once the value ships to crates.io, **any** subsequent
 /// change to the on-disk manifest layout under it is breaking and
-/// MUST introduce a new `MANIFEST_LAYOUT_VERSION_V{N+1}` constant
-/// — even if the change is otherwise additive. The CURRENT
+/// MUST introduce a new `MANIFEST_LAYOUT_VERSION_V2` constant
+/// (and `_V3`, `_V4`, ... for each subsequent post-release break,
+/// incrementing the numeric suffix every time) — even if the change
+/// is otherwise additive. The CURRENT
 /// pointer's canonical digest binds this value, so a layout-only
 /// break is detected at recovery without requiring a
 /// [`crate::FormatVersion`] bump.


### PR DESCRIPTION
## Summary

Document the amendment policy for both on-disk version identifiers in the crate:

- `crate::FormatVersion` (Block / SST layout)
- `MANIFEST_LAYOUT_VERSION_V1` (manifest framing — footer fields, TOC encoding, head-mirror geometry)

Both evolve at **independent cadences** and follow the same amendment rule: pre-release amendments are free; once a value ships to crates.io, ANY subsequent on-disk byte change under it requires a new variant / constant — even if otherwise additive.

## Why

Pre-V5 the project tolerated in-place layout amendments under unreleased `FormatVersion` values. With V5 about to ship (release-plz PR #272 held for the V5 batch), the amendment policy needs to be documented in code where future contributors will find it. The two-layer distinction (block/SST format vs manifest framing) also needs to be explicit so a manifest-only break isn't conflated with a `FormatVersion` bump.

## Changes

- `src/format_version.rs` — extended docstring on `FormatVersion` enum: amendment policy, relationship table to `manifest_layout_version`, practical checklist for PR authors touching on-disk bytes.
- `src/manifest_blocks/mod.rs` — extended docstring on `MANIFEST_LAYOUT_VERSION_V1` with the same pre-release / post-release amendment rule.

## Testing

- Lint clean (\`--all-features --lib --tests -- -D warnings\`)
- Doc tests: 43 passed, 0 failed
- No code changes — pure documentation.

Closes #351