### PR TITLE
feat(query): cold-block partial decode with resumable zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ log = "0.4.32"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.30", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.32", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,3 +277,9 @@ name = "compaction"
 harness = false
 path = "benches/compaction.rs"
 required-features = ["zstd"]
+
+[[bench]]
+name = "partial_decode"
+harness = false
+path = "benches/partial_decode.rs"
+required-features = ["zstd"]

--- a/benches/partial_decode.rs
+++ b/benches/partial_decode.rs
@@ -29,7 +29,8 @@ fn key(i: u64) -> Vec<u8> {
 /// is the signal that matters for the partial-decode path (a cold-block decode
 /// is a tail event), so it is surfaced explicitly rather than hidden in a mean.
 fn run_window_reads(tree: &lsm_tree::AnyTree, iters: u64, stride: u64) -> Duration {
-    let mut lat_us: Vec<u64> = Vec::with_capacity(iters as usize);
+    let mut lat_us: Vec<u64> =
+        Vec::with_capacity(usize::try_from(iters).expect("iters fits usize"));
     let mut lo = 0u64;
     let batch_start = Instant::now();
     for _ in 0..iters {
@@ -38,7 +39,7 @@ fn run_window_reads(tree: &lsm_tree::AnyTree, iters: u64, stride: u64) -> Durati
         for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
             std::hint::black_box(g.key().unwrap());
         }
-        lat_us.push(t0.elapsed().as_micros() as u64);
+        lat_us.push(u64::try_from(t0.elapsed().as_micros()).expect("elapsed micros fits u64"));
     }
     let elapsed = batch_start.elapsed();
     if !lat_us.is_empty() {

--- a/benches/partial_decode.rs
+++ b/benches/partial_decode.rs
@@ -23,6 +23,37 @@ fn key(i: u64) -> Vec<u8> {
     format!("key-{i:08}").into_bytes()
 }
 
+/// Runs `iters` distinct small range reads marching by `stride`, capturing
+/// per-query latency to report tail percentiles (P50/P99/P999) on stderr in
+/// addition to the aggregate elapsed Duration criterion measures. Tail latency
+/// is the signal that matters for the partial-decode path (a cold-block decode
+/// is a tail event), so it is surfaced explicitly rather than hidden in a mean.
+fn run_window_reads(tree: &lsm_tree::AnyTree, iters: u64, stride: u64) -> Duration {
+    let mut lat_us: Vec<u64> = Vec::with_capacity(iters as usize);
+    let mut lo = 0u64;
+    let batch_start = Instant::now();
+    for _ in 0..iters {
+        lo = (lo + stride) % (N - SPAN);
+        let t0 = Instant::now();
+        for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
+            std::hint::black_box(g.key().unwrap());
+        }
+        lat_us.push(t0.elapsed().as_micros() as u64);
+    }
+    let elapsed = batch_start.elapsed();
+    if !lat_us.is_empty() {
+        lat_us.sort_unstable();
+        let at = |num: usize, den: usize| lat_us[(lat_us.len() * num / den).min(lat_us.len() - 1)];
+        eprintln!(
+            "    tail latency: p50={}us p99={}us p999={}us",
+            at(50, 100),
+            at(99, 100),
+            at(999, 1000),
+        );
+    }
+    elapsed
+}
+
 fn bench_partial_range(c: &mut Criterion) {
     let dir = tempfile::tempdir().unwrap();
     let tree = Config::new(
@@ -59,17 +90,7 @@ fn bench_partial_range(c: &mut Criterion) {
     // Exercises that resume keeps this at parity with full decode + block cache
     // (it was a ~3x regression before the resumable decoder).
     c.bench_function("range_small_window_marching_in_block", |b| {
-        b.iter_custom(|iters| {
-            let start = Instant::now();
-            let mut lo = 0u64;
-            for _ in 0..iters {
-                lo = (lo + 137) % (N - SPAN);
-                for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
-                    std::hint::black_box(g.key().unwrap());
-                }
-            }
-            start.elapsed()
-        });
+        b.iter_custom(|iters| run_window_reads(&tree, iters, 137));
     });
 
     // Favorable-to-partial pattern: a large prime stride makes each query land
@@ -77,20 +98,8 @@ fn bench_partial_range(c: &mut Criterion) {
     // cold touch — the partial path decodes only the inner blocks up to the
     // window and skips the trailing ones.
     c.bench_function("range_small_window_uniform_cross_block", |b| {
-        b.iter_custom(|iters| {
-            let start = Instant::now();
-            let mut lo = 0u64;
-            for _ in 0..iters {
-                lo = (lo + 6_151) % (N - SPAN);
-                for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
-                    std::hint::black_box(g.key().unwrap());
-                }
-            }
-            start.elapsed()
-        });
+        b.iter_custom(|iters| run_window_reads(&tree, iters, 6_151));
     });
-
-    let _ = Duration::from_secs(0);
 }
 
 criterion_group!(benches, bench_partial_range);

--- a/benches/partial_decode.rs
+++ b/benches/partial_decode.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Range-query throughput over large cold-tier zstd blocks (#257).
+//!
+//! Builds a tree with 256 KiB data blocks at zstd L19 (so each block splits
+//! into many inner zstd blocks and the `block_layout` section is present), then
+//! times many DISTINCT small range reads spread across the tree with a tiny
+//! block cache (so reads are cache-cold). On a build with the partial-decode
+//! path, each read decodes only the inner blocks covering its key range; on a
+//! build without it, each read decodes the whole 256 KiB block — the A/B delta
+//! is the win. Run on this branch and on the pre-#257 baseline to compare.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lsm_tree::config::{BlockSizePolicy, CompressionPolicy};
+use lsm_tree::{AbstractTree, CompressionType, Config, Guard, SeqNo, SequenceNumberCounter};
+use std::time::{Duration, Instant};
+
+const N: u64 = 60_000;
+const SPAN: u64 = 4; // keys read per range
+
+fn key(i: u64) -> Vec<u8> {
+    format!("key-{i:08}").into_bytes()
+}
+
+fn bench_partial_range(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(
+        CompressionType::zstd(19).expect("level"),
+    ))
+    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    // Tiny block cache so each distinct read is cache-cold (the partial-decode
+    // win is on the first decode; warm reads hit the cache regardless).
+    .use_cache(std::sync::Arc::new(lsm_tree::Cache::with_capacity_bytes(
+        1024 * 1024,
+    )))
+    .open()
+    .unwrap();
+
+    for i in 0..N {
+        tree.insert(
+            key(i),
+            format!("value-{i:08}-padding-padding").into_bytes(),
+            0,
+        );
+    }
+    tree.flush_active_memtable(0).unwrap();
+
+    // Adversarial-to-partial pattern: small step keeps many consecutive windows
+    // inside the same large block with a monotonically rising upper, so the
+    // partial path repeatedly re-decodes a growing prefix (no resumable decode
+    // upstream) while full-decode + block-cache amortizes one decode per block.
+    c.bench_function("range_small_window_marching_in_block", |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            let mut lo = 0u64;
+            for _ in 0..iters {
+                lo = (lo + 137) % (N - SPAN);
+                for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
+                    std::hint::black_box(g.key().unwrap());
+                }
+            }
+            start.elapsed()
+        });
+    });
+
+    // Favorable-to-partial pattern: a large prime stride makes each query land
+    // in a DIFFERENT block (no in-block monotonic growth), so each is a single
+    // cold touch — the partial path decodes only the inner blocks up to the
+    // window and skips the trailing ones.
+    c.bench_function("range_small_window_uniform_cross_block", |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            let mut lo = 0u64;
+            for _ in 0..iters {
+                lo = (lo + 6_151) % (N - SPAN);
+                for g in tree.range(key(lo)..key(lo + SPAN), SeqNo::MAX, None) {
+                    std::hint::black_box(g.key().unwrap());
+                }
+            }
+            start.elapsed()
+        });
+    });
+
+    let _ = Duration::from_secs(0);
+}
+
+criterion_group!(benches, bench_partial_range);
+criterion_main!(benches);

--- a/benches/partial_decode.rs
+++ b/benches/partial_decode.rs
@@ -3,13 +3,13 @@
 
 //! Range-query throughput over large cold-tier zstd blocks (#257).
 //!
-//! Builds a tree with 256 KiB data blocks at zstd L19 (so each block splits
-//! into many inner zstd blocks and the `block_layout` section is present), then
-//! times many DISTINCT small range reads spread across the tree with a tiny
-//! block cache (so reads are cache-cold). On a build with the partial-decode
-//! path, each read decodes only the inner blocks covering its key range; on a
-//! build without it, each read decodes the whole 256 KiB block — the A/B delta
-//! is the win. Run on this branch and on the pre-#257 baseline to compare.
+//! Builds a tree with 512 KiB data blocks at zstd L19 (above the partial tier's
+//! 256 KiB engage floor; production cold blocks are far larger), so each block
+//! splits into many inner zstd blocks and the `block_layout` section is present.
+//! Times small range reads with a tiny block cache. With the partial path on, a
+//! read decodes only the inner blocks covering its key range and a wider read
+//! RESUMES (decoding just the new tail blocks); with it off, each cold read
+//! decodes the whole block. Toggle `LSM_PARTIAL_DECODE` for the A/B.
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use lsm_tree::config::{BlockSizePolicy, CompressionPolicy};
@@ -33,7 +33,9 @@ fn bench_partial_range(c: &mut Criterion) {
     .data_block_compression_policy(CompressionPolicy::all(
         CompressionType::zstd(19).expect("level"),
     ))
-    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    // Above the partial tier's 256 KiB engage floor (production cold blocks are
+    // far larger; this is the smallest size at which the path turns on).
+    .data_block_size_policy(BlockSizePolicy::all(512 * 1024))
     // Tiny block cache so each distinct read is cache-cold (the partial-decode
     // win is on the first decode; warm reads hit the cache regardless).
     .use_cache(std::sync::Arc::new(lsm_tree::Cache::with_capacity_bytes(
@@ -51,10 +53,11 @@ fn bench_partial_range(c: &mut Criterion) {
     }
     tree.flush_active_memtable(0).unwrap();
 
-    // Adversarial-to-partial pattern: small step keeps many consecutive windows
-    // inside the same large block with a monotonically rising upper, so the
-    // partial path repeatedly re-decodes a growing prefix (no resumable decode
-    // upstream) while full-decode + block-cache amortizes one decode per block.
+    // In-block marching: a small step keeps many consecutive windows inside the
+    // same block with a monotonically rising upper, so the partial path RESUMES
+    // (decoding only each new tail) and eventually promotes to a full block.
+    // Exercises that resume keeps this at parity with full decode + block cache
+    // (it was a ~3x regression before the resumable decoder).
     c.bench_function("range_small_window_marching_in_block", |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,17 +4,45 @@
 
 use crate::table::block::Header;
 use crate::table::{Block, BlockOffset};
-use crate::{GlobalTableId, UserValue};
+use crate::{GlobalTableId, UserKey, UserValue};
 use quick_cache::Weighter;
 use quick_cache::sync::Cache as QuickCache;
 
 const TAG_BLOCK: u8 = 0;
 const TAG_BLOB: u8 = 1;
+const TAG_PARTIAL_BLOCK: u8 = 2;
 
 #[derive(Clone)]
 enum Item {
     Block(Block),
     Blob(UserValue),
+    /// A partial (covering) data block synthesized for the adaptive partial-tier
+    /// read path: only the inner zstd blocks up to `covered_upper` are decoded,
+    /// so a cold block keeps just the touched fraction resident. Serves any range
+    /// whose upper bound is `<= covered_upper`; a wider query grows the extent
+    /// (high-water). The access stats drive promotion to a full resident block
+    /// (see [`Cache::peek_partial_block`]).
+    PartialBlock(PartialBlockEntry),
+}
+
+/// A cached partial (covering) data block plus the access stats the partial-tier
+/// promotion heuristic reads: how much of the block is decoded and how often it
+/// has been served. When a cold block is read often enough or its decoded
+/// fraction passes the promotion threshold, the reader decodes it fully and
+/// caches the whole block instead, evicting this entry.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct PartialBlockEntry {
+    /// Synthesized standalone data block covering `[block_start, covered_upper]`.
+    pub block: Block,
+    /// Highest user key the synthesized block covers (its last complete entry).
+    pub covered_upper: UserKey,
+    /// Inner zstd blocks decoded into `block` so far.
+    pub covered_blocks: u32,
+    /// Total inner zstd blocks in the full data block.
+    pub total_blocks: u32,
+    /// Number of times this partial entry has served a read (promotion input).
+    pub hits: u32,
 }
 
 #[derive(Eq, std::hash::Hash, PartialEq)]
@@ -39,6 +67,11 @@ impl Weighter<CacheKey, Item> for BlockWeighter {
                     + u64::from(b.header.uncompressed_length)
             }
             Blob(b) => b.len() as u64,
+            Item::PartialBlock(entry) => {
+                (Header::header_len(entry.block.header.block_type) as u64)
+                    + u64::from(entry.block.header.uncompressed_length)
+                    + entry.covered_upper.len() as u64
+            }
         }
     }
 }
@@ -122,8 +155,60 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Block(block) => block,
-            Item::Blob(_) => unreachable!("invalid cache item"),
+            Item::Blob(_) | Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })
+    }
+
+    /// Whether a full (non-partial) data block is already resident for `offset`.
+    /// The partial-tier reader uses this to bail out (let the normal cached path
+    /// serve) once a block has been promoted to a full resident block.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn has_block(&self, id: GlobalTableId, offset: BlockOffset) -> bool {
+        let key: CacheKey = (TAG_BLOCK, id.tree_id(), id.table_id(), *offset).into();
+        self.data.peek(&key).is_some()
+    }
+
+    /// Reads the cached partial-block entry for `offset` (block + access stats),
+    /// without mutating it. The caller checks coverage against its query, applies
+    /// the promotion heuristic, then re-inserts with bumped stats, grows the
+    /// extent, or promotes to a full block.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn peek_partial_block(
+        &self,
+        id: GlobalTableId,
+        offset: BlockOffset,
+    ) -> Option<PartialBlockEntry> {
+        let key: CacheKey = (TAG_PARTIAL_BLOCK, id.tree_id(), id.table_id(), *offset).into();
+        match self.data.peek(&key) {
+            Some(Item::PartialBlock(entry)) => Some(entry),
+            _ => None,
+        }
+    }
+
+    /// Inserts or replaces the partial-block entry for `offset` (high-water
+    /// growth: a wider covering block with more decoded inner blocks replaces a
+    /// narrower one).
+    #[doc(hidden)]
+    pub fn insert_partial_block(
+        &self,
+        id: GlobalTableId,
+        offset: BlockOffset,
+        entry: PartialBlockEntry,
+    ) {
+        self.data.insert(
+            (TAG_PARTIAL_BLOCK, id.tree_id(), id.table_id(), *offset).into(),
+            Item::PartialBlock(entry),
+        );
+    }
+
+    /// Drops the partial-block entry for `offset` (used on promotion to a full
+    /// resident block, so the stale partial does not linger).
+    #[doc(hidden)]
+    pub fn evict_partial_block(&self, id: GlobalTableId, offset: BlockOffset) {
+        let key: CacheKey = (TAG_PARTIAL_BLOCK, id.tree_id(), id.table_id(), *offset).into();
+        self.data.remove(&key);
     }
 
     #[doc(hidden)]
@@ -158,7 +243,7 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Blob(blob) => blob,
-            Item::Block(_) => unreachable!("invalid cache item"),
+            Item::Block(_) | Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,43 +2,47 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(feature = "zstd")]
+use crate::UserKey;
 use crate::table::block::Header;
 use crate::table::{Block, BlockOffset};
-use crate::{GlobalTableId, UserKey, UserValue};
+use crate::{GlobalTableId, UserValue};
 use quick_cache::Weighter;
 use quick_cache::sync::Cache as QuickCache;
 
 const TAG_BLOCK: u8 = 0;
 const TAG_BLOB: u8 = 1;
+#[cfg(feature = "zstd")]
 const TAG_PARTIAL_BLOCK: u8 = 2;
 
 #[derive(Clone)]
 enum Item {
     Block(Block),
     Blob(UserValue),
-    /// A partial (covering) data block synthesized for the adaptive partial-tier
-    /// read path: only the inner zstd blocks up to `covered_upper` are decoded,
-    /// so a cold block keeps just the touched fraction resident. Serves any range
-    /// whose upper bound is `<= covered_upper`; a wider query grows the extent
-    /// (high-water). The access stats drive promotion to a full resident block
-    /// (see [`Cache::peek_partial_block`]).
+    /// The adaptive partial-tier entry for a cold zstd block: the decompressed
+    /// prefix + resume snapshot (so a later read extends it without re-decoding
+    /// from block 0) plus the access stats driving promotion to a full resident
+    /// block. The served data block is synthesized on demand from the prefix, so
+    /// only the touched fraction stays resident. See [`Cache::peek_partial_block`].
+    #[cfg(feature = "zstd")]
     PartialBlock(PartialBlockEntry),
 }
 
-/// A cached partial (covering) data block plus the access stats the partial-tier
-/// promotion heuristic reads: how much of the block is decoded and how often it
-/// has been served. When a cold block is read often enough or its decoded
-/// fraction passes the promotion threshold, the reader decodes it fully and
-/// caches the whole block instead, evicting this entry.
+/// A cached partial-tier entry: the resumable decode state for a cold block plus
+/// the access stats the promotion heuristic reads. When the block is read often
+/// enough or its decoded fraction passes the promotion threshold, the reader
+/// decodes it fully and caches the whole block instead, evicting this entry.
+#[cfg(feature = "zstd")]
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct PartialBlockEntry {
-    /// Synthesized standalone data block covering `[block_start, covered_upper]`.
-    pub block: Block,
-    /// Highest user key the synthesized block covers (its last complete entry).
+    /// Resumable decode state: the decompressed prefix (`window_prime`), the
+    /// entropy/repcode snapshot, the inner-block count, and the compressed
+    /// cursor. The served data block is synthesized from `window_prime`; growth
+    /// resumes from the snapshot.
+    pub resume: crate::table::lazy_block::PartialResume,
+    /// Highest user key the decoded prefix covers (its last complete entry).
     pub covered_upper: UserKey,
-    /// Inner zstd blocks decoded into `block` so far.
-    pub covered_blocks: u32,
     /// Total inner zstd blocks in the full data block.
     pub total_blocks: u32,
     /// Number of times this partial entry has served a read (promotion input).
@@ -67,10 +71,12 @@ impl Weighter<CacheKey, Item> for BlockWeighter {
                     + u64::from(b.header.uncompressed_length)
             }
             Blob(b) => b.len() as u64,
+            // Weighed by the resident decompressed prefix + covered key; the
+            // shared `Arc<ResumeState>` scratch is approximated by a small fixed
+            // term rather than counted per entry.
+            #[cfg(feature = "zstd")]
             Item::PartialBlock(entry) => {
-                (Header::header_len(entry.block.header.block_type) as u64)
-                    + u64::from(entry.block.header.uncompressed_length)
-                    + entry.covered_upper.len() as u64
+                entry.resume.window_prime.len() as u64 + entry.covered_upper.len() as u64 + 64
             }
         }
     }
@@ -155,13 +161,16 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Block(block) => block,
-            Item::Blob(_) | Item::PartialBlock(_) => unreachable!("invalid cache item"),
+            Item::Blob(_) => unreachable!("invalid cache item"),
+            #[cfg(feature = "zstd")]
+            Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })
     }
 
     /// Whether a full (non-partial) data block is already resident for `offset`.
     /// The partial-tier reader uses this to bail out (let the normal cached path
     /// serve) once a block has been promoted to a full resident block.
+    #[cfg(feature = "zstd")]
     #[doc(hidden)]
     #[must_use]
     pub fn has_block(&self, id: GlobalTableId, offset: BlockOffset) -> bool {
@@ -169,10 +178,11 @@ impl Cache {
         self.data.peek(&key).is_some()
     }
 
-    /// Reads the cached partial-block entry for `offset` (block + access stats),
-    /// without mutating it. The caller checks coverage against its query, applies
-    /// the promotion heuristic, then re-inserts with bumped stats, grows the
-    /// extent, or promotes to a full block.
+    /// Reads the cached partial-tier entry for `offset` (resume state + access
+    /// stats), without mutating it. The caller checks coverage against its query,
+    /// applies the promotion heuristic, then re-inserts with bumped stats, grows
+    /// the extent, or promotes to a full block.
+    #[cfg(feature = "zstd")]
     #[doc(hidden)]
     #[must_use]
     pub fn peek_partial_block(
@@ -187,9 +197,10 @@ impl Cache {
         }
     }
 
-    /// Inserts or replaces the partial-block entry for `offset` (high-water
-    /// growth: a wider covering block with more decoded inner blocks replaces a
+    /// Inserts or replaces the partial-tier entry for `offset` (high-water
+    /// growth: a wider covering prefix with more decoded inner blocks replaces a
     /// narrower one).
+    #[cfg(feature = "zstd")]
     #[doc(hidden)]
     pub fn insert_partial_block(
         &self,
@@ -203,8 +214,9 @@ impl Cache {
         );
     }
 
-    /// Drops the partial-block entry for `offset` (used on promotion to a full
+    /// Drops the partial-tier entry for `offset` (used on promotion to a full
     /// resident block, so the stale partial does not linger).
+    #[cfg(feature = "zstd")]
     #[doc(hidden)]
     pub fn evict_partial_block(&self, id: GlobalTableId, offset: BlockOffset) {
         let key: CacheKey = (TAG_PARTIAL_BLOCK, id.tree_id(), id.table_id(), *offset).into();
@@ -243,7 +255,9 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Blob(blob) => blob,
-            Item::Block(_) | Item::PartialBlock(_) => unreachable!("invalid cache item"),
+            Item::Block(_) => unreachable!("invalid cache item"),
+            #[cfg(feature = "zstd")]
+            Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })
     }
 }

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -25,6 +25,24 @@ pub trait CompressionProvider {
     /// Compress `data` at the given zstd level (1–22).
     fn compress(data: &[u8], level: i32) -> crate::Result<Vec<u8>>;
 
+    /// Compress `data`, additionally returning the inner zstd-block layout of
+    /// the produced frame: the cumulative decompressed END offset of each inner
+    /// block (a monotonically increasing prefix sum whose last entry equals the
+    /// total decompressed size). A reader can binary-search this array to map a
+    /// decompressed byte offset to the inner-block index covering it, then
+    /// partial-decode only the covering blocks (see
+    /// [`FrameDecoder::decode_blocks_partial`](structured_zstd::decoding::FrameDecoder::decode_blocks_partial)).
+    ///
+    /// The layout is returned **empty** when the frame is a single inner block
+    /// (nothing to skip, so the caller persists no per-block table) or when the
+    /// backend could not capture it. The compressed bytes are identical to
+    /// [`compress`](Self::compress); only the side-channel layout differs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if compression fails.
+    fn compress_with_layout(data: &[u8], level: i32) -> crate::Result<(Vec<u8>, Vec<u32>)>;
+
     /// Decompress a zstd frame, pre-allocating `capacity` bytes.
     fn decompress(data: &[u8], capacity: usize) -> crate::Result<Vec<u8>>;
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -263,77 +263,68 @@ fn inner_block_layout(
     ends
 }
 
+/// Runs `f` with a thread-local [`FrameCompressor`] cached by `level` (rebuilt
+/// only on a level change). Shared by [`ZstdProvider::compress`] and
+/// `compress_with_layout` so interleaving them at the same level reuses one
+/// compressor instead of maintaining two separate thread-local caches.
+///
+/// `compress_slice_to_vec` builds a fresh `FrameCompressor` (and its matcher
+/// tables) on every call; reusing one per thread avoids that per-block
+/// reconstruction — most visible at btultra2 / L22, where the tables are large.
+/// `compress_independent_frame` still resets per-frame state and re-derives the
+/// source-size hint from `data`, so the L22 small-source parameter set is still
+/// selected for the 4-64 KiB blocks an LSM writes. Default generics keep the
+/// cached type `'static` for thread-local storage.
+fn with_tls_compressor<R>(
+    level: i32,
+    f: impl FnOnce(&mut structured_zstd::encoding::FrameCompressor) -> R,
+) -> R {
+    use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+    thread_local! {
+        static TLS_COMPRESSOR: std::cell::RefCell<Option<(i32, FrameCompressor)>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    TLS_COMPRESSOR.with(|cell| {
+        let mut state = cell.borrow_mut();
+        if !matches!(&*state, Some((l, _)) if *l == level) {
+            *state = Some((
+                level,
+                FrameCompressor::new(CompressionLevel::from_level(level)),
+            ));
+        }
+        let Some((_, compressor)) = state.as_mut() else {
+            unreachable!("TLS_COMPRESSOR initialised above");
+        };
+        f(compressor)
+    })
+}
+
 /// Pure Rust zstd backend.
 pub struct ZstdProvider;
 
 impl CompressionProvider for ZstdProvider {
     fn compress(data: &[u8], level: i32) -> crate::Result<Vec<u8>> {
-        use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
-
-        // Thread-local compressor reused across blocks. `compress_slice_to_vec`
-        // builds a fresh `FrameCompressor` (and its matcher tables) on every
-        // call; reusing one per thread avoids that per-block reconstruction —
-        // most visible at btultra2 / L22, where the tables are large. Keyed by
-        // level so a level change rebuilds the compressor.
-        //
-        // `compress_independent_frame_into` emits a standalone frame: it resets
-        // per-frame state and re-derives the source-size hint from `data`, so
-        // the L22 small-source parameter set is still selected for the 4-64 KiB
-        // blocks an LSM writes (the ~34x win the old size-hint path delivered).
-        // Default generics (`R = &'static [u8]`, `W = Vec<u8>`) keep the cached
-        // type `'static` for thread-local storage.
-        thread_local! {
-            static TLS_COMPRESSOR: std::cell::RefCell<Option<(i32, FrameCompressor)>> =
-                const { std::cell::RefCell::new(None) };
-        }
-
-        TLS_COMPRESSOR.with(|cell| {
-            let mut state = cell.borrow_mut();
-            if !matches!(&*state, Some((l, _)) if *l == level) {
-                *state = Some((
-                    level,
-                    FrameCompressor::new(CompressionLevel::from_level(level)),
-                ));
-            }
-            let Some((_, compressor)) = state.as_mut() else {
-                unreachable!("TLS_COMPRESSOR initialised above");
-            };
-            // `compress_independent_frame` is the `FrameCompressor` CCtx-style
-            // single-frame API (structured-zstd >= 0.0.29); it allocates a fresh
-            // output Vec and emits one standalone frame.
-            Ok(compressor.compress_independent_frame(data))
-        })
+        // `compress_independent_frame` is the `FrameCompressor` CCtx-style
+        // single-frame API (structured-zstd >= 0.0.29): it allocates a fresh
+        // output Vec and emits one standalone frame.
+        Ok(with_tls_compressor(level, |compressor| {
+            compressor.compress_independent_frame(data)
+        }))
     }
 
     fn compress_with_layout(data: &[u8], level: i32) -> crate::Result<(Vec<u8>, Vec<u32>)> {
-        use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
-
-        // Mirrors `compress`'s thread-local reuse, but also reads back the
-        // frame layout the encoder recorded during this emit
-        // (`last_frame_emit_info`, captured under the `lsm` feature). The
-        // layout is only meaningful when the frame split into >= 2 inner zstd
-        // blocks; for a single-block frame there is nothing to partial-decode,
-        // so an empty layout is returned and no per-block table is persisted.
-        thread_local! {
-            static TLS_COMPRESSOR: std::cell::RefCell<Option<(i32, FrameCompressor)>> =
-                const { std::cell::RefCell::new(None) };
-        }
-
-        TLS_COMPRESSOR.with(|cell| {
-            let mut state = cell.borrow_mut();
-            if !matches!(&*state, Some((l, _)) if *l == level) {
-                *state = Some((
-                    level,
-                    FrameCompressor::new(CompressionLevel::from_level(level)),
-                ));
-            }
-            let Some((_, compressor)) = state.as_mut() else {
-                unreachable!("TLS_COMPRESSOR initialised above");
-            };
+        // Mirrors `compress`, but also reads back the frame layout the encoder
+        // recorded during this emit (`last_frame_emit_info`, under the `lsm`
+        // feature). The layout is only meaningful when the frame split into
+        // >= 2 inner zstd blocks; a single-block frame returns an empty layout
+        // (nothing to partial-decode) and no per-block table is persisted.
+        Ok(with_tls_compressor(level, |compressor| {
             let frame = compressor.compress_independent_frame(data);
             let layout = inner_block_layout(compressor.last_frame_emit_info());
-            Ok((frame, layout))
-        })
+            (frame, layout)
+        }))
     }
 
     fn decompress(data: &[u8], capacity: usize) -> crate::Result<Vec<u8>> {

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -573,7 +573,7 @@ impl CompressionProvider for ZstdProvider {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "test code")]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
     use super::*;
     use crate::compression::ZstdDictionary;

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -234,6 +234,35 @@ fn do_decompress_with_dict(
     }
 }
 
+/// Extract the inner-block layout (cumulative decompressed END offsets) from a
+/// just-emitted frame's [`FrameEmitInfo`].
+///
+/// Returns an empty `Vec` when the frame has fewer than two inner blocks
+/// (nothing to partial-decode), when the encoder did not capture layout
+/// (`None`), or when any cumulative offset would not fit `u32` (the per-block
+/// table is then skipped and the reader falls back to full decode — never a
+/// correctness risk, only a missed optimisation).
+fn inner_block_layout(
+    info: Option<&structured_zstd::encoding::frame_emit_info::FrameEmitInfo>,
+) -> Vec<u32> {
+    let Some(info) = info else { return Vec::new() };
+    let n = info.blocks.len();
+    if n < 2 {
+        return Vec::new();
+    }
+    let mut ends = Vec::with_capacity(n);
+    for i in 0..n {
+        let Some(range) = info.decompressed_byte_range(i) else {
+            return Vec::new();
+        };
+        let Ok(end) = u32::try_from(range.end) else {
+            return Vec::new();
+        };
+        ends.push(end);
+    }
+    ends
+}
+
 /// Pure Rust zstd backend.
 pub struct ZstdProvider;
 
@@ -273,6 +302,37 @@ impl CompressionProvider for ZstdProvider {
             // single-frame API (structured-zstd >= 0.0.29); it allocates a fresh
             // output Vec and emits one standalone frame.
             Ok(compressor.compress_independent_frame(data))
+        })
+    }
+
+    fn compress_with_layout(data: &[u8], level: i32) -> crate::Result<(Vec<u8>, Vec<u32>)> {
+        use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+        // Mirrors `compress`'s thread-local reuse, but also reads back the
+        // frame layout the encoder recorded during this emit
+        // (`last_frame_emit_info`, captured under the `lsm` feature). The
+        // layout is only meaningful when the frame split into >= 2 inner zstd
+        // blocks; for a single-block frame there is nothing to partial-decode,
+        // so an empty layout is returned and no per-block table is persisted.
+        thread_local! {
+            static TLS_COMPRESSOR: std::cell::RefCell<Option<(i32, FrameCompressor)>> =
+                const { std::cell::RefCell::new(None) };
+        }
+
+        TLS_COMPRESSOR.with(|cell| {
+            let mut state = cell.borrow_mut();
+            if !matches!(&*state, Some((l, _)) if *l == level) {
+                *state = Some((
+                    level,
+                    FrameCompressor::new(CompressionLevel::from_level(level)),
+                ));
+            }
+            let Some((_, compressor)) = state.as_mut() else {
+                unreachable!("TLS_COMPRESSOR initialised above");
+            };
+            let frame = compressor.compress_independent_frame(data);
+            let layout = inner_block_layout(compressor.last_frame_emit_info());
+            Ok((frame, layout))
         })
     }
 
