### PR TITLE
ci(benchmark): publish compare-rocksdb overlay reports to gh-pages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,10 @@ jobs:
     # self-hosted runners (if added later) without the label
     # won't pick the job up.
     runs-on: [self-hosted, gpu-private-systems]
-    timeout-minutes: 30
+    # 60 (was 30): absorbs the compare-rocksdb head-to-head pass added
+    # below (bounded criterion settings, but the zstd22/10k write points
+    # are seconds each) plus the first-run librocksdb-sys C++ compile.
+    timeout-minutes: 60
     steps:
       # v6 requires runner ≥2.327.1 (node24 runtime) — the self-hosted
       # runner has a current runner agent that satisfies this.
@@ -133,3 +136,70 @@ jobs:
           # Store data for PRs without pushing (compare only)
           save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           benchmark-data-dir-path: dev/bench
+
+      # Head-to-head RocksDB comparison. Distinct from the db_bench
+      # trend above (single-engine, value-over-commits): this runs the
+      # standalone `tools/compare-rocksdb` criterion harness where every
+      # scenario runs BOTH engines in the same process, so each criterion
+      # group is an ours-vs-rocksdb overlay chart. Because the comparison
+      # is a ratio measured on one host in one run, it stays meaningful
+      # even if this runner's CPU changes between runs.
+      #
+      # Bounded criterion settings keep the heavy zstd22/10k write points
+      # from dominating the timeout: a small sample count with a short
+      # measurement window still yields a stable median for the dashboard
+      # without the default 100-sample sweep (which on a multi-second-per
+      # -iteration point would run for many minutes each).
+      #
+      # Runner requirement: librocksdb-sys builds from source via bindgen,
+      # so the host must have a C/C++ toolchain + libclang. On Linux
+      # bindgen finds the distro libclang.so without env-var help.
+      - name: Run compare-rocksdb head-to-head benches
+        run: |
+          cd tools/compare-rocksdb
+          cargo bench --bench compare -- \
+            --sample-size 10 --warm-up-time 1 --measurement-time 5
+
+      # Publish the criterion HTML report tree (per-group overlay charts)
+      # to gh-pages under dev/compare, alongside the db_bench dashboard at
+      # dev/bench. Manual git push (rather than a third-party publish
+      # action) keeps the workflow's "every `uses:` pinned to a SHA"
+      # hardening policy intact and reuses the same App-scoped token the
+      # benchmark-action step uses. Only publishes on main pushes; PR /
+      # workflow_dispatch runs produce the reports as a job artifact path
+      # but do not mutate gh-pages.
+      - name: Publish compare-rocksdb overlay reports to gh-pages
+        if: >
+          steps.bot-token.outputs.token != '' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          src="tools/compare-rocksdb/target/criterion"
+          if [ ! -d "$src/report" ]; then
+            echo "::error::criterion report tree not found at $src/report"
+            exit 1
+          fi
+          work="$(mktemp -d)"
+          git clone --depth 1 --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$work"
+          # Replace the previous report tree wholesale so deleted /
+          # renamed scenarios don't leave stale pages behind; dev/bench
+          # and every other gh-pages path are untouched.
+          rm -rf "$work/dev/compare"
+          mkdir -p "$work/dev/compare"
+          cp -R "$src/." "$work/dev/compare/"
+          cd "$work"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dev/compare
+          if git diff --cached --quiet; then
+            echo "::notice::compare-rocksdb reports unchanged — nothing to publish"
+          else
+            git commit -m "bench: refresh compare-rocksdb overlay reports (dev/compare)"
+            git push origin gh-pages
+            echo "::notice::published compare-rocksdb overlays to dev/compare/report/index.html"
+          fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -184,14 +184,30 @@ jobs:
             echo "::error::criterion report tree not found at $src/report"
             exit 1
           fi
-          work="$(mktemp -d)"
+          # Explicit template (not bare `mktemp -d`, which is GNU-only and
+          # fails on macOS/BSD with "too few X's") so the step survives a
+          # future runner-OS change.
+          work="$(mktemp -d "${TMPDIR:-/tmp}/compare-ghpages.XXXXXXXX")"
           # Remove the temp clone on every exit path (success, error, or
-          # cancellation): its .git/config holds the installation token in
-          # plaintext, and uncleaned temp dirs leak disk on a long-lived
+          # cancellation) so it doesn't leak disk on a long-lived
           # self-hosted runner.
           trap 'rm -rf "$work"' EXIT
