### PR TITLE
test(compare): add surrealkv as a third bench engine

### DIFF
--- a/tools/compare-rocksdb/Cargo.toml
+++ b/tools/compare-rocksdb/Cargo.toml
@@ -32,6 +32,15 @@ lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["zstd"
 # C-toolchain compile burden scales with the codecs the workloads
 # actually need (a future `*_lz4` variant adds rocksdb's `lz4`).
 rocksdb = { version = "0.24", default-features = false, features = ["zstd"] }
+# SurrealKV — pure-Rust embedded LSM/MVCC store, the Rust-native
+# comparison point. Not published to crates.io, so pinned to a git tag
+# for reproducibility. No FFI / libclang burden (unlike rocksdb).
+surrealkv = { git = "https://github.com/surrealdb/surrealkv", tag = "v0.21.2" }
+# SurrealKV needs a tokio runtime: its `build()` spawns background
+# compaction tasks via `tokio::spawn`, and `commit()` is async. The
+# criterion harness is sync, so each surrealkv arm owns a multi-thread
+# runtime and drives open / commit through `rt.block_on`.
+tokio = { version = "1", features = ["rt-multi-thread"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 

--- a/tools/compare-rocksdb/Cargo.toml
+++ b/tools/compare-rocksdb/Cargo.toml
@@ -35,7 +35,11 @@ rocksdb = { version = "0.24", default-features = false, features = ["zstd"] }
 # SurrealKV — pure-Rust embedded LSM/MVCC store, the Rust-native
 # comparison point. Not published to crates.io, so pinned to a git tag
 # for reproducibility. No FFI / libclang burden (unlike rocksdb).
-surrealkv = { git = "https://github.com/surrealdb/surrealkv", tag = "v0.21.2" }
+# Pinned to the exact commit behind tag v0.21.2. The repo gitignores
+# Cargo.lock, so a bare `tag = "v0.21.2"` could silently resolve to a
+# different commit if the tag were ever retargeted — `rev` makes the
+# benchmark dependency reproducible.
+surrealkv = { git = "https://github.com/surrealdb/surrealkv", rev = "d7e85669f59493c9501adcf0289e497ee206ffae" } # v0.21.2
 # SurrealKV needs a tokio runtime: its `build()` spawns background
 # compaction tasks via `tokio::spawn`, and `commit()` is async. The
 # criterion harness is sync, so each surrealkv arm owns a multi-thread

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -162,6 +162,23 @@ fn populate_surrealkv(
     Ok(tree)
 }
 
+/// Builds a warm, on-disk SurrealKV tree for the read / scan / seek / overwrite
+/// groups: a tokio runtime plus a tree already populated and fsynced. Returns
+/// both so the caller binds them as `let (rt, tree) = ...` — the runtime drops
+/// LAST (after the tree), keeping its background compaction tasks alive for the
+/// whole timed read phase. Fallible end-to-end so the open/begin/set/commit I/O
+/// path propagates errors; the caller panics once with the engine label at the
+/// Criterion closure boundary (which cannot itself return `Result`), mirroring
+/// how `run_write_throughput` surfaces failures.
+fn setup_surrealkv_warm(
+    dir: &std::path::Path,
+    inputs: &WorkloadInputs,
+) -> Result<(tokio::runtime::Runtime, SkvTree), Box<dyn std::error::Error>> {
+    let rt = skv_runtime()?;
+    let tree = populate_surrealkv(&rt, dir, inputs)?;
+    Ok((rt, tree))
+}
+
 /// Engine under test. The harness runs each workload once per
 /// variant and emits per-engine timings under the same criterion
 /// `BenchmarkGroup`, so the gh-pages dashboard can plot them
@@ -636,9 +653,8 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                     Engine::SurrealKv => {
                         // `rt` outlives `tree` (drops last) so its background
                         // tasks keep running for the whole read phase.
-                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
-                            .expect("surrealkv: populate");
+                        let (_rt, tree) = setup_surrealkv_warm(dir.path(), &inputs)
+                            .unwrap_or_else(|e| panic!("surrealkv: warm setup: {e}"));
                         // One read snapshot, reused across all iterations — the
                         // closest analogue of the other engines' direct warm
                         // reads (a single consistent view, no per-get txn churn).
@@ -752,9 +768,8 @@ fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compress
                         });
                     }
                     Engine::SurrealKv => {
-                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
-                            .expect("surrealkv: populate");
+                        let (_rt, tree) = setup_surrealkv_warm(dir.path(), &inputs)
+                            .unwrap_or_else(|e| panic!("surrealkv: warm setup: {e}"));
                         let txn = tree.begin().expect("surrealkv: begin");
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
@@ -834,9 +849,8 @@ fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compres
                         });
                     }
                     Engine::SurrealKv => {
-                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
-                            .expect("surrealkv: populate");
+                        let (_rt, tree) = setup_surrealkv_warm(dir.path(), &inputs)
+                            .unwrap_or_else(|e| panic!("surrealkv: warm setup: {e}"));
                         let txn = tree.begin().expect("surrealkv: begin");
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
@@ -922,9 +936,8 @@ fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compressi
                             Engine::SurrealKv => {
                                 // First copy (untimed) so the timed pass
                                 // overwrites existing keys.
-                                let rt = skv_runtime().expect("surrealkv: tokio runtime");
-                                let tree = populate_surrealkv(&rt, dir.path(), &inputs)
-                                    .expect("surrealkv: populate");
+                                let (rt, tree) = setup_surrealkv_warm(dir.path(), &inputs)
+                                    .unwrap_or_else(|e| panic!("surrealkv: warm setup: {e}"));
                                 let start = std::time::Instant::now();
                                 let mut txn = tree.begin().expect("surrealkv: begin");
                                 for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -36,8 +36,10 @@
 //! The shared workload closure is parameterised over an [`Engine`]
 //! enum so the per-engine glue (open, put, get, flush, close) lives
 //! in exactly one place per engine and the workload code stays
-//! engine-agnostic. Adding a third engine (Pebble, LevelDB,
-//! sled, …) is "add a variant + match arm" — no workload rewrite.
+//! engine-agnostic. Three engines today: `ours`, `rocksdb`, and
+//! `surrealkv` (pure-Rust embedded LSM/MVCC). SurrealKV has no zstd
+//! codec, so it overlays ONLY on the `None`-compression groups (see
+//! [`engines_for`]); the `_zstd22` groups stay ours-vs-rocksdb.
 //!
 //! ## Compression axis + cross-engine overlay
 //!
@@ -49,11 +51,12 @@
 //! pinned to level 22 — so the no-compression and high-ratio paths sit
 //! side-by-side on the dashboard.
 //!
-//! Within each group both engines run in the SAME process and the SAME
-//! invocation, so criterion plots them as an overlay (ours vs rocksdb)
-//! on one chart. Because the comparison is a ratio measured on one host
-//! in one run, it stays meaningful even if the bench host's CPU changes
-//! between runs — the absolute numbers move, the relative gap does not.
+//! Within each group every engine runs in the SAME process and the SAME
+//! invocation, so criterion plots them as an overlay (ours vs rocksdb,
+//! plus surrealkv on the `None` groups) on one chart. Because the
+//! comparison is a ratio measured on one host in one run, it stays
+//! meaningful even if the bench host's CPU changes between runs — the
+//! absolute numbers move, the relative gap does not.
 //!
 //! ## Workload coverage
 //!
@@ -93,6 +96,65 @@ use lsm_tree::{
     AbstractTree, CompressionType, Config, Guard, MAX_SEQNO, SequenceNumberCounter,
     config::CompressionPolicy,
 };
+use surrealkv::{
+    Durability as SkvDurability, LSMIterator as _, Options as SkvOptions, Tree as SkvTree,
+    TreeBuilder as SkvTreeBuilder,
+};
+
+/// Full-keyspace scan bounds for SurrealKV's `range(start, end)` (start
+/// inclusive, end exclusive). Keys are 16-byte big-endian; a 17-byte all-`0xFF`
+/// upper bound sorts after every 16-byte key, so the half-open range covers the
+/// whole keyspace.
+const SKV_MIN_KEY: &[u8] = &[0u8; 16];
+const SKV_MAX_KEY: &[u8] = &[0xFFu8; 17];
+
+/// A multi-thread tokio runtime for SurrealKV. Each surrealkv bench arm owns
+/// one for its whole duration: `build()` spawns background compaction tasks via
+/// `tokio::spawn` (so it must run inside a runtime context, here via
+/// `block_on`), and those tasks need worker threads to keep running while the
+/// tree is read. The runtime must outlive the tree.
+fn skv_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().expect("surrealkv: tokio runtime")
+}
+
+/// Opens a fresh SurrealKV tree at `dir` on `rt`. Compression is left at the
+/// default (`None`) — SurrealKV has no zstd, and it only runs in the
+/// None-compression groups (see [`engines_for`]). `build()` is sync but spawns
+/// background tasks, so it runs inside `rt.block_on` to see the runtime.
+fn open_surrealkv(rt: &tokio::runtime::Runtime, dir: &std::path::Path) -> SkvTree {
+    let path = dir.to_path_buf();
+    rt.block_on(async move {
+        let opts = SkvOptions::new().with_path(path);
+        SkvTreeBuilder::with_options(opts).build()
+    })
+    .expect("surrealkv: open")
+}
+
+/// Populates a SurrealKV tree with `inputs` in a single write transaction and
+/// commits with `Immediate` durability (fsync) — the flush-to-disk equivalent
+/// of `ours`' `flush_active_memtable` / rocksdb's `flush`, so the warm-read
+/// groups start from an on-disk state. `commit()` is async; driven via
+/// `rt.block_on`.
+///
+/// NOTE: SurrealKV is versioned/MVCC — a single committed write per key here, so
+/// there is no extra version history, but its write path still carries MVCC
+/// bookkeeping the flat-LSM engines do not. Read this in the comparison as
+/// "Rust-native LSM with MVCC semantics", not a byte-for-byte equivalent setup.
+fn populate_surrealkv(
+    rt: &tokio::runtime::Runtime,
+    dir: &std::path::Path,
+    inputs: &WorkloadInputs,
+) -> SkvTree {
+    let tree = open_surrealkv(rt, dir);
+    let mut txn = tree.begin().expect("surrealkv: begin");
+    for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
+        txn.set(key.as_slice(), value.as_slice())
+            .expect("surrealkv: set");
+    }
+    txn.set_durability(SkvDurability::Immediate);
+    rt.block_on(txn.commit()).expect("surrealkv: commit");
+    tree
+}
 
 /// Engine under test. The harness runs each workload once per
 /// variant and emits per-engine timings under the same criterion
