### PR TITLE
build(deps): gate tempfile behind std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ path = "src/lib.rs"
 default = ["std"]
 std = [
     "dep:arc-swap",
+    "dep:tempfile",
     "byteorder/std",
     "rustc-hash/std",
     "varint-rs/std",
@@ -140,7 +141,11 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # sfa is vendored under src/sfa/ (upstream does not accept PRs; pinning
 # the format to in-tree code lets us evolve it locally without waiting
 # for a release we cannot influence). License files preserved alongside.
-tempfile = "3.20.0"
+# Only used by std-bound test fixtures and the `get_tmp_folder` helper
+# (which itself uses `std::env`). Optional + gated behind the `std`
+# feature so the no-std build does not pull in `fastrand` (which
+# transitively does `extern crate std`).
+tempfile = { version = "3.20.0", optional = true }
 varint-rs = { version = "2.2.0", default-features = false }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 # Exact pin on a prerelease — RC API can churn between releases, so locking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,7 @@ pub use compression::ZstdDictionary;
 #[cfg(feature = "metrics")]
 pub use metrics::Metrics;
 
+#[cfg(feature = "std")]
 #[doc(hidden)]
 #[must_use]
 #[allow(missing_docs, clippy::missing_errors_doc, clippy::unwrap_used)]


### PR DESCRIPTION
## Summary

`tempfile` was unconditional in `[dependencies]` even though it pulls in `fastrand` (which contains `extern crate std` directly) and transitively forces `once_cell` through feature unification into a std-bound configuration. The only production use is `pub fn get_tmp_folder` which itself reads `std::env`, so cfg-gating both behind the `std` feature is mechanical with zero impact on default builds.

## Impact on `no-std-check`

**Error count: 786 -> 559 (-227, -29%)**

The drop is larger than the direct fastrand contribution because removing the `tempfile -> fastrand -> once_cell` feature-unification chain releases `once_cell` from its forced std mode (245 errors) alongside `fastrand` itself (3 errors).

| Dep | Before | After |
|-----|--------|-------|
| fastrand | 3 errors | gone (no longer in dep graph) |
| once_cell | 245 errors | gone (feature unification released) |

## Changes

- `Cargo.toml`: `tempfile` becomes `optional = true`; `dep:tempfile` added to the `std` feature.
- `src/lib.rs`: `pub fn get_tmp_folder` now carries `#[cfg(feature = "std")]`.
- Test modules and dev-deps continue to see tempfile unchanged — tests run under default features which enable std.

## Remaining `no-std-check` blockers (out of scope, follow-up PRs)

- `quick_cache` (582 errors) — std-only by source; gating it cascades into the `cache` module + every `Tree::open` consumer
- `byteview` (65 errors) — std-only by source; needs vendor/fork

## Testing

- `cargo check --all-features` — passes
- `cargo nextest run --workspace` — 1510 passed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean

Part of #358