### PR TITLE
feat(compaction): parallel sub-compaction across key ranges

### DIFF
--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -192,6 +192,24 @@ pub(super) struct ProducedOutput {
     blob_frag_map: FragmentationMap,
 }
 
+impl ProducedOutput {
+    /// Marks this produced-but-not-installed output's freshly written files as
+    /// deleted. Used when a sibling sub-compaction fails and the shared
+    /// [`install_merge`] is skipped: each already-finished sub-compaction has
+    /// finalized its SSTs and blob files on disk, so without this they would be
+    /// orphaned. Only the newly created files are dropped — input tables stay
+    /// intact (the caller un-hides them) and rewritten-blob-file drops are left
+    /// for a later successful compaction.
+    pub(super) fn rollback_uninstalled(&self) {
+        for table in &self.created_tables {
+            table.mark_as_deleted();
+        }
+        for blob_file in &self.created_blob_files {
+            blob_file.mark_as_deleted();
+        }
+    }
+}
+
 // TODO: find a better name
 pub(super) trait CompactionFlavour {
     fn write(&mut self, item: InternalValue) -> crate::Result<()>;

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -45,6 +45,11 @@ pub(super) fn prepare_table_writer(
     version: &Version,
     opts: &Options,
     payload: &CompactionPayload,
+    // When false, the writer compresses blocks serially. Used by parallel
+    // sub-compactions, which already run on the compaction pool: re-submitting
+    // block compression to the same pool from a pool thread would deadlock
+    // (the draining thread parks on a worker slot that can't be scheduled).
+    block_parallel: bool,
 ) -> crate::Result<MultiWriter> {
     let (table_base_folder, level_fs) = opts.config.tables_folder_for_level(payload.dest_level);
 
@@ -155,11 +160,19 @@ pub(super) fn prepare_table_writer(
     // Parallel block compression: hand the (per-tree or caller-shared) pool to
     // the writer so its CPU-bound transform work runs on worker threads while
     // writes stay ordered. None / single-thread leaves the serial path.
+    // Skipped for sub-compaction writers (block_parallel = false), which already
+    // occupy a pool thread and would deadlock re-submitting to the same pool.
     #[cfg(feature = "std")]
-    let table_writer = table_writer.use_parallel_compression(
-        opts.config.compaction_pool.clone(),
-        opts.config.compaction_threads,
-    );
+    let table_writer = if block_parallel {
+        table_writer.use_parallel_compression(
+            opts.config.compaction_pool.clone(),
+            opts.config.compaction_threads,
+        )
+    } else {
+        table_writer
+    };
+    #[cfg(not(feature = "std"))]
+    let _ = block_parallel;
 
     Ok(table_writer)
 }

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -93,7 +93,7 @@ impl CompactionResult {
 ///
 /// The compaction strategy chooses which tables to compact and how.
 /// That information is given to the compactor.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Input {
     /// Tables to compact
     pub table_ids: HashSet<TableId>,

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -135,7 +135,7 @@ pub enum Choice {
 /// The strategy receives the levels of the LSM-tree as argument
 /// and emits a choice on what to do.
 #[expect(clippy::module_name_repetitions)]
-pub trait CompactionStrategy {
+pub trait CompactionStrategy: Send + Sync {
     /// Gets the compaction strategy name.
     fn get_name(&self) -> &'static str;
 

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -41,6 +41,7 @@ pub type CompactionReader<'a> = Box<dyn Iterator<Item = crate::Result<InternalVa
 pub const SUBCOMPACTION_MIN_INPUT_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Compaction options
+#[derive(Clone)]
 pub struct Options {
     pub tree_id: TreeId,
 
@@ -344,6 +345,17 @@ fn ranges_from_boundaries(
     ranges
 }
 
+/// Error returned when a sub-compaction is interrupted by the stop signal, so
+/// the parallel caller re-shows the inputs and skips the atomic install instead
+/// of committing a truncated sub-range.
+#[cfg(feature = "std")]
+fn cancelled_compaction() -> crate::Error {
+    crate::Error::Io(std::io::Error::new(
+        std::io::ErrorKind::Interrupted,
+        "sub-compaction cancelled by stop signal",
+    ))
+}
+
 /// Runs one sub-compaction over the key range `bounds`: builds a bounded merge
 /// stream of the inputs, applies the same transforms as the serial path
 /// (tombstone eviction, KV-separation drop tracking, compaction filter), writes
@@ -384,15 +396,14 @@ fn run_subcompaction(
         opts.config.merge_operator.clone(),
         opts.config.comparator.clone(),
     ) else {
-        // Inputs vanished mid-flight (validated by the caller, so unexpected):
-        // emit an empty output rather than corrupting the merge.
-        let table_writer = super::flavour::prepare_table_writer(version, opts, payload)?;
-        return Box::new(StandardCompaction::new(table_writer, tables_for_deletion)).produce(
-            opts,
-            dst_lvl,
-            blob_frag_map,
-            Vec::new(),
-        );
+        // The caller validated every input exists, so a missing table here is
+        // unexpected. Fail closed: an empty output would let the install delete
+        // the source tables (this range may own input deletion) while producing
+        // no replacement SSTs. Returning an error makes the parallel caller
+        // re-show the inputs and skip the install entirely.
+        return Err(crate::Error::Io(std::io::Error::other(
+            "sub-compaction input tables disappeared mid-flight",
+        )));
     };
 
     merge_iter = merge_iter
@@ -422,7 +433,9 @@ fn run_subcompaction(
         &filter_ctx,
     ));
 
-    let table_writer = super::flavour::prepare_table_writer(version, opts, payload)?;
+    // block_parallel = false: this sub-compaction already runs on a pool thread,
+    // so its block compression must stay serial (nested-pool deadlock otherwise).
+    let table_writer = super::flavour::prepare_table_writer(version, opts, payload, false)?;
     let mut compactor: Box<dyn CompactionFlavour> =
         Box::new(StandardCompaction::new(table_writer, tables_for_deletion));
 
@@ -441,15 +454,17 @@ fn run_subcompaction(
             .rate_limiter
             .request_interruptible(io_bytes, || opts.stop_signal.is_stopped())
         {
-            log::debug!("Stopping sub-compaction because of stop signal (I/O throttle)");
-            break;
+            // Abort, do not produce: a truncated sub-range would be installed
+            // atomically alongside its siblings, dropping the unwritten tail of
+            // this range (a gap in the middle of the key space). The error makes
+            // the caller re-show the inputs and skip the install.
+            return Err(cancelled_compaction());
         }
 
         compactor.write(item)?;
 
         if idx % 1_000_000 == 0 && opts.stop_signal.is_stopped() {
-            log::debug!("Stopping sub-compaction because of stop signal");
-            break;
+            return Err(cancelled_compaction());
         }
     }
 
@@ -651,7 +666,9 @@ fn merge_tables(
         return Ok(CompactionResult::nothing());
     }
 
-    let current_super_version = version_history_lock.latest_version();
+    // Arc so the snapshot can be shared with sub-compactions running on the
+    // configured compaction pool (fire-and-forget executor needs `'static`).
+    let current_super_version = Arc::new(version_history_lock.latest_version());
 
     let Some(tables) = payload
         .table_ids
@@ -729,65 +746,92 @@ fn merge_tables(
                 .hide(payload.table_ids.iter().copied());
             drop(compaction_state);
 
-            // First range runs on this thread; the rest on scoped workers. Only
-            // the first carries the input tables to delete, so they are dropped
-            // exactly once at install.
+            // Run the sub-compactions on the configured compaction pool (NOT raw
+            // threads), so a caller-shared pool bounds total threads across
+            // trees. The executor is fire-and-forget + `'static`, so each task
+            // owns an Arc'd snapshot of the context; results come back over an
+            // mpsc channel, indexed by range. Only range 0 carries the input
+            // tables to delete, so they are dropped exactly once at install. No
+            // pool configured (e.g. caller injected none) → run sequentially.
             let num_ranges = ranges.len();
-            // `ranges_from_boundaries` always emits at least two ranges when
-            // boundaries is non-empty (checked above), so split_first is Some.
-            let Some((first_range, rest_ranges)) = ranges.split_first() else {
-                unreachable!("non-empty boundaries yield >= 2 ranges");
-            };
+            let only_first_owns_inputs =
+                |idx: usize| if idx == 0 { tables.clone() } else { Vec::new() };
 
             let outputs: Vec<crate::Result<super::flavour::ProducedOutput>> =
-                std::thread::scope(|scope| {
-                    let version = &current_super_version.version;
-                    let rts = input_range_tombstones.as_slice();
-                    let blobs_dir = blobs_folder.as_path();
+                if let Some(spawner) = opts.config.compaction_pool.clone() {
+                    let opts = Arc::new(opts.clone());
+                    let payload = Arc::new(payload.clone());
+                    let version = Arc::clone(&current_super_version);
+                    let rts = Arc::new(input_range_tombstones.clone());
+                    let blobs = Arc::new(blobs_folder);
 
-                    let handles: Vec<_> = rest_ranges
-                        .iter()
-                        .map(|range| {
-                            let range = range.clone();
-                            scope.spawn(move || {
-                                run_subcompaction(
-                                    opts,
-                                    payload,
-                                    version,
-                                    Vec::new(),
-                                    rts,
-                                    range,
-                                    dst_lvl,
-                                    is_last_level,
-                                    blobs_dir,
-                                )
-                            })
-                        })
-                        .collect();
-
-                    let first = run_subcompaction(
-                        opts,
-                        payload,
-                        version,
-                        tables.clone(),
-                        rts,
-                        first_range.clone(),
-                        dst_lvl,
-                        is_last_level,
-                        blobs_dir,
-                    );
-
-                    let mut outputs = Vec::with_capacity(num_ranges);
-                    outputs.push(first);
-                    for handle in handles {
-                        outputs.push(handle.join().unwrap_or_else(|_| {
-                            Err(crate::Error::Io(std::io::Error::other(
-                                "sub-compaction worker panicked",
-                            )))
+                    let (tx, rx) = std::sync::mpsc::channel();
+                    for (idx, range) in ranges.iter().cloned().enumerate() {
+                        let tx = tx.clone();
+                        let opts = Arc::clone(&opts);
+                        let payload = Arc::clone(&payload);
+                        let version = Arc::clone(&version);
+                        let rts = Arc::clone(&rts);
+                        let blobs = Arc::clone(&blobs);
+                        let tables_for_deletion = only_first_owns_inputs(idx);
+                        spawner.spawn(Box::new(move || {
+                            let out = run_subcompaction(
+                                &opts,
+                                &payload,
+                                &version.version,
+                                tables_for_deletion,
+                                &rts,
+                                range,
+                                dst_lvl,
+                                is_last_level,
+                                &blobs,
+                            );
+                            // The receiver outlives every send (it drains N
+                            // items below), so this cannot fail.
+                            let _ = tx.send((idx, out));
                         }));
                     }
-                    outputs
-                });
+                    drop(tx);
+
+                    let mut slots: Vec<Option<crate::Result<super::flavour::ProducedOutput>>> =
+                        (0..num_ranges).map(|_| None).collect();
+                    for (idx, out) in rx {
+                        if let Some(slot) = slots.get_mut(idx) {
+                            *slot = Some(out);
+                        }
+                    }
+                    slots
+                        .into_iter()
+                        .map(|slot| {
+                            slot.unwrap_or_else(|| {
+                                // A worker panicked before sending: treat as a
+                                // failed sub-compaction so install is skipped.
+                                Err(crate::Error::Io(std::io::Error::other(
+                                    "sub-compaction worker did not report a result",
+                                )))
+                            })
+                        })
+                        .collect()
+                } else {
+                    ranges
+                        .iter()
+                        .cloned()
+                        .enumerate()
+                        .map(|(idx, range)| {
+                            run_subcompaction(
+                                opts,
+                                payload,
+                                &current_super_version.version,
+                                only_first_owns_inputs(idx),
+                                &input_range_tombstones,
+                                range,
+                                dst_lvl,
+                                is_last_level,
+                                &blobs_folder,
+                            )
+                        })
+                        .collect()
+                };
 
             let outputs = outputs
                 .into_iter()
@@ -884,8 +928,9 @@ fn merge_tables(
         &filter_ctx,
     ));
 
+    // Serial (single-stream) compaction: block compression may use the pool.
     let table_writer =
-        super::flavour::prepare_table_writer(&current_super_version.version, opts, payload)?;
+        super::flavour::prepare_table_writer(&current_super_version.version, opts, payload, true)?;
 
     let start = Instant::now();
 

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -833,17 +833,37 @@ fn merge_tables(
                         .collect()
                 };
 
-            let outputs = outputs
-                .into_iter()
-                .collect::<crate::Result<Vec<_>>>()
-                .inspect_err(|e| {
-                    log::error!("Sub-compaction failed: {e:?}");
+            // Collect outputs keeping every successful one, so a single failed
+            // range can roll back the SSTs/blob files its succeeded siblings
+            // already finalized on disk (collecting straight into Result would
+            // drop those Ok outputs and leak their files). On the first error:
+            // mark the committed outputs deleted, un-hide the inputs, propagate.
+            let mut committed = Vec::with_capacity(outputs.len());
+            let mut first_err = None;
+            for out in outputs {
+                match out {
+                    Ok(done) => committed.push(done),
+                    Err(e) => {
+                        first_err = Some(e);
+                        break;
+                    }
+                }
+            }
+            if let Some(err) = first_err {
+                log::error!("Sub-compaction failed: {err:?}");
+                for done in &committed {
+                    done.rollback_uninstalled();
+                }
+                {
                     #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
                     let mut state = opts.compaction_state.lock().expect("lock is poisoned");
                     state
                         .hidden_set_mut()
                         .show(payload.table_ids.iter().copied());
-                })?;
+                }
+                return Err(err);
+            }
+            let outputs = committed;
 
             // Re-acquire locks and install one atomic version edit for all outputs.
             #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -302,7 +302,10 @@ fn subcompaction_boundaries(
         return Vec::new();
     }
     keys.sort_by(|a, b| comparator.compare(a, b));
-    keys.dedup();
+    // Dedup under the configured comparator, not raw bytes: a custom comparator
+    // can rank two byte-distinct keys as equal, and a leftover equal cut point
+    // would make adjacent sub-compaction ranges overlap or gap.
+    keys.dedup_by(|a, b| comparator.compare(a, b).is_eq());
     // The global maximum is not a cut point (splitting after it yields an empty
     // trailing range); the rest are interior boundaries.
     keys.pop();
@@ -854,9 +857,12 @@ fn merge_tables(
             for out in outputs {
                 match out {
                     Ok(done) => committed.push(done),
+                    // Keep scanning after an error: ranges complete in any order,
+                    // so a later Ok must still be collected and rolled back (an
+                    // [Ok, Err, Ok] layout would otherwise orphan the trailing
+                    // Ok's finalized files). Keep only the first error to return.
                     Err(e) => {
-                        first_err = Some(e);
-                        break;
+                        first_err.get_or_insert(e);
                     }
                 }
             }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -399,6 +399,19 @@ fn run_subcompaction(
 ) -> crate::Result<super::flavour::ProducedOutput> {
     use super::flavour::CompactionFlavour;
 
+    // Test-only failpoint: the first range to observe an armed flag fails (and
+    // disarms it), so exactly one sub-compaction errors while its siblings
+    // succeed — deterministically driving the rollback path that marks the
+    // siblings' finalized files deleted and restores the hidden inputs.
+    #[cfg(test)]
+    if opts
+        .config
+        .fail_one_subcompaction
+        .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+        return Err(cancelled_compaction());
+    }
+
     let mut blob_frag_map = FragmentationMap::default();
 
     let to_compact = payload.table_ids.iter().copied().collect::<Vec<_>>();
@@ -1353,6 +1366,81 @@ mod tests {
             Some(&b'a'),
             "the surviving boundary should be from the deduped a-group",
         );
+    }
+
+    /// A failing sub-compaction range must abort the whole compaction, roll
+    /// back the finalized files of the ranges that DID succeed, and restore the
+    /// hidden input tables — leaving the tree fully readable with nothing
+    /// partially installed. Drives the parallel rollback path via the test
+    /// failpoint (one range errors, its siblings succeed and are rolled back).
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn failed_subcompaction_rolls_back_and_restores_inputs() -> crate::Result<()> {
+        use std::sync::atomic::Ordering;
+
+        const N: u64 = 4_000;
+        let key = |i: u64| format!("key_{i:08}");
+        let val = |i: u64, generation: u64| format!("g{generation}-{i}-{}", "x".repeat(40));
+
+        let dir = tempfile::tempdir()?;
+        let config = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_size_policy(BlockSizePolicy::all(512))
+        .compaction_threads(4)
+        .subcompaction_min_bytes(0)
+        // KV separation so the surviving sub-compactions also produce blob
+        // files, exercising the blob-file arm of the rollback as well.
+        .with_kv_separation(Some(
+            KvSeparationOptions::default().separation_threshold(16),
+        ));
+        // Share the failpoint handle before the config is consumed by open().
+        let failpoint = config.fail_one_subcompaction.clone();
+        let tree = config.open()?;
+
+        // Populate the bottom level with several tables (the split boundaries).
+        for i in 0..N {
+            tree.insert(key(i), val(i, 0), i);
+        }
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(4_096, 0)?;
+
+        // Overwrite the whole keyspace into L0; the next compaction merges it
+        // into the populated bottom and splits into parallel sub-compactions.
+        for i in 0..N {
+            tree.insert(key(i), val(i, 1), N + i);
+        }
+        tree.flush_active_memtable(0)?;
+        let tables_before = tree.table_count();
+
+        // Arm: exactly one sub-compaction range will error.
+        failpoint.store(true, Ordering::SeqCst);
+        let result = tree.major_compact(u64::MAX, 0);
+
+        assert!(
+            result.is_err(),
+            "a failing sub-compaction range must abort the compaction",
+        );
+        assert!(
+            !failpoint.load(Ordering::SeqCst),
+            "the failpoint should have fired and disarmed itself",
+        );
+        assert_eq!(
+            tree.table_count(),
+            tables_before,
+            "rollback must leave nothing partially installed",
+        );
+        for i in 0..N {
+            assert_eq!(
+                tree.get(key(i), crate::MAX_SEQNO)?.as_deref(),
+                Some(val(i, 1).as_bytes()),
+                "value for {} must survive the rolled-back compaction",
+                key(i),
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -249,7 +249,7 @@ fn create_compaction_stream<'a>(
 #[cfg(feature = "std")]
 fn create_bounded_compaction_stream<'a>(
     version: &'a Version,
-    to_compact: &[TableId],
+    to_compact: &HashSet<TableId>,
     bounds: (std::ops::Bound<UserKey>, std::ops::Bound<UserKey>),
     eviction_seqno: SeqNo,
     merge_operator: Option<Arc<dyn crate::merge_operator::MergeOperator>>,
@@ -414,11 +414,9 @@ fn run_subcompaction(
 
     let mut blob_frag_map = FragmentationMap::default();
 
-    let to_compact = payload.table_ids.iter().copied().collect::<Vec<_>>();
-
     let Some(mut merge_iter) = create_bounded_compaction_stream(
         version,
-        &to_compact,
+        &payload.table_ids,
         bounds,
         opts.mvcc_gc_watermark,
         opts.config.merge_operator.clone(),
@@ -916,6 +914,9 @@ fn merge_tables(
             let tables_out =
                 super::flavour::install_merge(&mut version_history_lock, opts, payload, outputs)
                     .inspect_err(|e| {
+                        // install_merge marks its own created tables/blob files
+                        // deleted if the version edit fails, so the caller only
+                        // restores the hidden inputs here (the outputs are gone).
                         log::error!("Sub-compaction install failed: {e:?}");
                         compaction_state
                             .hidden_set_mut()

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -5,7 +5,7 @@
 use super::{CompactionAction, CompactionResult, CompactionStrategy, Input as CompactionPayload};
 use crate::{
     BlobFile, Config, HashSet, InternalValue, SeqNo, SequenceNumberCounter,
-    SharedSequenceNumberGenerator, Table, TableId,
+    SharedSequenceNumberGenerator, Table, TableId, UserKey,
     blob_tree::FragmentationMap,
     compaction::{
         Choice,
@@ -31,6 +31,14 @@ use std::{
 use crate::metrics::Metrics;
 
 pub type CompactionReader<'a> = Box<dyn Iterator<Item = crate::Result<InternalValue>> + 'a>;
+
+/// Minimum total input size for a compaction to be split into parallel
+/// sub-compactions. Below this the per-thread setup + the extra output tables
+/// (one per sub-range) cost more than the parallelism buys, so the compaction
+/// stays single-threaded (which also keeps small/test compactions producing a
+/// single merged table). Default for [`Config::subcompaction_min_bytes`].
+#[cfg(feature = "std")]
+pub const SUBCOMPACTION_MIN_INPUT_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Compaction options
 pub struct Options {
@@ -228,6 +236,233 @@ fn create_compaction_stream<'a>(
     } else {
         None
     })
+}
+
+/// Like [`create_compaction_stream`] but restricts every input table to the key
+/// range `bounds`, used by parallel sub-compactions where each thread owns a
+/// disjoint slice of the key space. Each input table is read via
+/// [`crate::Table::range`] (a raw, all-seqno, key-bounded scan that seeks within
+/// the table), so a sub-compaction only touches the blocks overlapping its
+/// slice. The bounds must partition the key space across sub-compactions
+/// (`Included(lo)..Excluded(hi)`) so every entry lands in exactly one.
+#[cfg(feature = "std")]
+fn create_bounded_compaction_stream<'a>(
+    version: &'a Version,
+    to_compact: &[TableId],
+    bounds: (std::ops::Bound<UserKey>, std::ops::Bound<UserKey>),
+    eviction_seqno: SeqNo,
+    merge_operator: Option<Arc<dyn crate::merge_operator::MergeOperator>>,
+    comparator: crate::comparator::SharedComparator,
+) -> Option<CompactionStream<'a, Merger<CompactionReader<'a>>>> {
+    let mut readers: Vec<CompactionReader<'_>> = vec![];
+    let mut found = 0;
+
+    for run in version.iter_levels().flat_map(|lvl| lvl.iter()) {
+        for table in run.iter().filter(|x| to_compact.contains(&x.metadata.id)) {
+            found += 1;
+            readers.push(Box::new(table.range(bounds.clone())));
+        }
+    }
+
+    if found == to_compact.len() {
+        Some(
+            CompactionStream::new(Merger::new(readers, comparator), eviction_seqno)
+                .with_merge_operator(merge_operator),
+        )
+    } else {
+        None
+    }
+}
+
+/// Interior split-boundary keys for a parallel compaction, derived from the
+/// destination level's existing table boundaries (`RocksDB`'s approach: aligning
+/// sub-compaction cuts to target-level files keeps outputs structured). Returns
+/// at most `max_ranges - 1` keys (evenly sampled), sorted by `comparator`.
+/// Empty → the compaction stays single-threaded (no usable cut points).
+#[cfg(feature = "std")]
+fn subcompaction_boundaries(
+    version: &Version,
+    dest_level: usize,
+    max_ranges: usize,
+    comparator: &crate::comparator::SharedComparator,
+) -> Vec<UserKey> {
+    if max_ranges < 2 {
+        return Vec::new();
+    }
+    let Some(level) = version.level(dest_level) else {
+        return Vec::new();
+    };
+    let mut keys: Vec<UserKey> = level
+        .iter()
+        .flat_map(|run| run.iter())
+        .map(|t| t.metadata.key_range.max().clone())
+        .collect();
+    if keys.len() < 2 {
+        return Vec::new();
+    }
+    keys.sort_by(|a, b| comparator.compare(a, b));
+    keys.dedup();
+    // The global maximum is not a cut point (splitting after it yields an empty
+    // trailing range); the rest are interior boundaries.
+    keys.pop();
+    if keys.is_empty() {
+        return Vec::new();
+    }
+    let want = (max_ranges - 1).min(keys.len());
+    if want == keys.len() {
+        return keys;
+    }
+    // Evenly sample `want` boundaries across the candidates.
+    let mut out = Vec::with_capacity(want);
+    for i in 1..=want {
+        let idx = ((i * keys.len()) / (want + 1)).min(keys.len() - 1);
+        if let Some(key) = keys.get(idx) {
+            out.push(key.clone());
+        }
+    }
+    out.dedup();
+    out
+}
+
+/// Turns interior boundary keys into `boundaries.len() + 1` disjoint key ranges
+/// that partition the whole key space: `(Unbounded, Excluded(b0))`,
+/// `[Included(b_i), Excluded(b_{i+1}))`, …, `[Included(b_last), Unbounded)`.
+/// Every entry falls in exactly one range, so the sub-compaction outputs union
+/// to the same set the serial compaction would produce.
+#[cfg(feature = "std")]
+fn ranges_from_boundaries(
+    boundaries: &[UserKey],
+) -> Vec<(std::ops::Bound<UserKey>, std::ops::Bound<UserKey>)> {
+    use std::ops::Bound::{Excluded, Included, Unbounded};
+    let mut ranges = Vec::with_capacity(boundaries.len() + 1);
+    let mut lo = Unbounded;
+    for b in boundaries {
+        ranges.push((lo.clone(), Excluded(b.clone())));
+        lo = Included(b.clone());
+    }
+    ranges.push((lo, Unbounded));
+    ranges
+}
+
+/// Runs one sub-compaction over the key range `bounds`: builds a bounded merge
+/// stream of the inputs, applies the same transforms as the serial path
+/// (tombstone eviction, KV-separation drop tracking, compaction filter), writes
+/// its output SSTs, and returns a [`ProducedOutput`](super::flavour::ProducedOutput)
+/// WITHOUT installing a version edit (the caller merges all outputs into one).
+/// Only the sub-compaction that `owns_input_deletion` carries the input tables
+/// to be dropped, so the shared inputs are marked deleted exactly once.
+#[cfg(feature = "std")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "a sub-compaction needs the full compaction context (opts, payload, \
+              version, inputs, range, level info, blob folder) threaded in by value/ref \
+              so it can run on its own thread; bundling into a struct would just move \
+              the argument list"
+)]
+fn run_subcompaction(
+    opts: &Options,
+    payload: &CompactionPayload,
+    version: &Version,
+    tables_for_deletion: Vec<Table>,
+    input_range_tombstones: &[crate::range_tombstone::RangeTombstone],
+    bounds: (std::ops::Bound<UserKey>, std::ops::Bound<UserKey>),
+    dst_lvl: usize,
+    is_last_level: bool,
+    blobs_folder: &std::path::Path,
+) -> crate::Result<super::flavour::ProducedOutput> {
+    use super::flavour::CompactionFlavour;
+
+    let mut blob_frag_map = FragmentationMap::default();
+
+    let to_compact = payload.table_ids.iter().copied().collect::<Vec<_>>();
+
+    let Some(mut merge_iter) = create_bounded_compaction_stream(
+        version,
+        &to_compact,
+        bounds,
+        opts.mvcc_gc_watermark,
+        opts.config.merge_operator.clone(),
+        opts.config.comparator.clone(),
+    ) else {
+        // Inputs vanished mid-flight (validated by the caller, so unexpected):
+        // emit an empty output rather than corrupting the merge.
+        let table_writer = super::flavour::prepare_table_writer(version, opts, payload)?;
+        return Box::new(StandardCompaction::new(table_writer, tables_for_deletion)).produce(
+            opts,
+            dst_lvl,
+            blob_frag_map,
+            Vec::new(),
+        );
+    };
+
+    merge_iter = merge_iter
+        .evict_tombstones(is_last_level)
+        .zero_seqnos(false);
+
+    let filter_ctx = Context { is_last_level };
+    let mut compaction_filter = opts
+        .config
+        .compaction_filter_factory
+        .as_ref()
+        .map(|f| f.make_filter(&filter_ctx));
+
+    // KV separation (no relocation on this path): track fragmentation from
+    // dropped/GC'd entries so the merged install updates blob GC stats.
+    if opts.config.kv_separation_opts.is_some() {
+        merge_iter = merge_iter.with_drop_callback(&mut blob_frag_map);
+    }
+
+    let mut filter_blob_writer = None;
+    let merge_iter = merge_iter.with_filter(StreamFilterAdapter::new(
+        compaction_filter.as_deref_mut(),
+        opts,
+        version,
+        blobs_folder,
+        &mut filter_blob_writer,
+        &filter_ctx,
+    ));
+
+    let table_writer = super::flavour::prepare_table_writer(version, opts, payload)?;
+    let mut compactor: Box<dyn CompactionFlavour> =
+        Box::new(StandardCompaction::new(table_writer, tables_for_deletion));
+
+    // Propagate range tombstones to this sub-range's output; the writer clips
+    // them to each output table's key range (a boundary-spanning RT is written
+    // clipped on both sides, which is correct).
+    if !input_range_tombstones.is_empty() {
+        compactor.write_range_tombstones(input_range_tombstones);
+    }
+
+    for (idx, item) in merge_iter.enumerate() {
+        let item = item?;
+
+        let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
+        if opts
+            .rate_limiter
+            .request_interruptible(io_bytes, || opts.stop_signal.is_stopped())
+        {
+            log::debug!("Stopping sub-compaction because of stop signal (I/O throttle)");
+            break;
+        }
+
+        compactor.write(item)?;
+
+        if idx % 1_000_000 == 0 && opts.stop_signal.is_stopped() {
+            log::debug!("Stopping sub-compaction because of stop signal");
+            break;
+        }
+    }
+
+    if let Some(filter) = compaction_filter {
+        filter.finish();
+    }
+
+    let extra_blob_files = filter_blob_writer
+        .map(BlobFileWriter::finish)
+        .transpose()?
+        .unwrap_or_default();
+
+    compactor.produce(opts, dst_lvl, blob_frag_map, extra_blob_files)
 }
 
 #[expect(
@@ -442,6 +677,166 @@ fn merge_tables(
         .collect();
     input_range_tombstones.sort();
     input_range_tombstones.dedup();
+
+    // ---- Parallel sub-compaction (std only) ----
+    // A non-relocating compaction can be split into disjoint key ranges that
+    // compact in parallel — each writes its own SSTs, then all merge into one
+    // atomic version edit. Active blob relocation stays single-threaded and
+    // falls through to the serial path below.
+    #[cfg(feature = "std")]
+    {
+        let threads = opts.config.compaction_threads;
+        let dst_lvl: usize = payload.canonical_level.into();
+        let is_last_level = payload.dest_level == opts.config.level_count - 1;
+
+        // Only KV-separated trees with fragmented blob files relocate; that
+        // path is not split here.
+        let relocating = match &opts.config.kv_separation_opts {
+            Some(blob_opts) => !pick_blob_files_to_rewrite(
+                &payload.table_ids,
+                &current_super_version.version,
+                blob_opts,
+            )?
+            .is_empty(),
+            None => false,
+        };
+
+        let total_input_bytes: u64 = tables.iter().map(Table::file_size).sum();
+
+        let boundaries = if threads > 1
+            && !relocating
+            && total_input_bytes >= opts.config.subcompaction_min_bytes
+        {
+            subcompaction_boundaries(
+                &current_super_version.version,
+                payload.dest_level as usize,
+                threads,
+                &opts.config.comparator,
+            )
+        } else {
+            Vec::new()
+        };
+
+        if !boundaries.is_empty() {
+            let blobs_folder = opts.config.path.join(BLOBS_FOLDER);
+            let ranges = ranges_from_boundaries(&boundaries);
+
+            // Hand off: hide inputs, release the exclusive + version locks for
+            // the CPU-heavy parallel phase.
+            drop(version_history_lock);
+            compaction_state
+                .hidden_set_mut()
+                .hide(payload.table_ids.iter().copied());
+            drop(compaction_state);
+
+            // First range runs on this thread; the rest on scoped workers. Only
+            // the first carries the input tables to delete, so they are dropped
+            // exactly once at install.
+            let num_ranges = ranges.len();
+            // `ranges_from_boundaries` always emits at least two ranges when
+            // boundaries is non-empty (checked above), so split_first is Some.
+            let Some((first_range, rest_ranges)) = ranges.split_first() else {
+                unreachable!("non-empty boundaries yield >= 2 ranges");
+            };
+
+            let outputs: Vec<crate::Result<super::flavour::ProducedOutput>> =
+                std::thread::scope(|scope| {
+                    let version = &current_super_version.version;
+                    let rts = input_range_tombstones.as_slice();
+                    let blobs_dir = blobs_folder.as_path();
+
+                    let handles: Vec<_> = rest_ranges
+                        .iter()
+                        .map(|range| {
+                            let range = range.clone();
+                            scope.spawn(move || {
+                                run_subcompaction(
+                                    opts,
+                                    payload,
+                                    version,
+                                    Vec::new(),
+                                    rts,
+                                    range,
+                                    dst_lvl,
+                                    is_last_level,
+                                    blobs_dir,
+                                )
+                            })
+                        })
+                        .collect();
+
+                    let first = run_subcompaction(
+                        opts,
+                        payload,
+                        version,
+                        tables.clone(),
+                        rts,
+                        first_range.clone(),
+                        dst_lvl,
+                        is_last_level,
+                        blobs_dir,
+                    );
+
+                    let mut outputs = Vec::with_capacity(num_ranges);
+                    outputs.push(first);
+                    for handle in handles {
+                        outputs.push(handle.join().unwrap_or_else(|_| {
+                            Err(crate::Error::Io(std::io::Error::other(
+                                "sub-compaction worker panicked",
+                            )))
+                        }));
+                    }
+                    outputs
+                });
+
+            let outputs = outputs
+                .into_iter()
+                .collect::<crate::Result<Vec<_>>>()
+                .inspect_err(|e| {
+                    log::error!("Sub-compaction failed: {e:?}");
+                    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+                    let mut state = opts.compaction_state.lock().expect("lock is poisoned");
+                    state
+                        .hidden_set_mut()
+                        .show(payload.table_ids.iter().copied());
+                })?;
+
+            // Re-acquire locks and install one atomic version edit for all outputs.
+            #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+            let mut compaction_state = opts.compaction_state.lock().expect("lock is poisoned");
+            #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+            let mut version_history_lock = opts.version_history.write().expect("lock is poisoned");
+
+            let tables_out =
+                super::flavour::install_merge(&mut version_history_lock, opts, payload, outputs)
+                    .inspect_err(|e| {
+                        log::error!("Sub-compaction install failed: {e:?}");
+                        compaction_state
+                            .hidden_set_mut()
+                            .show(payload.table_ids.iter().copied());
+                    })?;
+
+            compaction_state
+                .hidden_set_mut()
+                .show(payload.table_ids.iter().copied());
+
+            version_history_lock
+                .maintenance(&opts.config.path, opts.mvcc_gc_watermark, &*opts.config.fs)
+                .inspect_err(|e| log::error!("Manifest maintenance failed: {e:?}"))?;
+
+            drop(version_history_lock);
+            drop(compaction_state);
+
+            log::trace!("Parallel compaction done in {num_ranges} sub-ranges");
+
+            return Ok(CompactionResult {
+                action: CompactionAction::Merged,
+                dest_level: Some(payload.dest_level),
+                tables_in,
+                tables_out,
+            });
+        }
+    }
 
     let mut blob_frag_map = FragmentationMap::default();
 

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -477,7 +477,18 @@ fn run_subcompaction(
         .transpose()?
         .unwrap_or_default();
 
-    compactor.produce(opts, dst_lvl, blob_frag_map, extra_blob_files)
+    // produce() consumes the (already finalized on disk) filter blob files; if
+    // it fails, mark them deleted so they are not orphaned. The parallel caller
+    // rolls back sibling outputs on error but cannot reach this range's own
+    // filter blobs, so clean them up here.
+    let rollback_extra_blob_files = extra_blob_files.clone();
+    compactor
+        .produce(opts, dst_lvl, blob_frag_map, extra_blob_files)
+        .inspect_err(|_| {
+            for blob_file in &rollback_extra_blob_files {
+                blob_file.mark_as_deleted();
+            }
+        })
 }
 
 #[expect(

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -275,6 +275,28 @@ fn create_bounded_compaction_stream<'a>(
     }
 }
 
+/// Sorts the destination-level max-keys, drops comparator-equal duplicates, and
+/// removes the global maximum (splitting after it yields an empty trailing
+/// range), returning the candidate interior boundary keys. Split out of
+/// [`subcompaction_boundaries`] so the comparator-equality dedup is unit
+/// testable without constructing a full [`Version`].
+#[cfg(feature = "std")]
+fn boundary_candidates(
+    mut keys: Vec<UserKey>,
+    comparator: &crate::comparator::SharedComparator,
+) -> Vec<UserKey> {
+    if keys.len() < 2 {
+        return Vec::new();
+    }
+    keys.sort_by(|a, b| comparator.compare(a, b));
+    // Dedup under the configured comparator, not raw bytes: a custom comparator
+    // can rank two byte-distinct keys as equal, and a leftover equal cut point
+    // would make adjacent sub-compaction ranges overlap or gap.
+    keys.dedup_by(|a, b| comparator.compare(a, b).is_eq());
+    keys.pop();
+    keys
+}
+
 /// Interior split-boundary keys for a parallel compaction, derived from the
 /// destination level's existing table boundaries (`RocksDB`'s approach: aligning
 /// sub-compaction cuts to target-level files keeps outputs structured). Returns
@@ -293,22 +315,12 @@ fn subcompaction_boundaries(
     let Some(level) = version.level(dest_level) else {
         return Vec::new();
     };
-    let mut keys: Vec<UserKey> = level
+    let keys: Vec<UserKey> = level
         .iter()
         .flat_map(|run| run.iter())
         .map(|t| t.metadata.key_range.max().clone())
         .collect();
-    if keys.len() < 2 {
-        return Vec::new();
-    }
-    keys.sort_by(|a, b| comparator.compare(a, b));
-    // Dedup under the configured comparator, not raw bytes: a custom comparator
-    // can rank two byte-distinct keys as equal, and a leftover equal cut point
-    // would make adjacent sub-compaction ranges overlap or gap.
-    keys.dedup_by(|a, b| comparator.compare(a, b).is_eq());
-    // The global maximum is not a cut point (splitting after it yields an empty
-    // trailing range); the rest are interior boundaries.
-    keys.pop();
+    let keys = boundary_candidates(keys, comparator);
     if keys.is_empty() {
         return Vec::new();
     }
@@ -1303,6 +1315,45 @@ mod tests {
     };
     use std::sync::Arc;
     use test_log::test;
+
+    /// Ranks keys by their first byte only, so byte-distinct keys that share a
+    /// first byte compare equal — exercises the comparator-aware dedup path that
+    /// raw `dedup()` would miss.
+    struct FirstByteComparator;
+    impl crate::comparator::UserComparator for FirstByteComparator {
+        fn name(&self) -> &'static str {
+            "test-first-byte"
+        }
+
+        fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+            a.first().cmp(&b.first())
+        }
+    }
+
+    #[test]
+    fn boundary_candidates_dedups_comparator_equal_keys() {
+        let cmp: crate::comparator::SharedComparator = Arc::new(FirstByteComparator);
+        // "a1" and "a2" are byte-distinct but compare equal under the first-byte
+        // comparator; "b1" is in a different group. Raw dedup() would keep both
+        // a-keys (not byte-identical) and, after popping the global max, leave
+        // two boundaries in the "a" group → overlapping sub-compaction ranges.
+        let keys = vec![
+            crate::UserKey::from("a1"),
+            crate::UserKey::from("a2"),
+            crate::UserKey::from("b1"),
+        ];
+        let out = super::boundary_candidates(keys, &cmp);
+        assert_eq!(
+            out.len(),
+            1,
+            "comparator-equal keys must collapse to a single boundary candidate",
+        );
+        assert_eq!(
+            out.first().and_then(|k| k.first()),
+            Some(&b'a'),
+            "the surviving boundary should be from the deduped a-group",
+        );
+    }
 
     #[test]
     fn compaction_stream_run_not_found() -> crate::Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -538,6 +538,15 @@ pub struct Config {
     #[cfg(feature = "std")]
     pub(crate) compaction_pool: Option<Arc<dyn crate::table::writer::CompactionSpawner>>,
 
+    /// Minimum total input size (bytes) for a compaction to be split into
+    /// parallel sub-compactions. Below it the compaction stays single-threaded
+    /// (per-thread setup + extra output tables outweigh the parallelism on small
+    /// compactions). Default
+    /// [`SUBCOMPACTION_MIN_INPUT_BYTES`](crate::compaction::worker::SUBCOMPACTION_MIN_INPUT_BYTES)
+    /// (8 MiB). Set via [`Config::subcompaction_min_bytes`].
+    #[cfg(feature = "std")]
+    pub(crate) subcompaction_min_bytes: u64,
+
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
     /// When set together with a [`CompressionType::ZstdDict`] compression
@@ -654,6 +663,8 @@ impl Default for Config {
                 .map_or(1, |n| (n.get() / 2).max(1)),
             #[cfg(feature = "std")]
             compaction_pool: None,
+            #[cfg(feature = "std")]
+            subcompaction_min_bytes: crate::compaction::worker::SUBCOMPACTION_MIN_INPUT_BYTES,
         }
     }
 }
@@ -1381,6 +1392,17 @@ impl Config {
         // Clamp to >= 1: the documented semantics treat `1` as "serial", and a
         // 0-thread pool would be an invalid state.
         self.compaction_threads = threads.max(1);
+        self
+    }
+
+    /// Sets the minimum total input size (bytes) for a compaction to be split
+    /// into parallel sub-compactions. Default 8 MiB. `0` splits every eligible
+    /// compaction; a large value effectively disables sub-compaction (block
+    /// compression still parallelizes via [`Self::compaction_threads`]).
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn subcompaction_min_bytes(mut self, bytes: u64) -> Self {
+        self.subcompaction_min_bytes = bytes;
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -521,11 +521,14 @@ pub struct Config {
     /// [`Config::compaction_rate_limit`].
     pub(crate) compaction_rate_limit: u64,
 
-    /// Worker-thread count for the parallel block-compression pipeline used
-    /// during compaction. Default `max(1, available_parallelism / 2)` — leaves
-    /// half the cores for application work. `1` (or no `parallel` feature) keeps
-    /// compaction on the serial path. Sizes the per-tree default pool built at
-    /// open when [`Self::compaction_pool`] is `None`. Set via
+    /// Worker-thread count for compaction parallelism (`std` only), used two
+    /// ways: it sizes the per-tree block-compression pool built at open when
+    /// [`Self::compaction_pool`] is `None`, and it caps how many range-parallel
+    /// sub-compactions a single compaction is split into. Default
+    /// `max(1, available_parallelism / 2)` — leaves half the cores for
+    /// application work. `1` forces the serial path for both. Without the
+    /// `parallel` feature there is no built-in pool, so block compression and
+    /// sub-compaction ranges run serially even for a value > 1. Set via
     /// [`Config::compaction_threads`].
     #[cfg(feature = "std")] // no-std: parallel compaction unavailable (no threads)
     pub(crate) compaction_threads: usize,
@@ -1380,12 +1383,14 @@ impl Config {
         self
     }
 
-    /// Sets the compaction parallel-compression worker-thread count.
+    /// Sets the compaction worker-thread count.
     ///
-    /// Sizes the per-tree pool built at open when no shared pool is supplied
-    /// (see [`Self::compaction_pool`]). `1` keeps compaction serial. Default is
-    /// `max(1, available_parallelism / 2)`. Ignored without the `parallel`
-    /// feature (no built-in pool to size).
+    /// Under `std` this both sizes the per-tree block-compression pool built at
+    /// open when no shared pool is supplied (see [`Self::compaction_pool`]) and
+    /// caps how many range-parallel sub-compactions a compaction splits into.
+    /// `1` keeps compaction serial. Default is `max(1, available_parallelism /
+    /// 2)`. Without the `parallel` feature there is no built-in pool, so the
+    /// work runs serially even for a value > 1.
     #[cfg(feature = "std")]
     #[must_use]
     pub fn compaction_threads(mut self, threads: usize) -> Self {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -550,6 +550,13 @@ pub struct Config {
     #[cfg(feature = "std")]
     pub(crate) subcompaction_min_bytes: u64,
 
+    /// Test-only failpoint: when armed, the first parallel sub-compaction range
+    /// that observes it returns an error and disarms it, so the crash-safety
+    /// rollback paths (sibling output rollback, input restore) can be exercised
+    /// deterministically. Behind `cfg(test)`, never compiled into release builds.
+    #[cfg(all(test, feature = "std"))]
+    pub(crate) fail_one_subcompaction: Arc<std::sync::atomic::AtomicBool>,
+
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
     /// When set together with a [`CompressionType::ZstdDict`] compression
@@ -668,6 +675,8 @@ impl Default for Config {
             compaction_pool: None,
             #[cfg(feature = "std")]
             subcompaction_min_bytes: crate::compaction::worker::SUBCOMPACTION_MIN_INPUT_BYTES,
+            #[cfg(all(test, feature = "std"))]
+            fail_one_subcompaction: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 }

--- a/tests/sub_compaction.rs
+++ b/tests/sub_compaction.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Parallel sub-compaction correctness: a compaction split into disjoint key
+//! ranges across worker threads must produce exactly the same logical content
+//! as a single-threaded compaction. A split-boundary off-by-one would silently
+//! lose or duplicate keys, so this compares every key against the serial path
+//! and confirms the split actually happened (more output tables than serial).
+
+#![cfg(feature = "std")]
+#![expect(clippy::unwrap_used, reason = "test code")]
+
+use lsm_tree::config::{BlockSizePolicy, KvSeparationOptions};
+use lsm_tree::{AbstractTree, AnyTree, Config, MAX_SEQNO, SequenceNumberCounter};
+use tempfile::{TempDir, tempdir};
+use test_log::test;
+
+const N: u64 = 4_000;
+
+fn key_for(i: u64) -> String {
+    format!("key_{i:08}")
+}
+
+fn value_for(i: u64, generation: u64) -> String {
+    // Padded so blocks fill quickly (many blocks per table) and, with KV
+    // separation on, the value clears the separation threshold.
+    format!("gen{generation}-value-{i}-{}", "padding".repeat(8))
+}
+
+/// Builds a tree, then runs a two-phase compaction:
+///   1. write generation 0, flush, compact with a small target so the bottom
+///      level ends up with several tables (the boundaries a later sub-compaction
+///      splits on);
+///   2. overwrite every key (generation 1), flush, then `major_compact` — which,
+///      with `threads > 1` and `min_bytes` low enough, splits across the
+///      bottom-level boundaries into parallel sub-compactions.
+fn build(threads: usize, min_bytes: u64, kv_separation: bool) -> (AnyTree, TempDir) {
+    let dir = tempdir().unwrap();
+    let config = Config::new(
+        &dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .compaction_threads(threads)
+    .subcompaction_min_bytes(min_bytes);
+
+    let config = if kv_separation {
+        config.with_kv_separation(Some(
+            KvSeparationOptions::default().separation_threshold(16),
+        ))
+    } else {
+        config
+    };
+
+    let tree = config.open().unwrap();
+
+    // Step 1: populate the bottom level with several tables (split boundaries).
+    for i in 0..N {
+        tree.insert(key_for(i), value_for(i, 0), i);
+    }
+    tree.flush_active_memtable(0).unwrap();
+    tree.major_compact(4_096, 0).unwrap();
+
+    // Step 2: overwrite everything, then compact into the populated bottom
+    // level — this is the compaction that splits when parallel.
+    for i in 0..N {
+        tree.insert(key_for(i), value_for(i, 1), N + i);
+    }
+    tree.flush_active_memtable(0).unwrap();
+    tree.major_compact(u64::MAX, 0).unwrap();
+
+    (tree, dir)
+}
+
+fn assert_parallel_matches_serial(kv_separation: bool) {
+    // Parallel: 4 threads, sub-compaction forced on (min size 0).
+    let (parallel, _dp) = build(4, 0, kv_separation);
+    // Serial baseline: single-threaded, sub-compaction disabled.
+    let (serial, _ds) = build(1, u64::MAX, kv_separation);
+
+    // Every key must read back the latest (generation 1) value on both engines.
+    for i in 0..N {
+        let key = key_for(i);
+        let expected = value_for(i, 1);
+
+        let p = parallel.get(&key, MAX_SEQNO).unwrap();
+        assert_eq!(
+            p.as_deref(),
+            Some(expected.as_bytes()),
+            "parallel: wrong/missing value for {key} (kv_separation={kv_separation})",
+        );
+
+        let s = serial.get(&key, MAX_SEQNO).unwrap();
+        assert_eq!(
+            s.as_deref(),
+            Some(expected.as_bytes()),
+            "serial: wrong/missing value for {key} (kv_separation={kv_separation})",
+        );
+    }
+
+    // Non-vacuous: the parallel compaction must actually have split into more
+    // output tables than the single-table serial compaction.
+    assert!(
+        parallel.table_count() > serial.table_count(),
+        "sub-compaction should split into multiple tables \
+         (parallel={}, serial={}, kv_separation={kv_separation})",
+        parallel.table_count(),
+        serial.table_count(),
+    );
+}
+
+#[test]
+fn sub_compaction_matches_serial_plain() {
+    assert_parallel_matches_serial(false);
+}
+
+#[test]
+fn sub_compaction_matches_serial_kv_separated() {
+    assert_parallel_matches_serial(true);
+}

--- a/tests/sub_compaction.rs
+++ b/tests/sub_compaction.rs
@@ -99,6 +99,14 @@ fn assert_parallel_matches_serial(kv_separation: bool) {
         );
     }
 
+    // Serial baseline: single-threaded major compaction into the bottom level
+    // with sub-compaction disabled produces exactly one merged table.
+    assert_eq!(
+        serial.table_count(),
+        1,
+        "serial baseline should produce a single merged table (kv_separation={kv_separation})",
+    );
+
     // Non-vacuous: the parallel compaction must actually have split into more
     // output tables than the single-table serial compaction.
     assert!(

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -887,6 +887,180 @@ fn compaction_variant(c: &mut Criterion, group_name: &str, level: i32) {
     group.finish();
 }
 
+/// High-entropy 256-byte value: an xorshift fill so zstd does real,
+/// parallelizable work during sub-compaction. The 0xAA `value_for`
+/// compresses to almost nothing, which would hide any compaction-CPU
+/// parallelism behind near-zero codec time.
+fn value_incompressible(i: u64) -> Vec<u8> {
+    let mut s = i.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut v = vec![0_u8; 256];
+    for chunk in v.chunks_mut(8) {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        let bytes = s.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+    v
+}
+
+/// Precomputed high-entropy workload for the sub-compaction head-to-head,
+/// built once per `n` outside the timing loop.
+struct SubcompactionInputs {
+    keys: Vec<[u8; 16]>,
+    values: Vec<Vec<u8>>,
+}
+
+impl SubcompactionInputs {
+    fn build(n_keys: u64) -> Self {
+        let n = usize::try_from(n_keys).expect("n_keys fits in usize");
+        let mut keys = Vec::with_capacity(n);
+        let mut values = Vec::with_capacity(n);
+        for i in 0..n_keys {
+            keys.push(key_for(i));
+            values.push(value_incompressible(i));
+        }
+        Self { keys, values }
+    }
+}
+
+/// Bottom-level target file size for the two-phase setup: small enough
+/// that the populated bottom level holds several tables — the boundaries
+/// the timed compaction splits on — on both engines.
+const SUBCOMPACTION_BOTTOM_TARGET: u64 = 1024 * 1024;
+/// Sub-compaction worker threads (ours: range-parallel split; RocksDB:
+/// `max_subcompactions`).
+const SUBCOMPACTION_THREADS: usize = 4;
+
+/// Times one range-parallel compaction: a full-keyspace overwrite (gen 1)
+/// merged into a pre-populated bottom level (gen 0). Only the second
+/// compaction is timed — the gen-0 populate and the gen-1 L0 writes are
+/// excluded. Ours forces the split (`subcompaction_min_bytes = 0`, so the
+/// populated bottom's table boundaries drive the range partition); RocksDB
+/// runs with `max_subcompactions = 4`, so the head-to-head isolates the
+/// range-parallel mechanism on both sides.
+fn run_subcompaction_bench(
+    engine: Engine,
+    level: i32,
+    inputs: &SubcompactionInputs,
+) -> Result<Duration, Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let total = inputs.keys.len() as u64;
+    // Flush the gen-1 overwrite into COMPACTION_FLUSHES L0 tables.
+    let flush_points: Vec<u64> = (1..COMPACTION_FLUSHES)
+        .map(|b| (b * total) / COMPACTION_FLUSHES)
+        .collect();
+
+    let elapsed = match engine {
+        Engine::Ours => {
+            let tree = Config::new(
+                dir.path(),
+                SequenceNumberCounter::default(),
+                SequenceNumberCounter::default(),
+            )
+            .data_block_compression_policy(CompressionPolicy::all(CompressionType::Zstd(level)))
+            .compaction_threads(SUBCOMPACTION_THREADS)
+            .subcompaction_min_bytes(0)
+            .open()?;
+
+            // Step 1: populate the bottom level with several tables.
+            for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
+                tree.insert(key, value, seqno);
+            }
+            tree.flush_active_memtable(0)?;
+            tree.major_compact(SUBCOMPACTION_BOTTOM_TARGET, 0)?;
+
+            // Step 2: overwrite the whole keyspace into fresh L0 tables.
+            let mut written = 0u64;
+            for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(total..) {
+                tree.insert(key, value, seqno);
+                written += 1;
+                if flush_points.contains(&written) {
+                    tree.flush_active_memtable(0)?;
+                }
+            }
+            tree.flush_active_memtable(0)?;
+
+            let start = std::time::Instant::now();
+            tree.major_compact(u64::MAX, 0)?;
+            start.elapsed()
+        }
+        Engine::RocksDb => {
+            let mut opts = rocksdb::Options::default();
+            opts.create_if_missing(true);
+            opts.set_disable_auto_compactions(true);
+            opts.set_compression_type(rocksdb::DBCompressionType::Zstd);
+            opts.set_compression_options(-14, level, 0, 0);
+            // Give RocksDB the matching parallelism knob + a small target file
+            // size so the bottom level also splits into several files.
+            opts.set_max_subcompactions(SUBCOMPACTION_THREADS as u32);
+            opts.set_target_file_size_base(SUBCOMPACTION_BOTTOM_TARGET);
+
+            let db = rocksdb::DB::open(&opts, dir.path())?;
+            let mut write_opts = rocksdb::WriteOptions::default();
+            write_opts.disable_wal(true);
+
+            // Step 1: populate the bottom level.
+            for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
+                db.put_opt(key, value, &write_opts)?;
+            }
+            db.flush()?;
+            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+
+            // Step 2: overwrite the whole keyspace into fresh L0 tables.
+            let mut written = 0u64;
+            for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
+                db.put_opt(key, value, &write_opts)?;
+                written += 1;
+                if flush_points.contains(&written) {
+                    db.flush()?;
+                }
+            }
+            db.flush()?;
+
+            let start = std::time::Instant::now();
+            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+            start.elapsed()
+        }
+    };
+    drop(dir);
+    Ok(elapsed)
+}
+
+fn subcompaction_variant(c: &mut Criterion, group_name: &str, level: i32) {
+    let mut group = c.benchmark_group(group_name);
+    for &n in &[40_000_u64, 100_000_u64] {
+        let inputs = SubcompactionInputs::build(n);
+        group.throughput(Throughput::Elements(n));
+        for engine in [Engine::Ours, Engine::RocksDb] {
+            group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
+                let mut samples = Vec::new();
+                b.iter_custom(|iters| {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let elapsed = run_subcompaction_bench(engine, level, &inputs)
+                            .unwrap_or_else(|e| {
+                                panic!("run_subcompaction_bench failed for {}: {e}", engine.label())
+                            });
+                        samples.push(elapsed);
+                        total += elapsed;
+                    }
+                    total
+                });
+                report_percentiles(&format!("{group_name}/{}/{n}", engine.label()), samples);
+            });
+        }
+    }
+    group.finish();
+}
+
+/// Sub-compaction head-to-head: our range-parallel split vs RocksDB
+/// `max_subcompactions`, at both ends of the zstd spectrum.
+fn bench_subcompaction(c: &mut Criterion) {
+    subcompaction_variant(c, "subcompaction_zstd1", 1);
+    subcompaction_variant(c, "subcompaction_zstd22", 22);
+}
+
 criterion_group!(
     benches,
     bench_write_throughput,
@@ -894,6 +1068,7 @@ criterion_group!(
     bench_range_scan,
     bench_seek_random,
     bench_overwrite,
-    bench_compaction
+    bench_compaction,
+    bench_subcompaction
 );
 criterion_main!(benches);

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -994,8 +994,11 @@ fn run_subcompaction_bench(
             opts.set_disable_auto_compactions(true);
             opts.set_compression_type(rocksdb::DBCompressionType::Zstd);
             opts.set_compression_options(-14, level, 0, 0);
-            // Give RocksDB the matching parallelism knob + a small target file
-            // size so the bottom level also splits into several files.
+            // Give RocksDB the matching parallelism knobs + a small target file
+            // size so the bottom level also splits into several files. Our
+            // compaction_threads drives BOTH range-split and the block-
+            // compression pool, so match both on the RocksDB side.
+            opts.set_compression_options_parallel_threads(SUBCOMPACTION_THREADS as i32);
             opts.set_max_subcompactions(SUBCOMPACTION_THREADS as u32);
             opts.set_target_file_size_base(SUBCOMPACTION_BOTTOM_TARGET);
 

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -781,6 +781,9 @@ fn run_compaction(
             )
             .data_block_compression_policy(CompressionPolicy::all(CompressionType::Zstd(level)))
             .compaction_threads(COMPACTION_THREADS)
+            // Disable range-split sub-compaction so this bench isolates parallel
+            // block compression only, matching RocksDB's max_subcompactions(1).
+            .subcompaction_min_bytes(u64::MAX)
             .open()?;
 
             let mut written = 0u64;


### PR DESCRIPTION
## Summary

Phase 2 of #144 (stacked on #401): split a non-relocating compaction into
disjoint key ranges that compact in parallel, each writing its own SSTs, then
merge all into one atomic version edit. Compounds with #401's parallel block
compression (an N-way split, each compressing on its own threads).

## Changes

- Split boundaries from the destination level's table boundaries
  (`subcompaction_boundaries`) → disjoint ranges (`ranges_from_boundaries`);
  each input table read range-bounded via `Table::range`
  (`create_bounded_compaction_stream`).
- `run_subcompaction`: full per-range pipeline (tombstone eviction,
  KV-separation drop tracking, compaction filter) returning a `ProducedOutput`
  without touching the version. First range on the calling thread, rest on
  `std::thread::scope` workers; only the first carries the input tables to
  delete (dropped once at install).
- Gated to non-relocating compactions (active blob relocation stays
  single-threaded — it already parallelizes block compression). Skipped below
  `Config::subcompaction_min_bytes` (default 8 MiB) so small compactions stay a
  single merged table.
- `CompactionStrategy: Send + Sync` (to share `Options` across workers; all
  strategies already satisfy it).

## Testing

- `tests/sub_compaction.rs`: compares parallel output against the serial path
  key-for-key (plain **and** KV-separated) and asserts the split actually
  happened (more output tables than serial) — guarding against split-boundary
  off-by-one (silent loss/dup).
- Full lib suite (1225) green with sub-compaction active by default; key
  compaction + blob-relocation integration tests green.
- clippy `--all-features --all-targets -D warnings`, fmt, rustdoc clean.
- no-std unchanged (the whole path is std-gated).

> Stacked on #401 — review/merge #401 first, then this rebases onto main.

Part of #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range-parallel sub-compaction: eligible compactions can split into parallel tasks to use multiple CPU cores and produce atomic outputs.

* **Configuration**
  * New setting to control minimum size for splitting compactions (0 forces splits).
  * Option to enable parallel block compression and clearer docs on compression threads sizing/capping.

* **Reliability**
  * Sub-compactions are cancellable, roll back on failure, and restore inputs to avoid partial installs.

* **Performance**
  * Benchmarks added to measure parallel sub-compaction.

* **Tests**
  * Integration tests verify parallel results match serial compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->