### PR TITLE
perf(memtable): stop zeroing the arena, restore cheap fixed-block decode

### DIFF
--- a/src/memtable/arena.rs
+++ b/src/memtable/arena.rs
@@ -4,88 +4,46 @@
 
 //! Multi-block bump-allocating arena for skiplist node storage.
 //!
-//! Blocks grow **geometrically**: the first chunk is small ([`FIRST_BLOCK_SIZE`])
-//! and each subsequent chunk doubles (the largest is `2^31`). A small memtable
-//! therefore allocates (and zeroes) only a small first chunk instead of one
-//! fixed giant block; a large one grows on demand. The arena never
-//! pre-allocates a contiguous buffer, so it works on 32-bit targets too.
-//! Once a block cannot fit an allocation, a new (larger) one is allocated and
-//! the remaining space is abandoned (negligible for typical < 100-byte nodes).
+//! Blocks are allocated lazily — the arena never pre-allocates a large
+//! contiguous buffer, so it works on 32-bit targets with limited address space.
+//! Once a block is full, a new one is allocated and the remaining space in the
+//! old block is abandoned (waste is negligible for typical node allocations of
+//! < 100 bytes).
 //!
-//! # Address encoding
+//! # Memory is uninitialized
 //!
-//! [`alloc`](Arena::alloc) returns an opaque `u32` global byte offset into the
-//! logical concatenation of all blocks. Offset `0` is the `UNSET` sentinel, so
-//! offsets start at `1`. With block sizes `2^S, 2^S, 2^(S+1), 2^(S+2), …`
-//! (`S` = [`FIRST_BLOCK_SHIFT`]), block `i >= 1` starts at `2^(S+i-1)`, which
-//! makes the offset → `(block, within)` decode a constant-time bit operation
-//! (a `leading_zeros`, no table, no search). Total addressable space is 4 GiB.
+//! Blocks are allocated with [`alloc`](std::alloc::alloc), NOT `alloc_zeroed`
+//! (same as the `RocksDB` arena, which uses an uninitialized `new char[]`). The
+//! caller MUST fully initialize every byte it later reads before publishing the
+//! allocation to other threads — the arena makes no zeroing guarantee. The
+//! skiplist upholds this: each node's header, key/value fields, and all
+//! `[0, height)` tower slots are written before the node is linked via a
+//! release CAS, and the head sentinel's full tower is UNSET-initialized at
+//! creation. This removes the per-flush zeroing cost (a fresh memtable no
+//! longer eagerly zeroes its arena block).
 
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
-/// Shift of the first (and second) arena chunk: `2^16 = 64 KiB`. Blocks 0 and 1
-/// are this size; block `i >= 2` is `2^(FIRST_BLOCK_SHIFT + i - 1)` (doubling).
-const FIRST_BLOCK_SHIFT: u32 = 16;
+/// Bits used for the within-block offset.
+///
+/// On 64-bit: 2^26 = 64 MiB per block (1M entries fit in block 0,
+/// avoiding multi-block decode overhead).
+/// On 32-bit: 2^22 = 4 MiB per block (keeps allocation within
+/// the limited virtual address space).
+#[cfg(target_pointer_width = "32")]
+const BLOCK_SHIFT: u32 = 22;
+#[cfg(not(target_pointer_width = "32"))]
+const BLOCK_SHIFT: u32 = 26;
 
-/// Size of the first two arena chunks in bytes (`64 KiB`).
-const FIRST_BLOCK_SIZE: u32 = 1 << FIRST_BLOCK_SHIFT;
+/// Size of each arena block in bytes.
+const BLOCK_SIZE: u32 = 1 << BLOCK_SHIFT;
 
-/// Maximum number of blocks: `33 - FIRST_BLOCK_SHIFT`. Block `i >= 1` starts at
-/// `2.pow(FIRST_BLOCK_SHIFT + i - 1)`; the last start representable in a `u32`
-/// is `2.pow(31)`, so the blocks span the full 4 GiB `u32` address space.
-const MAX_BLOCKS: usize = (33 - FIRST_BLOCK_SHIFT) as usize;
+/// Bitmask for extracting the within-block offset from an encoded u32.
+const BLOCK_MASK: u32 = BLOCK_SIZE - 1;
 
