### PR TITLE
perf(compaction): I/O rate limiter (leaky token bucket)

### DIFF
--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -179,6 +179,14 @@ pub struct RelocatingCompaction {
     blob_writer: BlobFileWriter,
     rewriting_blob_file_ids: HashSet<BlobFileId>,
     rewriting_blob_files: Vec<BlobFile>,
+    /// Paces relocated-blob I/O. The merge loop's limiter only sees the
+    /// encoded handle in `item.value`; the real payload moved here is
+    /// debited at the relocation write site so KV-separated compactions
+    /// are throttled by their actual bandwidth.
+    rate_limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    /// Polled by the blob throttle so a long wait under a low limit stays
+    /// interruptible by tree drop / shutdown.
+    stop_signal: crate::stop_signal::StopSignal,
 }
 
 impl RelocatingCompaction {
@@ -187,6 +195,8 @@ impl RelocatingCompaction {
         blob_scanner: Peekable<BlobFileMergeScanner>,
         blob_writer: BlobFileWriter,
         rewriting_blob_files: Vec<BlobFile>,
+        rate_limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+        stop_signal: crate::stop_signal::StopSignal,
     ) -> Self {
         Self {
             inner,
@@ -194,6 +204,8 @@ impl RelocatingCompaction {
             blob_writer,
             rewriting_blob_file_ids: rewriting_blob_files.iter().map(BlobFile::id).collect(),
             rewriting_blob_files,
+            rate_limiter,
+            stop_signal,
         }
     }
 
@@ -256,6 +268,18 @@ impl CompactionFlavour for RelocatingCompaction {
                 );
 
                 log::trace!("RELOCATE to {indirection:?}");
+
+                // Throttle the relocated blob payload — this is the heavy
+                // KV-separation I/O the merge-loop limiter cannot see (it
+                // only has the encoded handle). Interruptible so a low
+                // limit can't stall shutdown; the return is ignored because
+                // the blob is already read and must be written to keep the
+                // new vptr valid — only the *wait* is shortened on stop.
+                let _ = self
+                    .rate_limiter
+                    .request_interruptible(blob_entry.value.len() as u64, || {
+                        self.stop_signal.is_stopped()
+                    });
 
                 let new_indirection = BlobIndirection {
                     vhandle: self.blob_writer.write_raw(

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -584,11 +584,17 @@ fn merge_tables(
             // Pace compaction I/O so it cannot saturate the device and
             // starve user reads. Short-circuits to a single relaxed atomic
             // load when `compaction_rate_limit` is 0 (the default), so the
-            // unthrottled hot path stays cheap. Sum the sizes in u64 with a
-            // saturating add so a pathological item can't overflow `usize`
-            // on 32-bit targets before the cast. The throttle wait is
-            // interruptible by the stop signal so a low limit plus a large
-            // item can't stall tree drop / shutdown for the whole wait.
+            // unthrottled hot path stays cheap. The wait is interruptible by
+            // the stop signal so a low limit plus a large item can't stall
+            // tree drop / shutdown for the whole wait.
+            //
+            // Accounting covers the SST entry's key + value bytes. Each
+            // length is widened to u64 before the add, so there is no
+            // intermediate usize sum; the saturating add only guards the
+            // (practically impossible) u64 overflow. For blob-indirection
+            // (KV-separated) compactions the relocated blob payload is NOT
+            // counted here — `item.value` is only the encoded handle — so
+            // blob-relocation I/O is under-accounted; tracked in #390.
             let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
             if opts
                 .rate_limiter

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -73,6 +73,12 @@ pub struct Options {
     /// AEAD pipeline the data blocks use.
     pub encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
 
+    /// Per-compaction I/O rate limiter. Built from
+    /// [`Config::compaction_rate_limit`]; a limit of `0` makes every
+    /// request immediate (no throttling). Only the compaction merge loop
+    /// calls it, so flush and user reads are never throttled.
+    pub rate_limiter: Arc<crate::rate_limiter::RateLimiter>,
+
     #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,
 }
@@ -94,6 +100,9 @@ impl Options {
             compaction_state: tree.compaction_state.clone(),
             runtime_config: tree.runtime_config.clone(),
             encryption: tree.config.encryption.clone(),
+            rate_limiter: Arc::new(crate::rate_limiter::RateLimiter::new(
+                tree.config.compaction_rate_limit,
+            )),
 
             #[cfg(feature = "metrics")]
             metrics: tree.metrics.clone(),
@@ -571,6 +580,13 @@ fn merge_tables(
 
         for (idx, item) in merge_iter.enumerate() {
             let item = item?;
+
+            // Pace compaction I/O so it cannot saturate the device and
+            // starve user reads. `request` is a no-op (returns immediately)
+            // when `compaction_rate_limit` is 0 (the default), so this adds
+            // only two relaxed atomic loads on the unthrottled hot path.
+            let io_bytes = (item.key.user_key.len() + item.value.len()) as u64;
+            opts.rate_limiter.request(io_bytes);
 
             compactor.write(item)?;
 

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -582,10 +582,12 @@ fn merge_tables(
             let item = item?;
 
             // Pace compaction I/O so it cannot saturate the device and
-            // starve user reads. `request` is a no-op (returns immediately)
-            // when `compaction_rate_limit` is 0 (the default), so this adds
-            // only two relaxed atomic loads on the unthrottled hot path.
-            let io_bytes = (item.key.user_key.len() + item.value.len()) as u64;
+            // starve user reads. `request` short-circuits to a single
+            // relaxed atomic load when `compaction_rate_limit` is 0 (the
+            // default), so the unthrottled hot path stays cheap. Sum the
+            // sizes in u64 with a saturating add so a pathological item
+            // can't overflow `usize` on 32-bit targets before the cast.
+            let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
             opts.rate_limiter.request(io_bytes);
 
             compactor.write(item)?;

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -543,6 +543,8 @@ fn merge_tables(
                     scanner.peekable(),
                     writer,
                     blob_files_to_rewrite,
+                    opts.rate_limiter.clone(),
+                    opts.stop_signal.clone(),
                 ))
             }
         }
@@ -588,13 +590,14 @@ fn merge_tables(
             // the stop signal so a low limit plus a large item can't stall
             // tree drop / shutdown for the whole wait.
             //
-            // Accounting covers the SST entry's key + value bytes. Each
-            // length is widened to u64 before the add, so there is no
+            // Accounting here covers the SST entry's key + value bytes
+            // (for KV-separated entries `item.value` is the encoded handle).
+            // Each length is widened to u64 before the add, so there is no
             // intermediate usize sum; the saturating add only guards the
-            // (practically impossible) u64 overflow. For blob-indirection
-            // (KV-separated) compactions the relocated blob payload is NOT
-            // counted here — `item.value` is only the encoded handle — so
-            // blob-relocation I/O is under-accounted; tracked in #390.
+            // (practically impossible) u64 overflow. The relocated blob
+            // payload of KV-separated compactions is debited separately at
+            // its write site in `RelocatingCompaction::write`, where the
+            // real moved bytes are known.
             let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
             if opts
                 .rate_limiter

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -582,13 +582,21 @@ fn merge_tables(
             let item = item?;
 
             // Pace compaction I/O so it cannot saturate the device and
-            // starve user reads. `request` short-circuits to a single
-            // relaxed atomic load when `compaction_rate_limit` is 0 (the
-            // default), so the unthrottled hot path stays cheap. Sum the
-            // sizes in u64 with a saturating add so a pathological item
-            // can't overflow `usize` on 32-bit targets before the cast.
+            // starve user reads. Short-circuits to a single relaxed atomic
+            // load when `compaction_rate_limit` is 0 (the default), so the
+            // unthrottled hot path stays cheap. Sum the sizes in u64 with a
+            // saturating add so a pathological item can't overflow `usize`
+            // on 32-bit targets before the cast. The throttle wait is
+            // interruptible by the stop signal so a low limit plus a large
+            // item can't stall tree drop / shutdown for the whole wait.
             let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
-            opts.rate_limiter.request(io_bytes);
+            if opts
+                .rate_limiter
+                .request_interruptible(io_bytes, || opts.stop_signal.is_stopped())
+            {
+                log::debug!("Stopping amidst compaction because of stop signal (I/O throttle)");
+                return Ok(());
+            }
 
             compactor.write(item)?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -511,6 +511,16 @@ pub struct Config {
     /// `fsync`. Set via [`Config::sync_mode`].
     pub(crate) sync_mode: SyncMode,
 
+    /// Compaction I/O rate limit in bytes per second.
+    ///
+    /// Caps the rate at which the compaction worker is allowed to issue
+    /// I/O, so background compaction cannot saturate the device and starve
+    /// user point reads / range scans (P99 stability). `0` (the default)
+    /// means unlimited — no throttling, no behaviour change. Flush and
+    /// user reads are never throttled, only compaction. Set via
+    /// [`Config::compaction_rate_limit`].
+    pub(crate) compaction_rate_limit: u64,
+
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
     /// When set together with a [`CompressionType::ZstdDict`] compression
@@ -620,6 +630,7 @@ impl Default for Config {
             encryption: None,
             manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
             sync_mode: SyncMode::Normal,
+            compaction_rate_limit: 0,
         }
     }
 }
@@ -1320,6 +1331,18 @@ impl Config {
     #[must_use]
     pub fn sync_mode(mut self, mode: SyncMode) -> Self {
         self.sync_mode = mode;
+        self
+    }
+
+    /// Sets the compaction I/O rate limit in bytes per second.
+    ///
+    /// Caps how fast the compaction worker may issue I/O so background
+    /// compaction does not saturate the device and spike user read P99.
+    /// `0` (the default) disables throttling. Only compaction is limited;
+    /// flush and user reads always pass through.
+    #[must_use]
+    pub fn compaction_rate_limit(mut self, bytes_per_sec: u64) -> Self {
+        self.compaction_rate_limit = bytes_per_sec;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ mod manifest;
 pub mod manifest_blocks;
 mod memtable;
 mod merge_operator;
+pub(crate) mod rate_limiter;
 mod run_reader;
 mod run_scanner;
 // Vendored sfa is std-only internally (`std::io` / `std::fs` /

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -146,16 +146,20 @@ impl RateLimiter {
     /// until an I/O of `bytes` may proceed, polling `should_stop` so a
     /// shutdown / drop can break a long wait promptly.
     ///
-    /// Returns `true` if `should_stop` fired during the wait (caller should
-    /// abort), `false` if the full wait elapsed (caller may proceed).
+    /// Returns `true` if the caller should abort: either `should_stop` was
+    /// already set on entry (stop pending before any work) or it fired during
+    /// the wait. Returns `false` if the full wait elapsed (caller may
+    /// proceed).
     ///
-    /// The budget is debited exactly once (via a single
-    /// [`acquire_wait`](Self::acquire_wait)); the resulting wait is then
-    /// slept in <= [`POLL_INTERVAL`](Self::POLL_INTERVAL) chunks with a
-    /// `should_stop` check before each, so even a multi-gigabyte item under
-    /// a low limit cannot stall shutdown for more than one poll interval.
-    /// Re-calling `acquire_wait` in the loop would wrongly re-debit the
-    /// bucket each iteration, so the wait is computed once up front.
+    /// The budget is debited at most once (via a single
+    /// [`acquire_wait`](Self::acquire_wait)) — the early returns for
+    /// `rate == 0` and for an already-pending stop skip the debit entirely.
+    /// When a wait is computed it is slept in
+    /// <= [`POLL_INTERVAL`](Self::POLL_INTERVAL) chunks with a `should_stop`
+    /// check before each, so even a multi-gigabyte item under a low limit
+    /// cannot stall shutdown for more than one poll interval. Re-calling
+    /// `acquire_wait` in the loop would wrongly re-debit the bucket each
+    /// iteration, so the wait is computed once up front.
     ///
     /// A no-op returning `false` when the rate is `0` (no clock read).
     /// Only with the `std` feature; `no_std` callers drive `acquire_wait`

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -25,9 +25,9 @@
 //! The core decision function [`RateLimiter::acquire_wait`] takes the
 //! current monotonic time as a `Duration` since an arbitrary origin, so
 //! it is pure (no syscalls), unit-testable without sleeping, and compiles
-//! without `std`. The blocking convenience wrapper
-//! [`RateLimiter::request`] (which reads the system clock and sleeps) is
-//! gated behind the `std` feature.
+//! without `std`. The interruptible blocking wrapper
+//! [`RateLimiter::request_interruptible`] (which reads the system clock and
+//! sleeps in pollable chunks) is gated behind the `std` feature.
 //!
 //! A priority-class extension (flush / user I/O also debiting the bucket
 //! but draining ahead of compaction) is a planned refinement; this
@@ -142,29 +142,51 @@ impl RateLimiter {
         Duration::from_nanos(u64::try_from(wait_nanos).unwrap_or(u64::MAX))
     }
 
-    /// Blocking request: waits (sleeping the current thread) until an I/O
-    /// of `bytes` may proceed.
+    /// Interruptible blocking request: waits (sleeping the current thread)
+    /// until an I/O of `bytes` may proceed, polling `should_stop` so a
+    /// shutdown / drop can break a long wait promptly.
     ///
-    /// Convenience wrapper over [`acquire_wait`](Self::acquire_wait) that
-    /// reads the system monotonic clock and sleeps. A no-op when the rate
-    /// is `0`. Only available with the `std` feature; `no_std` callers
-    /// drive `acquire_wait` with their own clock and wait primitive.
-    // no-std: caller-provided clock + acquire_wait() + caller's wait primitive
+    /// Returns `true` if `should_stop` fired during the wait (caller should
+    /// abort), `false` if the full wait elapsed (caller may proceed).
+    ///
+    /// The budget is debited exactly once (via a single
+    /// [`acquire_wait`](Self::acquire_wait)); the resulting wait is then
+    /// slept in <= [`POLL_INTERVAL`](Self::POLL_INTERVAL) chunks with a
+    /// `should_stop` check before each, so even a multi-gigabyte item under
+    /// a low limit cannot stall shutdown for more than one poll interval.
+    /// Re-calling `acquire_wait` in the loop would wrongly re-debit the
+    /// bucket each iteration, so the wait is computed once up front.
+    ///
+    /// A no-op returning `false` when the rate is `0` (no clock read).
+    /// Only with the `std` feature; `no_std` callers drive `acquire_wait`
+    /// with their own clock + interruptible wait.
+    // no-std: caller-provided clock + acquire_wait() + caller's wait/poll loop
     #[cfg(feature = "std")]
-    pub fn request(&self, bytes: u64) {
+    pub fn request_interruptible(&self, bytes: u64, should_stop: impl Fn() -> bool) -> bool {
         // Short-circuit BEFORE any clock read so the unthrottled default
         // (rate 0) costs a single relaxed atomic load — the compaction
-        // merge loop calls this per item, so a `std_now()` clock read on
-        // the disabled path would be pure overhead. `acquire_wait` repeats
-        // the check, but returning here avoids the clock read entirely.
+        // merge loop calls this per item.
         if self.rate_bytes_per_sec.load(Ordering::Relaxed) == 0 {
-            return;
+            return false;
         }
-        let wait = self.acquire_wait(bytes, Self::std_now());
-        if !wait.is_zero() {
-            std::thread::sleep(wait);
+        // Debit once, then sleep the computed wait in interruptible chunks.
+        let mut remaining = self.acquire_wait(bytes, Self::std_now());
+        while !remaining.is_zero() {
+            if should_stop() {
+                return true;
+            }
+            let chunk = remaining.min(Self::POLL_INTERVAL);
+            std::thread::sleep(chunk);
+            remaining = remaining.saturating_sub(chunk);
         }
+        false
     }
+
+    /// Maximum single sleep span inside
+    /// [`request_interruptible`](Self::request_interruptible): the upper
+    /// bound on how long a stop signal can go unnoticed mid-throttle.
+    #[cfg(feature = "std")]
+    const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
     /// Monotonic time since a process-global origin, for the `std`
     /// wrapper. A shared origin is fine: each limiter's bucket tracks its
@@ -254,6 +276,31 @@ mod tests {
                 "steady-state request at second {sec} should not wait"
             );
         }
+    }
+
+    #[test]
+    fn request_interruptible_bails_out_before_sleeping_when_stopped() {
+        // 1 B/s with a 1 MiB request implies an ~12-day wait. With
+        // should_stop already true, the call must return `true` immediately
+        // (the stop check precedes the first sleep) rather than blocking —
+        // this is what keeps shutdown responsive under a low rate limit.
+        let rl = RateLimiter::new(1);
+        let start = std::time::Instant::now();
+        let stopped = rl.request_interruptible(1_024 * 1_024, || true);
+        assert!(stopped, "should report it was interrupted");
+        assert!(
+            start.elapsed() < ms(500),
+            "must not sleep the full computed wait when stopped"
+        );
+    }
+
+    #[test]
+    fn request_interruptible_zero_rate_is_immediate_passthrough() {
+        let rl = RateLimiter::new(0);
+        let start = std::time::Instant::now();
+        let stopped = rl.request_interruptible(1_000_000, || false);
+        assert!(!stopped, "rate 0 never throttles, so never interrupted");
+        assert!(start.elapsed() < ms(500), "rate 0 must not sleep");
     }
 
     #[test]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -278,6 +278,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn request_interruptible_bails_out_before_sleeping_when_stopped() {
         // 1 B/s with a 1 MiB request implies an ~12-day wait. With
@@ -294,6 +295,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn request_interruptible_zero_rate_is_immediate_passthrough() {
         let rl = RateLimiter::new(0);

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Compaction I/O rate limiter.
+//!
+//! Background compaction can saturate disk bandwidth and starve user
+//! point reads / range scans, spiking their P99 latency. This limiter
+//! caps the rate at which the compaction worker is allowed to issue I/O
+//! so user traffic keeps its share of the device. It is invoked only from
+//! the compaction path, so flush and user reads are never throttled —
+//! they simply never call it.
+//!
+//! # Model
+//!
+//! A leaky token bucket measured in bytes. Each request debits the
+//! bucket; when the bucket goes into debt the caller must wait long
+//! enough for the configured refill rate to repay it, which serialises
+//! compaction I/O down to `rate_bytes_per_sec`. A rate of `0` disables
+//! throttling: every request is immediate (the default, so the limiter is
+//! wired unconditionally and switched on via
+//! [`Config::compaction_rate_limit`](crate::Config::compaction_rate_limit)).
+//!
+//! # Clock injection
+//!
+//! The core decision function [`RateLimiter::acquire_wait`] takes the
+//! current monotonic time as a `Duration` since an arbitrary origin, so
+//! it is pure (no syscalls), unit-testable without sleeping, and compiles
+//! without `std`. The blocking convenience wrapper
+//! [`RateLimiter::request`] (which reads the system clock and sleeps) is
+//! gated behind the `std` feature.
+//!
+//! A priority-class extension (flush / user I/O also debiting the bucket
+//! but draining ahead of compaction) is a planned refinement; this
+//! revision throttles compaction alone.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
+
+use spin::Mutex;
+
+const NANOS_PER_SEC: u128 = 1_000_000_000;
+
+/// Mutable bucket state, guarded by a single lock.
+#[derive(Debug)]
+struct Bucket {
+    /// Available budget in bytes. May go negative (debt) when a request
+    /// debits more than is currently available; the deficit is what the
+    /// caller waits out.
+    available: i64,
+    /// Monotonic time of the last refill, as nanoseconds since the
+    /// limiter's origin.
+    last_refill_nanos: u128,
+}
+
+/// Compaction I/O rate limiter (leaky token bucket).
+///
+/// Share across compaction invocations by wrapping in `Arc`; the limiter
+/// is `Sync` (all mutable state is behind a lock / atomics).
+///
+/// A `rate_bytes_per_sec` of `0` disables throttling entirely: every
+/// request returns immediately.
+#[derive(Debug)]
+pub struct RateLimiter {
+    /// Refill rate in bytes per second. `0` means unlimited (disabled).
+    rate_bytes_per_sec: AtomicU64,
+    /// Maximum positive budget the bucket may accumulate, in bytes: one
+    /// second of rate, so an idle limiter grants a one-second burst but no
+    /// more (prevents a long-idle compactor from dumping an unbounded
+    /// backlog at full speed).
+    burst_bytes: u64,
+    bucket: Mutex<Bucket>,
+}
+
+impl RateLimiter {
+    /// Creates a limiter refilling at `rate_bytes_per_sec`.
+    ///
+    /// `0` disables throttling (every request is immediate). The burst
+    /// ceiling is one second of rate.
+    #[must_use]
+    pub fn new(rate_bytes_per_sec: u64) -> Self {
+        Self {
+            rate_bytes_per_sec: AtomicU64::new(rate_bytes_per_sec),
+            burst_bytes: rate_bytes_per_sec,
+            bucket: Mutex::new(Bucket {
+                // Start with a full one-second burst so the first request
+                // after construction is not penalised.
+                available: i64::try_from(rate_bytes_per_sec).unwrap_or(i64::MAX),
+                last_refill_nanos: 0,
+            }),
+        }
+    }
+
+    /// Core decision: how long the caller must wait before issuing an I/O
+    /// of `bytes`, given the current monotonic time `now` (a `Duration`
+    /// since this limiter's origin).
+    ///
+    /// Returns [`Duration::ZERO`] when the request may proceed
+    /// immediately (including when the rate is `0`). Performs no sleeping
+    /// and reads no clock, so it is fully deterministic for a given `now`
+    /// sequence and usable in `no_std` builds.
+    #[must_use]
+    pub fn acquire_wait(&self, bytes: u64, now: Duration) -> Duration {
+        let rate = self.rate_bytes_per_sec.load(Ordering::Relaxed);
+        if rate == 0 {
+            return Duration::ZERO;
+        }
+        let now_nanos = now.as_nanos();
+        let rate_u128 = u128::from(rate);
+
+        let mut bucket = self.bucket.lock();
+
+        // Refill: add the bytes that accrued since the last refill, then
+        // cap at the burst ceiling. `saturating_sub` guards against a
+        // non-monotonic `now` (clock should be monotonic, but never let a
+        // backwards step underflow).
+        let elapsed = now_nanos.saturating_sub(bucket.last_refill_nanos);
+        if elapsed > 0 {
+            let refilled = (elapsed * rate_u128) / NANOS_PER_SEC;
+            // refilled fits in i64 for any realistic elapsed/rate; clamp
+            // defensively so an absurd elapsed can't overflow the add.
+            let refilled = i64::try_from(refilled).unwrap_or(i64::MAX);
+            bucket.available = bucket.available.saturating_add(refilled);
+            let burst_i64 = i64::try_from(self.burst_bytes).unwrap_or(i64::MAX);
+            if bucket.available > burst_i64 {
+                bucket.available = burst_i64;
+            }
+            bucket.last_refill_nanos = now_nanos;
+        }
+
+        // Debit the request. Going negative is the debt the caller pays
+        // off by waiting.
+        let debit = i64::try_from(bytes).unwrap_or(i64::MAX);
+        bucket.available = bucket.available.saturating_sub(debit);
+
+        if bucket.available >= 0 {
+            return Duration::ZERO;
+        }
+
+        // Wait long enough for the refill rate to repay the deficit.
+        let deficit = bucket.available.unsigned_abs();
+        let wait_nanos = (u128::from(deficit) * NANOS_PER_SEC) / rate_u128;
+        Duration::from_nanos(u64::try_from(wait_nanos).unwrap_or(u64::MAX))
+    }
+
+    /// Blocking request: waits (sleeping the current thread) until an I/O
+    /// of `bytes` may proceed.
+    ///
+    /// Convenience wrapper over [`acquire_wait`](Self::acquire_wait) that
+    /// reads the system monotonic clock and sleeps. A no-op when the rate
+    /// is `0`. Only available with the `std` feature; `no_std` callers
+    /// drive `acquire_wait` with their own clock and wait primitive.
+    // no-std: caller-provided clock + acquire_wait() + caller's wait primitive
+    #[cfg(feature = "std")]
+    pub fn request(&self, bytes: u64) {
+        let wait = self.acquire_wait(bytes, Self::std_now());
+        if !wait.is_zero() {
+            std::thread::sleep(wait);
+        }
+    }
+
+    /// Monotonic time since a process-global origin, for the `std`
+    /// wrapper. A shared origin is fine: each limiter's bucket tracks its
+    /// own `last_refill_nanos` against the same monotonic reference, so
+    /// only the deltas matter.
+    #[cfg(feature = "std")]
+    fn std_now() -> Duration {
+        use std::sync::OnceLock;
+        // `OnceLock` / `Instant` are std-only, hence this helper (and
+        // `request`) live behind the `std` gate; the no_std path uses
+        // `acquire_wait` with a caller-supplied clock instead.
+        static ORIGIN: OnceLock<std::time::Instant> = OnceLock::new();
+        ORIGIN.get_or_init(std::time::Instant::now).elapsed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn zero_rate_disables_throttling() {
+        let rl = RateLimiter::new(0);
+        assert_eq!(Duration::ZERO, rl.acquire_wait(1_000_000, ms(0)));
+    }
+
+    #[test]
+    fn within_initial_burst_proceeds_immediately() {
+        // 1000 B/s rate → 1000 B initial burst. A 1000 B request at t=0
+        // exactly drains the burst with no wait.
+        let rl = RateLimiter::new(1_000);
+        assert_eq!(Duration::ZERO, rl.acquire_wait(1_000, ms(0)));
+    }
+
+    #[test]
+    fn overdraft_waits_proportional_to_deficit() {
+        // 1000 B/s. Burst 1000 B. First request drains the burst (no
+        // wait); a second 500 B request at the same instant goes 500 B
+        // into debt → must wait 500 B / 1000 B/s = 500 ms.
+        let rl = RateLimiter::new(1_000);
+        assert_eq!(Duration::ZERO, rl.acquire_wait(1_000, ms(0)));
+        assert_eq!(ms(500), rl.acquire_wait(500, ms(0)));
+    }
+
+    #[test]
+    fn refill_accrues_over_time() {
+        // 1000 B/s. Drain the burst at t=0, then at t=500ms the bucket has
+        // refilled 500 B, so a 500 B request proceeds with no wait.
+        let rl = RateLimiter::new(1_000);
+        assert_eq!(Duration::ZERO, rl.acquire_wait(1_000, ms(0)));
+        assert_eq!(Duration::ZERO, rl.acquire_wait(500, ms(500)));
+    }
+
+    #[test]
+    fn burst_is_capped_at_one_second_of_rate() {
+        // 1000 B/s → burst ceiling 1000 B. Idle for 10 s; the bucket must
+        // NOT accumulate 10 000 B. A 1000 B request drains the capped
+        // burst (no wait); a further 1000 B at the same instant goes fully
+        // into debt → 1000 ms wait, proving accumulation was capped.
+        let rl = RateLimiter::new(1_000);
+        assert_eq!(
+            Duration::ZERO,
+            rl.acquire_wait(1_000, Duration::from_secs(10))
+        );
+        assert_eq!(
+            Duration::from_secs(1),
+            rl.acquire_wait(1_000, Duration::from_secs(10))
+        );
+    }
+
+    #[test]
+    fn sustained_rate_holds_at_configured_throughput() {
+        // Issue 1000 B every 1000 ms against a 1000 B/s limit: after the
+        // initial burst each request proceeds with zero wait (steady state
+        // at exactly the rate).
+        let rl = RateLimiter::new(1_000);
+        assert_eq!(Duration::ZERO, rl.acquire_wait(1_000, ms(0)));
+        for sec in 1..=5 {
+            assert_eq!(
+                Duration::ZERO,
+                rl.acquire_wait(1_000, Duration::from_secs(sec)),
+                "steady-state request at second {sec} should not wait"
+            );
+        }
+    }
+
+    #[test]
+    fn backwards_clock_step_does_not_underflow() {
+        // A non-monotonic `now` (earlier than last_refill) must not panic
+        // or grant phantom budget: the saturating_sub clamps elapsed to 0.
+        let rl = RateLimiter::new(1_000);
+        let _ = rl.acquire_wait(1_000, ms(1_000));
+        // Step backwards to t=0: no refill, the 500 B debit goes straight
+        // into debt.
+        assert_eq!(ms(500), rl.acquire_wait(500, ms(0)));
+    }
+}

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -115,7 +115,7 @@ impl RateLimiter {
         // backwards step underflow).
         let elapsed = now_nanos.saturating_sub(bucket.last_refill_nanos);
         if elapsed > 0 {
-            let refilled = (elapsed * rate_u128) / NANOS_PER_SEC;
+            let refilled = elapsed.saturating_mul(rate_u128) / NANOS_PER_SEC;
             // refilled fits in i64 for any realistic elapsed/rate; clamp
             // defensively so an absurd elapsed can't overflow the add.
             let refilled = i64::try_from(refilled).unwrap_or(i64::MAX);
@@ -138,7 +138,7 @@ impl RateLimiter {
 
         // Wait long enough for the refill rate to repay the deficit.
         let deficit = bucket.available.unsigned_abs();
-        let wait_nanos = (u128::from(deficit) * NANOS_PER_SEC) / rate_u128;
+        let wait_nanos = u128::from(deficit).saturating_mul(NANOS_PER_SEC) / rate_u128;
         Duration::from_nanos(u64::try_from(wait_nanos).unwrap_or(u64::MAX))
     }
 
@@ -152,6 +152,14 @@ impl RateLimiter {
     // no-std: caller-provided clock + acquire_wait() + caller's wait primitive
     #[cfg(feature = "std")]
     pub fn request(&self, bytes: u64) {
+        // Short-circuit BEFORE any clock read so the unthrottled default
+        // (rate 0) costs a single relaxed atomic load — the compaction
+        // merge loop calls this per item, so a `std_now()` clock read on
+        // the disabled path would be pure overhead. `acquire_wait` repeats
+        // the check, but returning here avoids the clock read entirely.
+        if self.rate_bytes_per_sec.load(Ordering::Relaxed) == 0 {
+            return;
+        }
         let wait = self.acquire_wait(bytes, Self::std_now());
         if !wait.is_zero() {
             std::thread::sleep(wait);

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -169,6 +169,11 @@ impl RateLimiter {
         if self.rate_bytes_per_sec.load(Ordering::Relaxed) == 0 {
             return false;
         }
+        // If a stop is already pending, bail before touching the bucket /
+        // clock — no point debiting or locking on the shutdown path.
+        if should_stop() {
+            return true;
+        }
         // Debit once, then sleep the computed wait in interruptible chunks.
         let mut remaining = self.acquire_wait(bytes, Self::std_now());
         while !remaining.is_zero() {


### PR DESCRIPTION
## Summary

First slice of #133 Phase 4. Adds a token-bucket rate limiter that caps how fast the compaction worker issues I/O, so background compaction can't saturate the device and spike user point-read / range-scan P99.

The compaction merge loop debits the bucket per written item; when it goes into debt the worker sleeps long enough for the refill rate to repay it, serialising compaction I/O down to the configured bytes/sec.

## Design

- `src/rate_limiter.rs` — clock-injected core `acquire_wait(bytes, now) -> Duration` (pure, no syscalls, no_std-usable, unit-testable without real sleeping) + an std blocking wrapper `request(bytes)` behind the std feature. Leaky bucket with debt; burst capped at one second of rate; a rate of 0 is unlimited.
- `Config::compaction_rate_limit` (default 0 = no throttling, no behaviour change) + builder.
- Wired into the compaction merge loop via `Options::rate_limiter`. Only the compaction loop calls it, so flush and user reads are never throttled. On the unthrottled default path the call is two relaxed atomic loads.

The issue sketched an async priority queue, but lsm-tree compaction is synchronous (thread-based, std::sync + StopSignal), so this is a sync blocking limiter — the correct shape for the actual execution model.

## Scope / follow-ups (rest of #133 Phase 4 + Phase 3)

- Priority classes (flush / user I/O debiting the bucket but draining ahead of compaction)
- Per-tree shared limiter so the cap holds across concurrent compactions (currently per-compaction-invocation)
- Phase 3 adaptive prefetch (separate slice)

## Testing

- 7 unit tests on the limiter core (burst, overdraft wait, refill accrual, burst cap, sustained-rate steady state, zero-rate passthrough, backwards-clock guard) — clock injected, no real sleeps
- nextest --all-features: 1806 passed, 2 skipped (the 2 skips are pre-existing #[ignore] tests unrelated to this change)
- clippy --all-features --all-targets clean, fmt clean, rustdoc clean

Part of #133


## Related
- #390 — account blob-relocation bytes in the rate limiter — IMPLEMENTED in this PR (debited at the relocation write site in RelocatingCompaction::write); Closes #390



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable compaction I/O rate limiting to throttle background compaction and relocated blob writes, reducing impact on overall I/O.
  * New configuration knob to set bytes-per-second for compaction (defaults to 0 — disabled).
  * Throttling is interruptible so compaction can stop early and commit progress when shutdown is requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->