@@ -957,6 +1017,94 @@ mod tests {
         assert!(
             matches!(result, Err(crate::Error::DecompressedSizeTooLarge { .. })),
             "capacity=0 must return DecompressedSizeTooLarge; got {result:?}",
+        );
+    }
+
+    // --- compress_with_layout (#257 inner-block layout) tests ---
+
+    /// Build a realistic sorted-KV data-block payload of about `target` bytes:
+    /// monotonically increasing keys + short values, the shape a flushed
+    /// memtable serialises into a data block.
+    fn sorted_kv_payload(target: usize) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(target + 64);
+        let mut i = 0u64;
+        while buf.len() < target {
+            buf.extend_from_slice(format!("key-{i:012}").as_bytes());
+            buf.push(0);
+            buf.extend_from_slice(format!("value-{i:08}-payload").as_bytes());
+            buf.push(0);
+            i += 1;
+        }
+        buf
+    }
+
+    #[test]
+    fn compress_with_layout_single_inner_block_returns_empty_layout() {
+        // A small (default-sized) block compresses to a single inner zstd
+        // block: nothing to partial-decode, so the layout must be empty and no
+        // per-block table is persisted by the caller.
+        let payload = sorted_kv_payload(4 * 1024);
+        let (frame, layout) =
+            ZstdProvider::compress_with_layout(&payload, 3).expect("compress with layout");
+        assert!(
+            layout.is_empty(),
+            "single-inner-block frame must yield an empty layout, got {layout:?}",
+        );
+        // The compressed bytes still round-trip.
+        let back = ZstdProvider::decompress(&frame, payload.len() + 1).expect("decompress");
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn compress_with_layout_multi_inner_block_offsets_are_monotonic_and_total() {
+        // A large block at a high level pre-splits into several inner zstd
+        // blocks. The layout must be strictly increasing cumulative ends whose
+        // last entry equals the total decompressed size.
+        let payload = sorted_kv_payload(256 * 1024);
+        let (_frame, layout) =
+            ZstdProvider::compress_with_layout(&payload, 19).expect("compress with layout");
+        assert!(
+            layout.len() >= 2,
+            "256 KiB @ L19 must split into >= 2 inner blocks, got {} block(s)",
+            layout.len(),
+        );
+        assert!(
+            layout.windows(2).all(|w| w[0] < w[1]),
+            "cumulative ends must be strictly increasing: {layout:?}",
+        );
+        assert_eq!(
+            *layout.last().expect("non-empty layout") as usize,
+            payload.len(),
+            "last cumulative end must equal the total decompressed size",
+        );
+    }
+
+    #[test]
+    fn compress_with_layout_subrange_partial_decode_matches_full_slice() {
+        // The persisted layout must let a reader decode exactly the inner-block
+        // subset and get bytes identical to the matching full-decode slice —
+        // the core correctness contract of the partial-decode read path.
+        use structured_zstd::decoding::FrameDecoder;
+
+        let payload = sorted_kv_payload(256 * 1024);
+        let (frame, layout) =
+            ZstdProvider::compress_with_layout(&payload, 19).expect("compress with layout");
+        let nblocks = layout.len();
+        assert!(nblocks >= 2, "need a multi-block frame");
+
+        // Decode the first inner block only, then assert it equals the prefix
+        // of the full payload up to that block's cumulative end.
+        let mut src = frame.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut src).expect("reset frame header");
+        let pd = dec
+            .decode_blocks_partial(&mut src, 0, 1)
+            .expect("partial decode of first inner block");
+        let want_end = layout[0] as usize;
+        assert_eq!(
+            pd.data.as_slice(),
+            &payload[..want_end],
+            "partial-decode [0,1) must equal the full-decode slice [0,{want_end})",
         );
     }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -1098,7 +1098,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         dec.reset(&mut src).expect("reset frame header");
         let pd = dec
-            .decode_blocks_partial(&mut src, 0, 1)
+            .decode_blocks_partial(&mut src, 0, 1, None, false)
             .expect("partial decode of first inner block");
         let want_end = layout[0] as usize;
         assert_eq!(

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -149,6 +149,14 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         self.restart_interval
     }
 
+    /// Byte length of the entry region (offset where the trailer begins).
+    /// Test-only: lets headerless-decode tests slice the exact entry region.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn entries_end_for_test(&self) -> Option<usize> {
+        self.cached_entries_end
+    }
+
     /// Extracts the reusable trailer metadata from a fully-constructed
     /// decoder so future decodes of the same block can skip the trailer
     /// parse via [`Self::from_meta`].
@@ -299,6 +307,74 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     )]
     pub fn new(block: &'a Block) -> Self {
         Self::try_new(block).expect("valid block trailer")
+    }
+
+    /// Builds a forward-only decoder over a block whose bytes are JUST the
+    /// entry region, with NO trailer (restart array / binary index / hash
+    /// index). Used for partial-decode reads, where `block.data` is the
+    /// contiguous decompressed prefix of a subset of inner zstd blocks (the
+    /// trailer lives in a later inner block that was skipped).
+    ///
+    /// Only forward iteration ([`Iterator::next`]) is valid: there is no
+    /// index, so seeking / binary search / backward iteration are unsupported.
+    /// `restart_interval` must match the value the block was encoded with
+    /// (per-SST constant from `TableMeta`); restart heads are positional, so
+    /// the forward scan reconstructs every key from byte 0 without the trailer.
+    /// `entries_end` is the length of the entry region (== `block.data.len()`
+    /// for a clean prefix); a partial prefix may end mid-entry, in which case
+    /// the final truncated entry parses to `None` and iteration stops cleanly
+    /// before it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `restart_interval == 0` (a zero interval has no restart heads,
+    /// so positional restart tracking is undefined).
+    #[must_use]
+    // Consumed by the range-query partial-decode read path (wired next); the
+    // forward-from-prefix mechanism is proven by its tests already.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by range-query partial decode wiring (next slice)"
+        )
+    )]
+    pub(crate) fn new_forward_headerless(
+        block: &'a Block,
+        restart_interval: u8,
+        entries_end: usize,
+    ) -> Self {
+        assert!(
+            restart_interval > 0,
+            "restart_interval must be non-zero for headerless forward decode",
+        );
+        Self {
+            block,
+            phantom: PhantomData,
+            lo_scanner: LoScanner {
+                offset: 0,
+                remaining_in_interval: 0,
+                base_key_offset: None,
+                base_key_end: None,
+            },
+            // No backward cursor: base_key_offset stays None so `next` never
+            // treats the (zeroed) hi_scanner.offset as an upper bound.
+            hi_scanner: HiScanner {
+                offset: 0,
+                ptr_idx: 0,
+                stack: Vec::new(),
+                base_key_offset: None,
+                base_key_end: None,
+            },
+            restart_interval,
+            // No trailer/index: keep these zeroed. Forward `next` reads neither.
+            binary_index_step_size: 2,
+            binary_index_offset: 0,
+            binary_index_len: 0,
+            hash_index_len: 0,
+            hash_index_offset: 0,
+            cached_entries_end: Some(entries_end),
+        }
     }
 
     fn binary_index_bounds(&self) -> Option<(usize, usize)> {

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -339,6 +339,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     ///
     /// Panics if `restart_interval == 0` (a zero interval has no restart heads,
     /// so positional restart tracking is undefined).
+    #[cfg(feature = "zstd")]
     #[must_use]
     pub(crate) fn new_forward_headerless(
         block: &'a Block,
@@ -383,6 +384,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     /// past the last complete entry. Used to synthesize a binary-index trailer
     /// over a decoded prefix (whose tail may be a truncated entry, which this
     /// scan stops cleanly before — see [`Self::new_forward_headerless`]).
+    #[cfg(feature = "zstd")]
     pub(crate) fn scan_restart_offsets(mut self) -> (Vec<u32>, usize, usize) {
         let mut restart_offsets = Vec::new();
         let mut item_count = 0usize;

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -378,6 +378,37 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         }
     }
 
+    /// Forward-scan a headerless block, returning the byte offset of every
+    /// restart head, the count of complete entries, and the byte offset just
+    /// past the last complete entry. Used to synthesize a binary-index trailer
+    /// over a decoded prefix (whose tail may be a truncated entry, which this
+    /// scan stops cleanly before — see [`Self::new_forward_headerless`]).
+    pub(crate) fn scan_restart_offsets(mut self) -> (Vec<u32>, usize, usize) {
+        let mut restart_offsets = Vec::new();
+        let mut item_count = 0usize;
+        // `next()` clobbers `lo_scanner.offset` to `data.len()` when it stops on
+        // a truncated tail entry, so track the end of the last COMPLETE entry
+        // ourselves rather than reading the post-loop scanner offset.
+        let mut last_complete_end = 0usize;
+        loop {
+            let is_restart = self.lo_scanner.remaining_in_interval == 0;
+            let head = self.lo_scanner.offset;
+            if self.next().is_none() {
+                break;
+            }
+            if is_restart {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "block offsets are far below u32::MAX"
+                )]
+                restart_offsets.push(head as u32);
+            }
+            item_count += 1;
+            last_complete_end = self.lo_scanner.offset;
+        }
+        (restart_offsets, item_count, last_complete_end)
+    }
+
     fn binary_index_bounds(&self) -> Option<(usize, usize)> {
         let step_size = match self.binary_index_step_size {
             2 | 4 => usize::from(self.binary_index_step_size),

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -157,6 +157,16 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         self.cached_entries_end
     }
 
+    /// Entry-region bytes the decoder parses. Single seam for byte access so a
+    /// lazily-decoded backing (decode only the inner blocks a read covers) can
+    /// later replace the resident slice without touching every read site.
+    /// Returns `'a`-lifetime bytes (tied to the block, not `&self`), preserving
+    /// the disjoint borrow that lets reads coexist with scanner-state mutation.
+    #[inline]
+    fn entries(&self) -> &'a [u8] {
+        &self.block.data
+    }
+
     /// Extracts the reusable trailer metadata from a fully-constructed
     /// decoder so future decodes of the same block can skip the trailer
     /// parse via [`Self::from_meta`].
@@ -445,7 +455,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         if pos >= entries_end {
             return None;
         }
-        let bytes = &self.block.data;
+        let bytes = self.entries();
         let mut cursor = Self::reader_at(bytes, pos)?;
         Item::parse_restart_key(&mut cursor, pos, bytes, entries_end)
     }
@@ -588,7 +598,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     }
 
     fn exhaust(&mut self) {
-        let end = self.block.data.len();
+        let end = self.entries().len();
 
         self.lo_scanner.offset = end;
         self.lo_scanner.remaining_in_interval = 0;
@@ -749,7 +759,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
             self.hi_scanner.offset = binary_index.get(self.hi_scanner.ptr_idx);
 
             let offset = self.hi_scanner.offset;
-            let Some(mut reader) = Self::reader_at(&self.block.data, offset) else {
+            let Some(mut reader) = Self::reader_at(self.entries(), offset) else {
                 self.poison_back_cursor();
                 return;
             };
@@ -775,7 +785,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
 
         for _ in 1..self.restart_interval {
             let offset = self.hi_scanner.offset;
-            let Some(mut reader) = Self::reader_at(&self.block.data, offset) else {
+            let Some(mut reader) = Self::reader_at(self.entries(), offset) else {
                 self.poison_back_cursor();
                 return;
             };
@@ -820,7 +830,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
 
         let is_restart = self.hi_scanner.stack.is_empty();
 
-        let mut reader = Self::reader_at(&self.block.data, offset)?;
+        let mut reader = Self::reader_at(self.entries(), offset)?;
 
         Self::parse_current_item(
             &mut reader,
@@ -849,7 +859,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
 
             let is_restart = self.lo_scanner.remaining_in_interval == 0;
 
-            let Some(mut reader) = Self::reader_at(&self.block.data, self.lo_scanner.offset) else {
+            let Some(mut reader) = Self::reader_at(self.entries(), self.lo_scanner.offset) else {
                 break;
             };
 
@@ -864,7 +874,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
                 break;
             };
 
-            if !pred(&item, &self.block.data) {
+            if !pred(&item, self.entries()) {
                 break;
             }
 
@@ -910,7 +920,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
 
             let is_restart = self.hi_scanner.stack.len() == 1;
 
-            let Some(mut reader) = Self::reader_at(&self.block.data, offset) else {
+            let Some(mut reader) = Self::reader_at(self.entries(), offset) else {
                 break;
             };
 
@@ -925,7 +935,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
                 break;
             };
 
-            if cmp(&item, &self.block.data) != std::cmp::Ordering::Greater {
+            if cmp(&item, self.entries()) != std::cmp::Ordering::Greater {
                 break;
             }
 
@@ -940,7 +950,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         let should_restore = if let Some(&offset) = self.hi_scanner.stack.last() {
             let is_restart = self.hi_scanner.stack.len() == 1;
 
-            let Some(mut reader) = Self::reader_at(&self.block.data, offset) else {
+            let Some(mut reader) = Self::reader_at(self.entries(), offset) else {
                 return;
             };
 
@@ -955,7 +965,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
                 return;
             };
 
-            cmp(&item, &self.block.data) == std::cmp::Ordering::Less
+            cmp(&item, self.entries()) == std::cmp::Ordering::Less
         } else {
             true
         };
@@ -975,7 +985,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         };
         let is_restart = self.hi_scanner.stack.len() == 1;
 
-        let Some(mut reader) = Self::reader_at(&self.block.data, offset) else {
+        let Some(mut reader) = Self::reader_at(self.entries(), offset) else {
             return;
         };
 
@@ -1006,7 +1016,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         let entries_end = self.entries_end()?;
         let is_restart = self.hi_scanner.stack.len() == 1;
 
-        let mut reader = Self::reader_at(&self.block.data, offset)?;
+        let mut reader = Self::reader_at(self.entries(), offset)?;
 
         let item = Self::parse_current_item(
             &mut reader,
@@ -1017,7 +1027,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
             entries_end,
         )?;
 
-        Some(cmp(&item, &self.block.data))
+        Some(cmp(&item, self.entries()))
     }
 
     #[must_use]
@@ -1052,7 +1062,7 @@ impl<Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Iterator for Decoder<'_,
 
     fn next(&mut self) -> Option<Self::Item> {
         let entries_end = self.entries_end()?;
-        if self.lo_scanner.offset >= self.block.data.len() {
+        if self.lo_scanner.offset >= self.entries().len() {
             return None;
         }
 
@@ -1064,7 +1074,7 @@ impl<Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Iterator for Decoder<'_,
 
         let is_restart: bool = self.lo_scanner.remaining_in_interval == 0;
 
-        let mut reader = Cursor::new(self.block.data.get(self.lo_scanner.offset..)?);
+        let mut reader = Cursor::new(self.entries().get(self.lo_scanner.offset..)?);
 
         #[expect(
             clippy::cast_possible_truncation,
@@ -1094,7 +1104,7 @@ impl<Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Iterator for Decoder<'_,
                 self.lo_scanner.remaining_in_interval -= 1;
             }
         } else {
-            self.lo_scanner.offset = self.block.data.len();
+            self.lo_scanner.offset = self.entries().len();
             self.lo_scanner.remaining_in_interval = 0;
             self.lo_scanner.base_key_offset = None;
             self.lo_scanner.base_key_end = None;

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -340,15 +340,6 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     /// Panics if `restart_interval == 0` (a zero interval has no restart heads,
     /// so positional restart tracking is undefined).
     #[must_use]
-    // Consumed by the range-query partial-decode read path (wired next); the
-    // forward-from-prefix mechanism is proven by its tests already.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by range-query partial decode wiring (next slice)"
-        )
-    )]
     pub(crate) fn new_forward_headerless(
         block: &'a Block,
         restart_interval: u8,

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -1367,6 +1367,89 @@ impl Block {
 
         Ok((Self { header, data }, ecc_status))
     }
+
+    /// Reads a data block's verified COMPRESSED payload (the zstd frame) WITHOUT
+    /// decompressing it, for partial / lazy decode. Returns the header and the
+    /// compressed-frame bytes (checksum-verified; ECC-recovered if a recognized
+    /// parity trailer is present).
+    ///
+    /// Non-encrypted blocks only — the caller must ensure
+    /// `transform.encryption().is_none()` (an encrypted block's plaintext frame
+    /// is only available after a whole-block decrypt, which defeats the lazy
+    /// path). Mirrors the non-encrypted read+verify of
+    /// [`Self::from_file_with_status`], stopping before decompression.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on a framing / checksum failure (unrecoverable), or if
+    /// called for an encrypted transform.
+    #[cfg(feature = "zstd")]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the range-iterator partial path (next step)"
+        )
+    )]
+    pub(crate) fn read_data_frame(
+        file: &dyn FsFile,
+        handle: BlockHandle,
+        transform: &BlockTransform<'_>,
+    ) -> crate::Result<(Header, Slice)> {
+        if transform.encryption().is_some() {
+            return Err(crate::Error::Io(std::io::Error::other(
+                "read_data_frame: encrypted blocks are not supported on the lazy path",
+            )));
+        }
+
+        let buf = crate::file::read_exact(file, *handle.offset(), handle.size() as usize)?;
+        let parsed_header = Header::decode_from(&mut &buf[..])?;
+        let header_len = Header::header_len(parsed_header.block_type);
+
+        let has_ecc = block_has_parity(&parsed_header, transform);
+        let ecc_length = if has_ecc {
+            expected_parity_len(
+                parsed_header.data_length,
+                block_ecc_params(&parsed_header, transform),
+            )
+        } else {
+            0
+        };
+
+        let actual_payload_plus_ecc = buf.len().saturating_sub(header_len);
+        let actual_data_len = parsed_header.data_length as usize;
+        let _ecc_status = classify_block_trailer(
+            has_ecc,
+            actual_payload_plus_ecc,
+            actual_data_len,
+            ecc_length,
+            &handle,
+        )?;
+
+        let payload: Slice = if ecc_length == 0 {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "actual_data_len <= post-header len, checked via classify_block_trailer"
+            )]
+            let checksum = Checksum::from_raw(crate::hash::hash128(
+                &buf[header_len..header_len + actual_data_len],
+            ));
+            checksum.check(parsed_header.checksum)?;
+            buf.slice(header_len..header_len + actual_data_len)
+        } else {
+            #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
+            let mut cursor = std::io::Cursor::new(&buf[header_len..]);
+            Slice::from(Self::read_payload_and_verify(
+                &mut cursor,
+                parsed_header.data_length,
+                ecc_length,
+                parsed_header.checksum,
+                block_ecc_params(&parsed_header, transform),
+            )?)
+        };
+
+        Ok((parsed_header, payload))
+    }
 }
 
 #[cfg(test)]
@@ -1500,6 +1583,37 @@ mod tests {
             )?,
         )?;
         assert_eq!(data, &*block.data);
+        Ok(())
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn read_data_frame_returns_decompressible_zstd_frame() -> crate::Result<()> {
+        // Repetitive payload so zstd produces a real (smaller) compressed frame.
+        let data: Vec<u8> = (0..40_000u32).map(|i| (i % 64) as u8).collect();
+        let transform =
+            crate::table::block::BlockTransform::from_parts(CompressionType::Zstd(3), None, None)?;
+        let tmp = write_block_to_tempfile(
+            &data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
+            &transform,
+        )?;
+
+        let (header, frame) = Block::read_data_frame(&tmp.file, tmp.handle, &transform)?;
+        // The returned bytes are the COMPRESSED frame: it must be smaller than
+        // the payload and must decompress back to the original (proving
+        // read_data_frame skipped decode yet returned a valid frame).
+        assert!(
+            frame.len() < data.len(),
+            "frame must be compressed (got {} for {} bytes)",
+            frame.len(),
+            data.len(),
+        );
+        let decompressed = crate::compression::ZstdBackend::decompress(
+            &frame,
+            header.uncompressed_length as usize + 1,
+        )?;
+        assert_eq!(decompressed, data, "frame must decompress to the original");
         Ok(())
     }
 

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -1384,13 +1384,6 @@ impl Block {
     /// Returns an error on a framing / checksum failure (unrecoverable), or if
     /// called for an encrypted transform.
     #[cfg(feature = "zstd")]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the range-iterator partial path (next step)"
-        )
-    )]
     pub(crate) fn read_data_frame(
         file: &dyn FsFile,
         handle: BlockHandle,

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -516,7 +516,10 @@ impl Block {
         // a non-dict zstd codec that split into >= 2 inner blocks (empty
         // otherwise). Enables range-query partial decode of large cold blocks.
         // `mut` is only exercised by the zstd Data arm below.
-        #[cfg_attr(not(zstd_any), allow(unused_mut))]
+        #[cfg_attr(
+            not(zstd_any),
+            expect(unused_mut, reason = "`layout` is only mutated on zstd-enabled builds")
+        )]
         let mut layout: Vec<u32> = Vec::new();
 
         match compression {
@@ -1395,8 +1398,35 @@ impl Block {
             )));
         }
 
