### PR TITLE
perf(table): raise index spill threshold to 4 MiB

### DIFF
--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -543,15 +543,18 @@ pub struct RuntimeConfig {
 
     /// Index-size threshold (bytes) at or below which an SST's block index
     /// is written single-level; above it the index spills to a two-level
-    /// (partitioned) layout. A single-level index is one block that the
-    /// reader pins whole, so a point read costs one index lookup — cheap
-    /// while the index is small. Past the threshold, partitioning bounds
-    /// resident index RAM (only the top-level index stays pinned) at the
-    /// cost of an extra per-lookup level.
+    /// (partitioned) layout. A single-level index is one block reached by a
+    /// single lookup, so a point read costs one index level instead of two.
+    /// On hot levels the block is pinned resident; on cold levels (per the
+    /// index-block pinning policy) it is paged through the shared block
+    /// cache, so a high threshold does not pin unbounded index RAM — the
+    /// cold-level single-level index is evictable just like a two-level
+    /// index's bottom partitions, but cheaper (one cache load + one
+    /// iterator versus two levels).
     ///
-    /// Default 256 KiB keeps typical SSTs single-level (matching the
-    /// point-read profile where single-level is both faster and
-    /// memory-cheap) while genuinely large indexes still partition. Takes
+    /// Default 4 MiB keeps SSTs up to a few-hundred-MB single-level (where
+    /// single-level beats two-level on point reads at every measured size
+    /// up to 1M keys) while genuinely huge indexes still partition. Takes
     /// effect on the next flush / compaction; existing SSTs keep their
     /// original layout (each SST self-describes it). `0` forces always-
     /// partition (spill on the first index entry).
@@ -882,13 +885,17 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_default_index_partition_spill_threshold_is_256kib() {
-        // Default keeps typical SSTs single-level (fast point reads) while
-        // large indexes still partition. A regression here would change the
-        // index layout — and thus point-read cost — of newly written SSTs.
+    fn runtime_config_default_index_partition_spill_threshold_is_4mib() {
+        // Default keeps SSTs up to a few-hundred-MB single-level (fast point
+        // reads; single-level beats two-level at every measured size up to
+        // 1M keys) while genuinely huge indexes still partition. On cold
+        // levels the single-level block is cache-managed (evictable), so the
+        // raised threshold does not pin unbounded index RAM. A regression
+        // here would change the index layout — and thus point-read cost — of
+        // newly written SSTs.
         assert_eq!(
             RuntimeConfig::default().index_partition_spill_threshold,
-            256 * 1024,
+            4 * 1024 * 1024,
         );
     }
 

--- a/src/table/writer/index/adaptive.rs
+++ b/src/table/writer/index/adaptive.rs
@@ -48,11 +48,14 @@ use std::{
 /// single-level. The estimate mirrors [`PartitionedIndexWriter`]'s own
 /// per-entry accounting (`end_key.len() + size_of::<KeyedBlockHandle>()`).
 ///
-/// A point read on a single-level index pins the whole index block in
-/// `FullBlockIndex`; this default keeps that cheap (a few hundred KB at
-/// most) while still letting genuinely large indexes partition. Tunable
-/// per tree (see the index-partition policy / runtime config).
-pub const DEFAULT_SPILL_THRESHOLD: u64 = 256 * 1024;
+/// A single-level index is reached by one lookup (versus two-level's two).
+/// On hot levels the reader pins the index block; on cold levels it pages
+/// the block through the shared block cache (evictable), so a multi-MiB
+/// threshold does not pin unbounded RAM. 4 MiB keeps SSTs up to a
+/// few-hundred-MB single-level (where single-level wins point reads) while
+/// genuinely huge indexes still partition. Tunable per tree (see the
+/// index-partition policy / runtime config).
+pub const DEFAULT_SPILL_THRESHOLD: u64 = 4 * 1024 * 1024;
 
 pub struct AdaptiveIndexWriter<W: Write + Seek + 'static> {
     // Forwarded config (applied to whichever inner writer is built).


### PR DESCRIPTION
## Summary

Raises `DEFAULT_SPILL_THRESHOLD` (the `index_partition_spill_threshold` runtime-config default) from **256 KiB to 4 MiB**, so SSTs with an index up to ~4 MiB (a few-hundred-MB SST) use the single-level index layout instead of spilling to two-level.

## Why

`point_read` benchmarks (compare-rocksdb) show single-level beats two-level at **every** measured size up to 1M keys (1.75 MiB index):

| size | two-level (256 KiB default) | single-level | RocksDB |
|------|------|------|------|
| 1k | 1.56 ms (1.60x) | **1.16 ms (1.18x)** | ~0.98 ms |
| 100k | — | **0.29 s (1.03x, par)** | 0.29 s |
| 1M | 3.37 s (1.10x) | **3.06 s (~1.00x, par)** | 3.07 s |

The 256 KiB default forced two-level for any SST whose index exceeded ~256 KiB (~36 MB SST), conceding the win on medium/large SSTs.

## Memory safety

Raising the threshold does **not** pin unbounded index RAM. A single-level index is only pinned resident on hot levels (per `index_block_pinning_policy`, default `[true, true, false]`). On cold levels — where the large bottom SSTs live — a single-level index is served by `VolatileBlockIndex`, which pages the index block through the shared block cache (evictable), exactly like a two-level index's bottom partitions, but cheaper: **one** cache load + one iterator versus two index levels. So the cache-managed single-level path that makes a high threshold safe already exists; this PR just lets more SSTs use it.

## Validation

- `cargo nextest run --lib --all-features`: 1223/1223 pass
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- **Pending:** compare-rocksdb `point_read` validation of the cold-level (cache-managed) single-level path vs two-level at 1M, on a quiet machine.

Part of #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default index partition spill threshold from 256 KiB to 4 MiB, affecting SST block-index partitioning behavior.
  * Updated documentation to clarify single-level versus partitioned index selection and corresponding performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->