### PR TITLE
feat(tooling): repair_db — rebuild MANIFEST from on-disk SSTs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ log = "0.4.30"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.28", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.29", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -239,17 +239,38 @@ pub struct ZstdProvider;
 
 impl CompressionProvider for ZstdProvider {
     fn compress(data: &[u8], level: i32) -> crate::Result<Vec<u8>> {
-        // `compress_slice_to_vec` (not `compress_to_vec`) for two reasons:
-        //   1. it takes `&[u8]`, skipping the `read_to_end` copy the generic
-        //      `Read` adapter does;
-        //   2. it sets the source-size hint, which at high levels (btultra2 /
-        //      L22) selects the small-source parameter set instead of the full
-        //      8 MiB tables — ~34x faster on the 4-64 KiB blocks an LSM writes.
-        let compressed = structured_zstd::encoding::compress_slice_to_vec(
-            data,
-            structured_zstd::encoding::CompressionLevel::from_level(level),
-        );
-        Ok(compressed)
+        use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+        // Thread-local compressor reused across blocks. `compress_slice_to_vec`
+        // builds a fresh `FrameCompressor` (and its matcher tables) on every
+        // call; reusing one per thread avoids that per-block reconstruction —
+        // most visible at btultra2 / L22, where the tables are large. Keyed by
+        // level so a level change rebuilds the compressor.
+        //
+        // `compress_independent_frame_into` emits a standalone frame: it resets
+        // per-frame state and re-derives the source-size hint from `data`, so
+        // the L22 small-source parameter set is still selected for the 4-64 KiB
+        // blocks an LSM writes (the ~34x win the old size-hint path delivered).
+        // Default generics (`R = &'static [u8]`, `W = Vec<u8>`) keep the cached
+        // type `'static` for thread-local storage.
+        thread_local! {
+            static TLS_COMPRESSOR: std::cell::RefCell<Option<(i32, FrameCompressor)>> =
+                const { std::cell::RefCell::new(None) };
+        }
+
+        TLS_COMPRESSOR.with(|cell| {
+            let mut state = cell.borrow_mut();
+            if !matches!(&*state, Some((l, _)) if *l == level) {
+                *state = Some((
+                    level,
+                    FrameCompressor::new(CompressionLevel::from_level(level)),
+                ));
+            }
+            let Some((_, compressor)) = state.as_mut() else {
+                unreachable!("TLS_COMPRESSOR initialised above");
+            };
+            Ok(compressor.compress_independent_frame(data))
+        })
     }
 
     fn decompress(data: &[u8], capacity: usize) -> crate::Result<Vec<u8>> {

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -260,7 +260,9 @@ impl CompressionProvider for ZstdProvider {
 
     fn compress_with_dict(data: &[u8], level: i32, dict_raw: &[u8]) -> crate::Result<Vec<u8>> {
         use structured_zstd::decoding::Dictionary;
-        use structured_zstd::encoding::{CompressionLevel, FrameCompressor, MatchGeneratorDriver};
+        use structured_zstd::encoding::{
+            CompressionLevel, EncoderDictionary, FrameCompressor, MatchGeneratorDriver,
+        };
 
         // Thread-local `FrameCompressor` with the dictionary pre-loaded.
         //
@@ -296,20 +298,23 @@ impl CompressionProvider for ZstdProvider {
                 const { std::cell::RefCell::new(None) };
         }
 
-        // `FrameCompressor::set_dictionary` accepts a parsed `Dictionary`.
+        // The encoder attaches the dictionary via the `EncoderDictionary`
+        // (CDict-analog) path, which parses for the encode side only.
         //
         // Two dictionary formats are supported:
         //
         // 1. **Finalized zstd dictionary** (magic bytes `37 A4 30 EC` prefix): produced by
         //    `zstd --train` / `zstd::dict::from_continuous` and the C zstd library.
         //    Contains entropy tables (Huffman + FSE) that prime the compressor's
-        //    coding state for better ratios. Parsed via `Dictionary::decode_dict`.
+        //    coding state for better ratios. Attached via `set_dictionary_from_bytes`
+        //    (which builds an `EncoderDictionary`, skipping the decode lookup tables).
         //
         // 2. **Raw content dictionary** (no magic): a bare byte sequence used as
         //    LZ77 history to improve match distances on repetitive data. No entropy
-        //    table seeding. Parsed via `Dictionary::from_raw_content`.
+        //    table seeding. Parsed via `Dictionary::from_raw_content`, then wrapped
+        //    in an `EncoderDictionary` and attached via `set_encoder_dictionary`.
         //
-        // `set_dictionary` transparently handles both formats, so a
+        // Both formats end up attached as an `EncoderDictionary`, so a
         // `ZstdDictionary` created from a raw training corpus (without a
         // finalized header) compresses just as one created from a
         // finalized dictionary.
@@ -331,26 +336,36 @@ impl CompressionProvider for ZstdProvider {
             // Re-initialise if this is the first call in this thread or if the
             // dictionary or compression level has changed.
             if !matches!(&*state, Some((k, l, _)) if *k == dict_key && *l == level) {
-                let dictionary = if dict_raw.starts_with(&DICT_MAGIC) {
-                    Dictionary::decode_dict(dict_raw)
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+                let mut compressor = FrameCompressor::new(CompressionLevel::from_level(level));
+                if dict_raw.starts_with(&DICT_MAGIC) {
+                    // Finalized dict: parse for the ENCODER side only via
+                    // `EncoderDictionary` (the `set_dictionary_from_bytes` path),
+                    // which skips building the decode lookup tables the encoder
+                    // never reads. Cheaper than the old `decode_dict` full parse
+                    // on every cache miss — most visible at btultra2 / L22, where
+                    // dictionary parsing dominates the miss-path cost.
+                    compressor
+                        .set_dictionary_from_bytes(dict_raw)
+                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
                 } else {
+                    // Raw-content dict (no magic header): there is no serialized
+                    // dictionary blob to parse for encoding, so wrap the
+                    // raw-content `Dictionary` as an `EncoderDictionary` and
+                    // attach it without a reparse.
                     #[expect(
                         clippy::cast_possible_truncation,
                         reason = "intentional: lower 32 bits of xxh3 as internal dict id"
                     )]
                     let id = {
                         let h = dict_key as u32;
-                        h.max(1) // id=0 is rejected by set_dictionary; internal use only
+                        h.max(1) // id=0 is rejected by the attach path; internal use only
                     };
-                    Dictionary::from_raw_content(id, dict_raw.to_vec())
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
-                };
-
-                let mut compressor = FrameCompressor::new(CompressionLevel::from_level(level));
-                compressor
-                    .set_dictionary(dictionary)
-                    .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                    let dictionary = Dictionary::from_raw_content(id, dict_raw.to_vec())
+                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                    compressor
+                        .set_encoder_dictionary(EncoderDictionary::from_dictionary(dictionary))
+                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                }
                 *state = Some((dict_key, level, compressor));
             }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -269,6 +269,9 @@ impl CompressionProvider for ZstdProvider {
             let Some((_, compressor)) = state.as_mut() else {
                 unreachable!("TLS_COMPRESSOR initialised above");
             };
+            // `compress_independent_frame` is the `FrameCompressor` CCtx-style
+            // single-frame API (structured-zstd >= 0.0.29); it allocates a fresh
+            // output Vec and emits one standalone frame.
             Ok(compressor.compress_independent_frame(data))
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,10 @@ pub mod range;
 /// Runtime-toggleable configuration (`RuntimeConfig` + atomic-swap handle).
 pub mod runtime_config;
 
+/// Disaster-recovery: rebuild a missing/corrupt manifest from on-disk SSTs.
+#[cfg(feature = "std")]
+pub mod repair;
+
 pub(crate) mod active_tombstone_set;
 pub(crate) mod range_tombstone;
 pub(crate) mod range_tombstone_filter;
@@ -370,6 +374,8 @@ pub use encryption::EncryptionProvider;
 pub use encryption::Aes256GcmProvider;
 
 pub use pinnable_slice::PinnableSlice;
+#[cfg(feature = "std")]
+pub use repair::RepairReport;
 pub use write_batch::WriteBatch;
 
 pub use {

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Last-resort `MANIFEST` reconstruction from the SST files on disk.
+//!
+//! Once a tree has a `MANIFEST`, that manifest is a single point of failure for
+//! the database as a whole: a corrupt manifest means the tree cannot open at
+//! all, even when every SST on disk is intact. Repair scans the table folder(s),
+//! reads each SST's own metadata, and writes a fresh manifest referencing what
+//! is actually present.
+//!
+//! ## What is recovered, what is lost
+//!
+//! Every readable SST is preserved. What the rebuilt manifest cannot know is the
+//! LSM level structure (which file lived at which level) and any version edits
+//! that had not yet been durably logged (an in-flight compaction's output
+//! placement, recent table deletions). Following the RocksDB `RepairDB()`
+//! pattern, all recovered SSTs are placed at L0 ordered by sequence number
+//! (newest first) and a normal background compaction redistributes them into
+//! proper levels on the next open. Reads are correct throughout: L0 permits
+//! overlapping runs, and the merge reader resolves the latest value by sequence
+//! number regardless of physical placement.
+//!
+//! ## Correctness of the recomputed table checksum
+//!
+//! The manifest binds each table by its whole-file XXH3-128 checksum. A normal
+//! write computes that digest incrementally as the file is streamed out, and the
+//! file is written strictly sequentially (no seek-back rewrites after the digest
+//! is taken), so the on-disk bytes equal the hashed byte stream. Repair therefore
+//! recomputes the identical digest by streaming the file start to end. The data
+//! itself is protected independently by per-block checksums, which
+//! [`Table::recover`] validates as it parses, so an SST that survives recovery is
+//! structurally sound.
+//!
+//! ## Scope
+//!
+//! KV-separated (blob) trees are not yet supported: their manifest also tracks
+//! blob-file fragmentation statistics that cannot be reconstructed from a
+//! directory scan alone. Repairing one returns [`crate::Error::FeatureUnsupported`].
+
+use crate::{
+    Table, TableId,
+    config::{Config, TreeType},
+    version::{BlobFileList, Level, Run, Version},
+};
+use std::{path::PathBuf, sync::Arc};
+
+/// Outcome of a [`Config::repair`] run.
+///
+/// `recovered` plus `unreadable` accounts for every SST-named file the scan
+/// considered. `unreadable_files` carries the per-file reason a file was skipped
+/// so an operator can decide whether to investigate or discard it.
+#[derive(Debug)]
+pub struct RepairReport {
+    /// Number of SSTs whose metadata parsed and that are now referenced by the
+    /// rebuilt manifest.
+    pub recovered: usize,
+
+    /// Number of SST-named files that could not be opened or parsed and were
+    /// therefore left out of the manifest.
+    pub unreadable: usize,
+
+    /// Path and human-readable error for each unreadable file.
+    pub unreadable_files: Vec<(PathBuf, String)>,
+
+    /// Description of the level-assignment strategy used (constant for now;
+    /// surfaced so the report is self-explanatory and forward-compatible).
+    pub method: &'static str,
+
+    /// Operator-facing caveats about the rebuilt state.
+    pub warnings: Vec<&'static str>,
+}
+
+/// Streams `path` start to end through XXH3-128, matching the digest a normal
+/// table write accumulates via `ChecksummedWriter`.
+fn compute_table_checksum(fs: &dyn crate::fs::Fs, path: &std::path::Path) -> crate::Result<u128> {
+    let mut file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
+    let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+    let mut buf = vec![0u8; 256 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        // `Read::read` guarantees `n <= buf.len()`, so `get(..n)` is always
+        // `Some`; an empty read signals EOF.
+        match buf.get(..n) {
+            None | Some([]) => break,
+            Some(chunk) => hasher.update(chunk),
+        }
+    }
+    Ok(hasher.digest128())
+}
+
+/// Highest existing `v{N}` manifest id in `folder`, if any. The rebuilt manifest
+/// uses `max + 1` so it supersedes any stale version file and the `current`
+/// pointer never races a half-written predecessor.
+fn highest_existing_version_id(fs: &dyn crate::fs::Fs, folder: &std::path::Path) -> Option<u64> {
+    let entries = fs.read_dir(folder).ok()?;
+    entries
+        .into_iter()
+        .filter_map(|e| {
+            e.file_name
+                .strip_prefix('v')
+                .and_then(|rest| rest.parse::<u64>().ok())
+        })
+        .max()
+}
+
+impl Config {
+    /// Rebuilds the `MANIFEST` for the tree at this config's path from the SST
+    /// files present on disk, then returns a [`RepairReport`].
+    ///
+    /// Use this only when a tree fails to open because its manifest is missing
+    /// or corrupt but the SST files are intact. After a successful repair the
+    /// tree opens normally; all recovered data is at L0 and a background
+    /// compaction restructures it into proper levels (expect elevated I/O for a
+    /// period proportional to the data size).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::FeatureUnsupported`] for KV-separated (blob)
+    /// trees, and propagates any I/O error from scanning the directory or
+    /// writing the new manifest. Individual unreadable SSTs do not fail the
+    /// repair; they are reported in [`RepairReport::unreadable_files`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lsm_tree::{Config, SequenceNumberCounter};
+    ///
+    /// let config = Config::new(
+    ///     "/var/lib/mydb",
+    ///     SequenceNumberCounter::default(),
+    ///     SequenceNumberCounter::default(),
+    /// );
+    /// let report = config.repair()?;
+    /// println!("recovered {} tables, {} unreadable", report.recovered, report.unreadable);
+    /// # Ok::<(), lsm_tree::Error>(())
+    /// ```
+    pub fn repair(self) -> crate::Result<RepairReport> {
+        repair_tree(&self)
+    }
+}
+
+/// Core repair routine. Separated from the [`Config::repair`] entry point so the
+/// logic is testable against a borrowed config.
+fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
+    if config.kv_separation_opts.is_some() {
+        // The blob manifest also records per-blob-file fragmentation stats that
+        // a directory scan cannot reconstruct; supporting it needs its own
+        // design (tracked in #408). Fail loudly rather than write a manifest
+        // that drops blobs.
+        return Err(crate::Error::FeatureUnsupported(
+            "repair of KV-separated (blob) trees",
+        ));
+    }
+
+    let mut recovered_tables: Vec<Table> = Vec::new();
+    let mut unreadable_files: Vec<(PathBuf, String)> = Vec::new();
+    // Guard against the same file surfacing twice (symlinked / aliased table
+    // folders) so a table is not added to two L0 runs.
+    let mut seen_ids: crate::HashSet<TableId> = crate::HashSet::default();
+
+    for (table_base_folder, folder_fs) in config.all_tables_folders() {
+        if !folder_fs.exists(&table_base_folder)? {
+            continue;
+        }
+
+        for dirent in folder_fs.read_dir(&table_base_folder)? {
+            let crate::fs::FsDirEntry {
+                path: table_path,
+                file_name,
+                is_dir,
+            } = dirent;
+
+            // https://en.wikipedia.org/wiki/.DS_Store
+            if is_dir || file_name == ".DS_Store" || file_name.starts_with("._") {
+                continue;
+            }
+
+            let Ok(table_id) = file_name.parse::<TableId>() else {
+                unreadable_files.push((table_path, "file name is not a table id".to_owned()));
+                continue;
+            };
+
+            if !seen_ids.insert(table_id) {
+                // Already recovered via another scanned folder; skip silently.
+                continue;
+            }
+
+            let checksum = match compute_table_checksum(&*folder_fs, &table_path) {
+                Ok(c) => crate::Checksum::from_raw(c),
+                Err(e) => {
+                    unreadable_files.push((table_path, e.to_string()));
+                    continue;
+                }
+            };
+
+            // global_seqno = 0: a recovered table's intrinsic sequence numbers
+            // are authoritative; there is no ingestion-time translation offset
+            // to reapply. tree_id = 0 and descriptor_table = None keep the
+            // transient open from polluting any shared cache keyed by the real
+            // tree id (the tree is reopened fresh after repair).
+            let recovered = Table::recover(
+                table_path.clone(),
+                checksum,
+                0,
+                0,
+                config.cache.clone(),
+                None,
+                folder_fs.clone(),
+                false,
+                false,
+                config.encryption.clone(),
+                #[cfg(zstd_any)]
+                config.zstd_dictionary.clone(),
+                config.comparator.clone(),
+                #[cfg(feature = "metrics")]
+                Arc::new(crate::metrics::Metrics::default()),
+            );
+
+            match recovered {
+                Ok(table) => recovered_tables.push(table),
+                Err(e) => {
+                    seen_ids.remove(&table_id);
+                    unreadable_files.push((table_path, e.to_string()));
+                }
+            }
+        }
+    }
+
+    // Newest first: higher sequence number nearer the L0 head, matching the
+    // ordering the merge reader expects for its newest-run-first short-circuit.
+    recovered_tables.sort_by_key(|t| std::cmp::Reverse(t.get_highest_seqno()));
+
+    // Each recovered table becomes its own single-table L0 run. L0 permits
+    // overlapping runs, so this is always legal regardless of key overlap;
+    // background compaction collapses them into sorted lower levels later.
+    let l0_runs = recovered_tables
+        .iter()
+        .cloned()
+        .filter_map(|t| Run::new(vec![t]).map(Arc::new))
+        .collect::<Vec<_>>();
+
+    let mut levels = Vec::with_capacity(config.level_count.into());
+    levels.push(Level::from_runs(l0_runs));
+    for _ in 1..config.level_count {
+        levels.push(Level::empty());
+    }
+
+    let version_id = highest_existing_version_id(&*config.fs, &config.path)
+        .map_or(0, |max| max.saturating_add(1));
+
+    let version = Version::from_levels(
+        version_id,
+        TreeType::Standard,
+        levels,
+        BlobFileList::new(crate::HashMap::default()),
+        crate::blob_tree::FragmentationMap::default(),
+    );
+
+    crate::version::persist_version(
+        &config.path,
+        &version,
+        config.comparator.name(),
+        &*config.fs,
+        Arc::new(crate::runtime_config::RuntimeConfig::default()),
+        config.encryption.clone(),
+        config.sync_mode,
+    )?;
+
+    Ok(RepairReport {
+        recovered: recovered_tables.len(),
+        unreadable: unreadable_files.len(),
+        unreadable_files,
+        method: "all-to-L0 with sequence-number ordering",
+        warnings: vec![
+            "All recovered tables placed at L0; background compaction will redistribute them",
+            "Recent unlogged version edits (in-flight compactions, recent deletions) are lost",
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_table_checksum, highest_existing_version_id};
+    use crate::fs::StdFs;
+    use test_log::test;
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test assertion")]
+    fn compute_table_checksum_matches_oneshot_xxh3() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("000007");
+        // Larger than the 256 KiB read buffer so the chunked read loop is
+        // exercised across multiple iterations.
+        let payload: Vec<u8> = (0..600_000u32).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, &payload).unwrap();
+
+        let got = compute_table_checksum(&StdFs, &path)?;
+        let expected = xxhash_rust::xxh3::xxh3_128(&payload);
+        assert_eq!(
+            got, expected,
+            "streamed digest must equal the one-shot xxh3-128 digest",
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test assertion")]
+    fn highest_existing_version_id_picks_the_max_and_ignores_non_versions() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["v2", "v10", "v3", "current", "vNaN", "notaversion"] {
+            std::fs::write(dir.path().join(name), b"x").unwrap();
+        }
+        assert_eq!(highest_existing_version_id(&StdFs, dir.path()), Some(10));
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used, reason = "test assertion")]
+    fn highest_existing_version_id_none_when_no_versions_present() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("current"), b"x").unwrap();
+        assert_eq!(highest_existing_version_id(&StdFs, dir.path()), None);
+    }
+}

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -113,6 +113,29 @@ fn highest_existing_version_id(
         .max())
 }
 
+/// Moves a file that does not belong in `tables/` (a non-table-id name) into a
+/// sibling `repair-quarantine/` directory, so a subsequent `Tree::open` — which
+/// rejects non-numeric names in `tables/` — succeeds. Returns the new path.
+///
+/// Quarantine (move) rather than delete: the file was not created by repair, so
+/// it is preserved for the operator to inspect. The quarantine dir is a sibling
+/// of the table folder (same filesystem) so the move is a plain rename.
+fn quarantine_file(
+    fs: &dyn crate::fs::Fs,
+    table_base_folder: &std::path::Path,
+    src: &std::path::Path,
+    file_name: &str,
+) -> crate::Result<PathBuf> {
+    let quarantine_dir = table_base_folder
+        .parent()
+        .unwrap_or(table_base_folder)
+        .join("repair-quarantine");
+    fs.create_dir_all(&quarantine_dir)?;
+    let dest = quarantine_dir.join(file_name);
+    fs.rename(src, &dest)?;
+    Ok(dest)
+}
+
 impl Config {
     /// Rebuilds the `MANIFEST` for the tree at this config's path from the SST
     /// files present on disk, then returns a [`RepairReport`].
@@ -189,7 +212,23 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
             }
 
             let Ok(table_id) = file_name.parse::<TableId>() else {
-                unreadable_files.push((table_path, "file name is not a table id".to_owned()));
+                // A non-numeric name cannot be a table id, and `Tree::open`
+                // rejects such a file outright (recovery parses every name in
+                // `tables/`). Leaving it in place would let repair report
+                // success while the tree still cannot reopen, so move it out of
+                // `tables/` into a sibling quarantine dir; report where it went.
+                let reason =
+                    match quarantine_file(&*folder_fs, &table_base_folder, &table_path, &file_name)
+                    {
+                        Ok(dest) => {
+                            format!(
+                                "file name is not a table id; quarantined to {}",
+                                dest.display()
+                            )
+                        }
+                        Err(e) => format!("file name is not a table id; quarantine failed: {e}"),
+                    };
+                unreadable_files.push((table_path, reason));
                 continue;
             };
 

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -94,16 +94,23 @@ fn compute_table_checksum(fs: &dyn crate::fs::Fs, path: &std::path::Path) -> cra
 /// Highest existing `v{N}` manifest id in `folder`, if any. The rebuilt manifest
 /// uses `max + 1` so it supersedes any stale version file and the `current`
 /// pointer never races a half-written predecessor.
-fn highest_existing_version_id(fs: &dyn crate::fs::Fs, folder: &std::path::Path) -> Option<u64> {
-    let entries = fs.read_dir(folder).ok()?;
-    entries
+///
+/// A directory-read failure is propagated (not swallowed as "no versions"): a
+/// transient scan error must not silently reset the version chain to `0` and
+/// risk reusing a live version id.
+fn highest_existing_version_id(
+    fs: &dyn crate::fs::Fs,
+    folder: &std::path::Path,
+) -> crate::Result<Option<u64>> {
+    Ok(fs
+        .read_dir(folder)?
         .into_iter()
         .filter_map(|e| {
             e.file_name
                 .strip_prefix('v')
                 .and_then(|rest| rest.parse::<u64>().ok())
         })
-        .max()
+        .max())
 }
 
 impl Config {
@@ -260,7 +267,7 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         levels.push(Level::empty());
     }
 
-    let version_id = highest_existing_version_id(&*config.fs, &config.path)
+    let version_id = highest_existing_version_id(&*config.fs, &config.path)?
         .map_or(0, |max| max.saturating_add(1));
 
     let version = Version::from_levels(
@@ -271,12 +278,18 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         crate::blob_tree::FragmentationMap::default(),
     );
 
+    // Persist with the tree's own runtime config, not defaults: it drives the
+    // manifest framing (checksum algorithm, page ECC, footer mirror, manifest
+    // KV checksums), so defaulting it would rewrite a recovered tree's manifest
+    // metadata to settings it never used. The last live runtime config died with
+    // the lost manifest; the config supplied to `repair` is the authoritative
+    // replacement.
     crate::version::persist_version(
         &config.path,
         &version,
         config.comparator.name(),
         &*config.fs,
-        Arc::new(crate::runtime_config::RuntimeConfig::default()),
+        Arc::new(config.initial_runtime_config.clone()),
         config.encryption.clone(),
         config.sync_mode,
     )?;
@@ -320,19 +333,21 @@ mod tests {
 
     #[test]
     #[expect(clippy::unwrap_used, reason = "test assertion")]
-    fn highest_existing_version_id_picks_the_max_and_ignores_non_versions() {
-        let dir = tempfile::tempdir().unwrap();
+    fn highest_existing_version_id_picks_the_max_and_ignores_non_versions() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
         for name in ["v2", "v10", "v3", "current", "vNaN", "notaversion"] {
             std::fs::write(dir.path().join(name), b"x").unwrap();
         }
-        assert_eq!(highest_existing_version_id(&StdFs, dir.path()), Some(10));
+        assert_eq!(highest_existing_version_id(&StdFs, dir.path())?, Some(10));
+        Ok(())
     }
 
     #[test]
     #[expect(clippy::unwrap_used, reason = "test assertion")]
-    fn highest_existing_version_id_none_when_no_versions_present() {
-        let dir = tempfile::tempdir().unwrap();
+    fn highest_existing_version_id_none_when_no_versions_present() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
         std::fs::write(dir.path().join("current"), b"x").unwrap();
-        assert_eq!(highest_existing_version_id(&StdFs, dir.path()), None);
+        assert_eq!(highest_existing_version_id(&StdFs, dir.path())?, None);
+        Ok(())
     }
 }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -79,12 +79,14 @@ fn compute_table_checksum(fs: &dyn crate::fs::Fs, path: &std::path::Path) -> cra
     let mut buf = vec![0u8; 256 * 1024];
     loop {
         let n = file.read(&mut buf)?;
-        // `Read::read` guarantees `n <= buf.len()`, so `get(..n)` is always
-        // `Some`; an empty read signals EOF.
-        match buf.get(..n) {
-            None | Some([]) => break,
-            Some(chunk) => hasher.update(chunk),
+        if n == 0 {
+            break; // EOF
         }
+        // `get(..n)` rather than `buf[..n]` to satisfy
+        // `deny(clippy::indexing_slicing)`; `Read::read` guarantees
+        // `n <= buf.len()`, so this slice is always present.
+        let Some(chunk) = buf.get(..n) else { break };
+        hasher.update(chunk);
     }
     Ok(hasher.digest128())
 }
@@ -133,10 +135,13 @@ impl Config {
     /// );
     /// let report = config.repair()?;
     /// println!("recovered {} tables, {} unreadable", report.recovered, report.unreadable);
+    ///
+    /// // `repair` borrows, so the same config opens the rebuilt tree.
+    /// let _tree = config.open()?;
     /// # Ok::<(), lsm_tree::Error>(())
     /// ```
-    pub fn repair(self) -> crate::Result<RepairReport> {
-        repair_tree(&self)
+    pub fn repair(&self) -> crate::Result<RepairReport> {
+        repair_tree(self)
     }
 }
 
@@ -189,6 +194,10 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
             let checksum = match compute_table_checksum(&*folder_fs, &table_path) {
                 Ok(c) => crate::Checksum::from_raw(c),
                 Err(e) => {
+                    // Mirror the `Table::recover` failure path below: free the id
+                    // so an aliased copy in another scanned folder can still be
+                    // retried.
+                    seen_ids.remove(&table_id);
                     unreadable_files.push((table_path, e.to_string()));
                     continue;
                 }
@@ -234,11 +243,16 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
     // Each recovered table becomes its own single-table L0 run. L0 permits
     // overlapping runs, so this is always legal regardless of key overlap;
     // background compaction collapses them into sorted lower levels later.
+    // `Run::new` only returns `None` for an empty run, which `vec![t]` never is,
+    // so no table is dropped here — but build the runs explicitly and derive the
+    // recovered count from what actually lands in the manifest, so the report
+    // can never overcount relative to the persisted version.
     let l0_runs = recovered_tables
         .iter()
         .cloned()
         .filter_map(|t| Run::new(vec![t]).map(Arc::new))
         .collect::<Vec<_>>();
+    let recovered = l0_runs.len();
 
     let mut levels = Vec::with_capacity(config.level_count.into());
     levels.push(Level::from_runs(l0_runs));
@@ -268,7 +282,7 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
     )?;
 
     Ok(RepairReport {
-        recovered: recovered_tables.len(),
+        recovered,
         unreadable: unreadable_files.len(),
         unreadable_files,
         method: "all-to-L0 with sequence-number ordering",

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -352,14 +352,13 @@ mod tests {
     use test_log::test;
 
     #[test]
-    #[expect(clippy::unwrap_used, reason = "test assertion")]
     fn compute_table_checksum_matches_oneshot_xxh3() -> crate::Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("000007");
         // Larger than the 256 KiB read buffer so the chunked read loop is
         // exercised across multiple iterations.
         let payload: Vec<u8> = (0..600_000u32).map(|i| (i % 251) as u8).collect();
-        std::fs::write(&path, &payload).unwrap();
+        std::fs::write(&path, &payload)?;
 
         let got = compute_table_checksum(&StdFs, &path)?;
         let expected = xxhash_rust::xxh3::xxh3_128(&payload);
@@ -371,21 +370,19 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::unwrap_used, reason = "test assertion")]
     fn highest_existing_version_id_picks_the_max_and_ignores_non_versions() -> crate::Result<()> {
         let dir = tempfile::tempdir()?;
         for name in ["v2", "v10", "v3", "current", "vNaN", "notaversion"] {
-            std::fs::write(dir.path().join(name), b"x").unwrap();
+            std::fs::write(dir.path().join(name), b"x")?;
         }
         assert_eq!(highest_existing_version_id(&StdFs, dir.path())?, Some(10));
         Ok(())
     }
 
     #[test]
-    #[expect(clippy::unwrap_used, reason = "test assertion")]
     fn highest_existing_version_id_none_when_no_versions_present() -> crate::Result<()> {
         let dir = tempfile::tempdir()?;
-        std::fs::write(dir.path().join("current"), b"x").unwrap();
+        std::fs::write(dir.path().join("current"), b"x")?;
         assert_eq!(highest_existing_version_id(&StdFs, dir.path())?, None);
         Ok(())
     }

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -291,6 +291,100 @@ fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> 
     Ok(())
 }
 
+// A production-written SST that is later corrupted must be rejected by
+// `Table::recover` during repair (per-block / structural validation), reported,
+// and skipped — while intact SSTs still recover and the tree reopens.
+#[test]
+fn repair_rejects_corrupted_sst_and_recovers_the_rest() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..25 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+        for i in 25..50 {
+            tree.insert(key(i), format!("v0-{i}"), 1000 + i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let total = count_sst_files(dir.path())?;
+    assert!(
+        total >= 2,
+        "need two SSTs (intact + corrupted), got {total}"
+    );
+    nuke_manifest(dir.path())?;
+
+    // Corrupt the newest SST (highest table id = second flush, keys 25..50) by
+    // tampering its SFA trailer, so `Table::recover` rejects it. Production write
+    // path: a real flushed table, single trailing region flipped.
+    let tables = dir.path().join("tables");
+    let newest = std::fs::read_dir(&tables)?
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .parse::<u64>()
+                .ok()
+                .map(|id| (id, e.path()))
+        })
+        .max_by_key(|(id, _)| *id)
+        .expect("at least one SST")
+        .1;
+    let mut bytes = std::fs::read(&newest)?;
+    let n = bytes.len();
+    for b in &mut bytes[n - 32..] {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&newest, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(report.unreadable, 1, "the corrupted SST must be rejected");
+    assert!(
+        report.unreadable_files[0]
+            .0
+            .ends_with(newest.file_name().expect("file name")),
+        "the corrupted SST must be the reported unreadable entry",
+    );
+    assert_eq!(
+        report.recovered,
+        total - 1,
+        "every intact SST must still be recovered",
+    );
+
+    // Reopen succeeds; the intact SST's keys read back (the corrupted SST's keys
+    // are gone — it was not added to the manifest and is orphan-cleaned on open).
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in 0..25 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v0-{i}").as_bytes()),
+            "intact key {} must survive repair",
+            key(i),
+        );
+    }
+
+    Ok(())
+}
+
 // A table-id-named entry that cannot even be opened (here a dangling symlink)
 // must be reported via the checksum step's failure path, not abort the repair.
 #[cfg(unix)]

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Disaster-recovery: rebuilding the manifest from on-disk SSTs.
+//!
+//! The contract under test: after the manifest (and its `current` pointer) is
+//! gone, `Config::repair` reconstructs a manifest from the SST files alone such
+//! that every previously written key is still readable on reopen. Recent
+//! unlogged version edits may be lost, but no readable SST's data is dropped.
+
+#![cfg(feature = "std")]
+
+use lsm_tree::{AbstractTree, Config, KvSeparationOptions, MAX_SEQNO, SequenceNumberCounter};
+use test_log::test;
+
+fn key(i: u64) -> String {
+    format!("k{i:05}")
+}
+
+/// Removes every `v{N}` manifest file and the `current` pointer from a tree
+/// directory, simulating a manifest loss while leaving the SSTs intact.
+fn nuke_manifest(dir: &std::path::Path) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let is_version = name
+            .strip_prefix('v')
+            .is_some_and(|rest| rest.parse::<u64>().is_ok());
+        if is_version || name == "current" {
+            std::fs::remove_file(entry.path()).unwrap();
+        }
+    }
+}
+
+fn count_sst_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir.join("tables"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().parse::<u64>().is_ok())
+        .count()
+}
+
+#[test]
+fn repair_rebuilds_manifest_and_preserves_all_keys() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    // Three flushes → three L0 tables, with an overwrite in the last batch so
+    // repair has to preserve the latest value across overlapping L0 runs.
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        for i in 0..100 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        for i in 100..200 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        // Overwrite the first 50 keys with higher seqnos in a fresh table.
+        for i in 0..50 {
+            tree.insert(key(i), format!("v1-{i}"), 1_000 + i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let sst_count = count_sst_files(dir.path());
+    assert!(sst_count >= 3, "expected at least 3 SSTs, got {sst_count}");
+
+    nuke_manifest(dir.path());
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, sst_count,
+        "every SST on disk must be recovered",
+    );
+    assert_eq!(report.unreadable, 0, "no SST should be unreadable");
+
+    // Reopen and verify every key reads back its latest value.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    for i in 0..50 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v1-{i}").as_bytes()),
+            "overwritten key {} must read the latest value after repair",
+            key(i),
+        );
+    }
+    for i in 50..200 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v0-{i}").as_bytes()),
+            "key {} must survive repair",
+            key(i),
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..100 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let good_count = count_sst_files(dir.path());
+    assert!(good_count >= 1);
+
+    nuke_manifest(dir.path());
+
+    // Drop a garbage file with a table-id-shaped name into the tables folder.
+    // A free id well above any the tree allocated avoids colliding with a real
+    // table that could then be silently overwritten.
+    let bogus = dir.path().join("tables").join("999999");
+    std::fs::write(&bogus, b"not a valid sst file at all").unwrap();
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(report.recovered, good_count, "real SSTs must be recovered");
+    assert_eq!(report.unreadable, 1, "the garbage file must be reported");
+    assert!(
+        report.unreadable_files[0].0.ends_with("999999"),
+        "the reported unreadable path must be the garbage file",
+    );
+
+    // The intact data is still fully readable.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in 0..100 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v0-{i}").as_bytes()),
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn repair_rejects_kv_separated_trees() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(KvSeparationOptions::default()))
+        .open()?;
+        tree.insert("k", "v", 0);
+        tree.flush_active_memtable(0)?;
+    }
+
+    nuke_manifest(dir.path());
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default()))
+    .repair();
+
+    assert!(
+        matches!(result, Err(lsm_tree::Error::FeatureUnsupported(_))),
+        "blob trees are not yet repairable, got {result:?}",
+    );
+
+    Ok(())
+}

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -244,9 +244,9 @@ fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> 
     let good_count = count_sst_files(dir.path())?;
     nuke_manifest(dir.path())?;
 
