### PR TITLE
feat(index): per-block seqno bounds in SST index entries

### DIFF
--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -94,6 +94,13 @@ pub(super) fn prepare_table_writer(
     let last_level = (version.level_count() - 1) as u8;
     let is_last_level = payload.dest_level == last_level;
 
+    // One runtime-config snapshot for the whole writer setup: reading
+    // `load_full()` per field could straddle a concurrent
+    // `update_runtime_config`, letting one SST mix `seqno_in_index` from
+    // snapshot A with `kv_checksums` from snapshot B and breaking the
+    // single-snapshot-per-compaction contract.
+    let rc = opts.runtime_config.load_full();
+
     let table_writer = table_writer
         .use_data_block_restart_interval(data_block_restart_interval)
         .use_index_block_restart_interval(index_block_restart_interval)
@@ -112,7 +119,7 @@ pub(super) fn prepare_table_writer(
         // snapshot so a compaction started after a toggle rewrites its
         // output SSTs in the new index format (compaction is the migration
         // mechanism for the on-disk index layout).
-        .use_seqno_in_index(opts.runtime_config.load_full().seqno_in_index)
+        .use_seqno_in_index(rc.seqno_in_index)
         .use_bloom_policy({
             use crate::config::FilterPolicyEntry::{Bloom, None};
             use crate::table::filter::BloomConstructionPolicy;
@@ -137,10 +144,7 @@ pub(super) fn prepare_table_writer(
     // per-KV footer and leaves the `KV_CHECKSUM_FOOTER` flag clear (the
     // data-block payload encoding is unchanged; the V5 header/meta layout
     // still differs from pre-V5 regardless).
-    let table_writer = {
-        let rc = opts.runtime_config.load_full();
-        table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo)
-    };
+    let table_writer = table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
 
     #[cfg(zstd_any)]
     let table_writer = table_writer.use_zstd_dictionary(opts.config.zstd_dictionary.clone());

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -108,6 +108,11 @@ pub(super) fn prepare_table_writer(
         .use_prefix_extractor(opts.config.prefix_extractor.clone())
         .use_encryption(opts.config.encryption.clone())
         .use_page_ecc(opts.config.page_ecc)
+        // `seqno_in_index` is a live runtime config: read off the current
+        // snapshot so a compaction started after a toggle rewrites its
+        // output SSTs in the new index format (compaction is the migration
+        // mechanism for the on-disk index layout).
+        .use_seqno_in_index(opts.runtime_config.load_full().seqno_in_index)
         .use_bloom_policy({
             use crate::config::FilterPolicyEntry::{Bloom, None};
             use crate::table::filter::BloomConstructionPolicy;

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -530,9 +530,11 @@ pub struct RuntimeConfig {
     ///
     /// Default `false`: index blocks are byte-identical to the pre-#224
     /// `index_format = 0` format, and `scan_since_seqno` falls back to a
-    /// per-entry filter. Read paths dispatch on each SST's own
-    /// `index_format` byte regardless of this setting, so mixed-format
-    /// trees (some SSTs migrated, some not) read correctly.
+    /// per-entry filter. Decoding is marker-based: each index entry is
+    /// self-describing (legacy markers `0`/`1`, seqno-bounded `2`/`3`), so
+    /// mixed-format trees (some SSTs migrated, some not) read correctly
+    /// regardless of this setting; the stored `index_format` byte is a
+    /// metadata hint, not the decode switch.
     ///
     /// Toggle takes effect on the next compaction / flush; existing SSTs
     /// keep their original `index_format`. Compaction migrates source

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -383,6 +383,12 @@ impl TableIdRange {
 // no-std: pure data — compiles under `--no-default-features --features alloc`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "config POD: each bool is an independent on/off feature toggle \
+              (manifest mirror, manifest per-KV checksums, page ECC, seqno-in-index); \
+              folding them into enums would obscure the per-feature config contract"
+)]
 pub struct RuntimeConfig {
     /// Algorithm for Block-level integrity (the checksum in
     /// `BlockHeader`). Default: [`ChecksumAlgorithm::Xxh3_64`].
@@ -514,6 +520,24 @@ pub struct RuntimeConfig {
     /// is enabled (useful when the per-KV checksums themselves are
     /// considered sufficient and ECC is wanted only on value bytes).
     pub kv_checksums_ecc_override: Option<bool>,
+
+    /// Per-block seqno bounds in SST index entries (#224). When `true`,
+    /// SSTs written by the next flush / compaction record each data
+    /// block's `seqno_min` / `seqno_max` in its index entry
+    /// (`index_format = 1` in the table Properties), enabling fast
+    /// `scan_since_seqno` via block-skip: the scan skips any block whose
+    /// `seqno_max < target` without reading it.
+    ///
+    /// Default `false`: index blocks are byte-identical to the pre-#224
+    /// `index_format = 0` format, and `scan_since_seqno` falls back to a
+    /// per-entry filter. Read paths dispatch on each SST's own
+    /// `index_format` byte regardless of this setting, so mixed-format
+    /// trees (some SSTs migrated, some not) read correctly.
+    ///
+    /// Toggle takes effect on the next compaction / flush; existing SSTs
+    /// keep their original `index_format`. Compaction migrates source
+    /// SSTs to the current setting over time.
+    pub seqno_in_index: bool,
 }
 
 impl Default for RuntimeConfig {
@@ -528,6 +552,7 @@ impl Default for RuntimeConfig {
             page_ecc: false,
             data_block_ecc_override: None,
             kv_checksums_ecc_override: None,
+            seqno_in_index: false,
         }
     }
 }
@@ -826,6 +851,15 @@ mod tests {
         assert!(!cfg.page_ecc);
         assert_eq!(cfg.data_block_ecc_override, None);
         assert_eq!(cfg.kv_checksums_ecc_override, None);
+    }
+
+    #[test]
+    fn runtime_config_default_seqno_in_index_off() {
+        // seqno_in_index is explicit opt-in (#224): default false keeps
+        // index blocks byte-identical to the pre-#224 index_format=0
+        // format. A regression flipping this default would change the
+        // on-disk index layout for every existing tree.
+        assert!(!RuntimeConfig::default().seqno_in_index);
     }
 
     #[test]

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -257,6 +257,13 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         let seqno_bounds = if has_bounds {
             let seqno_min = reader.read_u64_varint().ok()?;
             let seqno_max = reader.read_u64_varint().ok()?;
+            // Reject inverted bounds: a forged `seqno_max < seqno_min` would
+            // let a seqno-scoped scan skip a block that still holds visible
+            // entries, silently returning incomplete results. Surface it as a
+            // decode failure instead of propagating bogus bounds.
+            if seqno_min > seqno_max {
+                return None;
+            }
             Some((seqno_min, seqno_max))
         } else {
             None
@@ -370,6 +377,11 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         let seqno_bounds = if has_bounds {
             let seqno_min = reader.read_u64_varint().ok()?;
             let seqno_max = reader.read_u64_varint().ok()?;
+            // Reject inverted bounds (see `parse_full`): a forged
+            // `seqno_max < seqno_min` could drive an incorrect block-skip.
+            if seqno_min > seqno_max {
+                return None;
+            }
             Some((seqno_min, seqno_max))
         } else {
             None
@@ -670,6 +682,65 @@ mod tests {
         assert_eq!(
             bytes.get(parsed.end_key.0..parsed.end_key.1).unwrap(),
             b"abcdef"
+        );
+    }
+
+    #[test]
+    fn full_entry_with_inverted_seqno_bounds_is_rejected() {
+        // A forged entry whose seqno_min > seqno_max must fail to decode, not
+        // propagate bounds that could drive an incorrect seqno block-skip
+        // (skipping a block that still holds visible entries).
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(9, 3); // inverted: min > max
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle.encode_full_into(&mut bytes, &mut state).unwrap();
+        assert_eq!(bytes.first().copied(), Some(2));
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
+            &mut cursor,
+            0,
+            bytes.len(),
+        );
+        assert!(
+            parsed.is_none(),
+            "inverted seqno bounds (min > max) must be rejected on decode",
+        );
+    }
+
+    #[test]
+    fn truncated_entry_with_inverted_seqno_bounds_is_rejected() {
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(9, 3); // inverted: min > max
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle
+            .encode_truncated_into(&mut bytes, &mut state, 2)
+            .unwrap();
+        assert_eq!(bytes.first().copied(), Some(3));
+
+        let offset = 16;
+        let entries_end = offset + bytes.len();
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
+            &mut cursor,
+            offset,
+            12,
+            16,
+            entries_end,
+        );
+        assert!(
+            parsed.is_none(),
+            "inverted seqno bounds (min > max) must be rejected on decode",
         );
     }
 

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -74,6 +74,14 @@ pub struct KeyedBlockHandle {
     /// Seqno of last item in block
     seqno: SeqNo,
 
+    /// Per-block seqno bounds `(min, max)` for the referenced data block.
+    /// `Some` ⇒ this index entry uses the seqno-bounded wire format (markers
+    /// 2 / 3), letting a seqno-scoped scan skip a data block whose `max` is
+    /// below the target without reading it; `None` ⇒ legacy entry (markers
+    /// 0 / 1, no bounds on disk). The writer sets this uniformly per SST from
+    /// the runtime config; the decoder populates it from the on-disk marker.
+    seqno_bounds: Option<(SeqNo, SeqNo)>,
+
     inner: BlockHandle,
 }
 
@@ -94,8 +102,17 @@ impl KeyedBlockHandle {
         Self {
             end_key,
             seqno,
+            seqno_bounds: None,
             inner: handle,
         }
+    }
+
+    /// Attaches per-block seqno bounds `(min, max)`, switching this handle to
+    /// the seqno-bounded wire format (markers 2 / 3) when encoded.
+    #[must_use]
+    pub fn with_seqno_bounds(mut self, seqno_min: SeqNo, seqno_max: SeqNo) -> Self {
+        self.seqno_bounds = Some((seqno_min, seqno_max));
+        self
     }
 
     #[must_use]
@@ -136,15 +153,28 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         writer: &mut W,
         state: &mut BlockOffset,
     ) -> crate::Result<()> {
-        // We encode restart markers as:
+        // Legacy full entry (marker 0):
         // [marker=0] [offset] [size] [seqno] [key len] [end key]
         // 1          2        3      4       5         6
+        //
+        // Seqno-bounded full entry (marker 2): same, with per-block seqno
+        // bounds inserted right after [seqno]:
+        // [marker=2] [offset] [size] [seqno] [seqno min] [seqno max] [key len] [end key]
+        // 1          2        3      4       4a          4b          5         6
 
-        writer.write_u8(0)?; // 1
+        match self.seqno_bounds {
+            None => writer.write_u8(0)?, // 1
+            Some(_) => writer.write_u8(2)?,
+        }
 
         self.inner.encode_into(writer)?; // 2, 3
 
         unwrap!(writer.write_u64_varint(self.seqno)); // 4
+
+        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
+            writer.write_u64_varint(seqno_min)?; // 4a
+            writer.write_u64_varint(seqno_max)?; // 4b
+        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(self.end_key.len() as u16)?; // 5
@@ -162,13 +192,24 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         _state: &mut BlockOffset,
         shared_len: usize,
     ) -> crate::Result<()> {
-        // We encode truncated index entries as:
+        // Legacy truncated entry (marker 1):
         // [marker=1] [offset] [size] [seqno] [shared prefix len] [rest key len] [rest key]
         // 1          2        3      4       5                   6              7
-        writer.write_u8(1)?;
+        //
+        // Seqno-bounded truncated entry (marker 3): same, with per-block seqno
+        // bounds inserted right after [seqno].
+        match self.seqno_bounds {
+            None => writer.write_u8(1)?,
+            Some(_) => writer.write_u8(3)?,
+        }
 
         self.inner.encode_into(writer)?;
         writer.write_u64_varint(self.seqno)?;
+
+        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
+            writer.write_u64_varint(seqno_min)?;
+            writer.write_u64_varint(seqno_max)?;
+        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(shared_len as u16)?;
@@ -203,12 +244,23 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        if marker != 0 {
-            return None;
-        }
+        // Full entries are marker 0 (legacy) or marker 2 (seqno-bounded).
+        let has_bounds = match marker {
+            0 => false,
+            2 => true,
+            _ => return None,
+        };
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
+
+        let seqno_bounds = if has_bounds {
+            let seqno_min = reader.read_u64_varint().ok()?;
+            let seqno_max = reader.read_u64_varint().ok()?;
+            Some((seqno_min, seqno_max))
+        } else {
+            None
+        };
 
         let key_len: usize = reader.read_u16_varint().ok()?.into();
         #[expect(
@@ -237,6 +289,7 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
+            seqno_bounds,
         })
     }
 
@@ -251,13 +304,22 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        if marker != 0 {
-            return None;
-        }
+        // Restart heads are full entries: marker 0 (legacy) or 2 (seqno-bounded).
+        let has_bounds = match marker {
+            0 => false,
+            2 => true,
+            _ => return None,
+        };
 
         let _file_offset = reader.read_u64_varint().ok()?;
         let _size = reader.read_u32_varint().ok()?;
         let seqno = reader.read_u64_varint().ok()?;
+
+        if has_bounds {
+            // Skip per-block seqno bounds; the restart key only needs the key.
+            let _seqno_min = reader.read_u64_varint().ok()?;
+            let _seqno_max = reader.read_u64_varint().ok()?;
+        }
 
         let key_len: usize = reader.read_u16_varint().ok()?.into();
         #[expect(
@@ -295,12 +357,23 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             return None;
         }
 
-        if marker != 1 {
-            return None;
-        }
+        // Truncated entries are marker 1 (legacy) or marker 3 (seqno-bounded).
+        let has_bounds = match marker {
+            1 => false,
+            3 => true,
+            _ => return None,
+        };
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
+
+        let seqno_bounds = if has_bounds {
+            let seqno_min = reader.read_u64_varint().ok()?;
+            let seqno_max = reader.read_u64_varint().ok()?;
+            Some((seqno_min, seqno_max))
+        } else {
+            None
+        };
 
         let shared_prefix_len: usize = reader.read_u16_varint().ok()?.into();
         let rest_key_len: usize = reader.read_u16_varint().ok()?.into();
@@ -347,6 +420,7 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
+            seqno_bounds,
         })
     }
 }
