### PR TITLE
perf(fs): pure hard_link; single SyncMode-aware cross-fs copy path

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -130,13 +130,13 @@ impl Drop for RootCleanup<'_> {
 ///    different `Arc<dyn Fs>` handle — common when `level_routes`
 ///    builds `Arc::new(StdFs)` independently from `config.fs`) will
 ///    succeed in O(1) without doubling disk usage. `StdFs::hard_link`
-///    handles its own `EXDEV` → byte-copy fallback transparently.
-/// 2. **On `NotFound`** (the dst backend doesn't see `src` at all —
-///    e.g. `MemFs` target with `StdFs` source) **or `Unsupported`**
-///    (in-memory backends that don't implement linking), stream bytes
-///    through both trait objects. This is the only path that doubles
-///    storage. The fallback itself is silent here (the [`StdFs`] EXDEV
-///    fallback emits one [`log::debug`] per file); operator-visible
+///    is a pure link — it surfaces the underlying error rather than
+///    copying.
+/// 2. **On cross-device (`EXDEV` / `CrossesDevices`), `Unsupported`, or
+///    `NotFound`**, stream bytes through both trait objects. This is the
+///    only path that doubles storage, and it owns the cross-filesystem
+///    copy so the copied file's durability honors `sync_mode` (via
+///    `sync_all_with` below). Logged at [`log::debug`]; operator-visible
 ///    notification of unexpected copies is the checkpoint driver's
 ///    responsibility — a per-file warning would drown real signal on
 ///    a misconfigured tier with thousands of SSTs.