+        // Pre-allocation sanity cap on `handle.size()`, mirroring
+        // `from_file_with_status`: reject an absurd on-disk size before
+        // allocating the read buffer, so a corrupt handle cannot force a huge
+        // allocation. Non-encrypted path (encryption rejected above), so no
+        // encryption overhead; the ECC term uses the block's ACTUAL per-SST
+        // scheme (never a hardcoded one) and is 0 when there is no parity.
+        let max_ecc_overhead = match transform.ecc_params() {
+            Some(params) => u64::from(expected_parity_len(MAX_DECOMPRESSION_SIZE, params)),
+            None => 0,
+        };
+        let max_on_disk_size =
+            u64::from(MAX_DECOMPRESSION_SIZE) + max_ecc_overhead + Header::MAX_LEN as u64;
+        if u64::from(handle.size()) > max_on_disk_size {
+            return Err(crate::Error::DecompressedSizeTooLarge {
+                declared: u64::from(handle.size()),
+                limit: max_on_disk_size,
+            });
+        }
+
         let buf = crate::file::read_exact(file, *handle.offset(), handle.size() as usize)?;
         let parsed_header = Header::decode_from(&mut &buf[..])?;
+        // Reject a header that declares a decompressed size past the cap before
+        // the lazy decode path trusts it.
+        if parsed_header.uncompressed_length > MAX_DECOMPRESSION_SIZE {
+            return Err(crate::Error::DecompressedSizeTooLarge {
+                declared: u64::from(parsed_header.uncompressed_length),
+                limit: u64::from(MAX_DECOMPRESSION_SIZE),
+            });
+        }
         let header_len = Header::header_len(parsed_header.block_type);
 
         let has_ecc = block_has_parity(&parsed_header, transform);
@@ -1607,6 +1637,30 @@ mod tests {
             header.uncompressed_length as usize + 1,
         )?;
         assert_eq!(decompressed, data, "frame must decompress to the original");
+        Ok(())
+    }
+
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn read_data_frame_rejects_oversized_handle() -> crate::Result<()> {
+        // A handle declaring an absurd on-disk size must be rejected by the
+        // pre-allocation cap before any read / allocation, mirroring
+        // `from_file_with_status`.
+        let data: Vec<u8> = (0..1_000u32).map(|i| (i % 64) as u8).collect();
+        let transform =
+            crate::table::block::BlockTransform::from_parts(CompressionType::Zstd(3), None, None)?;
+        let tmp = write_block_to_tempfile(
+            &data,
+            crate::table::block::BlockIdentity::for_test(0, 0, BlockType::Data),
+            &transform,
+        )?;
+        let oversized = BlockHandle::new(tmp.handle.offset(), u32::MAX);
+        let err = Block::read_data_frame(&tmp.file, oversized, &transform)
+            .expect_err("oversized handle must be rejected");
+        assert!(
+            matches!(err, crate::Error::DecompressedSizeTooLarge { .. }),
+            "expected DecompressedSizeTooLarge, got {err:?}",
+        );
         Ok(())
     }
 

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -181,6 +181,13 @@ pub(crate) struct PreparedBlock<'a> {
     /// Reed-Solomon parity trailer, present only when page-ECC is active and
     /// the payload was non-empty. Always `None` without the `page_ecc` feature.
     parity: Option<Vec<u8>>,
+    /// Inner zstd-block layout of the compressed payload: cumulative
+    /// decompressed END offsets, one per inner block (the last equals the
+    /// uncompressed length). Empty unless this is a `Data` block compressed
+    /// into >= 2 inner zstd blocks; lets the reader partial-decode a key-range
+    /// subset instead of the whole block. See
+    /// [`CompressionProvider::compress_with_layout`](crate::compression::CompressionProvider::compress_with_layout).
+    pub(crate) layout: Vec<u32>,
 }
 
 impl PreparedBlock<'_> {
@@ -194,6 +201,7 @@ impl PreparedBlock<'_> {
             header: self.header,
             payload: Cow::Owned(self.payload.into_owned()),
             parity: self.parity,
+            layout: self.layout,
         }
     }
 
@@ -504,6 +512,13 @@ impl Block {
         #[cfg(any(feature = "lz4", zstd_any))]
         let mut compressed_buf: Option<Vec<u8>> = None;
 
+        // Inner zstd-block layout, captured only for Data blocks compressed with
+        // a non-dict zstd codec that split into >= 2 inner blocks (empty
+        // otherwise). Enables range-query partial decode of large cold blocks.
+        // `mut` is only exercised by the zstd Data arm below.
+        #[cfg_attr(not(zstd_any), allow(unused_mut))]
+        let mut layout: Vec<u32> = Vec::new();
+
         match compression {
             CompressionType::None => {}
 
@@ -514,7 +529,14 @@ impl Block {
 
             #[cfg(zstd_any)]
             CompressionType::Zstd(level) => {
-                compressed_buf = Some(crate::compression::ZstdBackend::compress(data, level)?);
+                if block_type == BlockType::Data {
+                    let (buf, lay) =
+                        crate::compression::ZstdBackend::compress_with_layout(data, level)?;
+                    compressed_buf = Some(buf);
+                    layout = lay;
+                } else {
+                    compressed_buf = Some(crate::compression::ZstdBackend::compress(data, level)?);
+                }
             }
 
             #[cfg(zstd_any)]
@@ -642,6 +664,7 @@ impl Block {
             header,
             payload,
             parity: parity_buf,
+            layout,
         })
     }
 

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -989,25 +989,25 @@ impl Block {
         // near-limit encrypted+ECC blocks the writer can produce.
         let enc_overhead = encryption.map_or(0u64, |e| u64::from(e.max_overhead()));
         let max_payload = u64::from(MAX_DECOMPRESSION_SIZE) + enc_overhead;
-        // ECC parity scales with the (data_shards, parity_shards) scheme, not a
-        // fixed RS(4,2). A high-overhead scheme (parity_shards > data_shards /
-        // 2, e.g. RS(2,4)) produces a larger trailer than the old `N/2 + 4`
-        // RS(4,2) approximation, so that bound would reject a legitimate
-        // near-limit block. Size the cap from the actual scheme this block is
-        // read with (`transform.ecc_params()`), keeping RS(4,2) in the running
-        // max so self-describing blocks (which carry no transform ECC but are
-        // written RS(4,2)) stay covered.
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "max_payload is MAX_DECOMPRESSION_SIZE (+ enc overhead), well below u32::MAX"
-        )]
-        let max_payload_u32 = max_payload.min(u64::from(u32::MAX)) as u32;
-        let max_ecc_overhead = [Some(EccParams::RS_4_2), transform.ecc_params()]
-            .into_iter()
-            .flatten()
-            .map(|params| u64::from(expected_parity_len(max_payload_u32, params)))
-            .max()
-            .unwrap_or(0);
+        // Pre-allocation sanity cap on `handle.size()`: reject an absurd on-disk
+        // size before allocating the read buffer. The ECC-OFF path adds NO ECC
+        // term and runs NO ECC math — when there is no parity, the cap is just
+        // payload + header. When ECC is on, the cap allows the block's ACTUAL
+        // scheme parity (from the per-SST descriptor carried by `transform`),
+        // never a hardcoded scheme. Self-describing blocks (Meta / Manifest)
+        // carry their own small RS parity but are orders of magnitude below
+        // `max_payload`, so they pass this cap without an explicit ECC term.
+        let max_ecc_overhead = match transform.ecc_params() {
+            Some(params) => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "max_payload is MAX_DECOMPRESSION_SIZE (+ enc overhead), well below u32::MAX"
+                )]
+                let max_payload_u32 = max_payload.min(u64::from(u32::MAX)) as u32;
+                u64::from(expected_parity_len(max_payload_u32, params))
+            }
+            None => 0,
+        };
         let max_on_disk_size = max_payload + max_ecc_overhead + Header::MAX_LEN as u64;
 
         if u64::from(handle.size()) > max_on_disk_size {

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -38,6 +38,12 @@ pub enum BlockType {
     /// mirrored at file offset 0 in a 4 KiB padded region for
     /// partial-write recovery.
     ManifestFooter,
+    /// Optional per-table index of inner zstd-block layouts: for each data
+    /// block that compressed into >= 2 inner zstd blocks, its file offset and
+    /// the cumulative decompressed END offsets of those inner blocks. Lets a
+    /// range query partial-decode only the inner blocks covering a key range.
+    /// Absent unless the table has at least one such multi-inner-block block.
+    BlockLayout,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -58,6 +64,7 @@ impl From<BlockType> for u8 {
             BlockType::RangeTombstone => 4,
             BlockType::Manifest => 5,
             BlockType::ManifestFooter => 6,
+            BlockType::BlockLayout => 7,
         }
     }
 }
@@ -74,6 +81,7 @@ impl TryFrom<u8> for BlockType {
             4 => Ok(Self::RangeTombstone),
             5 => Ok(Self::Manifest),
             6 => Ok(Self::ManifestFooter),
+            7 => Ok(Self::BlockLayout),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -99,6 +107,7 @@ mod tests {
             (4, BlockType::RangeTombstone),
             (5, BlockType::Manifest),
             (6, BlockType::ManifestFooter),
+            (7, BlockType::BlockLayout),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -117,9 +126,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 7 is the first
+        // not a silent coercion to a known variant. 8 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(7).is_err());
+        assert!(BlockType::try_from(8).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Codec for the optional per-table `block_layout` section.
+//!
+//! For each data block that compressed into two or more inner zstd blocks, the
+//! section records the block's file offset and the cumulative decompressed END
+//! offset of every inner block (a prefix sum whose last entry equals the
+//! block's uncompressed length). A range query binary-searches the entry for a
+//! block, then maps a decompressed byte range to the inner-block indices
+//! covering it and partial-decodes only those blocks instead of the whole
+//! frame.
+//!
+//! The section is absent unless at least one data block split into >= 2 inner
+//! blocks, so default small-block tables carry no extra bytes.
+//!
+//! # Wire format
+//!
+//! ```text
+//! [entry_count : u32 LE]
+//! repeated entry_count times, ascending by block offset:
+//!   [block_offset : u64 LE]
+//!   [inner_count  : u32 LE]   (always >= 2)
+//!   [end_0 : u32 LE] [end_1 : u32 LE] ... [end_{inner_count-1} : u32 LE]
+//! ```
+
+use crate::table::block::BlockOffset;
+use byteorder::{LittleEndian, ReadBytesExt};
+
+/// Serialize the per-block inner-block layouts into `out`.
+///
+/// `layouts` must be sorted ascending by block offset (the writer produces
+/// them in write order, which is ascending) and every `ends` array must have
+/// length >= 2 (single-inner-block blocks are not recorded).
+///
+/// Writes via `extend_from_slice` (infallible on `Vec`), so no I/O error path.
+pub fn encode_block_layouts(out: &mut Vec<u8>, layouts: &[(BlockOffset, Vec<u32>)]) {
+    // entry_count fits u32: a table cannot hold more data blocks than u32 file
+    // offsets address, and the writer only pushes split blocks.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "data-block count is bounded well within u32"
+    )]
+    let count = layouts.len() as u32;
+    out.extend_from_slice(&count.to_le_bytes());
+    for (offset, ends) in layouts {
+        out.extend_from_slice(&offset.0.to_le_bytes());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "inner-block count is bounded well within u32"
+        )]
+        let inner = ends.len() as u32;
+        out.extend_from_slice(&inner.to_le_bytes());
+        for &end in ends {
+            out.extend_from_slice(&end.to_le_bytes());
+        }
+    }
+}
+
+/// Decoded `block_layout` section: a lookup from a data block's file offset to
+/// the cumulative decompressed END offsets of its inner zstd blocks.
+#[derive(Debug, Default, Clone)]
+pub struct BlockLayoutMap {
+    /// `(block_offset, cumulative_inner_block_ends)`, sorted ascending by
+    /// offset for binary-search lookup.
+    entries: Vec<(u64, Vec<u32>)>,
+}
+
+impl BlockLayoutMap {
+    /// Decode a `block_layout` section payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload is truncated, an inner count is < 2, or
+    /// the entries are not strictly ascending by offset (a corrupt section
+    /// must surface rather than silently mis-map a range).
+    pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
+        let mut r = bytes;
+        let count = r.read_u32::<LittleEndian>()?;
+        let mut entries = Vec::with_capacity(count as usize);
+        let mut prev: Option<u64> = None;
+        for _ in 0..count {
+            let offset = r.read_u64::<LittleEndian>()?;
+            if let Some(p) = prev
+                && offset <= p
+            {
+                return Err(crate::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "block_layout entries must be strictly ascending by offset",
+                )));
+            }
+            prev = Some(offset);
+            let inner = r.read_u32::<LittleEndian>()?;
+            if inner < 2 {
+                return Err(crate::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "block_layout entry must have >= 2 inner blocks",
+                )));
+            }
+            let mut ends = Vec::with_capacity(inner as usize);
+            for _ in 0..inner {
+                ends.push(r.read_u32::<LittleEndian>()?);
+            }
+            entries.push((offset, ends));
+        }
+        Ok(Self { entries })
+    }
+
+    /// Cumulative inner-block END offsets for the data block at `offset`, or
+    /// `None` if the block was not recorded (single inner block → full decode).
+    // Consumed by the range-query partial-decode read path (wired in a
+    // follow-up slice); the section is already produced and reloaded today.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by range-query partial decode (next slice)"
+        )
+    )]
+    pub fn ends_for(&self, offset: u64) -> Option<&[u32]> {
+        let idx = self
+            .entries
+            .binary_search_by_key(&offset, |(o, _)| *o)
+            .ok()?;
+        self.entries.get(idx).map(|(_, ends)| ends.as_slice())
+    }
+
+    /// Number of recorded multi-inner-block data blocks.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Recorded block offsets, ascending. Test-only enumeration helper.
+    #[cfg(test)]
+    pub(crate) fn offsets(&self) -> Vec<u64> {
+        self.entries.iter().map(|(o, _)| *o).collect()
+    }
+}
+
+/// Map a half-open decompressed byte range `[lower, upper)` to the half-open
+/// inner-block index range `[start_block, end_block)` that covers it, given the
+/// cumulative inner-block END offsets `ends`.
+///
+/// `start_block` is the first inner block whose bytes reach past `lower`;
+/// `end_block` is one past the last inner block needed to cover `upper`. The
+/// caller passes these to
+/// [`decode_blocks_partial`](structured_zstd::decoding::FrameDecoder::decode_blocks_partial);
+/// blocks before `start_block` are still decoded into the shared window but not
+/// returned, and blocks at/after `end_block` are skipped entirely (the win).
+///
+/// Returns `None` (caller falls back to full decode) if `ends` is empty or
+/// `lower >= total` (range past the block's data — nothing to map).
+// Consumed by the range-query partial-decode read path (wired in a follow-up
+// slice); kept here with its unit tests as the mapping is format-stable.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by range-query partial decode (next slice)"
+    )
+)]
+pub fn map_byte_range_to_blocks(ends: &[u32], lower: u32, upper: u32) -> Option<(u32, u32)> {
+    let total = *ends.last()?;
+    if lower >= total {
+        return None;
+    }
+    // First block whose cumulative end is strictly greater than `lower` contains
+    // `lower` (ends are exclusive upper bounds of each block's byte span).
+    let start = ends.partition_point(|&e| e <= lower);
+    // Last block needed for `upper`: the block containing `upper - 1` (clamp
+    // `upper` to `total`). `end_block` is one past it (exclusive).
+    let upper_clamped = upper.min(total);
+    let last = if upper_clamped == 0 {
+        0
+    } else {
+        ends.partition_point(|&e| e < upper_clamped)
+    };
+    let end = (last + 1).min(ends.len());
+    // start <= end always holds because lower < upper_clamped <= total here
+    // (lower < total checked above; if upper <= lower the caller filters first).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "inner-block indices bounded by ends.len(), well within u32"
+    )]
+    Some((start as u32, end as u32))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrips_entries() {
+        let layouts = vec![
+            (BlockOffset(0), vec![100, 250, 400]),
+            (BlockOffset(512), vec![80, 160]),
+        ];
+        let mut buf = Vec::new();
+        encode_block_layouts(&mut buf, &layouts);
+        let map = BlockLayoutMap::decode(&buf).expect("decode");
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.ends_for(0), Some([100u32, 250, 400].as_slice()));
+        assert_eq!(map.ends_for(512), Some([80u32, 160].as_slice()));
+        assert_eq!(map.ends_for(999), None, "unrecorded offset → None");
+    }
+
+    #[test]
+    fn decode_rejects_non_ascending_offsets() {
+        let layouts = vec![
+            (BlockOffset(512), vec![80, 160]),
+            (BlockOffset(0), vec![100, 250]),
+        ];
+        let mut buf = Vec::new();
+        encode_block_layouts(&mut buf, &layouts);
+        assert!(
+            BlockLayoutMap::decode(&buf).is_err(),
+            "non-ascending offsets must be rejected",
+        );
+    }
+
+    #[test]
+    fn empty_layouts_decode_to_empty_map() {
+        let mut buf = Vec::new();
+        encode_block_layouts(&mut buf, &[]);
+        let map = BlockLayoutMap::decode(&buf).expect("decode empty");
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.ends_for(0), None);
+    }
+
+    #[test]
+    fn map_byte_range_single_block_subset() {
+        // ends: block0=[0,100) block1=[100,250) block2=[250,400)
+        let ends = [100u32, 250, 400];
+        // Range fully inside block 0 → [0, 1).
+        assert_eq!(map_byte_range_to_blocks(&ends, 10, 50), Some((0, 1)));
+        // Range inside block 1 → [1, 2).
+        assert_eq!(map_byte_range_to_blocks(&ends, 120, 200), Some((1, 2)));
+        // Range spanning block 0 and 1 → [0, 2).
+        assert_eq!(map_byte_range_to_blocks(&ends, 50, 150), Some((0, 2)));
+        // Range reaching the tail → [1, 3).
+        assert_eq!(map_byte_range_to_blocks(&ends, 120, 400), Some((1, 3)));
+        // Whole block → [0, 3).
+        assert_eq!(map_byte_range_to_blocks(&ends, 0, 400), Some((0, 3)));
+    }
+
+    #[test]
+    fn map_byte_range_past_end_returns_none() {
+        let ends = [100u32, 250, 400];
+        assert_eq!(map_byte_range_to_blocks(&ends, 400, 500), None);
+        assert_eq!(map_byte_range_to_blocks(&[], 0, 10), None);
+    }
+
+    #[test]
+    fn map_byte_range_boundary_is_exclusive_end() {
+        // upper exactly on a block boundary must NOT pull in the next block.
+        let ends = [100u32, 250, 400];
+        // [0, 100) is exactly block 0.
+        assert_eq!(map_byte_range_to_blocks(&ends, 0, 100), Some((0, 1)));
+        // [100, 250) is exactly block 1.
+        assert_eq!(map_byte_range_to_blocks(&ends, 100, 250), Some((1, 2)));
+    }
+}

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use crate::table::block::BlockOffset;
-use byteorder::{LittleEndian, ReadBytesExt};
 
 /// Serialize the per-block inner-block layouts into `out`.
 ///
@@ -75,31 +74,48 @@ impl BlockLayoutMap {
     /// the entries are not strictly ascending by offset (a corrupt section
     /// must surface rather than silently mis-map a range).
     pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
+        // Manual little-endian slice parsing (no `std::io::Read`), so the codec
+        // stays `no_std + alloc`-clean. Any truncation or invariant violation
+        // surfaces as a typed `InvalidHeader`, not a stringly-typed I/O error.
+        const ERR: crate::Error = crate::Error::InvalidHeader("BlockLayout");
+
+        fn take<'a>(r: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+            if r.len() < n {
+                return None;
+            }
+            let (head, tail) = r.split_at(n);
+            *r = tail;
+            Some(head)
+        }
+        fn read_u32(r: &mut &[u8]) -> Option<u32> {
+            let b: [u8; 4] = take(r, 4)?.try_into().ok()?;
+            Some(u32::from_le_bytes(b))
+        }
+        fn read_u64(r: &mut &[u8]) -> Option<u64> {
+            let b: [u8; 8] = take(r, 8)?.try_into().ok()?;
+            Some(u64::from_le_bytes(b))
+        }
+
         let mut r = bytes;
-        let count = r.read_u32::<LittleEndian>()?;
+        let count = read_u32(&mut r).ok_or(ERR)?;
         let mut entries = Vec::with_capacity(count as usize);
         let mut prev: Option<u64> = None;
         for _ in 0..count {
-            let offset = r.read_u64::<LittleEndian>()?;
-            if let Some(p) = prev
-                && offset <= p
-            {
-                return Err(crate::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "block_layout entries must be strictly ascending by offset",
-                )));
+            let offset = read_u64(&mut r).ok_or(ERR)?;
+            // Entries must be strictly ascending by offset (else a lookup could
+            // silently mis-map a range).
+            if prev.is_some_and(|p| offset <= p) {
+                return Err(ERR);
             }
             prev = Some(offset);
-            let inner = r.read_u32::<LittleEndian>()?;
+            let inner = read_u32(&mut r).ok_or(ERR)?;
+            // A recorded block always split into >= 2 inner blocks.
             if inner < 2 {
-                return Err(crate::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "block_layout entry must have >= 2 inner blocks",
-                )));
+                return Err(ERR);
             }
             let mut ends = Vec::with_capacity(inner as usize);
             for _ in 0..inner {
-                ends.push(r.read_u32::<LittleEndian>()?);
+                ends.push(read_u32(&mut r).ok_or(ERR)?);
             }
             entries.push((offset, ends));
         }