@@ -502,10 +576,9 @@ mod tests {
     #[test]
     fn parse_truncated_rejects_invalid_marker() {
         let mut bytes = make_truncated_entry(1);
-        let invalid_marker = match TRAILER_START_MARKER {
-            2 => 3,
-            _ => 2,
-        };
+        // 99 is outside the valid marker set {0 full, 1 truncated, 2 full+bounds,
+        // 3 truncated+bounds, 255 trailer}, so parse_truncated must reject it.
+        let invalid_marker = 99u8;
         *bytes.get_mut(0).unwrap() = invalid_marker;
         let offset = 16;
         let entries_end = offset + bytes.len();
@@ -551,5 +624,111 @@ mod tests {
             bytes.len(),
         );
         assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn full_entry_without_bounds_keeps_legacy_marker() {
+        // A handle with no seqno bounds must encode with the legacy full
+        // marker (0) so off-mode SSTs stay byte-identical to the prior layout.
+        let bytes = make_full_entry();
+        assert_eq!(bytes.first().copied(), Some(0));
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
+            &mut cursor,
+            0,
+            bytes.len(),
+        )
+        .unwrap();
+        assert_eq!(parsed.seqno_bounds, None);
+    }
+
+    #[test]
+    fn full_entry_with_seqno_bounds_round_trips() {
+        // marker 2: seqno bounds survive an encode -> parse_full round-trip,
+        // and the marker byte switches to the seqno-bounded variant.
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(3, 9);
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle.encode_full_into(&mut bytes, &mut state).unwrap();
+        assert_eq!(bytes.first().copied(), Some(2));
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
+            &mut cursor,
+            0,
+            bytes.len(),
+        )
+        .unwrap();
+        assert_eq!(parsed.seqno, 7);
+        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
+        assert_eq!(
+            bytes.get(parsed.end_key.0..parsed.end_key.1).unwrap(),
+            b"abcdef"
+        );
+    }
+
+    #[test]
+    fn truncated_entry_with_seqno_bounds_round_trips() {
+        // marker 3: seqno bounds survive an encode -> parse_truncated
+        // round-trip on a truncated (prefix-compressed) entry.
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(3, 9);
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle
+            .encode_truncated_into(&mut bytes, &mut state, 2)
+            .unwrap();
+        assert_eq!(bytes.first().copied(), Some(3));
+
+        let offset = 16;
+        let entries_end = offset + bytes.len();
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
+            &mut cursor,
+            offset,
+            12,
+            16,
+            entries_end,
+        )
+        .unwrap();
+        assert_eq!(parsed.seqno, 7);
+        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
+    }
+
+    #[test]
+    fn parse_restart_key_skips_seqno_bounds_on_marker_2() {
+        // parse_restart_key must step over the two seqno-bounds varints so the
+        // returned restart key is correct for a marker-2 (seqno-bounded) head.
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(3, 9);
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle.encode_full_into(&mut bytes, &mut state).unwrap();
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let (key, seqno) =
+            <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
+                &mut cursor,
+                0,
+                bytes.as_slice(),
+                bytes.len(),
+            )
+            .unwrap();
+        assert_eq!(key, b"abcdef");
+        assert_eq!(seqno, 7);
     }
 }

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -169,7 +169,7 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
 
         self.inner.encode_into(writer)?; // 2, 3
 