@@ -102,6 +164,10 @@ use lsm_tree::{
 enum Engine {
     Ours,
     RocksDb,
+    /// SurrealKV — pure-Rust embedded LSM/MVCC store. No zstd codec
+    /// (only None / Snappy), so it participates ONLY in the
+    /// None-compression (codec-neutral) groups — see [`engines_for`].
+    SurrealKv,
 }
 
 impl Engine {
@@ -109,7 +175,22 @@ impl Engine {
         match self {
             Self::Ours => "ours",
             Self::RocksDb => "rocksdb",
+            Self::SurrealKv => "surrealkv",
         }
+    }
+}
+
+/// Engines to overlay for a given compression variant.
+///
+/// SurrealKV has no zstd codec (its `CompressionType` is `None` / `Snappy`
+/// only), so it cannot match the `Zstd22` variant apples-to-apples — adding a
+/// non-zstd line to a zstd22 graph would misrepresent the comparison. It is
+/// therefore restricted to the `None`-compression groups, where all three
+/// engines run codec-neutral. The `_zstd22` groups stay ours-vs-rocksdb.
+fn engines_for(compression: Compression) -> &'static [Engine] {
+    match compression {
+        Compression::None => &[Engine::Ours, Engine::RocksDb, Engine::SurrealKv],
+        Compression::Zstd22 => &[Engine::Ours, Engine::RocksDb],
     }
 }
 