@@ -108,15 +124,7 @@ impl BlockLayoutMap {
 
     /// Cumulative inner-block END offsets for the data block at `offset`, or
     /// `None` if the block was not recorded (single inner block → full decode).
-    // Consumed by the range-query partial-decode read path (wired in a
-    // follow-up slice); the section is already produced and reloaded today.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by range-query partial decode (next slice)"
-        )
-    )]
+    #[cfg(feature = "zstd")]
     pub fn ends_for(&self, offset: u64) -> Option<&[u32]> {
         let idx = self
             .entries

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -208,9 +208,28 @@ mod tests {
         encode_block_layouts(&mut buf, &layouts);
         let map = BlockLayoutMap::decode(&buf).expect("decode");
         assert_eq!(map.len(), 2);
-        assert_eq!(map.ends_for(0), Some([100u32, 250, 400].as_slice()));
-        assert_eq!(map.ends_for(512), Some([80u32, 160].as_slice()));
-        assert_eq!(map.ends_for(999), None, "unrecorded offset → None");
+        // `ends_for` is only compiled for the zstd partial-decode read path.
+        #[cfg(feature = "zstd")]
+        {
+            assert_eq!(map.ends_for(0), Some([100u32, 250, 400].as_slice()));
+            assert_eq!(map.ends_for(512), Some([80u32, 160].as_slice()));
+            assert_eq!(map.ends_for(999), None, "unrecorded offset → None");
+        }
+    }
+
+    #[test]
+    fn decode_rejects_inner_count_less_than_two() {
+        // A recorded block must always have >= 2 inner blocks; a hand-crafted
+        // payload with inner_count = 1 must be rejected (corruption guard).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u32.to_le_bytes()); // entry_count = 1
+        buf.extend_from_slice(&0u64.to_le_bytes()); // block_offset = 0
+        buf.extend_from_slice(&1u32.to_le_bytes()); // inner_count = 1 (invalid)
+        buf.extend_from_slice(&100u32.to_le_bytes()); // one end offset
+        assert!(
+            BlockLayoutMap::decode(&buf).is_err(),
+            "inner_count < 2 must be rejected",
+        );
     }
 
     #[test]
@@ -233,6 +252,7 @@ mod tests {
         encode_block_layouts(&mut buf, &[]);
         let map = BlockLayoutMap::decode(&buf).expect("decode empty");
         assert_eq!(map.len(), 0);
+        #[cfg(feature = "zstd")]
         assert_eq!(map.ends_for(0), None);
     }
 

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -227,8 +227,11 @@ mod tests {
         buf.extend_from_slice(&1u32.to_le_bytes()); // inner_count = 1 (invalid)
         buf.extend_from_slice(&100u32.to_le_bytes()); // one end offset
         assert!(
-            BlockLayoutMap::decode(&buf).is_err(),
-            "inner_count < 2 must be rejected",
+            matches!(
+                BlockLayoutMap::decode(&buf),
+                Err(crate::Error::InvalidHeader("BlockLayout"))
+            ),
+            "inner_count < 2 must surface as InvalidHeader(\"BlockLayout\")",
         );
     }
 

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1,4 +1,4 @@
-#[expect(clippy::expect_used)]
+#[expect(clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use crate::comparator::default_comparator;
     use crate::{

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1767,5 +1767,131 @@ mod tests {
             }
             Ok(())
         }
+
+        /// The headerless forward decoder — fed only the entry region of a block
+        /// (no trailer / restart index) — must reconstruct exactly the same
+        /// forward sequence as a normal full decode. This is the read-side core
+        /// of range-query partial decode, where the decompressed prefix of a
+        /// subset of inner zstd blocks carries entries but not the trailer.
+        #[test]
+        fn headerless_forward_decode_matches_full_forward_decode() -> crate::Result<()> {
+            use crate::Slice;
+            use crate::comparator::default_comparator;
+            use crate::table::block::Decoder;
+            use crate::table::data_block::DataBlockParsedItem;
+
+            let items: Vec<InternalValue> = (0u64..200)
+                .map(|i| {
+                    InternalValue::from_components(
+                        format!("key-{i:08}").into_bytes(),
+                        format!("val-{i:08}").into_bytes(),
+                        0,
+                        Value,
+                    )
+                })
+                .collect();
+
+            for restart_interval in [1u8, 4, 16] {
+                let bytes = DataBlock::encode_into_vec(&items, restart_interval, 0.0)?;
+                let full_block = Block {
+                    data: Slice::from(bytes),
+                    header: Header::test_dummy(BlockType::Data),
+                };
+
+                // Reference: full forward decode of every entry.
+                let data_block = DataBlock::new(full_block.clone());
+                let reference: Vec<InternalValue> = data_block
+                    .iter(default_comparator())
+                    .map(|x| x.materialize(data_block.as_slice()))
+                    .collect();
+                assert_eq!(reference.len(), items.len());
+
+                // Entry-region length + restart interval from a normal decoder.
+                let probe = Decoder::<InternalValue, DataBlockParsedItem>::new(&full_block);
+                let entries_end = probe.entries_end_for_test().expect("entries_end");
+                let ri = probe.restart_interval();
+
+                // Headerless forward decode over the EXACT entry region (no trailer).
+                let prefix_block = Block {
+                    data: full_block.data.slice(0..entries_end),
+                    header: Header::test_dummy(BlockType::Data),
+                };
+                let got: Vec<InternalValue> =
+                    Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+                        &prefix_block,
+                        ri,
+                        entries_end,
+                    )
+                    .map(|x| x.materialize(&prefix_block.data))
+                    .collect();
+
+                assert_eq!(
+                    got, reference,
+                    "headerless forward (ri={restart_interval}) must equal full forward decode",
+                );
+            }
+            Ok(())
+        }
+
+        /// A prefix that ends MID-ENTRY (an inner zstd block boundary need not
+        /// align with a KV entry) must yield every complete entry before the cut
+        /// and drop the truncated tail cleanly — no panic, no garbage entry.
+        #[test]
+        fn headerless_forward_decode_stops_cleanly_on_truncated_prefix() -> crate::Result<()> {
+            use crate::Slice;
+            use crate::table::block::Decoder;
+            use crate::table::data_block::DataBlockParsedItem;
+
+            let items: Vec<InternalValue> = (0u64..200)
+                .map(|i| {
+                    InternalValue::from_components(
+                        format!("key-{i:08}").into_bytes(),
+                        format!("val-{i:08}").into_bytes(),
+                        0,
+                        Value,
+                    )
+                })
+                .collect();
+
+            let bytes = DataBlock::encode_into_vec(&items, 16, 0.0)?;
+            let full_block = Block {
+                data: Slice::from(bytes),
+                header: Header::test_dummy(BlockType::Data),
+            };
+
+            let probe = Decoder::<InternalValue, DataBlockParsedItem>::new(&full_block);
+            let entries_end = probe.entries_end_for_test().expect("entries_end");
+            let ri = probe.restart_interval();
+
+            // Cut a few bytes short of the entry region end (into the last entry).
+            let cut = entries_end - 3;
+            let prefix_block = Block {
+                data: full_block.data.slice(0..cut),
+                header: Header::test_dummy(BlockType::Data),
+            };
+            let got: Vec<InternalValue> =
+                Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+                    &prefix_block,
+                    ri,
+                    cut,
+                )
+                .map(|x| x.materialize(&prefix_block.data))
+                .collect();
+
+            assert!(
+                !got.is_empty(),
+                "complete entries before the cut must decode"
+            );
+            assert!(
+                got.len() < items.len(),
+                "a truncated prefix must drop at least the tail entry",
+            );
+            assert_eq!(
+                got,
+                items[..got.len()].to_vec(),
+                "decoded entries must match the original block prefix exactly",
+            );
+            Ok(())
+        }
     }
 }

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1773,6 +1773,8 @@ mod tests {
         /// forward sequence as a normal full decode. This is the read-side core
         /// of range-query partial decode, where the decompressed prefix of a
         /// subset of inner zstd blocks carries entries but not the trailer.
+        // `new_forward_headerless` is only compiled for the zstd partial path.
+        #[cfg(feature = "zstd")]
         #[test]
         fn headerless_forward_decode_matches_full_forward_decode() -> crate::Result<()> {
             use crate::Slice;
@@ -1836,6 +1838,7 @@ mod tests {
         /// A prefix that ends MID-ENTRY (an inner zstd block boundary need not
         /// align with a KV entry) must yield every complete entry before the cut
         /// and drop the truncated tail cleanly — no panic, no garbage entry.
+        #[cfg(feature = "zstd")]
         #[test]
         fn headerless_forward_decode_stops_cleanly_on_truncated_prefix() -> crate::Result<()> {
             use crate::Slice;

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -86,13 +86,13 @@ pub struct Inner {
     /// `block_layout` section. Empty (no entries) when the table has no
     /// multi-inner-block data blocks. Lets a range query partial-decode only
     /// the inner blocks covering a key range in a large cold block.
-    // Read by the range-query partial-decode path (wired in a follow-up slice);
-    // the section is already produced and reloaded into this field today.
+    // Read only by the zstd partial-decode path; in a no-zstd build it is still
+    // loaded (always empty there, since no zstd blocks ever split) but unread.
     #[cfg_attr(
-        not(test),
+        not(feature = "zstd"),
         expect(
             dead_code,
-            reason = "consumed by range-query partial decode (next slice)"
+            reason = "consumed only by the zstd partial-decode read path"
         )
     )]
     pub(crate) block_layout: BlockLayoutMap,

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -5,7 +5,10 @@
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
 
-use super::{block_index::BlockIndexImpl, meta::ParsedMeta, regions::ParsedRegions};
+use super::{
+    block_index::BlockIndexImpl, block_layout::BlockLayoutMap, meta::ParsedMeta,
+    regions::ParsedRegions,
+};
 use crate::deletion_pause::DeletionPause;
 use crate::{
     Checksum, GlobalTableId, SeqNo,
@@ -78,6 +81,21 @@ pub struct Inner {
 
     /// Range tombstones stored in this table. Loaded on open.
     pub(crate) range_tombstones: Vec<RangeTombstone>,
+
+    /// Inner zstd-block layout index, loaded on open from the optional
+    /// `block_layout` section. Empty (no entries) when the table has no
+    /// multi-inner-block data blocks. Lets a range query partial-decode only
+    /// the inner blocks covering a key range in a large cold block.
+    // Read by the range-query partial-decode path (wired in a follow-up slice);
+    // the section is already produced and reloaded into this field today.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by range-query partial decode (next slice)"
+        )
+    )]
+    pub(crate) block_layout: BlockLayoutMap,
 
     /// Block encryption provider for encryption at rest.
     pub(crate) encryption: Option<Arc<dyn EncryptionProvider>>,

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(feature = "zstd")]
+use super::KeyedBlockHandle;
 use super::{BlockOffset, DataBlock, GlobalTableId, data_block::Iter as DataBlockIter};
 use crate::{
     Cache, CompressionType, InternalValue, SeqNo, UserKey,
@@ -120,6 +122,17 @@ pub struct Iter {
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
     comparator: SharedComparator,
 
+    /// Per-table inner-block layout (clone). Drives the partial-decode path:
+    /// when a data block has a recorded layout and the query upper bound falls
+    /// within it, only the inner zstd blocks covering `[start, upper]` are
+    /// decoded (trailing blocks skipped).
+    #[cfg(feature = "zstd")]
+    block_layout: crate::table::block_layout::BlockLayoutMap,
+    /// Data-block restart interval, to rebuild a positional index when
+    /// synthesizing a partial block's trailer.
+    #[cfg(feature = "zstd")]
+    data_block_restart_interval: u8,
+
     index_initialized: bool,
 
     lo_offset: BlockOffset,
@@ -157,6 +170,8 @@ impl Iter {
         has_kv_footer: bool,
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
+        #[cfg(feature = "zstd")] block_layout: crate::table::block_layout::BlockLayoutMap,
+        #[cfg(feature = "zstd")] data_block_restart_interval: u8,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> Self {
         Self {
@@ -175,6 +190,11 @@ impl Iter {
             #[cfg(zstd_any)]
             zstd_dictionary,
             comparator,
+
+            #[cfg(feature = "zstd")]
+            block_layout,
+            #[cfg(feature = "zstd")]
+            data_block_restart_interval,
 
             index_initialized: false,
 
@@ -198,6 +218,58 @@ impl Iter {
 
     pub fn set_upper_bound(&mut self, bound: Bound) {
         self.range.1 = Some(bound);
+    }
+
+    /// Try to build a partial (covering) data block for `handle` instead of
+    /// fully decoding it: decode only the inner zstd blocks up to the query's
+    /// upper bound, skipping the trailing blocks. Returns `None` (caller does a
+    /// full load) unless ALL hold: plain zstd, no encryption, the block has a
+    /// recorded multi-inner-block layout, the query has an upper bound, and that
+    /// upper bound falls within this block (for a block entirely below `upper`
+    /// the whole block is in range and a full decode is cheaper than
+    /// synthesizing one).
+    #[cfg(feature = "zstd")]
+    fn try_partial_block(&self, handle: &KeyedBlockHandle) -> crate::Result<Option<DataBlock>> {
+        if !matches!(self.compression, CompressionType::Zstd(_)) || self.encryption.is_some() {
+            return Ok(None);
+        }
+        let Some(Bound::Included(upper) | Bound::Excluded(upper)) = &self.range.1 else {
+            return Ok(None);
+        };
+        if self.comparator.compare(upper, handle.end_key()) == std::cmp::Ordering::Greater {
+            return Ok(None);
+        }
+        let Some(ends) = self.block_layout.ends_for(*handle.offset()) else {
+            return Ok(None);
+        };
+        let ends = ends.to_vec();
+
+        let (fd, _cache_event) = self
+            .file_accessor
+            .get_or_open_table(&self.table_id, &self.path)?;
+        let transform = crate::table::block::BlockTransform::from_parts(
+            self.compression,
+            None,
+            #[cfg(zstd_any)]
+            None,
+        )?;
+        let transform = match self.ecc {
+            Some(ecc) => transform.with_ecc(ecc),
+            None => transform,
+        };
+        let (_header, frame) = crate::table::block::Block::read_data_frame(
+            fd.as_ref(),
+            BlockHandle::new(handle.offset(), handle.size()),
+            &transform,
+        )?;
+        let (block, _blocks) = crate::table::lazy_block::partial_data_block(
+            frame.to_vec(),
+            ends,
+            self.data_block_restart_interval,
+            &self.comparator,
+            upper,
+        )?;
+        Ok(Some(block))
     }
 }
 
@@ -300,29 +372,43 @@ impl Iterator for Iter {
                 Err(e) => return self.poison(e),
             };
 
-            // Load the next data block via `load_block`, which checks the block cache
-            // internally and validates block type on both cache-hit and I/O paths.
-            let block = match load_block(
-                self.table_id,
-                &self.path,
-                &self.file_accessor,
-                &self.cache,
-                &BlockHandle::new(handle.offset(), handle.size()),
-                crate::table::block::BlockType::Data,
-                self.compression,
-                self.encryption.as_deref(),
-                self.ecc,
-                #[cfg(zstd_any)]
-                self.zstd_dictionary.as_deref(),
-                #[cfg(feature = "metrics")]
-                &self.metrics,
-            ) {
-                Ok(b) => b,
+            // Partial-decode fast path: for a large multi-inner-block zstd block
+            // whose recorded layout lets us skip the inner blocks past the query
+            // upper bound, decode only the covering prefix. Falls back to a full
+            // load (which checks the block cache) otherwise.
+            #[cfg(feature = "zstd")]
+            let partial = match self.try_partial_block(&handle) {
+                Ok(p) => p,
                 Err(e) => return self.poison(e),
             };
-            let block = match DataBlock::from_loaded(block, self.has_kv_footer) {
-                Ok(b) => b,
-                Err(e) => return self.poison(e),
+            #[cfg(not(feature = "zstd"))]
+            let partial: Option<DataBlock> = None;
+
+            let block = if let Some(db) = partial {
+                db
+            } else {
+                let raw = match load_block(
+                    self.table_id,
+                    &self.path,
+                    &self.file_accessor,
+                    &self.cache,
+                    &BlockHandle::new(handle.offset(), handle.size()),
+                    crate::table::block::BlockType::Data,
+                    self.compression,
+                    self.encryption.as_deref(),
+                    self.ecc,
+                    #[cfg(zstd_any)]
+                    self.zstd_dictionary.as_deref(),
+                    #[cfg(feature = "metrics")]
+                    &self.metrics,
+                ) {
+                    Ok(b) => b,
+                    Err(e) => return self.poison(e),
+                };
+                match DataBlock::from_loaded(raw, self.has_kv_footer) {
+                    Ok(b) => b,
+                    Err(e) => return self.poison(e),
+                }
             };
 
             let mut reader = match create_data_block_reader(block, self.comparator.clone()) {
@@ -432,29 +518,43 @@ impl DoubleEndedIterator for Iter {
                 Err(e) => return self.poison(e),
             };
 
-            // Load the next data block via `load_block`, which checks the block cache
-            // internally and validates block type on both cache-hit and I/O paths.
-            let block = match load_block(
-                self.table_id,
-                &self.path,
-                &self.file_accessor,
-                &self.cache,
-                &BlockHandle::new(handle.offset(), handle.size()),
-                crate::table::block::BlockType::Data,
-                self.compression,
-                self.encryption.as_deref(),
-                self.ecc,
-                #[cfg(zstd_any)]
-                self.zstd_dictionary.as_deref(),
-                #[cfg(feature = "metrics")]
-                &self.metrics,
-            ) {
-                Ok(b) => b,
+            // Partial-decode fast path: for a large multi-inner-block zstd block
+            // whose recorded layout lets us skip the inner blocks past the query
+            // upper bound, decode only the covering prefix. Falls back to a full
+            // load (which checks the block cache) otherwise.
+            #[cfg(feature = "zstd")]
+            let partial = match self.try_partial_block(&handle) {
+                Ok(p) => p,
                 Err(e) => return self.poison(e),
             };
-            let block = match DataBlock::from_loaded(block, self.has_kv_footer) {
-                Ok(b) => b,
-                Err(e) => return self.poison(e),
+            #[cfg(not(feature = "zstd"))]
+            let partial: Option<DataBlock> = None;
+
+            let block = if let Some(db) = partial {
+                db
+            } else {
+                let raw = match load_block(
+                    self.table_id,
+                    &self.path,
+                    &self.file_accessor,
+                    &self.cache,
+                    &BlockHandle::new(handle.offset(), handle.size()),
+                    crate::table::block::BlockType::Data,
+                    self.compression,
+                    self.encryption.as_deref(),
+                    self.ecc,
+                    #[cfg(zstd_any)]
+                    self.zstd_dictionary.as_deref(),
+                    #[cfg(feature = "metrics")]
+                    &self.metrics,
+                ) {
+                    Ok(b) => b,
+                    Err(e) => return self.poison(e),
+                };
+                match DataBlock::from_loaded(raw, self.has_kv_footer) {
+                    Ok(b) => b,
+                    Err(e) => return self.poison(e),
+                }
             };
 
             let mut reader = match create_data_block_reader(block, self.comparator.clone()) {

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -25,6 +25,50 @@ use crate::metrics::Metrics;
 
 type InnerIter<'a> = DataBlockIter<'a>;
 
+/// Whether the range-query partial-decode path is engaged (opt-in, OFF by
+/// default). Set `LSM_PARTIAL_DECODE` to `1` / `on` / `true` / `yes` to enable.
+///
+/// The path is currently a perf regression for forward range scans: decoding
+/// inner zstd block `N` drains the match window, so growing the covered extent
+/// must re-decode `[0, N)` from scratch each step. A multi-read sweep of one
+/// large cold block therefore cascades into re-decoding the whole block, which
+/// full decode + block cache does in a single pass. It flips to a win once a
+/// resumable (non-draining, window-priming) decoder lands upstream
+/// (structured-zstd#368): then a grown extent decodes only the new tail blocks,
+/// and this gate defaults ON. All machinery (block layout, lazy block, partial
+/// cache) is in place so that switch is a one-line change plus the resumable
+/// `ensure_decoded_to`.
+// no-std: feature-gate behind `std`; a no-std build has no env, default OFF.
+#[cfg(feature = "zstd")]
+fn partial_decode_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("LSM_PARTIAL_DECODE")
+            .ok()
+            .is_some_and(|v| matches!(v.trim(), "1" | "on" | "true" | "yes"))
+    })
+}
+
+/// Promote a partially-decoded cold block to a full resident block once it has
+/// been served this many times: a repeatedly-read block earns its full memory.
+#[cfg(feature = "zstd")]
+const PARTIAL_PROMOTE_HITS: u32 = 4;
+
+/// Promote once covering a query would decode at least this percentage of the
+/// block's inner zstd blocks: past this point the partial saves little memory
+/// and a single full decode beats re-growing the extent.
+#[cfg(feature = "zstd")]
+const PARTIAL_PROMOTE_FRACTION_PCT: u32 = 75;
+
+/// Whether `covered` of `total` inner blocks reaches the promotion fraction.
+/// `total == 0` never promotes (no layout → partial tier does not apply).
+#[cfg(feature = "zstd")]
+fn promote_by_fraction(covered: u32, total: u32) -> bool {
+    total > 0
+        && u64::from(covered) * 100 >= u64::from(total) * u64::from(PARTIAL_PROMOTE_FRACTION_PCT)
+}
+
 pub enum Bound {
     Included(UserKey),
     Excluded(UserKey),
@@ -220,17 +264,30 @@ impl Iter {
         self.range.1 = Some(bound);
     }
 
-    /// Try to build a partial (covering) data block for `handle` instead of
-    /// fully decoding it: decode only the inner zstd blocks up to the query's
-    /// upper bound, skipping the trailing blocks. Returns `None` (caller does a
-    /// full load) unless ALL hold: plain zstd, no encryption, the block has a
-    /// recorded multi-inner-block layout, the query has an upper bound, and that
-    /// upper bound falls within this block (for a block entirely below `upper`
-    /// the whole block is in range and a full decode is cheaper than
-    /// synthesizing one).
+    /// Adaptive partial-tier read for `handle`: keep a cold block only partially
+    /// decoded (the touched fraction) instead of materializing the whole block,
+    /// and promote it to a full resident block once access justifies the memory.
+    /// Returns `None` (caller does a full load + caches the whole block) when the
+    /// partial tier does not apply or the block should be promoted:
+    ///
+    /// - not plain zstd, encrypted, no recorded multi-inner-block layout, or no
+    ///   query upper bound (an unbounded scan reads the whole block anyway);
+    /// - the block sits entirely below `upper` (fully in range → full decode);
+    /// - the block is already resident as a full block (let the cache serve it);
+    /// - PROMOTION: the cached partial has been served [`PARTIAL_PROMOTE_HITS`]
+    ///   times, or covering the query would decode at least
+    ///   [`PARTIAL_PROMOTE_FRACTION_PCT`]% of the inner blocks — at that point a
+    ///   single full decode + block cache beats re-growing the partial extent
+    ///   (which, lacking a resumable decoder, re-decodes from inner block 0).
+    ///
+    /// Otherwise it returns a synthesized covering block and caches it with the
+    /// extent + access stats for the next read.
     #[cfg(feature = "zstd")]
     fn try_partial_block(&self, handle: &KeyedBlockHandle) -> crate::Result<Option<DataBlock>> {
-        if !matches!(self.compression, CompressionType::Zstd(_)) || self.encryption.is_some() {
+        if !partial_decode_enabled()
+            || !matches!(self.compression, CompressionType::Zstd(_))
+            || self.encryption.is_some()
+        {
             return Ok(None);
         }
         let Some(Bound::Included(upper) | Bound::Excluded(upper)) = &self.range.1 else {
@@ -242,7 +299,52 @@ impl Iter {
         let Some(ends) = self.block_layout.ends_for(*handle.offset()) else {
             return Ok(None);
         };
+        let offset = BlockOffset(*handle.offset());
+        // Already promoted to a full resident block → let the normal cached load
+        // path serve it (no point re-synthesizing a partial alongside it).
+        if self.cache.has_block(self.table_id, offset) {
+            return Ok(None);
+        }
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "inner-block count is bounded well within u32"
+        )]
+        let total_blocks = ends.len() as u32;
         let ends = ends.to_vec();
+
+        // Existing partial entry: serve from it (bumping hits) when it already
+        // covers the query, else decide whether to grow it or promote. The fall-
+        // through value is the hit count carried into the grown entry.
+        let carried_hits = match self.cache.peek_partial_block(self.table_id, offset) {
+            Some(entry) => {
+                let covered = self.comparator.compare(&entry.covered_upper, upper)
+                    != std::cmp::Ordering::Less;
+                if covered {
+                    let hits = entry.hits + 1;
+                    if hits >= PARTIAL_PROMOTE_HITS {
+                        // Hot enough: promote to a full resident block.
+                        self.cache.evict_partial_block(self.table_id, offset);
+                        return Ok(None);
+                    }
+                    let block = entry.block.clone();
+                    self.cache.insert_partial_block(
+                        self.table_id,
+                        offset,
+                        crate::cache::PartialBlockEntry { hits, ..entry },
+                    );
+                    return Ok(Some(DataBlock::new(block)));
+                }
+                // Coverage miss → would grow the extent. If most of the block is
+                // already decoded, a full decode is cheaper than re-growing (the
+                // grow re-decodes from inner block 0 without a resumable decoder).
+                if promote_by_fraction(entry.covered_blocks, total_blocks) {
+                    self.cache.evict_partial_block(self.table_id, offset);
+                    return Ok(None);
+                }
+                entry.hits
+            }
+            None => 0,
+        };
 
         let (fd, _cache_event) = self
             .file_accessor
@@ -262,13 +364,34 @@ impl Iter {
             BlockHandle::new(handle.offset(), handle.size()),
             &transform,
         )?;
-        let (block, _blocks) = crate::table::lazy_block::partial_data_block(
+        let (block, blocks, covered_upper) = crate::table::lazy_block::partial_data_block(
             frame.to_vec(),
             ends,
             self.data_block_restart_interval,
             &self.comparator,
             upper,
         )?;
+        // Covering this query already decoded most of the block → promote: throw
+        // the partial away and let the caller cache the whole block.
+        if promote_by_fraction(blocks, total_blocks) {
+            self.cache.evict_partial_block(self.table_id, offset);
+            return Ok(None);
+        }
+        // Cache the synthesized block tagged with the extent it covers + carried
+        // access stats, so the next read reuses or grows it (high-water growth).
+        if let Some(covered) = covered_upper {
+            self.cache.insert_partial_block(
+                self.table_id,
+                offset,
+                crate::cache::PartialBlockEntry {
+                    block: block.inner.clone(),
+                    covered_upper: covered,
+                    covered_blocks: blocks,
+                    total_blocks,
+                    hits: carried_hits,
+                },
+            );
+        }
         Ok(Some(block))
     }
 }
@@ -585,5 +708,37 @@ impl DoubleEndedIterator for Iter {
                 return Some(Ok(item));
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "zstd"))]
+mod promote_tests {
+    use super::promote_by_fraction;
+
+    #[test]
+    fn promote_by_fraction_triggers_at_or_above_threshold() {
+        // 75% threshold: 3 of 4 blocks == exactly 75% → promote.
+        assert!(promote_by_fraction(3, 4));
+        // 6 of 8 == 75% → promote.
+        assert!(promote_by_fraction(6, 8));
+        // Full coverage always promotes.
+        assert!(promote_by_fraction(10, 10));
+    }
+
+    #[test]
+    fn promote_by_fraction_holds_below_threshold() {
+        // 2 of 4 == 50% → keep partial.
+        assert!(!promote_by_fraction(2, 4));
+        // 1 of 8 → keep partial.
+        assert!(!promote_by_fraction(1, 8));
+        // 5 of 8 == 62.5% → keep partial.
+        assert!(!promote_by_fraction(5, 8));
+    }
+
+    #[test]
+    fn promote_by_fraction_zero_total_never_promotes() {
+        // No layout (total == 0): the partial tier does not apply, never promote.
+        assert!(!promote_by_fraction(0, 0));
+        assert!(!promote_by_fraction(5, 0));
     }
 }

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -25,19 +25,16 @@ use crate::metrics::Metrics;
 
 type InnerIter<'a> = DataBlockIter<'a>;
 
-/// Whether the range-query partial-decode path is engaged (opt-in, OFF by
+/// Whether the cold-block partial-tier read path is engaged (opt-in, OFF by
 /// default). Set `LSM_PARTIAL_DECODE` to `1` / `on` / `true` / `yes` to enable.
 ///
-/// The path is currently a perf regression for forward range scans: decoding
-/// inner zstd block `N` drains the match window, so growing the covered extent
-/// must re-decode `[0, N)` from scratch each step. A multi-read sweep of one
-/// large cold block therefore cascades into re-decoding the whole block, which
-/// full decode + block cache does in a single pass. It flips to a win once a
-/// resumable (non-draining, window-priming) decoder lands upstream
-/// (structured-zstd#368): then a grown extent decodes only the new tail blocks,
-/// and this gate defaults ON. All machinery (block layout, lazy block, partial
-/// cache) is in place so that switch is a one-line change plus the resumable
-/// `ensure_decoded_to`.
+/// On a large cold zstd block, a bounded range decodes only the inner blocks up
+/// to its upper bound and keeps just that decompressed prefix resident; growing
+/// the extent RESUMES from a cached entropy/window snapshot (decoding only the
+/// new tail blocks) rather than re-decompressing from block 0. Repeatedly read
+/// or mostly-decoded blocks promote to a full resident block. Off by default
+/// while the path is being validated against full decode + block cache; flip the
+/// env to compare.
 // no-std: feature-gate behind `std`; a no-std build has no env, default OFF.
 #[cfg(feature = "zstd")]
 fn partial_decode_enabled() -> bool {
@@ -49,6 +46,13 @@ fn partial_decode_enabled() -> bool {
             .is_some_and(|v| matches!(v.trim(), "1" | "on" | "true" | "yes"))
     })
 }
+
+/// Minimum decompressed block size for the partial tier to engage. Below this a
+/// block decodes fully: the decode it would save is cheap relative to the
+/// per-call setup (decoder reset, window prime, trailer synthesis), so partial
+/// would cost more than it saves. Only genuinely large cold blocks qualify.
+#[cfg(feature = "zstd")]
+const PARTIAL_MIN_BLOCK_BYTES: usize = 256 * 1024;
 
 /// Promote a partially-decoded cold block to a full resident block once it has
 /// been served this many times: a repeatedly-read block earns its full memory.
@@ -305,6 +309,13 @@ impl Iter {
         if self.cache.has_block(self.table_id, offset) {
             return Ok(None);
         }
+        // Cold-block gate: only engage on genuinely large blocks (the cold tier
+        // runs multi-MB blocks) where decoding a fraction saves far more than the
+        // per-call setup. The total decompressed size is the last cumulative end.
+        let total_bytes = ends.last().copied().unwrap_or(0) as usize;
+        if total_bytes < PARTIAL_MIN_BLOCK_BYTES {
+            return Ok(None);
+        }
         #[expect(
             clippy::cast_possible_truncation,
             reason = "inner-block count is bounded well within u32"
@@ -314,37 +325,43 @@ impl Iter {
 
         // Existing partial entry: serve from it (bumping hits) when it already
         // covers the query, else decide whether to grow it or promote. The fall-
-        // through value is the hit count carried into the grown entry.
-        let carried_hits = match self.cache.peek_partial_block(self.table_id, offset) {
-            Some(entry) => {
-                let covered = self.comparator.compare(&entry.covered_upper, upper)
-                    != std::cmp::Ordering::Less;
-                if covered {
-                    let hits = entry.hits + 1;
-                    if hits >= PARTIAL_PROMOTE_HITS {
-                        // Hot enough: promote to a full resident block.
+        // through carries the hit count + the resume payload to continue from.
+        let (carried_hits, carried_resume) =
+            match self.cache.peek_partial_block(self.table_id, offset) {
+                Some(entry) => {
+                    let covered = self.comparator.compare(&entry.covered_upper, upper)
+                        != std::cmp::Ordering::Less;
+                    if covered {
+                        let hits = entry.hits + 1;
+                        if hits >= PARTIAL_PROMOTE_HITS {
+                            // Hot enough: promote to a full resident block.
+                            self.cache.evict_partial_block(self.table_id, offset);
+                            return Ok(None);
+                        }
+                        // Synthesize the served block from the cached decompressed
+                        // prefix (only the touched fraction is held in memory).
+                        let block = crate::table::lazy_block::synthesize_data_block(
+                            &entry.resume.window_prime,
+                            self.data_block_restart_interval,
+                        )?;
+                        self.cache.insert_partial_block(
+                            self.table_id,
+                            offset,
+                            crate::cache::PartialBlockEntry { hits, ..entry },
+                        );
+                        return Ok(Some(block));
+                    }
+                    // Coverage miss → grow the extent by resuming from the snapshot.
+                    // If most of the block is already decoded, a full decode + block
+                    // cache beats holding a near-complete partial, so promote.
+                    if promote_by_fraction(entry.resume.decoded_blocks, total_blocks) {
                         self.cache.evict_partial_block(self.table_id, offset);
                         return Ok(None);
                     }
-                    let block = entry.block.clone();
-                    self.cache.insert_partial_block(
-                        self.table_id,
-                        offset,
-                        crate::cache::PartialBlockEntry { hits, ..entry },
-                    );
-                    return Ok(Some(DataBlock::new(block)));
+                    (entry.hits, Some(entry.resume))
                 }
-                // Coverage miss → would grow the extent. If most of the block is
-                // already decoded, a full decode is cheaper than re-growing (the
-                // grow re-decodes from inner block 0 without a resumable decoder).
-                if promote_by_fraction(entry.covered_blocks, total_blocks) {
-                    self.cache.evict_partial_block(self.table_id, offset);
-                    return Ok(None);
-                }
-                entry.hits
-            }
-            None => 0,
-        };
+                None => (0, None),
+            };
 
         let (fd, _cache_event) = self
             .file_accessor
@@ -364,29 +381,31 @@ impl Iter {
             BlockHandle::new(handle.offset(), handle.size()),
             &transform,
         )?;
-        let (block, blocks, covered_upper) = crate::table::lazy_block::partial_data_block(
+        // Cold first touch (carried_resume None) or resume-grow from the cached
+        // snapshot — either way only the new tail blocks are decompressed.
+        let (block, covered_upper, payload) = crate::table::lazy_block::partial_data_block(
             frame.to_vec(),
             ends,
             self.data_block_restart_interval,
             &self.comparator,
             upper,
+            carried_resume,
         )?;
-        // Covering this query already decoded most of the block → promote: throw
-        // the partial away and let the caller cache the whole block.
-        if promote_by_fraction(blocks, total_blocks) {
+        // Covering this query decoded most of the block → promote: drop the
+        // partial and let the caller cache the whole block.
+        if promote_by_fraction(payload.decoded_blocks, total_blocks) {
             self.cache.evict_partial_block(self.table_id, offset);
             return Ok(None);
         }
-        // Cache the synthesized block tagged with the extent it covers + carried
-        // access stats, so the next read reuses or grows it (high-water growth).
+        // Cache the resume payload tagged with the extent it covers + carried
+        // access stats, so the next read serves or resume-grows it.
         if let Some(covered) = covered_upper {
             self.cache.insert_partial_block(
                 self.table_id,
                 offset,
                 crate::cache::PartialBlockEntry {
-                    block: block.inner.clone(),
+                    resume: payload,
                     covered_upper: covered,
-                    covered_blocks: blocks,
                     total_blocks,
                     hits: carried_hits,
                 },

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -34,6 +34,10 @@
     )
 )]
 
+use crate::comparator::SharedComparator;
+use crate::table::block::{Block, BlockType, Decoder, Header, ParsedItem};
+use crate::table::data_block::DataBlockParsedItem;
+use crate::{Checksum, InternalValue, Slice};
 use structured_zstd::decoding::FrameDecoder;
 
 /// A data block decoded lazily from its compressed zstd frame, inner block by
@@ -161,6 +165,93 @@ impl LazyBlock {
     }
 }
 
+/// Collect the entries in `[lower, upper)` from a compressed data-block `frame`,
+/// decoding only the inner zstd blocks the range covers and skipping the
+/// trailing blocks after `upper` (the perf win). `lower` is inclusive, `upper`
+/// exclusive; `None` means unbounded on that side.
+///
+/// The covering prefix is decoded (growing geometrically until the first key
+/// `>= upper` is reached, or the block is exhausted), then walked with a
+/// trailer-independent forward decoder. Returns the in-range entries and the
+/// number of inner blocks that had to be decoded (so callers / tests can see
+/// the trailing blocks were skipped).
+///
+/// # Errors
+///
+/// Returns an error if the frame header or an inner block fails to decode.
+pub fn collect_range_partial(
+    frame: Vec<u8>,
+    ends: Vec<u32>,
+    restart_interval: u8,
+    comparator: &SharedComparator,
+    lower: Option<&[u8]>,
+    upper: Option<&[u8]>,
+) -> crate::Result<(Vec<InternalValue>, u32)> {
+    let mut lazy = LazyBlock::new(frame, ends)?;
+    let total = lazy.total_len();
+    let mut extent = 0usize;
+    let mut out = Vec::new();
+
+    loop {
+        // Grow the decoded extent geometrically; the drain-on-return decode is
+        // re-run from block 0 per growth, so geometric steps keep total decode
+        // work O(final extent) rather than O(extent^2).
+        extent = if extent == 0 {
+            (64 * 1024).min(total)
+        } else {
+            extent.saturating_mul(2).min(total)
+        };
+        lazy.ensure_decoded_to(extent)?;
+        let prefix = lazy.decoded();
+        let entries_end = prefix.len();
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "prefix length <= block size, well within u32"
+        )]
+        let synthetic_len = entries_end as u32;
+        let block = Block {
+            header: Header {
+                block_type: BlockType::Data,
+                block_flags: 0,
+                checksum: Checksum::from_raw(0),
+                data_length: synthetic_len,
+                uncompressed_length: synthetic_len,
+            },
+            data: Slice::from(prefix),
+        };
+
+        out.clear();
+        let mut reached_upper = upper.is_none();
+        let decoder = Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+            &block,
+            restart_interval,
+            entries_end,
+        );
+        for item in decoder {
+            let kv = item.materialize(&block.data);
+            if let Some(up) = upper
+                && comparator.compare(&kv.key.user_key, up) != std::cmp::Ordering::Less
+            {
+                reached_upper = true;
+                break;
+            }
+            if let Some(lo) = lower
+                && comparator.compare(&kv.key.user_key, lo) == std::cmp::Ordering::Less
+            {
+                continue;
+            }
+            out.push(kv);
+        }
+
+        if reached_upper || entries_end >= total {
+            break;
+        }
+    }
+
+    Ok((out, lazy.decoded_blocks()))
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
@@ -235,6 +326,51 @@ mod tests {
         assert!(
             lazy.decoded_blocks() < nblocks as u32,
             "must NOT have decoded the whole block for a partial read",
+        );
+    }
+
+    #[test]
+    fn collect_range_partial_matches_full_and_skips_trailing() {
+        use crate::table::block::{Block, BlockType, Header, ParsedItem};
+        use crate::{Slice, comparator::default_comparator};
+
+        let (frame, ends, block_bytes) = large_block_frame();
+        let nblocks = ends.len() as u32;
+        let comparator = default_comparator();
+
+        // Full reference: real block, iterate, filter [lower, upper).
+        let full = DataBlock::new(Block {
+            data: Slice::from(block_bytes),
+            header: Header::test_dummy(BlockType::Data),
+        });
+        // Keys are "key-{i:012}"; pick a range near the block start so the
+        // trailing inner blocks are skippable.
+        let lower = b"key-000000000010".to_vec();
+        let upper = b"key-000000000050".to_vec();
+        let reference: Vec<InternalValue> = full
+            .iter(comparator.clone())
+            .map(|x| x.materialize(full.as_slice()))
+            .filter(|kv| {
+                let k = kv.key.user_key.as_ref();
+                k >= lower.as_slice() && k < upper.as_slice()
+            })
+            .collect();
+        assert_eq!(reference.len(), 40, "i=10..50 → 40 entries");
+
+        let (got, blocks) = collect_range_partial(
+            frame,
+            ends,
+            16, // restart_interval used by large_block_frame
+            &comparator,
+            Some(&lower),
+            Some(&upper),
+        )
+        .expect("partial range");
+
+        assert_eq!(got, reference, "partial range must equal the full range");
+        assert!(
+            blocks < nblocks,
+            "a near-start range must skip trailing inner blocks: decoded {blocks}/{nblocks}",
         );
     }
 

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Lazily-decoded data block: decode only the inner zstd blocks a read
+//! actually touches, growing the decompressed prefix on demand.
+//!
+//! A large cold-tier data block compresses into many inner zstd blocks (see
+//! the per-table `block_layout` section). A range query that reads only the
+//! start of such a block should pay to decompress only the inner blocks
+//! covering its key range, not the whole block.
+//!
+//! [`LazyBlock`] decodes the inner blocks `[0, end_block)` that cover a read's
+//! key range and skips the trailing blocks (the perf win). A range query knows
+//! its upper bound up front, so it decodes ONCE to the needed extent.
+//!
+//! `decode_blocks_partial` drains the in-range output from the match window on
+//! return, so consecutive calls cannot resume one another (a later block would
+//! lack the earlier blocks as match history). Each extent growth therefore
+//! re-decodes the covering prefix in a single call from block 0. True
+//! incremental resume (decode block N continuing, without re-decoding the
+//! prefix) needs a window-priming decoder API tracked in structured-zstd#368.
+//!
+//! It is a TRANSIENT, single-thread engine (`FrameDecoder` is not `Send`): a
+//! live `LazyBlock` lives on the stack for one block access, while the cache
+//! stores only the grown decompressed bytes (a follow-up wires that path).
+
+// The lazy-decode engine is exercised by its tests; its production consumer
+// (the range-query iterator + cache path) lands in a follow-up slice.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by the range-query partial-decode wiring (next slice)"
+    )
+)]
+
+use structured_zstd::decoding::FrameDecoder;
+
+/// A data block decoded lazily from its compressed zstd frame, inner block by
+/// inner block, on demand.
+pub struct LazyBlock {
+    /// Compressed zstd frame (the block payload after decrypt + ECC verify),
+    /// owned so the resumable decoder can read further inner blocks on top-up.
+    source: std::io::Cursor<Vec<u8>>,
+    /// Decoder, reset before each (re-)decode of the covering prefix.
+    decoder: FrameDecoder,
+    /// Cumulative decompressed END offset of each inner block (the persisted
+    /// `block_layout`). `ends.last()` == total decompressed size.
+    ends: Vec<u32>,
+    /// Count of inner blocks already decoded into `decompressed`.
+    decoded_blocks: u32,
+    /// Decompressed bytes of inner blocks `[0, decoded_blocks)`, contiguous.
+    decompressed: Vec<u8>,
+}
+
+impl LazyBlock {
+    /// Wraps a compressed `frame` with its inner-block `ends` layout (the
+    /// persisted cumulative decompressed offsets). Reads the frame header
+    /// up front; decodes no block bodies until [`Self::ensure_decoded_to`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the frame header is malformed.
+    pub fn new(frame: Vec<u8>, ends: Vec<u32>) -> crate::Result<Self> {
+        let mut source = std::io::Cursor::new(frame);
+        let mut decoder = FrameDecoder::new();
+        decoder
+            .reset(&mut source)
+            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+        Ok(Self {
+            source,
+            decoder,
+            ends,
+            decoded_blocks: 0,
+            decompressed: Vec::new(),
+        })
+    }
+
+    /// Total decompressed size of the block (last cumulative end).
+    pub fn total_len(&self) -> usize {
+        self.ends.last().copied().unwrap_or(0) as usize
+    }
+
+    /// Decompressed prefix decoded so far.
+    pub fn decoded(&self) -> &[u8] {
+        &self.decompressed
+    }
+
+    /// Number of inner blocks decoded so far (for laziness assertions / tests).
+    pub fn decoded_blocks(&self) -> u32 {
+        self.decoded_blocks
+    }
+
+    /// Grow the decompressed prefix until it covers byte offset `upto`
+    /// (exclusive), decoding inner blocks `[0, end_block)` where `end_block`
+    /// covers `upto` and skipping the trailing blocks. A no-op when the prefix
+    /// already reaches `upto`.
+    ///
+    /// `decode_blocks_partial` returns (and drains from the match window) the
+    /// in-range output, so consecutive calls cannot resume one another — a
+    /// later block would lack the earlier blocks as match history. Each growth
+    /// therefore re-decodes the covering prefix in a SINGLE call from block 0
+    /// (within one call the window is maintained until the final drain). A
+    /// range query knows its upper bound up front, so it calls this ONCE for
+    /// the extent it needs — one decode, trailing blocks skipped. (True
+    /// incremental resume without re-decoding the prefix needs the
+    /// window-priming decoder API tracked in structured-zstd#368.)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an inner block fails to decode (corruption).
+    pub fn ensure_decoded_to(&mut self, upto: usize) -> crate::Result<()> {
+        if upto <= self.decompressed.len() {
+            return Ok(());
+        }
+        // Inner block whose decompressed range covers `upto - 1` (the first
+        // block whose cumulative end exceeds it), clamped to the last block.
+        let probe = upto.saturating_sub(1);
+        let target = self
+            .ends
+            .partition_point(|&e| (e as usize) <= probe)
+            .min(self.ends.len().saturating_sub(1));
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "inner-block index is bounded by ends.len(), well within u32"
+        )]
+        let end_block = (target + 1) as u32;
+        if end_block <= self.decoded_blocks {
+            return Ok(());
+        }
+
+        // Re-read the frame header and decode `[0, end_block)` in one call: the
+        // drain-on-return behaviour means a single call is the only way to keep
+        // each block's match history available to the next.
+        self.source.set_position(0);
+        self.decoder
+            .reset(&mut self.source)
+            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+        let pd = self
+            .decoder
+            .decode_blocks_partial(&mut self.source, 0, end_block)
+            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+        if let Some((idx, err)) = pd.stopped_at {
+            return Err(crate::Error::Io(std::io::Error::other(format!(
+                "lazy partial decode stopped at inner block {idx}: {err:?}"
+            ))));
+        }
+        self.decompressed.clear();
+        self.decompressed.extend_from_slice(&pd.data);
+        self.decoded_blocks = pd.blocks_decoded;
+        Ok(())
+    }
+
+    /// Decode the whole block (all inner blocks).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any inner block fails to decode.
+    pub fn ensure_fully_decoded(&mut self) -> crate::Result<()> {
+        self.ensure_decoded_to(self.total_len())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::compression::{CompressionProvider as _, ZstdBackend};
+    use crate::table::DataBlock;
+    use crate::{InternalValue, ValueType::Value};
+    use test_log::test;
+
+    /// Build a large sorted-KV data block, compress it, and return the frame +
+    /// inner-block `ends` layout and the full decompressed reference bytes.
+    fn large_block_frame() -> (Vec<u8>, Vec<u32>, Vec<u8>) {
+        let items: Vec<InternalValue> = (0u64..20_000)
+            .map(|i| {
+                InternalValue::from_components(
+                    format!("key-{i:012}").into_bytes(),
+                    format!("value-{i:08}-payload").into_bytes(),
+                    0,
+                    Value,
+                )
+            })
+            .collect();
+        // One big data block (no spill): encode all entries into a single block.
+        let block_bytes = DataBlock::encode_into_vec(&items, 16, 0.0).expect("encode block");
+        // High level so the frame pre-splits into many inner zstd blocks.
+        let (frame, ends) =
+            ZstdBackend::compress_with_layout(&block_bytes, 19).expect("compress with layout");
+        assert!(
+            ends.len() >= 4,
+            "fixture must split into several inner blocks, got {}",
+            ends.len(),
+        );
+        let reference =
+            ZstdBackend::decompress(&frame, block_bytes.len() + 1).expect("full decompress");
+        assert_eq!(reference, block_bytes);
+        (frame, ends, reference)
+    }
+
+    #[test]
+    fn lazy_block_decodes_only_touched_inner_blocks() {
+        let (frame, ends, reference) = large_block_frame();
+        let nblocks = ends.len();
+
+        let mut lazy = LazyBlock::new(frame, ends.clone()).expect("new lazy block");
+        assert_eq!(lazy.decoded_blocks(), 0, "no block bodies decoded up front");
+        assert!(lazy.decoded().is_empty());
+
+        // Touch a byte inside the first inner block → only block 0 decoded.
+        lazy.ensure_decoded_to(1).expect("decode to byte 1");
+        assert_eq!(
+            lazy.decoded_blocks(),
+            1,
+            "only the first inner block decoded"
+        );
+        assert_eq!(lazy.decoded().len(), ends[0] as usize);
+        assert_eq!(lazy.decoded(), &reference[..ends[0] as usize]);
+
+        // Idempotent: already covered → no further decode.
+        lazy.ensure_decoded_to(ends[0] as usize)
+            .expect("idempotent");
+        assert_eq!(lazy.decoded_blocks(), 1);
+
+        // Top-up to span into the third inner block → blocks 0..=2 decoded.
+        let upto = ends[1] as usize + 1;
+        lazy.ensure_decoded_to(upto).expect("top up");
+        assert_eq!(
+            lazy.decoded_blocks(),
+            3,
+            "topped up to cover the third block"
+        );
+        assert_eq!(lazy.decoded(), &reference[..ends[2] as usize]);
+        assert!(
+            lazy.decoded_blocks() < nblocks as u32,
+            "must NOT have decoded the whole block for a partial read",
+        );
+    }
+
+    #[test]
+    fn lazy_block_full_decode_matches_reference() {
+        let (frame, ends, reference) = large_block_frame();
+        let mut lazy = LazyBlock::new(frame, ends.clone()).expect("new lazy block");
+        lazy.ensure_fully_decoded().expect("full decode");
+        assert_eq!(lazy.decoded_blocks(), ends.len() as u32);
+        assert_eq!(lazy.decoded(), reference.as_slice());
+    }
+
+    #[test]
+    fn lazy_block_growing_extents_equal_one_shot_full() {
+        // Growing the decoded extent in steps (each a re-decode of the covering
+        // prefix) must always equal the matching prefix of a full decode and
+        // converge to the whole block.
+        let (frame, ends, reference) = large_block_frame();
+        let mut lazy = LazyBlock::new(frame, ends.clone()).expect("new lazy block");
+        let total = reference.len();
+        let mut cursor = 0usize;
+        while cursor < total {
+            cursor = (cursor + 64 * 1024).min(total);
+            lazy.ensure_decoded_to(cursor).expect("grow extent");
+            assert_eq!(lazy.decoded(), &reference[..lazy.decoded().len()]);
+        }
+        assert_eq!(lazy.decoded(), reference.as_slice());
+    }
+}

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -35,6 +35,7 @@
 )]
 
 use crate::comparator::SharedComparator;
+use crate::table::DataBlock;
 use crate::table::block::{Block, BlockType, Decoder, Header, ParsedItem};
 use crate::table::data_block::DataBlockParsedItem;
 use crate::{Checksum, InternalValue, Slice};
@@ -252,6 +253,167 @@ pub fn collect_range_partial(
     Ok((out, lazy.decoded_blocks()))
 }
 
+/// Synthesize a valid standalone data-block (`entries ‖ trailer`) from a
+/// decoded entry-region `prefix`, so the normal trailer-driven decoder / seek
+/// path can read it. The binary index is rebuilt from the prefix's positional
+/// restart heads (no trailer needed in the source); no hash index is emitted
+/// (seek falls back to binary search). A truncated tail entry in `prefix` is
+/// dropped (only complete entries are indexed and kept).
+///
+/// # Errors
+///
+/// Returns an error if the binary index fails to serialize.
+fn synthesize_block_bytes(prefix: &[u8], restart_interval: u8) -> crate::Result<Vec<u8>> {
+    use crate::table::block::TRAILER_START_MARKER;
+    use crate::table::block::binary_index::Builder as BinaryIndexBuilder;
+
+    // Scan the prefix's complete entries for restart-head offsets, the item
+    // count, and the end of the last complete entry (truncated tail excluded).
+    let probe = Block {
+        header: synthetic_header(prefix.len()),
+        data: Slice::from(prefix),
+    };
+    let (restart_offsets, item_count, entries_end) =
+        Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+            &probe,
+            restart_interval,
+            prefix.len(),
+        )
+        .scan_restart_offsets();
+
+    let mut out =
+        Vec::with_capacity(entries_end + 1 + restart_offsets.len() * 4 + TRAILER_FOOTER_SIZE);
+    out.extend_from_slice(prefix.get(..entries_end).unwrap_or(prefix));
+    out.push(TRAILER_START_MARKER);
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "block offsets are far below u32::MAX"
+    )]
+    let binary_index_offset = out.len() as u32;
+    let mut bib = BinaryIndexBuilder::new(restart_offsets.len());
+    for off in restart_offsets {
+        bib.insert(off);
+    }
+    let (step_size, binary_index_len) = bib.write(&mut out)?;
+
+    // Footer — byte-for-byte the layout `Trailer::write` emits.
+    out.push(restart_interval);
+    out.push(step_size);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "index pointers <= item count, far below u32::MAX"
+    )]
+    out.extend_from_slice(&(binary_index_len as u32).to_le_bytes());
+    out.extend_from_slice(&binary_index_offset.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // hash_index_len
+    out.extend_from_slice(&0u32.to_le_bytes()); // hash_index_offset
+    out.push(1); // prefix truncation on
+    out.push(0); // fixed key size (u8, unused)
+    out.extend_from_slice(&0u16.to_le_bytes()); // fixed key size (u16, unused)
+    out.push(0); // fixed value size (u8, unused)
+    out.extend_from_slice(&0u32.to_le_bytes()); // fixed value size (u32, unused)
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "item count far below u32::MAX for a single block"
+    )]
+    out.extend_from_slice(&(item_count as u32).to_le_bytes());
+
+    Ok(out)
+}
+
+/// Trailer footer size in bytes (mirrors `Trailer::TRAILER_SIZE`): the fixed
+/// fields after the (optional) hash index.
+const TRAILER_FOOTER_SIZE: usize = 31;
+
+/// Synthetic block header for a decoder-only block built from decoded bytes
+/// (checksum / lengths are not consulted by the entry decoder).
+fn synthetic_header(len: usize) -> Header {
+    use crate::table::block::BlockType;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "block length is far below u32::MAX"
+    )]
+    let len = len as u32;
+    Header {
+        block_type: BlockType::Data,
+        block_flags: 0,
+        checksum: Checksum::from_raw(0),
+        data_length: len,
+        uncompressed_length: len,
+    }
+}
+
+/// Build a standalone `DataBlock` covering `[block_start, upper]` from a
+/// compressed `frame`, decoding only the inner zstd blocks needed to reach
+/// `upper` (skipping the trailing blocks) and synthesizing a trailer so the
+/// normal seek / iterate path works. The caller's iterator then trims to the
+/// exact query bounds. Returns the block and the number of inner blocks
+/// decoded.
+///
+/// # Errors
+///
+/// Returns an error if the frame or an inner block fails to decode, or the
+/// trailer fails to synthesize.
+pub fn partial_data_block(
+    frame: Vec<u8>,
+    ends: Vec<u32>,
+    restart_interval: u8,
+    comparator: &SharedComparator,
+    upper: &[u8],
+) -> crate::Result<(DataBlock, u32)> {
+    let mut lazy = LazyBlock::new(frame, ends)?;
+    let total = lazy.total_len();
+    let mut extent = 0usize;
+
+    // Grow the decoded extent until a key strictly greater than `upper` appears
+    // (so `upper`'s entry is fully decoded) or the block is exhausted.
+    loop {
+        extent = if extent == 0 {
+            (64 * 1024).min(total)
+        } else {
+            extent.saturating_mul(2).min(total)
+        };
+        lazy.ensure_decoded_to(extent)?;
+        if extent >= total
+            || prefix_reaches_past(lazy.decoded(), restart_interval, comparator, upper)
+        {
+            break;
+        }
+    }
+
+    let bytes = synthesize_block_bytes(lazy.decoded(), restart_interval)?;
+    let blocks = lazy.decoded_blocks();
+    let block = DataBlock::new(Block {
+        header: synthetic_header(bytes.len()),
+        data: Slice::from(bytes),
+    });
+    Ok((block, blocks))
+}
+
+/// Whether the decoded `prefix` contains an entry whose key is strictly greater
+/// than `upper` (i.e. the prefix already covers everything `<= upper`).
+fn prefix_reaches_past(
+    prefix: &[u8],
+    restart_interval: u8,
+    comparator: &SharedComparator,
+    upper: &[u8],
+) -> bool {
+    let probe = Block {
+        header: synthetic_header(prefix.len()),
+        data: Slice::from(prefix),
+    };
+    Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+        &probe,
+        restart_interval,
+        prefix.len(),
+    )
+    .any(|item| {
+        comparator.compare(item.materialize(&probe.data).key.user_key.as_ref(), upper)
+            == std::cmp::Ordering::Greater
+    })
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
@@ -398,5 +560,203 @@ mod tests {
             assert_eq!(lazy.decoded(), &reference[..lazy.decoded().len()]);
         }
         assert_eq!(lazy.decoded(), reference.as_slice());