-        unwrap!(writer.write_u64_varint(self.seqno)); // 4
+        writer.write_u64_varint(self.seqno)?; // 4
 
         if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
             writer.write_u64_varint(seqno_min)?; // 4a

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -717,7 +717,11 @@ mod tests {
         // Layout: [marker=2][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
         // all single-byte varints, so the bounds sit at indices 4 and 5.
         assert_eq!(bytes.first().copied(), Some(2));
-        assert_eq!((bytes[4], bytes[5]), (3, 9), "bound varint layout changed");
+        assert_eq!(
+            (bytes.get(4).copied(), bytes.get(5).copied()),
+            (Some(3), Some(9)),
+            "bound varint layout changed",
+        );
         bytes.swap(4, 5); // → seqno_min=9, seqno_max=3 (inverted)
 
         let mut cursor = Cursor::new(bytes.as_slice());
@@ -747,7 +751,11 @@ mod tests {
             .unwrap();
         // Layout: [marker=3][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
         assert_eq!(bytes.first().copied(), Some(3));
-        assert_eq!((bytes[4], bytes[5]), (3, 9), "bound varint layout changed");
+        assert_eq!(
+            (bytes.get(4).copied(), bytes.get(5).copied()),
+            (Some(3), Some(9)),
+            "bound varint layout changed",
+        );
         bytes.swap(4, 5); // invert
 
         let offset = 16;

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -336,9 +336,15 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         let seqno = reader.read_u64_varint().ok()?;
 
         if has_bounds {
-            // Skip per-block seqno bounds; the restart key only needs the key.
-            let _seqno_min = reader.read_u64_varint().ok()?;
-            let _seqno_max = reader.read_u64_varint().ok()?;
+            // The restart key only needs the key, but still reject inverted
+            // bounds (seqno_min > seqno_max) here as `parse_full` /
+            // `parse_truncated` do — a malformed marker-2 head must not feed a
+            // forged entry into restart-table navigation.
+            let seqno_min = reader.read_u64_varint().ok()?;
+            let seqno_max = reader.read_u64_varint().ok()?;
+            if seqno_min > seqno_max {
+                return None;
+            }
         }
 
         let key_len: usize = reader.read_u16_varint().ok()?.into();
@@ -831,5 +837,40 @@ mod tests {
             .unwrap();
         assert_eq!(key, b"abcdef");
         assert_eq!(seqno, 7);
+    }
+
+    #[test]
+    fn parse_restart_key_rejects_inverted_seqno_bounds() {
+        // A marker-2 restart head with seqno_min > seqno_max must be rejected
+        // (like parse_full / parse_truncated), not feed a forged entry into
+        // restart-table navigation. Build valid (3, 9), then swap the two
+        // single-byte bound varints on the wire to invert them.
+        let handle = KeyedBlockHandle::new(
+            b"abcdef".to_vec().into(),
+            7,
+            BlockHandle::new(BlockOffset(0), 1),
+        )
+        .with_seqno_bounds(3, 9);
+        let mut bytes = Vec::new();
+        let mut state = BlockOffset(0);
+        handle.encode_full_into(&mut bytes, &mut state).unwrap();
+        assert_eq!(
+            (bytes.get(4).copied(), bytes.get(5).copied()),
+            (Some(3), Some(9)),
+            "bound varint layout changed",
+        );
+        bytes.swap(4, 5); // invert
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
+            &mut cursor,
+            0,
+            bytes.as_slice(),
+            bytes.len(),
+        );
+        assert!(
+            parsed.is_none(),
+            "inverted seqno bounds must be rejected by parse_restart_key",
+        );
     }
 }

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -109,8 +109,21 @@ impl KeyedBlockHandle {
 
     /// Attaches per-block seqno bounds `(min, max)`, switching this handle to
     /// the seqno-bounded wire format (markers 2 / 3) when encoded.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `seqno_min > seqno_max`. Inverted bounds are
+    /// a caller invariant violation (the writer derives them from a single
+    /// min/max fold over the block, so it cannot produce them); encoding an
+    /// inverted pair would let a seqno-scoped scan skip a block that still
+    /// holds visible entries. Corruption arriving from disk is rejected
+    /// separately on the decode path (`parse_full` / `parse_truncated`).
     #[must_use]
     pub fn with_seqno_bounds(mut self, seqno_min: SeqNo, seqno_max: SeqNo) -> Self {
+        debug_assert!(
+            seqno_min <= seqno_max,
+            "inverted seqno bounds: min {seqno_min} > max {seqno_max}",
+        );
         self.seqno_bounds = Some((seqno_min, seqno_max));
         self
     }
@@ -689,17 +702,23 @@ mod tests {
     fn full_entry_with_inverted_seqno_bounds_is_rejected() {
         // A forged entry whose seqno_min > seqno_max must fail to decode, not
         // propagate bounds that could drive an incorrect seqno block-skip
-        // (skipping a block that still holds visible entries).
+        // (skipping a block that still holds visible entries). Build a VALID
+        // (3, 9) entry — `with_seqno_bounds` debug-asserts min <= max — then
+        // swap the two single-byte bound varints on the wire to invert them.
         let handle = KeyedBlockHandle::new(
             b"abcdef".to_vec().into(),
             7,
             BlockHandle::new(BlockOffset(0), 1),
         )
-        .with_seqno_bounds(9, 3); // inverted: min > max
+        .with_seqno_bounds(3, 9);
         let mut bytes = Vec::new();
         let mut state = BlockOffset(0);
         handle.encode_full_into(&mut bytes, &mut state).unwrap();
+        // Layout: [marker=2][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
+        // all single-byte varints, so the bounds sit at indices 4 and 5.
         assert_eq!(bytes.first().copied(), Some(2));
+        assert_eq!((bytes[4], bytes[5]), (3, 9), "bound varint layout changed");
+        bytes.swap(4, 5); // → seqno_min=9, seqno_max=3 (inverted)
 
         let mut cursor = Cursor::new(bytes.as_slice());
         let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
@@ -720,13 +739,16 @@ mod tests {
             7,
             BlockHandle::new(BlockOffset(0), 1),
         )
-        .with_seqno_bounds(9, 3); // inverted: min > max
+        .with_seqno_bounds(3, 9);
         let mut bytes = Vec::new();
         let mut state = BlockOffset(0);
         handle
             .encode_truncated_into(&mut bytes, &mut state, 2)
             .unwrap();
+        // Layout: [marker=3][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
         assert_eq!(bytes.first().copied(), Some(3));
+        assert_eq!((bytes[4], bytes[5]), (3, 9), "bound varint layout changed");
+        bytes.swap(4, 5); // invert
 
         let offset = 16;
         let entries_end = offset + bytes.len();

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -29,6 +29,9 @@ pub struct IndexBlockParsedItem {
     pub prefix: Option<SliceIndexes>,
     pub end_key: SliceIndexes,
     pub seqno: SeqNo,
+    /// Per-block seqno bounds `(min, max)`, present only for seqno-bounded
+    /// index entries (markers 2 / 3); `None` for legacy entries.
+    pub seqno_bounds: Option<(SeqNo, SeqNo)>,
 }
 
 impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
@@ -83,7 +86,12 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
             bytes.slice(self.end_key.0..self.end_key.1)
         };
 
-        KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size))
+        let handle =
+            KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size));
+        match self.seqno_bounds {
+            Some((seqno_min, seqno_max)) => handle.with_seqno_bounds(seqno_min, seqno_max),
+            None => handle,
+        }
     }
 }
 

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -8,7 +8,6 @@ use crate::{
     CompressionType, KeyRange, SeqNo, TableId, checksum::ChecksumType, coding::Decode,
     comparator::default_comparator, runtime_config::ChecksumAlgorithm, table::block::BlockType,
 };