-    // A non-numeric file name cannot be a table id and must be reported, not
-    // parsed. Removed before reopen so it does not trip the stricter open-time
-    // scan (which rejects non-numeric names outright).
+    // A non-numeric file name cannot be a table id. Repair must move it out of
+    // `tables/` (Tree::open rejects non-numeric names outright), otherwise repair
+    // would report success while the DB still cannot reopen.
     let bad = dir.path().join("tables").join("not-a-table-id");
     std::fs::write(&bad, b"whatever")?;
 
@@ -268,6 +268,25 @@ fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> 
         "the reason should explain the name is not a table id, got: {}",
         report.unreadable_files[0].1,
     );
+
+    // The junk must no longer sit in `tables/` — repair quarantines it so the
+    // tree reopens cleanly WITHOUT any manual cleanup.
+    assert!(
+        !dir.path().join("tables").join("not-a-table-id").exists(),
+        "non-table-id file must be moved out of tables/ by repair",
+    );
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in 0..20 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(format!("v0-{i}").as_bytes()),
+        );
+    }
 
     Ok(())
 }

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -19,6 +19,10 @@ fn key(i: u64) -> String {
 
 /// Removes every `v{N}` manifest file and the `current` pointer from a tree
 /// directory, simulating a manifest loss while leaving the SSTs intact.
+///
+/// Keep in sync with the copy in `tools/sst-dump/tests/repair_smoke.rs` (a
+/// separate crate, so the helper cannot be shared directly): both encode the
+/// manifest file-naming convention (`v{N}` + `current`).
 fn nuke_manifest(dir: &std::path::Path) {
     for entry in std::fs::read_dir(dir).unwrap() {
         let entry = entry.unwrap();
@@ -146,6 +150,10 @@ fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> 
     let bogus = dir.path().join("tables").join("999999");
     std::fs::write(&bogus, b"not a valid sst file at all").unwrap();
 
+    // A macOS Finder artifact must be silently skipped, not counted as
+    // unreadable.
+    std::fs::write(dir.path().join("tables").join(".DS_Store"), b"\x00").unwrap();
+
     let report = Config::new(
         dir.path(),
         SequenceNumberCounter::default(),
@@ -173,6 +181,138 @@ fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> 
             Some(format!("v0-{i}").as_bytes()),
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn repair_with_no_ssts_produces_empty_readable_tree() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    // Open and close without ever flushing: the manifest exists but no SST does
+    // (manifest lost before the first flush is the scenario).
+    {
+        let _tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+    }
+
+    nuke_manifest(dir.path());
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(report.recovered, 0, "no SSTs to recover");
+    assert_eq!(report.unreadable, 0);
+
+    // The rebuilt (empty) manifest must still open cleanly and read as empty.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    assert_eq!(tree.get("anything", MAX_SEQNO)?, None);
+
+    Ok(())
+}
+
+#[test]
+fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..20 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let good_count = count_sst_files(dir.path());
+    nuke_manifest(dir.path());
+
+    // A non-numeric file name cannot be a table id and must be reported, not
+    // parsed. Removed before reopen so it does not trip the stricter open-time
+    // scan (which rejects non-numeric names outright).
+    let bad = dir.path().join("tables").join("not-a-table-id");
+    std::fs::write(&bad, b"whatever").unwrap();
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(report.recovered, good_count);
+    assert_eq!(report.unreadable, 1);
+    assert!(
+        report.unreadable_files[0].0.ends_with("not-a-table-id"),
+        "the non-numeric file must be the reported unreadable entry",
+    );
+    assert!(
+        report.unreadable_files[0].1.contains("table id"),
+        "the reason should explain the name is not a table id, got: {}",
+        report.unreadable_files[0].1,
+    );
+
+    Ok(())
+}
+
+// A table-id-named entry that cannot even be opened (here a dangling symlink)
+// must be reported via the checksum step's failure path, not abort the repair.
+#[cfg(unix)]
+#[test]
+fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..20 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let good_count = count_sst_files(dir.path());
+    nuke_manifest(dir.path());
+
+    // Dangling symlink with a valid table-id name: `read_dir` lists it and the
+    // name parses, but opening it to checksum fails.
+    let dangling = dir.path().join("tables").join("888888");
+    std::os::unix::fs::symlink(dir.path().join("does-not-exist"), &dangling).unwrap();
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, good_count,
+        "real SSTs must still be recovered"
+    );
+    assert_eq!(report.unreadable, 1, "the unopenable file must be reported");
+    assert!(report.unreadable_files[0].0.ends_with("888888"));
 
     Ok(())
 }

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -23,26 +23,26 @@ fn key(i: u64) -> String {
 /// Keep in sync with the copy in `tools/sst-dump/tests/repair_smoke.rs` (a
 /// separate crate, so the helper cannot be shared directly): both encode the
 /// manifest file-naming convention (`v{N}` + `current`).
-fn nuke_manifest(dir: &std::path::Path) {
-    for entry in std::fs::read_dir(dir).unwrap() {
-        let entry = entry.unwrap();
+fn nuke_manifest(dir: &std::path::Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
         let name = entry.file_name();
         let name = name.to_string_lossy();
         let is_version = name
             .strip_prefix('v')
             .is_some_and(|rest| rest.parse::<u64>().is_ok());
         if is_version || name == "current" {
-            std::fs::remove_file(entry.path()).unwrap();
+            std::fs::remove_file(entry.path())?;
         }
     }
+    Ok(())
 }
 
-fn count_sst_files(dir: &std::path::Path) -> usize {
-    std::fs::read_dir(dir.join("tables"))
-        .unwrap()
+fn count_sst_files(dir: &std::path::Path) -> std::io::Result<usize> {
+    Ok(std::fs::read_dir(dir.join("tables"))?
         .filter_map(Result::ok)
         .filter(|e| e.file_name().to_string_lossy().parse::<u64>().is_ok())
-        .count()
+        .count())
 }
 
 #[test]
@@ -76,10 +76,10 @@ fn repair_rebuilds_manifest_and_preserves_all_keys() -> lsm_tree::Result<()> {
         tree.flush_active_memtable(0)?;
     }
 
-    let sst_count = count_sst_files(dir.path());
+    let sst_count = count_sst_files(dir.path())?;
     assert!(sst_count >= 3, "expected at least 3 SSTs, got {sst_count}");
 
-    nuke_manifest(dir.path());
+    nuke_manifest(dir.path())?;
 
     let report = Config::new(
         dir.path(),
@@ -139,20 +139,20 @@ fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> 
         tree.flush_active_memtable(0)?;
     }
 
-    let good_count = count_sst_files(dir.path());
+    let good_count = count_sst_files(dir.path())?;
     assert!(good_count >= 1);
 
-    nuke_manifest(dir.path());
+    nuke_manifest(dir.path())?;
 
     // Drop a garbage file with a table-id-shaped name into the tables folder.
     // A free id well above any the tree allocated avoids colliding with a real
     // table that could then be silently overwritten.
     let bogus = dir.path().join("tables").join("999999");
-    std::fs::write(&bogus, b"not a valid sst file at all").unwrap();
+    std::fs::write(&bogus, b"not a valid sst file at all")?;
 
     // A macOS Finder artifact must be silently skipped, not counted as
     // unreadable.
-    std::fs::write(dir.path().join("tables").join(".DS_Store"), b"\x00").unwrap();
+    std::fs::write(dir.path().join("tables").join(".DS_Store"), b"\x00")?;
 
     let report = Config::new(
         dir.path(),
@@ -200,7 +200,7 @@ fn repair_with_no_ssts_produces_empty_readable_tree() -> lsm_tree::Result<()> {
         .open()?;
     }
 
-    nuke_manifest(dir.path());
+    nuke_manifest(dir.path())?;
 
     let report = Config::new(
         dir.path(),
@@ -241,14 +241,14 @@ fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> 
         tree.flush_active_memtable(0)?;
     }
 
-    let good_count = count_sst_files(dir.path());
-    nuke_manifest(dir.path());
+    let good_count = count_sst_files(dir.path())?;
+    nuke_manifest(dir.path())?;
 
     // A non-numeric file name cannot be a table id and must be reported, not
     // parsed. Removed before reopen so it does not trip the stricter open-time
     // scan (which rejects non-numeric names outright).
     let bad = dir.path().join("tables").join("not-a-table-id");
-    std::fs::write(&bad, b"whatever").unwrap();
+    std::fs::write(&bad, b"whatever")?;
 
     let report = Config::new(
         dir.path(),
@@ -292,13 +292,13 @@ fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
         tree.flush_active_memtable(0)?;
     }
 
-    let good_count = count_sst_files(dir.path());
-    nuke_manifest(dir.path());
+    let good_count = count_sst_files(dir.path())?;
+    nuke_manifest(dir.path())?;
 
     // Dangling symlink with a valid table-id name: `read_dir` lists it and the
     // name parses, but opening it to checksum fails.
     let dangling = dir.path().join("tables").join("888888");
-    std::os::unix::fs::symlink(dir.path().join("does-not-exist"), &dangling).unwrap();
+    std::os::unix::fs::symlink(dir.path().join("does-not-exist"), &dangling)?;
 
     let report = Config::new(
         dir.path(),
@@ -333,7 +333,7 @@ fn repair_rejects_kv_separated_trees() -> lsm_tree::Result<()> {
         tree.flush_active_memtable(0)?;
     }
 
-    nuke_manifest(dir.path());
+    nuke_manifest(dir.path())?;
 
     let result = Config::new(
         dir.path(),

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -155,6 +155,21 @@ enum Command {
         keys_only: bool,
     },
 
+    /// Rebuild a missing or corrupt `MANIFEST` from the SST files on
+    /// disk. Here the leading path argument is the DB **directory**
+    /// (not a single SST). Scans `<db-dir>/tables`, reads each SST's
+    /// own metadata, and writes a fresh manifest placing every
+    /// recovered table at L0 (background compaction restructures it on
+    /// the next open). Recent unlogged version edits (in-flight
+    /// compactions, recent deletions) are lost; all readable data is
+    /// preserved.
+    ///
+    /// Uses the default comparator and no encryption: a tree created
+    /// with a custom comparator or with encryption must be repaired via
+    /// the library `Config::repair` API with the matching config.
+    /// KV-separated (blob) trees are not supported by repair.
+    Repair,
+
     /// Print sizing stats for the SST's BuRR filter: on-disk filter
     /// section bytes, BuRR layer count, item count from meta, and
     /// approximate bits-per-key. Only single-block (full) filters
@@ -184,7 +199,40 @@ fn main() -> ExitCode {
             keys_only,
         } => run_dump(&cli.file, from.as_deref(), to.as_deref(), max, keys_only),
         Command::FilterStats => run_filter_stats(&cli.file),
+        Command::Repair => run_repair(&cli.file),
     }
+}
+
+fn run_repair(db_dir: &std::path::Path) -> ExitCode {
+    use lsm_tree::{Config, SequenceNumberCounter};
+
+    let config = Config::new(
+        db_dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    );
+
+    let report = match config.repair() {
+        Ok(report) => report,
+        Err(err) => {
+            eprintln!("repair failed: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("db dir:        {}", db_dir.display());
+    println!("method:        {}", report.method);
+    println!("recovered:     {}", report.recovered);
+    println!("unreadable:    {}", report.unreadable);
+    for (path, reason) in &report.unreadable_files {
+        println!("  skipped {} — {reason}", path.display());
+    }
+    for warning in &report.warnings {
+        println!("warning:       {warning}");
+    }
+    println!("status:        manifest rebuilt");
+
+    ExitCode::SUCCESS
 }
 
 fn run_verify(path: &std::path::Path, verbose: bool) -> ExitCode {

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -41,8 +41,11 @@ const HEX_MAX_LEN: u64 = 1024 * 1024;
     version
 )]
 struct Cli {
-    /// Path to the SST file (typically `<dir>/tables/<id>`).
-    file: PathBuf,
+    /// Path target, interpreted per subcommand:
+    /// - an SST file (typically `<dir>/tables/<id>`) for `verify`, `hex`,
+    ///   `properties`, `index-dump`, `dump`, `filter-stats`
+    /// - the DB **directory** (the tree root containing `tables/`) for `repair`
+    path: PathBuf,
 
     #[command(subcommand)]
     command: Command,
@@ -184,22 +187,22 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Verify { verbose } => run_verify(&cli.file, verbose),
+        Command::Verify { verbose } => run_verify(&cli.path, verbose),
         Command::Hex {
             offset,
             len,
             no_header,
-        } => run_hex(&cli.file, offset, len, no_header),
-        Command::Properties => run_properties(&cli.file),
-        Command::IndexDump => run_index_dump(&cli.file),
+        } => run_hex(&cli.path, offset, len, no_header),
+        Command::Properties => run_properties(&cli.path),
+        Command::IndexDump => run_index_dump(&cli.path),
         Command::Dump {
             from,
             to,
             max,
             keys_only,
-        } => run_dump(&cli.file, from.as_deref(), to.as_deref(), max, keys_only),
-        Command::FilterStats => run_filter_stats(&cli.file),
-        Command::Repair => run_repair(&cli.file),
+        } => run_dump(&cli.path, from.as_deref(), to.as_deref(), max, keys_only),
+        Command::FilterStats => run_filter_stats(&cli.path),
+        Command::Repair => run_repair(&cli.path),
     }
 }
 

--- a/tools/sst-dump/tests/repair_smoke.rs
+++ b/tools/sst-dump/tests/repair_smoke.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test for `sst-dump repair`: build a real tree via
+//! `lsm-tree`, delete its manifest, drive the `repair` subcommand against the DB
+//! directory, and assert the manifest is rebuilt (exit 0) and the tree reopens
+//! with all keys intact.
+
+use lsm_tree::{AbstractTree, Config, MAX_SEQNO, SequenceNumberCounter};
+use std::process::Command;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+fn nuke_manifest(dir: &std::path::Path) {
+    for entry in std::fs::read_dir(dir).expect("read dir") {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let is_version = name
+            .strip_prefix('v')
+            .is_some_and(|rest| rest.parse::<u64>().is_ok());
+        if is_version || name == "current" {
+            std::fs::remove_file(entry.path()).expect("remove manifest file");
+        }
+    }
+}
+
+#[test]
+fn repair_rebuilds_manifest_and_db_reopens() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()
+        .expect("open tree");
+        for i in 0u64..200 {
+            tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+
+    nuke_manifest(dir.path());
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(dir.path())
+        .arg("repair")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        out.status.success(),
+        "repair should exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("manifest rebuilt"),
+        "unexpected output: {stdout}",
+    );
+
+    // The DB must reopen and serve every key after the rebuild.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("reopen tree after repair");
+    for i in 0u64..200 {
+        assert_eq!(
+            tree.get(format!("key-{i:06}"), MAX_SEQNO)
+                .expect("get")
+                .as_deref(),
+            Some(format!("value-{i}").as_bytes()),
+        );
+    }
+}

--- a/tools/sst-dump/tests/repair_smoke.rs
+++ b/tools/sst-dump/tests/repair_smoke.rs
@@ -14,23 +14,24 @@ const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
 /// Keep in sync with the copy in the `lsm-tree` crate's `tests/repair.rs` (a
 /// separate crate, so the helper cannot be shared directly): both encode the
 /// manifest file-naming convention (`v{N}` + `current`).
-fn nuke_manifest(dir: &std::path::Path) {
-    for entry in std::fs::read_dir(dir).expect("read dir") {
-        let entry = entry.expect("dir entry");
+fn nuke_manifest(dir: &std::path::Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
         let name = entry.file_name();
         let name = name.to_string_lossy();
         let is_version = name
             .strip_prefix('v')
             .is_some_and(|rest| rest.parse::<u64>().is_ok());
         if is_version || name == "current" {
-            std::fs::remove_file(entry.path()).expect("remove manifest file");
+            std::fs::remove_file(entry.path())?;
         }
     }
+    Ok(())
 }
 
 #[test]
-fn repair_rebuilds_manifest_and_db_reopens() {
-    let dir = tempfile::tempdir().expect("tempdir");
+fn repair_rebuilds_manifest_and_db_reopens() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
 
     {
         let tree = Config::new(
@@ -38,21 +39,19 @@ fn repair_rebuilds_manifest_and_db_reopens() {
             SequenceNumberCounter::default(),
             SequenceNumberCounter::default(),
         )
-        .open()
-        .expect("open tree");
+        .open()?;
         for i in 0u64..200 {
             tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
         }
-        tree.flush_active_memtable(0).expect("flush");
+        tree.flush_active_memtable(0)?;
     }
 
-    nuke_manifest(dir.path());
+    nuke_manifest(dir.path())?;
 
     let out = Command::new(SST_DUMP_BIN)
         .arg(dir.path())
         .arg("repair")
-        .output()
-        .expect("spawn sst-dump");
+        .output()?;
 
     assert!(
         out.status.success(),
@@ -71,14 +70,11 @@ fn repair_rebuilds_manifest_and_db_reopens() {
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
-    .open()
-    .expect("reopen tree after repair");
+    .open()?;
     for i in 0u64..200 {
-        assert_eq!(
-            tree.get(format!("key-{i:06}"), MAX_SEQNO)
-                .expect("get")
-                .as_deref(),
-            Some(format!("value-{i}").as_bytes()),
-        );
+        let got = tree.get(format!("key-{i:06}"), MAX_SEQNO)?;
+        assert_eq!(got.as_deref(), Some(format!("value-{i}").as_bytes()));
     }
+
+    Ok(())
 }

--- a/tools/sst-dump/tests/repair_smoke.rs
+++ b/tools/sst-dump/tests/repair_smoke.rs
@@ -11,6 +11,9 @@ use std::process::Command;
 
 const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
 
+/// Keep in sync with the copy in the `lsm-tree` crate's `tests/repair.rs` (a
+/// separate crate, so the helper cannot be shared directly): both encode the
+/// manifest file-naming convention (`v{N}` + `current`).
 fn nuke_manifest(dir: &std::path::Path) {
     for entry in std::fs::read_dir(dir).expect("read dir") {
         let entry = entry.expect("dir entry");


### PR DESCRIPTION
## Summary

Two related pieces:

1. **`repair_db`** — last-resort `MANIFEST` reconstruction from the SST files on disk (`Config::repair()` + `sst-dump <db-dir> repair`).
2. **structured-zstd 0.0.29 bump + encoder-side dictionary / compressor-reuse adoption** — picked up while the repair path exercises the compression stack; roughly halves our zstd:22 encode time.

## repair_db

- `Config::repair() -> Result<RepairReport>`: scans the table folder(s), recomputes each SST's whole-file XXH3-128 checksum, validates readability via `Table::recover`, and writes a fresh manifest placing every recovered table at L0 (RocksDB `RepairDB()` pattern; background compaction restructures on next open).
- Unreadable files are reported and skipped, not fatal. KV-separated (blob) trees return `FeatureUnsupported` (tracked in #408).
- `sst-dump <db-dir> repair` CLI wrapper.

## Compression (structured-zstd 0.0.29)

- `build(deps)`: 0.0.28 → 0.0.29 (per-strategy block-split, decode-bomb output bound, donor-correct block-split).
- **A**: attach the encode dictionary via `EncoderDictionary` (`set_dictionary_from_bytes` / `set_encoder_dictionary`) — parses for the encoder side only, skipping the decode lookup tables the compressor never reads.
- **B**: reuse a thread-local `FrameCompressor` across block frames via `compress_independent_frame` — avoids reconstructing matcher tables per block; the independent-frame path re-derives the source-size hint so the L22 small-source parameter set is still selected.

### Measured (local compare-rocksdb, zstd:22, median)

| bench | ours | rocksdb | A+B delta |
|-------|------|---------|-----------|
| write_throughput / 10k | 3.38 s | 4.11 s | ~2x faster |
| overwrite / 10k | 2.92 s | 4.11 s | ~2x faster |
| major_compact / 10k | 0.87 s | 1.06 s | ~2x faster |

Our zstd:22 encode now beats RocksDB on these. (zstd:1 also improved ~30% but still trails RocksDB; the subcompaction gap is split out as #410.)

## Testing

- repair: manifest-loss round-trip (all keys readable after repair incl. overwrites), unreadable-file skip, non-table-id / dangling-symlink / .DS_Store handling, zero-SST, blob-tree rejection; CLI smoke test.
- compression: dictionary round-trip / wrong-dict rejection / per-level / encryption / blob / major-compaction (39 tests) unchanged; full workspace suite green; clippy `--all-features` + fmt clean; doc tests pass.

## Related

- #408 — repair for KV-separated (blob) trees (follow-up)
- #410 — subcompaction far slower than RocksDB (perf investigation, split out)

Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a disaster-recovery repair mechanism to rebuild missing or corrupt manifests from on-disk SST files.
  * Added a CLI "repair" command to run reconstruction and print a repair report.

* **Behavior & Reliability**
  * Recovery skips or quarantines unreadable or non-table files, preserves readable data, and reports recovered/unreadable counts, per-file reasons, and warnings.
  * Rejects unsupported KV-separated/tree formats.

* **Tests**
  * Added unit and end-to-end tests covering repair scenarios and edge cases.

* **Improvements**
  * Improved compression performance by reusing compressors and refining dictionary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->