### PR TITLE
ci: allow test-only pedantic lints tripped by test-log 0.2.21

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,21 @@
 #![warn(clippy::multiple_crate_versions)]
 #![allow(clippy::option_if_let_else)]
 #![warn(clippy::redundant_feature_names)]
+// The `#[test_log::test]` attribute macro expands to a body that places
+// `use` items after statements, which trips `items_after_statements` in
+// the test build (`clippy --all-targets`). The lint fires only on the
+// macro's generated code, not on anything hand-written, so allow it
+// crate-wide rather than annotating every instrumented test.
+#![allow(clippy::items_after_statements)]
+// Test fixtures routinely bind closely-named locals (`dict_a` / `dict_b`,
+// `tree_1` / `tree_2`) where the similarity is the point; `similar_names`
+// is pedantic noise on that style.
+#![allow(clippy::similar_names)]
+// Long scenario tests (fuzz harnesses, multi-phase integration cases)
+// legitimately run past the `too_many_lines` ceiling; splitting them
+// would obscure the scenario. The lint is only reached under
+// `--all-targets`, which lints test bodies.
+#![allow(clippy::too_many_lines)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 // `alloc` is the minimal hard dependency — the crate uses `Arc`, `Vec`,


### PR DESCRIPTION
## Summary

Restores the `test-zstd` CI job to green. It was failing on every PR (and would have turned `main` red on the next run) with 172 clippy errors that have nothing to do with the PRs that surfaced them.

## Root cause

`test-log` released 0.2.21. Its `#[test_log::test]` attribute macro expands to a test body that places `use` items after statements. The crate carries `#![warn(clippy::pedantic, clippy::nursery)]`, and the `test-zstd` job is the only one that runs clippy with `--all-targets` (i.e. lints test code). On the newer macro output that combination trips:

- `items_after_statements` — the macro's generated `use` placement
- `similar_names` — closely-named test fixtures (`dict_a`/`dict_b`, etc.)
- `too_many_lines` — long fuzz / scenario test functions

All three fire only on generated code or test fixtures, never on a production path. The `lint` job (clippy `--all-features`, no `--all-targets`) was unaffected, which is why this only showed up under `test-zstd`.

## Change

Three crate-level `#![allow(...)]` in `src/lib.rs`, each with a comment explaining why it is benign. No production code or behaviour changes.

## Testing

- `cargo clippy --no-default-features --features zstd,lz4 --all-targets -- -D warnings` (the failing CI command) — now clean (was 172 errors)
- `cargo clippy --all-features -- -D warnings` (the `lint` job) — clean
- `cargo nextest run --all-features` — 1738 passed