-use byteorder::{LittleEndian, ReadBytesExt};
 use std::ops::Deref;
 
 /// Nanosecond timestamp.
@@ -120,6 +119,19 @@ macro_rules! read_u64 {
         let bytes = <[u8; 8]>::try_from(&item.value[..])
             .map_err(|_| crate::Error::InvalidHeader("TableMeta"))?;
         u64::from_le_bytes(bytes)
+    }};
+}
+
+macro_rules! read_u128 {
+    ($block:expr, $name:expr, $cmp:expr) => {{
+        let item = $block
+            .point_read($name, SeqNo::MAX, $cmp)?
+            .ok_or(crate::Error::InvalidHeader("TableMeta"))?;
+        // Exactly sixteen little-endian bytes — same exact-width contract as
+        // read_u64!, so an overlong / short payload is rejected as corrupt meta.
+        let bytes = <[u8; 16]>::try_from(&item.value[..])
+            .map_err(|_| crate::Error::InvalidHeader("TableMeta"))?;
+        u128::from_le_bytes(bytes)
     }};
 }
 
@@ -241,14 +253,7 @@ impl ParsedMeta {
         let weak_tombstone_count = read_u64!(block, b"weak_tombstone_count", &cmp);
         let weak_tombstone_reclaimable = read_u64!(block, b"weak_tombstone_reclaimable", &cmp);
 
-        let created_at = {
-            let bytes = block
-                .point_read(b"created_at", SeqNo::MAX, &cmp)?
-                .ok_or(crate::Error::InvalidHeader("TableMeta"))?;
-
-            let mut bytes = &bytes.value[..];
-            bytes.read_u128::<LittleEndian>()?.into()
-        };
+        let created_at = read_u128!(block, b"created_at", &cmp).into();
 
         let key_range = KeyRange::new((
             block
@@ -262,24 +267,8 @@ impl ParsedMeta {
         ));
 
         let seqnos = {
-            let min = {
-                let bytes = block
-                    .point_read(b"seqno#min", SeqNo::MAX, &cmp)?
-                    .ok_or(crate::Error::InvalidHeader("TableMeta"))?
-                    .value;
-                let mut bytes = &bytes[..];
-                bytes.read_u64::<LittleEndian>()?
-            };
-
-            let max = {
-                let bytes = block
-                    .point_read(b"seqno#max", SeqNo::MAX, &cmp)?
-                    .ok_or(crate::Error::InvalidHeader("TableMeta"))?
-                    .value;
-                let mut bytes = &bytes[..];
-                bytes.read_u64::<LittleEndian>()?
-            };
-
+            let min = read_u64!(block, b"seqno#min", &cmp);
+            let max = read_u64!(block, b"seqno#max", &cmp);
             (min, max)
         };
 
@@ -292,8 +281,11 @@ impl ParsedMeta {
         // surface metadata corruption rather than silently falling back.
         let highest_kv_seqno =
             if let Some(item) = block.point_read(b"seqno#kv_max", SeqNo::MAX, &cmp)? {
-                let mut bytes = &item.value[..];
-                validated_kv_seqno(bytes.read_u64::<LittleEndian>()?, seqnos.1)?
+                // Present-but-wrong-width is corrupt meta — require exactly 8
+                // bytes rather than truncating an overlong payload.
+                let bytes = <[u8; 8]>::try_from(&item.value[..])
+                    .map_err(|_| crate::Error::InvalidHeader("TableMeta"))?;
+                validated_kv_seqno(u64::from_le_bytes(bytes), seqnos.1)?
             } else {
                 seqnos.1
             };
@@ -338,15 +330,14 @@ impl ParsedMeta {
         // format, no per-block seqno bounds).
         let index_format = match block.point_read(b"index_format", SeqNo::MAX, &cmp)? {
             None => 0u8,
-            // The value must be EXACTLY one byte. `read_u8` alone would ignore
-            // trailing bytes, so a corrupt payload like `[1, 0xFF]` would parse
-            // as `1`. Since this byte selects the index-entry decoder, require
-            // an exact one-byte payload and reject anything else.
-            Some(item) if item.value.len() == 1 => {
-                let mut bytes = &item.value[..];
-                bytes.read_u8()?
-            }
-            Some(_) => return Err(crate::Error::InvalidHeader("TableMeta")),
+            // The value must be EXACTLY one byte. Matching a single-element slice
+            // rejects trailing bytes, so a corrupt payload like `[1, 0xFF]` is an
+            // error rather than parsing as `1`. Since this byte selects the
+            // index-entry decoder, require an exact one-byte payload.
+            Some(item) => match &item.value[..] {
+                [b] => *b,
+                _ => return Err(crate::Error::InvalidHeader("TableMeta")),
+            },
         };
         // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
         // this format slice. Reject any other byte as corrupt / forward-
@@ -680,6 +671,33 @@ mod tests {
                 .find(|iv| &*iv.key.user_key == key.as_bytes())
             {
                 *item = meta(key, &[0u8, 0xFF]);
+            }
+            let result = load_meta_from_items(&items);
+            assert!(
+                matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+                "overlong {key} payload must be rejected, got {result:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn load_with_handle_overlong_fixed_width_field_is_rejected() {
+        // created_at (16 B) and the seqno fields (8 B each) are fixed-width;
+        // an overlong payload (junk byte appended) must be rejected as
+        // InvalidHeader, not silently truncated to the leading bytes.
+        for (key, mut value) in [
+            ("created_at", 1_000_000u128.to_le_bytes().to_vec()),
+            ("seqno#min", 1u64.to_le_bytes().to_vec()),
+            ("seqno#max", 10u64.to_le_bytes().to_vec()),
+            ("seqno#kv_max", 5u64.to_le_bytes().to_vec()),
+        ] {
+            value.push(0xFF); // overlong
+            let mut items = valid_meta_items();
+            if let Some(item) = items
+                .iter_mut()
+                .find(|iv| &*iv.key.user_key == key.as_bytes())
+            {
+                *item = meta(key, &value);
             }
             let result = load_meta_from_items(&items);
             assert!(

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -332,8 +332,9 @@ impl ParsedMeta {
             None => 0u8,
             // The value must be EXACTLY one byte. Matching a single-element slice
             // rejects trailing bytes, so a corrupt payload like `[1, 0xFF]` is an
-            // error rather than parsing as `1`. Since this byte selects the
-            // index-entry decoder, require an exact one-byte payload.
+            // error rather than parsing as `1`. This byte is a metadata hint
+            // recording which index format the writer emitted; the per-entry
+            // decode itself dispatches on per-entry markers, not on this value.
             Some(item) => match &item.value[..] {
                 [b] => *b,
                 _ => return Err(crate::Error::InvalidHeader("TableMeta")),
@@ -341,8 +342,7 @@ impl ParsedMeta {
         };
         // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
         // this format slice. Reject any other byte as corrupt / forward-
-        // incompatible metadata rather than letting a bogus on-disk format
-        // flow downstream to the index decoder.
+        // incompatible metadata rather than trusting a bogus on-disk hint.
         if index_format > 1 {
             return Err(crate::Error::InvalidHeader("TableMeta"));
         }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -551,6 +551,22 @@ mod tests {
         }
     }
 
+    #[test]
+    fn index_format_overlong_payload_is_rejected() {
+        // The index_format value must be exactly one byte. A payload with
+        // trailing bytes (e.g. [1, 0xFF]) would otherwise parse as 1 because
+        // read_u8 ignores the remainder — since this byte selects the index
+        // decoder, an overlong payload is corrupt metadata and must be rejected.
+        let mut items = valid_meta_items();
+        items.push(meta("index_format", &[1u8, 0xFF]));
+        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
+        let result = load_meta_from_items(&items);
+        assert!(
+            matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+            "overlong index_format payload must be rejected, got {result:?}",
+        );
+    }
+
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.
     #[test]
     fn load_with_handle_missing_table_version_returns_err() {

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -81,6 +81,17 @@ pub struct ParsedMeta {
     /// types (`Meta` / `Manifest` / `ManifestFooter`) keep the byte and still
     /// carry a per-block `ECC_PARITY` flag.
     pub page_ecc: bool,
+
+    /// Index block format for this SST (#224). `0` = legacy: index
+    /// entries carry no per-block seqno bounds (byte-identical to the
+    /// pre-#224 format). `1` = each index entry includes
+    /// `seqno_min` / `seqno_max` for its data block, enabling
+    /// `scan_since_seqno` block-skip.
+    ///
+    /// Optional on disk: SSTs written before this field existed lack the
+    /// `index_format` property and parse as `0`, so legacy tables read
+    /// correctly and fall back to the per-entry filter scan path.
+    pub index_format: u8,
 }
 
 macro_rules! read_u8 {
@@ -322,6 +333,17 @@ impl ParsedMeta {
 
         let page_ecc = read_u8!(block, b"descriptor#page_ecc", &cmp) != 0;
 
+        // Optional field introduced for scan_since_seqno block-skip (#224).
+        // SSTs written before this key existed parse as 0 (legacy index
+        // format, no per-block seqno bounds). A present-but-truncated value
+        // propagates the I/O error to surface metadata corruption.
+        let index_format = block
+            .point_read(b"index_format", SeqNo::MAX, &cmp)?
+            .map_or(Ok(0u8), |item| {
+                let mut bytes = &item.value[..];
+                bytes.read_u8()
+            })?;
+
         Ok(Self {
             id,
             created_at,
@@ -339,6 +361,7 @@ impl ParsedMeta {
             index_block_compression,
             kv_checksum_algo,
             page_ecc,
+            index_format,
         })
     }
 }
@@ -474,6 +497,28 @@ mod tests {
         let items = valid_meta_items();
         let result = load_meta_from_items(&items);
         assert!(result.is_ok(), "valid meta must parse: {result:?}");
+    }
+
+    #[test]
+    fn index_format_absent_parses_as_legacy_zero() {
+        // valid_meta_items() carries no `index_format` key (legacy SST).
+        // It must parse as index_format = 0 so pre-#224 tables fall back
+        // to the per-entry scan path.
+        let meta = load_meta_from_items(&valid_meta_items()).unwrap();
+        assert_eq!(meta.index_format, 0);
+    }
+
+    #[test]
+    fn index_format_present_parses_its_value() {
+        // An SST carrying `index_format = 1` must parse as 1 so the read
+        // path knows the index entries hold per-block seqno bounds.
+        let mut items = valid_meta_items();
+        // Insert in sorted position (between filter_hash_type and
+        // index_keys_have_seqno) to keep the block ordered.
+        items.push(meta("index_format", &[1u8]));
+        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
+        let meta = load_meta_from_items(&items).unwrap();
+        assert_eq!(meta.index_format, 1);
     }
 
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -343,6 +343,13 @@ impl ParsedMeta {
                 let mut bytes = &item.value[..];
                 bytes.read_u8()
             })?;
+        // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
+        // this format slice. Reject any other byte as corrupt / forward-
+        // incompatible metadata rather than letting a bogus on-disk format
+        // flow downstream to the index decoder.
+        if index_format > 1 {
+            return Err(crate::Error::InvalidHeader("TableMeta"));
+        }
 
         Ok(Self {
             id,
@@ -519,6 +526,24 @@ mod tests {
         items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
         let meta = load_meta_from_items(&items).unwrap();
         assert_eq!(meta.index_format, 1);
+    }
+
+    #[test]
+    fn index_format_unknown_byte_is_rejected() {
+        // Only 0 and 1 are defined in this format slice; a present-but-unknown
+        // byte (e.g. corrupt metadata, or a forward-incompatible writer) must
+        // fail fast as InvalidHeader rather than flowing downstream as a bogus
+        // on-disk index format.
+        for bad in [2u8, 255u8] {
+            let mut items = valid_meta_items();
+            items.push(meta("index_format", &[bad]));
+            items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
+            let result = load_meta_from_items(&items);
+            assert!(
+                matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+                "index_format = {bad} must be rejected, got {result:?}",
+            );
+        }
     }
 
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -335,14 +335,19 @@ impl ParsedMeta {
 
         // Optional field introduced for scan_since_seqno block-skip (#224).
         // SSTs written before this key existed parse as 0 (legacy index
-        // format, no per-block seqno bounds). A present-but-truncated value
-        // propagates the I/O error to surface metadata corruption.
-        let index_format = block
-            .point_read(b"index_format", SeqNo::MAX, &cmp)?
-            .map_or(Ok(0u8), |item| {
+        // format, no per-block seqno bounds).
+        let index_format = match block.point_read(b"index_format", SeqNo::MAX, &cmp)? {
+            None => 0u8,
+            // The value must be EXACTLY one byte. `read_u8` alone would ignore
+            // trailing bytes, so a corrupt payload like `[1, 0xFF]` would parse
+            // as `1`. Since this byte selects the index-entry decoder, require
+            // an exact one-byte payload and reject anything else.
+            Some(item) if item.value.len() == 1 => {
                 let mut bytes = &item.value[..];
-                bytes.read_u8()
-            })?;
+                bytes.read_u8()?
+            }
+            Some(_) => return Err(crate::Error::InvalidHeader("TableMeta")),
+        };
         // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
         // this format slice. Reject any other byte as corrupt / forward-
         // incompatible metadata rather than letting a bogus on-disk format

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -87,6 +87,12 @@ pub struct MultiWriter {
         crate::runtime_config::ChecksumAlgorithm,
     )>,
 
+    /// `seqno_in_index` runtime config — preserved here so the rotation
+    /// path stamps the same index format on every successor [`Writer`],
+    /// keeping all SSTs of one flush / compaction at a uniform
+    /// `index_format`.
+    use_seqno_in_index: bool,
+
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
 }
@@ -145,6 +151,7 @@ impl MultiWriter {
             page_ecc: false,
 
             kv_checksum: None,
+            use_seqno_in_index: false,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -449,6 +456,16 @@ impl MultiWriter {
         self
     }
 
+    /// Wires the `seqno_in_index` runtime config through to the inner
+    /// [`Writer`] and preserves it across rotations so every successor
+    /// writer stamps the same `index_format` on its index entries.
+    #[must_use]
+    pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
+        self.use_seqno_in_index = seqno_in_index;
+        self.writer = self.writer.use_seqno_in_index(seqno_in_index);
+        self
+    }
+
     #[cfg(zstd_any)]
     #[must_use]
     pub fn use_zstd_dictionary(
@@ -489,6 +506,7 @@ impl MultiWriter {
         if let Some((policy, algo)) = self.kv_checksum {
             new_writer = new_writer.use_kv_checksums(policy, algo);
         }
+        new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
 
         #[cfg(zstd_any)]
         {

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -131,6 +131,16 @@ pub struct Writer {
         crate::runtime_config::ChecksumAlgorithm,
     )>,
 
+    /// Per-block seqno bounds opt-in (the `seqno_in_index` runtime config).
+    /// When `true`, every data-block index entry carries `(seqno_min,
+    /// seqno_max)` (wire markers 2 / 3) and the SST is tagged
+    /// `index_format = 1`, letting a seqno-scoped scan skip blocks below the
+    /// target without reading them. Default `false` (legacy `index_format =
+    /// 0`, byte-identical index entries). Caller wires the live runtime
+    /// config into this field via [`Self::use_seqno_in_index`] before the
+    /// first key is added.
+    use_seqno_in_index: bool,
+
     /// Pre-trained zstd dictionary for dictionary compression
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
@@ -208,6 +218,7 @@ impl Writer {
             page_ecc: false,
 
             kv_checksum: None,
+            use_seqno_in_index: false,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -405,6 +416,19 @@ impl Writer {
         self
     }
 
+    /// Enables per-block seqno bounds in the data-block index (the
+    /// `seqno_in_index` runtime config). When `true`, each index entry
+    /// carries `(seqno_min, seqno_max)` and the SST is tagged
+    /// `index_format = 1`. Must be called BEFORE the first key is added so
+    /// every index entry in the table uses the same format; callers
+    /// (`Tree` flush + compaction worker) pass the live config once at
+    /// writer construction. Default `false` (legacy `index_format = 0`).
+    #[must_use]
+    pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
+        self.use_seqno_in_index = seqno_in_index;
+        self
+    }
+
     #[must_use]
     pub fn use_bloom_policy(mut self, bloom_policy: BloomConstructionPolicy) -> Self {
         self.bloom_policy = bloom_policy;
@@ -578,12 +602,35 @@ impl Writer {
 
         let bytes_written = header.on_disk_size();
 
-        self.index_writer
-            .register_data_block(KeyedBlockHandle::new(
-                last.key.user_key.clone(),
-                last.key.seqno,
-                BlockHandle::new(self.meta.file_pos, bytes_written),
-            ))?;
+        let mut handle = KeyedBlockHandle::new(
+            last.key.user_key.clone(),
+            last.key.seqno,
+            BlockHandle::new(self.meta.file_pos, bytes_written),
+        );
+
+        if self.use_seqno_in_index {
+            // Per-block seqno bounds let a seqno-scoped scan skip this whole
+            // block when its `max` is below the target. The chunk is still
+            // intact here (popped further down), so min/max is a single pass
+            // over entries already in hand: zero extra tracking.
+            #[expect(clippy::expect_used, reason = "chunk is non-empty (last exists)")]
+            let seqno_min = self
+                .chunk
+                .iter()
+                .map(|e| e.key.seqno)
+                .min()
+                .expect("chunk is non-empty");
+            #[expect(clippy::expect_used, reason = "chunk is non-empty (last exists)")]
+            let seqno_max = self
+                .chunk
+                .iter()
+                .map(|e| e.key.seqno)
+                .max()
+                .expect("chunk is non-empty");
+            handle = handle.with_seqno_bounds(seqno_min, seqno_max);
+        }
+
+        self.index_writer.register_data_block(handle)?;
 
         // Adjust metadata
         self.meta.file_pos += u64::from(bytes_written);
@@ -825,10 +872,11 @@ impl Writer {
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
-            // Always 0 for now: the writer is not yet wired to the runtime
-            // `seqno_in_index` config, so every SST uses the legacy index
-            // format (byte-identical to the pre-#224 layout).
-            index_format: 0,
+            // `1` when the writer was built with `use_seqno_in_index(true)`:
+            // every data-block index entry carries `(seqno_min, seqno_max)`
+            // (wire markers 2 / 3) for seqno-scoped block-skip. `0` is the
+            // legacy format, byte-identical to the pre-seqno-bounds layout.
+            index_format: u8::from(self.use_seqno_in_index),
             range_tombstone_count,
             // `block_offset` here feeds `BlockIdentity` which today is
             // unused (`let _ = identity;` in `Block::write_into` /
@@ -1116,11 +1164,11 @@ fn write_meta_section<W: std::io::Write + std::io::Seek>(
         meta("descriptor#page_ecc", &[u8::from(effective_page_ecc)]),
         meta("file_size", &p.file_size.to_le_bytes()),
         meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
-        // Index block format (#224): 0 = legacy (no per-block seqno
-        // bounds in index entries). The seqno-bounded format (1) is
-        // emitted once the writer is wired to the runtime
-        // `seqno_in_index` config; until then every SST is index_format=0,
-        // byte-identical to the pre-#224 layout.
+        // Index block format: 0 = legacy (no per-block seqno bounds in
+        // index entries, byte-identical to the prior layout); 1 = each
+        // data-block index entry carries `(seqno_min, seqno_max)` for
+        // seqno-scoped block-skip. Set from the writer's `seqno_in_index`
+        // config at build time.
         meta("index_format", &[p.index_format]),
         meta("index_keys_have_seqno", &[0x1]),
         meta("initial_level", &p.initial_level.to_le_bytes()),

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -825,6 +825,10 @@ impl Writer {
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
+            // Always 0 for now: the writer is not yet wired to the runtime
+            // `seqno_in_index` config, so every SST uses the legacy index
+            // format (byte-identical to the pre-#224 layout).
+            index_format: 0,
             range_tombstone_count,
             // `block_offset` here feeds `BlockIdentity` which today is
             // unused (`let _ = identity;` in `Block::write_into` /
@@ -1035,6 +1039,10 @@ struct MetaSectionParams<'a> {
     data_block_restart_interval: u8,
     index_block_restart_interval: u8,
     initial_level: u8,
+    /// Index block format byte written to the SST Properties (#224).
+    /// `0` = legacy (no per-block seqno bounds). Currently always `0`
+    /// until the writer is wired to the runtime `seqno_in_index` config.
+    index_format: u8,
     range_tombstone_count: u64,
     block_offset: u64,
     /// `created_at` snapshot taken once in `finish()`. Both MID and
@@ -1108,6 +1116,12 @@ fn write_meta_section<W: std::io::Write + std::io::Seek>(
         meta("descriptor#page_ecc", &[u8::from(effective_page_ecc)]),
         meta("file_size", &p.file_size.to_le_bytes()),
         meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
+        // Index block format (#224): 0 = legacy (no per-block seqno
+        // bounds in index entries). The seqno-bounded format (1) is
+        // emitted once the writer is wired to the runtime
+        // `seqno_in_index` config; until then every SST is index_format=0,
+        // byte-identical to the pre-#224 layout.
+        meta("index_format", &[p.index_format]),
         meta("index_keys_have_seqno", &[0x1]),
         meta("initial_level", &p.initial_level.to_le_bytes()),
         meta("item_count", &p.item_count.to_le_bytes()),

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -611,22 +611,16 @@ impl Writer {
         if self.use_seqno_in_index {
             // Per-block seqno bounds let a seqno-scoped scan skip this whole
             // block when its `max` is below the target. The chunk is still
-            // intact here (popped further down), so min/max is a single pass
-            // over entries already in hand: zero extra tracking.
-            #[expect(clippy::expect_used, reason = "chunk is non-empty (last exists)")]
-            let seqno_min = self
+            // intact here (popped further down), so both bounds come from a
+            // single fold over entries already in hand: zero extra tracking,
+            // one pass. Seeds (MAX, MIN) are overwritten on the first entry
+            // because the chunk is non-empty (`last` exists above).
+            let (seqno_min, seqno_max) = self
                 .chunk
                 .iter()
-                .map(|e| e.key.seqno)
-                .min()
-                .expect("chunk is non-empty");
-            #[expect(clippy::expect_used, reason = "chunk is non-empty (last exists)")]
-            let seqno_max = self
-                .chunk
-                .iter()
-                .map(|e| e.key.seqno)
-                .max()
-                .expect("chunk is non-empty");
+                .fold((u64::MAX, u64::MIN), |(min, max), e| {
+                    (min.min(e.key.seqno), max.max(e.key.seqno))
+                });
             handle = handle.with_seqno_bounds(seqno_min, seqno_max);
         }
 
@@ -1088,8 +1082,9 @@ struct MetaSectionParams<'a> {
     index_block_restart_interval: u8,
     initial_level: u8,
     /// Index block format byte written to the SST Properties (#224).
-    /// `0` = legacy (no per-block seqno bounds). Currently always `0`
-    /// until the writer is wired to the runtime `seqno_in_index` config.
+    /// `0` = legacy (no per-block seqno bounds); `1` = each data-block
+    /// index entry carries `(seqno_min, seqno_max)`. Set from the writer's
+    /// `seqno_in_index` config (`u8::from(self.use_seqno_in_index)`).
     index_format: u8,
     range_tombstone_count: u64,
     block_offset: u64,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -425,6 +425,12 @@ impl Writer {
     /// writer construction. Default `false` (legacy `index_format = 0`).
     #[must_use]
     pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
+        // Must be fixed before the first key: `finish()` stamps a single
+        // SST-wide `index_format` from the final flag, while `spill_block`
+        // snapshots it per block — a mid-write toggle would leave mixed
+        // index-entry encodings behind incorrect table metadata. Same
+        // contract as `use_page_ecc` / `use_kv_checksums`.
+        self.assert_not_started("use_seqno_in_index");
         self.use_seqno_in_index = seqno_in_index;
         self
     }

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -125,19 +125,16 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_prefix_extractor(tree.config.prefix_extractor.clone());
         writer = writer.use_encryption(tree.config.encryption.clone());
         writer = writer.use_page_ecc(tree.config.page_ecc);
-        // `seqno_in_index` is a live runtime config; read off the current
-        // snapshot so ingested SSTs match the index format in force.
-        writer = writer.use_seqno_in_index(tree.0.runtime_config.load_full().seqno_in_index);
 
-        // Per-KV checksums follow the live runtime config snapshot (same as
-        // the flush / compaction write paths). `Off` (default) emits no
-        // per-KV footer and leaves the `KV_CHECKSUM_FOOTER` flag clear (the
-        // data-block payload encoding is unchanged; the V5 header/meta layout
-        // still differs from pre-V5 regardless).
-        {
-            let rc = tree.0.runtime_config.load_full();
-            writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
-        }
+        // One runtime-config snapshot for the whole ingestion writer setup, so
+        // a concurrent `update_runtime_config` can't leave the ingested SST
+        // with `seqno_in_index` from one snapshot and checksum settings from
+        // another. `Off` (default) emits no per-KV footer and leaves the
+        // data-block payload encoding unchanged; the index format follows the
+        // policy in force at ingestion.
+        let rc = tree.0.runtime_config.load_full();
+        writer = writer.use_seqno_in_index(rc.seqno_in_index);
+        writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
 
         #[cfg(zstd_any)]
         {

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -125,6 +125,9 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_prefix_extractor(tree.config.prefix_extractor.clone());
         writer = writer.use_encryption(tree.config.encryption.clone());
         writer = writer.use_page_ecc(tree.config.page_ecc);
+        // `seqno_in_index` is a live runtime config; read off the current
+        // snapshot so ingested SSTs match the index format in force.
+        writer = writer.use_seqno_in_index(tree.0.runtime_config.load_full().seqno_in_index);
 
         // Per-KV checksums follow the live runtime config snapshot (same as
         // the flush / compaction write paths). `Off` (default) emits no

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -504,23 +504,20 @@ impl AbstractTree for Tree {
         table_writer = table_writer.use_prefix_extractor(self.config.prefix_extractor.clone());
         table_writer = table_writer.use_encryption(self.config.encryption.clone());
         table_writer = table_writer.use_page_ecc(self.config.page_ecc);
-        // `seqno_in_index` is a live runtime config (toggleable via
-        // `update_runtime_config`), read once per flush off the current
-        // snapshot so the resulting SST's index format matches the policy
-        // in force at flush time.
-        table_writer =
-            table_writer.use_seqno_in_index(self.0.runtime_config.load_full().seqno_in_index);
 
-        // Per-KV checksums follow the LIVE runtime config snapshot so a
-        // toggle via `update_runtime_config` takes effect on the next
-        // flush. `Off` (default) emits no per-KV footer and leaves the
-        // data-block payload encoding unchanged (the V5 header carries a
-        // block_flags byte and the meta block a descriptor key regardless,
-        // so the on-disk bytes are not identical to a pre-V5 table).
-        {
-            let rc = self.0.runtime_config.load_full();
-            table_writer = table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
-        }
+        // One runtime-config snapshot for the whole flush writer setup. Both
+        // `seqno_in_index` and the per-KV checksum policy are live (toggleable
+        // via `update_runtime_config`); reading `load_full()` per field could
+        // straddle a concurrent update and mix two snapshots into one SST.
+        // Compaction is the migration mechanism, so a toggle takes effect on
+        // the next flush / compaction.
+        let rc = self.0.runtime_config.load_full();
+        table_writer = table_writer.use_seqno_in_index(rc.seqno_in_index);
+        // `Off` (default) emits no per-KV footer and leaves the data-block
+        // payload encoding unchanged (the V5 header carries a block_flags byte
+        // and the meta block a descriptor key regardless, so the on-disk bytes
+        // are not identical to a pre-V5 table).
+        table_writer = table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
 
         #[cfg(zstd_any)]
         {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -504,6 +504,12 @@ impl AbstractTree for Tree {
         table_writer = table_writer.use_prefix_extractor(self.config.prefix_extractor.clone());
         table_writer = table_writer.use_encryption(self.config.encryption.clone());
         table_writer = table_writer.use_page_ecc(self.config.page_ecc);
+        // `seqno_in_index` is a live runtime config (toggleable via
+        // `update_runtime_config`), read once per flush off the current
+        // snapshot so the resulting SST's index format matches the policy
+        // in force at flush time.
+        table_writer =
+            table_writer.use_seqno_in_index(self.0.runtime_config.load_full().seqno_in_index);
 
         // Per-KV checksums follow the LIVE runtime config snapshot so a
         // toggle via `update_runtime_config` takes effect on the next

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -173,6 +173,63 @@ fn tree_kv_checksums_all_levels_round_trips_through_disk() {
     }
 }
 
+#[test]
+fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> {
+    // With `seqno_in_index` enabled, every data-block index entry is written
+    // in the seqno-bounded format (markers 2 / 3) and the SST is tagged
+    // index_format=1. The whole point of the format is that the data must
+    // read back identically: flush, point-read, reopen, point-read again.
+    // Reopen is the load-bearing step — it re-parses the on-disk index from
+    // scratch, so a broken seqno-bounded decode surfaces as a read failure.
+    let folder = get_tmp_folder();
+
+    {
+        let tree = open_tree(folder.path());
+        tree.update_runtime_config(|cfg| {
+            cfg.seqno_in_index = true;
+        })?;
+
+        // Enough keys (with rising seqnos) to spill multiple data blocks, so
+        // the index holds several entries with differing seqno bounds.
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let value = format!("value{i:05}");
+            tree.insert(key.as_bytes(), value.as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+            assert_eq!(
+                got.as_deref(),
+                Some(format!("value{i:05}").as_bytes()),
+                "post-flush read of {key} must return its value"
+            );
+        }
+    }
+
+    // Reopen: the index blocks are decoded fresh from disk. Runtime config
+    // resets to default on reopen (not persisted), but the on-disk
+    // index_format=1 entries must still decode via per-marker dispatch.
+    let tree = open_tree(folder.path());
+    for i in 0..500u64 {
+        let key = format!("key{i:05}");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("value{i:05}").as_bytes()),
+            "post-reopen read of {key} must return its value"
+        );
+    }
+
+    // A key never inserted must still be absent (index seek lands correctly
+    // on the seqno-bounded entries).
+    assert!(tree.get(b"key99999", SeqNo::MAX)?.is_none());
+
+    Ok(())
+}
+
 /// Locks the public contract of `Tree::update_runtime_config` when
 /// the build does NOT enable the `page_ecc` cargo feature:
 /// flipping `page_ecc = true` must return the typed error AND

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -198,6 +198,22 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
         }
         tree.flush_active_memtable(0)?;
 
+        // Make the multi-block precondition explicit: the per-block
+        // seqno-bounds path is only exercised when the SST holds more than one
+        // data block. If a future default (block size / dataset) drops this to
+        // a single block, fail loudly here instead of silently no longer
+        // covering the bug class this test locks down.
+        let data_blocks: u64 = tree
+            .current_version()
+            .iter_tables()
+            .map(|t| t.metadata.data_block_count)
+            .sum();
+        assert!(
+            data_blocks > 1,
+            "test must produce >1 data block to exercise per-block seqno \
+             bounds, got {data_blocks}",
+        );
+
         for i in 0..500u64 {
             let key = format!("key{i:05}");
             let got = tree.get(key.as_bytes(), SeqNo::MAX)?;


### PR DESCRIPTION
> **Stacked on #369 (#298).** This branch is rebased on top of `feat/#298-per-kv-protection`, so the diff currently also shows #369's commits (per-KV checksum footers, Page ECC, the `block_flags` transform descriptors). Those are NOT part of #224's own change — once #369 merges, this PR rebases onto `main` and the diff narrows to the `seqno_in_index` work described below. Review #224's own changes via the commit list (`feat(runtime-config)`/`feat(table)`/`feat(index)` + their review-fix commits), not the combined file diff.

## Summary

Lands the on-disk format slice for `scan_since_seqno` (#224): SST index
entries can carry per-block `(seqno_min, seqno_max)` so a seqno-scoped scan
can skip a whole data block whose `max` is below the target without reading
it. This is the V5-gating part of #224 (it changes the on-disk wire format);
the `Tree::scan_since_seqno` public API + block-skip read path + CDC event
stream land in a follow-up PR (they are read-only and do not change the
on-disk format).

**Default off, byte-identical.** `RuntimeConfig.seqno_in_index` defaults
`false`; when off, index blocks are byte-identical to the pre-#224
`index_format = 0` layout. The capability is purely additive within V5
(no format-version bump): a tree opts in at runtime, and the next flush /
compaction starts emitting the bounded format.

## What changed

- **`RuntimeConfig.seqno_in_index: bool`** (default `false`) — runtime switch,
  toggleable via `update_runtime_config`. Read off the current snapshot in
  flush / compaction / ingest and preserved across writer rotation.
- **`index_format` byte in the SST Properties block** (per-SST, per Q8): `0` =
  legacy (no per-block seqno bounds), `1` = index entries carry the bounds.
  Parsed as optional — SSTs written before the key existed read as `0`.
- **Self-describing index entries** — wire markers `0`/`1` stay the legacy
  full/truncated entries; `2`/`3` add the two bounds right after the entry
  seqno. Decode dispatches on the marker, so legacy and mixed-format trees
  read transparently with no per-SST flag threaded through the block decoder.
- The writer computes the bounds in one pass over the spill chunk (already in
  hand) and tags `index_format = 1` only when `seqno_in_index` is on.

## Testing

- Full suite (default features): 1566 passed
- Full suite (`--all-features`): 1792 passed
- Lint (`--all-features --all-targets` and default-feature), fmt, and rustdoc with warnings-as-errors: clean
- New unit tests: marker 2/3 round-trip, `parse_restart_key` skips bounds on marker 2, `index_format` absent maps to 0 / present maps to 1, inverted-bounds rejection, unknown `index_format` rejection
- New integration test: `seqno_in_index_round_trips_through_disk_and_reopen` (asserts multi-block precondition)
- Wire-compat: with `seqno_in_index = false`, index layout is byte-identical to legacy

Part of #224. Depends on #352 (RuntimeConfig foundation, merged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-block sequence number indexing as configurable runtime behavior for improved index efficiency.
  * Added support for KV checksums in SST files to enhance data integrity verification.
  * Extended metadata to expose checksum algorithms and index format information.

* **Tests**
  * Added integration test validating index format persistence through disk flushes and tree reopens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