@@ -340,6 +421,20 @@ fn run_write_throughput(
             // work doesn't leak into the timed window.
             start.elapsed()
         }
+        Engine::SurrealKv => {
+            // One write transaction, committed with Immediate durability
+            // (fsync) — the flush barrier equivalent of the other engines'
+            // terminal flush. `commit()` is async; driven via the runtime.
+            let rt = skv_runtime();
+            let tree = open_surrealkv(&rt, dir.path());
+            let mut txn = tree.begin()?;
+            for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
+                txn.set(key.as_slice(), value.as_slice())?;
+            }
+            txn.set_durability(SkvDurability::Immediate);
+            rt.block_on(txn.commit())?;
+            start.elapsed()
+        }
     };
     drop(dir);
     Ok(elapsed)
@@ -361,7 +456,7 @@ fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Co
         // does no per-iteration allocation.
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for engine in [Engine::Ours, Engine::RocksDb] {
+        for &engine in engines_for(compression) {
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 b.iter_custom(|iters| {
                     let mut total = Duration::ZERO;
@@ -440,7 +535,7 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for engine in [Engine::Ours, Engine::RocksDb] {
+        for &engine in engines_for(compression) {
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 // The temp dir + engine handle outlive every timed
                 // iteration: build the on-disk database once here so
@@ -512,6 +607,34 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                             start.elapsed()
                         });
                     }
+                    Engine::SurrealKv => {
+                        // `rt` outlives `tree` (drops last) so its background
+                        // tasks keep running for the whole read phase.
+                        let rt = skv_runtime();
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        // One read snapshot, reused across all iterations — the
+                        // closest analogue of the other engines' direct warm
+                        // reads (a single consistent view, no per-get txn churn).
+                        let txn = tree.begin().expect("surrealkv: begin");
+                        for key in &inputs.keys {
+                            assert!(
+                                txn.get(key.as_slice())
+                                    .expect("surrealkv: verify")
+                                    .is_some(),
+                                "surrealkv: key unexpectedly missing"
+                            );
+                        }
+                        b.iter_custom(|iters| {
+                            let start = std::time::Instant::now();
+                            for _ in 0..iters {
+                                for key in &inputs.keys {
+                                    let got = txn.get(key.as_slice()).expect("surrealkv: get");
+                                    std::hint::black_box(got);
+                                }
+                            }
+                            start.elapsed()
+                        });
+                    }
                 }
             });
         }