+    }
+
+    /// A block synthesized (trailer rebuilt) from a full block's entry region
+    /// must be indistinguishable from the original under forward iteration,
+    /// backward iteration, and seek to arbitrary keys — proving the rebuilt
+    /// binary-index trailer is wire-correct.
+    #[test]
+    fn synthesized_block_matches_original_seek_iter_both_ways() {
+        use crate::SeqNo;
+        use crate::comparator::default_comparator;
+        use crate::table::block::Decoder as BlockDecoder;
+        use crate::table::block::{Block, BlockType, Header, ParsedItem};
+        use crate::table::data_block::DataBlockParsedItem;
+
+        let items: Vec<InternalValue> = (0u64..500)
+            .map(|i| {
+                InternalValue::from_components(
+                    format!("key-{i:06}").into_bytes(),
+                    format!("value-{i:06}").into_bytes(),
+                    0,
+                    Value,
+                )
+            })
+            .collect();
+        let ri = 16u8;
+        let block_bytes = DataBlock::encode_into_vec(&items, ri, 0.0).expect("encode");
+        let cmp = default_comparator();
+
+        let full = DataBlock::new(Block {
+            data: Slice::from(block_bytes.clone()),
+            header: Header::test_dummy(BlockType::Data),
+        });
+
+        // Entry-region prefix (no trailer), via the real decoder's entries_end.
+        let entries_end = BlockDecoder::<InternalValue, DataBlockParsedItem>::new(&Block {
+            data: Slice::from(block_bytes.clone()),
+            header: Header::test_dummy(BlockType::Data),
+        })
+        .entries_end_for_test()
+        .expect("entries_end");
+        let prefix = &block_bytes[..entries_end];
+
+        let synth_bytes = synthesize_block_bytes(prefix, ri).expect("synthesize");
+        let synth = DataBlock::new(Block {
+            data: Slice::from(synth_bytes),
+            header: Header::test_dummy(BlockType::Data),
+        });
+
+        // Forward iteration identical (and equals the original items).
+        let full_fwd: Vec<InternalValue> = full
+            .iter(cmp.clone())
+            .map(|x| x.materialize(full.as_slice()))
+            .collect();
+        let synth_fwd: Vec<InternalValue> = synth
+            .iter(cmp.clone())
+            .map(|x| x.materialize(synth.as_slice()))
+            .collect();
+        assert_eq!(full_fwd, items, "sanity: full forward == items");
+        assert_eq!(synth_fwd, full_fwd, "synth forward must equal full forward");
+
+        // Backward iteration identical.
+        let full_bwd: Vec<InternalValue> = full
+            .iter(cmp.clone())
+            .rev()
+            .map(|x| x.materialize(full.as_slice()))
+            .collect();
+        let synth_bwd: Vec<InternalValue> = synth
+            .iter(cmp.clone())
+            .rev()
+            .map(|x| x.materialize(synth.as_slice()))
+            .collect();
+        assert_eq!(
+            synth_bwd, full_bwd,
+            "synth backward must equal full backward"
+        );
+
+        // Seek to arbitrary keys (including misses between keys) identical.
+        for needle in [
+            b"key-000000".to_vec(),
+            b"key-000001".to_vec(),
+            b"key-000250".to_vec(),
+            b"key-000499".to_vec(),
+            b"key-0002".to_vec(),   // prefix / between keys
+            b"key-999999".to_vec(), // past end
+        ] {
+            let mut fi = full.iter(cmp.clone());
+            fi.seek(&needle, SeqNo::MAX);
+            let f: Vec<InternalValue> = fi.map(|x| x.materialize(full.as_slice())).collect();
+
+            let mut si = synth.iter(cmp.clone());
+            si.seek(&needle, SeqNo::MAX);
+            let s: Vec<InternalValue> = si.map(|x| x.materialize(synth.as_slice())).collect();
+
+            assert_eq!(s, f, "synth seek({needle:?}) must equal full seek");
+        }
+    }
+
+    /// `partial_data_block` builds, from a compressed frame, a block covering
+    /// `[start, upper]` by decoding only the inner blocks up to `upper`. Its
+    /// range scan must equal the full block's, and it must decode strictly fewer
+    /// inner blocks for a near-start upper bound.
+    #[test]
+    fn partial_data_block_range_matches_full_and_skips_trailing() {
+        use crate::SeqNo;
+        use crate::comparator::default_comparator;
+        use crate::table::block::{Block, BlockType, Header, ParsedItem};
+
+        let (frame, ends, block_bytes) = large_block_frame();
+        let nblocks = ends.len() as u32;
+        let cmp = default_comparator();
+
+        let full = DataBlock::new(Block {
+            data: Slice::from(block_bytes),
+            header: Header::test_dummy(BlockType::Data),
+        });
+
+        // Near-start window so trailing inner blocks are skippable.
+        let lower = b"key-000000000010".to_vec();
+        let upper = b"key-000000000050".to_vec();
+
+        // Full reference: seek the range on the whole block.
+        let mut fi = full.iter(cmp.clone());
+        fi.seek(&lower, SeqNo::MAX);
+        fi.seek_upper_exclusive(&upper, SeqNo::MAX);
+        let reference: Vec<InternalValue> = fi.map(|x| x.materialize(full.as_slice())).collect();
+        assert_eq!(reference.len(), 40, "i=10..50 → 40 entries");
+
+        // Partial: build a covering block from the frame, then seek the same range.
+        let (partial, blocks) =
+            partial_data_block(frame, ends, 16, &cmp, &upper).expect("partial block");
+        assert!(
+            blocks < nblocks,
+            "near-start upper must skip trailing inner blocks: {blocks}/{nblocks}",
+        );
+        let mut pi = partial.iter(cmp.clone());
+        pi.seek(&lower, SeqNo::MAX);
+        pi.seek_upper_exclusive(&upper, SeqNo::MAX);
+        let got: Vec<InternalValue> = pi.map(|x| x.materialize(partial.as_slice())).collect();
+
+        assert_eq!(
+            got, reference,
+            "partial range scan must equal the full range scan"
+        );
+    }
+
+    /// Synthesizing over a prefix that ends mid-entry (inner-block boundaries
+    /// need not align with KV entries) must drop the truncated tail and produce
+    /// a valid block of the complete-entry prefix.
+    #[test]
+    fn synthesize_handles_truncated_prefix() {
+        use crate::comparator::default_comparator;
+        use crate::table::block::Decoder as BlockDecoder;
+        use crate::table::block::{Block, BlockType, Header, ParsedItem};
+        use crate::table::data_block::DataBlockParsedItem;
+
+        let items: Vec<InternalValue> = (0u64..300)
+            .map(|i| {
+                InternalValue::from_components(
+                    format!("key-{i:06}").into_bytes(),
+                    format!("value-{i:06}").into_bytes(),
+                    0,
+                    Value,
+                )
+            })
+            .collect();
+        let ri = 16u8;
+        let block_bytes = DataBlock::encode_into_vec(&items, ri, 0.0).expect("encode");
+        let cmp = default_comparator();
+
+        let entries_end = BlockDecoder::<InternalValue, DataBlockParsedItem>::new(&Block {
+            data: Slice::from(block_bytes.clone()),
+            header: Header::test_dummy(BlockType::Data),
+        })
+        .entries_end_for_test()
+        .expect("entries_end");
+
+        // Cut a few bytes into the last entry.
+        let prefix = &block_bytes[..entries_end - 3];
+        let synth_bytes = synthesize_block_bytes(prefix, ri).expect("synthesize truncated");
+        let synth = DataBlock::new(Block {
+            data: Slice::from(synth_bytes),
+            header: Header::test_dummy(BlockType::Data),
+        });
+
+        let got: Vec<InternalValue> = synth
+            .iter(cmp)
+            .map(|x| x.materialize(synth.as_slice()))
+            .collect();
+        assert!(!got.is_empty());
+        assert!(
+            got.len() < items.len(),
+            "truncated tail entry must be dropped"
+        );
+        assert_eq!(
+            got,
+            items[..got.len()].to_vec(),
+            "must be a clean entry prefix"
+        );
     }
 }

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -9,35 +9,59 @@
 //! start of such a block should pay to decompress only the inner blocks
 //! covering its key range, not the whole block.
 //!
