### PR TITLE
perf(read): lock-free latest-version fast path for point reads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,11 +110,11 @@ bytes = { version = "1", optional = true }
 byteorder = { package = "byteorder-lite", version = "0.1.0", default-features = false }
 byteview = "~0.10.1"
 # Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
-# std-bound — `RuntimeConfigHandle` is gated behind the `std` feature,
-# and so is this dep. Without `std`, only `runtime_config::types`
-# (alloc-friendly POD data) compiles, keeping the no-std-check job
-# from regressing on this crate's behalf. Types stay reachable from
-# downstream no_std consumers (block decoders, format constants).
+# Lock-free atomic Arc swap. `arc-swap` 1.x is NOT `#![no_std]` (it requires
+# `std`), so it stays an optional dependency enabled only by the `std`
+# feature. Both its consumers — `RuntimeConfigHandle` and the version
+# latest-`SuperVersion` mirror on the point-read fast path — gate their use
+# behind `#[cfg(feature = "std")]` so the no-std-check job never sees it.
 arc-swap = { version = "1.9", optional = true }
 enum_dispatch = "0.3.13"
 log = "0.4.30"

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -50,6 +50,12 @@ pub struct TreeInner {
 
     pub(crate) version_history: Arc<RwLock<SuperVersions>>,
 
+    /// Lock-free mirror of the latest `SuperVersion` (shared with
+    /// [`version_history`](Self::version_history) via
+    /// [`SuperVersions::latest_handle`]). The point-read hot path loads this
+    /// for `MAX_SEQNO` reads instead of taking the history `RwLock`.
+    pub(crate) latest_super_version: Arc<arc_swap::ArcSwap<crate::version::SuperVersion>>,
+
     pub(crate) compaction_state: Arc<Mutex<CompactionState>>,
 
     /// Tree configuration
@@ -131,17 +137,17 @@ impl TreeInner {
         let comparator = config.comparator.clone();
         let sync_mode = config.sync_mode;
 
+        let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        let latest_super_version = super_versions.latest_handle();
+
         Ok(Self {
             id: get_next_tree_id(),
             memtable_id_counter: SequenceNumberCounter::new(1),
             table_id_counter: SequenceNumberCounter::default(),
             blob_file_id_counter: SequenceNumberCounter::default(),
             config: Arc::new(config),
-            version_history: Arc::new(RwLock::new(SuperVersions::new(
-                version,
-                &comparator,
-                sync_mode,
-            ))),
+            version_history: Arc::new(RwLock::new(super_versions)),
+            latest_super_version,
             stop_signal: StopSignal::default(),
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -54,6 +54,10 @@ pub struct TreeInner {
     /// [`version_history`](Self::version_history) via
     /// [`SuperVersions::latest_handle`]). The point-read hot path loads this
     /// for `MAX_SEQNO` reads instead of taking the history `RwLock`.
+    ///
+    /// `std`-only: `arc-swap` is not `#![no_std]`, so the lock-free mirror is
+    /// absent under no-std and point reads fall back to the history `RwLock`.
+    #[cfg(feature = "std")]
     pub(crate) latest_super_version: Arc<arc_swap::ArcSwap<crate::version::SuperVersion>>,
 
     pub(crate) compaction_state: Arc<Mutex<CompactionState>>,
@@ -138,6 +142,7 @@ impl TreeInner {
         let sync_mode = config.sync_mode;
 
         let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        #[cfg(feature = "std")]
         let latest_super_version = super_versions.latest_handle();
 
         Ok(Self {
@@ -147,6 +152,7 @@ impl TreeInner {
             blob_file_id_counter: SequenceNumberCounter::default(),
             config: Arc::new(config),
             version_history: Arc::new(RwLock::new(super_versions)),
+            #[cfg(feature = "std")]
             latest_super_version,
             stop_signal: StopSignal::default(),
             major_compaction_lock: RwLock::default(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -248,14 +248,20 @@ impl AbstractTree for Tree {
         // Recent inserts stay visible because they mutate the shared
         // `active_memtable` behind a stable Arc; the back only changes on
         // flush / compaction, which refresh this mirror under the write lock.
-        let latest = self.latest_super_version.load();
-        if seqno > latest.seqno {
-            return Self::get_internal_entry_from_version(
-                &latest,
-                key,
-                seqno,
-                self.config.comparator.as_ref(),
-            );
+        //
+        // std-only: the mirror needs `arc-swap` (not no_std). Under no-std we
+        // skip straight to the history RwLock path below.
+        #[cfg(feature = "std")]
+        {
+            let latest = self.latest_super_version.load();
+            if seqno > latest.seqno {
+                return Self::get_internal_entry_from_version(
+                    &latest,
+                    key,
+                    seqno,
+                    self.config.comparator.as_ref(),
+                );
+            }
         }
 
         // Historical snapshot read (seqno <= latest.seqno): consult the locked
@@ -2093,6 +2099,7 @@ impl Tree {
         let initial_runtime = config.initial_runtime_config.clone();
         let sync_mode = config.sync_mode;
         let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        #[cfg(feature = "std")]
         let latest_super_version = super_versions.latest_handle();
         let inner = TreeInner {
             id: tree_id,
@@ -2100,6 +2107,7 @@ impl Tree {
             table_id_counter: SequenceNumberCounter::new(highest_table_id + 1),
             blob_file_id_counter: SequenceNumberCounter::default(),
             version_history: Arc::new(RwLock::new(super_versions)),
+            #[cfg(feature = "std")]
             latest_super_version,
             stop_signal: StopSignal::default(),
             config: Arc::new(config),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -240,6 +240,26 @@ impl AbstractTree for Tree {
     }
 
     fn get_internal_entry(&self, key: &[u8], seqno: SeqNo) -> crate::Result<Option<InternalValue>> {
+        // Lock-free fast path: when reading at or beyond the latest installed
+        // version (always the case for MAX_SEQNO, and the common case), the
+        // mirrored latest SuperVersion is exactly what `get_version_for_snapshot`
+        // would return (it yields the latest iff `latest.seqno < seqno`), so
+        // load it without taking the history RwLock or cloning a deque entry.
+        // Recent inserts stay visible because they mutate the shared
+        // `active_memtable` behind a stable Arc; the back only changes on
+        // flush / compaction, which refresh this mirror under the write lock.
+        let latest = self.latest_super_version.load();
+        if seqno > latest.seqno {
+            return Self::get_internal_entry_from_version(
+                &latest,
+                key,
+                seqno,
+                self.config.comparator.as_ref(),
+            );
+        }
+
+        // Historical snapshot read (seqno <= latest.seqno): consult the locked
+        // version history for the correct point-in-time SuperVersion.
         #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         let super_version = self
             .version_history
@@ -2072,16 +2092,15 @@ impl Tree {
         // move.
         let initial_runtime = config.initial_runtime_config.clone();
         let sync_mode = config.sync_mode;
+        let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        let latest_super_version = super_versions.latest_handle();
         let inner = TreeInner {
             id: tree_id,
             memtable_id_counter: SequenceNumberCounter::new(1),
             table_id_counter: SequenceNumberCounter::new(highest_table_id + 1),
             blob_file_id_counter: SequenceNumberCounter::default(),
-            version_history: Arc::new(RwLock::new(SuperVersions::new(
-                version,
-                &comparator,
-                sync_mode,
-            ))),
+            version_history: Arc::new(RwLock::new(super_versions)),
+            latest_super_version,
             stop_signal: StopSignal::default(),
             config: Arc::new(config),
             major_compaction_lock: RwLock::default(),

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -244,8 +244,12 @@ impl SuperVersions {
     /// [`append_version`](Self::append_version) /
     /// [`replace_latest_version`](Self::replace_latest_version) under the
     /// history write lock.
+    ///
+    /// Crate-internal: exposing the `ArcSwap` publicly would let a downstream
+    /// caller `store()` into it without the version-history write lock,
+    /// breaking the "mirror only changes at back-changing sites" invariant.
     #[must_use]
-    pub fn latest_handle(&self) -> Arc<ArcSwap<SuperVersion>> {
+    pub(crate) fn latest_handle(&self) -> Arc<ArcSwap<SuperVersion>> {
         Arc::clone(&self.latest)
     }
 

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -10,6 +10,7 @@ use crate::{
     tree::sealed::SealedMemtables,
     version::{Version, persist_version},
 };
+use arc_swap::ArcSwap;
 use std::{collections::VecDeque, path::Path, sync::Arc};
 
 /// A super version is a point-in-time snapshot of memtables and a [`Version`] (list of disk files)
@@ -37,20 +38,33 @@ pub struct SuperVersions {
     /// Durability level (`Config::sync_mode`) applied to every manifest /
     /// version persist this history performs. Immutable for the tree's life.
     sync_mode: SyncMode,
+
+    /// Lock-free mirror of the latest (back) `SuperVersion`, shared with the
+    /// `Tree` so a point read at `MAX_SEQNO` can load the current snapshot
+    /// without taking the history `RwLock` or cloning the deque entry. Kept
+    /// in sync under the same write lock at every site that changes the back
+    /// (construction, [`append_version`](Self::append_version),
+    /// [`replace_latest_version`](Self::replace_latest_version)). Recent
+    /// inserts remain visible through it because they mutate the shared
+    /// `active_memtable` behind a stable `Arc` — the back only changes on
+    /// flush / compaction.
+    latest: Arc<ArcSwap<SuperVersion>>,
 }
 
 impl SuperVersions {
     pub fn new(version: Version, comparator: &SharedComparator, sync_mode: SyncMode) -> Self {
         let comparator_name: Arc<str> = comparator.name().into();
 
+        let initial = SuperVersion {
+            active_memtable: Arc::new(Memtable::new(0, comparator.clone())),
+            sealed_memtables: Arc::default(),
+            version,
+            seqno: 0,
+        };
+
         Self {
-            versions: vec![SuperVersion {
-                active_memtable: Arc::new(Memtable::new(0, comparator.clone())),
-                sealed_memtables: Arc::default(),
-                version,
-                seqno: 0,
-            }]
-            .into(),
+            latest: Arc::new(ArcSwap::from_pointee(initial.clone())),
+            versions: vec![initial].into(),
             comparator_name,
             sync_mode,
         }
@@ -209,13 +223,30 @@ impl SuperVersions {
     }
 
     pub fn append_version(&mut self, version: SuperVersion) {
+        // Mirror the new back into the lock-free latest pointer so point
+        // reads at MAX_SEQNO see it without taking the history lock.
+        self.latest.store(Arc::new(version.clone()));
         self.versions.push_back(version);
     }
 
     pub fn replace_latest_version(&mut self, version: SuperVersion) {
         if self.versions.pop_back().is_some() {
+            self.latest.store(Arc::new(version.clone()));
             self.versions.push_back(version);
         }
+    }
+
+    /// Returns a handle to the lock-free latest-`SuperVersion` mirror.
+    ///
+    /// The `Tree` stores a clone of this handle and reads it on the point-read
+    /// hot path (`get` at `MAX_SEQNO`) to avoid the history `RwLock`. The
+    /// handle stays valid for the tree's lifetime; the pointee is swapped by
+    /// [`append_version`](Self::append_version) /
+    /// [`replace_latest_version`](Self::replace_latest_version) under the
+    /// history write lock.
+    #[must_use]
+    pub fn latest_handle(&self) -> Arc<ArcSwap<SuperVersion>> {
+        Arc::clone(&self.latest)
     }
 
     pub fn latest_version(&self) -> SuperVersion {
@@ -270,10 +301,21 @@ mod tests {
     }
 
     fn test_super_versions(versions: Vec<SuperVersion>) -> SuperVersions {
+        #[expect(
+            clippy::expect_used,
+            reason = "test helper: every caller passes a non-empty version list"
+        )]
+        let latest = Arc::new(ArcSwap::from_pointee(
+            versions
+                .last()
+                .cloned()
+                .expect("test helper requires at least one version"),
+        ));
         SuperVersions {
             versions: versions.into(),
             comparator_name: "default".into(),
             sync_mode: SyncMode::Normal,
+            latest,
         }
     }
 

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -10,6 +10,7 @@ use crate::{
     tree::sealed::SealedMemtables,
     version::{Version, persist_version},
 };
+#[cfg(feature = "std")]
 use arc_swap::ArcSwap;
 use std::{collections::VecDeque, path::Path, sync::Arc};
 
@@ -48,6 +49,11 @@ pub struct SuperVersions {
     /// inserts remain visible through it because they mutate the shared
     /// `active_memtable` behind a stable `Arc` — the back only changes on
     /// flush / compaction.
+    ///
+    /// `std`-only: `arc-swap` is not `#![no_std]`. A no-std build (where
+    /// `SuperVersions` is already std-bound for other reasons) simply does
+    /// without the lock-free mirror.
+    #[cfg(feature = "std")]
     latest: Arc<ArcSwap<SuperVersion>>,
 }
 
@@ -63,6 +69,7 @@ impl SuperVersions {
         };
 
         Self {
+            #[cfg(feature = "std")]
             latest: Arc::new(ArcSwap::from_pointee(initial.clone())),
             versions: vec![initial].into(),
             comparator_name,
@@ -225,12 +232,14 @@ impl SuperVersions {
     pub fn append_version(&mut self, version: SuperVersion) {
         // Mirror the new back into the lock-free latest pointer so point
         // reads at MAX_SEQNO see it without taking the history lock.
+        #[cfg(feature = "std")]
         self.latest.store(Arc::new(version.clone()));
         self.versions.push_back(version);
     }
 
     pub fn replace_latest_version(&mut self, version: SuperVersion) {
         if self.versions.pop_back().is_some() {
+            #[cfg(feature = "std")]
             self.latest.store(Arc::new(version.clone()));
             self.versions.push_back(version);
         }
@@ -248,6 +257,9 @@ impl SuperVersions {
     /// Crate-internal: exposing the `ArcSwap` publicly would let a downstream
     /// caller `store()` into it without the version-history write lock,
     /// breaking the "mirror only changes at back-changing sites" invariant.
+    ///
+    /// `std`-only: the mirror exists only when `arc-swap` is available.
+    #[cfg(feature = "std")]
     #[must_use]
     pub(crate) fn latest_handle(&self) -> Arc<ArcSwap<SuperVersion>> {
         Arc::clone(&self.latest)
@@ -305,6 +317,7 @@ mod tests {
     }
 
     fn test_super_versions(versions: Vec<SuperVersion>) -> SuperVersions {
+        #[cfg(feature = "std")]
         #[expect(
             clippy::expect_used,
             reason = "test helper: every caller passes a non-empty version list"
@@ -319,6 +332,7 @@ mod tests {
             versions: versions.into(),
             comparator_name: "default".into(),
             sync_mode: SyncMode::Normal,
+            #[cfg(feature = "std")]
             latest,
         }
     }


### PR DESCRIPTION
## Summary

Attacks the measured point_read ~1.5x gap vs RocksDB. Every point read at MAX_SEQNO took version_history.read() (a RwLock) plus get_version_for_snapshot, which clones the SuperVersion (atomic refcount bumps on active_memtable / sealed_memtables / version). On the warm read hot path that lock + multi-Arc-clone per get is pure overhead.

Adapted from RocksDB's DBImpl::GetImpl, which keeps a thread-local cached SuperVersion and only re-locks when the version changed.

## Change

- SuperVersions holds an Arc<ArcSwap<SuperVersion>> mirroring the latest (back) version, shared with the Tree via latest_handle().
- A read at seqno > latest.seqno (always true for MAX_SEQNO, the common case) loads the mirror lock-free (one atomic, no RwLock, no deque clone). This is exactly the version get_version_for_snapshot would return (it yields the latest iff latest.seqno < seqno).
- Historical snapshot reads (seqno <= latest.seqno) keep the locked path.

## Correctness

- The mirror is refreshed under the existing write lock at the only three sites that change the back of the version deque: construction, append_version, replace_latest_version. GC pop_front only removes the front, never the back.
- Recent inserts stay visible because they mutate the shared active_memtable behind a stable Arc; the back only changes on flush / compaction, which refresh the mirror.
- A read may observe a version one install behind a concurrent flush/compaction, identical to the prior RwLock semantics; snapshot consistency is preserved.

## Testing

- cargo nextest run --all-features: 1799 passed, 2 skipped (clean single run), exercising both the lock-free and historical paths.
- clippy --all-features --all-targets clean, fmt clean, rustdoc clean.

Part of the point_read perf work. Closes #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Adds a lock-free fast path that mirrors the latest data snapshot to speed point reads of the most-recent state, reducing latency under high read workloads while preserving historical read behavior.
* **Documentation**
  * Clarifies rationale for optional arc-swap usage and its conditional scope.
* **Tests**
  * Updates test helper initialization to account for the new latest-snapshot mirror.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->