@@ -571,7 +694,7 @@ fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compress
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for engine in [Engine::Ours, Engine::RocksDb] {
+        for &engine in engines_for(compression) {
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
@@ -601,6 +724,26 @@ fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compress
                             start.elapsed()
                         });
                     }
+                    Engine::SurrealKv => {
+                        let rt = skv_runtime();
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        let txn = tree.begin().expect("surrealkv: begin");
+                        b.iter_custom(|iters| {
+                            let start = std::time::Instant::now();
+                            for _ in 0..iters {
+                                let mut iter = txn
+                                    .range(SKV_MIN_KEY, SKV_MAX_KEY)
+                                    .expect("surrealkv: range");
+                                iter.seek_first().expect("surrealkv: seek_first");
+                                while iter.valid() {
+                                    let v = iter.value().expect("surrealkv: scan value");
+                                    std::hint::black_box(v);
+                                    iter.next().expect("surrealkv: scan next");
+                                }
+                            }
+                            start.elapsed()
+                        });
+                    }
                 }
             });
         }
@@ -624,7 +767,7 @@ fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compres
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for engine in [Engine::Ours, Engine::RocksDb] {
+        for &engine in engines_for(compression) {
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
@@ -662,6 +805,32 @@ fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compres
                             start.elapsed()
                         });
                     }
