### PR TITLE
feat(manifest): incremental manifest via append-only edit log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ log = "0.4.32"
 # `Fs` trait it interacts with, not from its own synchronisation.
 spin = { version = "0.12", default-features = false, features = ["mutex", "spin_mutex"] }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.32", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.33", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -511,6 +511,19 @@ pub struct Config {
     /// `fsync`. Set via [`Config::sync_mode`].
     pub(crate) sync_mode: SyncMode,
 
+    /// Edit-log size (bytes) past which the next manifest persist rotates: it
+    /// writes a fresh full snapshot and starts an empty log instead of appending
+    /// another [`VersionEdit`](crate::version::edit::VersionEdit). Bounds both
+    /// recovery replay time (edits to re-apply) and log disk use, while keeping
+    /// the common per-flush path a tiny `O(changed-levels)` append rather than an
+    /// `O(all-SSTs)` full manifest rewrite.
+    ///
+    /// Defaults to 1 MiB (≈ tens of thousands of edits). Set via
+    /// [`Config::manifest_log_rotate_bytes`]. A smaller value rotates more
+    /// often (shorter recovery, more frequent full-snapshot writes); `0` rotates
+    /// on every upgrade, degenerating to the full-rewrite-per-version behaviour.
+    pub(crate) manifest_log_rotate_bytes: u64,
+
     /// Compaction I/O rate limit in bytes per second.
     ///
     /// Caps the rate at which the compaction worker is allowed to issue
@@ -666,6 +679,7 @@ impl Default for Config {
             encryption: None,
             manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
             sync_mode: SyncMode::Normal,
+            manifest_log_rotate_bytes: 1024 * 1024,
             compaction_rate_limit: 0,
 
             #[cfg(feature = "std")]
@@ -1392,6 +1406,18 @@ impl Config {
     #[must_use]
     pub fn sync_mode(mut self, mode: SyncMode) -> Self {
         self.sync_mode = mode;
+        self
+    }
+
+    /// Sets the edit-log rotation threshold in bytes (default 1 MiB).
+    ///
+    /// Once the manifest edit log exceeds this size, the next version upgrade
+    /// writes a fresh full snapshot and starts an empty log instead of appending
+    /// another edit. Lower it to shorten recovery replay and cap log size at the
+    /// cost of more frequent full-snapshot writes; `0` rotates on every upgrade.
+    #[must_use]
+    pub fn manifest_log_rotate_bytes(mut self, bytes: u64) -> Self {
+        self.manifest_log_rotate_bytes = bytes;
         self
     }
 

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -333,6 +333,17 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         config.sync_mode,
     )?;
 
+    // A rebuilt snapshot is a complete generation on its own. Drop any edit log
+    // that would otherwise be replayed on top of it: the lost manifest's
+    // generation may have left an `edits-{version_id}` describing the old
+    // layout, which would corrupt recovery if layered over the fresh snapshot.
+    let log_path = config.path.join(format!("edits-{version_id}"));
+    match config.fs.remove_file(&log_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
+
     Ok(RepairReport {
         recovered,
         unreadable: unreadable_files.len(),

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -333,15 +333,20 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         config.sync_mode,
     )?;
 
-    // A rebuilt snapshot is a complete generation on its own. Drop any edit log
-    // that would otherwise be replayed on top of it: the lost manifest's
-    // generation may have left an `edits-{version_id}` describing the old
-    // layout, which would corrupt recovery if layered over the fresh snapshot.
-    let log_path = config.path.join(format!("edits-{version_id}"));
-    match config.fs.remove_file(&log_path) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e.into()),
+    // A rebuilt snapshot is a complete generation on its own. Sweep every stale
+    // edit log so nothing is replayed on top of it: the lost manifest's
+    // generation left its log under an OLDER snapshot id (the rebuilt snapshot
+    // uses `max(v*) + 1`), so removing only `edits-{version_id}` would normally
+    // miss it. Drop all `edits-*` — none belong to the fresh snapshot.
+    for dirent in config.fs.read_dir(&config.path)? {
+        if dirent.is_dir || !dirent.file_name.starts_with("edits-") {
+            continue;
+        }
+        match config.fs.remove_file(&dirent.path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
     }
 
     Ok(RepairReport {

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -146,6 +146,15 @@ impl Config {
     /// compaction restructures it into proper levels (expect elevated I/O for a
     /// period proportional to the data size).
     ///
+    /// # Exclusive access (required)
+    ///
+    /// The caller MUST guarantee no other instance has this tree directory open.
+    /// Repair rewrites `CURRENT`, writes a fresh snapshot, and removes the stale
+    /// `edits-*` logs in place — `lsm-tree` takes no cross-process directory lock
+    /// here (nor does [`Config::open`]; exclusive directory ownership is the
+    /// embedder's responsibility). Running repair against a live tree corrupts
+    /// that instance's manifest state.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::FeatureUnsupported`] for KV-separated (blob)

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -141,7 +141,16 @@ impl TreeInner {
         let comparator = config.comparator.clone();
         let sync_mode = config.sync_mode;
 
-        let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        // The first persist above wrote the full snapshot `v{version.id()}` and
+        // pointed CURRENT at it, so that id is the initial manifest snapshot.
+        let snapshot_id = version.id();
+        let super_versions = SuperVersions::new(
+            version,
+            &comparator,
+            sync_mode,
+            snapshot_id,
+            config.manifest_log_rotate_bytes,
+        );
         #[cfg(feature = "std")]
         let latest_super_version = super_versions.latest_handle();
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2037,12 +2037,17 @@ impl Tree {
         // NOTE: the version file is read twice (here for metadata, then inside
         // recover_levels for table/blob data). This is intentional — metadata
         // validation must complete before any disk-mutating recovery work.
+        // Version id of the on-disk snapshot CURRENT references. This is the
+        // base the edit log replays on top of; the live version id can be higher
+        // (it has no `v{id}` file of its own). Threaded into the version history
+        // so the next persist appends to / rotates the right snapshot's log.
+        let snapshot_id = crate::version::recovery::get_current_version(
+            &config.path,
+            &*config.fs,
+            config.encryption.clone(),
+        )?;
         {
-            let version_id = crate::version::recovery::get_current_version(
-                &config.path,
-                &*config.fs,
-                config.encryption.clone(),
-            )?;
+            let version_id = snapshot_id;
             let manifest_path = config.path.join(format!("v{version_id}"));
             // Open the manifest with a default runtime snapshot:
             // ECC awareness is captured per-Block via the header
@@ -2124,7 +2129,13 @@ impl Tree {
         // move.
         let initial_runtime = config.initial_runtime_config.clone();
         let sync_mode = config.sync_mode;
-        let super_versions = SuperVersions::new(version, &comparator, sync_mode);
+        let super_versions = SuperVersions::new(
+            version,
+            &comparator,
+            sync_mode,
+            snapshot_id,
+            config.manifest_log_rotate_bytes,
+        );
         #[cfg(feature = "std")]
         let latest_super_version = super_versions.latest_handle();
         let inner = TreeInner {
@@ -2234,6 +2245,11 @@ impl Tree {
             config.manifest_recovery_mode,
             config.encryption.clone(),
         )?;
+
+        // The on-disk snapshot CURRENT points at — the generation orphan cleanup
+        // must preserve. Intermediate versions live only in the edit log, so the
+        // latest version id (`version.id()`) has no `v{id}` file of its own.
+        let snapshot_id = recovery.snapshot_id;
 
         let mut table_map = {
             let mut result: crate::HashMap<TableId, (u8 /* Level index */, Checksum, SeqNo)> =
@@ -2428,8 +2444,11 @@ impl Tree {
         let version = Version::from_recovery(recovery, &tables, &blob_files)?;
 
         // NOTE: Cleanup old versions
-        // But only after we definitely recovered the latest version
-        Self::cleanup_orphaned_version(tree_path, version.id(), &*config.fs)?;
+        // But only after we definitely recovered the latest version.
+        // Preserve the snapshot CURRENT references (and its `edits-` log) — the
+        // latest version id has no file of its own under the incremental
+        // manifest, so cleaning by it would delete the live snapshot.
+        Self::cleanup_orphaned_version(tree_path, snapshot_id, &*config.fs)?;
 
         for (table_path, orphan_fs) in orphaned_tables {
             log::debug!("Deleting orphaned table {}", table_path.display());
@@ -2454,20 +2473,29 @@ impl Tree {
     /// function now fails fast on non-UTF-8 names. This is intentional: version
     /// files are always `v{u64}` — any non-UTF-8 entry indicates filesystem
     /// corruption and should surface as an error rather than be silently ignored.
+    /// Removes stale manifest files left by older generations: every `v{id}`
+    /// snapshot except the live one (`v{snapshot_id}`) and every `edits-{id}`
+    /// log except the live snapshot's (`edits-{snapshot_id}`). A crashed
+    /// rotation can leak an old snapshot or its log; this sweeps them on open.
+    /// The live snapshot and log are exactly the generation `CURRENT` points at.
     fn cleanup_orphaned_version(
         path: &Path,
-        latest_version_id: crate::version::VersionId,
+        snapshot_id: crate::version::VersionId,
         fs: &dyn crate::fs::Fs,
     ) -> crate::Result<()> {
-        let version_str = format!("v{latest_version_id}");
+        let snapshot_str = format!("v{snapshot_id}");
+        let log_str = format!("edits-{snapshot_id}");
 
         for dirent in fs.read_dir(path)? {
             if dirent.is_dir {
                 continue;
             }
 
-            if dirent.file_name.starts_with('v') && dirent.file_name != version_str {
-                log::trace!("Cleanup orphaned version {}", dirent.file_name);
+            let name = &dirent.file_name;
+            let is_orphan_snapshot = name.starts_with('v') && *name != snapshot_str;
+            let is_orphan_log = name.starts_with("edits-") && *name != log_str;
+            if is_orphan_snapshot || is_orphan_log {
+                log::trace!("Cleanup orphaned manifest file {name}");
                 match fs.remove_file(&dirent.path) {
                     Ok(()) => {}
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Compute the [`VersionEdit`] between two consecutive [`Version`]s.
+//!
+//! [`Version::diff`] is the producer side of the incremental manifest: given the
+//! prior version and the one a flush / compaction just built, it emits the
+//! delta the engine appends to the edit log. The delta carries the full new run
+//! layout of every level that changed (so recovery rebuilds run grouping
+//! verbatim — see [`super::edit`]) plus per-id blob add / remove and a GC-stats
+//! snapshot when it changed.
+
+use super::Version;
+use super::edit::{AddedBlobFile, ChangedLevel, TableDesc, VersionEdit};
+use crate::coding::Encode;
+
+impl Version {
+    /// Computes the edit that turns `prior` into `self`.
+    ///
+    /// A level is emitted (with its full new run layout) only when its layout
+    /// differs from `prior`; unchanged levels are omitted. Blob files are a flat
+    /// id-keyed list, so they get a per-id add / remove delta. GC stats are
+    /// included only when they changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding the GC-stats snapshot fails, or
+    /// [`crate::Error::Unrecoverable`] if the level count exceeds `u8::MAX` (the
+    /// format caps levels at 255, so this is unreachable for any version the
+    /// engine builds).
+    pub(crate) fn diff(&self, prior: &Self) -> crate::Result<VersionEdit> {
+        let level_count = self.level_count().max(prior.level_count());
+        let mut changed_levels = Vec::new();
+        for idx in 0..level_count {
+            let cur = level_runs(self.level(idx));
+            let old = level_runs(prior.level(idx));
+            if cur != old {
+                let level = u8::try_from(idx).map_err(|_| crate::Error::Unrecoverable)?;
+                changed_levels.push(ChangedLevel { level, runs: cur });
+            }
+        }
+
+        // Blob files added or whose checksum changed.
+        let mut added_blob_files = Vec::new();
+        for bf in self.blob_files.iter() {
+            let cur = bf.checksum().into_u128();
+            let was = prior
+                .blob_files
+                .get(bf.id())
+                .map(|p| p.checksum().into_u128());
+            if was != Some(cur) {
+                added_blob_files.push(AddedBlobFile {
+                    id: bf.id(),
+                    checksum: cur,
+                });
+            }
+        }
+        // Blob files present before but gone now.
+        let mut removed_blob_file_ids = Vec::new();
+        for bf in prior.blob_files.iter() {
+            if !self.blob_files.contains_key(bf.id()) {
+                removed_blob_file_ids.push(bf.id());
+            }
+        }
+
+        let gc_stats = if self.gc_stats() == prior.gc_stats() {
+            None
+        } else {
+            let mut buf = Vec::new();
+            self.gc_stats().encode_into(&mut buf)?;
+            Some(buf)
+        };
+
+        Ok(VersionEdit {
+            new_version_id: self.id(),
+            changed_levels,
+            added_blob_files,
+            removed_blob_file_ids,
+            gc_stats,
+        })
+    }
+}
+
+/// The run layout of one level as plain descriptors, for cheap structural
+/// comparison and direct reuse as a [`ChangedLevel`]'s `runs`. An absent level
+/// (index past the version's level count) is an empty layout.
+fn level_runs(level: Option<&super::Level>) -> Vec<Vec<TableDesc>> {
+    level.map_or_else(Vec::new, |lvl| {
+        lvl.iter()
+            .map(|run| {
+                run.iter()
+                    .map(|t| TableDesc {
+                        id: t.id(),
+                        checksum: t.checksum().into_u128(),
+                        global_seqno: t.global_seqno(),
+                    })
+                    .collect()
+            })
+            .collect()
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::TreeType;
+    use crate::blob_tree::FragmentationMap;
+    use crate::version::BlobFileList;
+
+    fn empty_version(id: u64) -> Version {
+        Version::new(id, TreeType::Standard)
+    }
+
+    #[test]
+    fn diff_of_two_empty_versions_only_bumps_the_id() {
+        let v1 = empty_version(1);
+        let v2 = empty_version(2);
+        let edit = v2.diff(&v1).expect("diff");
+        assert_eq!(edit.new_version_id, 2);
+        assert!(edit.changed_levels.is_empty(), "no level changed");
+        assert!(edit.added_blob_files.is_empty());
+        assert!(edit.removed_blob_file_ids.is_empty());
+        assert!(
+            edit.gc_stats.is_none(),
+            "identical (empty) GC stats are not re-emitted",
+        );
+    }
+
+    #[test]
+    fn diff_emits_gc_stats_only_when_changed() {
+        let v1 = empty_version(1);
+        // Build v2 with a non-empty GC-stats map (everything else empty).
+        let mut gc = FragmentationMap::default();
+        gc.insert(7, crate::blob_tree::FragmentationEntry::new(3, 100, 120));
+        let v2 = Version::from_levels(2, TreeType::Standard, vec![], BlobFileList::default(), gc);
+
+        let edit = v2.diff(&v1).expect("diff");
+        assert!(
+            edit.gc_stats.is_some(),
+            "changed GC stats must be carried in the edit",
+        );
+        // And a diff against an identical map drops it again.
+        let v3 = Version::from_levels(
+            3,
+            TreeType::Standard,
+            vec![],
+            BlobFileList::default(),
+            v2.gc_stats().clone(),
+        );
+        let edit2 = v3.diff(&v2).expect("diff");
+        assert!(
+            edit2.gc_stats.is_none(),
+            "unchanged GC stats between v2 and v3 are not re-emitted",
+        );
+    }
+
+    #[test]
+    fn diff_handles_growing_level_count_without_panic() {
+        // prior has 0 levels, self has 2 (both empty) → still no changed levels,
+        // and the u8 level-index conversion stays in range.
+        let v1 = empty_version(1);
+        let v2 = Version::from_levels(
+            2,
+            TreeType::Standard,
+            vec![
+                crate::version::Level::from_runs(vec![]),
+                crate::version::Level::from_runs(vec![]),
+            ],
+            BlobFileList::default(),
+            FragmentationMap::default(),
+        );
+        let edit = v2.diff(&v1).expect("diff");
+        assert!(
+            edit.changed_levels.is_empty(),
+            "empty levels on both sides are equal regardless of count",
+        );
+    }
+}

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Incremental manifest `VersionEdit`: the delta between two consecutive
+//! [`Version`](super::Version)s.
+//!
+//! Instead of rewriting the whole manifest on every flush / compaction, the
+//! engine appends one `VersionEdit` record describing what changed and, on
+//! recovery, loads the latest full snapshot then replays the appended edits in
+//! order to reconstruct the current version.
+//!
+//! # Why levels are encoded whole, not per-table
+//!
+//! A [`Version`](super::Version) lays each level out as a list of *runs*, and
+//! each run is an independent comparator-sorted table sequence (L0 keeps one run
+//! per flush, overlapping; tiered levels keep several runs). That run grouping
+//! is load-bearing — recovery rebuilds it verbatim via
+//! [`Version::from_recovery`](super::Version::from_recovery). A flat
+//! `added / removed table id` delta would lose which run a table belongs to, so
+//! an edit instead carries the **full new run layout of every level it
+//! changed** ([`ChangedLevel`]). Table removal is therefore implicit: a table
+//! that a compaction drops simply isn't in the new layout of its level.
+//!
+//! This is not the per-flush waste it looks like: flushes and compactions
+//! already rewrite whole runs / levels, so a changed level's layout is exactly
+//! what the operation produced. Levels the edit doesn't mention stay as-is.
+//!
+//! Blob files have no run structure (a flat id-keyed list), so they keep a
+//! natural per-id add / remove delta.
+//!
+//! # Wire format
+//!
+//! A `VersionEdit` is serialized as the payload of a single
+//! [`framing`](super::framing) record (`len + xxh3_64 + payload`), so a
+//! power-loss-truncated or bit-flipped trailing edit is detected and dropped on
+//! replay (the torn tail is never applied). The payload is:
+//!
+//! ```text
+//! new_version_id      : u64 LE
+//! changed_level_count : u32 LE
+//!   repeat (changed level):
+//!     level     : u8
+//!     run_count : u32 LE
+//!       repeat (run):
+//!         table_count : u32 LE
+//!           repeat (table): id u64 LE | checksum_type u8 | checksum u128 LE | global_seqno u64 LE
+//! added_blob_count    : u32 LE
+//!   repeat: id u64 LE | checksum_type u8 | checksum u128 LE
+//! removed_blob_count  : u32 LE
+//!   repeat: id u64 LE
+//! gc_stats_len        : u32 LE   (0 = GC stats unchanged from the prior version)
+//!   gc_stats bytes    : [u8; gc_stats_len]
+//! ```
+//!
+//! The per-table / per-blob record bodies are byte-identical to the snapshot
+//! encoding in [`Version::encode_into`](super::Version::encode_into) (plus the
+//! explicit `level`, which the snapshot encodes positionally), so the same
+//! record shape is recognised on both paths.
+
+use super::framing;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{Read, Write};
+
+/// One table in a run: the snapshot's per-table record minus the positional
+/// level (the enclosing [`ChangedLevel`] carries the level explicitly).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableDesc {
+    /// Table id.
+    pub id: u64,
+    /// XXH3-128 checksum of the table file.
+    pub checksum: u128,
+    /// Global sequence number stamped on the table.
+    pub global_seqno: u64,
+}
+
+/// The full new run layout of one LSM level that an edit replaces wholesale.
+///
+/// `runs` is `[run][table]`: each inner `Vec` is one comparator-sorted run, in
+/// the same order the snapshot persists it. An empty `runs` means the edit
+/// empties the level (e.g. a compaction drained it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangedLevel {
+    /// LSM level this layout replaces.
+    pub level: u8,
+    /// New run layout of the level: `runs[r]` is the tables of run `r`, in
+    /// persisted (comparator-sorted) order.
+    pub runs: Vec<Vec<TableDesc>>,
+}
+
+/// A blob file added by an edit. Mirrors the snapshot's per-blob record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddedBlobFile {
+    /// Blob file id.
+    pub id: u64,
+    /// XXH3-128 checksum of the blob file.
+    pub checksum: u128,
+}
+
+/// The delta between two consecutive versions: what one flush / compaction
+/// changed. Applied in order on top of a snapshot during recovery.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VersionEdit {
+    /// Version id this edit produces (the prior version id + 1).
+    pub new_version_id: u64,
+    /// Levels this edit changed, each carrying its full new run layout.
+    /// Levels not listed are unchanged from the prior version.
+    pub changed_levels: Vec<ChangedLevel>,
+    /// Blob files this edit adds.
+    pub added_blob_files: Vec<AddedBlobFile>,
+    /// Blob file ids this edit removes.
+    pub removed_blob_file_ids: Vec<u64>,
+    /// Encoded GC-stats (`FragmentationMap`) snapshot as of this version, or
+    /// `None` when unchanged from the prior version. Opaque bytes at this layer
+    /// (encoded / decoded by the version layer that owns the map).
+    pub gc_stats: Option<Vec<u8>>,
+}
+
+/// `checksum_type` byte written for XXH3-128 (matches the snapshot encoder).
+const CHECKSUM_TYPE_XXH3: u8 = 0;
+
+impl VersionEdit {
+    /// Serializes the edit payload (without the framing header) into `out`.
+    fn encode_payload(&self, out: &mut Vec<u8>) -> crate::Result<()> {
+        out.write_u64::<LittleEndian>(self.new_version_id)?;
+
+        out.write_u32::<LittleEndian>(u32_len(self.changed_levels.len())?)?;
+        for cl in &self.changed_levels {
+            out.write_u8(cl.level)?;
+            out.write_u32::<LittleEndian>(u32_len(cl.runs.len())?)?;
+            for run in &cl.runs {
+                out.write_u32::<LittleEndian>(u32_len(run.len())?)?;
+                for t in run {
+                    out.write_u64::<LittleEndian>(t.id)?;
+                    out.write_u8(CHECKSUM_TYPE_XXH3)?;
+                    out.write_u128::<LittleEndian>(t.checksum)?;
+                    out.write_u64::<LittleEndian>(t.global_seqno)?;
+                }
+            }
+        }
+
+        out.write_u32::<LittleEndian>(u32_len(self.added_blob_files.len())?)?;
+        for b in &self.added_blob_files {
+            out.write_u64::<LittleEndian>(b.id)?;
+            out.write_u8(CHECKSUM_TYPE_XXH3)?;
+            out.write_u128::<LittleEndian>(b.checksum)?;
+        }
+
+        out.write_u32::<LittleEndian>(u32_len(self.removed_blob_file_ids.len())?)?;
+        for &id in &self.removed_blob_file_ids {
+            out.write_u64::<LittleEndian>(id)?;
+        }
+
+        match &self.gc_stats {
+            Some(bytes) => {
+                out.write_u32::<LittleEndian>(u32_len(bytes.len())?)?;
+                out.write_all(bytes)?;
+            }
+            None => out.write_u32::<LittleEndian>(0)?,
+        }
+        Ok(())
+    }
+
+    /// Appends this edit as one framed record to `writer`, reusing `scratch`
+    /// for the payload assembly (no per-edit heap allocation after warm-up).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the payload exceeds the framing payload cap or a
+    /// write fails.
+    pub fn append_to<W: Write>(&self, writer: &mut W, scratch: &mut Vec<u8>) -> crate::Result<()> {
+        framing::write_framed_record(writer, scratch, |payload| self.encode_payload(payload))
+    }
+
+    /// Decodes a `VersionEdit` from a framed-record payload (the bytes between
+    /// the framing header and the next record).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidHeader`] if the payload is truncated or a
+    /// count exceeds the remaining bytes (a corrupt edit must surface, never
+    /// silently mis-apply).
+    pub fn decode_payload(mut bytes: &[u8]) -> crate::Result<Self> {
+        const ERR: crate::Error = crate::Error::InvalidHeader("VersionEdit");
+        let r = &mut bytes;
+
+        let new_version_id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+
+        let changed_level_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+        let mut changed_levels = Vec::with_capacity(cap(changed_level_count));
+        for _ in 0..changed_level_count {
+            let level = r.read_u8().map_err(|_| ERR)?;
+            let run_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+            let mut runs = Vec::with_capacity(cap(run_count));
+            for _ in 0..run_count {
+                let table_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+                let mut run = Vec::with_capacity(cap(table_count));
+                for _ in 0..table_count {
+                    let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+                    let _checksum_type = r.read_u8().map_err(|_| ERR)?;
+                    let checksum = r.read_u128::<LittleEndian>().map_err(|_| ERR)?;
+                    let global_seqno = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+                    run.push(TableDesc {
+                        id,
+                        checksum,
+                        global_seqno,
+                    });
+                }
+                runs.push(run);
+            }
+            changed_levels.push(ChangedLevel { level, runs });
+        }
+
+        let added_blob_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+        let mut added_blob_files = Vec::with_capacity(cap(added_blob_count));
+        for _ in 0..added_blob_count {
+            let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+            let _checksum_type = r.read_u8().map_err(|_| ERR)?;
+            let checksum = r.read_u128::<LittleEndian>().map_err(|_| ERR)?;
+            added_blob_files.push(AddedBlobFile { id, checksum });
+        }
+
+        let removed_blob_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+        let mut removed_blob_file_ids = Vec::with_capacity(cap(removed_blob_count));
+        for _ in 0..removed_blob_count {
+            removed_blob_file_ids.push(r.read_u64::<LittleEndian>().map_err(|_| ERR)?);
+        }
+
+        let gc_stats_len = r.read_u32::<LittleEndian>().map_err(|_| ERR)? as usize;
+        let gc_stats = if gc_stats_len == 0 {
+            None
+        } else {
+            if r.len() < gc_stats_len {
+                return Err(ERR);
+            }
+            let (head, _tail) = r.split_at(gc_stats_len);
+            Some(head.to_vec())
+        };
+
+        Ok(Self {
+            new_version_id,
+            changed_levels,
+            added_blob_files,
+            removed_blob_file_ids,
+            gc_stats,
+        })
+    }
+}
+
+/// Replays an edit log: reads framed `VersionEdit` records from `reader` in
+/// order and returns the durable prefix. Replay STOPS at the first record that
+/// is not cleanly `Ok` (torn tail, bad checksum, bad/short header) — under the
+/// append-only invariant a crash can only ever truncate or corrupt the trailing
+/// record, so the clean prefix is exactly the set of durably-committed edits.
+/// The dropped tail (and anything after it) was never acknowledged upward, so a
+/// higher-level journal replays that data.
+///
+/// A record whose framing is `Ok` (full payload + matching checksum) but whose
+/// payload fails to decode is a genuine format error, not power loss, and is
+/// surfaced as an error rather than silently truncating the log.
+///
+/// # Errors
+///
+/// Returns an I/O error from `reader` (other than EOF, which ends replay), or
+/// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode.
+pub fn replay_edits<R: Read>(reader: &mut R) -> crate::Result<Vec<VersionEdit>> {
+    use framing::FramedRecordOutcome;
+
+    let mut edits = Vec::new();
+    let mut scratch = Vec::new();
+    // Loop until the first non-`Ok` outcome: under the append-only invariant a
+    // crash truncates / corrupts only the trailing record, so the first
+    // TailTruncation / ChecksumMismatch / Bad-or-LenMismatch header ends the
+    // durable prefix. A clean record that fails to *decode* is a real format
+    // error and propagates via `?`.
+    while matches!(
+        framing::read_framed_record(reader, u64::MAX, None, &mut scratch)?,
+        FramedRecordOutcome::Ok
+    ) {
+        edits.push(VersionEdit::decode_payload(&scratch)?);
+    }
+    Ok(edits)
+}
+
+/// A `usize` count that must fit in `u32` for the wire format.
+fn u32_len(n: usize) -> crate::Result<u32> {
+    u32::try_from(n).map_err(|_| crate::Error::Unrecoverable)
+}
+
+/// Pre-allocation cap for a decoded count: never trust an on-disk count to size
+/// a `Vec` directly (a corrupt count could request a huge allocation); the read
+/// loop still fails on truncation once the bytes run out.
+fn cap(count: u32) -> usize {
+    (count as usize).min(1024)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
+mod tests {
+    use super::*;
+
+    fn sample() -> VersionEdit {
+        VersionEdit {
+            new_version_id: 42,
+            changed_levels: vec![
+                ChangedLevel {
+                    level: 0,
+                    // L0: two single-table runs (one per flush), overlapping.
+                    runs: vec![
+                        vec![TableDesc {
+                            id: 7,
+                            checksum: 0x1122_3344_5566_7788_99AA_BBCC_DDEE_FF00,
+                            global_seqno: 100,
+                        }],
+                        vec![TableDesc {
+                            id: 8,
+                            checksum: 1,
+                            global_seqno: 101,
+                        }],
+                    ],
+                },
+                ChangedLevel {
+                    level: 3,
+                    // Tiered level: one run holding two sorted tables.
+                    runs: vec![vec![
+                        TableDesc {
+                            id: 10,
+                            checksum: 2,
+                            global_seqno: 50,
+                        },
+                        TableDesc {
+                            id: 11,
+                            checksum: 3,
+                            global_seqno: 51,
+                        },
+                    ]],
+                },
+            ],
+            added_blob_files: vec![AddedBlobFile {
+                id: 9,
+                checksum: 0xDEAD_BEEF,
+            }],
+            removed_blob_file_ids: vec![4],
+            gc_stats: Some(vec![0xAB; 20]),
+        }
+    }
+
+    #[test]
+    fn framed_roundtrip_recovers_the_edit() {
+        let edit = sample();
+        let mut buf = Vec::new();
+        let mut scratch = Vec::new();
+        edit.append_to(&mut buf, &mut scratch).expect("append");
+
+        let mut payload = Vec::new();
+        let outcome =
+            framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload).expect("read");
+        assert!(
+            matches!(outcome, framing::FramedRecordOutcome::Ok),
+            "clean record must decode Ok, got {outcome:?}",
+        );
+        let decoded = VersionEdit::decode_payload(&payload).expect("decode");
+        assert_eq!(decoded, edit);
+    }
+
+    #[test]
+    fn empty_level_layout_roundtrips() {
+        // A compaction that drains a level emits an empty-runs ChangedLevel.
+        let mut edit = sample();
+        edit.changed_levels.push(ChangedLevel {
+            level: 2,
+            runs: vec![],
+        });
+        let mut buf = Vec::new();
+        edit.append_to(&mut buf, &mut Vec::new()).expect("append");
+        let mut payload = Vec::new();
+        framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload).expect("read");
+        assert_eq!(VersionEdit::decode_payload(&payload).expect("decode"), edit);
+    }
+
+    #[test]
+    fn empty_gc_stats_roundtrips_as_none() {
+        let mut edit = sample();
+        edit.gc_stats = None;
+        let mut buf = Vec::new();
+        edit.append_to(&mut buf, &mut Vec::new()).expect("append");
+        let mut payload = Vec::new();
+        framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload).expect("read");
+        assert_eq!(VersionEdit::decode_payload(&payload).expect("decode"), edit);
+    }
+
+    #[test]
+    fn truncated_trailing_record_is_detected() {
+        // A power-loss-truncated edit must NOT decode as Ok — replay stops here.
+        let edit = sample();
+        let mut buf = Vec::new();
+        edit.append_to(&mut buf, &mut Vec::new()).expect("append");
+        buf.truncate(buf.len() - 5); // chop the tail
+        let mut payload = Vec::new();
+        let outcome = framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload)
+            .expect("read does not error on truncation");
+        assert!(
+            !matches!(outcome, framing::FramedRecordOutcome::Ok),
+            "truncated record must not be Ok, got {outcome:?}",
+        );
+    }
+
+    #[test]
+    fn bitflip_in_payload_fails_checksum() {
+        let edit = sample();
+        let mut buf = Vec::new();
+        edit.append_to(&mut buf, &mut Vec::new()).expect("append");
+        // Flip a byte in the payload region (past the 12-byte framing header).
+        let last = buf.len() - 1;
+        buf[last] ^= 0xFF;
+        let mut payload = Vec::new();
+        let outcome =
+            framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload).expect("read");
+        assert!(
+            matches!(
+                outcome,
+                framing::FramedRecordOutcome::ChecksumMismatch { .. }
+            ),
+            "bit-flip must surface as ChecksumMismatch, got {outcome:?}",
+        );
+    }
+
+    #[test]
+    fn replay_recovers_all_durable_edits_in_order() {
+        let mut log = Vec::new();
+        let mut scratch = Vec::new();
+        let edits: Vec<VersionEdit> = (0..5)
+            .map(|i| {
+                let mut e = sample();
+                e.new_version_id = 100 + i;
+                e
+            })
+            .collect();
+        for e in &edits {
+            e.append_to(&mut log, &mut scratch).expect("append");
+        }
+        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        assert_eq!(replayed, edits, "replay must recover every edit in order");
+    }
+
+    #[test]
+    fn replay_stops_at_torn_tail_keeping_clean_prefix() {
+        // Two clean edits + a truncated third: replay keeps the first two.
+        let mut log = Vec::new();
+        let mut scratch = Vec::new();
+        let mut e0 = sample();
+        e0.new_version_id = 1;
+        let mut e1 = sample();
+        e1.new_version_id = 2;
+        e0.append_to(&mut log, &mut scratch).expect("append e0");
+        e1.append_to(&mut log, &mut scratch).expect("append e1");
+        let clean_len = log.len();
+        // Append a third edit, then chop its tail (simulated power loss).
+        let mut e2 = sample();
+        e2.new_version_id = 3;
+        e2.append_to(&mut log, &mut scratch).expect("append e2");
+        log.truncate(clean_len + 6); // partial third record
+
+        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        assert_eq!(replayed, vec![e0, e1], "torn tail dropped, prefix kept");
+    }
+
+    #[test]
+    fn replay_stops_at_bitflipped_record() {
+        // A bit-flip in the second record stops replay after the first.
+        let mut log = Vec::new();
+        let mut scratch = Vec::new();
+        let mut e0 = sample();
+        e0.new_version_id = 1;
+        let mut e1 = sample();
+        e1.new_version_id = 2;
+        e0.append_to(&mut log, &mut scratch).expect("append e0");
+        let after_e0 = log.len();
+        e1.append_to(&mut log, &mut scratch).expect("append e1");
+        // Corrupt a payload byte of the second record (past its framing header).
+        let target = after_e0 + framing::FRAME_HEADER_LEN + 2;
+        log[target] ^= 0xFF;
+
+        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        assert_eq!(replayed, vec![e0], "replay stops at the corrupted record");
+    }
+
+    #[test]
+    fn replay_of_empty_log_is_empty() {
+        let replayed = replay_edits(&mut &[][..]).expect("replay");
+        assert!(replayed.is_empty(), "empty log → no edits");
+    }
+
+    #[test]
+    fn decode_rejects_truncated_payload() {
+        let edit = sample();
+        let mut payload = Vec::new();
+        edit.encode_payload(&mut payload).expect("encode");
+        payload.truncate(payload.len() / 2);
+        assert!(
+            matches!(
+                VersionEdit::decode_payload(&payload),
+                Err(crate::Error::InvalidHeader("VersionEdit"))
+            ),
+            "a truncated payload must surface InvalidHeader",
+        );
+    }
+}

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -196,7 +196,10 @@ impl VersionEdit {
                 let mut run = Vec::with_capacity(cap(table_count));
                 for _ in 0..table_count {
                     let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
-                    let _checksum_type = r.read_u8().map_err(|_| ERR)?;
+                    let checksum_type = r.read_u8().map_err(|_| ERR)?;
+                    if checksum_type != CHECKSUM_TYPE_XXH3 {
+                        return Err(ERR);
+                    }
                     let checksum = r.read_u128::<LittleEndian>().map_err(|_| ERR)?;
                     let global_seqno = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
                     run.push(TableDesc {
@@ -214,7 +217,10 @@ impl VersionEdit {
         let mut added_blob_files = Vec::with_capacity(cap(added_blob_count));
         for _ in 0..added_blob_count {
             let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
-            let _checksum_type = r.read_u8().map_err(|_| ERR)?;
+            let checksum_type = r.read_u8().map_err(|_| ERR)?;
+            if checksum_type != CHECKSUM_TYPE_XXH3 {
+                return Err(ERR);
+            }
             let checksum = r.read_u128::<LittleEndian>().map_err(|_| ERR)?;
             added_blob_files.push(AddedBlobFile { id, checksum });
         }
@@ -232,9 +238,18 @@ impl VersionEdit {
             if r.len() < gc_stats_len {
                 return Err(ERR);
             }
-            let (head, _tail) = r.split_at(gc_stats_len);
+            let (head, tail) = r.split_at(gc_stats_len);
+            *r = tail;
             Some(head.to_vec())
         };
+
+        // A well-formed edit consumes its payload exactly. Trailing bytes mean a
+        // corrupt / mis-encoded record (format drift, not power loss — the
+        // framing checksum already passed), so reject rather than silently
+        // accept a truncated interpretation.
+        if !r.is_empty() {
+            return Err(ERR);
+        }
 
         Ok(Self {
             new_version_id,
@@ -488,6 +503,43 @@ mod tests {
     fn replay_of_empty_log_is_empty() {
         let replayed = replay_edits(&mut &[][..]).expect("replay");
         assert!(replayed.is_empty(), "empty log → no edits");
+    }
+
+    #[test]
+    fn decode_rejects_unknown_table_checksum_type() {
+        // Flip the table record's checksum_type byte to a non-XXH3 value: the
+        // framing checksum still matches (we corrupt the decoded payload, not
+        // the wire), so only the in-decode validation can catch it.
+        let edit = sample();
+        let mut payload = Vec::new();
+        edit.encode_payload(&mut payload).expect("encode");
+        // Layout: new_version_id(8) | changed_level_count(4) | level(1) |
+        // run_count(4) | table_count(4) | id(8) | checksum_type(1) | ...
+        let cs_type_off = 8 + 4 + 1 + 4 + 4 + 8;
+        payload[cs_type_off] = 0xEE; // not CHECKSUM_TYPE_XXH3
+        assert!(
+            matches!(
+                VersionEdit::decode_payload(&payload),
+                Err(crate::Error::InvalidHeader("VersionEdit"))
+            ),
+            "an unknown table checksum_type tag must be rejected",
+        );
+    }
+
+    #[test]
+    fn decode_rejects_trailing_garbage() {
+        // A well-formed edit followed by extra bytes is a malformed record.
+        let edit = sample();
+        let mut payload = Vec::new();
+        edit.encode_payload(&mut payload).expect("encode");
+        payload.extend_from_slice(&[0xAB, 0xCD]);
+        assert!(
+            matches!(
+                VersionEdit::decode_payload(&payload),
+                Err(crate::Error::InvalidHeader("VersionEdit"))
+            ),
+            "trailing bytes after a complete edit must be rejected",
+        );
     }
 
     #[test]

--- a/src/version/edit_log.rs
+++ b/src/version/edit_log.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! On-disk edit log for the incremental manifest.
+//!
+//! A manifest generation is a full snapshot (`v{N}`) plus this append-only log
+//! of [`VersionEdit`] records written after it. Each flush / compaction appends
+//! one framed edit and fsyncs, so the structural change is durable before the
+//! operation is acknowledged upward (the engine has no WAL — durability of data
+//! lives a layer above, but the manifest is the crash anchor for the LSM's own
+//! structure). On recovery the snapshot is loaded and the log replayed; a
+//! power-loss-truncated trailing record is dropped (see [`replay_log`]).
+//!
+//! Rotation (writing a fresh snapshot and starting a new log) is driven by
+//! [`log_size`] exceeding a threshold; the snapshot switch is done atomically
+//! via the `CURRENT` pointer (see the recovery / persist layers).
+
+use super::edit::{VersionEdit, replay_edits};
+use crate::fs::{Fs, FsOpenOptions, SyncMode};
+use std::io::{Seek, SeekFrom};
+use std::path::Path;
+
+/// Appends one framed [`VersionEdit`] to the log at `path` (created on first
+/// write) and fsyncs per `sync_mode`, so the edit is durable before the caller
+/// acknowledges the flush / compaction. `scratch` is reused for payload
+/// assembly across calls (no per-edit heap allocation after warm-up).
+///
+/// # Errors
+///
+/// Returns an I/O error if the open, write, or fsync fails, or a framing error
+/// if the edit payload exceeds the record cap.
+pub fn append_edit(
+    fs: &dyn Fs,
+    path: &Path,
+    edit: &VersionEdit,
+    scratch: &mut Vec<u8>,
+    sync_mode: SyncMode,
+) -> crate::Result<()> {
+    let mut file = fs
+        .open(
+            path,
+            &FsOpenOptions::new().write(true).create(true).append(true),
+        )
+        .map_err(crate::Error::Io)?;
+    edit.append_to(&mut file, scratch)?;
+    file.sync_all_with(sync_mode).map_err(crate::Error::Io)?;
+    Ok(())
+}
+
+/// Replays the durable prefix of the log at `path`. An absent log is an empty
+/// edit list (a snapshot with no edits yet). Replay stops at the first
+/// torn / bad-checksum trailing record (see [`replay_edits`]).
+///
+/// # Errors
+///
+/// Returns an I/O error if the open (other than not-found) or a read fails, or
+/// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode.
+pub fn replay_log(fs: &dyn Fs, path: &Path) -> crate::Result<Vec<VersionEdit>> {
+    match fs.open(path, &FsOpenOptions::new().read(true)) {
+        Ok(mut file) => replay_edits(&mut file),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(crate::Error::Io(e)),
+    }
+}
+
+/// Current size of the log at `path` in bytes (`0` if absent). Drives snapshot
+/// rotation: once the log grows past the configured threshold, the next persist
+/// writes a fresh snapshot and starts a new (empty) log.
+///
+/// # Errors
+///
+/// Returns an I/O error if the open (other than not-found) or the seek fails.
+pub fn log_size(fs: &dyn Fs, path: &Path) -> crate::Result<u64> {
+    match fs.open(path, &FsOpenOptions::new().read(true)) {
+        Ok(mut file) => file.seek(SeekFrom::End(0)).map_err(crate::Error::Io),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(e) => Err(crate::Error::Io(e)),
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::super::edit::{ChangedLevel, TableDesc, VersionEdit};
+    use super::*;
+    use crate::fs::StdFs;
+
+    fn edit(id: u64) -> VersionEdit {
+        VersionEdit {
+            new_version_id: id,
+            changed_levels: vec![ChangedLevel {
+                level: 0,
+                runs: vec![vec![TableDesc {
+                    id,
+                    checksum: u128::from(id) * 7,
+                    global_seqno: id * 10,
+                }]],
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn append_then_replay_roundtrips_all_edits() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-0");
+        let mut scratch = Vec::new();
+        let edits: Vec<VersionEdit> = (1..=4).map(edit).collect();
+        for e in &edits {
+            append_edit(&StdFs, &path, e, &mut scratch, SyncMode::Normal).expect("append");
+        }
+        let replayed = replay_log(&StdFs, &path).expect("replay");
+        assert_eq!(replayed, edits, "append+replay must round-trip in order");
+    }
+
+    #[test]
+    fn replay_absent_log_is_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-missing");
+        assert!(replay_log(&StdFs, &path).expect("replay").is_empty());
+        assert_eq!(log_size(&StdFs, &path).expect("size"), 0);
+    }
+
+    #[test]
+    fn torn_tail_record_is_dropped_on_replay() {
+        // Append three edits, then truncate the file mid-third record (simulated
+        // power loss): replay keeps the first two, drops the torn tail.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-torn");
+        let mut scratch = Vec::new();
+        for i in 1..=2 {
+            append_edit(&StdFs, &path, &edit(i), &mut scratch, SyncMode::Normal).expect("append");
+        }
+        let clean = log_size(&StdFs, &path).expect("size");
+        append_edit(&StdFs, &path, &edit(3), &mut scratch, SyncMode::Normal).expect("append");
+
+        // Truncate to a few bytes past the clean prefix → partial third record.
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open");
+        f.set_len(clean + 5).expect("truncate");
+        drop(f);
+
+        let replayed = replay_log(&StdFs, &path).expect("replay");
+        assert_eq!(
+            replayed,
+            vec![edit(1), edit(2)],
+            "torn tail dropped, clean prefix kept",
+        );
+    }
+
+    #[test]
+    fn log_size_grows_with_appends() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-size");
+        let mut scratch = Vec::new();
+        let s0 = log_size(&StdFs, &path).expect("size");
+        append_edit(&StdFs, &path, &edit(1), &mut scratch, SyncMode::Normal).expect("append");
+        let s1 = log_size(&StdFs, &path).expect("size");
+        append_edit(&StdFs, &path, &edit(2), &mut scratch, SyncMode::Normal).expect("append");
+        let s2 = log_size(&StdFs, &path).expect("size");
+        assert_eq!(s0, 0);
+        assert!(s1 > s0 && s2 > s1, "log grows with each appended edit");
+    }
+}

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -3,6 +3,9 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 mod blob_file_list;
+mod diff;
+pub mod edit;
+pub mod edit_log;
 // `framing` uses `std::io::{Read, Write}`. The whole `version`
 // module (recovery, persist, super_version, this file's
 // `Version::encode_into`) is also std-bound today and consumes

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -184,7 +184,7 @@ pub fn get_current_version(
     Ok(version_id)
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct RecoveredTable {
     pub id: TableId,
     pub checksum: Checksum,
@@ -232,6 +232,15 @@ pub struct RecoveryStats {
 #[derive(Debug)]
 pub struct Recovery {
     pub tree_type: TreeType,
+    /// Version id of the on-disk snapshot the `CURRENT` pointer references —
+    /// the base the edit log is replayed on top of. The snapshot file
+    /// `v{snapshot_id}` and its log `edits-{snapshot_id}` are the generation
+    /// that must survive orphan cleanup; intermediate versions live only in the
+    /// log. Equals [`Self::curr_version_id`] when the log is empty (just after a
+    /// rotation) and is `<=` it otherwise.
+    pub snapshot_id: VersionId,
+    /// Version id of the recovered state: the snapshot's id advanced by every
+    /// edit replayed from the log (so the next persist continues from here).
     pub curr_version_id: VersionId,
     pub table_ids: Vec<Vec<Vec<RecoveredTable>>>,
     pub blob_file_ids: Vec<(BlobFileId, Checksum)>,
@@ -263,6 +272,68 @@ pub struct Recovery {
         )
     )]
     pub stats: RecoveryStats,
+}
+
+impl Recovery {
+    /// Applies one edit-log [`VersionEdit`](super::edit::VersionEdit) on top of
+    /// the recovered snapshot state, in place — the consumer side of the
+    /// incremental manifest. Edits are replayed in order after the snapshot to
+    /// reconstruct the current version.
+    ///
+    /// A changed level replaces its run layout wholesale (a dropped table is
+    /// simply absent from the new layout; an emptied level becomes zero runs).
+    /// Blob files take a per-id add / remove (an added id whose entry already
+    /// exists overwrites its checksum). GC stats overwrite when the edit carries
+    /// them. The version id advances to the edit's `new_version_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the edit's GC-stats payload fails to decode.
+    pub(crate) fn apply_edit(&mut self, edit: &super::edit::VersionEdit) -> crate::Result<()> {
+        for cl in &edit.changed_levels {
+            let idx = usize::from(cl.level);
+            if idx >= self.table_ids.len() {
+                self.table_ids.resize_with(idx + 1, Vec::new);
+            }
+            let new_layout = cl
+                .runs
+                .iter()
+                .map(|run| {
+                    run.iter()
+                        .map(|t| RecoveredTable {
+                            id: t.id,
+                            checksum: Checksum::from_raw(t.checksum),
+                            global_seqno: t.global_seqno,
+                        })
+                        .collect()
+                })
+                .collect();
+            // `idx < len` holds: the resize above grew the vec to `idx + 1`.
+            if let Some(slot) = self.table_ids.get_mut(idx) {
+                *slot = new_layout;
+            }
+        }
+
+        if !edit.removed_blob_file_ids.is_empty() {
+            self.blob_file_ids
+                .retain(|(id, _)| !edit.removed_blob_file_ids.contains(id));
+        }
+        for b in &edit.added_blob_files {
+            let checksum = Checksum::from_raw(b.checksum);
+            if let Some(entry) = self.blob_file_ids.iter_mut().find(|(id, _)| *id == b.id) {
+                entry.1 = checksum;
+            } else {
+                self.blob_file_ids.push((b.id, checksum));
+            }
+        }
+
+        if let Some(bytes) = &edit.gc_stats {
+            self.gc_stats = crate::blob_tree::FragmentationMap::decode_from(&mut &bytes[..])?;
+        }
+
+        self.curr_version_id = edit.new_version_id;
+        Ok(())
+    }
 }
 
 #[expect(
@@ -1045,7 +1116,7 @@ pub fn recover(
         }
     };
 
-    Ok(Recovery {
+    let mut recovery = Recovery {
         tree_type: {
             if archive.section("tree_type").is_none() {
                 log::error!(
@@ -1060,6 +1131,7 @@ pub fn recover(
                 .ok_or(crate::Error::InvalidHeader("TreeType"))?;
             TreeType::try_from(byte).map_err(|()| crate::Error::InvalidHeader("TreeType"))?
         },
+        snapshot_id: curr_version_id,
         curr_version_id,
         table_ids: levels,
         blob_file_ids,
@@ -1071,7 +1143,28 @@ pub fn recover(
             blob_dropped_to_tail,
             blob_dropped_to_corruption,
         },
-    })
+    };
+
+    // Replay the incremental edit log layered on top of the snapshot. The log
+    // `edits-{snapshot_id}` holds every VersionEdit appended since the snapshot
+    // was written; applying them in order reconstructs the current version.
+    // `replay_log` returns only the durable prefix — a power-loss-truncated
+    // trailing edit is dropped (it was never acknowledged upward), which is the
+    // same tail-tolerance the snapshot sections already grant. Each applied edit
+    // advances `recovery.curr_version_id` past the snapshot's id.
+    let log_path = folder.join(format!("edits-{curr_version_id}"));
+    let edits = super::edit_log::replay_log(fs, &log_path)?;
+    if !edits.is_empty() {
+        log::info!(
+            "Replaying {} manifest edit(s) on top of snapshot #{curr_version_id}",
+            edits.len(),
+        );
+        for edit in &edits {
+            recovery.apply_edit(edit)?;
+        }
+    }
+
+    Ok(recovery)
 }
 
 #[cfg(test)]
@@ -1082,9 +1175,180 @@ pub fn recover(
 )]
 mod tests {
     use super::*;
+    use crate::coding::Encode;
     use crate::fs::{FsOpenOptions, MemFs};
+    use crate::version::edit::{AddedBlobFile, ChangedLevel, TableDesc, VersionEdit};
     use byteorder::{LittleEndian, WriteBytesExt};
     use std::io::Write;
+
+    /// A snapshot-state `Recovery` with the given level layout and no blobs /
+    /// GC stats — the starting point an edit is applied on top of.
+    fn recovery_with(version_id: u64, table_ids: Vec<Vec<Vec<RecoveredTable>>>) -> Recovery {
+        Recovery {
+            tree_type: TreeType::Standard,
+            snapshot_id: version_id,
+            curr_version_id: version_id,
+            table_ids,
+            blob_file_ids: Vec::new(),
+            gc_stats: crate::blob_tree::FragmentationMap::default(),
+            stats: RecoveryStats::default(),
+        }
+    }
+
+    fn rtable(id: u64, seqno: u64) -> RecoveredTable {
+        RecoveredTable {
+            id,
+            checksum: Checksum::from_raw(u128::from(id) * 31),
+            global_seqno: seqno,
+        }
+    }
+
+    fn tdesc(id: u64, seqno: u64) -> TableDesc {
+        TableDesc {
+            id,
+            checksum: u128::from(id) * 31,
+            global_seqno: seqno,
+        }
+    }
+
+    #[test]
+    fn apply_replaces_a_changed_levels_run_layout_wholesale() {
+        // L0 starts with one run; the edit gives it a two-run layout.
+        let mut rec = recovery_with(1, vec![vec![vec![rtable(1, 10)]]]);
+        let edit = VersionEdit {
+            new_version_id: 2,
+            changed_levels: vec![ChangedLevel {
+                level: 0,
+                runs: vec![vec![tdesc(1, 10)], vec![tdesc(2, 11)]],
+            }],
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+
+        assert_eq!(rec.curr_version_id, 2);
+        assert_eq!(
+            rec.table_ids,
+            vec![vec![vec![rtable(1, 10)], vec![rtable(2, 11)]]],
+            "changed level's run grouping must be reconstructed exactly",
+        );
+    }
+
+    #[test]
+    fn apply_leaves_unmentioned_levels_untouched() {
+        let mut rec = recovery_with(1, vec![vec![vec![rtable(1, 10)]], vec![vec![rtable(9, 5)]]]);
+        // Edit only changes L0; L1 must survive verbatim.
+        let edit = VersionEdit {
+            new_version_id: 2,
+            changed_levels: vec![ChangedLevel {
+                level: 0,
+                runs: vec![vec![tdesc(3, 12)]],
+            }],
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+
+        assert_eq!(rec.table_ids[0], vec![vec![rtable(3, 12)]]);
+        assert_eq!(
+            rec.table_ids[1],
+            vec![vec![rtable(9, 5)]],
+            "a level the edit does not mention is left as-is",
+        );
+    }
+
+    #[test]
+    fn apply_empties_a_drained_level() {
+        let mut rec = recovery_with(1, vec![vec![vec![rtable(1, 10)]]]);
+        let edit = VersionEdit {
+            new_version_id: 2,
+            changed_levels: vec![ChangedLevel {
+                level: 0,
+                runs: vec![],
+            }],
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+        assert!(
+            rec.table_ids[0].is_empty(),
+            "a compaction that drains a level leaves zero runs",
+        );
+    }
+
+    #[test]
+    fn apply_grows_levels_for_a_higher_index() {
+        // Recovery snapshot only has L0; edit targets L2 (compaction output).
+        let mut rec = recovery_with(1, vec![vec![vec![rtable(1, 10)]]]);
+        let edit = VersionEdit {
+            new_version_id: 2,
+            changed_levels: vec![ChangedLevel {
+                level: 2,
+                runs: vec![vec![tdesc(5, 20)]],
+            }],
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+        assert_eq!(rec.table_ids.len(), 3, "levels grew to fit index 2");
+        assert!(rec.table_ids[1].is_empty(), "the gap level is empty");
+        assert_eq!(rec.table_ids[2], vec![vec![rtable(5, 20)]]);
+    }
+
+    #[test]
+    fn apply_adds_updates_and_removes_blob_files() {
+        let mut rec = recovery_with(1, vec![]);
+        rec.blob_file_ids = vec![(100, Checksum::from_raw(1)), (200, Checksum::from_raw(2))];
+        let edit = VersionEdit {
+            new_version_id: 2,
+            added_blob_files: vec![
+                // New blob 300, plus an in-place checksum update of 100.
+                AddedBlobFile {
+                    id: 300,
+                    checksum: 9,
+                },
+                AddedBlobFile {
+                    id: 100,
+                    checksum: 7,
+                },
+            ],
+            removed_blob_file_ids: vec![200],
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+
+        assert!(
+            !rec.blob_file_ids.iter().any(|(id, _)| *id == 200),
+            "removed blob is gone",
+        );
+        assert_eq!(
+            rec.blob_file_ids
+                .iter()
+                .find(|(id, _)| *id == 100)
+                .map(|(_, c)| *c),
+            Some(Checksum::from_raw(7)),
+            "existing blob's checksum updated in place",
+        );
+        assert!(
+            rec.blob_file_ids
+                .iter()
+                .any(|(id, c)| *id == 300 && *c == Checksum::from_raw(9)),
+            "new blob appended",
+        );
+    }
+
+    #[test]
+    fn apply_overwrites_gc_stats_when_present() {
+        let mut rec = recovery_with(1, vec![]);
+        let mut gc = crate::blob_tree::FragmentationMap::default();
+        gc.insert(42, crate::blob_tree::FragmentationEntry::new(2, 50, 60));
+        let mut bytes = Vec::new();
+        gc.encode_into(&mut bytes).expect("encode gc");
+
+        let edit = VersionEdit {
+            new_version_id: 2,
+            gc_stats: Some(bytes),
+            ..Default::default()
+        };
+        rec.apply_edit(&edit).expect("apply");
+        assert_eq!(rec.gc_stats, gc, "GC stats overwritten from the edit");
+    }
 
     /// Write a CURRENT pointer so `recover()` can find the version file.
     ///

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -316,13 +316,28 @@ impl SuperVersions {
         )?;
         self.snapshot_id = next.id();
 
-        // CURRENT now names the new snapshot; the old generation is unreferenced.
-        // Delete its log first (so a crash here can't leave a long log attached
-        // to a snapshot CURRENT no longer points at), then the old snapshot file.
-        // Both removals tolerate a missing file (a prior crash may have raced).
-        remove_if_present(fs, &log_path)?;
+        // The durable commit point of a rotation is the CURRENT repoint inside
+        // `persist_version` above — past it, the rotation has SUCCEEDED. Deleting
+        // the old generation's log + snapshot is pure garbage collection, so it
+        // is best-effort: a failure here must NOT propagate, or the caller
+        // (`upgrade_version_with_seqno`) would skip `append_version` /
+        // `fetch_max` and keep stale in-memory state while CURRENT already names
+        // the new snapshot — an on-disk/in-memory divergence. A leaked old file
+        // is harmless and swept by `cleanup_orphaned_version` on the next open.
+        if let Err(e) = remove_if_present(fs, &log_path) {
+            log::warn!(
+                "rotation: failed to remove old edit log {}: {e}",
+                log_path.display()
+            );
+        }
         if old_snapshot != self.snapshot_id {
-            remove_if_present(fs, &tree_path.join(format!("v{old_snapshot}")))?;
+            let old_path = tree_path.join(format!("v{old_snapshot}"));
+            if let Err(e) = remove_if_present(fs, &old_path) {
+                log::warn!(
+                    "rotation: failed to remove old snapshot {}: {e}",
+                    old_path.display()
+                );
+            }
         }
         Ok(())
     }

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -491,6 +491,53 @@ mod tests {
     }
 
     #[test]
+    fn super_version_gc_preserves_current_snapshot_file() -> crate::Result<()> {
+        // The CURRENT snapshot file must survive GC even when its in-memory
+        // version is evicted from the history — `CURRENT` still points at it and
+        // the edit log layers on top. Set snapshot_id to a seeded v{id} that GC
+        // will evict, and assert its file stays while a non-snapshot evictee is
+        // removed.
+        let fs = MemFs::new();
+        let dir = Path::new("/gc/snapshot");
+        let mut history = test_super_versions(vec![
+            SuperVersion {
+                active_memtable: Arc::new(new_memtable(0)),
+                sealed_memtables: Arc::default(),
+                version: Version::new(1, crate::TreeType::Standard),
+                seqno: 0,
+            },
+            SuperVersion {
+                active_memtable: Arc::new(new_memtable(0)),
+                sealed_memtables: Arc::default(),
+                version: Version::new(2, crate::TreeType::Standard),
+                seqno: 1,
+            },
+            SuperVersion {
+                active_memtable: Arc::new(new_memtable(0)),
+                sealed_memtables: Arc::default(),
+                version: Version::new(3, crate::TreeType::Standard),
+                seqno: 2,
+            },
+        ]);
+        // CURRENT points at v1 (the snapshot the edit log is layered on).
+        history.snapshot_id = 1;
+        seed_version_files(dir, &history, &fs)?;
+
+        // Watermark 3 evicts v1 (seqno 0) and v2 (seqno 1) from the history.
+        history.maintenance(dir, 3, &fs)?;
+
+        assert!(
+            fs.exists(&dir.join("v1"))?,
+            "the CURRENT snapshot file must NOT be GC'd even when its version is evicted"
+        );
+        assert!(
+            !fs.exists(&dir.join("v2"))?,
+            "a non-snapshot evicted version's file is still removed"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn super_version_gc_below_watermark_simple() -> crate::Result<()> {
         let fs = MemFs::new();
         let dir = Path::new("/gc/simple");

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -8,8 +8,18 @@ use crate::{
     fs::{Fs, SyncMode},
     memtable::Memtable,
     tree::sealed::SealedMemtables,
-    version::{Version, persist_version},
+    version::{Version, VersionId, edit_log, persist_version},
 };
+
+/// Removes `path`, treating an already-absent file as success — a prior crash
+/// (or a racing rotation) may have removed it already.
+fn remove_if_present(fs: &dyn Fs, path: &Path) -> crate::Result<()> {
+    match fs.remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
 #[cfg(feature = "std")]
 use arc_swap::ArcSwap;
 use std::{collections::VecDeque, path::Path, sync::Arc};
@@ -40,6 +50,19 @@ pub struct SuperVersions {
     /// version persist this history performs. Immutable for the tree's life.
     sync_mode: SyncMode,
 
+    /// Version id of the on-disk snapshot the `CURRENT` pointer references. Each
+    /// version upgrade appends a [`VersionEdit`](crate::version::edit::VersionEdit)
+    /// to the log `edits-{snapshot_id}` instead of rewriting the whole manifest;
+    /// once that log grows past [`Self::log_rotate_bytes`] the next upgrade
+    /// rotates — writes a fresh snapshot, repoints `CURRENT`, starts an empty
+    /// log — and this id advances to the new snapshot's.
+    snapshot_id: VersionId,
+
+    /// Edit-log size (bytes) past which the next upgrade rotates instead of
+    /// appending (`Config::manifest_log_rotate_bytes`, default 1 MiB). Immutable
+    /// for the tree's life.
+    log_rotate_bytes: u64,
+
     /// Lock-free mirror of the latest (back) `SuperVersion`, shared with the
     /// `Tree` so a point read at `MAX_SEQNO` can load the current snapshot
     /// without taking the history `RwLock` or cloning the deque entry. Kept
@@ -58,7 +81,18 @@ pub struct SuperVersions {
 }
 
 impl SuperVersions {
-    pub fn new(version: Version, comparator: &SharedComparator, sync_mode: SyncMode) -> Self {
+    /// Builds the in-memory version history. `snapshot_id` is the version id of
+    /// the on-disk snapshot `CURRENT` points at — `version.id()` on a fresh
+    /// create (the first persist writes that snapshot), or the recovered
+    /// snapshot id on open (which may be `< version.id()` when edits were
+    /// replayed on top of it).
+    pub fn new(
+        version: Version,
+        comparator: &SharedComparator,
+        sync_mode: SyncMode,
+        snapshot_id: VersionId,
+        log_rotate_bytes: u64,
+    ) -> Self {
         let comparator_name: Arc<str> = comparator.name().into();
 
         let initial = SuperVersion {
@@ -74,6 +108,8 @@ impl SuperVersions {
             versions: vec![initial].into(),
             comparator_name,
             sync_mode,
+            snapshot_id,
+            log_rotate_bytes,
         }
     }
 
@@ -125,17 +161,24 @@ impl SuperVersions {
                     break;
                 };
 
-                log::trace!(
-                    "Removing version #{} (seqno={})",
-                    head.version.id(),
-                    head.seqno,
-                );
+                let evicted_id = head.version.id();
+                log::trace!("Removing version #{evicted_id} (seqno={})", head.seqno);
 
-                let path = folder.join(format!("v{}", head.version.id()));
-                match fs.remove_file(&path) {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(e.into()),
+                // Under the incremental manifest only the CURRENT snapshot has a
+                // `v{id}` file on disk; intermediate versions live in the edit
+                // log and have no file (so removing them is a no-op NotFound).
+                // The snapshot file must NOT be removed here even when its
+                // in-memory version is evicted from the history — `CURRENT` still
+                // points at it and the log layers on top. Its lifecycle belongs
+                // to rotation (which writes the next snapshot and deletes the old
+                // one only after `CURRENT` is repointed).
+                if evicted_id != self.snapshot_id {
+                    let path = folder.join(format!("v{evicted_id}"));
+                    match fs.remove_file(&path) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => return Err(e.into()),
+                    }
                 }
 
                 self.versions.pop_front();
@@ -207,18 +250,18 @@ impl SuperVersions {
         runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
         encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
     ) -> crate::Result<()> {
-        let mut next_version = f(&self.latest_version())?;
+        let prior = self.latest_version();
+        let mut next_version = f(&prior)?;
         next_version.seqno = seqno;
         log::trace!("Next version seqno={}", next_version.seqno);
 
-        persist_version(
+        self.persist_change(
             tree_path,
+            &prior.version,
             &next_version.version,
-            &self.comparator_name,
             fs,
             runtime,
             encryption,
-            self.sync_mode,
         )?;
         self.append_version(next_version);
 
@@ -226,6 +269,61 @@ impl SuperVersions {
         let next_visible = seqno.saturating_add(1).min(MAX_SEQNO);
         visible_seqno.fetch_max(next_visible);
 
+        Ok(())
+    }
+
+    /// Persists the transition from `prior` to `next` to disk, durably, the
+    /// incremental way: append one [`VersionEdit`](crate::version::edit::VersionEdit)
+    /// to the current snapshot's log (the common, O(changed-levels) path), or
+    /// rotate when that log has grown past [`Self::log_rotate_bytes`].
+    ///
+    /// Rotation writes a fresh full snapshot for `next`, fsyncs it, and atomically
+    /// repoints `CURRENT` (all inside [`persist_version`]); only after `CURRENT`
+    /// commits does it delete the previous snapshot file and its log. Crash points:
+    /// before the `CURRENT` switch, `CURRENT` still names the old snapshot and its
+    /// log is intact (recover old + replay); after the switch, the new snapshot is
+    /// complete and its log is empty (recover new, no edits). A torn trailing edit
+    /// from an interrupted append is dropped on replay — the operation that wrote
+    /// it was never acknowledged upward.
+    fn persist_change(
+        &mut self,
+        tree_path: &Path,
+        prior: &Version,
+        next: &Version,
+        fs: &dyn Fs,
+        runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
+        encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+    ) -> crate::Result<()> {
+        let log_path = tree_path.join(format!("edits-{}", self.snapshot_id));
+
+        if edit_log::log_size(fs, &log_path)? < self.log_rotate_bytes {
+            // Common path: append the delta and fsync. No snapshot rewrite.
+            let edit = next.diff(prior)?;
+            let mut scratch = Vec::new();
+            return edit_log::append_edit(fs, &log_path, &edit, &mut scratch, self.sync_mode);
+        }
+
+        // Rotation: write `next` as a fresh full snapshot and repoint CURRENT.
+        let old_snapshot = self.snapshot_id;
+        persist_version(
+            tree_path,
+            next,
+            &self.comparator_name,
+            fs,
+            runtime,
+            encryption,
+            self.sync_mode,
+        )?;
+        self.snapshot_id = next.id();
+
+        // CURRENT now names the new snapshot; the old generation is unreferenced.
+        // Delete its log first (so a crash here can't leave a long log attached
+        // to a snapshot CURRENT no longer points at), then the old snapshot file.
+        // Both removals tolerate a missing file (a prior crash may have raced).
+        remove_if_present(fs, &log_path)?;
+        if old_snapshot != self.snapshot_id {
+            remove_if_present(fs, &tree_path.join(format!("v{old_snapshot}")))?;
+        }
         Ok(())
     }
 
@@ -332,6 +430,8 @@ mod tests {
             versions: versions.into(),
             comparator_name: "default".into(),
             sync_mode: SyncMode::Normal,
+            snapshot_id: 0,
+            log_rotate_bytes: 1024 * 1024,
             #[cfg(feature = "std")]
             latest,
         }

--- a/tests/tree_recovery_versions.rs
+++ b/tests/tree_recovery_versions.rs
@@ -234,6 +234,13 @@ fn tree_rejects_unsupported_manifest_version() -> lsm_tree::Result<()> {
 
 #[test]
 fn tree_recovery_version_free_list() -> lsm_tree::Result<()> {
+    // Under the incremental manifest a version upgrade appends a VersionEdit to
+    // the snapshot's `edits-{snapshot_id}` log rather than writing a full
+    // `v{id}` per version. So only the snapshot file (`v0`, which CURRENT points
+    // at) exists on disk; intermediate versions live in the log. The in-memory
+    // free list still tracks every version for MVCC. On reopen the snapshot is
+    // loaded and the log replayed, and orphan-cleanup keeps exactly that one
+    // snapshot generation (`v0` + `edits-0`).
     let folder = get_tmp_folder();
 
     let path = folder.path();
@@ -245,17 +252,31 @@ fn tree_recovery_version_free_list() -> lsm_tree::Result<()> {
             SequenceNumberCounter::default(),
         )
         .open()?;
-        assert!(path.join("v0").try_exists()?);
+        assert!(
+            path.join("v0").try_exists()?,
+            "create writes the v0 snapshot"
+        );
 
         tree.insert("a", "a", 0);
         tree.flush_active_memtable(0)?;
         assert_eq!(1, tree.version_free_list_len());
-        assert!(path.join("v1").try_exists()?);
+        // The flush appended an edit to the log, not a new snapshot file.
+        assert!(
+            path.join("edits-0").try_exists()?,
+            "first upgrade appends to the snapshot's edit log"
+        );
+        assert!(
+            !path.join("v1").try_exists()?,
+            "no per-version snapshot file is written on append"
+        );
 
         tree.insert("b", "b", 0);
         tree.flush_active_memtable(0)?;
         assert_eq!(2, tree.version_free_list_len());
-        assert!(path.join("v2").try_exists()?);
+        assert!(
+            !path.join("v2").try_exists()?,
+            "second upgrade also appends, no v2 snapshot"
+        );
     }
 
     {
@@ -266,12 +287,160 @@ fn tree_recovery_version_free_list() -> lsm_tree::Result<()> {
         )
         .open()?;
         assert_eq!(0, tree.version_free_list_len());
-        assert!(!path.join("v0").try_exists()?);
+        // CURRENT still points at the v0 snapshot, with its edit log layered on
+        // top — both survive orphan cleanup; there is no v1/v2 to clean.
+        assert!(
+            path.join("v0").try_exists()?,
+            "the snapshot CURRENT references is preserved across reopen"
+        );
+        assert!(
+            path.join("edits-0").try_exists()?,
+            "its edit log is preserved"
+        );
         assert!(!path.join("v1").try_exists()?);
-        assert!(path.join("v2").try_exists()?);
+        assert!(!path.join("v2").try_exists()?);
 
+        // The replayed edits reconstruct both flushed tables.
         assert!(tree.contains_key("a", 1)?);
         assert!(tree.contains_key("b", 1)?);
+    }
+
+    Ok(())
+}
+
+/// Crash safety of the incremental manifest: a power-loss-truncated trailing
+/// edit in the log is dropped on recovery, and the tree recovers exactly the
+/// durable prefix — the state after the last fully-fsynced edit.
+///
+/// Two flushes append two edits to `edits-0`. Truncating the file mid-second
+/// record simulates a crash between the second flush's edit being partially
+/// written and its fsync completing. On reopen the snapshot (`v0`, empty) plus
+/// the first edit are replayed; the torn second edit is discarded. So `a` (first
+/// flush) is present and `b` (second flush) is gone — the second flush was never
+/// durably committed to the manifest, which is the contract: an unacknowledged
+/// write may be lost, but the recovered state is always internally consistent.
+#[test]
+fn tree_recovers_durable_prefix_when_edit_log_tail_is_torn() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+
+    let clean_after_first;
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        tree.insert("a", "a", 0);
+        tree.flush_active_memtable(0)?;
+        // Size of the log after exactly one durable edit — the boundary the torn
+        // tail must collapse back to.
+        clean_after_first = std::fs::metadata(path.join("edits-0"))?.len();
+
+        tree.insert("b", "b", 1);
+        tree.flush_active_memtable(1)?;
+    }
+
+    // The second edit made the log strictly longer; chop part of it off so the
+    // trailing record is incomplete (a framing-checksum / truncation failure on
+    // replay, not a clean record boundary).
+    let full = std::fs::metadata(path.join("edits-0"))?.len();
+    assert!(
+        full > clean_after_first,
+        "second flush must have appended a second edit ({full} > {clean_after_first})"
+    );
+    let torn_len = clean_after_first + (full - clean_after_first) / 2;
+    let log = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path.join("edits-0"))?;
+    log.set_len(torn_len)?;
+    log.sync_all()?;
+    drop(log);
+
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        assert!(
+            tree.contains_key("a", 2)?,
+            "the first flush's edit was durable — its key must survive"
+        );
+        assert!(
+            !tree.contains_key("b", 2)?,
+            "the second flush's edit was torn off — its key must be dropped"
+        );
+    }
+
+    Ok(())
+}
+
+/// Rotation: with a tiny rotate threshold every upgrade after the first writes
+/// a fresh full snapshot, repoints CURRENT, and garbage-collects the previous
+/// snapshot + its edit log — leaving exactly one live `v{id}` generation. After
+/// several rotating flushes the tree reopens cleanly and all keys read back.
+///
+/// `manifest_log_rotate_bytes(0)` forces a rotation on every upgrade (any
+/// non-empty log already exceeds 0), so this exercises the rotation path — and
+/// its old-generation cleanup — cheaply, without writing a megabyte of edits.
+#[test]
+fn tree_rotates_snapshot_and_gcs_old_generation() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .manifest_log_rotate_bytes(0)
+        .open()?;
+
+        // Threshold 0 means `log_size < 0` is never true, so every upgrade takes
+        // the rotation branch. Each rotation must leave only one snapshot file.
+        for i in 0u64..4 {
+            tree.insert(format!("k{i}"), format!("v{i}"), i);
+            tree.flush_active_memtable(i)?;
+
+            // Exactly one `v{id}` snapshot file exists at any time after a
+            // rotation (the old one is deleted once CURRENT is repointed).
+            let snapshots = std::fs::read_dir(path)?
+                .filter_map(Result::ok)
+                .filter(|e| {
+                    let n = e.file_name();
+                    let n = n.to_string_lossy();
+                    n.starts_with('v') && n[1..].bytes().all(|c| c.is_ascii_digit())
+                })
+                .count();
+            assert_eq!(
+                snapshots, 1,
+                "rotation must leave exactly one live snapshot file after flush {i}"
+            );
+        }
+    }
+
+    // Reopen: the single surviving snapshot is the full current state (its log is
+    // empty just after a rotation), so every key reads back.
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0u64..4 {
+            assert_eq!(
+                Some(format!("v{i}").as_bytes().into()),
+                tree.get(format!("k{i}"), 100)?,
+                "key k{i} must survive rotation + reopen"
+            );
+        }
     }
 
     Ok(())

--- a/tests/tree_recovery_versions.rs
+++ b/tests/tree_recovery_versions.rs
@@ -399,11 +399,12 @@ fn tree_rotates_snapshot_and_gcs_old_generation() -> lsm_tree::Result<()> {
             SequenceNumberCounter::default(),
             SequenceNumberCounter::default(),
         )
-        .manifest_log_rotate_bytes(0)
+        // Threshold 1: the first upgrade appends (log 0 < 1), the next rotates
+        // (log now > 1), and so on — so the run alternates append / rotate and
+        // every rotation must clean the previous generation's snapshot AND log.
+        .manifest_log_rotate_bytes(1)
         .open()?;
 
-        // Threshold 0 means `log_size < 0` is never true, so every upgrade takes
-        // the rotation branch. Each rotation must leave only one snapshot file.
         for i in 0u64..4 {
             tree.insert(format!("k{i}"), format!("v{i}"), i);
             tree.flush_active_memtable(i)?;
@@ -421,6 +422,25 @@ fn tree_rotates_snapshot_and_gcs_old_generation() -> lsm_tree::Result<()> {
             assert_eq!(
                 snapshots, 1,
                 "rotation must leave exactly one live snapshot file after flush {i}"
+            );
+
+            // The other half of the generation-GC contract: a rotation deletes
+            // the previous snapshot's edit log. At most one `edits-*` may exist
+            // at any point (the current snapshot's, present after an append and
+            // gone right after a rotate). A rotation that leaked old logs would
+            // accumulate them and trip this bound.
+            let edit_logs = std::fs::read_dir(path)?
+                .filter_map(Result::ok)
+                .filter(|e| {
+                    let n = e.file_name();
+                    let n = n.to_string_lossy();
+                    n.strip_prefix("edits-")
+                        .is_some_and(|rest| rest.bytes().all(|c| c.is_ascii_digit()))
+                })
+                .count();
+            assert!(
+                edit_logs <= 1,
+                "at most one edit log may exist; leaked old logs after flush {i} (found {edit_logs})"
             );
         }
     }


### PR DESCRIPTION
## Summary

Replaces the full-manifest-rewrite-per-version with a **snapshot + append-only edit log** model. The old path serialized **every SST** into a new `v{id}` file on every flush and compaction (`O(all-SSTs)`); the new path appends one framed `VersionEdit` describing only the changed levels (`O(changed-levels)`), rotating to a fresh snapshot only when the log passes a configurable threshold.

This closes the second-largest overwrite/flush perf gap (the per-flush manifest cost that grows with the number of SSTs).

## How it works

- A manifest generation = full snapshot `v{snapshot_id}` + append-only `edits-{snapshot_id}` log of `VersionEdit` deltas.
- Each version upgrade appends one edit and fsyncs. Once the log passes `Config::manifest_log_rotate_bytes` (default 1 MiB) the next upgrade rotates: writes a fresh snapshot, repoints `CURRENT` atomically, then deletes the previous snapshot + log. `CURRENT` only changes on rotation.
- A `VersionEdit` carries the **full new run layout** of every changed level (`ChangedLevel { level, runs }`) — run grouping is load-bearing for recovery, so a flat add/remove-id delta would lose it. Table removal is implicit; blob files keep a per-id delta.
- Every record is framed (`len + xxh3_64 + payload`); a power-loss-truncated or bit-flipped trailing edit is detected and dropped on replay.
- Recovery loads the snapshot `CURRENT` names, replays its log, applies each edit. The durable prefix is always recovered: a torn trailing edit (unacknowledged write) is dropped, and any prefix is internally consistent (edits apply in order and reference tables fsynced before their edit landed).
- Orphan cleanup preserves `v{snapshot_id}` + `edits-{snapshot_id}` and sweeps any `v*`/`edits-*` a crashed rotation leaked; manifest GC no longer deletes the live snapshot; `repair` drops any stale edit log so its rebuilt snapshot is a clean standalone generation.

## Performance (local ours-vs-ours, 300 small flushes, ×2)

| metric | main | this branch | delta |
|---|---|---|---|
| total | ~316 ms | ~219 ms | **−31%** |
| median flush | ~975 µs | ~653 µs | **−33%** |
| p99 flush | ~1.71 ms | ~1.41 ms | **−18%** |

Per-flush manifest cost drops ~33%; the gain scales with the number of SSTs the old full-rewrite had to serialize. Authoritative vs-RocksDB numbers come from the CI `compare-rocksdb` overwrite benchmark / dashboard.

## On-disk format

V5 is pre-release and amended in-place, so no format-version bump. No breaking change for any released version.

## Testing

- New: torn-edit-log-tail crash recovery (durable-prefix contract), snapshot rotation + old-generation GC, append-model version-file lifecycle, diff/apply unit coverage (run-layout reconstruction, blob add/update/remove, GC overwrite).
- Full regression green locally: 1118 lib unit + recovery/reopen + compaction/blob/ingest + repair/checkpoint + zstd + tree/mvcc suites. `clippy --all-features` (lib + tests) clean.

Refs #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable manifest log-rotation threshold and incremental edit logging for manifests.

* **Improvements**
  * Recovery replays incremental edit logs on top of snapshots and preserves the on-disk CURRENT snapshot during GC.
  * Orphan cleanup now removes leaked snapshot manifests and stale edit logs while keeping the live snapshot’s files.
  * Manifest persistence now rotates to full snapshots when logs exceed the configured threshold.

* **Bug Fixes**
  * Repair now removes stale per-snapshot edit logs (tolerating missing files) to avoid leftover edits.

* **Tests**
  * New tests for edit-log replay, torn-tail handling, snapshot rotation, and GC behavior.

* **Chores**
  * Updated structured-zstd dependency to 0.0.33.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->