### PR TITLE
feat(compaction): compaction-time range tombstones + bottommost seqno-zeroing

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -13,6 +13,8 @@ mod flavour;
 pub(crate) mod major;
 pub(crate) mod movedown;
 pub(crate) mod pulldown;
+#[cfg(feature = "std")]
+pub(crate) mod seqno_zeroer;
 pub(crate) mod state;
 pub(crate) mod stream;
 pub(crate) mod tiered;

--- a/src/compaction/seqno_zeroer.rs
+++ b/src/compaction/seqno_zeroer.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Bottommost sequence-number zeroing for compaction output.
+//!
+//! At the last level an entry whose seqno is already below the GC watermark (no
+//! live snapshot needs it) can have its seqno set to `0` — "0" packs to a single
+//! byte, and sequence numbers grow monotonically, so this saves space on the
+//! coldest, largest level.
+//!
+//! ## Why a range-tombstone gate is required (MVCC / PITR safety)
+//!
+//! Range tombstones are applied at read time by sequence-number comparison: a
+//! tombstone `RT@r` suppresses an entry `K@s` iff it covers `K` and `s < r`. If
+//! we zero `K@s` to `K@0`, then **any** covering tombstone with `r > 0` would
+//! suppress it — including:
+//!   - a tombstone older than the entry (`r < s`), which must NOT suppress it; and
+//!   - a tombstone newer than the entry (`r > s`) but with `r` above the
+//!     watermark, which must stay visible for snapshots in `[watermark, r)`.
+//!
+//! So a key is zeroed only when **no range tombstone in the whole version covers
+//! it**. Tombstones are gathered from every level (not just this compaction's
+//! inputs), so a tombstone in a level that is not part of this compaction still
+//! blocks zeroing — the "beyond output level" case.
+//!
+//! Zeroing the bottom version itself is PITR-safe: it only applies to the
+//! latest entry below the watermark (no snapshot reads below the watermark), and
+//! a newer version (real seqno > 0) always wins the merge over the zeroed one.
+//! Older-version ambiguity cannot arise at the last level for the same reason
+//! [`CompactionStream::evict_tombstones`] relies on: the last level is the
+//! authoritative bottom.
+
+use crate::active_tombstone_set::ActiveTombstoneSet;
+use crate::range_tombstone::RangeTombstone;
+use crate::{InternalValue, SeqNo, comparator::SharedComparator};
+
+/// Wraps a sorted compaction output stream and zeroes the seqno of entries that
+/// are GC-collapsible (below the watermark) and not covered by any range
+/// tombstone. See the module docs for the correctness argument.
+pub(super) struct BottommostSeqnoZeroer<I> {
+    inner: I,
+    /// When `false` (not the last level), the stream is a pass-through —
+    /// zeroing is only safe at the authoritative bottom.
+    enabled: bool,
+    comparator: SharedComparator,
+    /// Entries with `seqno < gc_seqno_threshold` are below the GC watermark and
+    /// eligible for zeroing (subject to the no-coverage rule).
+    gc_seqno_threshold: SeqNo,
+    /// Range tombstones from the whole version, sorted lazily by `start`.
+    tombstones: Vec<RangeTombstone>,
+    idx: usize,
+    active: ActiveTombstoneSet,
+    initialized: bool,
+}
+
+impl<I> BottommostSeqnoZeroer<I> {
+    pub(super) fn new(
+        inner: I,
+        enabled: bool,
+        tombstones: Vec<RangeTombstone>,
+        gc_seqno_threshold: SeqNo,
+        comparator: SharedComparator,
+    ) -> Self {
+        Self {
+            inner,
+            enabled,
+            comparator: comparator.clone(),
+            gc_seqno_threshold,
+            tombstones,
+            idx: 0,
+            active: ActiveTombstoneSet::new_with_comparator(comparator),
+            initialized: false,
+        }
+    }
+
+    fn ensure_sorted(&mut self) {
+        if !self.initialized {
+            let comparator = self.comparator.as_ref();
+            self.tombstones
+                .sort_by(|a, b| a.cmp_with_comparator(b, comparator));
+            self.initialized = true;
+        }
+    }
+
+    /// Returns `true` if any range tombstone covers `key` (any seqno). Keys
+    /// arrive in non-decreasing `user_key` order, so the active set is swept
+    /// monotonically.
+    fn covered(&mut self, key: &[u8]) -> bool {
+        while let Some(rt) = self.tombstones.get(self.idx) {
+            if self.comparator.compare(&rt.start, key) == std::cmp::Ordering::Greater {
+                break;
+            }
+            // cutoff = MAX so every tombstone is "visible": ANY covering
+            // tombstone (any seqno) blocks zeroing, since a zeroed entry would
+            // be shadowed by it at read time.
+            self.active.activate(rt, SeqNo::MAX);
+            self.idx += 1;
+        }
+        self.active.expire_until(key);
+        self.active.max_active_seqno().is_some()
+    }
+}
+
+impl<I: Iterator<Item = crate::Result<InternalValue>>> Iterator for BottommostSeqnoZeroer<I> {
+    type Item = crate::Result<InternalValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.enabled {
+            return self.inner.next();
+        }
+        self.ensure_sorted();
+        match self.inner.next()? {
+            Ok(mut kv) => {
+                if kv.key.seqno > 0
+                    && kv.key.seqno < self.gc_seqno_threshold
+                    && !self.covered(kv.key.user_key.as_ref())
+                {
+                    kv.key.seqno = 0;
+                }
+                Some(Ok(kv))
+            }
+            other => Some(other),
+        }
+    }
+}