+                    Engine::SurrealKv => {
+                        let rt = skv_runtime();
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        let txn = tree.begin().expect("surrealkv: begin");
+                        b.iter_custom(|iters| {
+                            let start = std::time::Instant::now();
+                            for _ in 0..iters {
+                                for key in &inputs.keys {
+                                    // Seek to the first key >= this key, read its
+                                    // value — the SurrealKV analogue of the
+                                    // index-descent-then-read the other engines do.
+                                    let mut it = txn
+                                        .range(key.as_slice(), SKV_MAX_KEY)
+                                        .expect("surrealkv: seek range");
+                                    it.seek_first().expect("surrealkv: seek_first");
+                                    let got = if it.valid() {
+                                        Some(it.value().expect("surrealkv: seek value"))
+                                    } else {
+                                        None
+                                    };
+                                    std::hint::black_box(got);
+                                }
+                            }
+                            start.elapsed()
+                        });
+                    }
                 }
             });
         }
@@ -686,7 +855,7 @@ fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compressi
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for engine in [Engine::Ours, Engine::RocksDb] {
+        for &engine in engines_for(compression) {
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 b.iter_custom(|iters| {
                     let mut total = Duration::ZERO;
@@ -719,6 +888,22 @@ fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compressi
                                         .expect("rocksdb: overwrite put");
                                 }
                                 db.flush().expect("rocksdb: overwrite flush");
+                                total += start.elapsed();
+                            }
+                            Engine::SurrealKv => {
+                                // First copy (untimed) so the timed pass
+                                // overwrites existing keys.
+                                let rt = skv_runtime();
+                                let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                                let start = std::time::Instant::now();
+                                let mut txn = tree.begin().expect("surrealkv: begin");
+                                for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
+                                    txn.set(key.as_slice(), value.as_slice())
+                                        .expect("surrealkv: overwrite set");
+                                }
+                                txn.set_durability(SkvDurability::Immediate);
+                                rt.block_on(txn.commit())
+                                    .expect("surrealkv: overwrite commit");
                                 total += start.elapsed();
                             }
                         }
@@ -829,6 +1014,12 @@ fn run_compaction(
             let start = std::time::Instant::now();
             db.compact_range(None::<&[u8]>, None::<&[u8]>);
             start.elapsed()
+        }
+        // The compaction benches are zstd-level workloads; SurrealKV has no zstd
+        // codec, so `engines_for` never yields it for these groups (its variant
+        // loop is fixed to ours+rocksdb). The arm exists only for exhaustiveness.
+        Engine::SurrealKv => {
+            unreachable!("surrealkv is excluded from zstd-level compaction benches")
         }
     };
     drop(dir);
@@ -1027,6 +1218,12 @@ fn run_subcompaction_bench(
             let start = std::time::Instant::now();
             db.compact_range(None::<&[u8]>, None::<&[u8]>);
             start.elapsed()
+        }
+        // The compaction benches are zstd-level workloads; SurrealKV has no zstd
+        // codec, so `engines_for` never yields it for these groups (its variant
+        // loop is fixed to ours+rocksdb). The arm exists only for exhaustiveness.
+        Engine::SurrealKv => {
+            unreachable!("surrealkv is excluded from zstd-level compaction benches")
         }
     };
     drop(dir);

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -113,21 +113,28 @@ const SKV_MAX_KEY: &[u8] = &[0xFFu8; 17];
 /// `tokio::spawn` (so it must run inside a runtime context, here via
 /// `block_on`), and those tasks need worker threads to keep running while the
 /// tree is read. The runtime must outlive the tree.