-//! [`LazyBlock`] decodes the inner blocks `[0, end_block)` that cover a read's
-//! key range and skips the trailing blocks (the perf win). A range query knows
-//! its upper bound up front, so it decodes ONCE to the needed extent.
-//!
-//! `decode_blocks_partial` drains the in-range output from the match window on
-//! return, so consecutive calls cannot resume one another (a later block would
-//! lack the earlier blocks as match history). Each extent growth therefore
-//! re-decodes the covering prefix in a single call from block 0. True
-//! incremental resume (decode block N continuing, without re-decoding the
-//! prefix) needs a window-priming decoder API tracked in structured-zstd#368.
+//! [`LazyBlock`] decodes the inner blocks covering a read's key range and skips
+//! the trailing blocks (the perf win). The first touch is a cold `[0, N)` pass;
+//! growing the covered extent RESUMES from a stored entropy/repcode snapshot +
+//! decompressed window ([`PartialResume`]), decoding only the new tail blocks
+//! instead of re-decompressing the prefix. The resume payload is cached
+//! alongside the partial block, so even a later range query (a fresh, dropped
+//! decoder) continues incrementally rather than from block 0.
 //!
 //! It is a TRANSIENT, single-thread engine (`FrameDecoder` is not `Send`): a
-//! live `LazyBlock` lives on the stack for one block access, while the cache
-//! stores only the grown decompressed bytes (a follow-up wires that path).
+//! live `LazyBlock` lives on the stack for one block access; the resumable
+//! state needed to continue later is handed back via [`LazyBlock::resume_payload`]
+//! and kept in the cache.
 
 use crate::comparator::SharedComparator;
 use crate::table::DataBlock;
 use crate::table::block::{Block, Decoder, Header, ParsedItem};
 use crate::table::data_block::DataBlockParsedItem;
 use crate::{Checksum, InternalValue, Slice, UserKey};
-use structured_zstd::decoding::FrameDecoder;
+use std::sync::Arc;
+use structured_zstd::decoding::{FrameDecoder, ResumeInput, ResumeState};
+
+/// Cross-call resume payload for a partially-decoded cold block, stored in the
+/// cache alongside the partial block so a later range query can extend the
+/// decoded prefix WITHOUT re-decompressing it from inner block 0.
+///
+/// Holds the decompressed prefix (`window_prime`), the entropy/repcode snapshot
+/// to resume at the next inner block, and the compressed-frame cursor of that
+/// block. The `ResumeState` is reference-counted because it carries the FSE /
+/// Huffman scratch and is not itself `Clone`.
+#[derive(Clone)]
+pub struct PartialResume {
+    /// Decompressed bytes of inner blocks `[0, decoded_blocks)`, contiguous.
+    /// Fed back as the resume match window and reused as the synthesized block's
+    /// entry region.
+    pub window_prime: Slice,
+    /// Number of inner blocks already decoded into `window_prime`.
+    pub decoded_blocks: u32,
+    /// Entropy/repcode snapshot to resume at inner block `decoded_blocks`, or
+    /// `None` when the frame has been fully decoded (nothing left to resume).
+    pub state: Option<Arc<ResumeState>>,
+    /// Absolute frame offset of inner block `decoded_blocks` (where the
+    /// resuming `decode_blocks_partial` repositions `source`).
+    pub compressed_cursor: u64,
+}
 
 /// A data block decoded lazily from its compressed zstd frame, inner block by
-/// inner block, on demand.
+/// inner block, on demand, with true incremental resume.
 pub struct LazyBlock {
     /// Compressed zstd frame (the block payload after decrypt + ECC verify),
     /// owned so the resumable decoder can read further inner blocks on top-up.
     source: std::io::Cursor<Vec<u8>>,
-    /// Decoder, reset before each (re-)decode of the covering prefix.
+    /// Decoder, reset (header re-parse) before each decode; resume restores the
+    /// entropy/repcode state so only the new tail blocks are decompressed.
     decoder: FrameDecoder,
     /// Cumulative decompressed END offset of each inner block (the persisted
     /// `block_layout`). `ends.last()` == total decompressed size.
@@ -46,12 +70,17 @@ pub struct LazyBlock {
     decoded_blocks: u32,
     /// Decompressed bytes of inner blocks `[0, decoded_blocks)`, contiguous.
     decompressed: Vec<u8>,
+    /// Resume snapshot to continue at `decoded_blocks`; `None` before the first
+    /// decode or once the frame is fully decoded.
+    resume_state: Option<Arc<ResumeState>>,
+    /// Absolute frame offset of inner block `decoded_blocks`.
+    compressed_cursor: u64,
 }
 
 impl LazyBlock {
-    /// Wraps a compressed `frame` with its inner-block `ends` layout (the
-    /// persisted cumulative decompressed offsets). Reads the frame header
-    /// up front; decodes no block bodies until [`Self::ensure_decoded_to`].
+    /// Wraps a compressed `frame` with its inner-block `ends` layout for a cold
+    /// (first-touch) decode. Reads the frame header up front; decodes no block
+    /// bodies until [`Self::ensure_decoded_to`].
     ///
     /// # Errors
     ///
@@ -68,7 +97,26 @@ impl LazyBlock {
             ends,
             decoded_blocks: 0,
             decompressed: Vec::new(),
+            resume_state: None,
+            compressed_cursor: 0,
         })
+    }
+
+    /// Resumes a partially-decoded block from a cached [`PartialResume`]: the
+    /// decompressed prefix and resume snapshot are seeded so
+    /// [`Self::ensure_decoded_to`] decodes only the new tail blocks. The frame
+    /// header is re-parsed lazily inside `ensure_decoded_to`, so this is
+    /// infallible.
+    pub fn from_resume(frame: Vec<u8>, ends: Vec<u32>, resume: PartialResume) -> Self {
+        Self {
+            source: std::io::Cursor::new(frame),
+            decoder: FrameDecoder::new(),
+            ends,
+            decoded_blocks: resume.decoded_blocks,
+            decompressed: resume.window_prime.to_vec(),
+            resume_state: resume.state,
+            compressed_cursor: resume.compressed_cursor,
+        }
     }
 
     /// Total decompressed size of the block (last cumulative end).
@@ -82,28 +130,41 @@ impl LazyBlock {
     }
 
     /// Number of inner blocks decoded so far (for laziness assertions / tests).
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "laziness assertion helper, used in tests")
+    )]
     pub fn decoded_blocks(&self) -> u32 {
         self.decoded_blocks
     }
 
+    /// Snapshot the current decode as a [`PartialResume`] for caching, so a
+    /// later read continues from here instead of re-decoding from block 0.
+    pub fn resume_payload(&self) -> PartialResume {
+        PartialResume {
+            window_prime: Slice::from(self.decompressed.as_slice()),
+            decoded_blocks: self.decoded_blocks,
+            state: self.resume_state.clone(),
+            compressed_cursor: self.compressed_cursor,
+        }
+    }
+
     /// Grow the decompressed prefix until it covers byte offset `upto`
-    /// (exclusive), decoding inner blocks `[0, end_block)` where `end_block`
-    /// covers `upto` and skipping the trailing blocks. A no-op when the prefix
-    /// already reaches `upto`.
+    /// (exclusive), decoding inner blocks up to the one covering `upto` and
+    /// skipping the trailing blocks. A no-op when the prefix already reaches
+    /// `upto`.
     ///
-    /// `decode_blocks_partial` returns (and drains from the match window) the
-    /// in-range output, so consecutive calls cannot resume one another — a
-    /// later block would lack the earlier blocks as match history. Each growth
-    /// therefore re-decodes the covering prefix in a SINGLE call from block 0
-    /// (within one call the window is maintained until the final drain). A
-    /// range query knows its upper bound up front, so it calls this ONCE for
-    /// the extent it needs — one decode, trailing blocks skipped. (True
-    /// incremental resume without re-decoding the prefix needs the
-    /// window-priming decoder API tracked in structured-zstd#368.)
+    /// The first decode is a cold `[0, end_block)` pass; every later growth
+    /// RESUMES from the stored entropy/repcode snapshot + decompressed window,
+    /// decoding only the new tail blocks `[decoded_blocks, end_block)` (no
+    /// re-decode of the prefix). `reset` re-parses the frame header from the
+    /// start, then `source` is repositioned to the resume block's compressed
+    /// offset.
     ///
     /// # Errors
     ///
-    /// Returns an error if an inner block fails to decode (corruption).
+    /// Returns an error if an inner block fails to decode (corruption), or a
+    /// resume snapshot is rejected (frame / window mismatch).
     pub fn ensure_decoded_to(&mut self, upto: usize) -> crate::Result<()> {
         if upto <= self.decompressed.len() {
             return Ok(());
@@ -124,25 +185,52 @@ impl LazyBlock {
             return Ok(());
         }
 
-        // Re-read the frame header and decode `[0, end_block)` in one call: the
-        // drain-on-return behaviour means a single call is the only way to keep
-        // each block's match history available to the next.
+        // `reset` re-parses the frame header (it reads from the start); for a
+        // resume we then reposition `source` to the resume block's offset.
         self.source.set_position(0);
         self.decoder
             .reset(&mut self.source)
             .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
-        let pd = self
-            .decoder
-            .decode_blocks_partial(&mut self.source, 0, end_block)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+
+        let resuming = self.resume_state.is_some();
+        let pd = if let Some(state) = self.resume_state.as_deref() {
+            self.source.set_position(self.compressed_cursor);
+            self.decoder
+                .decode_blocks_partial(
+                    &mut self.source,
+                    state.block_index(),
+                    end_block,
+                    Some(ResumeInput {
+                        window_prime: &self.decompressed,
+                        state,
+                    }),
+                    true,
+                )
+                .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+        } else {
+            self.decoder
+                .decode_blocks_partial(&mut self.source, 0, end_block, None, true)
+                .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+        };
         if let Some((idx, err)) = pd.stopped_at {
             return Err(crate::Error::Io(std::io::Error::other(format!(
                 "lazy partial decode stopped at inner block {idx}: {err:?}"
             ))));
         }
-        self.decompressed.clear();
-        self.decompressed.extend_from_slice(&pd.data);
-        self.decoded_blocks = pd.blocks_decoded;
+
+        // Fresh decode emits `[0, end_block)`; a resume emits only the new tail
+        // `[block_index, end_block)`, contiguous with the existing prefix.
+        let consumed = self.decoder.bytes_read_from_source();
+        if resuming {
+            self.decompressed.extend_from_slice(&pd.data);
+            self.compressed_cursor += consumed;
+        } else {
+            self.decompressed.clear();
+            self.decompressed.extend_from_slice(&pd.data);
+            self.compressed_cursor = consumed;
+        }
+        self.decoded_blocks = pd.start_block + pd.blocks_decoded;
+        self.resume_state = pd.resume_state.map(Arc::new);
         Ok(())
     }
 }
@@ -238,14 +326,35 @@ fn synthetic_header(len: usize) -> Header {
     }
 }
 
+/// Synthesize a standalone `DataBlock` (entries + trailer) from an
+/// already-decoded prefix, so the normal seek / iterate path can read it. Used
+/// to serve a cached partial block whose decompressed prefix is held in the
+/// cache (no re-decode).
+///
+/// # Errors
+///
+/// Returns an error if the trailer fails to synthesize.
+pub fn synthesize_data_block(prefix: &[u8], restart_interval: u8) -> crate::Result<DataBlock> {
+    let bytes = synthesize_block_bytes(prefix, restart_interval)?;
+    Ok(DataBlock::new(Block {
+        header: synthetic_header(bytes.len()),
+        data: Slice::from(bytes),
+    }))
+}
+
 /// Build a standalone `DataBlock` covering `[block_start, upper]` from a
 /// compressed `frame`, decoding only the inner zstd blocks needed to reach
 /// `upper` (skipping the trailing blocks) and synthesizing a trailer so the
 /// normal seek / iterate path works. The caller's iterator then trims to the
-/// exact query bounds. Returns the block, the number of inner blocks decoded,
-/// and the highest user key the block covers (its last complete entry's key, or
-/// `None` for an empty prefix) so callers can cache it tagged with the extent it
-/// satisfies.
+/// exact query bounds.
+///
+/// `resume` continues a previously-cached partial decode (see [`PartialResume`])
+/// so growing the extent decodes only the new tail blocks instead of from block
+/// 0. Pass `None` for a cold first-touch decode.
+///
+/// Returns the block, the highest user key it covers (its last complete entry's
+/// key, or `None` for an empty prefix), and the updated [`PartialResume`] to
+/// cache so the next read continues from here.
 ///
 /// # Errors
 ///
@@ -257,35 +366,36 @@ pub fn partial_data_block(
     restart_interval: u8,
     comparator: &SharedComparator,
     upper: &[u8],
-) -> crate::Result<(DataBlock, u32, Option<UserKey>)> {
-    let mut lazy = LazyBlock::new(frame, ends)?;
+    resume: Option<PartialResume>,
+) -> crate::Result<(DataBlock, Option<UserKey>, PartialResume)> {
+    let mut lazy = match resume {
+        Some(payload) => LazyBlock::from_resume(frame, ends, payload),
+        None => LazyBlock::new(frame, ends)?,
+    };
     let total = lazy.total_len();
-    let mut extent = 0usize;
 
     // Grow the decoded extent until a key strictly greater than `upper` appears
-    // (so `upper`'s entry is fully decoded) or the block is exhausted.
+    // (so `upper`'s entry is fully decoded) or the block is exhausted. A resumed
+    // block may already cover `upper`, in which case no decode happens.
     loop {
-        extent = if extent == 0 {
-            (64 * 1024).min(total)
-        } else {
-            extent.saturating_mul(2).min(total)
-        };
-        lazy.ensure_decoded_to(extent)?;
-        if extent >= total
-            || prefix_reaches_past(lazy.decoded(), restart_interval, comparator, upper)
+        if lazy.decoded().len() >= total
+            || (!lazy.decoded().is_empty()
+                && prefix_reaches_past(lazy.decoded(), restart_interval, comparator, upper))
         {
             break;
         }
+        let extent = if lazy.decoded().is_empty() {
+            (64 * 1024).min(total)
+        } else {
+            lazy.decoded().len().saturating_mul(2).min(total)
+        };
+        lazy.ensure_decoded_to(extent)?;
     }
 
     let covered_upper = last_complete_key(lazy.decoded(), restart_interval);
-    let bytes = synthesize_block_bytes(lazy.decoded(), restart_interval)?;
-    let blocks = lazy.decoded_blocks();
-    let block = DataBlock::new(Block {
-        header: synthetic_header(bytes.len()),
-        data: Slice::from(bytes),
-    });
-    Ok((block, blocks, covered_upper))
+    let block = synthesize_data_block(lazy.decoded(), restart_interval)?;
+    let payload = lazy.resume_payload();
+    Ok((block, covered_upper, payload))
 }
 
 /// The user key of the last COMPLETE entry in a decoded `prefix` (a truncated
