### PR TITLE
perf(fs): configurable SyncMode; default plain fsync on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,11 @@ reed-solomon-simd = { version = "3", optional = true, default-features = false }
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7", optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Plain `fsync` for SyncMode::Normal — std's `File::sync_all` issues the much
+# slower `fcntl(F_FULLFSYNC)` on macOS, which we only want under SyncMode::Full.
+libc = "0.2"
+
 [dev-dependencies]
 criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"

--- a/src/blob_tree/ingest.rs
+++ b/src/blob_tree/ingest.rs
@@ -52,7 +52,8 @@ impl<'a> BlobIngestion<'a> {
             tree.index.config.fs.clone(),
         )?
         .use_target_size(blob_file_size)
-        .use_compression(kv.compression);
+        .use_compression(kv.compression)
+        .use_sync_mode(tree.index.config.sync_mode);
 
         let separation_threshold = kv.separation_threshold;
 

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -166,7 +166,7 @@ impl BlobTree {
 
         let blobs_folder = index.config.path.join(BLOBS_FOLDER);
         (*index.config.fs).create_dir_all(&blobs_folder)?;
-        fsync_directory(&blobs_folder, &*index.config.fs)?;
+        fsync_directory(&blobs_folder, &*index.config.fs, index.config.sync_mode)?;
 
         let blob_file_id_to_continue_with = index
             .current_version()

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -548,7 +548,8 @@ impl AbstractTree for BlobTree {
                 self.index.config.fs.clone(),
             )?
             .use_target_size(kv_opts.file_target_size)
-            .use_compression(kv_opts.compression);
+            .use_compression(kv_opts.compression)
+            .use_sync_mode(self.index.config.sync_mode);
             #[cfg(zstd_any)]
             let w = w.use_zstd_dictionary(kv_opts.zstd_dictionary.clone());
             w

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -27,7 +27,7 @@
 use crate::{
     AbstractTree, CheckpointInfo,
     file::{BLOBS_FOLDER, CURRENT_VERSION_FILE, TABLES_FOLDER, fsync_directory},
-    fs::{Fs, FsFile, FsOpenOptions},
+    fs::{Fs, FsFile, FsOpenOptions, SyncMode},
     version::Version,
     vlog::BlobFile,
 };
@@ -154,6 +154,7 @@ pub fn link_or_copy_cross_fs(
     src: &Path,
     dst_fs: &Arc<dyn Fs>,
     dst: &Path,
+    sync_mode: SyncMode,
 ) -> std::io::Result<u64> {
     // Refuse to attempt `hard_link` unless both backends positively
     // assert (via `Fs::backend_id`) that they resolve paths against
@@ -259,7 +260,7 @@ pub fn link_or_copy_cross_fs(
             total = total.saturating_add(n as u64);
         }
         dst_file.flush()?;
-        FsFile::sync_all(&*dst_file)?;
+        FsFile::sync_all_with(&*dst_file, sync_mode)?;
         Ok(total)
     })();
 
