### PR TITLE
build(deps): bump structured-zstd 0.0.26 -> 0.0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ log = "0.4.30"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.26", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.28", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is


### PR DESCRIPTION
## Summary

Bumps the `structured-zstd` dependency from 0.0.26 to 0.0.28 (our fork). 0.0.27/0.0.28 are decode + encode performance work plus additive `kernel_*` CPU-tier selection features — no breaking API for the `std + lsm` feature set we use.

0.0.x releases are mutually semver-incompatible, so the pinned spec must move explicitly. `bitflags` and `log` already resolve to their latest compatible versions via their caret specs (Cargo.lock is gitignored for this library), so they need no Cargo.toml edit.

## Testing

- `cargo check --all-features`: clean on 0.0.28 (no API breakage)
- `cargo nextest run --all-features`: 1799 passed, 2 skipped (zstd roundtrip / dict / encryption suites green on the new codec)
- `cargo clippy --all-features --all-targets` clean

Closes #383