@@ -435,9 +545,9 @@ mod tests {
 
     #[test]
     fn lazy_block_growing_extents_equal_one_shot_full() {
-        // Growing the decoded extent in steps (each a re-decode of the covering
-        // prefix) must always equal the matching prefix of a full decode and
-        // converge to the whole block.
+        // Growing the decoded extent in steps (each a RESUME from the prior
+        // snapshot, decoding only the new tail blocks) must always equal the
+        // matching prefix of a full decode and converge to the whole block.
         let (frame, ends, reference) = large_block_frame();
         let mut lazy = LazyBlock::new(frame, ends).expect("new lazy block");
         let total = reference.len();
@@ -448,6 +558,45 @@ mod tests {
             assert_eq!(lazy.decoded(), &reference[..lazy.decoded().len()]);
         }
         assert_eq!(lazy.decoded(), reference.as_slice());
+    }
+
+    #[test]
+    fn lazy_block_resume_across_decoders_equals_full() {
+        // The resume path must work across a DROPPED decoder: decode a cold
+        // prefix, snapshot the resume payload, drop the LazyBlock, then rebuild a
+        // fresh one from the payload and grow it. Each growth resumes from the
+        // cached entropy/window snapshot (not block 0) yet must stay byte-
+        // identical to a one-shot full decode at every step.
+        let (frame, ends, reference) = large_block_frame();
+        let total = reference.len();
+
+        // Cold first touch: decode roughly the first quarter.
+        let mut lazy = LazyBlock::new(frame.clone(), ends.clone()).expect("new lazy block");
+        lazy.ensure_decoded_to((total / 4).max(1))
+            .expect("cold decode");
+        assert!(lazy.decoded_blocks() >= 1);
+        assert_eq!(lazy.decoded(), &reference[..lazy.decoded().len()]);
+        let mut payload = lazy.resume_payload();
+        let mut prev_len = lazy.decoded().len();
+        assert!(
+            payload.state.is_some(),
+            "mid-frame snapshot must be resumable"
+        );
+        drop(lazy);
+
+        // Resume across fresh (dropped) decoders, growing in quarter steps.
+        let mut target = prev_len;
+        while target < total {
+            target = (target + total / 4 + 1).min(total);
+            let mut resumed = LazyBlock::from_resume(frame.clone(), ends.clone(), payload.clone());
+            resumed.ensure_decoded_to(target).expect("resume grow");
+            // Must extend (not shrink / restart) and match the full reference.
+            assert!(resumed.decoded().len() >= prev_len);
+            assert_eq!(resumed.decoded(), &reference[..resumed.decoded().len()]);
+            prev_len = resumed.decoded().len();
+            payload = resumed.resume_payload();
+        }
+        assert_eq!(payload.window_prime.as_ref(), reference.as_slice());
     }
 
     /// A block synthesized (trailer rebuilt) from a full block's entry region
@@ -576,8 +725,9 @@ mod tests {
         assert_eq!(reference.len(), 40, "i=10..50 → 40 entries");
 
         // Partial: build a covering block from the frame, then seek the same range.
-        let (partial, blocks, covered_upper) =
-            partial_data_block(frame, ends, 16, &cmp, &upper).expect("partial block");
+        let (partial, covered_upper, payload) =
+            partial_data_block(frame, ends, 16, &cmp, &upper, None).expect("partial block");
+        let blocks = payload.decoded_blocks;
         assert!(
             blocks < nblocks,
             "near-start upper must skip trailing inner blocks: {blocks}/{nblocks}",
@@ -596,6 +746,56 @@ mod tests {
             got, reference,
             "partial range scan must equal the full range scan"
         );
+    }
+
+    /// `partial_data_block` fed a cached `PartialResume` must grow the covered
+    /// extent by RESUMING (decoding only the new tail blocks) and produce a block
+    /// whose wider range scan equals the full block's — proving the cache-resume
+    /// round-trip is correct end to end.
+    #[test]
+    fn partial_data_block_resume_grows_and_matches_full() {
+        use crate::SeqNo;
+        use crate::comparator::default_comparator;
+        use crate::table::block::{Block, BlockType, Header, ParsedItem};
+
+        let (frame, ends, block_bytes) = large_block_frame();
+        let cmp = default_comparator();
+        let full = DataBlock::new(Block {
+            data: Slice::from(block_bytes),
+            header: Header::test_dummy(BlockType::Data),
+        });
+
+        // First (cold) decode covering a near-start window; capture the resume.
+        let narrow = b"key-000000000050".to_vec();
+        let (_b0, _c0, payload) =
+            partial_data_block(frame.clone(), ends.clone(), 16, &cmp, &narrow, None)
+                .expect("cold partial");
+        let narrow_blocks = payload.decoded_blocks;
+
+        // Resume-grow to a much wider window; must decode strictly more blocks.
+        let lower = b"key-000000000010".to_vec();
+        let wide = b"key-000000005000".to_vec();
+        let (partial, _covered, payload2) =
+            partial_data_block(frame, ends, 16, &cmp, &wide, Some(payload)).expect("resume grow");
+        assert!(
+            payload2.decoded_blocks > narrow_blocks,
+            "resume must extend the decoded extent: {} -> {}",
+            narrow_blocks,
+            payload2.decoded_blocks,
+        );
+
+        // The grown block's range scan must equal the full block's.
+        let mut fi = full.iter(cmp.clone());
+        fi.seek(&lower, SeqNo::MAX);
+        fi.seek_upper_exclusive(&wide, SeqNo::MAX);
+        let reference: Vec<InternalValue> = fi.map(|x| x.materialize(full.as_slice())).collect();
+
+        let mut pi = partial.iter(cmp.clone());
+        pi.seek(&lower, SeqNo::MAX);
+        pi.seek_upper_exclusive(&wide, SeqNo::MAX);
+        let got: Vec<InternalValue> = pi.map(|x| x.materialize(partial.as_slice())).collect();
+
+        assert_eq!(got, reference, "resume-grown range scan must equal full");
     }
 
     /// Synthesizing over a prefix that ends mid-entry (inner-block boundaries

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -28,7 +28,7 @@ use crate::comparator::SharedComparator;
 use crate::table::DataBlock;
 use crate::table::block::{Block, Decoder, Header, ParsedItem};
 use crate::table::data_block::DataBlockParsedItem;
-use crate::{Checksum, InternalValue, Slice};
+use crate::{Checksum, InternalValue, Slice, UserKey};
 use structured_zstd::decoding::FrameDecoder;
 
 /// A data block decoded lazily from its compressed zstd frame, inner block by
@@ -242,8 +242,10 @@ fn synthetic_header(len: usize) -> Header {
 /// compressed `frame`, decoding only the inner zstd blocks needed to reach
 /// `upper` (skipping the trailing blocks) and synthesizing a trailer so the
 /// normal seek / iterate path works. The caller's iterator then trims to the
-/// exact query bounds. Returns the block and the number of inner blocks
-/// decoded.
+/// exact query bounds. Returns the block, the number of inner blocks decoded,
+/// and the highest user key the block covers (its last complete entry's key, or
+/// `None` for an empty prefix) so callers can cache it tagged with the extent it
+/// satisfies.
 ///
 /// # Errors
 ///
@@ -255,7 +257,7 @@ pub fn partial_data_block(
     restart_interval: u8,
     comparator: &SharedComparator,
     upper: &[u8],
-) -> crate::Result<(DataBlock, u32)> {
+) -> crate::Result<(DataBlock, u32, Option<UserKey>)> {
     let mut lazy = LazyBlock::new(frame, ends)?;
     let total = lazy.total_len();
     let mut extent = 0usize;
@@ -276,13 +278,44 @@ pub fn partial_data_block(
         }
     }
 
+    let covered_upper = last_complete_key(lazy.decoded(), restart_interval);
     let bytes = synthesize_block_bytes(lazy.decoded(), restart_interval)?;
     let blocks = lazy.decoded_blocks();
     let block = DataBlock::new(Block {
         header: synthetic_header(bytes.len()),
         data: Slice::from(bytes),
     });
-    Ok((block, blocks))
+    Ok((block, blocks, covered_upper))
+}
+
+/// The user key of the last COMPLETE entry in a decoded `prefix` (a truncated
+/// tail entry is excluded, matching [`synthesize_block_bytes`]). `None` when the
+/// prefix holds no complete entry. This is the highest key the synthesized
+/// partial block covers, used to tag the cache entry's extent.
+fn last_complete_key(prefix: &[u8], restart_interval: u8) -> Option<UserKey> {
+    let probe = Block {
+        header: synthetic_header(prefix.len()),
+        data: Slice::from(prefix),
+    };
+    // Bound the scan to the complete-entry region so a truncated tail entry is
+    // not materialized (its decoded bytes would be garbage).
+    let (_offsets, _count, entries_end) =
+        Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+            &probe,
+            restart_interval,
+            prefix.len(),
+        )
+        .scan_restart_offsets();
+    // Forward-consume to the last complete entry (the decoder is forward-only
+    // here; `fold` keeps the final key without a reverse pass).
+    Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
+        &probe,
+        restart_interval,
+        entries_end,
+    )
+    .fold(None, |_, item| {
+        Some(item.materialize(&probe.data).key.user_key)
+    })
 }
 
 /// Whether the decoded `prefix` contains an entry whose key is strictly greater
@@ -543,11 +576,16 @@ mod tests {
         assert_eq!(reference.len(), 40, "i=10..50 → 40 entries");
 
         // Partial: build a covering block from the frame, then seek the same range.
-        let (partial, blocks) =
+        let (partial, blocks, covered_upper) =
             partial_data_block(frame, ends, 16, &cmp, &upper).expect("partial block");
         assert!(
             blocks < nblocks,
             "near-start upper must skip trailing inner blocks: {blocks}/{nblocks}",
+        );
+        let covered = covered_upper.expect("covering block has a last key");
+        assert!(
+            cmp.compare(covered.as_ref(), &upper) != std::cmp::Ordering::Less,
+            "covered_upper ({covered:?}) must reach at least the query upper",
         );
         let mut pi = partial.iter(cmp.clone());
         pi.seek(&lower, SeqNo::MAX);

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -24,19 +24,9 @@
 //! live `LazyBlock` lives on the stack for one block access, while the cache
 //! stores only the grown decompressed bytes (a follow-up wires that path).
 
-// The lazy-decode engine is exercised by its tests; its production consumer
-// (the range-query iterator + cache path) lands in a follow-up slice.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by the range-query partial-decode wiring (next slice)"
-    )
-)]
-
 use crate::comparator::SharedComparator;
 use crate::table::DataBlock;
-use crate::table::block::{Block, BlockType, Decoder, Header, ParsedItem};
+use crate::table::block::{Block, Decoder, Header, ParsedItem};
 use crate::table::data_block::DataBlockParsedItem;
 use crate::{Checksum, InternalValue, Slice};
 use structured_zstd::decoding::FrameDecoder;
@@ -155,102 +145,6 @@ impl LazyBlock {
         self.decoded_blocks = pd.blocks_decoded;
         Ok(())
     }
-
-    /// Decode the whole block (all inner blocks).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any inner block fails to decode.
-    pub fn ensure_fully_decoded(&mut self) -> crate::Result<()> {
-        self.ensure_decoded_to(self.total_len())
-    }
-}
-
-/// Collect the entries in `[lower, upper)` from a compressed data-block `frame`,
-/// decoding only the inner zstd blocks the range covers and skipping the
-/// trailing blocks after `upper` (the perf win). `lower` is inclusive, `upper`
-/// exclusive; `None` means unbounded on that side.
-///
-/// The covering prefix is decoded (growing geometrically until the first key
-/// `>= upper` is reached, or the block is exhausted), then walked with a
-/// trailer-independent forward decoder. Returns the in-range entries and the
-/// number of inner blocks that had to be decoded (so callers / tests can see
-/// the trailing blocks were skipped).
-///
-/// # Errors
-///
-/// Returns an error if the frame header or an inner block fails to decode.
-pub fn collect_range_partial(
-    frame: Vec<u8>,
-    ends: Vec<u32>,
-    restart_interval: u8,
-    comparator: &SharedComparator,
-    lower: Option<&[u8]>,
-    upper: Option<&[u8]>,
-) -> crate::Result<(Vec<InternalValue>, u32)> {
-    let mut lazy = LazyBlock::new(frame, ends)?;
-    let total = lazy.total_len();
-    let mut extent = 0usize;
-    let mut out = Vec::new();
-
-    loop {
-        // Grow the decoded extent geometrically; the drain-on-return decode is
-        // re-run from block 0 per growth, so geometric steps keep total decode
-        // work O(final extent) rather than O(extent^2).
-        extent = if extent == 0 {
-            (64 * 1024).min(total)
-        } else {
-            extent.saturating_mul(2).min(total)
-        };
-        lazy.ensure_decoded_to(extent)?;
-        let prefix = lazy.decoded();
-        let entries_end = prefix.len();
-
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "prefix length <= block size, well within u32"
-        )]
-        let synthetic_len = entries_end as u32;
-        let block = Block {
-            header: Header {
-                block_type: BlockType::Data,
-                block_flags: 0,
-                checksum: Checksum::from_raw(0),
-                data_length: synthetic_len,
-                uncompressed_length: synthetic_len,
-            },
-            data: Slice::from(prefix),
-        };
-
-        out.clear();
-        let mut reached_upper = upper.is_none();
-        let decoder = Decoder::<InternalValue, DataBlockParsedItem>::new_forward_headerless(
-            &block,
-            restart_interval,
-            entries_end,
-        );
-        for item in decoder {
-            let kv = item.materialize(&block.data);
-            if let Some(up) = upper
-                && comparator.compare(&kv.key.user_key, up) != std::cmp::Ordering::Less
-            {
-                reached_upper = true;
-                break;
-            }
-            if let Some(lo) = lower
-                && comparator.compare(&kv.key.user_key, lo) == std::cmp::Ordering::Less
-            {
-                continue;
-            }
-            out.push(kv);
-        }
-
-        if reached_upper || entries_end >= total {
-            break;
-        }
-    }
-
-    Ok((out, lazy.decoded_blocks()))
 }
 
 /// Synthesize a valid standalone data-block (`entries ‖ trailer`) from a
