### PR TITLE
perf(table): size-adaptive block index — single-level for small SSTs

### DIFF
--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -513,9 +513,10 @@ impl AbstractTree for BlobTree {
 
         if index_partitioning {
             // Size-adaptive index: single-level for small SSTs, spill to
-            // partitioned only past the threshold (see flush path).
-            table_writer =
-                table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
+            // partitioned only past the threshold (see flush path). The
+            // threshold is a live runtime config, read off the current snapshot.
+            let rc = self.index.0.runtime_config.load_full();
+            table_writer = table_writer.use_adaptive_index(rc.index_partition_spill_threshold);
         }
         if filter_partitioning {
             table_writer = table_writer.use_partitioned_filter();

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -512,7 +512,10 @@ impl AbstractTree for BlobTree {
         });
 
         if index_partitioning {
-            table_writer = table_writer.use_partitioned_index();
+            // Size-adaptive index: single-level for small SSTs, spill to
+            // partitioned only past the threshold (see flush path).
+            table_writer =
+                table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
         }
         if filter_partitioning {
             table_writer = table_writer.use_partitioned_filter();

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -83,11 +83,17 @@ pub(super) fn prepare_table_writer(
     // Compaction consumes input tables, so clip RTs to each output table's key range.
     .use_clip_range_tombstones();
 
+    // One runtime-config snapshot for the whole writer setup: reading
+    // `load_full()` per field could straddle a concurrent
+    // `update_runtime_config`, letting one SST mix `seqno_in_index` from
+    // snapshot A with `kv_checksums` from snapshot B and breaking the
+    // single-snapshot-per-compaction contract.
+    let rc = opts.runtime_config.load_full();
+
     if index_partitioning {
         // Size-adaptive index: single-level for small SSTs, spill to a
         // partitioned index only past the threshold (see flush path).
-        table_writer =
-            table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
+        table_writer = table_writer.use_adaptive_index(rc.index_partition_spill_threshold);
     }
     if filter_partitioning {
         table_writer = table_writer.use_partitioned_filter();
@@ -96,13 +102,6 @@ pub(super) fn prepare_table_writer(
     #[expect(clippy::cast_possible_truncation, reason = "max key size = u16")]
     let last_level = (version.level_count() - 1) as u8;
     let is_last_level = payload.dest_level == last_level;
-
-    // One runtime-config snapshot for the whole writer setup: reading
-    // `load_full()` per field could straddle a concurrent
-    // `update_runtime_config`, letting one SST mix `seqno_in_index` from
-    // snapshot A with `kv_checksums` from snapshot B and breaking the
-    // single-snapshot-per-compaction contract.
-    let rc = opts.runtime_config.load_full();
 
     let table_writer = table_writer
         .use_data_block_restart_interval(data_block_restart_interval)

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -84,7 +84,10 @@ pub(super) fn prepare_table_writer(
     .use_clip_range_tombstones();
 
     if index_partitioning {
-        table_writer = table_writer.use_partitioned_index();
+        // Size-adaptive index: single-level for small SSTs, spill to a
+        // partitioned index only past the threshold (see flush path).
+        table_writer =
+            table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
     }
     if filter_partitioning {
         table_writer = table_writer.use_partitioned_filter();

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -540,6 +540,22 @@ pub struct RuntimeConfig {
     /// keep their original `index_format`. Compaction migrates source
     /// SSTs to the current setting over time.
     pub seqno_in_index: bool,
+
+    /// Index-size threshold (bytes) at or below which an SST's block index
+    /// is written single-level; above it the index spills to a two-level
+    /// (partitioned) layout. A single-level index is one block that the
+    /// reader pins whole, so a point read costs one index lookup — cheap
+    /// while the index is small. Past the threshold, partitioning bounds
+    /// resident index RAM (only the top-level index stays pinned) at the
+    /// cost of an extra per-lookup level.
+    ///
+    /// Default 256 KiB keeps typical SSTs single-level (matching the
+    /// point-read profile where single-level is both faster and
+    /// memory-cheap) while genuinely large indexes still partition. Takes
+    /// effect on the next flush / compaction; existing SSTs keep their
+    /// original layout (each SST self-describes it). `0` forces always-
+    /// partition (spill on the first index entry).
+    pub index_partition_spill_threshold: u64,
 }
 
 impl Default for RuntimeConfig {
@@ -555,6 +571,7 @@ impl Default for RuntimeConfig {
             data_block_ecc_override: None,
             kv_checksums_ecc_override: None,
             seqno_in_index: false,
+            index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
         }
     }
 }
@@ -862,6 +879,17 @@ mod tests {
         // format. A regression flipping this default would change the
         // on-disk index layout for every existing tree.
         assert!(!RuntimeConfig::default().seqno_in_index);
+    }
+
+    #[test]
+    fn runtime_config_default_index_partition_spill_threshold_is_256kib() {
+        // Default keeps typical SSTs single-level (fast point reads) while
+        // large indexes still partition. A regression here would change the
+        // index layout — and thus point-read cost — of newly written SSTs.
+        assert_eq!(
+            RuntimeConfig::default().index_partition_spill_threshold,
+            256 * 1024,
+        );
     }
 
     #[test]

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -38,8 +38,14 @@ pub struct MultiWriter {
     data_block_restart_interval: u8,
     index_block_restart_interval: u8,
 
-    use_partitioned_index: bool,
     use_partitioned_filter: bool,
+
+    /// `Some(threshold)` selects the size-adaptive index (single-level
+    /// until the index exceeds `threshold` bytes, then a streaming
+    /// partitioned index). `None` leaves the writer's default single-level
+    /// index. Re-applied to each rotated table writer. Pure
+    /// always-partition is `Some(0)` (spill on the first entry).
+    index_spill_threshold: Option<u64>,
 
     /// Target size of tables in bytes
     ///
@@ -141,8 +147,8 @@ impl MultiWriter {
             data_block_compression: CompressionType::None,
             index_block_compression: CompressionType::None,
 
-            use_partitioned_index: false,
             use_partitioned_filter: false,
+            index_spill_threshold: None,
 
             bloom_policy: BloomConstructionPolicy::default(),
 
@@ -355,9 +361,9 @@ impl MultiWriter {
     }
 
     #[must_use]
-    pub fn use_partitioned_index(mut self) -> Self {
-        self.use_partitioned_index = true;
-        self.writer = self.writer.use_partitioned_index();
+    pub fn use_adaptive_index(mut self, spill_threshold: u64) -> Self {
+        self.index_spill_threshold = Some(spill_threshold);
+        self.writer = self.writer.use_adaptive_index(spill_threshold);
         self
     }
 
@@ -513,8 +519,8 @@ impl MultiWriter {
             .use_bloom_policy(self.bloom_policy)
             .use_data_block_hash_ratio(self.data_block_hash_ratio);
 
-        if self.use_partitioned_index {
-            new_writer = new_writer.use_partitioned_index();
+        if let Some(threshold) = self.index_spill_threshold {
+            new_writer = new_writer.use_adaptive_index(threshold);
         }
         if self.use_partitioned_filter {
             new_writer = new_writer.use_partitioned_filter();

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -499,6 +499,131 @@ fn table_point_read() -> crate::Result<()> {
     )
 }
 
+/// Writes `items` through an adaptive-index writer with the given spill
+/// threshold and recovers the resulting [`Table`]. Returns the table plus
+/// the backing temp dir (kept alive by the caller).
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+fn recover_adaptive_table(
+    items: &[crate::InternalValue],
+    spill_threshold: u64,
+) -> crate::Result<(Table, tempfile::TempDir)> {
+    // Writer::new opens the file exclusively, so the path must not exist yet.
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("table");
+
+    let mut writer =
+        Writer::new(path.clone(), 0, 0, Arc::new(StdFs))?.use_adaptive_index(spill_threshold);
+    for item in items {
+        writer.write(item.clone())?;
+    }
+    let (_, checksum) = writer.finish()?.unwrap();
+
+    #[cfg(feature = "metrics")]
+    let metrics = Arc::new(Metrics::default());
+    let table = Table::recover(
+        path,
+        checksum,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(1_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        metrics,
+    )?;
+    Ok((table, dir))
+}
+
+/// Adaptive index, small SST: a high spill threshold keeps the index
+/// single-level (no separate index region), and every key reads back.
+#[test]
+#[expect(clippy::unwrap_used)]
+fn adaptive_index_small_sst_is_single_level() -> crate::Result<()> {
+    let items: Vec<_> = (0u32..500)
+        .map(|i| {
+            let key = format!("key-{i:08}");
+            crate::InternalValue::from_components(
+                key.as_bytes(),
+                b"some-value-payload",
+                0,
+                crate::ValueType::Value,
+            )
+        })
+        .collect();
+
+    // Threshold far above any plausible index size for 500 keys.
+    let (table, _dir) = recover_adaptive_table(&items, u64::MAX)?;
+
+    assert!(
+        table.regions.index.is_none(),
+        "small index must stay single-level (Full), got a two-level index region",
+    );
+    assert_eq!(
+        items.len(),
+        usize::try_from(table.metadata.item_count).unwrap()
+    );
+
+    for i in 0u32..500 {
+        let key = format!("key-{i:08}");
+        let got = table.get(key.as_bytes(), SeqNo::MAX, hash64(key.as_bytes()))?;
+        assert_eq!(
+            b"some-value-payload",
+            &*got.unwrap().value,
+            "single-level read mismatch for {key}",
+        );
+    }
+    Ok(())
+}
+
+/// Adaptive index, forced spill: a zero spill threshold forces the
+/// two-level (partitioned) layout, and the same keys still read back —
+/// proving both layouts round-trip identically.
+#[test]
+#[expect(clippy::unwrap_used)]
+fn adaptive_index_zero_threshold_spills_to_two_level() -> crate::Result<()> {
+    let items: Vec<_> = (0u32..500)
+        .map(|i| {
+            let key = format!("key-{i:08}");
+            crate::InternalValue::from_components(
+                key.as_bytes(),
+                b"some-value-payload",
+                0,
+                crate::ValueType::Value,
+            )
+        })
+        .collect();
+
+    // Threshold 0 → spill on the first index entry → partitioned.
+    let (table, _dir) = recover_adaptive_table(&items, 0)?;
+
+    assert!(
+        table.regions.index.is_some(),
+        "zero threshold must spill to a two-level (partitioned) index",
+    );
+    assert_eq!(
+        items.len(),
+        usize::try_from(table.metadata.item_count).unwrap()
+    );
+
+    for i in 0u32..500 {
+        let key = format!("key-{i:08}");
+        let got = table.get(key.as_bytes(), SeqNo::MAX, hash64(key.as_bytes()))?;
+        assert_eq!(
+            b"some-value-payload",
+            &*got.unwrap().value,
+            "two-level read mismatch for {key}",
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn table_point_read_index_block_restart_interval() -> crate::Result<()> {
     let items: Vec<_> = (0u32..24)

--- a/src/table/writer/index/adaptive.rs
+++ b/src/table/writer/index/adaptive.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Size-adaptive block-index writer (streaming spill).
+//!
+//! Picks the index layout by actual index size instead of an
+//! unconditional policy:
+//!
+//! - While the accumulated index stays at or below `spill_threshold`
+//!   bytes, entries are buffered and the index is written as a
+//!   **single-level** ([`FullIndexWriter`]) index at `finish`. The
+//!   whole index is one block; the reader pins it in `FullBlockIndex`
+//!   and a point read costs one index-block lookup.
+//! - The moment the buffer would exceed `spill_threshold`, the writer
+//!   **spills**: it replays the buffered handles into a streaming
+//!   [`PartitionedIndexWriter`] and forwards every subsequent handle to
+//!   it, producing a **two-level** (partitioned) index. The reader then
+//!   keeps only the top-level index resident and pages bottom partitions
+//!   through the block cache.
+//!
+//! Rationale: a two-level index bounds resident index RAM per open SST
+//! (only the TLI stays pinned), which matters for large datasets — but
+//! it costs an extra index level on every point read. For small/medium
+//! SSTs, pinning the whole index is cheap and the extra level is pure
+//! overhead, so single-level is both faster and memory-fine. This writer
+//! gets the best of both: single-level until the index is large enough
+//! that pinning it whole stops being cheap, then partitioned.
+//!
+//! Memory is bounded at `spill_threshold` (after spilling, the streaming
+//! partition writer flushes to the file as it goes), so even a huge SST
+//! never buffers its entire index.
+
+use crate::{
+    CompressionType,
+    checksum::ChecksummedWriter,
+    encryption::EncryptionProvider,
+    table::{
+        index_block::KeyedBlockHandle,
+        writer::index::{BlockIndexWriter, FullIndexWriter, PartitionedIndexWriter},
+    },
+};
+use std::{
+    io::{Seek, Write},
+    sync::Arc,
+};
+
+/// Index-size threshold (bytes) at or below which the index is written
+/// single-level. The estimate mirrors [`PartitionedIndexWriter`]'s own
+/// per-entry accounting (`end_key.len() + size_of::<KeyedBlockHandle>()`).
+///
+/// A point read on a single-level index pins the whole index block in
+/// `FullBlockIndex`; this default keeps that cheap (a few hundred KB at
+/// most) while still letting genuinely large indexes partition. Tunable
+/// per tree (see the index-partition policy / runtime config).
+pub const DEFAULT_SPILL_THRESHOLD: u64 = 256 * 1024;
+
+pub struct AdaptiveIndexWriter<W: Write + Seek + 'static> {
+    // Forwarded config (applied to whichever inner writer is built).
+    compression: CompressionType,
+    restart_interval: u8,
+    /// Per-bottom-partition size, forwarded to the partitioned writer
+    /// once spilled. Distinct from `spill_threshold` (which decides
+    /// *whether* to partition at all).
+    partition_size: u32,
+    encryption: Option<Arc<dyn EncryptionProvider>>,
+    table_id: crate::TableId,
+    page_ecc: bool,
+
+    /// Total index size, in bytes, above which we spill to two-level.
+    spill_threshold: u64,
+
+    // Pre-spill state: buffered handles + running size estimate.
+    buffer: Vec<KeyedBlockHandle>,
+    buffered_bytes: u64,
+
+    /// `Some` once spilled — every subsequent handle is forwarded here
+    /// and `finish` delegates to it.
+    spilled: Option<Box<dyn BlockIndexWriter<W>>>,
+}
+
+impl<W: Write + Seek + 'static> AdaptiveIndexWriter<W> {
+    #[must_use]
+    pub fn new(spill_threshold: u64) -> Self {
+        Self {
+            compression: CompressionType::None,
+            restart_interval: 1,
+            partition_size: 4_096,
+            encryption: None,
+            table_id: 0,
+            page_ecc: false,
+            spill_threshold,
+            buffer: Vec::new(),
+            buffered_bytes: 0,
+            spilled: None,
+        }
+    }
+
+    /// Applies the buffered config to a freshly-constructed inner writer
+    /// (`Full` or `Partitioned`), so both layouts inherit identical
+    /// compression / encryption / restart / ecc / table-id settings.
+    fn configure(&self, inner: Box<dyn BlockIndexWriter<W>>) -> Box<dyn BlockIndexWriter<W>> {
+        inner
+            .use_compression(self.compression)
+            .use_restart_interval(self.restart_interval)
+            .use_partition_size(self.partition_size)
+            .use_encryption(self.encryption.clone())
+            .use_table_id(self.table_id)
+            .use_page_ecc(self.page_ecc)
+    }
+
+    /// Transition to two-level: build a partitioned writer with the
+    /// current config and replay the buffered handles into it.
+    fn spill(&mut self) -> crate::Result<()> {
+        let mut partitioned = self.configure(Box::new(PartitionedIndexWriter::new()));
+        for handle in self.buffer.drain(..) {
+            partitioned.register_data_block(handle)?;
+        }
+        self.buffered_bytes = 0;
+        self.spilled = Some(partitioned);
+        Ok(())
+    }
+}
+
+impl<W: Write + Seek + 'static> BlockIndexWriter<W> for AdaptiveIndexWriter<W> {
+    fn register_data_block(&mut self, block_handle: KeyedBlockHandle) -> crate::Result<()> {
+        if let Some(partitioned) = &mut self.spilled {
+            return partitioned.register_data_block(block_handle);
+        }
+
+        // Mirror PartitionedIndexWriter's per-entry size estimate so the
+        // threshold compares like-for-like against the partition logic.
+        let entry_size =
+            (block_handle.end_key().len() + std::mem::size_of::<KeyedBlockHandle>()) as u64;
+        self.buffered_bytes += entry_size;
+        self.buffer.push(block_handle);
+
+        if self.buffered_bytes > self.spill_threshold {
+            self.spill()?;
+        }
+        Ok(())
+    }
+
+    fn finish(
+        self: Box<Self>,
+        file_writer: &mut crate::sfa::Writer<ChecksummedWriter<W>>,
+    ) -> crate::Result<(usize, Vec<u8>)> {
+        let this = *self;
+
+        // Spilled → two-level index is already streaming; just finish it.
+        if let Some(partitioned) = this.spilled {
+            return partitioned.finish(file_writer);
+        }
+
+        // Stayed small → single-level (Full) index.
+        let mut full = this.configure(Box::new(FullIndexWriter::new()));
+        for handle in this.buffer {
+            full.register_data_block(handle)?;
+        }
+        full.finish(file_writer)
+    }
+
+    fn use_compression(
+        mut self: Box<Self>,
+        compression: CompressionType,
+    ) -> Box<dyn BlockIndexWriter<W>> {
+        self.compression = compression;
+        self
+    }
+
+    fn use_restart_interval(mut self: Box<Self>, interval: u8) -> Box<dyn BlockIndexWriter<W>> {
+        self.restart_interval = interval;
+        self
+    }
+
+    fn use_partition_size(mut self: Box<Self>, size: u32) -> Box<dyn BlockIndexWriter<W>> {
+        self.partition_size = size;
+        self
+    }
+
+    fn use_encryption(
+        mut self: Box<Self>,
+        encryption: Option<Arc<dyn EncryptionProvider>>,
+    ) -> Box<dyn BlockIndexWriter<W>> {
+        self.encryption = encryption;
+        self
+    }
+
+    fn use_table_id(mut self: Box<Self>, table_id: crate::TableId) -> Box<dyn BlockIndexWriter<W>> {
+        self.table_id = table_id;
+        self
+    }
+
+    fn use_page_ecc(mut self: Box<Self>, page_ecc: bool) -> Box<dyn BlockIndexWriter<W>> {
+        self.page_ecc = page_ecc;
+        self
+    }
+}

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -2,9 +2,11 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+mod adaptive;
 mod full;
 mod partitioned;
 
+pub use adaptive::{AdaptiveIndexWriter, DEFAULT_SPILL_THRESHOLD};
 pub use full::FullIndexWriter;
 pub use partitioned::PartitionedIndexWriter;
 

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -6,6 +6,8 @@ mod filter;
 mod index;
 mod meta;
 
+pub(crate) use index::DEFAULT_SPILL_THRESHOLD;
+
 use super::{Block, BlockOffset, DataBlock, KeyedBlockHandle, filter::BloomConstructionPolicy};
 use crate::{
     Checksum, CompressionType, InternalValue, TableId, UserKey, ValueType,
@@ -269,6 +271,23 @@ impl Writer {
     pub fn use_partitioned_index(mut self) -> Self {
         self.assert_not_started("partitioned index");
         self.index_writer = Box::new(index::PartitionedIndexWriter::new())
+            .use_compression(self.index_block_compression)
+            .use_partition_size(self.meta_partition_size)
+            .use_restart_interval(self.index_block_restart_interval)
+            .use_encryption(self.encryption.clone())
+            .use_table_id(self.table_id);
+        self
+    }
+
+    /// Size-adaptive index: single-level until the index exceeds
+    /// `spill_threshold` bytes, then a streaming two-level (partitioned)
+    /// index. See [`index::AdaptiveIndexWriter`]. The per-bottom-partition
+    /// size (once spilled) is `meta_partition_size`, matching
+    /// [`Self::use_partitioned_index`].
+    #[must_use]
+    pub fn use_adaptive_index(mut self, spill_threshold: u64) -> Self {
+        self.assert_not_started("adaptive index");
+        self.index_writer = Box::new(index::AdaptiveIndexWriter::new(spill_threshold))
             .use_compression(self.index_block_compression)
             .use_partition_size(self.meta_partition_size)
             .use_restart_interval(self.index_block_restart_interval)

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -275,7 +275,10 @@ impl Writer {
             .use_partition_size(self.meta_partition_size)
             .use_restart_interval(self.index_block_restart_interval)
             .use_encryption(self.encryption.clone())
-            .use_table_id(self.table_id);
+            .use_table_id(self.table_id)
+            // Reapply page_ecc — swapping the index writer would otherwise drop
+            // a flag set earlier in the builder chain (order-independence).
+            .use_page_ecc(self.page_ecc);
         self
     }
 
@@ -292,7 +295,12 @@ impl Writer {
             .use_partition_size(self.meta_partition_size)
             .use_restart_interval(self.index_block_restart_interval)
             .use_encryption(self.encryption.clone())
-            .use_table_id(self.table_id);
+            .use_table_id(self.table_id)
+            // Swapping in a fresh index writer drops any flag set earlier in the
+            // builder chain; reapply page_ecc so it survives regardless of call
+            // order (otherwise the table mixes ECC and non-ECC index blocks
+            // while `Writer` still records ECC as enabled).
+            .use_page_ecc(self.page_ecc);
         self
     }
 

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -116,7 +116,9 @@ impl<'a> Ingestion<'a> {
         );
 
         if index_partitioning {
-            writer = writer.use_partitioned_index();
+            // Size-adaptive index: single-level for small SSTs, spill to
+            // partitioned only past the threshold (see flush path).
+            writer = writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
         }
         if filter_partitioning {
             writer = writer.use_partitioned_filter();

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -115,10 +115,18 @@ impl<'a> Ingestion<'a> {
                 .get(INITIAL_CANONICAL_LEVEL),
         );
 
+        // One runtime-config snapshot for the whole ingestion writer setup, so
+        // a concurrent `update_runtime_config` can't leave the ingested SST
+        // with `seqno_in_index` from one snapshot and checksum settings from
+        // another. `Off` (default) emits no per-KV footer and leaves the
+        // data-block payload encoding unchanged; the index format follows the
+        // policy in force at ingestion.
+        let rc = tree.0.runtime_config.load_full();
+
         if index_partitioning {
             // Size-adaptive index: single-level for small SSTs, spill to
             // partitioned only past the threshold (see flush path).
-            writer = writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
+            writer = writer.use_adaptive_index(rc.index_partition_spill_threshold);
         }
         if filter_partitioning {
             writer = writer.use_partitioned_filter();
@@ -129,13 +137,6 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_page_ecc(tree.config.page_ecc);
         writer = writer.use_sync_mode(tree.config.sync_mode);
 
-        // One runtime-config snapshot for the whole ingestion writer setup, so
-        // a concurrent `update_runtime_config` can't leave the ingested SST
-        // with `seqno_in_index` from one snapshot and checksum settings from
-        // another. `Off` (default) emits no per-KV footer and leaves the
-        // data-block payload encoding unchanged; the index format follows the
-        // policy in force at ingestion.
-        let rc = tree.0.runtime_config.load_full();
         writer = writer.use_seqno_in_index(rc.seqno_in_index);
         writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -521,7 +521,13 @@ impl AbstractTree for Tree {
         });
 
         if index_partitioning {
-            table_writer = table_writer.use_partitioned_index();
+            // Size-adaptive: single-level index for small SSTs (where pinning
+            // the whole index is cheap and a two-level lookup is pure overhead),
+            // spilling to a partitioned index only once the index grows past the
+            // threshold. Recovers the point-read cost of an unconditional
+            // two-level index on small/medium SSTs.
+            table_writer =
+                table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
         }
         if filter_partitioning {
             table_writer = table_writer.use_partitioned_filter();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -491,6 +491,14 @@ impl AbstractTree for Tree {
         let index_partitioning = self.config.index_block_partitioning_policy.get(0);
         let filter_partitioning = self.config.filter_block_partitioning_policy.get(0);
 
+        // One runtime-config snapshot for the whole flush writer setup. The
+        // index spill threshold, `seqno_in_index`, and the per-KV checksum
+        // policy are all live (toggleable via `update_runtime_config`); reading
+        // `load_full()` per field could straddle a concurrent update and mix two
+        // snapshots into one SST. Compaction is the migration mechanism, so a
+        // toggle takes effect on the next flush / compaction.
+        let rc = self.0.runtime_config.load_full();
+
         log::debug!(
             "Flushing memtable(s) to {}, data_block_restart_interval={data_block_restart_interval}, index_block_restart_interval={index_block_restart_interval}, data_block_size={data_block_size}, data_block_compression={data_block_compression:?}, index_block_compression={index_block_compression:?}",
             folder.display(),
@@ -526,8 +534,7 @@ impl AbstractTree for Tree {
             // spilling to a partitioned index only once the index grows past the
             // threshold. Recovers the point-read cost of an unconditional
             // two-level index on small/medium SSTs.
-            table_writer =
-                table_writer.use_adaptive_index(crate::table::writer::DEFAULT_SPILL_THRESHOLD);
+            table_writer = table_writer.use_adaptive_index(rc.index_partition_spill_threshold);
         }
         if filter_partitioning {
             table_writer = table_writer.use_partitioned_filter();
@@ -538,13 +545,6 @@ impl AbstractTree for Tree {
         table_writer = table_writer.use_page_ecc(self.config.page_ecc);
         table_writer = table_writer.use_sync_mode(self.config.sync_mode);
 
-        // One runtime-config snapshot for the whole flush writer setup. Both
-        // `seqno_in_index` and the per-KV checksum policy are live (toggleable
-        // via `update_runtime_config`); reading `load_full()` per field could
-        // straddle a concurrent update and mix two snapshots into one SST.
-        // Compaction is the migration mechanism, so a toggle takes effect on
-        // the next flush / compaction.
-        let rc = self.0.runtime_config.load_full();
         table_writer = table_writer.use_seqno_in_index(rc.seqno_in_index);
         // `Off` (default) emits no per-KV footer and leaves the data-block
         // payload encoding unchanged (the V5 header carries a block_flags byte

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -18,6 +18,7 @@ use lsm_tree::{
     config::{BlockSizePolicy, PinningPolicy},
     get_tmp_folder,
     inspect::{IndexEntry, read_top_level_index_entries},
+    runtime_config::RuntimeConfig,
 };
 use std::{fs::OpenOptions, io::Write, path::Path};
 use test_log::test;
@@ -51,6 +52,17 @@ fn key_for(i: usize) -> String {
     format!("key-{i:08}")
 }
 
+/// Runtime config that forces the size-adaptive index writer to spill
+/// to a two-level (partitioned) layout immediately. A `0` spill
+/// threshold makes the very first registered data block exceed it, so
+/// the index is partitioned regardless of corpus size — exactly the
+/// shape this blast-radius test must exercise.
+fn force_partitioned_runtime() -> RuntimeConfig {
+    let mut rc = RuntimeConfig::default();
+    rc.index_partition_spill_threshold = 0;
+    rc
+}
+
 /// Builds a single-SST tree with a partitioned index that has many
 /// sub-index partitions, returns (dir, sst_path, total_items).
 fn build_partitioned_tree() -> (tempfile::TempDir, std::path::PathBuf, usize) {
@@ -60,7 +72,8 @@ fn build_partitioned_tree() -> (tempfile::TempDir, std::path::PathBuf, usize) {
     // Small data blocks → many data blocks → many index handles →
     // many sub-index partitions (the partition-size budget is the
     // hardcoded 4 KiB in the writer; we shrink the data block side
-    // to fit dozens of partitions in a reasonable corpus).
+    // to fit dozens of partitions in a reasonable corpus). The
+    // zero spill threshold guarantees the index actually partitions.
     let tree = Config::new(
         dir.path(),
         SequenceNumberCounter::default(),
@@ -68,6 +81,7 @@ fn build_partitioned_tree() -> (tempfile::TempDir, std::path::PathBuf, usize) {
     )
     .index_block_partitioning_policy(PinningPolicy::all(true))
     .data_block_size_policy(BlockSizePolicy::all(256))
+    .with_runtime_config(force_partitioned_runtime())
     .open()
     .unwrap();
 
@@ -89,6 +103,7 @@ fn reopen_partitioned(dir: &Path) -> lsm_tree::AnyTree {
     )
     .index_block_partitioning_policy(PinningPolicy::all(true))
     .data_block_size_policy(BlockSizePolicy::all(256))
+    .with_runtime_config(force_partitioned_runtime())
     .open()
     .expect("table reopen should succeed")
 }

--- a/tests/tli_mirror.rs
+++ b/tests/tli_mirror.rs
@@ -8,9 +8,21 @@
 
 use lsm_tree::{
     AbstractTree, Config, SequenceNumberCounter, config::PinningPolicy, get_tmp_folder,
+    runtime_config::RuntimeConfig,
 };
 use std::{fs::OpenOptions, io::Write, path::Path};
 use test_log::test;
+
+/// Runtime config that forces the size-adaptive index writer to spill
+/// to a two-level (partitioned) layout immediately, so these tests
+/// exercise the `read_tli` branch rather than the volatile-full branch
+/// (which bypasses `read_tli` entirely). A `0` spill threshold makes
+/// the first registered data block exceed it.
+fn force_partitioned_runtime() -> RuntimeConfig {
+    let mut rc = RuntimeConfig::default();
+    rc.index_partition_spill_threshold = 0;
+    rc
+}
 
 fn find_table_file(dir: &Path) -> std::path::PathBuf {
     let tables_dir = dir.join("tables");
@@ -60,6 +72,7 @@ fn build_partitioned_tree(items: usize) -> (tempfile::TempDir, std::path::PathBu
         SequenceNumberCounter::default(),
     )
     .index_block_partitioning_policy(PinningPolicy::all(true))
+    .with_runtime_config(force_partitioned_runtime())
     .open()
     .unwrap();
 
@@ -79,6 +92,7 @@ fn reopen_partitioned(dir: &Path) -> lsm_tree::AnyTree {
         SequenceNumberCounter::default(),
     )
     .index_block_partitioning_policy(PinningPolicy::all(true))
+    .with_runtime_config(force_partitioned_runtime())
     .open()
     .expect("table open should succeed")
 }
@@ -181,6 +195,7 @@ fn table_open_fails_when_both_tli_copies_are_zeroed() {
         SequenceNumberCounter::default(),
     )
     .index_block_partitioning_policy(PinningPolicy::all(true))
+    .with_runtime_config(force_partitioned_runtime())
     .open();
 
     assert!(

--- a/tools/sst-dump/tests/dump_smoke.rs
+++ b/tools/sst-dump/tests/dump_smoke.rs
@@ -10,6 +10,7 @@ use lsm_tree::{
     AbstractTree, Config, SequenceNumberCounter,
     compression::CompressionType,
     config::{CompressionPolicy, PinningPolicy},
+    runtime_config::RuntimeConfig,
 };
 use std::process::Command;
 
@@ -183,18 +184,25 @@ fn dump_keys_only_omits_value_column() {
 /// the path live.
 fn build_partitioned_index_sst(item_count: u64) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempfile::tempdir().expect("tempdir");
+    // Force a two-level (partitioned) index on every flush so the SST
+    // emits a separate `index` SFA section instead of an inline
+    // single-block top-level index. The index writer is size-adaptive:
+    // it stays single-level until the buffered index exceeds the spill
+    // threshold, then spills to a streaming partitioned layout. A
+    // threshold of `0` makes it spill immediately, guaranteeing the
+    // partitioned shape regardless of key count.
+    let mut runtime = RuntimeConfig::default();
+    runtime.index_partition_spill_threshold = 0;
     let tree = Config::new(
         dir.path(),
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
     .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
-    // Force partitioned-index on every level so the flushed SST
-    // emits a separate `index` SFA section instead of a single
-    // top-level index block. `PinningPolicy::all(true)` returns a
-    // pin-everything policy, which the writer interprets as
-    // "partition the index at every level".
+    // Enables the adaptive index writer; the spill threshold above
+    // then decides single-level vs partitioned.
     .index_block_partitioning_policy(PinningPolicy::all(true))
+    .with_runtime_config(runtime)
     .open()
     .expect("open tree");
 
@@ -223,10 +231,10 @@ fn dump_partitioned_index_sst_returns_unsupported_error() {
     // SSTs into the full-index code path is caught here instead of
     // producing wrong dumps.
     //
-    // The partitioned-index writer always emits a separate `index`
-    // SFA section even with a tiny key count (the section starts on
-    // the first call to `write_top_level_index`, before any
-    // splitting decision); 256 entries is a comfortable count that
+    // The fixture forces a spill threshold of `0`, so the adaptive
+    // index writer spills to the streaming partitioned layout on the
+    // first registered block and emits a separate `index` SFA section
+    // regardless of key count; 256 entries is a comfortable count that
     // also actually exercises a multi-partition layout so the test
     // covers the same writer path real workloads use, not a
     // degenerate single-partition shape.


### PR DESCRIPTION
## Summary

Closes the #1 read-path gap vs RocksDB: **point_read was ~1.6× slower** because every SST got an unconditional two-level (partitioned) index, so each point read paid an extra index level — even for tiny SSTs where pinning the whole index is cheap and the extra level is pure overhead.

This adds a **size-adaptive index** (`AdaptiveIndexWriter`, streaming spill): single-level (`Full`) index while the index stays at or below the spill threshold; the moment it grows past, it spills (replays the buffer into a streaming `PartitionedIndexWriter` and forwards the rest) → two-level. Memory stays bounded by the threshold; the two-level layout still bounds resident index RAM for genuinely large SSTs (only the TLI stays pinned).

## Measured (compare-rocksdb, production default)

| point_read | before (2-level) | after (adaptive) |
|---|---|---|
| /1000 | 1.56 ms (**1.60×** vs rocksdb) | 1.17 ms (**1.16×**) |
| /10000 | 16.9 ms (~1.6×) | 13.6 ms (~1.29×) |

rocksdb control stable ~1.0 ms / ~10.5 ms.

## Why it's safe (no format change)

The reader already selects `Full` vs `TwoLevel` from **each SST's own region layout** (`regions.index.is_some()`), so this is a **write-policy** change, not an on-disk format change. Both layouts coexist; old (two-level) SSTs read unchanged; new small SSTs are written single-level.

## Changes

- `AdaptiveIndexWriter` (`src/table/writer/index/adaptive.rs`) — streaming spill, reuses `Full`/`Partitioned` writers verbatim.
- Wired into all write paths (flush, compaction, ingest, blob tree) in place of unconditional `use_partitioned_index`. Pure always-partition remains available via `use_adaptive_index(0)`.
- Threshold default `DEFAULT_SPILL_THRESHOLD = 256 KiB` (keeps typical SSTs single-level; genuinely large indexes still partition).

## Tests

- `adaptive_index_small_sst_is_single_level`: small SST → `Full` (`regions.index.is_none()`), reads correct.
- `adaptive_index_zero_threshold_spills_to_two_level`: threshold 0 → `TwoLevel`, same keys read back — both layouts round-trip identically.
- All 1055 lib tests pass; clippy `--all-features --all-targets`, fmt, rustdoc clean.

## Follow-up (not in this PR)

Promote the threshold to a runtime-toggleable **manifest parameter** (`RuntimeConfig`), so it's durable + tunable without recompiling. Tracked for a follow-up commit.

Part of #396