### PR TITLE
perf(io): drop cold-level SST output from the page cache after write

### DIFF
--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     checksum::{ChecksumType, ChecksummedWriter},
     coding::Encode,
     encryption::EncryptionProvider,
-    fs::{Fs, FsFile, FsOpenOptions, SyncMode},
+    fs::{FileHint, Fs, FsFile, FsOpenOptions, SyncMode},
     prefix::PrefixExtractor,
     range_tombstone::RangeTombstone,
     table::{
@@ -1048,7 +1048,20 @@ impl Writer {
         // `StdFs::hard_link`'s cross-device copy fallback (no trait param),
         // tracked in #377.
         let mut checksum = self.file_writer.into_inner()?;
-        FsFile::sync_all_with(&**checksum.inner_mut().get_mut(), self.sync_mode)?;
+        {
+            let file = checksum.inner_mut().get_mut();
+            FsFile::sync_all_with(&**file, self.sync_mode)?;
+            // Cold-level output (L1+) is compaction product: it isn't read
+            // back immediately, so drop its just-written pages from the OS
+            // page cache (advisory POSIX_FADV_DONTNEED) instead of letting
+            // them evict hot pages of files we are still serving reads from.
+            // L0 (flush output) is left cached — freshly written keys are
+            // often read back soon. Best-effort: hint() is advisory, so a
+            // failure just leaves the kernel on its default policy.
+            if self.initial_level >= 1 {
+                let _ = FsFile::hint(&**file, FileHint::WriteOnce);
+            }
+        }
         let checksum = checksum.checksum();
 
         // IMPORTANT: fsync folder on Unix


### PR DESCRIPTION
## Summary

Wires the previously-unused `FileHint::WriteOnce` (POSIX_FADV_DONTNEED). Until now only `FileHint::Sequential` was applied anywhere; `WriteOnce` was defined in the Fs layer but never called.

After the table writer syncs an output SST, if the SST level is >= 1 (compaction product), it advises the kernel to drop the just-written pages from the OS page cache. Cold compaction output isn't read back immediately, so pinning its pages only evicts hot pages of files still serving reads, hurting read P99. L0 (flush output) is intentionally left cached because freshly written keys are often read back soon.

## Details

- Single call site: src/table/writer/mod.rs finish, right after sync_all_with, gated on initial_level >= 1.
- Best-effort / advisory: hint() failures are ignored. The engine BlockCache is unaffected, so no correctness impact, purely a page-cache residency hint.

## Testing

- nextest --all-features: 1799 passed, 2 skipped (clean single run)
- clippy --all-features --all-targets clean, fmt clean, rustdoc clean

The hint is advisory and unobservable in functional results (consistent with the existing untested FileHint::Sequential site), so no dedicated assertion test is added; the full suite confirms no regression.

Part of #133. Closes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized file synchronization and page cache handling in write operations for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->