-/// Largest single allocation the arena can place in one (contiguous) block:
-/// the size of the biggest block, `2^31`. Requests at or above this are
-/// rejected (`alloc` returns `None`).
-const MAX_ALLOC: u32 = 1 << 31;
-
-/// Size in bytes of block `idx` (`2^16` for blocks 0 and 1, doubling after).
-#[inline]
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "idx < MAX_BLOCKS (<= 17), well within u32"
-)]
-const fn block_size(idx: usize) -> u32 {
-    if idx == 0 {
-        FIRST_BLOCK_SIZE
-    } else {
-        1u32 << (FIRST_BLOCK_SHIFT + idx as u32 - 1)
-    }
-}
-
-/// Global byte offset at which block `idx` starts. `0` for block 0; for
-/// `idx >= 1` it equals `block_size(idx)` (`2^(FIRST_BLOCK_SHIFT + idx - 1)`).
-#[inline]
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "idx < MAX_BLOCKS (<= 17), well within u32"
-)]
-const fn block_start(idx: usize) -> u32 {
-    if idx == 0 {
-        0
-    } else {
-        1u32 << (FIRST_BLOCK_SHIFT + idx as u32 - 1)
-    }
-}
-
-/// Decodes a global byte offset into `(block_index, within_block_offset)` in
-/// constant time. Offsets below [`FIRST_BLOCK_SIZE`] live in block 0; otherwise
-/// the block index is derived from the position of the offset's highest set bit
-/// (the buddy layout makes `block_start(i) == 2^(S+i-1)`).
-#[inline]
-fn locate(offset: u32) -> (usize, u32) {
-    if offset < FIRST_BLOCK_SIZE {
-        (0, offset)
-    } else {
-        // `offset >= FIRST_BLOCK_SIZE > 0`, so `ilog2()` is well-defined.
-        let highest_bit = offset.ilog2();
-        let block = (highest_bit - FIRST_BLOCK_SHIFT + 1) as usize;
-        let within = offset - (1u32 << highest_bit);
-        (block, within)
-    }
-}
+/// Maximum number of blocks.  Supports up to 4 GiB total arena capacity.
+const MAX_BLOCKS: usize = 1 << (32 - BLOCK_SHIFT);
 
 /// A multi-block bump-allocating arena.
 ///