--- a/src/compaction/seqno_zeroer.rs
+++ b/src/compaction/seqno_zeroer.rs
@@ -50,7 +50,7 @@ pub(super) struct BottommostSeqnoZeroer<I> {
     tombstones: Vec<RangeTombstone>,
     idx: usize,
     active: ActiveTombstoneSet,
-    initialized: bool,
+    tombstones_sorted: bool,
 }
 
 impl<I> BottommostSeqnoZeroer<I> {
@@ -69,23 +69,21 @@ impl<I> BottommostSeqnoZeroer<I> {
             tombstones,
             idx: 0,
             active: ActiveTombstoneSet::new_with_comparator(comparator),
-            initialized: false,
-        }
-    }
-
-    fn ensure_sorted(&mut self) {
-        if !self.initialized {
-            let comparator = self.comparator.as_ref();
-            self.tombstones
-                .sort_by(|a, b| a.cmp_with_comparator(b, comparator));
-            self.initialized = true;
+            tombstones_sorted: false,
         }
     }
 
     /// Returns `true` if any range tombstone covers `key` (any seqno). Keys
     /// arrive in non-decreasing `user_key` order, so the active set is swept
-    /// monotonically.
+    /// monotonically. The lazy sort lives here (not in `next`) so streams whose
+    /// entries are all ineligible for zeroing never pay for it.
     fn covered(&mut self, key: &[u8]) -> bool {
+        if !self.tombstones_sorted {
+            let comparator = self.comparator.as_ref();
+            self.tombstones
+                .sort_by(|a, b| a.cmp_with_comparator(b, comparator));
+            self.tombstones_sorted = true;
+        }
         while let Some(rt) = self.tombstones.get(self.idx) {
             if self.comparator.compare(&rt.start, key) == std::cmp::Ordering::Greater {
                 break;
@@ -108,7 +106,6 @@ impl<I: Iterator<Item = crate::Result<InternalValue>>> Iterator for BottommostSe
         if !self.enabled {
             return self.inner.next();
         }
-        self.ensure_sorted();
         match self.inner.next()? {
             Ok(mut kv) => {
                 if kv.key.seqno > 0

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -1299,7 +1299,6 @@ mod tests {
         }
 
         #[test]
-        #[allow(clippy::unwrap_used, reason = "test assertion")]
         fn compaction_merge_mixed_keys() -> crate::Result<()> {
             // Multiple keys, some with merge operands, some without
             let vec = vec![
@@ -1539,7 +1538,6 @@ mod tests {
 
         /// Complete merge (with base) emits Value; partial merge emits MergeOperand.
         #[test]
-        #[allow(clippy::unwrap_used, reason = "test assertion")]
         fn compaction_merge_complete_vs_partial() -> crate::Result<()> {
             // Complete merge: operand + base → Value
             #[rustfmt::skip]

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -2,6 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::active_tombstone_set::ActiveTombstoneSet;
+use crate::comparator::SharedComparator;
+use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, UserKey, UserValue, ValueType, merge_operator::MergeOperator};
 use std::{collections::VecDeque, iter::Peekable, sync::Arc};
 
@@ -69,6 +72,16 @@ pub struct CompactionStream<'a, I: Iterator<Item = Item>, F: StreamFilter = NoFi
     /// Entries that could not be merged (e.g., Indirection base) and need
     /// to be re-emitted unchanged on subsequent `next()` calls.
     pending: VecDeque<InternalValue>,
+
+    /// Range tombstones with `seqno <= gc_seqno_threshold` whose covered entries
+    /// can be physically dropped during this (bottommost) compaction: every
+    /// live snapshot (>= the watermark) sees them in effect, so the covered KVs
+    /// are deleted for all readers. Empty when RT application is not enabled.
+    rt_apply: Vec<RangeTombstone>,
+    rt_comparator: Option<SharedComparator>,
+    rt_active: Option<ActiveTombstoneSet>,
+    rt_idx: usize,
+    rt_sorted: bool,
 }
 
 impl<I: Iterator<Item = Item>> CompactionStream<'_, I, NoFilter> {
@@ -86,6 +99,11 @@ impl<I: Iterator<Item = Item>> CompactionStream<'_, I, NoFilter> {
             zero_seqnos: false,
             merge_operator: None,
             pending: VecDeque::new(),
+            rt_apply: Vec::new(),
+            rt_comparator: None,
+            rt_active: None,
+            rt_idx: 0,
+            rt_sorted: false,
         }
     }
 }
@@ -102,6 +120,11 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
             zero_seqnos: self.zero_seqnos,
             merge_operator: self.merge_operator,
             pending: self.pending,
+            rt_apply: self.rt_apply,
+            rt_comparator: self.rt_comparator,
+            rt_active: self.rt_active,
+            rt_idx: self.rt_idx,
+            rt_sorted: self.rt_sorted,
         }
     }
 
@@ -129,6 +152,61 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
     pub fn zero_seqnos(mut self, b: bool) -> Self {
         self.zero_seqnos = b;
         self
+    }
+
+    /// Enables compaction-time range-tombstone application: surviving entries
+    /// covered by a tombstone whose seqno is `<= gc_seqno_threshold` (the
+    /// watermark) and higher than the entry's seqno are physically dropped (and
+    /// reported to the drop callback for blob-GC accounting) instead of being
+    /// carried to the output and suppressed at read time.
+    ///
+    /// Only watermark-or-below tombstones are applied: a newer tombstone might
+    /// not be in effect for a snapshot between the entry's seqno and the
+    /// tombstone's, so those entries are preserved (PITR/MVCC safety). Pass
+    /// tombstones gathered from the whole version; this filters them to the
+    /// applicable set.
+    #[must_use]
+    pub fn with_range_tombstone_application(
+        mut self,
+        tombstones: Vec<RangeTombstone>,
+        comparator: SharedComparator,
+    ) -> Self {
+        self.rt_apply = tombstones
+            .into_iter()
+            .filter(|rt| rt.seqno <= self.gc_seqno_threshold)
+            .collect();
+        self.rt_active = Some(ActiveTombstoneSet::new_with_comparator(comparator.clone()));
+        self.rt_comparator = Some(comparator);
+        self
+    }
+
+    /// Returns `true` if `user_key`/`seqno` is covered by an applicable
+    /// (watermark-or-below) range tombstone with a higher seqno — meaning the
+    /// entry is deleted for every live snapshot and can be physically dropped.
+    /// Entries arrive in non-decreasing `user_key` order, so the active set is
+    /// swept monotonically.
+    fn covered_by_applied_tombstone(&mut self, user_key: &[u8], seqno: SeqNo) -> bool {
+        let (Some(comparator), Some(active)) =
+            (self.rt_comparator.as_ref(), self.rt_active.as_mut())
+        else {
+            return false;
+        };
+        if !self.rt_sorted {
+            self.rt_apply
+                .sort_by(|a, b| a.cmp_with_comparator(b, comparator.as_ref()));
+            self.rt_sorted = true;
+        }
+        while let Some(rt) = self.rt_apply.get(self.rt_idx) {
+            if comparator.compare(&rt.start, user_key) == std::cmp::Ordering::Greater {
+                break;
+            }
+            // cutoff = MAX: every applicable tombstone is active; `is_suppressed`
+            // then drops the entry iff some active tombstone outranks its seqno.
+            active.activate(rt, SeqNo::MAX);
+            self.rt_idx += 1;
+        }
+        active.expire_until(user_key);
+        active.is_suppressed(seqno)
     }
 
     /// Collects merge operands and resolves them via the merge operator.
@@ -347,6 +425,17 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> Iterator for Compaction
                         if let Some(merge_op) = self.merge_operator.clone() {
                             let mut merged =
                                 fail_iter!(self.resolve_merge_operands(head, merge_op.as_ref()));
+                            // Drop the merged result if an applicable tombstone
+                            // outranks it (same rule as the main emit path).
+                            if self.covered_by_applied_tombstone(
+                                merged.key.user_key.as_ref(),
+                                merged.key.seqno,
+                            ) {
+                                if let Some(watcher) = &mut self.dropped_callback {
+                                    watcher.on_dropped(&merged);
+                                }
+                                continue;
+                            }
                             // Skip zeroing for partial merges (MergeOperand) to avoid duplicate keys
                             if self.zero_seqnos
                                 && merged.key.seqno < self.gc_seqno_threshold
@@ -387,6 +476,17 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> Iterator for Compaction
                     let merged = fail_iter!(self.resolve_merge_operands(head, merge_op.as_ref()));
                     head = merged;
                 }
+            }
+
+            // Compaction-time range-tombstone application: physically drop the
+            // surviving entry when an applicable (watermark-or-below) tombstone
+            // outranks it, accounting it to the drop callback (blob GC) instead
+            // of carrying it to the output to be suppressed at every read.
+            if self.covered_by_applied_tombstone(head.key.user_key.as_ref(), head.key.seqno) {
+                if let Some(watcher) = &mut self.dropped_callback {
+                    watcher.on_dropped(&head);
+                }
+                continue;
             }
 
             // Zero seqnos below GC, but skip MergeOperands (duplicate key risk)

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -73,10 +73,13 @@ pub struct CompactionStream<'a, I: Iterator<Item = Item>, F: StreamFilter = NoFi
     /// to be re-emitted unchanged on subsequent `next()` calls.
     pending: VecDeque<InternalValue>,
 
-    /// Range tombstones with `seqno <= gc_seqno_threshold` whose covered entries
-    /// can be physically dropped during this (bottommost) compaction: every
-    /// live snapshot (>= the watermark) sees them in effect, so the covered KVs
-    /// are deleted for all readers. Empty when RT application is not enabled.
+    /// Range tombstones strictly below the watermark (`seqno <
+    /// gc_seqno_threshold`) whose covered entries can be physically dropped
+    /// during this (bottommost) compaction: every live snapshot (which reads at
+    /// or above the watermark) sees them in effect, so the covered KVs are
+    /// deleted for all readers. A tombstone exactly at the watermark is excluded
+    /// — it is invisible to a read at the watermark. Empty when RT application is
+    /// not enabled.
     rt_apply: Vec<RangeTombstone>,
     rt_comparator: Option<SharedComparator>,
     rt_active: Option<ActiveTombstoneSet>,
@@ -155,16 +158,18 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
     }
 
     /// Enables compaction-time range-tombstone application: surviving entries
