### PR TITLE
build(deps): trim no-std-check errors via default-features=false on three deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,12 @@ path = "src/lib.rs"
 # std-only primitives behind `#[cfg(feature = "std")]`, and pick external
 # crates that support no-std.
 default = ["std"]
-std = ["dep:arc-swap"]
+std = [
+    "dep:arc-swap",
+    "byteorder/std",
+    "rustc-hash/std",
+    "varint-rs/std",
+]
 # `alloc` is the minimal hard requirement — the crate uses `Arc`,
 # `Vec`, `Box` everywhere. Listed explicitly so consumers can pick it up
 # without enabling `std` once the no-std migration completes per-module.
@@ -96,7 +101,7 @@ ribbon-serde = ["dep:serde"]
 
 [dependencies]
 bytes = { version = "1", optional = true }
-byteorder = { package = "byteorder-lite", version = "0.1.0" }
+byteorder = { package = "byteorder-lite", version = "0.1.0", default-features = false }
 byteview = "~0.10.1"
 # Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
 # std-bound — `RuntimeConfigHandle` is gated behind the `std` feature,
@@ -127,7 +132,7 @@ structured-zstd = { version = "0.0.25", optional = true, default-features = fals
 #     the shared `Arc<DeletionPause>` after recovery / compaction).
 once_cell = { version = "1", default-features = false, features = ["race"] }
 quick_cache = { version = "0.6.16", default-features = false, features = [] }
-rustc-hash = "2.1.1"
+rustc-hash = { version = "2.1.1", default-features = false }
 self_cell = "1.2.0"
 # Optional — only pulled in by the vendored Ribbon filter under the
 # `ribbon-serde` feature flag (off by default).
@@ -136,7 +141,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # the format to in-tree code lets us evolve it locally without waiting
 # for a release we cannot influence). License files preserved alongside.
 tempfile = "3.20.0"
-varint-rs = "2.2.0"
+varint-rs = { version = "2.2.0", default-features = false, features = ["signed"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 # Exact pin on a prerelease — RC API can churn between releases, so locking
 # the exact version is intentional. The 0.11 surface we depend on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # the format to in-tree code lets us evolve it locally without waiting
 # for a release we cannot influence). License files preserved alongside.
 tempfile = "3.20.0"
-varint-rs = { version = "2.2.0", default-features = false, features = ["signed"] }
+varint-rs = { version = "2.2.0", default-features = false }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 # Exact pin on a prerelease — RC API can churn between releases, so locking
 # the exact version is intentional. The 0.11 surface we depend on:


### PR DESCRIPTION
## Summary

Three direct deps (`byteorder-lite`, `rustc-hash`, `varint-rs`) defaulted to a `std` feature that pulled `extern crate std` unconditionally. Set `default-features = false` on each, route `std` back through the crate-level `std` feature so the std build is unchanged.

## Impact on `no-std-check`

`cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc`:

| Dep | Before | After |
|-----|--------|-------|
| byteorder-lite | 111 errors | 0 |
| rustc-hash | 1 error | 0 |
| varint-rs | 106 errors | 1 (upstream `zigzag.rs` uses `std::mem::size_of`; not fixable from Cargo.toml) |

**Total no-std-check errors: 925 -> 787 (-138, -15%)**

## Remaining failing transitive deps (out of scope)

Require source-level work to gate, vendor, or replace:

| Dep | Errors | Why |
|-----|--------|-----|
| `quick_cache` | 582 | Std-only by source; cache module is the natural cut point |
| `once_cell` | 245 | Feature unification overrides our explicit `default-features = false, features = ["race"]` config — some sibling dep forces std mode |
| `byteview` | 65 | Std-only by source |
| `fastrand` | 3 | Transitive via `tempfile` (which is unconditional in this crate) |
| `varint-rs` | 1 | Upstream bug — `std::mem::size_of` instead of `core::mem::size_of` in `zigzag.rs` |

## Approach

The issue #358 originally targeted gating the manifest+version+tree+checkpoint std-bound layer behind `feature = "std"`. Measurement shows the `no-std-check` failures come from transitive deps that fail BEFORE lsm-tree source is compiled, so module gating cannot help until those deps are addressed.

This PR is the cheapest-possible cargo-side win. The deeper cascade gating remains scoped to follow-up PRs:

1. Make `quick_cache` / `tempfile` optional, gated behind `std`
2. Vendor or fork `byteview` to lift the std requirement
3. Resolve `once_cell` feature unification (audit which sibling forces std)
4. File / fix upstream `varint-rs` zigzag bug

## Testing

- `cargo check --all-features` — passes
- `cargo nextest run --workspace` — 1510 passed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean

Part of #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved feature flag configuration to provide more explicit control over standard library support across dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/coordinode-lsm-tree/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->