### PR TITLE
test(compare): honest L3 compaction baseline vs RocksDB

### DIFF
--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -1044,6 +1044,13 @@ fn run_compaction(
             opts.set_compression_options_parallel_threads(COMPACTION_THREADS as i32);
             opts.set_max_subcompactions(1);
 
+            // Force the bottommost level to actually compact. RocksDB's manual
+            // compaction defaults to `kIfHaveCompactionFilter` (skip bottommost
+            // without a filter); `Force` makes the timed compaction do the full
+            // merge-into-bottom, matching ours' `major_compact`.
+            let mut compact_opts = rocksdb::CompactOptions::default();
+            compact_opts.set_bottommost_level_compaction(rocksdb::BottommostLevelCompaction::Force);
+
             let db = rocksdb::DB::open(&opts, dir.path())?;
             let mut write_opts = rocksdb::WriteOptions::default();
             write_opts.disable_wal(true);
@@ -1059,7 +1066,7 @@ fn run_compaction(
             db.flush()?; // final batch
 
             let start = std::time::Instant::now();
-            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+            db.compact_range_opt(None::<&[u8]>, None::<&[u8]>, &compact_opts);
             start.elapsed()
         }
         // The compaction benches are zstd-level workloads; SurrealKV has no zstd
@@ -1074,11 +1081,18 @@ fn run_compaction(
 }
 
 fn bench_compaction(c: &mut Criterion) {
-    // Two ends of the zstd spectrum: level 1 (cheap codec — non-compression
-    // overhead most visible) and level 22 (max — codec CPU dominates). Each is
-    // its own group, so each renders its own ours-vs-rocksdb overlay chart.
-    compaction_variant(c, "major_compact_zstd1", 1);
-    compaction_variant(c, "major_compact_zstd22", 22);
+    // Compaction output lands in the bottommost level. RocksDB's manual
+    // compaction compresses the bottommost output at zstd's default level (3)
+    // regardless of the configured `compression_opts.level` — the level setting
+    // does not reach the bottommost level, and the only way to override it
+    // (`set_bottommost_compression_options`) cannot carry parallel_threads, so it
+    // would force RocksDB single-threaded there. So the honest apples-to-apples
+    // compaction codec comparison is pinned to level 3 — the level RocksDB
+    // actually performs on the bottommost output — with both engines at 4-thread
+    // parallel block compression (RocksDB inherits the 4 threads from
+    // `compression_opts`; ours via `compaction_threads`). As structured-zstd's
+    // level-3 encoder improves, the gain shows directly against RocksDB here.
+    compaction_variant(c, "major_compact_zstd3", 3);
 }
 
 /// Reports compaction tail latency (P50/P95/P99) to stderr from per-iteration
@@ -1244,12 +1258,23 @@ fn run_subcompaction_bench(
             let mut write_opts = rocksdb::WriteOptions::default();
             write_opts.disable_wal(true);
 
+            // RocksDB's manual compaction defaults to
+            // `bottommost_level_compaction = kIfHaveCompactionFilter`: with no
+            // compaction filter it leaves the gen-1 overwrite at a higher level
+            // (reads still see it, newest-seqno wins) instead of rewriting the
+            // already-bottommost gen-0 data. That makes the timed compaction a
+            // near-no-op (it skips the expensive bottom rewrite), whereas ours'
+            // `major_compact` forces the full merge-into-bottom. Force RocksDB to
+            // rewrite the bottommost level so both engines do equivalent work.
+            let mut compact_opts = rocksdb::CompactOptions::default();
+            compact_opts.set_bottommost_level_compaction(rocksdb::BottommostLevelCompaction::Force);
+
             // Step 1: populate the bottom level.
             for (key, value) in inputs.keys.iter().zip(inputs.values.iter()) {
                 db.put_opt(key, value, &write_opts)?;
             }
             db.flush()?;
-            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+            db.compact_range_opt(None::<&[u8]>, None::<&[u8]>, &compact_opts);
 
             // Step 2: overwrite the whole keyspace into fresh L0 tables.
             let mut written = 0u64;
@@ -1263,7 +1288,7 @@ fn run_subcompaction_bench(
             db.flush()?;
 
             let start = std::time::Instant::now();
-            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+            db.compact_range_opt(None::<&[u8]>, None::<&[u8]>, &compact_opts);
             start.elapsed()
         }
         // The compaction benches are zstd-level workloads; SurrealKV has no zstd
@@ -1305,10 +1330,12 @@ fn subcompaction_variant(c: &mut Criterion, group_name: &str, level: i32) {
 }
 
 /// Sub-compaction head-to-head: our range-parallel split vs RocksDB
-/// `max_subcompactions`, at both ends of the zstd spectrum.
+/// `max_subcompactions`. Pinned to zstd level 3 — the level RocksDB actually
+/// applies to bottommost compaction output (see [`bench_compaction`]) — with
+/// both engines at 4-thread block compression, so the comparison is honest and
+/// tracks structured-zstd's level-3 encoder progress against RocksDB.
 fn bench_subcompaction(c: &mut Criterion) {
-    subcompaction_variant(c, "subcompaction_zstd1", 1);
-    subcompaction_variant(c, "subcompaction_zstd22", 22);
+    subcompaction_variant(c, "subcompaction_zstd3", 3);
 }
 
 criterion_group!(


### PR DESCRIPTION
## Summary

Makes the `compare-rocksdb` compaction / sub-compaction benches an honest apples-to-apples comparison. The previous groups reported RocksDB as 3-13× faster on the sub-compaction path; that turned out to be a benchmark artifact, not a real gap.

## Root cause

RocksDB's **manual** compaction (`compact_range`) diverged from our `major_compact` in two ways:

1. **`bottommost_level_compaction` defaults to `kIfHaveCompactionFilter`** — with no compaction filter, RocksDB leaves an overwrite at a higher level (reads still see it, newest-seqno wins) instead of rewriting the already-bottommost data. The timed sub-compaction was therefore a near-no-op while ours did the full merge-into-bottom.
2. **The configured `compression_opts.level` does not reach the bottommost level** — RocksDB compresses bottommost output at zstd's default level (3). The only override (`set_bottommost_compression_options`) cannot carry `parallel_threads`, so forcing a higher level there drops RocksDB to single-threaded — not apples-to-apples either.

Evidence: after forcing the bottommost rewrite, RocksDB sub-compaction at "zstd1" (55 ms) vs "zstd22" (199 ms) differed only ~3.6×, where a genuine L1→L22 codec step is ~50× — confirming the bottommost output was never compressed at the configured level.

## Changes

- Force the bottommost rewrite on both compaction arms via `compact_range_opt` + `BottommostLevelCompaction::Force`, so RocksDB does the same full merge-into-bottom as ours.
- Pin the compaction + sub-compaction comparison to **zstd level 3** — the level RocksDB actually applies to bottommost output — with **both engines at 4-thread** block compression (RocksDB inherits the threads from `compression_opts`; ours via `compaction_threads`). No bottommost-level override needed, so neither side is artificially single-threaded.
- Drop the misleading `*_zstd1` / `*_zstd22` compaction groups (ours-L1/L22 vs rocksdb-de-facto-L3) in favour of one honest `*_zstd3` group per type.

## Result (40k keys, level 3, 4 threads)

| bench | ours | rocksdb | verdict |
|---|---|---|---|
| `major_compact_zstd3` (single-stream) | ~43 ms | ~65 ms | ours ~1.5× faster |
| `subcompaction_zstd3` (range-split) | ~70 ms | ~55 ms | ours ~1.27× slower |

The "3-13×" gap was the artifact. Honest baseline: our single-stream compaction beats RocksDB; only the **range-split sub-compaction coordination** remains modestly behind — the real optimization target (flamegraph follow-up).

## Testing

- `cargo clippy --benches -- -D warnings` clean, `cargo fmt --check` clean.
- Bench-harness only; no library code changed.

Part of #410 (bench fairness / apples-to-apples verification; the range-split sub-compaction optimization remains open under #410).