-    /// covered by a tombstone whose seqno is `<= gc_seqno_threshold` (the
-    /// watermark) and higher than the entry's seqno are physically dropped (and
-    /// reported to the drop callback for blob-GC accounting) instead of being
-    /// carried to the output and suppressed at read time.
+    /// covered by a tombstone whose seqno is strictly below the watermark
+    /// (`seqno < gc_seqno_threshold`) and higher than the entry's seqno are
+    /// physically dropped (and reported to the drop callback for blob-GC
+    /// accounting) instead of being carried to the output and suppressed at read
+    /// time.
     ///
-    /// Only watermark-or-below tombstones are applied: a newer tombstone might
-    /// not be in effect for a snapshot between the entry's seqno and the
-    /// tombstone's, so those entries are preserved (PITR/MVCC safety). Pass
-    /// tombstones gathered from the whole version; this filters them to the
-    /// applicable set.
+    /// Only strictly-below-watermark tombstones are applied: a tombstone at or
+    /// above the watermark might not be in effect for a snapshot between the
+    /// entry's seqno and the tombstone's (a read at the watermark does not see a
+    /// tombstone at the watermark), so those entries are preserved (PITR/MVCC
+    /// safety). Pass tombstones gathered from the whole version; this filters
+    /// them to the applicable set.
     #[must_use]
     pub fn with_range_tombstone_application(
         mut self,
@@ -173,7 +178,11 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
     ) -> Self {
         self.rt_apply = tombstones
             .into_iter()
-            .filter(|rt| rt.seqno <= self.gc_seqno_threshold)
+            // Strict visibility (`seqno < threshold`), matching the read path and
+            // the point-key GC: a tombstone exactly at the watermark is still
+            // invisible to the oldest live snapshot (which reads at the
+            // watermark), so it must NOT physically drop covered keys yet.
+            .filter(|rt| rt.visible_at(self.gc_seqno_threshold))
             .collect();
         self.rt_active = Some(ActiveTombstoneSet::new_with_comparator(comparator.clone()));
         self.rt_comparator = Some(comparator);
@@ -181,8 +190,8 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
     }
 
     /// Returns `true` if `user_key`/`seqno` is covered by an applicable