+          # Supply the token through a credential helper that reads it from
+          # the environment at call time, so it appears neither in argv
+          # (visible via `ps` on a shared self-hosted host) nor in a
+          # persisted remote URL / .git/config. The clone + push both use a
+          # plain, secret-free https URL; GIT_CONFIG_* injects the helper
+          # into every git invocation in this step's environment.
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0=credential.helper
+          # SC2016: the single quotes are deliberate — `${GH_TOKEN}` must NOT
+          # expand here. It is expanded later by the helper's own shell when
+          # git invokes it, reading the token from the (exported) environment
+          # so it never lands in argv or config.
+          # shellcheck disable=SC2016
+          export GIT_CONFIG_VALUE_0='!f() { echo username=x-access-token; echo "password=${GH_TOKEN}"; }; f'
           git clone --depth 1 --branch gh-pages \
-            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$work"
+            "https://github.com/${REPO}.git" "$work"
           # Replace the previous report tree wholesale so deleted /
           # renamed scenarios don't leave stale pages behind; dev/bench
           # and every other gh-pages path are untouched.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -165,9 +165,10 @@ jobs:
       # dev/bench. Manual git push (rather than a third-party publish
       # action) keeps the workflow's "every `uses:` pinned to a SHA"
       # hardening policy intact and reuses the same App-scoped token the
-      # benchmark-action step uses. Only publishes on main pushes; PR /
-      # workflow_dispatch runs produce the reports as a job artifact path
-      # but do not mutate gh-pages.
+      # benchmark-action step uses. Only publishes on main pushes; on PR /
+      # workflow_dispatch runs the previous step still generates the report
+      # tree in the workspace, but this step is skipped (no artifact upload,
+      # no gh-pages mutation).
       - name: Publish compare-rocksdb overlay reports to gh-pages
         if: >
           steps.bot-token.outputs.token != '' &&
@@ -184,6 +185,11 @@ jobs:
             exit 1
           fi
           work="$(mktemp -d)"
+          # Remove the temp clone on every exit path (success, error, or
+          # cancellation): its .git/config holds the installation token in
+          # plaintext, and uncleaned temp dirs leak disk on a long-lived
+          # self-hosted runner.
+          trap 'rm -rf "$work"' EXIT
           git clone --depth 1 --branch gh-pages \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$work"
           # Replace the previous report tree wholesale so deleted /


### PR DESCRIPTION
## Summary

Wires the `tools/compare-rocksdb` head-to-head harness into the `benchmark.yml` self-hosted job so the ours-vs-rocksdb **overlay** charts get published, alongside the existing single-engine `db_bench` trend.

After the db_bench publish, the job now:

1. Runs `cargo bench --bench compare` with bounded criterion settings (`--sample-size 10 --warm-up-time 1 --measurement-time 5`) so the heavy zstd22/10k write points don't blow the timeout while still giving a stable median.
2. Pushes the generated `tools/compare-rocksdb/target/criterion/` report tree to `gh-pages:dev/compare/` (entry point `dev/compare/report/index.html`), via a manual git step. The existing `dev/bench` dashboard and all other gh-pages paths are untouched.

Each criterion group runs **both engines in the same process on the same host**, so every scenario chart is a host-independent ours-vs-rocksdb overlay (None baseline + `*_zstd22` sibling for all 5 scenarios: write_throughput, point_read, range_scan, seek_random, overwrite).

## Why a manual git push (not a publish action)

Keeps the workflow's "every `uses:` pinned to a SHA" hardening policy intact (no new third-party action) and reuses the same App-scoped token the `benchmark-action` step already uses. Publishing is gated to `push` on main; PR / `workflow_dispatch` runs generate the reports but don't mutate gh-pages.

## Constraints

- Job timeout bumped 30 -> 60 min (extra bench pass + first-run librocksdb-sys C++ compile).
- The self-hosted runner must have a C/C++ toolchain + libclang (librocksdb-sys builds via bindgen; distro libclang is found without env help on Linux).

## Testing

`benchmark.yml` runs only on `push` to main and `workflow_dispatch` (never on PRs), so this can't be exercised from the PR itself. Verified:

- `actionlint` clean on the added steps (only the pre-existing custom `gpu-private-systems` runner-label note remains)
- the bench command + report generation confirmed locally: `target/criterion/report/index.html` master index + per-group overlay reports for all 10 groups (5 scenarios x {none, zstd22})

End-to-end validation needs a `workflow_dispatch` run after merge (maintainer-only trigger).

Closes #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended benchmark workflow timeout from 30 to 60 minutes for more comprehensive testing.
  * Added automated publication of benchmark comparison reports to project documentation on main branch pushes, making performance data publicly accessible.
  * Integrated head-to-head performance comparison benchmarking with optimized sampling parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->