### PR TITLE
perf(read): borrow index block on point-read, parse trailer once

### DIFF
--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -122,10 +122,98 @@ pub struct Decoder<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> {
     cached_entries_end: Option<usize>,
 }
 
+/// Pre-parsed block-trailer metadata, extracted once and reused across
+/// many [`Decoder`] constructions over the same block.
+///
+/// All fields are small `Copy` integers read from the fixed trailer plus
+/// the derived `cached_entries_end`. Parsing the trailer (six reads +
+/// validation + `compute_entries_end`) is identical on every call, so a
+/// long-lived index that decodes the same block on every point read
+/// (e.g. [`crate::table::block_index::FullBlockIndex`]) can parse once at
+/// construction and hand this struct to [`Decoder::from_meta`] thereafter,
+/// turning per-lookup trailer parsing into a few field copies.
+#[derive(Clone, Copy, Debug)]
+pub struct DecoderMeta {
+    restart_interval: u8,
+    binary_index_step_size: u8,
+    binary_index_offset: u32,
+    binary_index_len: u32,
+    hash_index_len: u32,
+    hash_index_offset: u32,
+    cached_entries_end: usize,
+}
+
 impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Parsed> {
     #[must_use]
     pub fn restart_interval(&self) -> u8 {
         self.restart_interval
+    }
+
+    /// Extracts the reusable trailer metadata from a fully-constructed
+    /// decoder so future decodes of the same block can skip the trailer
+    /// parse via [`Self::from_meta`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cached_entries_end` was never computed, which cannot
+    /// happen for a decoder built by [`Self::try_new`] / [`Self::new`]
+    /// (both populate it before returning).
+    #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "try_new/new always populate cached_entries_end before returning"
+    )]
+    pub fn meta(&self) -> DecoderMeta {
+        DecoderMeta {
+            restart_interval: self.restart_interval,
+            binary_index_step_size: self.binary_index_step_size,
+            binary_index_offset: self.binary_index_offset,
+            binary_index_len: self.binary_index_len,
+            hash_index_len: self.hash_index_len,
+            hash_index_offset: self.hash_index_offset,
+            cached_entries_end: self
+                .cached_entries_end
+                .expect("cached_entries_end populated by constructor"),
+        }
+    }
+
+    /// Builds a decoder from a block plus already-parsed [`DecoderMeta`],
+    /// skipping the trailer read + validation + `compute_entries_end` that
+    /// [`Self::try_new`] performs. The caller guarantees `meta` was
+    /// produced by [`Self::meta`] on a decoder of the SAME block layout
+    /// (same trailer), so no validation is repeated.
+    ///
+    /// This is the parse-once fast path for hot read loops: the owning
+    /// index parses the trailer once and reuses `meta` on every lookup.
+    #[must_use]
+    pub fn from_meta(block: &'a Block, meta: DecoderMeta) -> Self {
+        Self {
+            block,
+            phantom: PhantomData,
+
+            lo_scanner: LoScanner {
+                offset: 0,
+                remaining_in_interval: 0,
+                base_key_offset: None,
+                base_key_end: None,
+            },
+
+            hi_scanner: HiScanner {
+                offset: 0,
+                ptr_idx: usize::try_from(meta.binary_index_len).unwrap_or(usize::MAX),
+                stack: Vec::new(),
+                base_key_offset: None,
+                base_key_end: None,
+            },
+
+            restart_interval: meta.restart_interval,
+            binary_index_step_size: meta.binary_index_step_size,
+            binary_index_offset: meta.binary_index_offset,
+            binary_index_len: meta.binary_index_len,
+            hash_index_len: meta.hash_index_len,
+            hash_index_offset: meta.hash_index_offset,
+            cached_entries_end: Some(meta.cached_entries_end),
+        }
     }
 
     /// Creates a new block decoder, returning an error on malformed trailer

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -17,7 +17,7 @@ mod trailer;
 mod transform;
 mod r#type;
 
-pub(crate) use decoder::{Decodable, Decoder, ParsedItem};
+pub(crate) use decoder::{Decodable, Decoder, DecoderMeta, ParsedItem};
 pub(crate) use encoder::{Encodable, Encoder};
 pub use header::Header;
 pub use identity::BlockIdentity;

--- a/src/table/block_index/full.rs
+++ b/src/table/block_index/full.rs
@@ -2,12 +2,12 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use crate::SeqNo;
 use crate::comparator::SharedComparator;
-use crate::table::block::{BlockType, Decoder};
+use crate::table::block::{BlockType, Decoder, DecoderMeta, ParsedItem};
 use crate::table::block_index::{BlockIndexIter, iter::OwnedIndexBlockIter};