@@ -284,6 +285,7 @@ pub fn link_tables(
     version: &Version,
     target_root: &Path,
     target_fs: &Arc<dyn Fs>,
+    sync_mode: SyncMode,
 ) -> crate::Result<(usize, u64)> {
     let tables_dir = target_root.join(TABLES_FOLDER);
     let mut count = 0usize;
@@ -295,7 +297,7 @@ pub fn link_tables(
         // Source Fs may differ from `target_fs` when `level_routes` points
         // a hot tier at one backend (e.g. tmpfs) and the rest of the tree
         // at another. `link_or_copy_cross_fs` picks the right strategy.
-        let written = link_or_copy_cross_fs(&table.fs, &table.path, target_fs, &dst)
+        let written = link_or_copy_cross_fs(&table.fs, &table.path, target_fs, &dst, sync_mode)
             .map_err(crate::Error::from)?;
         bytes = bytes.saturating_add(written);
         count = count.saturating_add(1);
@@ -312,6 +314,7 @@ pub fn link_blob_files(
     blob_files: impl IntoIterator<Item = BlobFile>,
     target_root: &Path,
     target_fs: &Arc<dyn Fs>,
+    sync_mode: SyncMode,
 ) -> crate::Result<(usize, u64)> {
     let blobs_dir = target_root.join(BLOBS_FOLDER);
     let mut count = 0usize;
@@ -319,7 +322,7 @@ pub fn link_blob_files(
 
     for blob in blob_files {
         let dst = blobs_dir.join(blob_link_name(blob.id()));
-        let written = link_or_copy_cross_fs(&blob.0.fs, &blob.0.path, target_fs, &dst)
+        let written = link_or_copy_cross_fs(&blob.0.fs, &blob.0.path, target_fs, &dst, sync_mode)
             .map_err(crate::Error::from)?;
         bytes = bytes.saturating_add(written);
         count = count.saturating_add(1);
@@ -343,6 +346,7 @@ fn copy_metadata_file_optional(
     target_fs: &dyn Fs,
     target_root: &Path,
     file_name: &str,
+    sync_mode: SyncMode,
 ) -> crate::Result<()> {
     let src = src_root.join(file_name);
     let mut src_file = match src_fs.open(&src, &FsOpenOptions::new().read(true)) {
@@ -355,7 +359,7 @@ fn copy_metadata_file_optional(
 
     std::io::copy(&mut src_file, &mut dst_file)?;
     dst_file.flush()?;
-    FsFile::sync_all(&*dst_file)?;
+    FsFile::sync_all_with(&*dst_file, sync_mode)?;
     Ok(())
 }
 
@@ -387,6 +391,7 @@ fn write_current_for_version(
     version_id: u64,
     runtime: Arc<crate::runtime_config::RuntimeConfig>,
     encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+    sync_mode: SyncMode,
 ) -> crate::Result<()> {
     use crate::checksum::ChecksumType;
     use crate::file::rewrite_atomic;
@@ -415,7 +420,12 @@ fn write_current_for_version(
     content.write_u128::<LittleEndian>(checksum)?;
     content.write_u8(u8::from(ChecksumType::Xxh3))?;
 
-    rewrite_atomic(&target_root.join(CURRENT_VERSION_FILE), &content, target_fs)?;
+    rewrite_atomic(
+        &target_root.join(CURRENT_VERSION_FILE),
+        &content,
+        target_fs,
+        sync_mode,
+    )?;
     Ok(())
 }
 
@@ -452,11 +462,19 @@ pub fn copy_metadata(
     comparator_name: &str,
     runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
     encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+    sync_mode: SyncMode,
 ) -> crate::Result<()> {
     // Manifest stores level count + comparator name. On a never-written
     // tree the manifest may legitimately be absent (recovery treats
     // missing manifest as a freshly-initialised tree), so this is optional.
-    copy_metadata_file_optional(src_fs, src_root, target_fs, target_root, "manifest")?;
+    copy_metadata_file_optional(
+        src_fs,
+        src_root,
+        target_fs,
+        target_root,
+        "manifest",
+        sync_mode,
+    )?;
     // Re-serialise the captured Version into target/v<id> rather than
     // copying the source file. Reason: SuperVersions::maintenance can
     // physically remove the source v<id> between current_version() and
@@ -479,6 +497,7 @@ pub fn copy_metadata(
         target_fs,
         Arc::clone(&runtime),
         encryption.clone(),
+        sync_mode,
     )?;
     // CURRENT pointer is generated fresh for the captured `version_id`
     // (NOT copied from source) so a concurrent publish to `v<N+1>` on
@@ -495,7 +514,14 @@ pub fn copy_metadata(
     // `persist_version` above used — the helper reopens the manifest
     // via `ManifestArchiveReader`, and an encrypted manifest reopened
     // without its provider would fail to decode the footer Block.
-    write_current_for_version(target_fs, target_root, version.id(), runtime, encryption)?;
+    write_current_for_version(
+        target_fs,
+        target_root,
+        version.id(),
+        runtime,
+        encryption,
+        sync_mode,
+    )?;
     Ok(())
 }
 
@@ -651,10 +677,18 @@ pub fn run_checkpoint<T: AbstractTree>(
 
     let version = tree.current_version();
 
-    let (sst_files, sst_bytes) = link_tables(&version, target_root, target_fs)?;
+    // Checkpoint fsyncs follow the source tree's configured durability.
+    let sync_mode = tree.tree_config().sync_mode;
+
+    let (sst_files, sst_bytes) = link_tables(&version, target_root, target_fs, sync_mode)?;
 
     let (blob_files, blob_bytes) = if include_blobs {
-        link_blob_files(version.blob_files.iter().cloned(), target_root, target_fs)?
+        link_blob_files(
+            version.blob_files.iter().cloned(),
+            target_root,
+            target_fs,
+            sync_mode,
+        )?
     } else {
         (0, 0)
     };
@@ -668,6 +702,7 @@ pub fn run_checkpoint<T: AbstractTree>(
         tree.tree_config().comparator.name(),
         Arc::clone(&params.runtime_config),
         params.encryption.clone(),
+        sync_mode,
     )?;
 
     // fsync each populated child directory BEFORE the root so the
@@ -675,12 +710,12 @@ pub fn run_checkpoint<T: AbstractTree>(
     // `current`, `manifest`, `v<id>`) survive a power loss. The root
     // fsync alone only persists the existence of `tables/` and
     // `blobs/`, not their contents.
-    fsync_directory(&target_root.join(TABLES_FOLDER), &**target_fs)?;
+    fsync_directory(&target_root.join(TABLES_FOLDER), &**target_fs, sync_mode)?;
     if include_blobs {
-        fsync_directory(&target_root.join(BLOBS_FOLDER), &**target_fs)?;
+        fsync_directory(&target_root.join(BLOBS_FOLDER), &**target_fs, sync_mode)?;
     }
 
-    fsync_directory(target_root, &**target_fs)?;
+    fsync_directory(target_root, &**target_fs, sync_mode)?;
 
     // Finally, fsync the directory that CONTAINS `target_root` so the
     // checkpoint's own directory entry survives a power loss even
@@ -698,7 +733,7 @@ pub fn run_checkpoint<T: AbstractTree>(
     if let Some(parent) = target_root.parent()
         && !parent.as_os_str().is_empty()
     {
-        fsync_directory(parent, &**target_fs)?;
+        fsync_directory(parent, &**target_fs, sync_mode)?;
     }
 
     cleanup.commit();
@@ -737,7 +772,7 @@ mod tests {
         mem_fs.create_dir_all(Path::new("/dst")).unwrap();
 
         let dst = Path::new("/dst/payload.bin");
-        let bytes = link_or_copy_cross_fs(&std_fs, &src, &mem_fs, dst).unwrap();
+        let bytes = link_or_copy_cross_fs(&std_fs, &src, &mem_fs, dst, SyncMode::Normal).unwrap();
         assert_eq!(bytes, b"cross-fs-payload".len() as u64);
 
         // Bytes landed in MemFs.

--- a/src/compaction/filter.rs
+++ b/src/compaction/filter.rs
@@ -253,7 +253,8 @@ impl<'a, 'b: 'a> StreamFilterAdapter<'a, 'b> {
                 self.shared.opts.config.fs.clone(),
             )?
             .use_target_size(blob_opts.file_target_size)
-            .use_compression(blob_opts.compression);
+            .use_compression(blob_opts.compression)
+            .use_sync_mode(self.shared.opts.config.sync_mode);
 
             self.blob_writer.insert(writer)
         };

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -115,6 +115,7 @@ pub(super) fn prepare_table_writer(
         .use_prefix_extractor(opts.config.prefix_extractor.clone())
         .use_encryption(opts.config.encryption.clone())
         .use_page_ecc(opts.config.page_ecc)
+        .use_sync_mode(opts.config.sync_mode)
         // `seqno_in_index` is a live runtime config: read off the current
         // snapshot so a compaction started after a toggle rewrites its
         // output SSTs in the new index format (compaction is the migration

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -524,7 +524,8 @@ fn merge_tables(
                     opts.config.fs.clone(),
                 )?
                 .use_target_size(blob_opts.file_target_size)
-                .use_passthrough_compression(blob_opts.compression);
+                .use_passthrough_compression(blob_opts.compression)
+                .use_sync_mode(opts.config.sync_mode);
 
                 let inner = StandardCompaction::new(table_writer, tables);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     comparator::{self, SharedComparator},
     encryption::EncryptionProvider,
     file::TABLES_FOLDER,
-    fs::{Fs, StdFs},
+    fs::{Fs, StdFs, SyncMode},
     merge_operator::MergeOperator,
     path::absolute_path,
     prefix::PrefixExtractor,
@@ -501,6 +501,16 @@ pub struct Config {
     /// motivate each mode.
     pub(crate) manifest_recovery_mode: ManifestRecoveryMode,
 
+    /// Durability level for every fsync the tree issues (SST writes,
+    /// manifest, version persist, directory syncs).
+    ///
+    /// Defaults to [`SyncMode::Normal`] (plain `fsync`), matching the
+    /// out-of-the-box durability of `RocksDB` and `SQLite`. Only observable on
+    /// macOS, where [`SyncMode::Full`] opts into the much slower
+    /// `F_FULLFSYNC` barrier; on other platforms both modes are plain
+    /// `fsync`. Set via [`Config::sync_mode`].
+    pub(crate) sync_mode: SyncMode,
+
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
     /// When set together with a [`CompressionType::ZstdDict`] compression
@@ -609,6 +619,7 @@ impl Default for Config {
             comparator: comparator::default_comparator(),
             encryption: None,
             manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
+            sync_mode: SyncMode::Normal,
         }
     }
 }
@@ -1296,6 +1307,19 @@ impl Config {
     #[must_use]
     pub fn manifest_recovery_mode(mut self, mode: ManifestRecoveryMode) -> Self {
         self.manifest_recovery_mode = mode;
+        self
+    }
+
+    /// Sets the durability level for every fsync the tree issues.
+    ///
+    /// Defaults to [`SyncMode::Normal`] (plain `fsync`, matching `RocksDB` /
+    /// `SQLite` defaults). Pass [`SyncMode::Full`] to force `F_FULLFSYNC` on
+    /// macOS for power-loss durability without an external journal — at a
+    /// large per-flush cost. On non-macOS platforms both modes are
+    /// identical (plain `fsync`).
+    #[must_use]
+    pub fn sync_mode(mut self, mode: SyncMode) -> Self {
+        self.sync_mode = mode;
         self
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     Slice,
-    fs::{Fs, FsFile},
+    fs::{Fs, FsFile, SyncMode},
 };
 use std::{io::Write, path::Path};
 
@@ -57,7 +57,12 @@ pub fn read_exact(file: &dyn FsFile, offset: u64, size: usize) -> std::io::Resul
 ///
 /// Writes `content` to a temporary file in the same directory, fsyncs it,
 /// then renames over `path`. This ensures readers never see a partial write.
-pub fn rewrite_atomic(path: &Path, content: &[u8], fs: &dyn Fs) -> std::io::Result<()> {
+pub fn rewrite_atomic(
+    path: &Path,
+    content: &[u8],
+    fs: &dyn Fs,
+    mode: SyncMode,
+) -> std::io::Result<()> {
     use crate::fs::FsOpenOptions;
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -84,7 +89,7 @@ pub fn rewrite_atomic(path: &Path, content: &[u8], fs: &dyn Fs) -> std::io::Resu
                 let write_result = file
                     .write_all(content)
                     .and_then(|()| file.flush())
-                    .and_then(|()| FsFile::sync_all(&*file));
+                    .and_then(|()| FsFile::sync_all_with(&*file, mode));
                 if let Err(e) = write_result {
                     drop(file);
                     let _ = fs.remove_file(&candidate);
@@ -104,7 +109,7 @@ pub fn rewrite_atomic(path: &Path, content: &[u8], fs: &dyn Fs) -> std::io::Resu
         let _ = fs.remove_file(&tmp_path);
         return Err(e);
     }
-    fsync_directory(folder, fs)?;
+    fsync_directory(folder, fs, mode)?;
 
     Ok(())
 }
@@ -114,8 +119,8 @@ pub fn rewrite_atomic(path: &Path, content: &[u8], fs: &dyn Fs) -> std::io::Resu
 /// On Windows, `StdFs::sync_directory` already returns `Ok(())` (directory
 /// fsync is unsupported), but non-`StdFs` backends (e.g., `MemFs`) may use
 /// this call for path validation. Always delegate rather than short-circuiting.
-pub fn fsync_directory(path: &Path, fs: &dyn Fs) -> std::io::Result<()> {
-    fs.sync_directory(path)
+pub fn fsync_directory(path: &Path, fs: &dyn Fs, mode: SyncMode) -> std::io::Result<()> {
+    fs.sync_directory_with(path, mode)
 }
 
 #[cfg(test)]
@@ -159,7 +164,7 @@ mod tests {
             write!(file, "asdasdasdasdasd")?;
         }
 
-        rewrite_atomic(&path, b"newcontent", &StdFs)?;
+        rewrite_atomic(&path, b"newcontent", &StdFs, SyncMode::Normal)?;
 
         let content = std::fs::read_to_string(&path)?;
         assert_eq!("newcontent", content);

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -264,12 +264,48 @@ pub enum FileHint {
     WriteOnce,
 }
 
+/// Durability level for a sync (fsync) operation.
+///
+/// The distinction is only observable on macOS, where Rust's
+/// [`std::fs::File::sync_all`] / [`sync_data`](std::fs::File::sync_data)
+/// both issue `fcntl(F_FULLFSYNC)` — a full hardware barrier that flushes
+/// the drive's write cache to the platters (~4 ms on a modern SSD). On
+/// every other platform `sync_all` is already a plain `fsync` and both
+/// variants behave identically.
+///
+/// [`Self::Normal`] is the default: it matches the durability that
+/// `RocksDB` and `SQLite` give out of the box (plain `fsync`, which on macOS
+/// reaches the drive cache but not necessarily the platters). [`Self::Full`]
+/// opts into `F_FULLFSYNC` on macOS for callers that need power-loss
+/// durability at the cost of a much slower flush.
+//
+// no-std: pure data type — `Copy` enum, no allocator needed.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SyncMode {
+    /// Plain `fsync` on every platform. On macOS this does NOT issue
+    /// `F_FULLFSYNC`, so it is dramatically faster but only guarantees the
+    /// data reached the drive's write cache (same as `RocksDB` / `SQLite`
+    /// defaults). The default.
+    #[default]
+    Normal,
+
+    /// Full durability. On macOS this issues `fcntl(F_FULLFSYNC)` so the
+    /// data survives power loss; elsewhere it is identical to
+    /// [`Self::Normal`]. Slower — opt in only when the workload needs
+    /// power-loss durability without an external journal.
+    Full,
+}
+
 /// Filesystem operations on an open file handle.
 ///
 /// Extends [`Read`] + [`Write`] + [`Seek`] with persistence and
 /// metadata operations needed by the storage engine.
 pub trait FsFile: Read + Write + Seek + Send + Sync {
     /// Flushes all OS-internal buffers and metadata to durable storage.
+    ///
+    /// Equivalent to [`sync_all_with`](Self::sync_all_with) with
+    /// [`SyncMode::Full`] — the strongest durability the platform offers
+    /// (`F_FULLFSYNC` on macOS).
     ///
     /// # Errors
     ///
@@ -278,10 +314,41 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
 
     /// Flushes file data (but not necessarily metadata) to durable storage.
     ///
+    /// Equivalent to [`sync_data_with`](Self::sync_data_with) with
+    /// [`SyncMode::Full`].
+    ///
     /// # Errors
     ///
     /// Returns an I/O error if the sync operation fails.
     fn sync_data(&self) -> io::Result<()>;
+
+    /// Flushes all buffers and metadata at the requested durability
+    /// [`SyncMode`].
+    ///
+    /// The default implementation ignores `mode` and delegates to
+    /// [`sync_all`](Self::sync_all) (full durability); backends where the
+    /// mode is observable (the std `File` backend on macOS) override this.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the sync operation fails.
+    fn sync_all_with(&self, mode: SyncMode) -> io::Result<()> {
+        let _ = mode;
+        self.sync_all()
+    }
+
+    /// Flushes file data at the requested durability [`SyncMode`].
+    ///
+    /// The default implementation ignores `mode` and delegates to
+    /// [`sync_data`](Self::sync_data).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the sync operation fails.
+    fn sync_data_with(&self, mode: SyncMode) -> io::Result<()> {
+        let _ = mode;
+        self.sync_data()
+    }
 
     /// Returns metadata for this open file handle.
     ///
@@ -476,6 +543,21 @@ pub trait Fs: Send + Sync + 'static {
     ///
     /// Returns an I/O error if the sync operation fails.
     fn sync_directory(&self, path: &Path) -> io::Result<()>;
+
+    /// Ensures directory metadata is persisted at the requested durability
+    /// [`SyncMode`].
+    ///
+    /// The default implementation ignores `mode` and delegates to
+    /// [`sync_directory`](Self::sync_directory); backends where the mode is
+    /// observable (the std backend on macOS) override this.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the sync operation fails.
+    fn sync_directory_with(&self, path: &Path, mode: SyncMode) -> io::Result<()> {
+        let _ = mode;
+        self.sync_directory(path)
+    }
 
     /// Returns `Ok(true)` if a file or directory exists at `path`.
     ///

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -2,10 +2,35 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use super::{FileHint, Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
+use super::{FileHint, Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions, SyncMode};
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::Path;
+
+/// Plain `fsync` (no `F_FULLFSYNC`) for [`SyncMode::Normal`].
+///
+/// On macOS, `File::sync_all` issues `fcntl(F_FULLFSYNC)` (a full hardware
+/// barrier, ~50× slower than `fsync`). `Normal` mode wants the cheaper plain
+/// `fsync` — which std does not expose on macOS — so call it directly via
+/// `libc`. On every other platform `File::sync_all` IS plain `fsync`, so just
+/// delegate.
+#[cfg(target_os = "macos")]
+fn normal_fsync(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    // SAFETY: `fd` is a valid open descriptor for the lifetime of `file`.
+    let rc = unsafe { libc::fsync(file.as_raw_fd()) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn normal_fsync(file: &File) -> io::Result<()> {
+    // No `F_FULLFSYNC` distinction off macOS — `sync_all` is plain `fsync`.
+    File::sync_all(file)
+}
 
 /// Default [`Fs`] implementation backed by [`std::fs`].
 ///
@@ -26,6 +51,25 @@ impl FsFile for File {
 
     fn sync_data(&self) -> io::Result<()> {
         Self::sync_data(self)
+    }
+
+    fn sync_all_with(&self, mode: SyncMode) -> io::Result<()> {
+        match mode {
+            // `File::sync_all` is `fcntl(F_FULLFSYNC)` on macOS.
+            SyncMode::Full => Self::sync_all(self),
+            SyncMode::Normal => normal_fsync(self),
+        }
+    }
+
+    fn sync_data_with(&self, mode: SyncMode) -> io::Result<()> {
+        match mode {
+            SyncMode::Full => Self::sync_data(self),
+            // Normal data-sync collapses to plain `fsync`: on macOS
+            // `sync_data` is also `F_FULLFSYNC`, and a plain `fsync` already
+            // covers the data, so there is no cheaper data-only barrier to
+            // issue.
+            SyncMode::Normal => normal_fsync(self),
+        }
     }
 
     fn metadata(&self) -> io::Result<FsMetadata> {
@@ -202,6 +246,30 @@ impl Fs for StdFs {
         #[cfg(target_os = "windows")]
         {
             let _ = path;
+            Ok(())
+        }
+    }
+
+    fn sync_directory_with(&self, path: &Path, mode: SyncMode) -> io::Result<()> {
+        #[cfg(not(target_os = "windows"))]
+        {
+            let dir = File::open(path)?;
+            if !dir.metadata()?.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "sync_directory: path is not a directory",
+                ));
+            }
+            match mode {
+                SyncMode::Full => dir.sync_all(),
+                SyncMode::Normal => normal_fsync(&dir),
+            }
+        }
+
+        // Windows cannot fsync directories — no-op.
+        #[cfg(target_os = "windows")]
+        {
+            let _ = (path, mode);
             Ok(())
         }
     }
@@ -626,6 +694,31 @@ mod tests {
         file.read_to_string(&mut buf)?;
         assert_eq!(buf, "hello world");
 
+        Ok(())
+    }
+
+    #[test]
+    fn std_fs_sync_with_both_modes_persists() -> io::Result<()> {
+        // Both durability modes must succeed and leave the bytes readable.
+        // On macOS this exercises the plain-`fsync` (Normal) and
+        // `F_FULLFSYNC` (Full) branches; elsewhere both are plain `fsync`.
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+        for (name, mode) in [("normal", SyncMode::Normal), ("full", SyncMode::Full)] {
+            let path = dir.path().join(name);
+            let mut file = fs.open(&path, &FsOpenOptions::new().write(true).create(true))?;
+            file.write_all(b"durable")?;
+            file.sync_data_with(mode)?;
+            file.sync_all_with(mode)?;
+            drop(file);
+            // Directory sync at both modes must also succeed.
+            fs.sync_directory_with(dir.path(), mode)?;
+
+            let mut file = fs.open(&path, &FsOpenOptions::new().read(true))?;
+            let mut buf = String::new();
+            file.read_to_string(&mut buf)?;
+            assert_eq!(buf, "durable", "{name} mode lost data");
+        }
         Ok(())
     }
 

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -379,6 +379,10 @@ fn copy_fallback(src: &Path, dst: &Path) -> io::Result<()> {
             )]
             dst_file.write_all(&buf[..n])?;
         }
+        // Full-durability sync: `hard_link` has no `SyncMode` parameter, so
+        // this cross-device fallback can't honor `Config::sync_mode` and uses
+        // `F_FULLFSYNC` on macOS regardless. Reachable only from cross-device
+        // checkpoint copies; threading `SyncMode` here is tracked in #377.
         dst_file.sync_all()
     })();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -152,6 +152,7 @@ mod tests {
             fs,
             std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
             None,
+            crate::fs::SyncMode::Normal,
         )?;
 
         writer.start("format_version")?;
@@ -242,6 +243,7 @@ mod tests {
             &StdFs,
             std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
             None,
+            crate::fs::SyncMode::Normal,
         )?;
         writer.start("format_version")?;
         writer.write_u8(FormatVersion::V5.into())?;

--- a/src/manifest_blocks/reader.rs
+++ b/src/manifest_blocks/reader.rs
@@ -737,7 +737,14 @@ mod tests {
     }
 
     fn write_manifest(fs: &MemFs, path: &Path, runtime: RuntimeConfig, sections: &[(&str, &[u8])]) {
-        let mut w = ManifestArchiveWriter::create(path, fs, Arc::new(runtime), None).unwrap();
+        let mut w = ManifestArchiveWriter::create(
+            path,
+            fs,
+            Arc::new(runtime),
+            None,
+            crate::fs::SyncMode::Normal,
+        )
+        .unwrap();
         for (name, data) in sections {
             w.start(name).unwrap();
             use std::io::Write;
@@ -1041,6 +1048,7 @@ mod tests {
             &fs,
             Arc::new(RuntimeConfig::default()),
             Some(Arc::clone(&enc)),
+            crate::fs::SyncMode::Normal,
         )
         .unwrap();
         w.start("format_version").unwrap();

--- a/src/manifest_blocks/writer.rs
+++ b/src/manifest_blocks/writer.rs
@@ -23,7 +23,7 @@
 
 use crate::{
     encryption::EncryptionProvider,
-    fs::{Fs, FsFile, FsOpenOptions},
+    fs::{Fs, FsFile, FsOpenOptions, SyncMode},
     manifest_blocks::{
         FLAG_FOOTER_MIRROR_ENABLED, HEAD_FOOTER_RESERVED_SIZE, MANIFEST_TABLE_ID_SENTINEL,
         MANIFEST_TREE_ID_SENTINEL, MAX_MANIFEST_BLOCK_SIZE, MAX_SECTION_NAME_BYTES,
@@ -81,6 +81,10 @@ pub struct ManifestArchiveWriter {
     /// the head reservation zeroes are written; advanced by each
     /// section's Block size.
     write_cursor: u64,
+
+    /// Durability level for the final `sync_all` of the manifest file,
+    /// plumbed from `Config::sync_mode`.
+    sync_mode: SyncMode,
 }
 
 struct CurrentSection {
@@ -105,6 +109,7 @@ impl ManifestArchiveWriter {
         fs: &dyn Fs,
         runtime: Arc<RuntimeConfig>,
         encryption: Option<Arc<dyn EncryptionProvider>>,
+        sync_mode: SyncMode,
     ) -> crate::Result<Self> {
         let mut file = fs.open(
             path,
@@ -132,6 +137,7 @@ impl ManifestArchiveWriter {
             toc: Vec::new(),
             section_names: BTreeSet::new(),
             write_cursor: HEAD_FOOTER_RESERVED_SIZE,
+            sync_mode,
         })
     }
 
@@ -351,7 +357,7 @@ impl ManifestArchiveWriter {
             }
         }
 
-        self.file.sync_all()?;
+        self.file.sync_all_with(self.sync_mode)?;
         Ok(payload)
     }
 
@@ -505,7 +511,7 @@ mod tests {
     use crate::runtime_config::RuntimeConfig;
 
     fn open_writer(fs: &dyn Fs, path: &Path, runtime: RuntimeConfig) -> ManifestArchiveWriter {
-        ManifestArchiveWriter::create(path, fs, Arc::new(runtime), None)
+        ManifestArchiveWriter::create(path, fs, Arc::new(runtime), None, SyncMode::Normal)
             .expect("manifest writer opens cleanly on a fresh path")
     }
 

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -5,9 +5,14 @@
 use super::{filter::BloomConstructionPolicy, writer::Writer};
 use crate::{
     Checksum, CompressionType, HashMap, SequenceNumberCounter, TableId, UserKey,
-    blob_tree::handle::BlobIndirection, encryption::EncryptionProvider, fs::Fs,
-    prefix::PrefixExtractor, range_tombstone::RangeTombstone, table::writer::LinkedFile,
-    value::InternalValue, vlog::BlobFileId,
+    blob_tree::handle::BlobIndirection,
+    encryption::EncryptionProvider,
+    fs::{Fs, SyncMode},
+    prefix::PrefixExtractor,
+    range_tombstone::RangeTombstone,
+    table::writer::LinkedFile,
+    value::InternalValue,
+    vlog::BlobFileId,
 };
 use std::{path::PathBuf, sync::Arc};
 
@@ -79,6 +84,10 @@ pub struct MultiWriter {
     /// can stamp the same flag on every successor [`Writer`].
     page_ecc: bool,
 
+    /// `Config::sync_mode` — preserved so every successor [`Writer`]
+    /// finishes its SST with the same durability level.
+    sync_mode: SyncMode,
+
     /// Per-KV checksum policy + algorithm (from the runtime
     /// `kv_checksums` config) — preserved here so the rotation path
     /// stamps the same setting on every successor [`Writer`].
@@ -149,6 +158,7 @@ impl MultiWriter {
             encryption: None,
 
             page_ecc: false,
+            sync_mode: SyncMode::Normal,
 
             kv_checksum: None,
             use_seqno_in_index: false,
@@ -435,6 +445,16 @@ impl MultiWriter {
         self
     }
 
+    /// Wires the tree's `Config::sync_mode` through to the inner [`Writer`]
+    /// and preserves it across rotations so every successor SST is finished
+    /// at the same durability level.
+    #[must_use]
+    pub fn use_sync_mode(mut self, sync_mode: SyncMode) -> Self {
+        self.sync_mode = sync_mode;
+        self.writer = self.writer.use_sync_mode(sync_mode);
+        self
+    }
+
     /// Wires the runtime `kv_checksums` policy + algorithm through to the
     /// inner [`Writer`] and preserves it across rotations so every
     /// successor writer applies the same per-KV checksum setting. `Off`
@@ -503,6 +523,7 @@ impl MultiWriter {
         new_writer = new_writer.use_prefix_extractor(self.prefix_extractor.clone());
         new_writer = new_writer.use_encryption(self.encryption.clone());
         new_writer = new_writer.use_page_ecc(self.page_ecc);
+        new_writer = new_writer.use_sync_mode(self.sync_mode);
         if let Some((policy, algo)) = self.kv_checksum {
             new_writer = new_writer.use_kv_checksums(policy, algo);
         }

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1041,7 +1041,12 @@ impl Writer {
         )?;
 
         // Write fixed-size trailer
-        // and flush & fsync the table file
+        // and flush & fsync the table file.
+        // SyncMode coverage: SST writer (here), manifest, version persist,
+        // directory syncs, and the blob-file writer all honor
+        // `Config::sync_mode`. The only remaining unconditional F_FULLFSYNC is
+        // `StdFs::hard_link`'s cross-device copy fallback (no trait param),
+        // tracked in #377.
         let mut checksum = self.file_writer.into_inner()?;
         FsFile::sync_all_with(&**checksum.inner_mut().get_mut(), self.sync_mode)?;
         let checksum = checksum.checksum();

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     checksum::{ChecksumType, ChecksummedWriter},
     coding::Encode,
     encryption::EncryptionProvider,
-    fs::{Fs, FsFile, FsOpenOptions},
+    fs::{Fs, FsFile, FsOpenOptions, SyncMode},
     prefix::PrefixExtractor,
     range_tombstone::RangeTombstone,
     table::{
@@ -118,6 +118,11 @@ pub struct Writer {
     /// is added.
     page_ecc: bool,
 
+    /// Durability level for the SST file + folder fsync at finish. Default
+    /// [`SyncMode::Normal`]; caller wires `Config::sync_mode` via
+    /// [`Self::use_sync_mode`].
+    sync_mode: SyncMode,
+
     /// Per-KV checksum policy + algorithm for data blocks. `None` (default)
     /// means no per-KV checksums: data blocks carry no per-KV footer, with
     /// the `KV_CHECKSUM_FOOTER` header flag clear.
@@ -216,6 +221,7 @@ impl Writer {
             encryption: None,
 
             page_ecc: false,
+            sync_mode: SyncMode::Normal,
 
             kv_checksum: None,
             use_seqno_in_index: false,
@@ -386,6 +392,14 @@ impl Writer {
         self.page_ecc = page_ecc;
         self.index_writer = self.index_writer.use_page_ecc(page_ecc);
         self.filter_writer = self.filter_writer.use_page_ecc(page_ecc);
+        self
+    }
+
+    /// Wires the tree's `Config::sync_mode` into this writer's final SST +
+    /// folder fsync.
+    #[must_use]
+    pub fn use_sync_mode(mut self, sync_mode: SyncMode) -> Self {
+        self.sync_mode = sync_mode;
         self
     }
 
@@ -1029,7 +1043,7 @@ impl Writer {
         // Write fixed-size trailer
         // and flush & fsync the table file
         let mut checksum = self.file_writer.into_inner()?;
-        FsFile::sync_all(&**checksum.inner_mut().get_mut())?;
+        FsFile::sync_all_with(&**checksum.inner_mut().get_mut(), self.sync_mode)?;
         let checksum = checksum.checksum();
 
         // IMPORTANT: fsync folder on Unix
@@ -1038,7 +1052,11 @@ impl Writer {
             clippy::expect_used,
             reason = "if there's no parent folder, something has gone horribly wrong"
         )]
-        crate::file::fsync_directory(self.path.parent().expect("should have folder"), &*self.fs)?;
+        crate::file::fsync_directory(
+            self.path.parent().expect("should have folder"),
+            &*self.fs,
+            self.sync_mode,
+        )?;
 
         log::debug!(
             "Written {} items in {} blocks into new table file #{}, written {} MiB",

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -125,6 +125,7 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_prefix_extractor(tree.config.prefix_extractor.clone());
         writer = writer.use_encryption(tree.config.encryption.clone());
         writer = writer.use_page_ecc(tree.config.page_ecc);
+        writer = writer.use_sync_mode(tree.config.sync_mode);
 
         // One runtime-config snapshot for the whole ingestion writer setup, so
         // a concurrent `update_runtime_config` can't leave the ingested SST

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -125,9 +125,11 @@ impl TreeInner {
             &*config.fs,
             std::sync::Arc::clone(&initial_runtime),
             config.encryption.clone(),
+            config.sync_mode,
         )?;
 
         let comparator = config.comparator.clone();
+        let sync_mode = config.sync_mode;
 
         Ok(Self {
             id: get_next_tree_id(),
@@ -135,7 +137,11 @@ impl TreeInner {
             table_id_counter: SequenceNumberCounter::default(),
             blob_file_id_counter: SequenceNumberCounter::default(),
             config: Arc::new(config),
-            version_history: Arc::new(RwLock::new(SuperVersions::new(version, &comparator))),
+            version_history: Arc::new(RwLock::new(SuperVersions::new(
+                version,
+                &comparator,
+                sync_mode,
+            ))),
             stop_signal: StopSignal::default(),
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -504,6 +504,7 @@ impl AbstractTree for Tree {
         table_writer = table_writer.use_prefix_extractor(self.config.prefix_extractor.clone());
         table_writer = table_writer.use_encryption(self.config.encryption.clone());
         table_writer = table_writer.use_page_ecc(self.config.page_ecc);
+        table_writer = table_writer.use_sync_mode(self.config.sync_mode);
 
         // One runtime-config snapshot for the whole flush writer setup. Both
         // `seqno_in_index` and the per-KV checksum policy are live (toggleable
@@ -2070,12 +2071,17 @@ impl Tree {
         // below — the runtime handle initializer needs it after the
         // move.
         let initial_runtime = config.initial_runtime_config.clone();
+        let sync_mode = config.sync_mode;
         let inner = TreeInner {
             id: tree_id,
             memtable_id_counter: SequenceNumberCounter::new(1),
             table_id_counter: SequenceNumberCounter::new(highest_table_id + 1),
             blob_file_id_counter: SequenceNumberCounter::default(),
-            version_history: Arc::new(RwLock::new(SuperVersions::new(version, &comparator))),
+            version_history: Arc::new(RwLock::new(SuperVersions::new(
+                version,
+                &comparator,
+                sync_mode,
+            ))),
             stop_signal: StopSignal::default(),
             config: Arc::new(config),
             major_compaction_lock: RwLock::default(),
@@ -2124,6 +2130,8 @@ impl Tree {
         let path = config.path.clone();
         log::trace!("Creating LSM-tree at {}", path.display());
 
+        let sync_mode = config.sync_mode;
+
         (*config.fs).create_dir_all(&path)?;
 
         // Create tables directories for all configured paths (primary + routes).
@@ -2132,17 +2140,17 @@ impl Tree {
         // to make all newly-created directory entries durable on POSIX.
         for (table_folder_path, folder_fs) in config.all_tables_folders() {
             folder_fs.create_dir_all(&table_folder_path)?;
-            fsync_directory(&table_folder_path, &*folder_fs)?;
+            fsync_directory(&table_folder_path, &*folder_fs, sync_mode)?;
             if let Some(parent) = table_folder_path.parent() {
-                fsync_directory(parent, &*folder_fs)?;
+                fsync_directory(parent, &*folder_fs, sync_mode)?;
                 if let Some(grandparent) = parent.parent() {
-                    fsync_directory(grandparent, &*folder_fs)?;
+                    fsync_directory(grandparent, &*folder_fs, sync_mode)?;
                 }
             }
         }
 
         // IMPORTANT: fsync primary folder on Unix
-        fsync_directory(&path, &*config.fs)?;
+        fsync_directory(&path, &*config.fs, sync_mode)?;
 
         let inner = TreeInner::create_new(config)?;
         Ok(Self(Arc::new(inner)))
@@ -2225,11 +2233,11 @@ impl Tree {
         for (table_base_folder, folder_fs) in &all_folders {
             if !folder_fs.exists(table_base_folder)? {
                 folder_fs.create_dir_all(table_base_folder)?;
-                fsync_directory(table_base_folder, &**folder_fs)?;
+                fsync_directory(table_base_folder, &**folder_fs, config.sync_mode)?;
                 if let Some(parent) = table_base_folder.parent() {
-                    fsync_directory(parent, &**folder_fs)?;
+                    fsync_directory(parent, &**folder_fs, config.sync_mode)?;
                     if let Some(grandparent) = parent.parent() {
-                        fsync_directory(grandparent, &**folder_fs)?;
+                        fsync_directory(grandparent, &**folder_fs, config.sync_mode)?;
                     }
                 }
             }

--- a/src/version/persist.rs
+++ b/src/version/persist.rs
@@ -1,7 +1,7 @@
 use crate::{
     encryption::EncryptionProvider,
     file::{CURRENT_VERSION_FILE, fsync_directory, rewrite_atomic},
-    fs::Fs,
+    fs::{Fs, SyncMode},
     manifest_blocks::{current_digest, writer::ManifestArchiveWriter},
     runtime_config::RuntimeConfig,
     version::Version,
@@ -25,6 +25,7 @@ pub fn persist_version(
     fs: &dyn Fs,
     runtime: Arc<RuntimeConfig>,
     encryption: Option<Arc<dyn EncryptionProvider>>,
+    sync_mode: SyncMode,
 ) -> crate::Result<()> {
     if comparator_name.len() > crate::comparator::MAX_COMPARATOR_NAME_BYTES {
         return Err(crate::Error::from(std::io::Error::new(
@@ -51,12 +52,12 @@ pub fn persist_version(
     // start() / finish()), and on finish() writes the tail footer
     // Block + size-hint trailer + optional head mirror per the
     // runtime config.
-    let mut writer = ManifestArchiveWriter::create(&path, fs, runtime, encryption)?;
+    let mut writer = ManifestArchiveWriter::create(&path, fs, runtime, encryption, sync_mode)?;
     version.encode_into(&mut writer, comparator_name)?;
     let footer = writer.finish()?;
 
     // IMPORTANT: fsync folder on Unix
-    fsync_directory(folder, fs)?;
+    fsync_directory(folder, fs, sync_mode)?;
 
     // CURRENT pointer carries a content-binding XXH3-128 over the
     // canonical footer payload (version_id + layout_version + flags +
@@ -88,6 +89,7 @@ pub fn persist_version(
         &folder.join(CURRENT_VERSION_FILE),
         &current_file_content,
         fs,
+        sync_mode,
     )?;
 
     Ok(())

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -1132,6 +1132,7 @@ mod tests {
             fs,
             std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
             None,
+            crate::fs::SyncMode::Normal,
         )
     }
 

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -5,7 +5,7 @@
 use crate::{
     MAX_SEQNO, SeqNo, SharedSequenceNumberGenerator,
     comparator::SharedComparator,
-    fs::Fs,
+    fs::{Fs, SyncMode},
     memtable::Memtable,
     tree::sealed::SealedMemtables,
     version::{Version, persist_version},
@@ -33,10 +33,14 @@ pub struct SuperVersions {
 
     /// Stable comparator identity persisted in every version file.
     comparator_name: Arc<str>,
+
+    /// Durability level (`Config::sync_mode`) applied to every manifest /
+    /// version persist this history performs. Immutable for the tree's life.
+    sync_mode: SyncMode,
 }
 
 impl SuperVersions {
-    pub fn new(version: Version, comparator: &SharedComparator) -> Self {
+    pub fn new(version: Version, comparator: &SharedComparator, sync_mode: SyncMode) -> Self {
         let comparator_name: Arc<str> = comparator.name().into();
 
         Self {
@@ -48,6 +52,7 @@ impl SuperVersions {
             }]
             .into(),
             comparator_name,
+            sync_mode,
         }
     }
 
@@ -192,6 +197,7 @@ impl SuperVersions {
             fs,
             runtime,
             encryption,
+            self.sync_mode,
         )?;
         self.append_version(next_version);
 
@@ -267,6 +273,7 @@ mod tests {
         SuperVersions {
             versions: versions.into(),
             comparator_name: "default".into(),
+            sync_mode: SyncMode::Normal,
         }
     }
 

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -7,7 +7,7 @@ use crate::fs::FsFile;
 use crate::{
     BlobFile, CompressionType, DescriptorTable, SeqNo, SequenceNumberCounter, TreeId,
     file_accessor::FileAccessor,
-    fs::Fs,
+    fs::{Fs, SyncMode},
     vlog::{
         ValueHandle,
         blob_file::{Inner as BlobFileInner, Metadata},
@@ -33,6 +33,10 @@ pub struct MultiWriter {
 
     compression: CompressionType,
     passthrough_compression: CompressionType,
+
+    /// Durability level wired from `Config::sync_mode`, stamped on every
+    /// rotated blob writer.
+    sync_mode: SyncMode,
 
     /// Dictionary for `ZstdDict` compression, shared across all rotated writers.
     #[cfg(zstd_any)]
@@ -72,6 +76,7 @@ impl MultiWriter {
 
             compression: CompressionType::None,
             passthrough_compression: CompressionType::None,
+            sync_mode: SyncMode::Normal,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -80,6 +85,15 @@ impl MultiWriter {
             descriptor_table,
             fs,
         })
+    }
+
+    /// Wires the tree's `Config::sync_mode` through to every blob file this
+    /// writer finalizes (active + rotated).
+    #[must_use]
+    pub fn use_sync_mode(mut self, sync_mode: SyncMode) -> Self {
+        self.sync_mode = sync_mode;
+        self.active_writer.sync_mode = sync_mode;
+        self
     }
 
     /// Sets the blob file target size.
@@ -132,7 +146,8 @@ impl MultiWriter {
 
         let new_writer = {
             let w = Writer::new(blob_file_path, new_blob_file_id, self.tree_id, &*self.fs)?
-                .use_compression(self.compression);
+                .use_compression(self.compression)
+                .use_sync_mode(self.sync_mode);
             #[cfg(zstd_any)]
             let w = w.use_zstd_dictionary(self.zstd_dictionary.clone());
             w

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -9,7 +9,7 @@ use super::meta::Metadata;
 use crate::{
     Checksum, CompressionType, KeyRange, SeqNo, TreeId, UserKey,
     checksum::ChecksummedWriter,
-    fs::{Fs, FsFile, FsOpenOptions},
+    fs::{Fs, FsFile, FsOpenOptions, SyncMode},
     time::unix_timestamp,
     vlog::BlobFileId,
 };
@@ -121,6 +121,11 @@ pub struct Writer {
 
     pub(crate) compression: CompressionType,
 
+    /// Durability level for the final blob-file fsync. Default
+    /// [`SyncMode::Normal`]; wired from `Config::sync_mode` via
+    /// [`Self::use_sync_mode`].
+    pub(crate) sync_mode: SyncMode,
+
     /// Dictionary for `ZstdDict` compression.  Must be supplied when
     /// `compression` is [`CompressionType::ZstdDict`].
     #[cfg(zstd_any)]
@@ -168,6 +173,7 @@ impl Writer {
             last_key: None,
 
             compression: CompressionType::None,
+            sync_mode: SyncMode::Normal,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -176,6 +182,13 @@ impl Writer {
 
     pub fn use_compression(mut self, compressor: CompressionType) -> Self {
         self.compression = compressor;
+        self
+    }
+
+    /// Wires the tree's `Config::sync_mode` into the final blob-file fsync.
+    #[must_use]
+    pub fn use_sync_mode(mut self, sync_mode: SyncMode) -> Self {
+        self.sync_mode = sync_mode;
         self
     }
 
@@ -390,7 +403,7 @@ impl Writer {
         metadata.encode_into(&mut self.writer)?;
 
         let mut checksum = self.writer.into_inner()?;
-        FsFile::sync_all(&**checksum.inner_mut().get_mut())?;
+        FsFile::sync_all_with(&**checksum.inner_mut().get_mut(), self.sync_mode)?;
         let checksum = checksum.checksum();
 
         Ok((metadata, checksum))

--- a/tests/sync_mode.rs
+++ b/tests/sync_mode.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end durability-mode coverage: a tree opened under either
+//! [`SyncMode`] must persist a flush and recover it after reopen. On macOS
+//! the two modes drive different fsync syscalls (plain `fsync` vs
+//! `F_FULLFSYNC`); elsewhere they are identical. Either way the persisted
+//! tree must be valid and re-openable.
+
+use lsm_tree::{AbstractTree, Config, SequenceNumberCounter, fs::SyncMode};
+
+fn roundtrip_under(mode: SyncMode) {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .sync_mode(mode)
+        .open()
+        .expect("open with sync mode");
+
+        for i in 0u64..256 {
+            tree.insert(i.to_be_bytes(), b"v", i);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+
+    // Reopen from disk — the flush must have produced a recoverable tree.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .sync_mode(mode)
+    .open()
+    .expect("reopen");
+
+    for i in 0u64..256 {
+        let got = tree.get(i.to_be_bytes(), lsm_tree::MAX_SEQNO).expect("get");
+        assert_eq!(
+            got.as_deref(),
+            Some(&b"v"[..]),
+            "lost key {i} under {mode:?}"
+        );
+    }
+}
+
+#[test]
+fn sync_mode_normal_flush_round_trips() {
+    roundtrip_under(SyncMode::Normal);
+}
+
+#[test]
+fn sync_mode_full_flush_round_trips() {
+    roundtrip_under(SyncMode::Full);
+}
+
+#[test]
+fn sync_mode_defaults_to_normal() {
+    // The default must be the cheaper plain-fsync mode (matching RocksDB /
+    // SQLite defaults), so macOS does not pay F_FULLFSYNC unless asked.
+    assert_eq!(SyncMode::default(), SyncMode::Normal);
+}

--- a/tests/tree_recovery_versions.rs
+++ b/tests/tree_recovery_versions.rs
@@ -65,6 +65,7 @@ fn rewrite_manifest_format_version(path: &Path, version: u8) -> lsm_tree::Result
         &lsm_tree::fs::StdFs,
         std::sync::Arc::new(lsm_tree::runtime_config::RuntimeConfig::default()),
         None,
+        lsm_tree::fs::SyncMode::Normal,
     )?;
     for (name, payload) in sections {
         w.start(&name)?;


### PR DESCRIPTION
## Summary

On macOS, Rust std maps **both** `File::sync_all` and `File::sync_data` to `fcntl(F_FULLFSYNC)` — a full hardware barrier. Measured on an M-series machine: `File::sync_all` **3.9 ms** vs plain `libc::fsync` **0.075 ms** (52x). A fresh open + flush issues ~8-10 sync points, so macOS paid ~40 ms of fixed cost per flush — dominating small-batch writes and slowing the whole test suite. RocksDB and SQLite default to plain `fsync`; we now match that.

This is also a durability-level choice: `F_FULLFSYNC` survives power loss; plain `fsync` reaches the drive cache (the RocksDB / SQLite default). On Linux there is no `F_FULLFSYNC` concept — `sync_all` is already plain `fsync`, so this only changes macOS behavior.

## Changes

Adds `SyncMode { Normal, Full }` with `Config::sync_mode` (default `Normal`):

- `Normal`: plain `fsync` on every platform; on macOS skips `F_FULLFSYNC`.
- `Full`: `F_FULLFSYNC` on macOS for power-loss durability; identical to `Normal` elsewhere.

`FsFile` gains `sync_all_with` / `sync_data_with`, `Fs` gains `sync_directory_with` (default impls delegate to the full-durability methods; the std `File` / `StdFs` backends override them, calling `libc::fsync` directly on macOS for `Normal`). The mode is threaded from `Config` through the SST writer, `MultiWriter`, manifest writer, version persist, directory fsyncs, tree open, checkpoint, and the **blob-file writer** (vlog `Writer` / `MultiWriter`, wired at flush / compaction / GC / ingest).

### Known limitation

`StdFs::hard_link`'s cross-device (EXDEV) copy fallback still issues an unconditional `F_FULLFSYNC` because `Fs::hard_link` has no `SyncMode` parameter. Reachable only from cross-device checkpoint copies; threading `SyncMode` there is tracked in #377.

## Effect

Default-feature test suite execution on this macOS machine: **~37.7 s → ~12.6 s** (~3x), purely from skipping `F_FULLFSYNC` on the many flushes tests perform. The same fixed-cost reduction shows up in the `compare-rocksdb` `write_throughput` workload.

## Testing

- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo fmt --check` clean; rustdoc `-D warnings` clean
- `cargo nextest run` 1574 passed; `--all-features` 1801 passed
- `tests/sync_mode.rs`: flush round-trips under both modes + default-is-Normal; fs-level `std_fs_sync_with_both_modes_persists` exercises the macOS plain-fsync and F_FULLFSYNC branches

Closes #373