-fn skv_runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Runtime::new().expect("surrealkv: tokio runtime")
+fn skv_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Runtime::new()
 }
 
 /// Opens a fresh SurrealKV tree at `dir` on `rt`. Compression is left at the
 /// default (`None`) — SurrealKV has no zstd, and it only runs in the
 /// None-compression groups (see [`engines_for`]). `build()` is sync but spawns
 /// background tasks, so it runs inside `rt.block_on` to see the runtime.
-fn open_surrealkv(rt: &tokio::runtime::Runtime, dir: &std::path::Path) -> SkvTree {
+///
+/// Returns `Result` so open failures propagate to the benchmark boundary (where
+/// the engine label is attached) rather than panicking on the I/O path — same
+/// shape as `open_ours` / `rocksdb::DB::open`.
+fn open_surrealkv(
+    rt: &tokio::runtime::Runtime,
+    dir: &std::path::Path,
+) -> Result<SkvTree, Box<dyn std::error::Error>> {
     let path = dir.to_path_buf();
-    rt.block_on(async move {
+    let tree = rt.block_on(async move {
         let opts = SkvOptions::new().with_path(path);
         SkvTreeBuilder::with_options(opts).build()
-    })
-    .expect("surrealkv: open")
+    })?;
+    Ok(tree)
 }
 
 /// Populates a SurrealKV tree with `inputs` in a single write transaction and
@@ -144,16 +151,15 @@ fn populate_surrealkv(
     rt: &tokio::runtime::Runtime,
     dir: &std::path::Path,
     inputs: &WorkloadInputs,
-) -> SkvTree {
-    let tree = open_surrealkv(rt, dir);
-    let mut txn = tree.begin().expect("surrealkv: begin");
+) -> Result<SkvTree, Box<dyn std::error::Error>> {
+    let tree = open_surrealkv(rt, dir)?;
+    let mut txn = tree.begin()?;
     for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
-        txn.set(key.as_slice(), value.as_slice())
-            .expect("surrealkv: set");
+        txn.set(key.as_slice(), value.as_slice())?;
     }
     txn.set_durability(SkvDurability::Immediate);
-    rt.block_on(txn.commit()).expect("surrealkv: commit");
-    tree
+    rt.block_on(txn.commit())?;
+    Ok(tree)
 }
 
 /// Engine under test. The harness runs each workload once per