-use crate::table::index_block::IndexBlockParsedItem;
+use crate::table::index_block::{IndexBlockParsedItem, Iter as BorrowedIndexIter};
 use crate::table::{IndexBlock, KeyedBlockHandle};
+use crate::{SeqNo, Slice};
 
 /// Index that translates item keys to data block handles
 ///
@@ -15,6 +15,10 @@ use crate::table::{IndexBlock, KeyedBlockHandle};
 pub struct FullBlockIndex {
     block: IndexBlock,
     comparator: SharedComparator,
+    /// Trailer metadata parsed once at construction. The point-read fast
+    /// path ([`Self::point_read_reader`]) reuses it instead of re-parsing
+    /// the trailer on every lookup.
+    meta: DecoderMeta,
 }
 
 impl FullBlockIndex {
@@ -35,13 +39,40 @@ impl FullBlockIndex {
             )));
         }
         // Validate trailer layout once at construction so later iter() calls
-        // cannot panic.
-        Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::try_new(&block.inner)?;
-        Ok(Self { block, comparator })
+        // cannot panic, and keep the parsed metadata so the point-read hot
+        // path can build decoders without re-parsing the trailer.
+        let meta = Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::try_new(&block.inner)?.meta();
+        Ok(Self {
+            block,
+            comparator,
+            meta,
+        })
     }
 
     pub fn inner(&self) -> &IndexBlock {
         &self.block
+    }
+
+    /// Borrowing point-read seek: positions a borrowing iterator at the
+    /// first block handle at or after `(needle, seqno)`.
+    ///
+    /// Unlike [`Self::forward_reader`] this does NOT clone the index block
+    /// (the returned iterator borrows it) and reuses the trailer metadata
+    /// parsed at construction, so a point read pays neither the block
+    /// refcount bump nor a trailer re-parse. Used by the table point-read
+    /// path; range scans keep the owned [`Self::forward_reader`].
+    pub fn point_read_reader(&self, needle: &[u8], seqno: SeqNo) -> Option<PointReadIter<'_>> {
+        let mut it = self
+            .block
+            .iter_with_meta(self.comparator.clone(), self.meta);
+        if it.seek(needle, seqno) {
+            Some(PointReadIter {
+                iter: it,
+                data: &self.block.inner.data,
+            })
+        } else {
+            None
+        }
     }
 
     pub fn forward_reader(&self, needle: &[u8], seqno: SeqNo) -> Option<Iter> {
@@ -58,6 +89,28 @@ impl FullBlockIndex {
             self.block.clone(),
             self.comparator.clone(),
         ))
+    }
+}
+
+/// Borrowing point-read iterator returned by
+/// [`FullBlockIndex::point_read_reader`].
+///
+/// Wraps the borrowing index-block [`BorrowedIndexIter`] (which yields raw
+/// parsed items) and materializes each into a [`KeyedBlockHandle`] against
+/// the borrowed block data. Both fields share an immutable borrow of the
+/// index block, so no `Arc`/`Bytes` clone happens per lookup.
+pub struct PointReadIter<'a> {
+    iter: BorrowedIndexIter<'a>,
+    data: &'a Slice,
+}
+
+impl Iterator for PointReadIter<'_> {
+    type Item = crate::Result<KeyedBlockHandle>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // materialize is infallible; wrap in Ok to match the owned
+        // `forward_reader` iterator's item type so the caller's `?` works.
+        self.iter.next().map(|item| Ok(item.materialize(self.data)))
     }
 }
 

--- a/src/table/block_index/mod.rs
+++ b/src/table/block_index/mod.rs
@@ -70,6 +70,47 @@ impl DoubleEndedIterator for BlockIndexIterImpl {
     }
 }
 
+/// Borrowing point-read iterator over block handles.
+///
+/// Returned by [`BlockIndexImpl::point_read_reader`]. For the common
+/// fully-pinned [`FullBlockIndex`] it borrows the index block (no per-lookup
+/// `Arc`/`Bytes` clone) and reuses the trailer metadata parsed at table
+/// open (no per-lookup trailer parse). The volatile / two-level variants
+/// keep the owned [`BlockIndexIterImpl`] path.
+pub enum PointReadIterImpl<'a> {
+    Full(self::full::PointReadIter<'a>),
+    Owned(BlockIndexIterImpl),
+}
+
+impl Iterator for PointReadIterImpl<'_> {
+    type Item = crate::Result<KeyedBlockHandle>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Full(i) => i.next(),
+            Self::Owned(i) => i.next(),
+        }
+    }
+}
+
+impl BlockIndexImpl {
+    /// Point-read seek that avoids the owned-iterator overhead where
+    /// possible. For [`Self::Full`] it returns a borrowing iterator (no
+    /// block clone, no trailer re-parse); other variants fall back to the
+    /// owned [`BlockIndex::forward_reader`].
+    pub fn point_read_reader(&self, needle: &[u8], seqno: SeqNo) -> Option<PointReadIterImpl<'_>> {
+        match self {
+            Self::Full(index) => index
+                .point_read_reader(needle, seqno)
+                .map(PointReadIterImpl::Full),
+            Self::VolatileFull(_) | Self::TwoLevel(_) => self
+                .forward_reader(needle, seqno)
+                .map(PointReadIterImpl::Owned),
+            Self::Closed => None,
+        }
+    }
+}
+
 /// The block index stores references to the positions of blocks on a file and their size
 ///
 /// __________________

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -16,7 +16,7 @@ use crate::Slice;
 use crate::{
     SeqNo,
     table::{
-        block::{Decoder, ParsedItem},
+        block::{Decoder, DecoderMeta, ParsedItem},
         util::{SliceIndexes, compare_prefixed_slice},
     },
 };
