### PR TITLE
fix(fs): silence unfulfilled non_snake_case expect on Windows

### DIFF
--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -602,7 +602,11 @@ mod sys {
         const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
 
         // SAFETY: declaration matches the Windows `LockFileEx` ABI and `Overlapped` layout.
-        #[expect(non_snake_case, reason = "FFI name matches Windows API")]
+        // `allow` not `expect`: the foreign-fn name `LockFileEx` is not flagged by
+        // `non_snake_case` on the Windows toolchain, so `expect` would be unfulfilled
+        // and warn on every build; `allow` documents the intentional API-matching name
+        // without depending on whether the lint fires.
+        #[allow(non_snake_case, reason = "FFI name matches Windows API")]
         unsafe extern "system" {
             fn LockFileEx(
                 h_file: *mut std::ffi::c_void,


### PR DESCRIPTION
## Summary

The `#[expect(non_snake_case, reason = "FFI name matches Windows API")]` on the `extern "system"` block declaring `LockFileEx` (`src/fs/std_fs.rs`, `#[cfg(windows)] mod sys`) was never fulfilled: parameters are already snake_case and the foreign-function name `LockFileEx` is not flagged by the `non_snake_case` lint on the Windows toolchain. This produced an `unfulfilled_lint_expectations` warning on every Windows build (doc-tests step).

Switches `#[expect(...)]` to `#[allow(...)]`, which stays silent whether or not the lint fires and preserves the documenting reason (the symbol must keep its Windows API name).

## Testing

Windows-gated code, not compilable on a non-Windows host; `fmt`/`clippy`/full suite green locally for the rest of the crate. The Windows CI job confirms the warning is gone.

Closes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal lint configuration for Windows compatibility without affecting functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->