@@ -371,6 +377,7 @@ fn open_ours(
 /// Keys / values are precomputed in `inputs` so the timed body
 /// does NO per-key allocation.
 fn run_write_throughput(
+    skv_rt: Option<&tokio::runtime::Runtime>,
     engine: Engine,
     compression: Compression,
     inputs: &WorkloadInputs,
@@ -425,8 +432,12 @@ fn run_write_throughput(
             // One write transaction, committed with Immediate durability
             // (fsync) — the flush barrier equivalent of the other engines'
             // terminal flush. `commit()` is async; driven via the runtime.
-            let rt = skv_runtime();
-            let tree = open_surrealkv(&rt, dir.path());
+            // The runtime is prebuilt once per variant (see
+            // `write_throughput_variant`) and borrowed here so tokio executor
+            // bootstrap is NOT charged to the timed write window.
+            let rt =
+                skv_rt.expect("surrealkv runtime must be prebuilt for None-compression benches");
+            let tree = open_surrealkv(rt, dir.path())?;
             let mut txn = tree.begin()?;
             for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
                 txn.set(key.as_slice(), value.as_slice())?;
@@ -450,6 +461,16 @@ fn bench_write_throughput(c: &mut Criterion) {
 
 fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
+    // SurrealKV participates only in the None-compression group (no zstd
+    // codec). Build its tokio runtime ONCE here, outside the timed write
+    // window, and reuse it across every sample: `Runtime::new` spins up worker
+    // threads, and charging that executor bootstrap to each timed write sample
+    // would bias surrealkv's throughput downward vs the other engines (which
+    // only pay open/write/flush). `None` for the zstd group where it doesn't run.
+    let skv_rt = match compression {
+        Compression::None => Some(skv_runtime().expect("surrealkv: tokio runtime")),
+        Compression::Zstd22 => None,
+    };
     for &n in &[1_000_u64, 10_000_u64] {
         // Precompute the keys + values ONCE per `n` (outside the
         // criterion warmup / measurement loop), so the timed body
@@ -471,9 +492,14 @@ fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Co
                         // no meaningful Duration to report — so
                         // surface it as a bench panic with the
                         // engine label for diagnosis.
-                        total += run_write_throughput(engine, compression, &inputs).unwrap_or_else(
-                            |e| panic!("run_write_throughput failed for {}: {e}", engine.label()),
-                        );
+                        total +=
+                            run_write_throughput(skv_rt.as_ref(), engine, compression, &inputs)
+                                .unwrap_or_else(|e| {
+                                    panic!(
+                                        "run_write_throughput failed for {}: {e}",
+                                        engine.label()
+                                    )
+                                });
                     }
                     total
                 });
@@ -610,8 +636,9 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                     Engine::SurrealKv => {
                         // `rt` outlives `tree` (drops last) so its background
                         // tasks keep running for the whole read phase.
-                        let rt = skv_runtime();
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
+                            .expect("surrealkv: populate");
                         // One read snapshot, reused across all iterations — the
                         // closest analogue of the other engines' direct warm
                         // reads (a single consistent view, no per-get txn churn).
@@ -725,8 +752,9 @@ fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compress
                         });
                     }
                     Engine::SurrealKv => {
-                        let rt = skv_runtime();
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
+                            .expect("surrealkv: populate");
                         let txn = tree.begin().expect("surrealkv: begin");
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
@@ -806,8 +834,9 @@ fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compres
                         });
                     }
                     Engine::SurrealKv => {
-                        let rt = skv_runtime();
-                        let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                        let rt = skv_runtime().expect("surrealkv: tokio runtime");
+                        let tree = populate_surrealkv(&rt, dir.path(), &inputs)
+                            .expect("surrealkv: populate");
                         let txn = tree.begin().expect("surrealkv: begin");
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
@@ -893,8 +922,9 @@ fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compressi
                             Engine::SurrealKv => {
                                 // First copy (untimed) so the timed pass
                                 // overwrites existing keys.
-                                let rt = skv_runtime();
-                                let tree = populate_surrealkv(&rt, dir.path(), &inputs);
+                                let rt = skv_runtime().expect("surrealkv: tokio runtime");
+                                let tree = populate_surrealkv(&rt, dir.path(), &inputs)
+                                    .expect("surrealkv: populate");
                                 let start = std::time::Instant::now();
                                 let mut txn = tree.begin().expect("surrealkv: begin");
                                 for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -143,10 +143,14 @@ fn open_surrealkv(
 /// groups start from an on-disk state. `commit()` is async; driven via
 /// `rt.block_on`.
 ///
-/// NOTE: SurrealKV is versioned/MVCC — a single committed write per key here, so
-/// there is no extra version history, but its write path still carries MVCC
-/// bookkeeping the flat-LSM engines do not. Read this in the comparison as
-/// "Rust-native LSM with MVCC semantics", not a byte-for-byte equivalent setup.
+/// NOTE: both engines are MVCC — ours tags every write with a sequence number
+/// and reads a snapshot via `get(key, seqno)`; surrealkv versions per
+/// transaction. So the write asymmetry here is NOT "MVCC vs flat": it is the
+/// write PATH. surrealkv runs a real transaction (begin / set / commit) with a
+/// per-commit `Immediate` fsync, plus vlog (KV-separation) and B+tree index
+/// upkeep, whereas our arm does seqno-tagged memtable inserts + one terminal
+/// flush. Read the comparison as two MVCC LSMs with different transaction /
+/// index layers, not a byte-for-byte equivalent setup.
 fn populate_surrealkv(
     rt: &tokio::runtime::Runtime,
     dir: &std::path::Path,


### PR DESCRIPTION
## Summary

Adds **SurrealKV** (`surrealdb/surrealkv`, Apache-2.0, pure-Rust embedded LSM/MVCC, git-pinned `v0.21.2`) as a third engine in the `compare-rocksdb` head-to-head harness, overlaid on the SAME criterion graphs as `ours` and `rocksdb` (same `BenchmarkGroup`, third `BenchmarkId` per workload).

## Changes

- `Engine::SurrealKv` + `engines_for(compression)` — surrealkv overlays ONLY on the `None`-compression groups (`write_throughput` / `point_read` / `range_scan` / `seek_random` / `overwrite`). SurrealKV has no zstd codec (its `CompressionType` is `None` / `Snappy` only), so the `_zstd22` and compaction groups stay ours-vs-rocksdb (a non-zstd line on a zstd22 graph would misrepresent the comparison).
- `open_surrealkv` / `populate_surrealkv` / `setup_surrealkv_warm` — the surrealkv helpers return `Result` so the open/begin/set/commit I/O path propagates errors; each arm panics once with the engine label at the Criterion boundary (the closure can't return `Result`). `build()` spawns background compaction tasks via `tokio::spawn` and `commit()` is async, so open/commit run through `rt.block_on`. The warm read/scan/seek/overwrite arms get their runtime + populated tree from `setup_surrealkv_warm` (runtime drops after the tree, keeping its tasks alive for the timed reads); the cold `write_throughput` arm prebuilds one runtime per variant so executor bootstrap is never charged to the timed window. Writes commit with `Durability::Immediate` (fsync) — the flush-to-disk equivalent of ours' `flush_active_memtable` / rocksdb's `flush`.
- Pure-Rust dep → no extra libclang/FFI burden (unlike rocksdb). `Cargo.lock` is gitignored for this crate, so only `Cargo.toml` + `compare.rs` change.

## Fair-comparison caveats (documented in-code)

- Both engines are MVCC (ours tags writes with a sequence number and reads a snapshot via `get(key, seqno)`; surrealkv versions per transaction), so the write asymmetry is the write PATH, not "MVCC vs flat": surrealkv runs a real transaction (begin / set / commit) with a per-commit `Immediate` fsync plus vlog (KV-separation) and B+tree index upkeep, vs our seqno-tagged memtable inserts + one terminal flush. Read it as two MVCC LSMs with different transaction / index layers, not a byte-for-byte equivalent setup.
- Restricted to `None`-compression groups (no zstd codec).

## Local results (3-way, None groups, this host)

| Workload | ours | rocksdb | surrealkv |
|---|---|---|---|
| write_throughput 1k / 10k | 2.72 / 12.7 ms | 4.26 / 15.3 ms | 30.9 / 43.8 ms |
| point_read 1k / 10k | 1.15 / 13.5 ms | 1.00 / 10.8 ms | 0.284 / 4.13 ms |
| range_scan 1k / 10k | 152 µs / 1.54 ms | 200 µs / 1.99 ms | 94 µs / 1.19 ms |
| seek_random 1k / 10k | 1.85 / 20.7 ms | 1.81 / 19.7 ms | 1.01 / 12.3 ms |
| overwrite 1k | 1.54 ms | 1.45 ms | 6.25 ms |

SurrealKV is markedly slower on writes (per-commit `Immediate` fsync + transaction / vlog overhead) and faster on reads / scans / seeks (B+tree index + KV-separation) — a useful Rust-native comparison point.

## Note

The gh-pages bench dashboard will pick up the surrealkv overlay on the next `compare-rocksdb` run, provided the bench runner can fetch the git dependency at build time.

Closes #424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SurrealKV as a third engine in the benchmark comparison suite.
  * Extended benchmarks to include SurrealKV for write throughput, point reads, range scans, seeks, and overwrites.
  * Added async runtime support and warm setup to keep SurrealKV background tasks alive during timed phases.
  * Excluded SurrealKV from compression-specific compaction benches to preserve valid comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