@@ -415,7 +309,12 @@ fn prefix_reaches_past(
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::cast_possible_truncation,
+    reason = "test code"
+)]
 mod tests {
     use super::*;
     use crate::compression::{CompressionProvider as _, ZstdBackend};
@@ -492,55 +391,11 @@ mod tests {
     }
 
     #[test]
-    fn collect_range_partial_matches_full_and_skips_trailing() {
-        use crate::table::block::{Block, BlockType, Header, ParsedItem};
-        use crate::{Slice, comparator::default_comparator};
-
-        let (frame, ends, block_bytes) = large_block_frame();
-        let nblocks = ends.len() as u32;
-        let comparator = default_comparator();
-
-        // Full reference: real block, iterate, filter [lower, upper).
-        let full = DataBlock::new(Block {
-            data: Slice::from(block_bytes),
-            header: Header::test_dummy(BlockType::Data),
-        });
-        // Keys are "key-{i:012}"; pick a range near the block start so the
-        // trailing inner blocks are skippable.
-        let lower = b"key-000000000010".to_vec();
-        let upper = b"key-000000000050".to_vec();
-        let reference: Vec<InternalValue> = full
-            .iter(comparator.clone())
-            .map(|x| x.materialize(full.as_slice()))
-            .filter(|kv| {
-                let k = kv.key.user_key.as_ref();
-                k >= lower.as_slice() && k < upper.as_slice()
-            })
-            .collect();
-        assert_eq!(reference.len(), 40, "i=10..50 → 40 entries");
-
-        let (got, blocks) = collect_range_partial(
-            frame,
-            ends,
-            16, // restart_interval used by large_block_frame
-            &comparator,
-            Some(&lower),
-            Some(&upper),
-        )
-        .expect("partial range");
-
-        assert_eq!(got, reference, "partial range must equal the full range");
-        assert!(
-            blocks < nblocks,
-            "a near-start range must skip trailing inner blocks: decoded {blocks}/{nblocks}",
-        );
-    }
-
-    #[test]
     fn lazy_block_full_decode_matches_reference() {
         let (frame, ends, reference) = large_block_frame();
         let mut lazy = LazyBlock::new(frame, ends.clone()).expect("new lazy block");
-        lazy.ensure_fully_decoded().expect("full decode");
+        let total = lazy.total_len();
+        lazy.ensure_decoded_to(total).expect("full decode");
         assert_eq!(lazy.decoded_blocks(), ends.len() as u32);
         assert_eq!(lazy.decoded(), reference.as_slice());
     }
@@ -551,7 +406,7 @@ mod tests {
         // prefix) must always equal the matching prefix of a full decode and
         // converge to the whole block.
         let (frame, ends, reference) = large_block_frame();
-        let mut lazy = LazyBlock::new(frame, ends.clone()).expect("new lazy block");
+        let mut lazy = LazyBlock::new(frame, ends).expect("new lazy block");
         let total = reference.len();
         let mut cursor = 0usize;
         while cursor < total {

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -108,6 +108,11 @@ pub struct ParsedMeta {
     /// `index_format` property and parse as `0`, so legacy tables read
     /// correctly and fall back to the per-entry filter scan path.
     pub index_format: u8,
+
+    /// Restart interval the data blocks were encoded with. Needed to rebuild a
+    /// positional restart index when partial-decoding a block on the lazy read
+    /// path (the restart heads sit every `data_block_restart_interval` entries).
+    pub data_block_restart_interval: u8,
 }
 
 macro_rules! read_u8 {
@@ -259,6 +264,10 @@ impl ParsedMeta {
 
         let _index_block_restart_interval =
             validated_restart_interval_index(read_u8!(block, b"restart_interval#index", &cmp))?;
+        // Data-block restart interval: needed to rebuild a positional restart
+        // index when partial-decoding a block (lazy read path).
+        let data_block_restart_interval =
+            validated_restart_interval_index(read_u8!(block, b"restart_interval#data", &cmp))?;
 
         let id = read_u64!(block, b"table_id", &cmp);
         let item_count = read_u64!(block, b"item_count", &cmp);
@@ -424,6 +433,7 @@ impl ParsedMeta {
             ecc_params,
             ecc_unrecognized,
             index_format,
+            data_block_restart_interval,
         })
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -11,6 +11,8 @@ mod id;
 mod index_block;
 mod inner;
 pub(crate) mod iter;
+#[cfg(feature = "zstd")]
+pub(crate) mod lazy_block;
 pub(crate) mod meta;
 pub(crate) mod multi_writer;
 pub(crate) mod regions;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -909,6 +909,10 @@ impl Table {
             #[cfg(zstd_any)]
             self.zstd_dictionary.clone(),
             self.comparator.clone(),
+            #[cfg(feature = "zstd")]
+            self.block_layout.clone(),
+            #[cfg(feature = "zstd")]
+            self.metadata.data_block_restart_interval,
             #[cfg(feature = "metrics")]
             self.metrics.clone(),
         );

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod block;
 pub(crate) mod block_index;
+pub(crate) mod block_layout;
 pub mod data_block;
 pub mod filter;
 mod id;
@@ -1374,6 +1375,52 @@ impl Table {
             Vec::new()
         };
 
+        // Load the optional inner-block layout section (present only when the
+        // table has data blocks that split into >= 2 inner zstd blocks). Mirrors
+        // the range-tombstone loader: same Plain/Encrypted (+ optional ECC)
+        // transform the writer used for this uncompressed meta section.
+        let block_layout = if let Some(bl_handle) = regions.block_layout {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                bl_handle,
+                crate::table::block::BlockIdentity {
+                    tree_id: 0,
+                    table_id: metadata.id,
+                    block_offset: *bl_handle.offset(),
+                    block_type: BlockType::BlockLayout,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+
+            if block.header.block_type != BlockType::BlockLayout {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+
+            let map = crate::table::block_layout::BlockLayoutMap::decode(&block.data)?;
+            log::trace!(
+                "Loaded block-layout index with {} multi-inner-block entries",
+                map.len(),
+            );
+            map
+        } else {
+            crate::table::block_layout::BlockLayoutMap::default()
+        };
+
         log::debug!(
             "Recovered table #{} from {}",
             metadata.id,
@@ -1410,6 +1457,7 @@ impl Table {
 
             cached_blob_bytes: std::sync::OnceLock::new(),
             range_tombstones,
+            block_layout,
             encryption,
 
             #[cfg(zstd_any)]

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -6,18 +6,18 @@ use super::{BlockHandle, BlockOffset};
 use crate::sfa::TocEntry;
 
 /// Converts a [`crate::sfa::TocEntry`] to our [`BlockHandle`] struct.
-fn toc_entry_to_handle(entry: &TocEntry) -> BlockHandle {
-    #[expect(
-        clippy::expect_used,
-        reason = "Function is only used for regions that do not exceed >= 4 GiB"
-    )]
-    BlockHandle::new(
-        BlockOffset(entry.pos()),
-        entry
-            .len()
-            .try_into()
-            .expect("region should not exceed 4 GiB"),
-    )
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidHeader`] if the on-disk region length does not
+/// fit a `u32` (a region >= 4 GiB), surfacing a corrupt TOC as a typed recovery
+/// error instead of panicking during table open.
+fn toc_entry_to_handle(entry: &TocEntry) -> crate::Result<BlockHandle> {
+    let size: u32 = entry
+        .len()
+        .try_into()
+        .map_err(|_| crate::Error::InvalidHeader("Toc"))?;
+    Ok(BlockHandle::new(BlockOffset(entry.pos()), size))
 }
 
 /// The regions block stores offsets to the different table file "regions"
@@ -101,28 +101,51 @@ pub struct ParsedRegions {
 impl ParsedRegions {
     pub fn parse_from_toc(toc: &crate::sfa::Toc) -> crate::Result<Self> {
         Ok(Self {
-            filter_tli: toc.section(b"filter_tli").map(toc_entry_to_handle),
+            filter_tli: toc
+                .section(b"filter_tli")
+                .map(toc_entry_to_handle)
+                .transpose()?,
             tli: toc
                 .section(b"tli")
                 .map(toc_entry_to_handle)
+                .transpose()?
                 .ok_or_else(|| {
                     log::error!("TLI should exist");
                     crate::Error::Unrecoverable
                 })?,
-            tli_tail: toc.section(b"tli_tail").map(toc_entry_to_handle),
-            index: toc.section(b"index").map(toc_entry_to_handle),
-            filter: toc.section(b"filter").map(toc_entry_to_handle),
-            range_tombstones: toc.section(b"range_tombstones").map(toc_entry_to_handle),
-            block_layout: toc.section(b"block_layout").map(toc_entry_to_handle),
-            linked_blob_files: toc.section(b"linked_blob_files").map(toc_entry_to_handle),
+            tli_tail: toc
+                .section(b"tli_tail")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            index: toc.section(b"index").map(toc_entry_to_handle).transpose()?,
+            filter: toc
+                .section(b"filter")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            range_tombstones: toc
+                .section(b"range_tombstones")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            block_layout: toc
+                .section(b"block_layout")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            linked_blob_files: toc
+                .section(b"linked_blob_files")
+                .map(toc_entry_to_handle)
+                .transpose()?,
             metadata: toc
                 .section(b"meta")
                 .map(toc_entry_to_handle)
+                .transpose()?
                 .ok_or_else(|| {
                     log::error!("Metadata should exist");
                     crate::Error::Unrecoverable
                 })?,
-            metadata_mid: toc.section(b"meta_mid").map(toc_entry_to_handle),
+            metadata_mid: toc
+                .section(b"meta_mid")
+                .map(toc_entry_to_handle)
+                .transpose()?,
         })
     }
 }

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -79,6 +79,10 @@ pub struct ParsedRegions {
     pub filter_tli: Option<BlockHandle>,
     pub filter: Option<BlockHandle>,
     pub range_tombstones: Option<BlockHandle>,
+    /// Optional inner zstd-block layout index (the `block_layout` section).
+    /// Present only when the table has at least one data block that compressed
+    /// into >= 2 inner zstd blocks; powers range-query partial decode.
+    pub block_layout: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -109,6 +113,7 @@ impl ParsedRegions {
             index: toc.section(b"index").map(toc_entry_to_handle),
             filter: toc.section(b"filter").map(toc_entry_to_handle),
             range_tombstones: toc.section(b"range_tombstones").map(toc_entry_to_handle),
+            block_layout: toc.section(b"block_layout").map(toc_entry_to_handle),
             linked_blob_files: toc.section(b"linked_blob_files").map(toc_entry_to_handle),
             metadata: toc
                 .section(b"meta")

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -463,6 +463,94 @@ fn make_test_dictionary() -> crate::compression::ZstdDictionary {
     crate::compression::ZstdDictionary::new(&samples)
 }
 
+/// A table with large data blocks compressed at a high zstd level splits each
+/// block into several inner zstd blocks. The writer must persist their
+/// cumulative decompressed-end layout in the `block_layout` section, and the
+/// reader must reload it on open. A default small-block table must NOT carry
+/// the section. This is the write → persist → reload contract for range-query
+/// partial decode.
+#[cfg(feature = "zstd")]
+#[test]
+#[expect(clippy::unwrap_used)]
+fn block_layout_section_roundtrips_for_large_zstd_blocks() {
+    use crate::cache::Cache;
+    use crate::fs::StdFs;
+    #[cfg(feature = "metrics")]
+    use crate::metrics::Metrics;
+    use crate::table::Writer;
+
+    // 256 KiB blocks at L19 split into many inner zstd blocks (the cold-tier
+    // shape); ~600 KiB of sorted KV yields at least one full multi-inner-block
+    // data block.
+    let items: Vec<crate::InternalValue> = (0u64..20_000)
+        .map(|i| {
+            crate::InternalValue::from_components(
+                format!("key-{i:012}").into_bytes(),
+                format!("value-{i:08}-payload").into_bytes(),
+                1,
+                crate::ValueType::Value,
+            )
+        })
+        .collect();
+
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("table");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))
+        .unwrap()
+        .use_data_block_size(256 * 1024)
+        .use_data_block_compression(crate::CompressionType::Zstd(19));
+    for item in &items {
+        writer.write(item.clone()).unwrap();
+    }
+    let (_, checksum) = writer.finish().unwrap().unwrap();
+
+    #[cfg(feature = "metrics")]
+    let metrics = Arc::new(Metrics::default());
+    let table = Table::recover(
+        file,
+        checksum,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(4_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        false,
+        false,
+        None,
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        metrics,
+    )
+    .unwrap();
+
+    assert!(
+        table.regions.block_layout.is_some(),
+        "large multi-inner-block table must carry a block_layout section",
+    );
+    assert!(
+        table.block_layout.len() >= 1,
+        "at least one data block must have a recorded inner-block layout",
+    );
+    // Every recorded entry must have strictly increasing cumulative ends whose
+    // last value is the block's uncompressed length (a non-trivial split).
+    for offset in table.block_layout.offsets() {
+        let ends = table
+            .block_layout
+            .ends_for(offset)
+            .expect("offsets() entries must resolve via ends_for");
+        assert!(
+            ends.len() >= 2,
+            "recorded block must have >= 2 inner blocks"
+        );
+        assert!(
+            ends.windows(2).all(|w| w[0] < w[1]),
+            "cumulative ends must be strictly increasing: {ends:?}",
+        );
+    }
+}
+
 #[test]
 #[expect(clippy::unwrap_used)]
 fn table_point_read() -> crate::Result<()> {

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -549,6 +549,49 @@ fn block_layout_section_roundtrips_for_large_zstd_blocks() {
             "cumulative ends must be strictly increasing: {ends:?}",
         );
     }
+
+    // Negative control: a default small-block (4 KiB) zstd table must NOT carry
+    // the section — each tiny block compresses into a single inner zstd block,
+    // so there is nothing to partial-decode and no layout is persisted.
+    let small_file = dir.path().join("table-small");
+    let mut small_writer = Writer::new(small_file.clone(), 0, 0, Arc::new(StdFs))
+        .unwrap()
+        .use_data_block_size(4 * 1024)
+        .use_data_block_compression(crate::CompressionType::Zstd(19));
+    for item in &items {
+        small_writer.write(item.clone()).unwrap();
+    }
+    let (_, small_checksum) = small_writer.finish().unwrap().unwrap();
+
+    #[cfg(feature = "metrics")]
+    let small_metrics = Arc::new(Metrics::default());
+    let small_table = Table::recover(
+        small_file,
+        small_checksum,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(4_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        false,
+        false,
+        None,
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        small_metrics,
+    )
+    .unwrap();
+
+    assert!(
+        small_table.regions.block_layout.is_none(),
+        "default small-block table must NOT carry a block_layout section",
+    );
+    assert_eq!(
+        small_table.block_layout.len(),
+        0,
+        "small-block table's layout map must be empty",
+    );
 }
 
 #[test]

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -92,9 +92,10 @@ pub fn load_block(
             BlockType::Data | BlockType::Meta => {
                 metrics.data_block_load_cached.fetch_add(1, Relaxed);
             }
-            // Manifest variants are rejected by the function-level
-            // guard above; nothing to do here.
-            BlockType::Manifest | BlockType::ManifestFooter => {}
+            // Manifest variants are rejected by the function-level guard
+            // above; the block-layout section is loaded once on open via
+            // `Block::from_file`, never through this cached data-block path.
+            BlockType::Manifest | BlockType::ManifestFooter | BlockType::BlockLayout => {}
         }
 
         return Ok(block);
@@ -191,9 +192,10 @@ pub fn load_block(
                 .data_block_io_requested
                 .fetch_add(handle.size().into(), Relaxed);
         }
-        // Manifest variants are rejected by the function-level
-        // guard above; nothing to do here.
-        BlockType::Manifest | BlockType::ManifestFooter => {}
+        // Manifest variants are rejected by the function-level guard above;
+        // the block-layout section is loaded once on open via
+        // `Block::from_file`, never through this cached data-block path.
+        BlockType::Manifest | BlockType::ManifestFooter | BlockType::BlockLayout => {}
     }
 
     cache.insert_block(table_id, handle.offset(), block.clone());

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -126,6 +126,15 @@ pub struct Writer {
     /// Range tombstones to be written as a separate block
     range_tombstones: Vec<RangeTombstone>,
 
+    /// Inner zstd-block layout per data block, accumulated in write order and
+    /// serialized into the optional `block_layout` SST section at finish. Only
+    /// data blocks that split into >= 2 inner zstd blocks contribute an entry
+    /// `(block_offset, cumulative_decompressed_ends)`; small single-inner-block
+    /// blocks (the default) contribute nothing, so the section is absent for a
+    /// table with no large multi-inner-block data blocks. Powers range-query
+    /// partial decode.
+    block_layouts: Vec<(BlockOffset, Vec<u32>)>,
+
     initial_level: u8,
 
     /// Block encryption provider (if encryption at rest is enabled)
@@ -250,6 +259,8 @@ impl Writer {
             index_writer: Box::new(FullIndexWriter::new()).use_table_id(table_id),
             filter_writer: Box::new(FullFilterWriter::new(BloomConstructionPolicy::default()))
                 .use_table_id(table_id),
+
+            block_layouts: Vec::new(),
 
             block_buffer: Vec::new(),
             file_writer: writer,
@@ -766,8 +777,23 @@ impl Writer {
             &mut self.block_buffer,
         )?;
 
-        let header = Block::write_into_with_flags(
-            &mut self.file_writer,
+        // Prepare then write in two steps (instead of `write_into_with_flags`)
+        // so the inner-block layout can be taken from the prepared block before
+        // `write_to` consumes it.
+        let transform = {
+            let t = crate::table::block::BlockTransform::from_parts(
+                self.data_block_compression,
+                self.encryption.as_deref(),
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+            )?;
+            if let Some(ecc) = self.ecc {
+                t.with_ecc(ecc)
+            } else {
+                t
+            }
+        };
+        let mut prepared = Block::prepare_with_flags(
             &self.block_buffer,
             super::block::BlockIdentity {
                 tree_id: 0,
@@ -780,23 +806,20 @@ impl Writer {
             // Data blocks use the configured codec and may carry a zstd dict;
             // encryption is optional. page_ecc upgrades the transform to its
             // matching `*Ecc` variant when the tree was opened with page_ecc.
-            &{
-                let t = crate::table::block::BlockTransform::from_parts(
-                    self.data_block_compression,
-                    self.encryption.as_deref(),
-                    #[cfg(zstd_any)]
-                    self.zstd_dictionary.as_deref(),
-                )?;
-                if let Some(ecc) = self.ecc {
-                    t.with_ecc(ecc)
-                } else {
-                    t
-                }
-            },
+            &transform,
             kv_flags,
         )?;
+        let layout = std::mem::take(&mut prepared.layout);
+        let header = prepared.write_to(&mut self.file_writer)?;
 
-        self.register_written_block(header, last_key, last_seqno, seqno_bounds, item_count)?;
+        self.register_written_block(
+            header,
+            layout,
+            last_key,
+            last_seqno,
+            seqno_bounds,
+            item_count,
+        )?;
 
         // IMPORTANT: Clear chunk after everything else
         self.chunk.clear();
@@ -845,12 +868,21 @@ impl Writer {
     fn register_written_block(
         &mut self,
         header: crate::table::block::Header,
+        layout: Vec<u32>,
         last_key: UserKey,
         last_seqno: crate::SeqNo,
         seqno_bounds: Option<(u64, u64)>,
         item_count: usize,
     ) -> crate::Result<()> {
         self.meta.uncompressed_size += u64::from(header.uncompressed_length);
+
+        // Record the inner zstd-block layout keyed by this block's file offset
+        // (`meta.file_pos`, captured before the increment below). Only
+        // multi-inner-block data blocks carry a non-empty layout, so single
+        // (default 4 KiB) blocks add nothing.
+        if !layout.is_empty() {
+            self.block_layouts.push((self.meta.file_pos, layout));
+        }
         // Size the block-handle with the scheme this writer actually wrote
         // the parity under (NOT the fixed RS(4,2) `on_disk_size` assumes),
         // or the handle over-reads on a non-default scheme.
@@ -905,12 +937,14 @@ impl Writer {
         let Some(prepared) = self.parallel.as_mut().and_then(BlockCompressor::take_next) else {
             return Ok(());
         };
-        let prepared = prepared?;
+        let mut prepared = prepared?;
         let Some(meta) = self.pending_meta.pop_front() else {
             return Err(crate::Error::Io(std::io::Error::other(
                 "parallel block pipeline meta desync",
             )));
         };
+        // Take the inner-block layout before `write_to` consumes the block.
+        let layout = std::mem::take(&mut prepared.layout);
         let header = prepared.write_to(&mut self.file_writer)?;
         // Header is Copy; read the in-flight size before handing it off.
         self.parallel_pending_bytes = self
@@ -918,6 +952,7 @@ impl Writer {
             .saturating_sub(u64::from(header.uncompressed_length));
         self.register_written_block(
             header,
+            layout,
             meta.last_key,
             meta.last_seqno,
             meta.seqno_bounds,
@@ -1034,6 +1069,46 @@ impl Writer {
         // Write filter
         log::trace!("Finishing filter writer");
         let filter_block_count = self.filter_writer.finish(&mut self.file_writer)?;
+
+        // Write the optional inner-block layout section (only when at least one
+        // data block split into >= 2 inner zstd blocks). Absent otherwise, so
+        // default small-block tables gain no bytes.
+        if !self.block_layouts.is_empty() {
+            self.file_writer.start("block_layout")?;
+
+            self.block_buffer.clear();
+            crate::table::block_layout::encode_block_layouts(
+                &mut self.block_buffer,
+                &self.block_layouts,
+            );
+
+            Block::write_into(
+                &mut self.file_writer,
+                &self.block_buffer,
+                crate::table::block::BlockIdentity {
+                    tree_id: 0,
+                    table_id: self.table_id,
+                    block_offset: *self.meta.file_pos,
+                    block_type: crate::table::block::BlockType::BlockLayout,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                // Layout metadata is small and read on the cold-block path;
+                // store it uncompressed. Encryption / page_ecc still apply via
+                // the configured providers, matching the other meta sections.
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
 
         // Write range tombstones block (if any)
         if !self.range_tombstones.is_empty() {

--- a/tests/partial_decode_range.rs
+++ b/tests/partial_decode_range.rs
@@ -180,6 +180,7 @@ fn partial_decode_reverse_ranges_match_expected() {
 
 #[test]
 fn partial_decode_empty_and_boundary_ranges() {
+    enable_partial_decode();
     let (_dir, tree) = large_zstd_block_tree();
 
     // Empty (lo == hi) and a range whose bounds fall between existing keys

--- a/tests/partial_decode_range.rs
+++ b/tests/partial_decode_range.rs
@@ -37,8 +37,9 @@ fn key(i: u64) -> Vec<u8> {
     format!("key-{i:08}").into_bytes()
 }
 
-/// Build a flushed tree with large (256 KiB) zstd-L19 data blocks, so blocks
-/// split into many inner zstd blocks and the `block_layout` section is present.
+/// Build a flushed tree with large (512 KiB) zstd-L19 data blocks (above the
+/// partial tier's 256 KiB engage floor), so blocks split into many inner zstd
+/// blocks and the `block_layout` section is present.
 fn large_zstd_block_tree() -> (tempfile::TempDir, lsm_tree::AnyTree) {
     let folder = get_tmp_folder();
     let dir = tempfile::TempDir::new_in(folder).unwrap();
@@ -50,12 +51,41 @@ fn large_zstd_block_tree() -> (tempfile::TempDir, lsm_tree::AnyTree) {
     .data_block_compression_policy(CompressionPolicy::all(
         CompressionType::zstd(19).expect("valid level"),
     ))
-    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    .data_block_size_policy(BlockSizePolicy::all(512 * 1024))
     .open()
     .unwrap();
 
     for i in 0..N {
-        // Values padded so 256 KiB blocks hold many entries across inner blocks.
+        // Values padded so 512 KiB blocks hold many entries across inner blocks.
+        tree.insert(
+            key(i),
+            format!("value-{i:08}-padding-padding").into_bytes(),
+            0,
+        );
+    }
+    tree.flush_active_memtable(0).unwrap();
+    (dir, tree)
+}
+
+/// Build a flushed tree with SMALL (64 KiB) zstd-L19 data blocks: they still
+/// split into a few inner blocks (so a layout is recorded), but each is below
+/// the partial tier's 256 KiB engage floor, so the partial path must skip them.
+fn small_zstd_block_tree() -> (tempfile::TempDir, lsm_tree::AnyTree) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(
+        CompressionType::zstd(19).expect("valid level"),
+    ))
+    .data_block_size_policy(BlockSizePolicy::all(64 * 1024))
+    .open()
+    .unwrap();
+
+    for i in 0..N {
         tree.insert(
             key(i),
             format!("value-{i:08}-padding-padding").into_bytes(),
@@ -79,7 +109,7 @@ fn large_zstd_block_tree_with_cache(cache: Arc<Cache>) -> (tempfile::TempDir, ls
     .data_block_compression_policy(CompressionPolicy::all(
         CompressionType::zstd(19).expect("valid level"),
     ))
-    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    .data_block_size_policy(BlockSizePolicy::all(512 * 1024))
     .use_cache(cache)
     .open()
     .unwrap();
@@ -171,6 +201,7 @@ fn partial_decode_cache_reuse_and_high_water_growth_stays_correct() {
     // block and serves / grows it on later reads of the same block. Correctness
     // must hold regardless of read order: a narrow read after a wide one reuses
     // the wider cached block; a wider read after a narrow one grows the extent.
+    enable_partial_decode();
     let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024));
     let (_dir, tree) = large_zstd_block_tree_with_cache(cache.clone());
 
@@ -255,5 +286,48 @@ fn partial_decode_promotion_paths_stay_correct() {
     assert_eq!(
         range_keys(&tree, 8_000, 8_010),
         (8_000..8_010).map(key).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn partial_decode_skips_blocks_below_engage_floor() {
+    // Small (64 KiB) blocks are below the partial tier's engage floor: the path
+    // must skip them and fall back to full decode, staying exactly correct.
+    enable_partial_decode();
+    let (_dir, tree) = small_zstd_block_tree();
+
+    for (lo, hi) in [(10u64, 50), (5_000, 5_004), (12_345, 12_900), (0, N)] {
+        let got = range_keys(&tree, lo, hi);
+        let expected: Vec<Vec<u8>> = (lo..hi.min(N)).map(key).collect();
+        assert_eq!(
+            got, expected,
+            "below-floor block range [{lo}, {hi}) must match full decode",
+        );
+    }
+}
+
+#[test]
+fn partial_decode_runtime_fraction_promotion_stays_correct() {
+    // A single read covering most of a large block decodes >= 75% of its inner
+    // blocks, tripping the runtime fraction-promotion path (decode fully + cache
+    // the whole block). Result must be exact, and a re-read off the now-resident
+    // full block must match too.
+    enable_partial_decode();
+    let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024));
+    let (_dir, tree) = large_zstd_block_tree_with_cache(cache);
+
+    // ~12.8k keys fit in a 512 KiB block; reading the first 12k covers well over
+    // 75% of the first block's inner blocks.
+    let wide = range_keys(&tree, 0, 12_000);
+    assert_eq!(wide, (0..12_000).map(key).collect::<Vec<_>>());
+
+    // Re-read a sub-window: served from the promoted full block, still exact.
+    assert_eq!(
+        range_keys(&tree, 50, 90),
+        (50..90).map(key).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        range_keys_rev(&tree, 50, 90),
+        (50..90).rev().map(key).collect::<Vec<_>>()
     );
 }

--- a/tests/partial_decode_range.rs
+++ b/tests/partial_decode_range.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end coverage for the range-query partial-decode path (#257).
+//!
+//! A tree configured with large data blocks + a high zstd level splits each
+//! data block into many inner zstd blocks and persists their layout, so a
+//! bounded range query transparently takes the partial-decode path (decode
+//! only the inner blocks the range covers). These tests assert the path is
+//! correctness-transparent: every bounded range — forward and reverse, at the
+//! block start, middle, across block boundaries, and empty — returns exactly
+//! the same keys a full decode would.
+
+#![cfg(feature = "zstd")]
+
+use lsm_tree::config::{BlockSizePolicy, CompressionPolicy};
+use lsm_tree::{
+    AbstractTree, CompressionType, Config, Guard, SeqNo, SequenceNumberCounter, get_tmp_folder,
+};
+use test_log::test;
+
+const N: u64 = 20_000;
+
+fn key(i: u64) -> Vec<u8> {
+    format!("key-{i:08}").into_bytes()
+}
+
+/// Build a flushed tree with large (256 KiB) zstd-L19 data blocks, so blocks
+/// split into many inner zstd blocks and the `block_layout` section is present.
+fn large_zstd_block_tree() -> (tempfile::TempDir, lsm_tree::AnyTree) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(
+        CompressionType::zstd(19).expect("valid level"),
+    ))
+    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    .open()
+    .unwrap();
+
+    for i in 0..N {
+        // Values padded so 256 KiB blocks hold many entries across inner blocks.
+        tree.insert(
+            key(i),
+            format!("value-{i:08}-padding-padding").into_bytes(),
+            0,
+        );
+    }
+    tree.flush_active_memtable(0).unwrap();
+    (dir, tree)
+}
+
+/// Collect the keys a forward range query returns.
+fn range_keys(tree: &lsm_tree::AnyTree, lo: u64, hi: u64) -> Vec<Vec<u8>> {
+    tree.range(key(lo)..key(hi), SeqNo::MAX, None)
+        .map(|g| g.key().unwrap().to_vec())
+        .collect()
+}
+
+/// Collect the keys a reverse range query returns.
+fn range_keys_rev(tree: &lsm_tree::AnyTree, lo: u64, hi: u64) -> Vec<Vec<u8>> {
+    tree.range(key(lo)..key(hi), SeqNo::MAX, None)
+        .rev()
+        .map(|g| g.key().unwrap().to_vec())
+        .collect()
+}
+
+#[test]
+fn partial_decode_forward_ranges_match_expected() {
+    let (_dir, tree) = large_zstd_block_tree();
+
+    // Windows at the block start, middle, a wide span, and crossing into the
+    // tail — all bounded (upper set) so the partial path is eligible.
+    for (lo, hi) in [
+        (10u64, 50),
+        (0, 1),
+        (5_000, 5_001),
+        (12_345, 12_900),
+        (0, N),
+    ] {
+        let got = range_keys(&tree, lo, hi);
+        let expected: Vec<Vec<u8>> = (lo..hi.min(N)).map(key).collect();
+        assert_eq!(
+            got, expected,
+            "forward range [{lo}, {hi}) must match the full-decode result",
+        );
+    }
+}
+
+#[test]
+fn partial_decode_reverse_ranges_match_expected() {
+    let (_dir, tree) = large_zstd_block_tree();
+
+    for (lo, hi) in [(10u64, 50), (5_000, 5_001), (12_345, 12_900)] {
+        let got = range_keys_rev(&tree, lo, hi);
+        let expected: Vec<Vec<u8>> = (lo..hi.min(N)).rev().map(key).collect();
+        assert_eq!(
+            got, expected,
+            "reverse range [{lo}, {hi}) must match the full-decode result",
+        );
+    }
+}
+
+#[test]
+fn partial_decode_empty_and_boundary_ranges() {
+    let (_dir, tree) = large_zstd_block_tree();
+
+    // Empty (lo == hi) and a range whose bounds fall between existing keys
+    // (`key-00000010x` sorts after `key-00000010`) must yield nothing / exact.
+    assert!(range_keys(&tree, 100, 100).is_empty(), "lo == hi → empty");
+
+    // Single-key window.
+    assert_eq!(range_keys(&tree, 9_999, 10_000), vec![key(9_999)]);
+
+    // A bounded window whose upper lands exactly on a key (exclusive) excludes
+    // that key.
+    let got = range_keys(&tree, 200, 205);
+    assert_eq!(got, (200..205).map(key).collect::<Vec<_>>());
+}

--- a/tests/partial_decode_range.rs
+++ b/tests/partial_decode_range.rs
@@ -15,11 +15,23 @@
 
 use lsm_tree::config::{BlockSizePolicy, CompressionPolicy};
 use lsm_tree::{
-    AbstractTree, CompressionType, Config, Guard, SeqNo, SequenceNumberCounter, get_tmp_folder,
+    AbstractTree, Cache, CompressionType, Config, Guard, SeqNo, SequenceNumberCounter,
+    get_tmp_folder,
 };
+use std::sync::Arc;
 use test_log::test;
 
 const N: u64 = 20_000;
+
+/// Opt into the partial-decode read path for this test process (it is OFF by
+/// default until a resumable decoder lands upstream). nextest isolates each test
+/// in its own process, so this env mutation does not leak between tests, and the
+/// path reads the flag once via a `OnceLock`. Call before opening any tree.
+fn enable_partial_decode() {
+    // SAFETY: set before any other thread in this single-test process reads the
+    // env; nextest runs each test in a dedicated process.
+    unsafe { std::env::set_var("LSM_PARTIAL_DECODE", "1") };
+}
 
 fn key(i: u64) -> Vec<u8> {
     format!("key-{i:08}").into_bytes()
@@ -54,6 +66,35 @@ fn large_zstd_block_tree() -> (tempfile::TempDir, lsm_tree::AnyTree) {
     (dir, tree)
 }
 
+/// Build a flushed tree like [`large_zstd_block_tree`] but with a caller-shared
+/// block cache, so the partial-decode cache path is exercised across reads.
+fn large_zstd_block_tree_with_cache(cache: Arc<Cache>) -> (tempfile::TempDir, lsm_tree::AnyTree) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(
+        CompressionType::zstd(19).expect("valid level"),
+    ))
+    .data_block_size_policy(BlockSizePolicy::all(256 * 1024))
+    .use_cache(cache)
+    .open()
+    .unwrap();
+
+    for i in 0..N {
+        tree.insert(
+            key(i),
+            format!("value-{i:08}-padding-padding").into_bytes(),
+            0,
+        );
+    }
+    tree.flush_active_memtable(0).unwrap();
+    (dir, tree)
+}
+
 /// Collect the keys a forward range query returns.
 fn range_keys(tree: &lsm_tree::AnyTree, lo: u64, hi: u64) -> Vec<Vec<u8>> {
     tree.range(key(lo)..key(hi), SeqNo::MAX, None)
@@ -71,6 +112,7 @@ fn range_keys_rev(tree: &lsm_tree::AnyTree, lo: u64, hi: u64) -> Vec<Vec<u8>> {
 
 #[test]
 fn partial_decode_forward_ranges_match_expected() {
+    enable_partial_decode();
     let (_dir, tree) = large_zstd_block_tree();
 
     // Windows at the block start, middle, a wide span, and crossing into the
@@ -93,6 +135,7 @@ fn partial_decode_forward_ranges_match_expected() {
 
 #[test]
 fn partial_decode_reverse_ranges_match_expected() {
+    enable_partial_decode();
     let (_dir, tree) = large_zstd_block_tree();
 
     for (lo, hi) in [(10u64, 50), (5_000, 5_001), (12_345, 12_900)] {
@@ -120,4 +163,97 @@ fn partial_decode_empty_and_boundary_ranges() {
     // that key.
     let got = range_keys(&tree, 200, 205);
     assert_eq!(got, (200..205).map(key).collect::<Vec<_>>());
+}
+
+#[test]
+fn partial_decode_cache_reuse_and_high_water_growth_stays_correct() {
+    // A shared cache so the partial-decode path caches the synthesized covering
+    // block and serves / grows it on later reads of the same block. Correctness
+    // must hold regardless of read order: a narrow read after a wide one reuses
+    // the wider cached block; a wider read after a narrow one grows the extent.
+    let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024));
+    let (_dir, tree) = large_zstd_block_tree_with_cache(cache.clone());
+
+    // All windows fall inside the first (large) data block so they share one
+    // cache slot, exercising reuse + high-water growth on a single offset.
+    let windows = [
+        (10u64, 30), // first read: partial decode, cache covered ~key29
+        (10, 300),   // wider: covered_upper grows, re-decode + re-cache
+        (10, 30),    // narrow again: must be served from the larger cache
+        (12, 18),    // narrower sub-window: served from cache
+        (250, 300),  // shifted but still within the grown extent: from cache
+        (10, 1_000), // even wider: grows the extent again
+        (500, 600),  // within the newly grown extent
+    ];
+    for (lo, hi) in windows {
+        let got = range_keys(&tree, lo, hi);
+        let expected: Vec<Vec<u8>> = (lo..hi.min(N)).map(key).collect();
+        assert_eq!(
+            got, expected,
+            "window [{lo}, {hi}) must match the full-decode result across cache reuse",
+        );
+        // Reverse over the same window must also be correct off the cached block.
+        let got_rev = range_keys_rev(&tree, lo, hi);
+        let expected_rev: Vec<Vec<u8>> = (lo..hi.min(N)).rev().map(key).collect();
+        assert_eq!(
+            got_rev, expected_rev,
+            "reverse window [{lo}, {hi}) must match across cache reuse",
+        );
+    }
+
+    // The partial path must actually have populated the cache (otherwise the
+    // test would silently pass on the full-decode fallback).
+    assert!(
+        cache.size() > 0,
+        "partial-decode reads must populate the shared cache",
+    );
+}
+
+#[test]
+fn partial_decode_promotion_paths_stay_correct() {
+    // Drive the adaptive heuristic through every branch on a shared cache:
+    // fraction-promotion (a wide window decoding most of a block), hits-promotion
+    // (the same covered window read repeatedly), and post-promotion reads (served
+    // from the now-resident full block). Correctness must hold throughout.
+    enable_partial_decode();
+    let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024));
+    let (_dir, tree) = large_zstd_block_tree_with_cache(cache.clone());
+
+    // Wide window: covers most of the first large block → fraction-promotion to
+    // a full resident block on the covering decode.
+    let got = range_keys(&tree, 0, 5_000);
+    assert_eq!(got, (0..5_000).map(key).collect::<Vec<_>>());
+
+    // hits-promotion: read a narrow covered window many times. Each pass after
+    // the partial is cached bumps the hit count; once it crosses the promotion
+    // threshold the block is decoded fully. Results stay identical every pass.
+    for _ in 0..8 {
+        let got = range_keys(&tree, 100, 130);
+        assert_eq!(
+            got,
+            (100..130).map(key).collect::<Vec<_>>(),
+            "repeated reads must stay correct across hits-promotion",
+        );
+    }
+
+    // After promotion the block is resident; a fresh sub-window is served from
+    // the full block and must still be exact (forward and reverse).
+    assert_eq!(
+        range_keys(&tree, 110, 115),
+        (110..115).map(key).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        range_keys_rev(&tree, 110, 115),
+        (110..115).rev().map(key).collect::<Vec<_>>(),
+    );
+
+    // A wide window spanning several blocks, then a narrow re-read inside it.
+    assert_eq!(
+        range_keys(&tree, 0, 9_000),
+        (0..9_000).map(key).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        range_keys(&tree, 8_000, 8_010),
+        (8_000..8_010).map(key).collect::<Vec<_>>()
+    );
 }


### PR DESCRIPTION
## Summary

Partial-decode read path for range queries over large cold-tier zstd blocks (#257): a bounded range decodes only the inner zstd blocks covering its key range and keeps just that decompressed prefix resident, instead of materializing the whole block.

- **Resumable decode** (structured-zstd 0.0.32): growing a block's covered extent RESUMES from a cached entropy/repcode snapshot + decompressed window, decoding only the new tail inner blocks. The resume payload (`window_prime` + `ResumeState` + compressed cursor) lives in the cache next to the partial entry, so even a later range query on a fresh decoder continues incrementally rather than from inner block 0.
- **Adaptive partial tier**: the served block is synthesized on demand from the cached prefix; a cold block holds only the touched fraction. Repeated reads (>= 4) or a >= 75% decoded fraction promote it to a full resident block.
- **Cold-block size gate**: engages only on blocks >= 256 KiB decompressed (production cold blocks run multi-MB); smaller blocks decode fully since the saved decode is cheap relative to setup.
- **Opt-in** via `LSM_PARTIAL_DECODE=1` while validated against full decode + block cache.

## Why

Without a resumable decoder, growing the covered extent re-decoded from block 0, cascading a forward sweep into re-decompressing the whole block (~3.2-3.4x slower than full decode + block cache on a same-binary A/B). The resumable decoder removes that cascade: the path is now at parity on whole-block-covering scans, and wins on random reads into large cold blocks where only a small fraction is touched (decode a ~12 KiB inner block instead of an 8-256 MB block, hold only that fraction in memory).

## Testing

- Resume across dropped decoders is byte-identical to a one-shot full decode.
- `partial_data_block` resume round-trip grows correctly and matches full.
- Cache reuse + high-water growth; runtime + fraction promotion; below-floor skip; forward/reverse/empty/boundary correctness all match full decode.
- `clippy --all-features` and `clippy --no-default-features --features zstd,lz4` clean; no-std `alloc` check flat.

Refs #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial decoding for cold zstd-compressed data blocks to serve range queries without full decompression
  * Lazy/resumable block decoding and per-table block-layout metadata to enable incremental reads and lower memory use

* **Bug Fixes / Stability**
  * Iterator and block-loading paths made exact and consistent when using partial decode and promotions

* **Tests**
  * Extensive unit, integration and benchmark coverage for partial-decode scenarios

* **Dependencies**
  * structured-zstd updated 0.0.30 → 0.0.32
<!-- end of auto-generated comment: release notes by coderabbit.ai -->