### PR TITLE
docs: fix broken and redundant intra-doc links across the crate

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -653,12 +653,12 @@ pub trait AbstractTree: sealed::Sealed {
     /// Will return `Err` if an IO error occurs.
     fn get<K: AsRef<[u8]>>(&self, key: K, seqno: SeqNo) -> crate::Result<Option<UserValue>>;
 
-    /// Retrieves an item from the tree as a [`PinnableSlice`].
+    /// Retrieves an item from the tree as a [`PinnableSlice`](crate::PinnableSlice).
     ///
     /// When the value is backed by an on-disk data block, implementations
-    /// may return [`PinnableSlice::Pinned`] holding a reference to that block's
+    /// may return [`PinnableSlice::Pinned`](crate::PinnableSlice::Pinned) holding a reference to that block's
     /// decompressed buffer (avoiding a data copy). Memtable and blob-resolved
-    /// values use [`PinnableSlice::Owned`]. The default implementation always
+    /// values use [`PinnableSlice::Owned`](crate::PinnableSlice::Owned). The default implementation always
     /// returns `Owned`; only [`Tree`] overrides with the pinned path.
     ///
     /// The existing [`AbstractTree::get`] method is unaffected.
@@ -793,7 +793,7 @@ pub trait AbstractTree: sealed::Sealed {
         keys.into_iter().map(|key| self.get(key, seqno)).collect()
     }
 
-    /// Applies a [`WriteBatch`] with the given sequence number.
+    /// Applies a [`WriteBatch`](crate::WriteBatch) with the given sequence number.
     ///
     /// All entries share a single seqno. This is more efficient than individual
     /// writes because the version-history lock and memtable size accounting

--- a/src/blob_tree/ingest.rs
+++ b/src/blob_tree/ingest.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use std::cmp::Ordering;
 
-/// Bulk ingestion for [`BlobTree`]
+/// Bulk ingestion for [`BlobTree`](crate::BlobTree)
 ///
 /// Items NEED to be added in ascending key order.
 ///

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -141,8 +141,8 @@ impl ZstdDictionary {
     /// and [`CompressionProvider::decompress_with_dict`].
     ///
     /// The handle stores the full 64-bit xxh3 hash of `raw` internally.
-    /// [`ZstdDictionary::id`] returns the lower 32 bits for external consumers
-    /// (config validation, frame header); [`ZstdDictionary::id64`] exposes the
+    /// [`Self::id`] returns the lower 32 bits for external consumers
+    /// (config validation, frame header); `id64` (crate-internal) exposes the
     /// full fingerprint for use as a cache key.
     #[must_use]
     pub fn new(raw: &[u8]) -> Self {
@@ -310,7 +310,7 @@ pub enum CompressionType {
     ///
     /// `level` is the compression level (1–22), `dict_id` identifies the
     /// dictionary (truncated xxh3 hash of the dictionary bytes). The actual
-    /// dictionary must be provided via [`Config`] or the relevant writer/reader.
+    /// dictionary must be provided via [`Config`](crate::Config) or the relevant writer/reader.
     #[cfg(zstd_any)]
     ZstdDict {
         /// Compression level (1–22)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -242,7 +242,7 @@ pub struct KvSeparationOptions {
     /// Pre-trained zstd dictionary for blob-file dictionary compression.
     ///
     /// Required when `compression` is [`CompressionType::ZstdDict`].
-    /// The `dict_id` in the compression type must match [`ZstdDictionary::id`].
+    /// The `dict_id` in the compression type must match [`ZstdDictionary::id`](crate::ZstdDictionary::id).
     #[cfg(zstd_any)]
     #[doc(hidden)]
     pub zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
@@ -329,7 +329,7 @@ impl KvSeparationOptions {
     ///
     /// Required when [`compression`](Self::compression) is set to
     /// [`CompressionType::ZstdDict`].  The `dict_id` encoded in the
-    /// compression type must equal [`ZstdDictionary::id()`] of the
+    /// compression type must equal [`ZstdDictionary::id()`](crate::ZstdDictionary::id) of the
     /// supplied dictionary; [`Config::open`] will return
     /// [`Error::ZstdDictMismatch`](crate::Error::ZstdDictMismatch) if
     /// they disagree.

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -71,7 +71,7 @@ pub fn parity_len(payload_len: usize) -> usize {
 
 /// Encodes a Reed-Solomon parity trailer for `payload`.
 ///
-/// Returns `Vec<u8>` of length [`parity_len(payload.len())`].
+/// Returns `Vec<u8>` of length [`parity_len`]`(payload.len())`.
 /// The caller writes the bytes verbatim after the payload and
 /// records `ecc_length = parity.len() as u32` in the block
 /// header.

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -71,7 +71,7 @@ pub fn parity_len(payload_len: usize) -> usize {
 
 /// Encodes a Reed-Solomon parity trailer for `payload`.
 ///
-/// Returns `Vec<u8>` of length [`parity_len`]`(payload.len())`.
+/// Returns a `Vec<u8>` of length [`parity_len`] for `payload.len()`.
 /// The caller writes the bytes verbatim after the payload and
 /// records `ecc_length = parity.len() as u32` in the block
 /// header.

--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -21,7 +21,7 @@
 //! The `MetadataFrame` layout is byte-aligned with §5.1; the
 //! `BodyFrame` layout is §5.2; AAD construction follows §5.3.
 //! Both writer and
-//! reader hit the same [`aad::build`] call with the same inputs, so
+//! reader hit the same [`aad::build`](super::aad::build) call with the same inputs, so
 //! the AEAD tag binds the ciphertext to the full block-identity +
 //! codec context + key-epoch tuple. AAD is never written to disk.
 
@@ -289,7 +289,7 @@ fn decode_metadata_payload(payload: &[u8]) -> Result<ParsedMetadata, DecryptErro
 ///
 /// Reads the active key from `key_chain` at `ctx.key_epoch`, draws
 /// a fresh 12-byte nonce from a CSPRNG, builds the 38-byte AAD via
-/// [`aad::build`], encrypts the plaintext in place via
+/// [`aad::build`](super::aad::build), encrypts the plaintext in place via
 /// [`encrypt_in_place`], and serialises the result.
 ///
 /// # Errors

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -21,29 +21,34 @@
 //! The AAD-bound on-disk block format from
 //! `docs/aad-block-format.md` ships in the submodules:
 //!
-//! - [`aad`]: pure-byte AAD construction, [`aad::SuiteId`] /
-//!   [`aad::EncryptionContext`], plus re-exports of the existing
+//! - `aad`: pure-byte AAD construction, `aad::SuiteId` /
+//!   `aad::EncryptionContext`, plus re-exports of the existing
 //!   `crate::table::block::BlockType` / `crate::table::block::BlockIdentity`
 //!   so the AAD path and the Block I/O path share one identity type.
-//! - [`error`]: `DecryptError` enum with one variant per decode-time
+//! - `error`: `DecryptError` enum with one variant per decode-time
 //!   failure mode (re-exported at the crate's encryption surface).
-//! - [`aead`] (feature `encryption`): per-suite AEAD dispatch
+//! - `aead` (feature `encryption`): per-suite AEAD dispatch
 //!   (AES-256-GCM, ChaCha20-Poly1305) that takes the 38-byte AAD
-//!   from [`aad::build`] and produces / verifies the
+//!   from `aad::build` and produces / verifies the
 //!   `(nonce, ciphertext, tag)` triple.
-//! - [`key_chain`]: the `KeyChain` trait + in-memory
+//! - `key_chain`: the `KeyChain` trait + in-memory
 //!   `StaticKeyChain` reference impl, decoupling KeyEpoch → key
 //!   lookup from the LSM crate.
-//! - [`block`] (features `encryption` + `zstd_any`): top-level
-//!   [`encrypt_block`] / [`decrypt_block`] entry points wrapping
+//! - `block` (features `encryption` + `zstd_any`): top-level
+//!   `encrypt_block` / `decrypt_block` entry points wrapping
 //!   the `MetadataFrame ‖ BodyFrame` skippable-frame wire format
-//!   and returning [`DecryptedBlock`] (plaintext + parsed codec
+//!   and returning `DecryptedBlock` (plaintext + parsed codec
 //!   context for the caller to thread through
 //!   `structured_zstd::FrameDecoder` setters).
 //!
+//! (Module and item names above are inline rather than intra-doc links
+//! because several — `aead`, `block`, `encrypt_block`, `decrypt_block`,
+//! `DecryptedBlock` — are feature-gated and absent from doc builds that
+//! omit those features, which would break the links.)
+//!
 //! Still pending in a follow-up: replacing the legacy
 //! [`Aes256GcmProvider`] Block I/O code path below with the
-//! [`encrypt_block`] / [`decrypt_block`] entry points at every
+//! `encrypt_block` / `decrypt_block` entry points at every
 //! `Block::write_into` / `Block::from_reader` site.
 
 pub mod aad;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -4,12 +4,12 @@
 
 //! Pluggable filesystem abstraction for I/O backends.
 //!
-//! The [`Fs`] trait is intended to abstract the filesystem operations
+//! The [`Fs`](crate::fs::Fs) trait is intended to abstract the filesystem operations
 //! that lsm-tree performs, allowing alternative backends such as
 //! `io_uring`, in-memory filesystems for deterministic testing, or cloud
 //! blob storage. Call-site migration is tracked in separate issues.
 //!
-//! The default implementation [`StdFs`] delegates to [`std::fs`] and
+//! The default implementation [`StdFs`](crate::fs::StdFs) delegates to [`std::fs`] and
 //! is a zero-sized type, so it adds no runtime overhead when used as a
 //! monomorphized generic parameter.
 //!
@@ -21,7 +21,7 @@
 //!   completion semantics — not yet implemented, tracked for when Windows
 //!   becomes a production target
 //! - **macOS / BSD**: no batched I/O API exists (`dispatch_io` and `kqueue`
-//!   do not help for storage I/O patterns); [`StdFs`] is the correct choice
+//!   do not help for storage I/O patterns); [`StdFs`](crate::fs::StdFs) is the correct choice
 
 mod aligned_buf;
 // `direct_io` is std-only (touches `std::fs::OpenOptions`). It is
@@ -390,7 +390,7 @@ pub trait Fs: Send + Sync + 'static {
     /// Unlike [`create_dir_all`](Self::create_dir_all), this method must
     /// FAIL with [`io::ErrorKind::AlreadyExists`] when `path` already
     /// exists — it is the POSIX `mkdir(2)` primitive used by
-    /// [`Tree::create_checkpoint`](crate::Tree::create_checkpoint) to
+    /// [`AbstractTree::create_checkpoint`](crate::AbstractTree::create_checkpoint) to
     /// claim its target directory without a TOCTOU window.
     ///
     /// The parent directory must already exist; this method does not
@@ -487,7 +487,7 @@ pub trait Fs: Send + Sync + 'static {
 
     /// Creates a hard link `dst` that refers to the same inode as `src`.
     ///
-    /// Used by [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+    /// Used by [`AbstractTree::create_checkpoint`](crate::AbstractTree::create_checkpoint)
     /// to snapshot SST and blob files in O(1) per file without duplicating
     /// data on disk. After the link is created, deleting either path leaves
     /// the other intact; the inode is reclaimed only after the last link
@@ -505,7 +505,7 @@ pub trait Fs: Send + Sync + 'static {
     /// operator-visible notification of unexpected copies are expected
     /// to aggregate per-checkpoint and emit a single summary warning.
     ///
-    /// In-memory backends ([`MemFs`](crate::fs::MemFs)) do not have inodes;
+    /// In-memory backends ([`MemFs`]) do not have inodes;
     /// they implement this as a byte copy that produces an independent file
     /// with the same contents.
     ///
@@ -545,7 +545,7 @@ pub trait Fs: Send + Sync + 'static {
     /// Examples of equal backend IDs:
     /// - All [`crate::fs::StdFs`] instances on the same host (one
     ///   shared kernel filesystem).
-    /// - A [`crate::fs::IoUringFs`] and a [`crate::fs::StdFs`] on the
+    /// - An `IoUringFs` and a [`crate::fs::StdFs`] on the
     ///   same host (the uring backend delegates path resolution to the
     ///   kernel).
     ///

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -15,7 +15,7 @@ pub enum AnyIngestion<'a> {
     /// Ingestion for a standard LSM-tree
     Standard(Ingestion<'a>),
 
-    /// Ingestion for a [`BlobTree`] with KV separation
+    /// Ingestion for a [`BlobTree`](crate::BlobTree) with KV separation
     Blob(BlobIngestion<'a>),
 }
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -5,7 +5,7 @@
 //!
 //! Companion to [`crate::verify`]: while `verify_block_checksums` walks
 //! every block and checks per-block XXH3, this module exposes a public
-//! read-only view of an SST's stored metadata ([`TableProperties`]) for
+//! read-only view of an SST's stored metadata ([`TableProperties`](crate::inspect::TableProperties)) for
 //! diagnostic tooling like `sst-dump properties` that needs the
 //! metadata fields without spinning up a [`Tree`](crate::Tree) or
 //! recovering the manifest.
@@ -601,7 +601,7 @@ impl Iterator for DataBlockEntryIter {
 /// encoded order, neither of which depends on the comparator. So a
 /// bounds-free walk of a custom-comparator SST through this facade
 /// streams entries in the SST's own sort order correctly. What this
-/// facade can't do is run [`crate::comparator::default_comparator`]
+/// facade can't do is run `crate::comparator::default_comparator`
 /// for seek / point-read / range-bounded operations layered on top
 /// (e.g. `sst-dump dump --from/--to` applies bytewise bounds and
 /// breaks early on the upper bound, which only makes sense for the

--- a/src/manifest_blocks/current_digest.rs
+++ b/src/manifest_blocks/current_digest.rs
@@ -29,7 +29,7 @@
 //!   per TOC entry. Sort order makes the digest insensitive to TOC
 //!   reordering that doesn't change the logical manifest. Each
 //!   section's content is bound through its own
-//!   [`Block::header::checksum`] — XXH3-128 over the section
+//!   `Block::header::checksum` — XXH3-128 over the section
 //!   Block's payload bytes (post-compression / post-encryption
 //!   stream, same bytes the Block layer's own integrity check
 //!   covers); the Block header and optional ECC trailer are

--- a/src/manifest_blocks/mod.rs
+++ b/src/manifest_blocks/mod.rs
@@ -30,7 +30,7 @@
 //! single-block recovery "for free" by reusing existing infrastructure.
 //!
 //! Section names mirror the previous sfa archive's section names so
-//! existing callers in [`crate::Manifest`] / [`crate::version::recovery`]
+//! existing callers in `crate::Manifest` / `crate::version::recovery`
 //! see the same logical surface during the migration; only the underlying
 //! framing changes.
 //!

--- a/src/manifest_blocks/writer.rs
+++ b/src/manifest_blocks/writer.rs
@@ -5,7 +5,7 @@
 //! that the V5-2 layout (`manifest_layout_version = 1`) describes.
 //!
 //! The writer mirrors the `crate::sfa::Writer` start / write / finish API
-//! so the call sites in [`crate::version::persist`] and the
+//! so the call sites in `crate::version::persist` and the
 //! V5-2-aware version encoder can migrate with minimal churn: open
 //! the writer, [`start`] a section, write its bytes via the
 //! [`Write`] impl, repeat per section, then [`finish`] to emit the

--- a/src/merge_source.rs
+++ b/src/merge_source.rs
@@ -25,11 +25,11 @@
 //!
 //! # Contract
 //!
-//! - [`Self::next`] yields items in ascending `InternalKey` order
+//! - [`MergeSource::next`] yields items in ascending `InternalKey` order
 //!   from the source's "front" cursor.
-//! - [`Self::next_back`] yields items in descending order from the
+//! - [`MergeSource::next_back`] yields items in descending order from the
 //!   source's "back" cursor.
-//! - [`Self::seek`] guarantees depend on the source's cursor model:
+//! - [`MergeSource::seek`] guarantees depend on the source's cursor model:
 //!
 //!   **Independent-cursor sources** (LSM SST scanners, `RunReader`s,
 //!   where calling `next` repeatedly does NOT advance the back

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -47,7 +47,7 @@ pub struct Metrics {
     pub(crate) io_skipped_by_filter: AtomicUsize,
 
     /// Number of segments skipped during prefix scans via
-    /// [`Tree::create_prefix`] where the per-table prefix bloom filter
+    /// [`Tree::create_prefix`](crate::Tree::create_prefix) where the per-table prefix bloom filter
     /// returned `Ok(false)`. Counted in both single-table and
     /// multi-table run paths of `TreeIter::create_range`.
     ///
@@ -238,7 +238,7 @@ impl Metrics {
         self.io_skipped_by_filter.load(Relaxed)
     }
 
-    /// Number of segments skipped during [`Tree::create_prefix`] scans
+    /// Number of segments skipped during [`Tree::create_prefix`](crate::Tree::create_prefix) scans
     /// by prefix bloom filters (single-table and multi-table run paths).
     ///
     /// Note: `BlobTree` prefix scans do not currently record this metric.

--- a/src/runtime_config/mod.rs
+++ b/src/runtime_config/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Layered tier separation
 //!
-//! [`RuntimeConfig`] and its companion enums are POD data with no
+//! [`RuntimeConfig`](crate::runtime_config::RuntimeConfig) and its companion enums are POD data with no
 //! I/O dependencies — they live in this module and compile under
 //! `no_std + alloc`. The mutable handle (crate-internal type
 //! `handle::RuntimeConfigHandle`) lives in a `pub(crate)` submodule
@@ -21,7 +21,7 @@
 //! re-exported: the stable public surface is
 //! [`crate::Tree::runtime_config`] /
 //! [`crate::Tree::update_runtime_config`], which return / accept
-//! [`RuntimeConfig`] only, so `arc-swap` stays an implementation
+//! [`RuntimeConfig`](crate::runtime_config::RuntimeConfig) only, so `arc-swap` stays an implementation
 //! detail and is not part of the crate's semver contract.
 //!
 //! Downstream no_std consumers (block decoders, format constants,
@@ -37,7 +37,7 @@
 //! [`crate::Tree::update_runtime_config`]) reads and updates it.
 //! The wiring lands with the V5-batch format features (manifest
 //! hardening, per-KV protection, scan-since-seqno), which extend
-//! [`RuntimeConfig`] with their own fields and load the snapshot at
+//! [`RuntimeConfig`](crate::runtime_config::RuntimeConfig) with their own fields and load the snapshot at
 //! block write / manifest commit / compaction boundaries.
 //!
 //! Once wired, the intended semantics are:

--- a/src/seqno.rs
+++ b/src/seqno.rs
@@ -46,18 +46,18 @@ pub const MAX_SEQNO: SeqNo = 0x7FFF_FFFF_FFFF_FFFF;
 ///   unique for the lifetime of the generator (modulo wrap-around, which
 ///   must not occur within the reserved MSB range).
 ///
-/// Implementors are also responsible for ensuring that [`get`] does not
-/// return values that violate these invariants, and that [`set`] and
-/// [`fetch_max`] do not violate them (e.g., by setting the counter to a
+/// Implementors are also responsible for ensuring that [`Self::get`] does not
+/// return values that violate these invariants, and that [`Self::set`] and
+/// [`Self::fetch_max`] do not violate them (e.g., by setting the counter to a
 /// value at or above `0x8000_0000_0000_0000`, or by moving the counter
-/// backwards such that subsequent calls to [`next`] would observe
+/// backwards such that subsequent calls to [`Self::next`] would observe
 /// non-monotonic sequence numbers).
 ///
-/// The [`set`] method is a special-case escape hatch intended for use
+/// The [`Self::set`] method is a special-case escape hatch intended for use
 /// during initialization or recovery. It may move the counter forwards
 /// or backwards and therefore **may** cause subsequent calls to
-/// [`next`] to observe non-monotonic sequence numbers. This is
-/// permitted; callers are responsible for using [`fetch_max`] (or other
+/// [`Self::next`] to observe non-monotonic sequence numbers. This is
+/// permitted; callers are responsible for using [`Self::fetch_max`] (or other
 /// application-level logic) after `set` if they need to reestablish any
 /// monotonicity guarantees.
 ///
@@ -87,7 +87,7 @@ pub trait SequenceNumberGenerator:
     /// Gets the current sequence number without incrementing.
     ///
     /// This should be consistent with the value that will be used as the
-    /// basis for the next call to [`next`], and must not itself alter the
+    /// basis for the next call to [`Self::next`], and must not itself alter the
     /// monotonicity guarantees.
     #[must_use]
     fn get(&self) -> SeqNo;
@@ -100,11 +100,11 @@ pub trait SequenceNumberGenerator:
     /// This method is intended for direct overrides (e.g., during
     /// initialization or recovery) and is **not** required to preserve
     /// monotonicity with respect to values previously returned by
-    /// [`next`]. In particular, calling `set` with a value lower than a
+    /// [`Self::next`]. In particular, calling `set` with a value lower than a
     /// previously returned `next` value may cause subsequent calls to
-    /// [`next`] to observe non-monotonic sequence numbers. This is
+    /// [`Self::next`] to observe non-monotonic sequence numbers. This is
     /// allowed; callers that need to advance the sequence number in a
-    /// monotonic fashion should prefer [`fetch_max`] instead of `set`.
+    /// monotonic fashion should prefer [`Self::fetch_max`] instead of `set`.
     fn set(&self, value: SeqNo);
 
     /// Atomically updates the sequence number to the maximum of
@@ -112,7 +112,7 @@ pub trait SequenceNumberGenerator:
     ///
     /// The resulting stored value must:
     /// - Remain strictly less than `0x8000_0000_0000_0000`.
-    /// - Preserve the monotonicity guarantees expected by [`next`].
+    /// - Preserve the monotonicity guarantees expected by [`Self::next`].
     fn fetch_max(&self, value: SeqNo);
 }
 

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -100,7 +100,7 @@ pub struct BlockIdentity {
 
     /// Identifier of the owning store unit — for SST blocks this is
     /// the per-tree [`crate::TableId`] (a `u64` alias); for blob
-    /// files it is the [`crate::vlog::BlobFileId`] (also a `u64`
+    /// files it is the `crate::vlog::BlobFileId` (also a `u64`
     /// alias). Combined with [`Self::tree_id`], gives the
     /// per-process unique discriminator that prevents block-swap
     /// attacks: AAD built from `(tree_id, table_id, block_offset)`

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -15,11 +15,11 @@ use super::threshold::{compute_thresholds, partition_keys_by_threshold};
 /// For each layer (0 to `max_layers - 1`):
 ///   1. Hash every input key with the layer's derived seed to produce a
 ///      `StandardEquation` (gives `start = block_idx * b + offset`).
-///   2. Run [`compute_thresholds`] over those equations to pick per-block
+///   2. Run `compute_thresholds` over those equations to pick per-block
 ///      threshold `τ_i`. A key with `offset < τ_i` is KEPT in this layer;
 ///      a key with `offset >= τ_i` is BUMPED to the next layer.
 ///   3. Partition keys into `kept` and `bumped` via
-///      [`partition_keys_by_threshold`].
+///      `partition_keys_by_threshold`.
 ///   4. Build a vendored Standard Ribbon over `kept` — the threshold
 ///      scheme caps per-block load to ~90%, so this build succeeds with
 ///      negligible probability of falling into Ribbon's

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -313,7 +313,7 @@ impl<S> core::fmt::Debug for BurrFilter<S> {
 /// This is the type the LSM filter framework consumes: it owns a borrowed
 /// slice of the on-disk filter block, parses the BuRR header, and answers
 /// `contains_hash` lookups. Wire format documented in
-/// [`super::wire`] — intentionally distinct from the vendored
+/// `super::wire` — intentionally distinct from the vendored
 /// `ribbon-serde` repr (that one is for in-memory snapshots).
 #[derive(Debug)]
 pub struct BurrFilterReader<'a> {


### PR DESCRIPTION
## Summary

`cargo doc --no-deps --all-features -D warnings` failed with **47 documentation errors** across 20 files. This fixes every one; the strict doc build is now clean.

The errors fell into three classes:

1. **Broken intra-doc links (most of them)** — shorthand `[`name`]` refs that rustdoc could not resolve:
   - trait methods referenced from the trait's own docs needed `Self::` / `Trait::` (e.g. `SequenceNumberGenerator::next`, `MergeSource::seek`)
   - crate types referenced from submodules needed `crate::` paths (e.g. `crate::PinnableSlice`, `crate::WriteBatch`, `crate::BlobTree`, `crate::Config`)
2. **Public docs linking to private items** — `BurrBuilder` → `compute_thresholds`, `encryption` → `error`, `table_id` → `crate::vlog::BlobFileId`, etc. Rendered as inline code (cannot link a public doc to a private item).
3. **Redundant explicit link target** — `[`MemFs`](crate::fs::MemFs)` where the label already names the target.

## Fix strategy

Each link handled individually:
- item is public → add the correct resolvable path
- item is private or feature-gated (so absent from some doc builds) → render as inline `code`

No code or behaviour changes — docs only.

## Testing

- `cargo doc --no-deps --all-features -D warnings` — **clean** (was 47 errors). This is the configuration docs.rs builds (`all-features = true` in `Cargo.toml`).
- `cargo build --all-features` — clean.
- `cargo test --doc --all-features` — 43 passed.

## Note (out of scope)

Under the narrower `--no-default-features --features encryption,page_ecc` doc build there remain ~5 broken links in feature-gated code (`pinnable_slice::Pinned`, `transform::with_dict`, zstd-dict refs in `inspect`). That combination is not built by docs.rs (which uses all-features) and is not gated by CI. `src/table/block/transform.rs` also carries some pre-existing duplicated doc prose unrelated to links. Both are left for a separate follow-up to keep this PR a clean all-features doc-lint fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved consistency and clarity of documentation comments and references throughout the codebase, including better formatting and fully-qualified paths for inline code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->