@@ -185,19 +185,20 @@ pub fn link_or_copy_cross_fs(
             // link itself.
             Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
             Err(e)
-                if matches!(
-                    e.kind(),
-                    std::io::ErrorKind::NotFound | std::io::ErrorKind::Unsupported
-                ) =>
+                if crate::fs::is_cross_device(&e) || e.kind() == std::io::ErrorKind::NotFound =>
             {
-                // Same kernel namespace but the link didn't take —
-                // either dst_fs's backend doesn't support hard_link at
-                // all, or the file moved out from under us before the
-                // syscall. Either way, fall through to the streamed
-                // copy below. Log at `debug` for symmetry with
-                // `StdFs::hard_link`'s EXDEV fallback — operators
-                // wanting visibility of unexpected full copies grep the
-                // `fs` / `checkpoint` modules at debug level. `warn`
+                // The link didn't take, for one of:
+                //   - cross-device (EXDEV / CrossesDevices) — src and dst
+                //     sit on different filesystems, so a true link is
+                //     impossible. `StdFs::hard_link` now surfaces this
+                //     instead of byte-copying, so the SyncMode-aware
+                //     streamed copy below owns the cross-fs copy and the
+                //     copied file honors `Config::sync_mode`.
+                //   - Unsupported — dst_fs's backend has no hard_link.
+                //   - NotFound — the file moved out before the syscall.
+                // All fall through to the streamed copy below. Log at
+                // `debug`: operators wanting visibility of full copies grep
+                // the `fs` / `checkpoint` modules at debug level; `warn`
                 // would drown real signal on a misconfigured tier with
                 // thousands of SSTs.
                 log::debug!(

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -576,21 +576,21 @@ pub trait Fs: Send + Sync + 'static {
     /// the other intact; the inode is reclaimed only after the last link
     /// is removed.
     ///
-    /// # Cross-filesystem fallback
+    /// # Cross-filesystem behaviour
     ///
-    /// Hard links cannot span filesystems. Implementations that detect a
-    /// cross-device situation (Unix `EXDEV`) MUST fall back to a byte copy
-    /// so that callers can treat `hard_link` as always-succeeding when the
-    /// destination filesystem is writable. The fallback emits a [`log::debug`]
-    /// trace per call (deliberately not `warn`: a tier-misconfigured
-    /// checkpoint can hit this path thousands of times per snapshot, and
-    /// per-file warnings would drown real signal). Callers that need
-    /// operator-visible notification of unexpected copies are expected
-    /// to aggregate per-checkpoint and emit a single summary warning.
+    /// Hard links cannot span filesystems. `hard_link` is a PURE link: on a
+    /// cross-device situation (Unix `EXDEV` / [`io::ErrorKind::CrossesDevices`])
+    /// implementations surface the error rather than silently byte-copying.
+    /// Callers that want a cross-filesystem copy use the checkpoint driver's
+    /// `link_or_copy_cross_fs`, which detects the cross-device (and
+    /// `Unsupported` / `NotFound`) error and performs a `SyncMode`-aware
+    /// streamed copy. Keeping the copy in one place means the copied file's
+    /// durability honors `Config::sync_mode` instead of an unconditional
+    /// barrier hidden inside `hard_link`.
     ///
-    /// In-memory backends ([`MemFs`]) do not have inodes;
-    /// they implement this as a byte copy that produces an independent file
-    /// with the same contents.
+    /// In-memory backends ([`MemFs`]) have no inodes; they implement this
+    /// as a byte copy that produces an independent file with the same
+    /// contents (their "link" semantics).
     ///
     /// # Default implementation
     ///
@@ -606,8 +606,8 @@ pub trait Fs: Send + Sync + 'static {
     /// # Errors
     ///
     /// Returns an I/O error if `src` does not exist, `dst` already exists,
-    /// the destination's parent directory is missing, or the fallback copy
-    /// fails.
+    /// the destination's parent directory is missing, or `src` and `dst`
+    /// are on different filesystems (cross-device — surfaced, not copied).
     fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let _ = (src, dst);
         Err(io::Error::new(

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -46,6 +46,7 @@ mod io_uring_fs;
 
 pub use mem_fs::MemFs;
 pub use std_fs::StdFs;
+pub(crate) use std_fs::is_cross_device;
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring_fs::{IoUringFs, is_io_uring_available};

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -316,7 +316,17 @@ pub const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
 /// misconfigurations. Operators hitting that edge case on Windows can
 /// fix it explicitly (move the target volume, adjust ACLs); the
 /// fall-back is opt-out by design.
-pub fn is_cross_device(err: &io::Error) -> bool {
+// `pub(crate)`, surfaced crate-wide via the `pub(crate) use` re-export in
+// `fs/mod.rs` so `checkpoint::link_or_copy_cross_fs` can detect cross-device
+// errors. The crate-scoped visibility (not `pub`) keeps this off any public
+// surface even if `std_fs` is ever exported. clippy's `redundant_pub_crate`
+// fires only because the enclosing module is currently private; the re-export
+// genuinely needs crate visibility, so the lint is a false positive here.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "re-exported crate-wide via fs::mod; pub(crate) communicates the intended scope"
+)]
+pub(crate) fn is_cross_device(err: &io::Error) -> bool {
     #[cfg(unix)]
     {
         // POSIX `EXDEV` ("invalid cross-device link"). The raw value is

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -279,23 +279,15 @@ impl Fs for StdFs {
     }
 
     fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
-        match std::fs::hard_link(src, dst) {
-            Ok(()) => Ok(()),
-            Err(e) if is_cross_device(&e) => {
-                // `debug!`, not `warn!`: a tier-misconfigured checkpoint
-                // can hit this path once per SST + once per blob (potentially
-                // thousands of times). The checkpoint driver is responsible
-                // for emitting a single summary warning if the fallback rate
-                // is excessive; per-file noise here would drown real logs.
-                log::debug!(
-                    "hard_link({}, {}) crossed filesystems — falling back to copy",
-                    src.display(),
-                    dst.display(),
-                );
-                copy_fallback(src, dst)
-            }
-            Err(e) => Err(e),
-        }
+        // Pure hard link. On a cross-device target this returns the EXDEV
+        // error instead of silently byte-copying: the copy belongs to the
+        // caller that actually wants a cross-filesystem copy
+        // (checkpoint's `link_or_copy_cross_fs`), which detects the
+        // cross-device error via `is_cross_device` and runs its own
+        // SyncMode-aware streamed copy. Keeping the copy in one place means
+        // the copied file's durability honors `Config::sync_mode` instead
+        // of always paying `F_FULLFSYNC` here.
+        std::fs::hard_link(src, dst)
     }
 
     fn backend_id(&self) -> Option<u64> {
@@ -324,7 +316,7 @@ pub const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
 /// misconfigurations. Operators hitting that edge case on Windows can
 /// fix it explicitly (move the target volume, adjust ACLs); the
 /// fall-back is opt-out by design.
-fn is_cross_device(err: &io::Error) -> bool {
+pub fn is_cross_device(err: &io::Error) -> bool {
     #[cfg(unix)]
     {
         // POSIX `EXDEV` ("invalid cross-device link"). The raw value is
@@ -343,56 +335,6 @@ fn is_cross_device(err: &io::Error) -> bool {
         err.kind(),
         io::ErrorKind::CrossesDevices | io::ErrorKind::Unsupported
     )
-}
-
-/// Byte-copy fallback used when [`hard_link`](Fs::hard_link) cannot create
-/// a true link (cross-device or in-memory FS without inode semantics).
-///
-/// Uses `create_new` semantics so an accidental clobber surfaces as
-/// [`io::ErrorKind::AlreadyExists`] — matching real `hard_link` behaviour.
-fn copy_fallback(src: &Path, dst: &Path) -> io::Result<()> {
-    use std::io::{Read, Write};
-
-    // Wrap the copy in an inner closure so any post-`create_new` error
-    // (ENOSPC, EIO, write_all failure, sync_all failure) triggers a
-    // best-effort unlink of the partially-written destination. Without
-    // this, a failed `copy_fallback` leaves a truncated file behind and
-    // the next retry surfaces as `AlreadyExists` — callers would then
-    // see a corrupt file from an operation that already reported error.
-    let res: io::Result<()> = (|| {
-        let mut src_file = File::open(src)?;
-        let mut dst_file = OpenOptions::new().write(true).create_new(true).open(dst)?;
-
-        // Heap-allocated buffer — checkpoint is cold-path I/O, so a
-        // 64 KiB Vec is cheaper than blowing past clippy's stack-array budget.
-        let mut buf = vec![0u8; 64 * 1024].into_boxed_slice();
-        loop {
-            let n = match src_file.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => n,
-                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                Err(e) => return Err(e),
-            };
-            #[expect(
-                clippy::indexing_slicing,
-                reason = "n was just produced by read() and bounded by buf.len()"
-            )]
-            dst_file.write_all(&buf[..n])?;
-        }
-        // Full-durability sync: `hard_link` has no `SyncMode` parameter, so
-        // this cross-device fallback can't honor `Config::sync_mode` and uses
-        // `F_FULLFSYNC` on macOS regardless. Reachable only from cross-device
-        // checkpoint copies; threading `SyncMode` here is tracked in #377.
-        dst_file.sync_all()
-    })();
-
-    if res.is_err() {
-        // Best-effort: if cleanup itself fails (permission denied,
-        // already removed by another process), there's nothing more we
-        // can do — the original error is what the caller needs to see.
-        let _ = std::fs::remove_file(dst);
-    }
-    res
 }
 
 // ---------------------------------------------------------------------------
@@ -1094,25 +1036,6 @@ mod tests {
         Ok(())
     }
 
-    /// Forces the EXDEV fallback by calling [`copy_fallback`] directly.
-    /// A real cross-device scenario needs two mounted filesystems which is
-    /// impractical in unit tests, but the fallback path itself is exercised.
-    #[test]
-    fn copy_fallback_copies_bytes_independently() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let src = dir.path().join("src");
-        let dst = dir.path().join("dst");
-        std::fs::write(&src, b"payload-for-fallback")?;
-
-        copy_fallback(&src, &dst)?;
-        assert_eq!(std::fs::read(&dst)?, b"payload-for-fallback");
-
-        // Writing to dst must NOT affect src (independent file).
-        std::fs::write(&dst, b"modified")?;
-        assert_eq!(std::fs::read(&src)?, b"payload-for-fallback");
-        Ok(())
-    }
-
     #[test]
     fn is_cross_device_detects_exdev_and_kind_variants() {
         // Synthesise a raw EXDEV error — what Linux/macOS/BSDs return when
@@ -1142,19 +1065,6 @@ mod tests {
         // needs to surface that error verbatim, not silently copy.
         let notfound = io::Error::from(io::ErrorKind::NotFound);
         assert!(!is_cross_device(&notfound));
-    }
-
-    #[test]
-    fn copy_fallback_refuses_to_overwrite() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let src = dir.path().join("src");
-        let dst = dir.path().join("dst");
-        std::fs::write(&src, b"src")?;
-        std::fs::write(&dst, b"dst")?;
-
-        let err = copy_fallback(&src, &dst).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
-        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`StdFs::hard_link` caught EXDEV (cross-device) internally and byte-copied the file with an unconditional `FsFile::sync_all`, so cross-device checkpoint copies paid `F_FULLFSYNC` on macOS regardless of `Config::sync_mode`. This was the last fsync site not honoring `SyncMode` (noted as a known limitation in #374).

## Changes

- `StdFs::hard_link` is now a **pure link** — it surfaces the EXDEV / cross-device error instead of silently byte-copying.
- Checkpoint's `link_or_copy_cross_fs` (the one production caller) already has a `SyncMode`-aware streamed copy; its `hard_link` fall-through now also triggers on cross-device errors (via `is_cross_device`), so the copied file's durability honors `Config::sync_mode`.
- This collapses the two cross-filesystem copy implementations into one: `copy_fallback` (and its two unit tests) are removed, leaving `link_or_copy_cross_fs` as the single copy path. `is_cross_device` is re-exported `pub(crate)` for the caller's detection.
- `MemFs` (in-memory copy = its link semantics) and `IoUringFs` (delegates to `StdFs`) are unaffected.

This is Option B from #377 (the architecturally cleaner one): rather than add a `SyncMode` parameter to the generic `Fs::hard_link` trait method — which is about linking, not fsync — the durability decision stays at the single layer that performs the copy.

## Testing

- `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo fmt --check` clean; rustdoc `-D warnings` clean
- `cargo nextest run` 1572 passed; `--all-features` 1799 passed (the −2 vs prior is the removed `copy_fallback` unit tests; cross-fs copy is covered by the `link_or_copy_cross_fs` StdFs→MemFs test + the `is_cross_device` detection test). A real EXDEV scenario needs two mounted filesystems, impractical in unit tests.

Closes #377