-    /// (watermark-or-below) range tombstone with a higher seqno — meaning the
-    /// entry is deleted for every live snapshot and can be physically dropped.
+    /// (strictly-below-watermark) range tombstone with a higher seqno — meaning
+    /// the entry is deleted for every live snapshot and can be physically dropped.
     /// Entries arrive in non-decreasing `user_key` order, so the active set is
     /// swept monotonically.
     fn covered_by_applied_tombstone(&mut self, user_key: &[u8], seqno: SeqNo) -> bool {
@@ -479,9 +488,9 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> Iterator for Compaction
             }
 
             // Compaction-time range-tombstone application: physically drop the
-            // surviving entry when an applicable (watermark-or-below) tombstone
-            // outranks it, accounting it to the drop callback (blob GC) instead
-            // of carrying it to the output to be suppressed at every read.
+            // surviving entry when an applicable (strictly-below-watermark)
+            // tombstone outranks it, accounting it to the drop callback (blob GC)
+            // instead of carrying it to the output to be suppressed at every read.
             if self.covered_by_applied_tombstone(head.key.user_key.as_ref(), head.key.seqno) {
                 if let Some(watcher) = &mut self.dropped_callback {
                     watcher.on_dropped(&head);

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1683,6 +1683,76 @@ mod tests {
         Ok(())
     }
 
+    /// A range tombstone whose seqno equals the GC watermark sits exactly on the
+    /// visibility boundary. RT visibility is strict (`visible_at` is `seqno <
+    /// read_seqno`), so the oldest live snapshot reading at `read_seqno ==
+    /// watermark` does NOT see `RT@watermark`. Compaction must therefore neither
+    /// apply it (physically dropping covered keys) nor GC it — doing either one
+    /// compaction too early makes a key that is still visible at the watermark
+    /// disappear. Reading the covered key at `read_seqno == watermark` (where the
+    /// tombstone is invisible but the key is committed) must still return it.
+    #[test]
+    fn range_tombstone_at_exact_watermark_is_not_applied_or_gced() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_size_policy(BlockSizePolicy::all(512))
+        .compaction_threads(4)
+        .subcompaction_min_bytes(0)
+        .open()?;
+
+        let key = |i: u64| format!("k{i:04}");
+        let val = |i: u64| format!("v{i}-{}", "x".repeat(40));
+
+        // Populate the bottom level (split boundaries for the final compaction).
+        // Covered keys live here at low seqnos (< the watermark).
+        for i in 0..200u64 {
+            tree.insert(key(i), val(i), i);
+        }
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(4_096, 0)?;
+
+        // Delete [k0000, k0050) at seqno 1000 and overwrite the rest into L0.
+        tree.remove_range(
+            crate::UserKey::from("k0000"),
+            crate::UserKey::from("k0050"),
+            1000,
+        );
+        for i in 50..200u64 {
+            tree.insert(key(i), val(i), 1001 + i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        // Compact to the bottom with the watermark set EXACTLY to the tombstone's
+        // seqno. At this boundary the tombstone is invisible to a read at the
+        // watermark, so its covered keys must be preserved, not dropped.
+        tree.major_compact(u64::MAX, 1000)?;
+
+        // Read at read_seqno == watermark: RT@1000 is invisible here
+        // (`1000 < 1000` is false), and each covered key was committed at
+        // seqno < 1000, so it must still be visible.
+        for i in 0..50u64 {
+            assert_eq!(
+                tree.get(key(i), 1000)?.as_deref(),
+                Some(val(i).as_bytes()),
+                "covered key {} must survive: RT@watermark is invisible at read==watermark",
+                key(i),
+            );
+        }
+
+        // The boundary tombstone must also be retained (not GC'd one compaction
+        // early), since snapshots at the watermark still rely on it.
+        let remaining = super::collect_version_tombstones(&tree.current_version());
+        assert!(
+            !remaining.is_empty(),
+            "a tombstone at the exact watermark must be retained, not GC'd",
+        );
+        Ok(())
+    }
+
     #[test]
     fn compaction_stream_run_not_found() -> crate::Result<()> {
         let folder = tempfile::tempdir()?;

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -318,7 +318,11 @@ fn range_tombstones_after_gc(
     input_rts
         .iter()
         .filter(|rt| {
-            if rt.seqno > watermark {
+            // Strict visibility: a tombstone at or above the watermark is still
+            // needed by the oldest live snapshot (which reads at the watermark
+            // and does not see `RT@watermark`), so keep it. Only strictly-below
+            // tombstones are candidates for GC.
+            if !rt.visible_at(watermark) {
                 return true;
             }
             version

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -281,6 +281,20 @@ fn create_bounded_compaction_stream<'a>(
 /// [`subcompaction_boundaries`] so the comparator-equality dedup is unit
 /// testable without constructing a full [`Version`].
 #[cfg(feature = "std")]
+/// Gathers every range tombstone in the version (all levels), to gate
+/// bottommost seqno-zeroing: a key covered by any tombstone keeps its real
+/// seqno. Includes tombstones from tables NOT in the current compaction, so
+/// "beyond output level" coverage is respected.
+#[cfg(feature = "std")]
+fn collect_version_tombstones(version: &Version) -> Vec<crate::range_tombstone::RangeTombstone> {
+    version
+        .iter_levels()
+        .flat_map(|level| level.iter())
+        .flat_map(|run| run.iter())
+        .flat_map(|t| t.range_tombstones().iter().cloned())
+        .collect()
+}
+
 fn boundary_candidates(
     mut keys: Vec<UserKey>,
     comparator: &crate::comparator::SharedComparator,
@@ -458,6 +472,22 @@ fn run_subcompaction(
         &mut filter_blob_writer,
         &filter_ctx,
     ));
+
+    // Bottommost seqno-zeroing: at the last level, entries below the GC
+    // watermark and not covered by any range tombstone get seqno 0 (packs to
+    // one byte). Tombstones are gathered from the whole version so coverage in
+    // levels outside this compaction still blocks zeroing.
+    let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
+        merge_iter,
+        is_last_level,
+        if is_last_level {
+            collect_version_tombstones(version)
+        } else {
+            Vec::new()
+        },
+        opts.mvcc_gc_watermark,
+        opts.config.comparator.clone(),
+    );
 
     // block_parallel = false: this sub-compaction already runs on a pool thread,
     // so its block compression must stay serial (nested-pool deadlock otherwise).
@@ -1067,6 +1097,14 @@ fn merge_tables(
     // IMPORTANT: Unlock exclusive compaction lock as we are now doing the actual (CPU-intensive) compaction
     drop(compaction_state);
 
+    // Whole-version tombstones for bottommost seqno-zeroing; gathered before the
+    // hidden-input phase and moved into the merge loop below.
+    let zeroing_tombstones = if is_last_level {
+        collect_version_tombstones(&current_super_version.version)
+    } else {
+        Vec::new()
+    };
+
     hidden_guard(payload, opts, || {
         // Propagate range tombstones to output tables BEFORE writing KV items,
         // so that if the compactor rotates tables during the merge loop,
@@ -1082,6 +1120,14 @@ fn merge_tables(
             );
             compactor.write_range_tombstones(&input_range_tombstones);
         }
+
+        let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
+            merge_iter,
+            is_last_level,
+            zeroing_tombstones,
+            opts.mvcc_gc_watermark,
+            opts.config.comparator.clone(),
+        );
 
         for (idx, item) in merge_iter.enumerate() {
             let item = item?;

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1179,24 +1179,22 @@ fn merge_tables(
         // so that if the compactor rotates tables during the merge loop,
         // earlier tables already carry the RT metadata.
         //
-        // At the last level a fully-applied tombstone (at/below the watermark,
-        // its covered KVs physically dropped this compaction) is GC'd — unless a
-        // table outside this compaction overlaps it, which would let dropping it
-        // resurrect a covered key.
-        let output_rts = range_tombstones_after_gc(
-            &input_range_tombstones,
-            &current_super_version.version,
-            &payload.table_ids,
-            opts.mvcc_gc_watermark,
-            is_last_level,
-            &opts.config.comparator,
-        );
-        if !output_rts.is_empty() {
+        // NOTE: this path does NOT GC fully-applied tombstones (unlike the
+        // parallel sub-compaction path). The serial stop-signal handling below
+        // commits whatever was written so far (`return Ok(())`), so a stop
+        // landing after this write but before the covered tail is processed
+        // could drop a below-watermark tombstone while some covered keys were
+        // never visited — resurrecting them. Tombstone GC therefore only runs in
+        // the sub-compaction path, which is atomic (it returns an error and
+        // rolls back on stop). Covered keys are still physically dropped here by
+        // the merge stream; keeping the tombstone is the conservative, correct
+        // choice when the compaction may commit partial output.
+        if !input_range_tombstones.is_empty() {
             log::debug!(
                 "Propagating {} range tombstones to compaction output",
-                output_rts.len(),
+                input_range_tombstones.len(),
             );
-            compactor.write_range_tombstones(&output_rts);
+            compactor.write_range_tombstones(&input_range_tombstones);
         }
 
         let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
@@ -1573,6 +1571,10 @@ mod tests {
     /// tombstone itself is GC'd. If the keys were only suppressed (not dropped)
     /// while the tombstone was GC'd, they would resurrect — so a `None` read
     /// after GC proves both the physical drop (#1) and the tombstone GC (#2).
+    ///
+    /// Routed through the atomic sub-compaction path (which is where GC runs):
+    /// `compaction_threads > 1` + `subcompaction_min_bytes = 0` + a populated
+    /// bottom level (split boundaries) make the final compaction split.
     #[test]
     fn last_level_applies_and_gcs_below_watermark_range_tombstone() -> crate::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -1581,25 +1583,39 @@ mod tests {
             SequenceNumberCounter::default(),
             SequenceNumberCounter::default(),
         )
+        .data_block_size_policy(BlockSizePolicy::all(512))
+        .compaction_threads(4)
+        .subcompaction_min_bytes(0)
         .open()?;
 
         let key = |i: u64| format!("k{i:04}");
-        for i in 0..50u64 {
-            tree.insert(key(i), "v", i);
+        let val = |i: u64| format!("v{i}-{}", "x".repeat(40));
+
+        // Step 1: populate the bottom level with several tables (split
+        // boundaries the final compaction can partition on).
+        for i in 0..200u64 {
+            tree.insert(key(i), val(i), i);
+        }
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(4_096, 0)?;
+
+        // Delete [k0000, k0050) at seqno 1000 and overwrite the rest into L0, so
+        // the next compaction merges L0 into the populated bottom and splits.
+        tree.remove_range(
+            crate::UserKey::from("k0000"),
+            crate::UserKey::from("k0050"),
+            1000,
+        );
+        for i in 50..200u64 {
+            tree.insert(key(i), val(i), 1001 + i);
         }
         tree.flush_active_memtable(0)?;
 
-        // Delete [k0000, k0025) with a tombstone at seqno 100, then compact to
-        // the bottom with a watermark (200) above it — fully applied.
-        tree.remove_range(
-            crate::UserKey::from("k0000"),
-            crate::UserKey::from("k0025"),
-            100,
-        );
-        tree.flush_active_memtable(0)?;
-        tree.major_compact(u64::MAX, 200)?;
+        // Compact to the bottom with a watermark (5000) above the tombstone:
+        // covered keys are physically dropped and the tombstone is GC'd.
+        tree.major_compact(u64::MAX, 5000)?;
 
-        for i in 0..25u64 {
+        for i in 0..50u64 {
             assert_eq!(
                 tree.get(key(i), crate::MAX_SEQNO)?,
                 None,
@@ -1607,7 +1623,7 @@ mod tests {
                 key(i),
             );
         }
-        for i in 25..50u64 {
+        for i in 50..200u64 {
             assert!(
                 tree.get(key(i), crate::MAX_SEQNO)?.is_some(),
                 "uncovered key {} must survive",

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1056,18 +1056,23 @@ fn merge_tables(
     let dst_lvl = payload.canonical_level.into();
     let is_last_level = payload.dest_level == opts.config.level_count - 1;
 
+    merge_iter = merge_iter
+        .evict_tombstones(is_last_level)
+        .zero_seqnos(false);
+
     // Whole-version tombstones for compaction-time RT application (drop covered
     // KVs in the merge) and the bottommost seqno-zeroing gate; gathered from
-    // every level so coverage outside this compaction is respected.
+    // every level so coverage outside this compaction is respected. Both the
+    // whole-version scan and the seqno-zeroer wrapper are std-only, so the
+    // bottommost RT-application + zeroing is gated here; without std the merge
+    // stream is iterated directly (see the zeroer wrap below).
+    #[cfg(feature = "std")]
     let zeroing_tombstones = if is_last_level {
         collect_version_tombstones(&current_super_version.version)
     } else {
         Vec::new()
     };
-
-    merge_iter = merge_iter
-        .evict_tombstones(is_last_level)
-        .zero_seqnos(false);
+    #[cfg(feature = "std")]
     if is_last_level {
         merge_iter = merge_iter.with_range_tombstone_application(
             zeroing_tombstones.clone(),
@@ -1197,6 +1202,10 @@ fn merge_tables(
             compactor.write_range_tombstones(&input_range_tombstones);
         }
 
+        // Bottommost seqno-zeroing is std-only (the zeroer and the whole-version
+        // tombstone scan live behind the std feature); without std, iterate the
+        // filtered merge stream directly.
+        #[cfg(feature = "std")]
         let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
             merge_iter,
             is_last_level,

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -280,7 +280,6 @@ fn create_bounded_compaction_stream<'a>(
 /// range), returning the candidate interior boundary keys. Split out of
 /// [`subcompaction_boundaries`] so the comparator-equality dedup is unit
 /// testable without constructing a full [`Version`].
-#[cfg(feature = "std")]
 /// Gathers every range tombstone in the version (all levels), to gate
 /// bottommost seqno-zeroing: a key covered by any tombstone keeps its real
 /// seqno. Includes tombstones from tables NOT in the current compaction, so
@@ -292,6 +291,49 @@ fn collect_version_tombstones(version: &Version) -> Vec<crate::range_tombstone::
         .flat_map(|level| level.iter())
         .flat_map(|run| run.iter())
         .flat_map(|t| t.range_tombstones().iter().cloned())
+        .collect()
+}
+
+/// Garbage-collects range tombstones for a bottommost compaction's output.
+///
+/// A tombstone at or below the watermark has been fully applied (every live
+/// snapshot sees it, and this compaction physically dropped the keys it covers),
+/// so it can be dropped — UNLESS a table outside this compaction overlaps its
+/// range and might still hold a covered key, in which case dropping it would
+/// resurrect that key. Tombstones above the watermark are always kept (read-time
+/// application still needs them). Non-bottommost compactions keep everything.
+#[cfg(feature = "std")]
+fn range_tombstones_after_gc(
+    input_rts: &[crate::range_tombstone::RangeTombstone],
+    version: &Version,
+    input_ids: &HashSet<TableId>,
+    watermark: SeqNo,
+    is_last_level: bool,
+    comparator: &crate::comparator::SharedComparator,
+) -> Vec<crate::range_tombstone::RangeTombstone> {
+    if !is_last_level {
+        return input_rts.to_vec();
+    }
+    let cmp = comparator.as_ref();
+    input_rts
+        .iter()
+        .filter(|rt| {
+            if rt.seqno > watermark {
+                return true;
+            }
+            version
+                .iter_levels()
+                .flat_map(|level| level.iter())
+                .flat_map(|run| run.iter())
+                .filter(|t| !input_ids.contains(&t.id()))
+                .any(|t| {
+                    let kr = &t.metadata.key_range;
+                    // [rt.start, rt.end) overlaps [kr.min, kr.max].
+                    cmp.compare(&rt.start, kr.max()) != std::cmp::Ordering::Greater
+                        && cmp.compare(kr.min(), &rt.end) == std::cmp::Ordering::Less
+                })
+        })
+        .cloned()
         .collect()
 }
 
@@ -446,9 +488,25 @@ fn run_subcompaction(
         )));
     };
 
+    // Whole-version range tombstones drive both compaction-time RT application
+    // (drop covered KVs in the merge, with blob-GC accounting) and the
+    // bottommost seqno-zeroing gate below. Gathered from every level so coverage
+    // outside this compaction is respected.
+    let version_tombstones = if is_last_level {
+        collect_version_tombstones(version)
+    } else {
+        Vec::new()
+    };
+
     merge_iter = merge_iter
         .evict_tombstones(is_last_level)
         .zero_seqnos(false);
+    if is_last_level {
+        merge_iter = merge_iter.with_range_tombstone_application(
+            version_tombstones.clone(),
+            opts.config.comparator.clone(),
+        );
+    }
 
     let filter_ctx = Context { is_last_level };
     let mut compaction_filter = opts
@@ -480,11 +538,7 @@ fn run_subcompaction(
     let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
         merge_iter,
         is_last_level,
-        if is_last_level {
-            collect_version_tombstones(version)
-        } else {
-            Vec::new()
-        },
+        version_tombstones,
         opts.mvcc_gc_watermark,
         opts.config.comparator.clone(),
     );
@@ -495,11 +549,19 @@ fn run_subcompaction(
     let mut compactor: Box<dyn CompactionFlavour> =
         Box::new(StandardCompaction::new(table_writer, tables_for_deletion));
 
-    // Propagate range tombstones to this sub-range's output; the writer clips
-    // them to each output table's key range (a boundary-spanning RT is written
-    // clipped on both sides, which is correct).
-    if !input_range_tombstones.is_empty() {
-        compactor.write_range_tombstones(input_range_tombstones);
+    // Propagate range tombstones to this sub-range's output (GC'd at the last
+    // level when fully applied); the writer clips them to each output table's
+    // key range (a boundary-spanning RT is written clipped on both sides).
+    let output_rts = range_tombstones_after_gc(
+        input_range_tombstones,
+        version,
+        &payload.table_ids,
+        opts.mvcc_gc_watermark,
+        is_last_level,
+        &opts.config.comparator,
+    );
+    if !output_rts.is_empty() {
+        compactor.write_range_tombstones(&output_rts);
     }
 
     for (idx, item) in merge_iter.enumerate() {
@@ -994,9 +1056,24 @@ fn merge_tables(
     let dst_lvl = payload.canonical_level.into();
     let is_last_level = payload.dest_level == opts.config.level_count - 1;
 
+    // Whole-version tombstones for compaction-time RT application (drop covered
+    // KVs in the merge) and the bottommost seqno-zeroing gate; gathered from
+    // every level so coverage outside this compaction is respected.
+    let zeroing_tombstones = if is_last_level {
+        collect_version_tombstones(&current_super_version.version)
+    } else {
+        Vec::new()
+    };
+
     merge_iter = merge_iter
         .evict_tombstones(is_last_level)
         .zero_seqnos(false);
+    if is_last_level {
+        merge_iter = merge_iter.with_range_tombstone_application(
+            zeroing_tombstones.clone(),
+            opts.config.comparator.clone(),
+        );
+    }
 
     let blobs_folder = opts.config.path.join(BLOBS_FOLDER);
 
@@ -1097,28 +1174,29 @@ fn merge_tables(
     // IMPORTANT: Unlock exclusive compaction lock as we are now doing the actual (CPU-intensive) compaction
     drop(compaction_state);
 
-    // Whole-version tombstones for bottommost seqno-zeroing; gathered before the
-    // hidden-input phase and moved into the merge loop below.
-    let zeroing_tombstones = if is_last_level {
-        collect_version_tombstones(&current_super_version.version)
-    } else {
-        Vec::new()
-    };
-
     hidden_guard(payload, opts, || {
         // Propagate range tombstones to output tables BEFORE writing KV items,
         // so that if the compactor rotates tables during the merge loop,
         // earlier tables already carry the RT metadata.
         //
-        // Keep RTs even at the last level until compaction itself becomes
-        // RT-aware and can physically drop covered KVs. Dropping the RT first
-        // would only remove the logical delete marker and can resurrect data.
-        if !input_range_tombstones.is_empty() {
+        // At the last level a fully-applied tombstone (at/below the watermark,
+        // its covered KVs physically dropped this compaction) is GC'd — unless a
+        // table outside this compaction overlaps it, which would let dropping it
+        // resurrect a covered key.
+        let output_rts = range_tombstones_after_gc(
+            &input_range_tombstones,
+            &current_super_version.version,
+            &payload.table_ids,
+            opts.mvcc_gc_watermark,
+            is_last_level,
+            &opts.config.comparator,
+        );
+        if !output_rts.is_empty() {
             log::debug!(
                 "Propagating {} range tombstones to compaction output",
-                input_range_tombstones.len(),
+                output_rts.len(),
             );
-            compactor.write_range_tombstones(&input_range_tombstones);
+            compactor.write_range_tombstones(&output_rts);
         }
 
         let merge_iter = super::seqno_zeroer::BottommostSeqnoZeroer::new(
@@ -1487,6 +1565,96 @@ mod tests {
                 key(i),
             );
         }
+        Ok(())
+    }
+
+    /// A range tombstone fully below the GC watermark must be applied during a
+    /// last-level compaction: its covered keys are physically dropped AND the
+    /// tombstone itself is GC'd. If the keys were only suppressed (not dropped)
+    /// while the tombstone was GC'd, they would resurrect — so a `None` read
+    /// after GC proves both the physical drop (#1) and the tombstone GC (#2).
+    #[test]
+    fn last_level_applies_and_gcs_below_watermark_range_tombstone() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        let key = |i: u64| format!("k{i:04}");
+        for i in 0..50u64 {
+            tree.insert(key(i), "v", i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        // Delete [k0000, k0025) with a tombstone at seqno 100, then compact to
+        // the bottom with a watermark (200) above it — fully applied.
+        tree.remove_range(
+            crate::UserKey::from("k0000"),
+            crate::UserKey::from("k0025"),
+            100,
+        );
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(u64::MAX, 200)?;
+
+        for i in 0..25u64 {
+            assert_eq!(
+                tree.get(key(i), crate::MAX_SEQNO)?,
+                None,
+                "covered key {} must be physically gone after GC",
+                key(i),
+            );
+        }
+        for i in 25..50u64 {
+            assert!(
+                tree.get(key(i), crate::MAX_SEQNO)?.is_some(),
+                "uncovered key {} must survive",
+                key(i),
+            );
+        }
+        let remaining = super::collect_version_tombstones(&tree.current_version());
+        assert!(
+            remaining.is_empty(),
+            "a fully-applied below-watermark tombstone must be GC'd, found {remaining:?}",
+        );
+        Ok(())
+    }
+
+    /// An above-watermark tombstone must be retained, not GC'd: read-time
+    /// application still needs it for snapshots that predate the tombstone.
+    #[test]
+    fn above_watermark_range_tombstone_is_retained() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        let key = |i: u64| format!("k{i:04}");
+        for i in 0..50u64 {
+            tree.insert(key(i), "v", i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        // Tombstone at seqno 100; compact with a watermark (50) BELOW it, so the
+        // tombstone is neither applied nor GC'd.
+        tree.remove_range(
+            crate::UserKey::from("k0000"),
+            crate::UserKey::from("k0025"),
+            100,
+        );
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(u64::MAX, 50)?;
+
+        let remaining = super::collect_version_tombstones(&tree.current_version());
+        assert!(
+            !remaining.is_empty(),
+            "an above-watermark tombstone must be retained, not GC'd",
+        );
         Ok(())
     }
 

--- a/tests/seqno_zeroing.rs
+++ b/tests/seqno_zeroing.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Bottommost seqno-zeroing correctness (no range tombstones): a last-level
+//! compaction zeroes the sequence numbers of entries below the GC watermark
+//! that no range tombstone covers. This must never change query results — a
+//! later higher-seqno overwrite has to win over a zeroed bottom entry, and
+//! re-compaction must keep the latest value. (Range-tombstone interaction is
+//! covered exhaustively by `prop_range_tombstone`.)
+
+#![cfg(feature = "std")]
+
+use lsm_tree::{AbstractTree, Config, MAX_SEQNO, SequenceNumberCounter};
+use test_log::test;
+
+const N: u64 = 200;
+
+fn key(i: u64) -> String {
+    format!("k{i:05}")
+}
+
+#[test]
+fn bottommost_seqno_zeroing_preserves_latest_value() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        &dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // Generation 0 at low seqnos, flushed to disk.
+    for i in 0..N {
+        tree.insert(key(i), format!("v0-{i}"), i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Compact to the last level with a GC watermark above every gen-0 seqno, so
+    // the surviving entries get their seqnos zeroed.
+    tree.major_compact(u64::MAX, 1_000)?;
+    for i in 0..N {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v0-{i}").as_bytes()),
+            "gen-0 value must read back after the zeroing compaction for {}",
+            key(i),
+        );
+    }
+
+    // Overwrite with strictly higher seqnos. The zeroed (seqno 0) bottom entries
+    // must NOT shadow these — the merge picks the highest seqno.
+    for i in 0..N {
+        tree.insert(key(i), format!("v1-{i}"), 2_000 + i);
+    }
+    tree.flush_active_memtable(0)?;
+    for i in 0..N {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v1-{i}").as_bytes()),
+            "higher-seqno overwrite must win over a zeroed bottom entry for {}",
+            key(i),
+        );
+    }
+
+    // Re-compact to the bottom: gen-1 is zeroed, gen-0 dropped. Latest persists.
+    tree.major_compact(u64::MAX, 10_000)?;
+    for i in 0..N {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v1-{i}").as_bytes()),
+            "latest value must persist across a second zeroing compaction for {}",
+            key(i),
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Makes the last level self-cleaning by handling range tombstones during compaction (RocksDB model) instead of only at read time, which unblocks bottommost sequence-number zeroing.

Three pieces, all gated on MVCC/PITR safety (single GC watermark `W`):

1. **Apply (compaction-time RT application).** `CompactionStream` physically drops a surviving entry covered by a tombstone `RT@r` with `r <= W` and `r > entry.seqno`, routing the drop through the existing drop callback so blob-GC fragmentation accounting stays correct. Only watermark-or-below tombstones are applied — every live snapshot (`>= W >= r`) sees them in effect; newer tombstones are preserved for read-time application so snapshots in `[W, r)` still see the entry (PITR).
2. **GC.** A fully-applied (`r <= W`) tombstone is dropped from the last-level output, unless a table **outside** this compaction overlaps its range (dropping it then could resurrect a covered key). Tombstones above `W` are always retained.
3. **Zero.** At the last level, an entry below `W` that no tombstone in the whole version covers gets its seqno set to `0` (packs to one byte). The whole-version coverage check includes tombstones in levels outside this compaction, so a zeroed entry can never be wrongly suppressed at read time.

Read-time range-tombstone application is unchanged (still required for not-yet-compacted data).

## Why it is correct

A zeroed entry has no surviving covering tombstone: `r <= W` tombstones are applied (their covered entries dropped) and GC'd; `r > W` tombstones block zeroing of the entries they cover. The watermark contract (no read below `W`) is the same one the existing `evict_tombstones` relies on.

## Testing

- `prop_range_tombstone` (3000 cases) and `prop_mvcc` green — these model RT + seqno + compaction + snapshot reads and caught earlier incorrect attempts.
- Unit tests: physical drop + tombstone GC at the last level (a `None` read after GC proves both — a non-dropped key would resurrect once its tombstone is GC'd); retention of an above-watermark tombstone; the zero / overwrite / re-compact cycle.
- Full MVCC / snapshot / blob-GC-stats / compaction suites green (frag accounting verified).

Closes #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compaction now applies range tombstones during compaction, zeroes bottommost sequence numbers when safe, and drops keys fully covered by applicable tombstones—reducing on-disk footprint and aiding reclamation while preserving visibility across levels.
* **Tests**
  * Added integration tests validating bottommost seqno-zeroing and compaction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->