@@ -149,6 +149,33 @@ impl IndexBlock {
     pub fn iter(&self, comparator: crate::comparator::SharedComparator) -> Iter<'_> {
         Iter::new(
             Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::new(&self.inner),
+            comparator,
+        )
+    }
+
+    /// Parses the block trailer once and returns the reusable
+    /// [`DecoderMeta`], so repeated lookups can build decoders via
+    /// [`Self::iter_with_meta`] without re-parsing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidTrailer`] / [`crate::Error::InvalidTag`]
+    /// if the block is not a valid index block.
+    pub fn decoder_meta(&self) -> crate::Result<DecoderMeta> {
+        Ok(Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::try_new(&self.inner)?.meta())
+    }
+
+    /// Builds a borrowing iterator from pre-parsed [`DecoderMeta`],
+    /// skipping the per-call trailer parse. `meta` must come from
+    /// [`Self::decoder_meta`] on this same block.
+    #[must_use]
+    pub fn iter_with_meta(
+        &self,
+        comparator: crate::comparator::SharedComparator,
+        meta: DecoderMeta,
+    ) -> Iter<'_> {
+        Iter::new(
+            Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::from_meta(&self.inner, meta),
             comparator,
         )
     }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -486,7 +486,10 @@ impl Table {
         key: &[u8],
         seqno: SeqNo,
     ) -> crate::Result<Option<(InternalValue, DataBlock)>> {
-        let Some(iter) = self.block_index.forward_reader(key, seqno) else {
+        // Borrowing point-read seek: avoids cloning the index block + reuses
+        // the trailer metadata parsed at table open (see
+        // `BlockIndexImpl::point_read_reader`).
+        let Some(iter) = self.block_index.point_read_reader(key, seqno) else {
             return Ok(None);
         };
 


### PR DESCRIPTION
## Summary

The point-read index lookup went through `FullBlockIndex::forward_reader` → `iter()`, which on every `get`:

1. **Cloned the index block** (`self.block.clone()` — a `Bytes` refcount bump) so the owned `self_cell` iterator could own its backing data, and
2. **Re-parsed the block trailer** (`Decoder::new` reads restart / binary-index metadata) even though `FullBlockIndex::new` already parsed + validated it once at table open and discarded it.

Neither is needed for a point read: the lookup is short-lived and can borrow the pinned index block, and the trailer metadata is immutable for the table's life.

## Changes

- `DecoderMeta` (`Copy`) captures the parsed trailer fields; `Decoder::meta()` extracts it, `Decoder::from_meta()` rebuilds a decoder without re-reading/validating the trailer.
- `FullBlockIndex` stores the `DecoderMeta` parsed once in `new()`.
- `FullBlockIndex::point_read_reader` returns a borrowing `PointReadIter` that borrows the pinned index block (no clone) and uses the cached meta (no re-parse), materializing handles lazily.
- `BlockIndexImpl::point_read_reader` dispatches: `Full` → borrowing path; volatile / two-level → existing owned `forward_reader`.
- `Table::point_read_inner` uses the borrowing reader.

Range scans keep the owned iterator unchanged; read correctness is identical.

## Effect

Per lookup this removes one `Bytes` refcount bump and the trailer re-parse from the hot read path. The absolute win is small relative to the ~1.5 us/get warm point-read cost, so it sits below the `compare-rocksdb` `point_read` measurement noise floor (the `ours/rocksdb` ratio stays ~1.5–1.6x, unchanged within run-to-run variance). This is an architectural overhead removal on the hot path, not a headline number — kept because removing avoidable per-lookup atomics + re-parsing is strictly better and these add up in P99.

## Testing

- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo fmt --check` clean; rustdoc `-D warnings` clean
- `cargo nextest run` 1570 passed (read path is correctness-critical; full suite green)

Closes #375
