### PR TITLE
build(deps): update structured-zstd to 0.0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ log = "0.4.30"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.25", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.26", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is


### PR DESCRIPTION
## Summary

Update structured-zstd 0.0.25 → 0.0.26.

0.0.26 ships:
- `FrameEmitInfo` block-layout introspection + opt-in per-block XXH64 sidecar (structured-zstd#173)
- skippable-payload visitor callback on `FrameDecoder` (structured-zstd#172 / #271)

The `FrameEmitInfo` surface is the prerequisite for the outer Reed-Solomon ECC layer over encrypted blocks (#254) and the forensics CLI block-structure dump (#256). This bump unblocks both.

## Compatibility

API-compatible with 0.0.25 — `FrameDecoder`, `expect_dict_id`, and `expect_window_descriptor` setters are all unchanged. No source changes required.

## Testing

- `cargo check --features zstd,encryption` — clean
- `cargo nextest run --features zstd,encryption,lz4 --lib` — 1117 passed, 0 failed
