### PR TITLE
perf(compression): pass source-size hint on zstd block compression

### DIFF
--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -239,8 +239,14 @@ pub struct ZstdProvider;
 
 impl CompressionProvider for ZstdProvider {
     fn compress(data: &[u8], level: i32) -> crate::Result<Vec<u8>> {
-        let compressed = structured_zstd::encoding::compress_to_vec(
-            std::io::Cursor::new(data),
+        // `compress_slice_to_vec` (not `compress_to_vec`) for two reasons:
+        //   1. it takes `&[u8]`, skipping the `read_to_end` copy the generic
+        //      `Read` adapter does;
+        //   2. it sets the source-size hint, which at high levels (btultra2 /
+        //      L22) selects the small-source parameter set instead of the full
+        //      8 MiB tables — ~34x faster on the 4-64 KiB blocks an LSM writes.
+        let compressed = structured_zstd::encoding::compress_slice_to_vec(
+            data,
             structured_zstd::encoding::CompressionLevel::from_level(level),
         );
         Ok(compressed)
@@ -376,6 +382,11 @@ impl CompressionProvider for ZstdProvider {
                     v
                 },
             );
+            // Size hint so btultra2 (L22) picks the small-source parameter set
+            // for this 4-64 KiB block instead of allocating the full 8 MiB
+            // tables — without it dictionary block compression at L22 runs ~34x
+            // slower (the matcher reset rebuilds the large tables every call).
+            compressor.set_source_size_hint(data.len() as u64);
             compressor.set_source(std::io::Cursor::new(src_buf));
             compressor.set_drain(Vec::new());
             compressor.compress();


### PR DESCRIPTION
## Summary

At high zstd levels (btultra2 / L22) a small 4-64 KiB block compressed **without** a source-size hint allocates the full ~8 MiB parameter tables and the optimal parser grinds over them. An LSM compaction compresses thousands of blocks per SST, so this dominated zstd-22 compaction CPU.

Measured (structured-zstd 0.0.28, L22, 4 KiB high-entropy blocks, single thread, release):

| path | throughput |
|------|-----------|
| non-dict, hint set | 6.8 MB/s |
| raw FrameCompressor, **no hint** | **0.2 MB/s** (~34x slower) |
| dict path (before) | 0.2 MB/s |
| dict path (after) | 4.7 MB/s |

## Changes

- **non-dict** `ZstdProvider::compress`: call `compress_slice_to_vec(&[u8])` directly instead of `compress_to_vec(Cursor)` — skips the `read_to_end` copy and sets the source-size hint internally.
- **dict** `ZstdProvider::compress_with_dict`: `set_source_size_hint(data.len())` before `compress()` so btultra2 selects the small-source parameter set.

## Correctness

Output stays a valid, independently-decodable frame — the hint only affects table sizing / the window-size header. Roundtrip + cross-decode + dict-roundtrip tests (91) pass unchanged. No wire-format or frame-independence change.

## Follow-up (separate)

structured-zstd PR #336 adds the incompressible early-out, a tiny-input table-size cap, prepared-dictionary reuse, and a public `compress_independent_frame` (CCtx-equivalent). Once it ships a release, adopt `compress_independent_frame` to reuse one compressor across blocks (amortize matcher tables, full RocksDB-style context reuse).

Closes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized compression backend efficiency with improved algorithm parameter selection for different data sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->