@@ -93,9 +51,9 @@ fn locate(offset: u32) -> (usize, u32) {
 /// bump cursor.  Blocks are allocated lazily via CAS on `AtomicPtr`, so only
 /// the blocks that are actually needed consume memory.
 ///
-/// The `u32` offset returned by [`alloc`](Self::alloc) is a global byte offset
-/// into the logical concatenation of the (geometrically growing) blocks; see
-/// the module docs for the encoding. Decode it with [`locate`].
+/// The u32 offset returned by [`alloc`](Self::alloc) encodes the block
+/// index in the high bits and the within-block offset in the low
+/// `BLOCK_SHIFT` bits (26 on 64-bit, 22 on 32-bit).
 pub struct Arena {
     /// Block pointers.  Null means not yet allocated.  Once set to non-null,
     /// a block pointer is never modified — reads may use `Relaxed` ordering
@@ -103,8 +61,8 @@ pub struct Arena {
     /// chain.
     blocks: Box<[AtomicPtr<u8>]>,
 
-    /// Allocation cursor: the next free global byte offset (across all blocks).
-    /// Starts at 1 (offset 0 is the UNSET sentinel).
+    /// Allocation cursor.  High 10 bits = block index, low 22 bits = offset
+    /// within that block.  Starts at 1 (offset 0 is the UNSET sentinel).
     cursor: AtomicU32,
 }
 
@@ -129,65 +87,70 @@ impl Arena {
 
     /// Allocates `size` bytes with the given alignment.
     ///
-    /// Returns the global byte offset, or `None` if `size` is zero,
-    /// `size >= MAX_ALLOC` (too large for any single block), `align` is not a
-    /// power of two, or the arena is exhausted (> 4 GiB total).
+    /// Returns the encoded offset, or `None` if `size` is zero,
+    /// `size >= BLOCK_SIZE`, `align` is not a power of two, or the
+    /// arena is exhausted (> 4 GiB total).
     pub fn alloc(&self, size: u32, align: u32) -> Option<u32> {
-        if !align.is_power_of_two() || size == 0 || size >= MAX_ALLOC {
+        if !align.is_power_of_two() || size == 0 || size >= BLOCK_SIZE {
             return None;
         }
 
         loop {
             // Acquire pairs with the AcqRel CAS below: any thread that reads
-            // a cursor value is guaranteed to see the corresponding
-            // blocks[block_idx] pointer set by ensure_block, which runs before
-            // the CAS that published this cursor value.
+            // a cursor value (block_idx, offset) is guaranteed to see the
+            // corresponding blocks[block_idx] pointer set by ensure_block,
+            // which runs before the CAS that published this cursor value.
             let cur = self.cursor.load(Ordering::Acquire);
-            let (block_idx, within) = locate(cur);
-            let bsize = block_size(block_idx);
-            // within < bsize <= 2^31 and align <= bsize, so no overflow.
-            let aligned = (within + align - 1) & !(align - 1);
+            let block_idx = cur >> BLOCK_SHIFT;
+            let offset = cur & BLOCK_MASK;
+            // Cannot overflow: offset < BLOCK_SIZE (≤ 2^26), align < BLOCK_SIZE.
+            let aligned = (offset + align - 1) & !(align - 1);
 
-            // Fits the current block? (`aligned + size <= bsize`, overflow-safe.)
-            if aligned.checked_add(size).is_some_and(|end| end <= bsize) {
-                // Ensure the block exists BEFORE publishing the offset via CAS —
-                // otherwise another thread could read the cursor, locate() the
-                // same block, and decode() before the block pointer is set.
-                self.ensure_block(block_idx);
+            if let Some(new_end) = aligned.checked_add(size) {
+                if new_end < BLOCK_SIZE {
+                    // Strict `<`: when new_end == BLOCK_SIZE the bitwise OR
+                    // on the next line would set bit BLOCK_SHIFT in new_end,
+                    // colliding with the block_idx bits and wrapping the
+                    // cursor back to offset 0 of the *current* block.
+                    // Falling through to the next-block path abandons any
+                    // remaining bytes in the current block (at most
+                    // `BLOCK_SIZE - offset`, including a would-have-fit
+                    // allocation at the end).  This waste is acceptable
+                    // for typical node sizes.  See #119.
+                    //
+                    // Ensure the block exists BEFORE publishing the offset via
+                    // CAS — otherwise another thread could read the cursor,
+                    // compute the same block_idx, and call decode() before the
+                    // block pointer is set.
+                    self.ensure_block(block_idx as usize);
 
-                let alloc_offset = block_start(block_idx) + aligned;
-                // Cannot overflow: alloc_offset + size <= block_start + bsize =
-                // block_start(block_idx + 1) <= 2^32 (== for the last block,
-                // where size keeps it strictly below since `size < MAX_ALLOC`).
-                let new_cursor = alloc_offset.checked_add(size)?;
-                if self
-                    .cursor
-                    .compare_exchange_weak(cur, new_cursor, Ordering::AcqRel, Ordering::Relaxed)
-                    .is_ok()
-                {
-                    return Some(alloc_offset);
+                    let new_cursor = (block_idx << BLOCK_SHIFT) | new_end;
+                    if self
+                        .cursor
+                        .compare_exchange_weak(cur, new_cursor, Ordering::AcqRel, Ordering::Relaxed)
+                        .is_ok()
+                    {
+                        return Some((block_idx << BLOCK_SHIFT) | aligned);
+                    }
+                } else {
+                    // Advance to the next block.  Ensure it exists BEFORE
+                    // publishing the new cursor, so that any thread reading
+                    // the cursor will find a valid block pointer.
+                    let new_block = block_idx + 1;
+                    if new_block as usize >= MAX_BLOCKS {
+                        return None;
+                    }
+                    self.ensure_block(new_block as usize);
+                    let new_cursor = new_block << BLOCK_SHIFT;
+                    let _ = self.cursor.compare_exchange_weak(
+                        cur,
+                        new_cursor,
+                        Ordering::AcqRel,
+                        Ordering::Relaxed,
+                    );
                 }
             } else {
-                // Doesn't fit: advance to the first later block large enough to
-                // hold `size` from offset 0 (skipping early small blocks for an
-                // outsized allocation). The abandoned tail of the current block
-                // is negligible for typical node sizes. Ensure the target block
-                // exists BEFORE publishing the cursor so a concurrent reader
-                // always finds a valid pointer.
-                let mut next = block_idx + 1;
-                while next < MAX_BLOCKS && block_size(next) < size {
-                    next += 1;
-                }
-                if next >= MAX_BLOCKS {
-                    return None;
-                }
-                self.ensure_block(next);
-                let _ = self.cursor.compare_exchange_weak(
-                    cur,
-                    block_start(next),
-                    Ordering::AcqRel,
-                    Ordering::Relaxed,
-                );
+                return None;
             }
         }
     }
@@ -203,8 +166,8 @@ impl Arena {
     pub unsafe fn get_bytes(&self, offset: u32, len: u32) -> &[u8] {
         let (ptr, off) = unsafe { self.decode(offset) };
         debug_assert!(
-            off + len as usize <= block_size(locate(offset).0) as usize,
-            "get_bytes: off={off} + len={len} exceeds block size (offset={offset})",
+            off + len as usize <= BLOCK_SIZE as usize,
+            "get_bytes: off={off} + len={len} exceeds BLOCK_SIZE={BLOCK_SIZE} (offset={offset})",
         );
         // SAFETY: caller guarantees the range is allocated and initialised.
         unsafe { std::slice::from_raw_parts(ptr.add(off), len as usize) }
@@ -252,6 +215,8 @@ impl Arena {
 
     /// Decodes an encoded offset into `(block_base_ptr, within_block_offset)`.
     ///
+    /// Decodes an encoded offset into `(block_base_ptr, within_block_offset)`.
+    ///
     /// Hot path: single `Acquire` load returns the cached block pointer.
     /// Cold path: spins until the block pointer becomes visible (another
     /// thread's `ensure_block` is in progress).
@@ -261,8 +226,8 @@ impl Arena {
         reason = "block_idx < MAX_BLOCKS by construction (alloc enforces this)"
     )]
     unsafe fn decode(&self, offset: u32) -> (*mut u8, usize) {
-        let (block_idx, within) = locate(offset);
-        let off = within as usize;
+        let block_idx = (offset >> BLOCK_SHIFT) as usize;
+        let off = (offset & BLOCK_MASK) as usize;
 
         let mut ptr = self.blocks[block_idx].load(Ordering::Acquire);
         if ptr.is_null() {
@@ -294,13 +259,21 @@ impl Arena {
         if self.blocks[idx].load(Ordering::Acquire).is_null() {
             // Allocate with explicit 4-byte alignment so that AtomicU32
             // accesses within the block are correctly aligned on all targets.
-            let layout = Self::block_layout(idx);
+            let layout = Self::block_layout();
 
-            // SAFETY: layout is non-zero (block_size(idx) > 0).
-            // alloc_zeroed guarantees zeroed memory (tower pointers = UNSET).
-            // Visibility: the CAS below (AcqRel) makes the zeroed contents
-            // visible to any thread that Acquire-loads the block pointer.
-            let raw = unsafe { std::alloc::alloc_zeroed(layout) };
+            // Blocks are NOT zeroed (`alloc`, not `alloc_zeroed`): like
+            // RocksDB's arena (`new char[]`, deliberately uninitialized), the
+            // skiplist fully initializes every node — header, key/value fields,
+            // and all `[0, height)` tower slots — BEFORE the node is published
+            // (linked via a release CAS), and the head sentinel's tower is
+            // explicitly UNSET-initialized at creation. No reader ever observes
+            // an unwritten byte, so eager zeroing is pure waste (the 64 MiB
+            // bzero-per-flush this used to pay). Lazy page-faulting still
+            // zero-fills only the pages actually touched, at the OS level.
+            // SAFETY: layout is non-zero (BLOCK_SIZE > 0). Visibility: the CAS
+            // below (AcqRel) makes the block pointer (and the writes the caller
+            // makes into it before publishing a node) visible to readers.
+            let raw = unsafe { std::alloc::alloc(layout) };
             if raw.is_null() {
                 std::alloc::handle_alloc_error(layout);
             }
@@ -318,11 +291,11 @@ impl Arena {
         }
     }
 
-    /// Layout for block `idx`: `block_size(idx)` bytes with 4-byte alignment
+    /// Layout for arena blocks: `BLOCK_SIZE` bytes with 4-byte alignment
     /// (required for `AtomicU32` tower pointers).
-    fn block_layout(idx: usize) -> std::alloc::Layout {
-        // SAFETY: block_size(idx) > 0 and align (4) is a power of two.
-        unsafe { std::alloc::Layout::from_size_align_unchecked(block_size(idx) as usize, 4) }
+    fn block_layout() -> std::alloc::Layout {
+        // SAFETY: BLOCK_SIZE > 0 and align (4) is a power of two.
+        unsafe { std::alloc::Layout::from_size_align_unchecked(BLOCK_SIZE as usize, 4) }
     }
 }
 
@@ -334,14 +307,14 @@ impl Default for Arena {
 
 impl Drop for Arena {
     fn drop(&mut self) {
-        for (idx, block) in self.blocks.iter().enumerate() {
+        let layout = Self::block_layout();
+        for block in &*self.blocks {
             let ptr = block.load(Ordering::Relaxed);
             if !ptr.is_null() {
-                // SAFETY: `ptr` was allocated for block `idx` using
-                // `block_layout(idx)`, so deallocating with the same per-index
-                // layout is valid.
+                // SAFETY: `ptr` was allocated for this arena using `block_layout()`,
+                // so deallocating with the same layout is valid.
                 unsafe {
-                    std::alloc::dealloc(ptr, Self::block_layout(idx));
+                    std::alloc::dealloc(ptr, layout);
                 }
             }
         }
@@ -391,121 +364,12 @@ mod tests {
     #[test]
     fn alloc_crosses_block_boundary() {
         let arena = Arena::new();
-        // Nearly fill block 0; the next alloc must spill into block 1.
-        let big = FIRST_BLOCK_SIZE - 64;
+        let big = BLOCK_SIZE - 64;
         let off1 = arena.alloc(big, 1).expect("ok");
-        assert_eq!(locate(off1).0, 0, "first alloc in block 0");
+        assert_eq!(off1 >> BLOCK_SHIFT, 0);
 
         let off2 = arena.alloc(128, 4).expect("ok");
-        assert_eq!(locate(off2).0, 1, "spill alloc in block 1");
-    }
-
-    #[test]
-    fn block_sizes_grow_geometrically() {
-        // Blocks 0 and 1 are the base size; each later block doubles.
-        assert_eq!(block_size(0), FIRST_BLOCK_SIZE);
-        assert_eq!(block_size(1), FIRST_BLOCK_SIZE);
-        assert_eq!(block_size(2), FIRST_BLOCK_SIZE * 2);
-        assert_eq!(block_size(3), FIRST_BLOCK_SIZE * 4);
-        // `block_start(i) == block_size(i)` for i >= 1 (the buddy layout), and
-        // each block ends exactly where the next begins.
-        for i in 1..(MAX_BLOCKS - 1) {
-            assert_eq!(block_start(i), block_size(i), "start==size for block {i}");
-            assert_eq!(
-                block_start(i) + block_size(i),
-                block_start(i + 1),
-                "block {i} ends where block {} begins",
-                i + 1,
-            );
-        }
-    }
-
-    #[test]
-    fn locate_round_trips_block_boundaries() {
-        // Every block start decodes to (that block, offset 0), and the last
-        // byte of each block decodes to (that block, size-1).
-        for i in 0..(MAX_BLOCKS - 1) {
-            let start = block_start(i);
-            // Block 0 start is the UNSET sentinel (offset 0); probe offset 1.
-            let probe = if i == 0 { 1 } else { start };
-            let (b, w) = locate(probe);
-            assert_eq!(b, i, "start of block {i} locates to block {i}");
-            assert_eq!(w, probe - start, "within offset at block {i} start");
-
-            let last = start + block_size(i) - 1;
-            let (lb, lw) = locate(last);
-            assert_eq!(lb, i, "last byte of block {i} locates to block {i}");
-            assert_eq!(
-                lw,
-                block_size(i) - 1,
-                "within offset of block {i} last byte"
-            );
-        }
-    }
-
-    #[test]
-    fn small_first_alloc_touches_only_block_zero() {
-        // A handful of tiny allocations must stay in block 0 — only that one
-        // small chunk is materialized (the whole point of geometric growth:
-        // a small memtable never zeroes a giant block).
-        let arena = Arena::new();
-        for _ in 0..100 {
-            let off = arena.alloc(32, 4).expect("ok");
-            assert_eq!(locate(off).0, 0, "tiny allocs stay in block 0");
-        }
-        assert!(
-            !arena.blocks[0].load(Ordering::Acquire).is_null(),
-            "block 0 allocated",
-        );
-        assert!(
-            arena.blocks[1].load(Ordering::Acquire).is_null(),
-            "block 1 must NOT be allocated for a small memtable",
-        );
-    }
-
-    #[test]
-    fn large_alloc_jumps_to_a_big_enough_block() {
-        // An allocation larger than the early small blocks must skip ahead to
-        // the first block big enough to hold it, and read/write correctly.
-        let arena = Arena::new();
-        let size = FIRST_BLOCK_SIZE * 3; // bigger than blocks 0,1 (64K) and 2 (128K)
-        let off = arena.alloc(size, 1).expect("large alloc");
-        let (block, within) = locate(off);
-        assert!(block_size(block) >= size, "landed in a big-enough block");
-        assert_eq!(within, 0, "outsized alloc starts at the block base");
-        // Write the whole region and read it back to prove the mapping is sound.
-        unsafe {
-            let bytes = arena.get_bytes_mut(off, size);
-            bytes[0] = 0x11;
-            bytes[size as usize - 1] = 0x22;
-        }
-        let read = unsafe { arena.get_bytes(off, size) };
-        assert_eq!(read[0], 0x11);
-        assert_eq!(read[size as usize - 1], 0x22);
-    }
-
-    #[test]
-    fn many_allocs_span_blocks_and_round_trip() {
-        // Fill across several geometric blocks with distinct payloads, then
-        // verify every allocation reads back its own bytes (no aliasing across
-        // the variable-size block boundaries).
-        let arena = Arena::new();
-        let mut offs = Vec::new();
-        for i in 0u32..5_000 {
-            let off = arena.alloc(40, 4).expect("ok");
-            unsafe {
-                let b = arena.get_bytes_mut(off, 4);
-                b.copy_from_slice(&i.to_le_bytes());
-            }
-            offs.push((off, i));
-        }
-        // Touched more than one block.
-        let max_block = offs.iter().map(|&(o, _)| locate(o).0).max().unwrap();
-        assert!(max_block >= 1, "5000 x 40B must span past block 0");
-        for (off, i) in offs {
-            let read = unsafe { arena.get_bytes(off, 4) };
-            assert_eq!(read, &i.to_le_bytes(), "alloc must read back its payload");
-        }
+        assert_eq!(off2 >> BLOCK_SHIFT, 1);
     }
 
     #[test]
@@ -556,8 +420,8 @@ mod tests {
         let arena = Arena::new();
         assert!(arena.alloc(100, 3).is_none()); // 3 is not a power of two
         assert!(arena.alloc(0, 4).is_none()); // zero size
-        assert!(arena.alloc(MAX_ALLOC, 1).is_none()); // size == MAX_ALLOC
-        assert!(arena.alloc(MAX_ALLOC + 1, 1).is_none()); // size > MAX_ALLOC
+        assert!(arena.alloc(BLOCK_SIZE, 1).is_none()); // size == BLOCK_SIZE
+        assert!(arena.alloc(BLOCK_SIZE + 1, 1).is_none()); // size > BLOCK_SIZE
     }
 
     #[test]
@@ -570,60 +434,66 @@ mod tests {
     #[test]
     fn drop_with_multiple_blocks() {
         let arena = Arena::new();
-        // Allocate across 2 blocks to exercise Drop on both (per-index layout).
-        let big = FIRST_BLOCK_SIZE - 8;
+        // Allocate across 2 blocks to exercise Drop on both.
+        let big = BLOCK_SIZE - 8;
         let _ = arena.alloc(big, 1).expect("block 0");
         let _ = arena.alloc(64, 4).expect("block 1");
         // Drop runs here — deallocates both blocks.
     }
 
-    /// An allocation that fills a block EXACTLY to its size must not corrupt
-    /// data: the exact-fill allocation succeeds in that block, the cursor lands
-    /// precisely on the next block's start, the following allocation advances to
-    /// it, and the prior block's bytes are preserved. (The global-offset
-    /// encoding has no carry/wrap hazard at the boundary; this guards the
-    /// `end <= bsize` boundary arithmetic.)
+    /// Regression test for #119: when an allocation fills a block exactly
+    /// to BLOCK_SIZE, the cursor OR produced `(block_idx << SHIFT) | BLOCK_SIZE`
+    /// which wrapped back to offset 0 of the *same* block, causing subsequent
+    /// allocations to overwrite existing data.
+    ///
+    /// The bug only triggers when block_idx >= 1 because for block 0
+    /// `(0 << SHIFT) | BLOCK_SIZE` correctly decodes as block 1, offset 0.
+    /// For block_idx >= 1 the BLOCK_SHIFT bit is already set in the block
+    /// index, so the OR does not carry and the cursor wraps.
     #[test]
     fn exact_block_fill_does_not_corrupt() {
         let arena = Arena::new();
 
-        // Jump the cursor directly to block 1, offset 0 — avoids materializing
-        // block 0 just to advance past it.
-        arena.cursor.store(block_start(1), Ordering::Relaxed);
+        // Jump the cursor directly to block 1, offset 0 — avoids allocating
+        // an entire block 0 (64 MiB on 64-bit) just to advance past it.
+        arena.cursor.store(1 << BLOCK_SHIFT, Ordering::Relaxed);
 
-        // Bring block 1's cursor to (size - 4).
-        let filler = block_size(1) - 4;
+        // Allocate (BLOCK_SIZE - 4) bytes to bring block 1's cursor to
+        // offset BLOCK_SIZE - 4.
+        let filler = BLOCK_SIZE - 4;
         let f = arena.alloc(filler, 1).expect("filler");
-        assert_eq!(locate(f).0, 1, "filler should be in block 1");
+        assert_eq!(f >> BLOCK_SHIFT, 1, "filler should be in block 1");
 
-        // Sentinel in the last allocated byte.
-        // SAFETY: `f` was just returned by alloc(filler, 1).
+        // Write a sentinel pattern into the last allocated byte.
+        // SAFETY: `f` was just returned by alloc(filler, 1), so
+        // [f, f+filler) is allocated and we have exclusive access.
         unsafe {
             let bytes = arena.get_bytes_mut(f, filler);
             bytes[filler as usize - 1] = 0xAB;
         }
 
-        // Cursor is now at (size - 4) in block 1. Allocate exactly 4 bytes
-        // (align=4): end == block_size(1) exactly. It fits block 1 (`end <=
-        // bsize`), and the cursor lands on block_start(2).
+        // Now cursor is at BLOCK_SIZE - 4 within block 1.  Allocate exactly
+        // 4 bytes (align=4): new_end = BLOCK_SIZE exactly.  With the fix,
+        // this allocation moves to block 2 (the tail bytes in block 1 are
+        // sacrificed).
         let boundary = arena.alloc(4, 4).expect("boundary alloc");
-        assert_eq!(locate(boundary).0, 1, "exact-fill alloc stays in block 1");
         assert_eq!(
-            arena.cursor.load(Ordering::Relaxed),
-            block_start(2),
-            "cursor lands exactly on the next block's start",
+            boundary >> BLOCK_SHIFT,
+            2,
+            "exact-fill allocation must advance to the next block"
         );
 
-        // The next allocation advances to block 2 (no wrap back into block 1).
+        // A further allocation must also be in block 2 (not wrap to block 1).
         let next = arena.alloc(8, 4).expect("next alloc");
         assert_eq!(
-            locate(next).0,
+            next >> BLOCK_SHIFT,
             2,
-            "subsequent allocation advances to block 2"
+            "subsequent allocation must stay in the advanced block"
         );
 
-        // The sentinel byte in block 1 must be intact.
-        // SAFETY: `f` is a valid allocation from above.
+        // Verify the sentinel byte in block 1 was NOT overwritten.
+        // SAFETY: `f` is the offset returned by alloc(filler, 1) above,
+        // guaranteeing [f, f+filler) is allocated and initialised.
         let read_sentinel = unsafe { arena.get_bytes(f, filler) };
         assert_eq!(
             read_sentinel[filler as usize - 1],

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -114,11 +114,16 @@ impl SkipMap {
             .alloc(head_size, 4)
             .expect("arena must fit at least the head sentinel");
 
-        // Head is zero-initialised by the arena; set the height byte.
-        // SAFETY: head was just allocated with size head_size >= OFF_HEIGHT+1;
-        // we have exclusive access because no other thread can see this arena yet.
+        // The arena no longer zeroes memory, so explicitly initialize the head
+        // sentinel: zero the whole node (header fields + all MAX_HEIGHT tower
+        // slots = UNSET), then stamp the height byte. The head's tower is read
+        // by every search start, so its slots MUST be UNSET before any reader;
+        // regular nodes self-initialize their `[0, height)` tower in `insert`.
+        // SAFETY: head was just allocated with size head_size; we have exclusive
+        // access because no other thread can see this arena yet.
         unsafe {
             let bytes = arena.get_bytes_mut(head, head_size);
+            bytes.fill(0);
             #[expect(
                 clippy::indexing_slicing,
                 reason = "OFF_HEIGHT (11) < head_size (104) by construction"
@@ -325,9 +330,14 @@ impl SkipMap {
             meta[8..10].copy_from_slice(&(key_bytes.len() as u16).to_ne_bytes());
             meta[10] = u8::from(key.value_type);
             meta[11] = height as u8;
-            // meta[12..16] reserved padding
+            // Arena memory is uninitialized — zero the reserved padding so the
+            // whole header is fully written before the node is published.
+            meta[12..16].copy_from_slice(&[0u8; 4]);
             meta[16..24].copy_from_slice(&key.seqno.to_ne_bytes());
-            // Tower entries are already zero (= UNSET) from arena zero-init.
+            // Tower slots [0, height) are NOT initialized here: `insert` writes
+            // every one of them (release store) before linking the node at that
+            // level, so no reader observes an unwritten slot even though the
+            // arena did not zero them.
         }
 
         node


### PR DESCRIPTION
## Summary

#417's geometric arena removed the small-memtable 64 MiB zeroing waste but its buddy decode (branch + `ilog2` + per-block size math) is far costlier than the previous fixed-block `cur >> SHIFT / & MASK` on the alloc/decode hot path. Skiplist traversal is decode-bound, so the db_bench trend shows **fillseq dropping ~33% (2.02M → 1.35M ops/sec) at the #417 commit**, and reads regressed too.

This matches RocksDB's arena (`memory/arena.cc`: `AllocateNewBlock` uses an uninitialized `new char[]`, with an explicit comment that `make_unique`'s zero-init is "not appropriate"):

- **Allocate blocks with `alloc`, not `alloc_zeroed`** — no eager zeroing. The 64 MiB-bzero-per-flush #417 was trying to avoid simply never happens; lazy page-faulting zero-fills only the pages actually touched.
- **Revert to the fixed-block decode** (`cur >> SHIFT / & MASK`) — restores the cheap hot path that #417's buddy geometry regressed.

### Why uninitialized memory is sound

The skiplist already initializes every regular node fully before publishing it: the header + key/value fields in `alloc_node`, and all `[0, height)` tower slots in `insert` (release store, then CAS-link at that level). No reader observes an unwritten slot. Two small fixes complete the contract:

- the head sentinel's full tower is now explicitly UNSET-initialized at creation (it previously relied on arena zeroing);
- `alloc_node` zeroes the previously-reserved header padding.

`ValueStore` is a separate store with its own `alloc_zeroed` and is unchanged.

## Validation

- Arena + skiplist + memtable suites pass.
- **miri clean** on the arena (incl. concurrent alloc) and single-threaded skiplist insert / range / reverse paths — no uninitialized-read UB.
- Local fillseq A/B (same machine): this branch 3.55M vs main 3.34M ops/sec — recovers the direction (the larger db_bench delta will show on the trend post-merge), while keeping the overwrite win (no eager bzero).
- `clippy --all-features` + `--no-default-features --features zstd,lz4` clean; no-std `alloc` count unchanged.

Closes #419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal memory allocation strategy with fixed-size blocks for improved predictability and resource efficiency.
  * Optimized memory initialization and encoding mechanisms in memory management subsystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->