### PR TITLE
feat(scan): scan_since_seqno CDC stream + synchronous clear() reclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,37 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 - Pluggable `Fs` trait — back the engine on the standard filesystem, on `io_uring`, on an in-memory `MemFs`, or on a custom implementation.
 - Pluggable `CompressionProvider` for third-party codecs.
 
+## Incremental scan / CDC
+
+`Tree::scan_since_seqno(target)` streams every change committed at or after a
+sequence number as `ScanSinceEvent`s (`Insert`, `MergeOperand`,
+`PointTombstone`, `RangeTombstone`), in increasing seqno order. It is a
+change-data-capture primitive: a downstream consumer (replica, Kafka connector,
+Debezium-style pipeline) replays the events in order to reconstruct the source's
+history. Superseded versions are preserved (no MVCC collapse) and tombstones are
+exposed, so deletes replay faithfully.
+
+With the runtime-toggleable `seqno_in_index` policy, each SST index entry
+carries its data block's `(seqno_min, seqno_max)`, and the scan **skips any data
+block whose `seqno_max` is below the target without reading it**. On a
+sparse-change workload (e.g. 1% of data changed since the last poll) this turns
+an O(data) scan into O(changed blocks). Trees with a mix of seqno-bounded and
+legacy SSTs are scanned transparently (legacy blocks fall back to a per-entry
+filter), so the policy can be enabled on a live tree and takes effect as
+compaction rewrites SSTs — no migration step, no format-version bump.
+
+| Engine | CDC granularity | Survives compaction | Embeddable | Block-skip |
+|--------|-----------------|---------------------|------------|------------|
+| RocksDB `GetUpdatesSince` | WAL events (lost after compaction) | no | yes | n/a |
+| Pebble | SST file (64–128 MB) | yes | yes | no |
+| CockroachDB changefeed | SST file | yes | no (distributed) | no |
+| FoundationDB | per-event | yes | no (distributed) | n/a |
+| **coordinode-lsm-tree** | **data block (4–32 KB)** | **yes** | **yes** | **yes** |
+
+The trade-off: there is no write-ahead log, so we do not offer WAL-style
+millisecond tailing of in-flight updates. For arbitrary historical-seqno queries
+(not just "since X"), pair with `Tree::create_checkpoint`.
+
 ## Limits
 
 - Keys: up to 65,535 bytes (the on-disk encoding caps the key-length field at `u16`).

--- a/src/background_deleter.rs
+++ b/src/background_deleter.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Rate-limited background file deleter.
+//!
+//! Obsolete on-disk files (SSTs, blob files) are reclaimed in two steps so a
+//! caller measuring disk footprint right after a logical delete (`clear`,
+//! compaction) sees the drop without the foreground thread blocking on the
+//! unlinks:
+//!
+//! 1. The reclaim site truncates the file to zero length **synchronously**
+//!    (an O(1) metadata op that returns its data blocks to the filesystem
+//!    immediately, so a `walkdir + sum(len)` scan reflects the reclaim at
+//!    once), then
+//! 2. enqueues the now-empty path here for the worker thread to `unlink` the
+//!    directory entry **off the foreground path**, optionally rate-limited so
+//!    a mass deletion (post-compaction, post-`clear` over thousands of files)
+//!    does not storm the device (mirrors `RocksDB`'s `DeleteScheduler`).
+//!
+//! The control this module provides — *when* and *how fast* entries are
+//! unlinked — is the part no filesystem primitive offers; the per-file op
+//! itself (`truncate` / `unlink`) is a plain `Fs` call.
+//!
+//! # no-std
+//!
+//! Background deletion needs a thread, so the whole module is gated behind the
+//! `std` feature. A `no_std` build reclaims files synchronously at the Drop
+//! site instead (no scheduler installed). The public surface stays the same
+//! shape so the call sites do not branch on the feature beyond "is a deleter
+//! installed".
+// no-std: synchronous reclaim at the Drop site (no background thread)
+
+#![cfg(feature = "std")]
+
+use crate::fs::Fs;
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        mpsc::{Receiver, Sender, channel},
+    },
+    thread::JoinHandle,
+    time::Duration,
+};
+
+/// A unit of background work: unlink `path` through `fs`.
+struct DeleteJob {
+    fs: Arc<dyn Fs>,
+    path: PathBuf,
+}
+
+/// Rate-limited background file deleter.
+///
+/// Cheap to clone-share via `Arc`. Enqueuing is a non-blocking channel send;
+/// the dedicated worker thread performs the unlinks. Dropping the deleter
+/// signals the worker to drain every queued job and exit, so no file is leaked
+/// on shutdown.
+pub struct BackgroundDeleter {
+    sender: Option<Sender<DeleteJob>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl core::fmt::Debug for BackgroundDeleter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BackgroundDeleter").finish_non_exhaustive()
+    }
+}
+
+impl BackgroundDeleter {
+    /// Spawns a background deleter.
+    ///
+    /// `min_interval` throttles the worker: it waits at least that long
+    /// between consecutive unlinks, capping the deletion rate so a mass
+    /// reclaim does not contend with foreground I/O. `None` means unlimited
+    /// (delete as fast as the queue drains, still off the foreground thread).
+    #[must_use]
+    pub fn new(min_interval: Option<Duration>) -> Self {
+        let (sender, receiver) = channel::<DeleteJob>();
+        let worker = std::thread::Builder::new()
+            .name("lsm-deleter".into())
+            .spawn(move || Self::run(&receiver, min_interval))
+            .ok();
+        Self {
+            sender: Some(sender),
+            worker,
+        }
+    }
+
+    /// Enqueues `path` for background unlink through `fs`.
+    ///
+    /// Non-blocking. If the worker thread has already exited (shutdown in
+    /// progress) the job is dropped — the file is then reclaimed on next
+    /// recovery's orphan sweep, never leaked silently into correctness.
+    pub fn enqueue(&self, fs: Arc<dyn Fs>, path: PathBuf) {
+        if let Some(sender) = &self.sender {
+            // A send error means the worker is gone; the path falls to the
+            // recovery orphan sweep rather than blocking the caller.
+            let _ = sender.send(DeleteJob { fs, path });
+        }
+    }
+
+    /// Worker loop: unlink each queued path, honoring the rate cap. Exits when
+    /// the channel closes (the deleter was dropped) and the queue is drained.
+    fn run(receiver: &Receiver<DeleteJob>, min_interval: Option<Duration>) {
+        while let Ok(job) = receiver.recv() {
+            if let Err(e) = job.fs.remove_file(&job.path) {
+                log::warn!(
+                    "background deleter failed to unlink {}: {e:?}",
+                    job.path.display(),
+                );
+            }
+            if let Some(interval) = min_interval {
+                std::thread::sleep(interval);
+            }
+        }
+    }
+}
+
+impl Drop for BackgroundDeleter {
+    fn drop(&mut self) {
+        // Close the channel so the worker's `recv` returns `Err` once the
+        // queue is empty, then join it — every already-enqueued unlink runs
+        // before we return, so a tree close does not leak obsolete files.
+        drop(self.sender.take());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code")]
+mod tests {
+    use super::*;
+    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use std::io::Write;
+
+    #[test]
+    fn drains_queued_deletions_on_drop() {
+        let fs: Arc<dyn Fs> = Arc::new(MemFs::default());
+        let paths: Vec<PathBuf> = (0..16).map(|i| PathBuf::from(format!("/f{i}"))).collect();
+        for p in &paths {
+            let mut f = fs
+                .open(p, &FsOpenOptions::new().write(true).create(true))
+                .unwrap();
+            f.write_all(b"data").unwrap();
+            f.flush().unwrap();
+            assert!(fs.open(p, &FsOpenOptions::new().read(true)).is_ok());
+        }
+
+        {
+            let deleter = BackgroundDeleter::new(None);
+            for p in &paths {
+                deleter.enqueue(Arc::clone(&fs), p.clone());
+            }
+            // Drop drains the queue and joins the worker: every enqueued unlink
+            // has completed by the time this scope ends.
+        }
+
+        for p in &paths {
+            assert!(
+                fs.open(p, &FsOpenOptions::new().read(true)).is_err(),
+                "{} should have been unlinked by the background deleter",
+                p.display(),
+            );
+        }
+    }
+}

--- a/src/background_deleter.rs
+++ b/src/background_deleter.rs
@@ -88,14 +88,32 @@ impl BackgroundDeleter {
 
     /// Enqueues `path` for background unlink through `fs`.
     ///
-    /// Non-blocking. If the worker thread has already exited (shutdown in
-    /// progress) the job is dropped — the file is then reclaimed on next
-    /// recovery's orphan sweep, never leaked silently into correctness.
+    /// Non-blocking on the happy path. If the worker is not running — the
+    /// thread failed to spawn in [`Self::new`], or the channel is otherwise
+    /// disconnected — the unlink is performed **synchronously** instead of
+    /// silently dropped: the caller has typically already truncated the file,
+    /// so dropping the job would leave a zero-length directory entry behind.
     pub fn enqueue(&self, fs: Arc<dyn Fs>, path: PathBuf) {
-        if let Some(sender) = &self.sender {
-            // A send error means the worker is gone; the path falls to the
-            // recovery orphan sweep rather than blocking the caller.
-            let _ = sender.send(DeleteJob { fs, path });
+        let job = DeleteJob { fs, path };
+        match &self.sender {
+            // `send` only fails if the receiver (worker) is gone; it hands the
+            // job back in the error, so reclaim it synchronously.
+            Some(sender) => {
+                if let Err(std::sync::mpsc::SendError(job)) = sender.send(job) {
+                    Self::unlink_now(&job);
+                }
+            }
+            None => Self::unlink_now(&job),
+        }
+    }
+
+    /// Synchronous unlink fallback for when the background worker is gone.
+    fn unlink_now(job: &DeleteJob) {
+        if let Err(e) = job.fs.remove_file(&job.path) {
+            log::warn!(
+                "background deleter sync fallback failed to unlink {}: {e:?}",
+                job.path.display(),
+            );
         }
     }
 

--- a/src/background_deleter.rs
+++ b/src/background_deleter.rs
@@ -21,6 +21,20 @@
 //! unlinked — is the part no filesystem primitive offers; the per-file op
 //! itself (`truncate` / `unlink`) is a plain `Fs` call.
 //!
+//! # Synchronous truncate is conditional
+//!
+//! Step 1 only runs when the reclaim site can confirm it owns the **sole** hard
+//! link to the inode (link count == 1, via [`Fs::hard_link_count`]). Truncating
+//! a shared inode would zero a checkpoint's hard-linked copy too, so when the
+//! link is shared — or the count can't be determined (e.g. a backend without a
+//! link-count primitive, currently non-Unix `StdFs`) — the truncate is skipped
+//! and reclaim is the async unlink (step 2) alone. The reclaim is still correct
+//! in that case; the *immediate* footprint drop (step 1) is the part that's
+//! conditional on link-count support, so it is effectively a Unix-only fast
+//! path today.
+//!
+//! [`Fs::hard_link_count`]: crate::fs::Fs::hard_link_count
+//!
 //! # no-std
 //!
 //! Background deletion needs a thread, so the whole module is gated behind the

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -413,6 +413,10 @@ impl AbstractTree for BlobTree {
         let config = self.tree_config();
         let mut versions = self.get_version_history_lock();
 
+        // Pre-clear snapshot: its tables AND blob files all become garbage once
+        // the new empty version is installed.
+        let prior = versions.latest_version();
+
         versions.upgrade_version(
             &config.path,
             |v| {
@@ -430,7 +434,23 @@ impl AbstractTree for BlobTree {
             &*config.fs,
             self.index.0.runtime_config.load_full(),
             self.index.0.config.encryption.clone(),
-        )
+        )?;
+
+        // Same MVCC-safe reclaim as the standard tree, plus the blob files:
+        // mark every obsolete table / blob file deleted, drop the history's
+        // hold, and let Inner::Drop reclaim each once its last reference is
+        // released (a live reader's snapshot clone defers deletion).
+        versions.drain_obsolete_to_latest();
+        drop(versions);
+
+        for table in prior.version.iter_tables() {
+            table.mark_as_deleted();
+        }
+        for blob_file in prior.version.blob_files.iter() {
+            blob_file.mark_as_deleted();
+        }
+
+        Ok(())
     }
 
     fn major_compact(

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -10,7 +10,7 @@ pub mod ingest;
 pub use gc::{FragmentationEntry, FragmentationMap};
 
 use crate::{
-    Cache, Config, Memtable, SeqNo, TableId, TreeId, UserKey, UserValue,
+    Cache, Config, Memtable, ScanSinceEvent, SeqNo, TableId, TreeId, UserKey, UserValue,
     abstract_tree::{AbstractTree, RangeItem},
     coding::Decode,
     iter_guard::{IterGuard, IterGuardImpl},
@@ -219,6 +219,48 @@ impl BlobTree {
         )?;
 
         Ok(Some(v))
+    }
+
+    /// Iterate change events with `seqno >= target_seqno`, resolving
+    /// KV-separated values.
+    ///
+    /// Same change-data-capture contract as [`Tree::scan_since_seqno`](crate::Tree::scan_since_seqno),
+    /// but a blob-indirected value is resolved from its blob file into a
+    /// [`ScanSinceEvent::Insert`] carrying the real value, so a downstream
+    /// consumer can replicate without access to the source's blob files.
+    /// Block-skip, seqno ordering, and tombstone handling are identical to the
+    /// standard-tree path (the same shared aggregation backs both).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal version-history lock is poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the index, a data block, or a referenced blob
+    /// fails.
+    pub fn scan_since_seqno(
+        &self,
+        target_seqno: SeqNo,
+    ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
+        self.index
+            .scan_since_seqno_with(target_seqno, |version, entry| {
+                let seqno = entry.key.seqno;
+                let (key, value) = resolve_value_handle(
+                    self.id(),
+                    self.blobs_folder.as_path(),
+                    &self.index.config.cache,
+                    version,
+                    entry,
+                    #[cfg(zstd_any)]
+                    self.index
+                        .config
+                        .kv_separation_opts
+                        .as_ref()
+                        .and_then(|o| o.zstd_dictionary.as_deref()),
+                )?;
+                Ok(ScanSinceEvent::Insert { key, value, seqno })
+            })
     }
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -798,6 +798,31 @@ pub trait Fs: Send + Sync + 'static {
         self.open(path, &FsOpenOptions::new().write(true))?
             .set_len(0)
     }
+
+    /// Number of hard links to the file at `path` (the inode's link count).
+    ///
+    /// Used to keep [`Self::truncate_file`] safe: truncation frees the inode's
+    /// blocks for **every** hard link, so a file a checkpoint has linked (via
+    /// [`Self::hard_link`]) must not be truncated — only unlinked. A caller
+    /// truncates only when this returns `Ok(1)` (it owns the sole link).
+    ///
+    /// # Default implementation
+    ///
+    /// Returns an `Unsupported` error so a backend that cannot report link
+    /// counts makes callers conservatively skip truncation (correctness over
+    /// the reclaim optimization). [`StdFs`] overrides it on Unix via `nlink`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the count cannot be determined (including the
+    /// `Unsupported` default).
+    fn hard_link_count(&self, path: &Path) -> io::Result<u64> {
+        let _ = path;
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "hard_link_count is not supported by this backend",
+        ))
+    }
 }
 
 /// Streamed independent copy of `src` to `dst` through `fs`'s own [`Fs::open`].

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -770,6 +770,34 @@ pub trait Fs: Send + Sync + 'static {
     fn reflink_file(&self, src: &Path, dst: &Path) -> io::Result<()> {
         copy_file_streamed(self, src, dst)
     }
+
+    /// Returns the data blocks of the file at `path` to the filesystem,
+    /// leaving a zero-length file in place.
+    ///
+    /// This is the synchronous half of obsolete-file reclaim: it frees the
+    /// space immediately (so a `walkdir + sum(len)` footprint scan reflects the
+    /// reclaim at once) and is O(1) — a metadata operation, not a data rewrite
+    /// — while the directory-entry `unlink` can be deferred to a background
+    /// deleter. Reclaim is split this way so a caller measuring disk usage
+    /// right after a logical delete sees the drop without the foreground thread
+    /// blocking on the unlink.
+    ///
+    /// # Default implementation
+    ///
+    /// Opens the file for writing and sets its length to zero. Portable across
+    /// every backend. A backend MAY override with a filesystem-specific
+    /// primitive when one is genuinely cheaper (none beats `set_len(0)` for the
+    /// length-based footprint today; the hook exists so an FS that grows one —
+    /// reported via [`Fs::capabilities`] — can plug it in without touching the
+    /// call sites). [`MemFs`] truncates its in-memory buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the file cannot be opened or truncated.
+    fn truncate_file(&self, path: &Path) -> io::Result<()> {
+        self.open(path, &FsOpenOptions::new().write(true))?
+            .set_len(0)
+    }
 }
 
 /// Streamed independent copy of `src` to `dst` through `fs`'s own [`Fs::open`].

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -294,6 +294,24 @@ impl Fs for StdFs {
         Some(KERNEL_BACKEND_ID)
     }
 
+    fn hard_link_count(&self, path: &Path) -> io::Result<u64> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Ok(std::fs::metadata(path)?.nlink())
+        }
+        // Windows: no portable nlink; fall back to the conservative
+        // "unsupported" contract so the reclaim path skips truncation.
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "hard_link_count requires a Unix target",
+            ))
+        }
+    }
+
     /// macOS: detects APFS (the common macOS filesystem with copy-on-write,
     /// reflink, and native snapshots) via `statfs(2)`'s `f_fstypename`. Other
     /// macOS filesystems (HFS+, exFAT, SMB/NFS mounts) and any detection failure

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -819,9 +819,16 @@ mod linux_caps {
             return FsCapabilities::default();
         }
         // SAFETY: statfs returned 0, so `buf` is initialized. `f_type` is
-        // `c_long` (i64) on 64-bit, matching the magic constants directly.
+        // `c_long` (i64) on glibc but `c_ulong` (u64) on musl, so normalize to
+        // i64 before matching the magic constants (their bit patterns are
+        // identical across the cast).
         #[expect(unsafe_code, reason = "read initialized statfs.f_type")]
-        let f_type: i64 = unsafe { buf.assume_init() }.f_type;
+        #[allow(
+            clippy::unnecessary_cast,
+            clippy::cast_possible_wrap,
+            reason = "f_type is i64 on glibc (no-op cast) and u64 on musl (cast required)"
+        )]
+        let f_type = unsafe { buf.assume_init() }.f_type as i64;
 
         match f_type {
             BTRFS | ZFS => FsCapabilities {
@@ -860,7 +867,9 @@ mod linux_caps {
         let rc = unsafe {
             libc::ioctl(
                 dst_f.as_raw_fd(),
-                libc::FICLONE as libc::c_ulong,
+                // ioctl's request param is c_ulong on glibc but c_int on musl;
+                // infer the target type so FICLONE casts to whichever applies.
+                libc::FICLONE as _,
                 src_f.as_raw_fd(),
             )
         };
@@ -914,7 +923,13 @@ mod linux_caps {
         let mut flags: libc::c_int = 0;
         // SAFETY: valid fd; GETFLAGS writes one `int` through the pointer arg.
         #[expect(unsafe_code, reason = "ioctl(FS_IOC_GETFLAGS) to read inode flags")]
-        let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_GETFLAGS, &raw mut flags) };
+        #[allow(
+            clippy::unnecessary_cast,
+            clippy::cast_possible_truncation,
+            reason = "ioctl request is c_ulong on glibc (no-op) but c_int on musl; \
+                      the 32-bit request code's low bits are preserved by truncation"
+        )]
+        let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_GETFLAGS as _, &raw mut flags) };
         if rc != 0 {
             return ignore_if_unsupported(io::Error::last_os_error());
         }
@@ -924,7 +939,13 @@ mod linux_caps {
         flags |= FS_NOCOW_FL;
         // SAFETY: valid fd; SETFLAGS reads one `int` through the pointer arg.
         #[expect(unsafe_code, reason = "ioctl(FS_IOC_SETFLAGS) to set FS_NOCOW_FL")]
-        let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_SETFLAGS, &raw const flags) };
+        #[allow(
+            clippy::unnecessary_cast,
+            clippy::cast_possible_truncation,
+            reason = "ioctl request is c_ulong on glibc (no-op) but c_int on musl; \
+                      the 32-bit request code's low bits are preserved by truncation"
+        )]
+        let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_SETFLAGS as _, &raw const flags) };
         if rc != 0 {
             return ignore_if_unsupported(io::Error::last_os_error());
         }

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -777,14 +777,22 @@ mod macos_caps {
 #[cfg(target_os = "linux")]
 mod linux_caps {
     use crate::fs::FsCapabilities;
-    use std::ffi::CString;
     use std::fs::{File, OpenOptions};
     use std::io;
-    use std::mem::MaybeUninit;
-    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::AsRawFd;
     use std::path::Path;
 
+    // statfs-based capability detection only compiles on 64-bit (the magic
+    // numbers exceed i32::MAX); these imports + helper feed only that path, so
+    // gate them to avoid unused-import / dead_code warnings on 32-bit targets.
+    #[cfg(target_pointer_width = "64")]
+    use std::ffi::CString;
+    #[cfg(target_pointer_width = "64")]
+    use std::mem::MaybeUninit;
+    #[cfg(target_pointer_width = "64")]
+    use std::os::unix::ffi::OsStrExt;
+
+    #[cfg(target_pointer_width = "64")]
     fn to_cstring(path: &Path) -> io::Result<CString> {
         CString::new(path.as_os_str().as_bytes()).map_err(|_| {
             io::Error::new(

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -300,8 +300,14 @@ impl Fs for StdFs {
             use std::os::unix::fs::MetadataExt;
             Ok(std::fs::metadata(path)?.nlink())
         }
-        // Windows: no portable nlink; fall back to the conservative
-        // "unsupported" contract so the reclaim path skips truncation.
+        // Windows: no portable stable-Rust nlink. NTFS hard links are real, so
+        // truncating without a confirmed link count could zero a checkpoint's
+        // hard-linked copy — the same hazard the Unix guard prevents. Report
+        // "unsupported" so the reclaim path conservatively SKIPS the
+        // synchronous truncate and relies on the async unlink alone (correct,
+        // just without the immediate-footprint fast path). Narrowing the
+        // contract this way is deliberate; raising it to truncate-on-Windows
+        // would need a winapi `GetFileInformationByHandle` link-count query.
         #[cfg(not(unix))]
         {
             let _ = path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ pub(crate) mod range_tombstone_filter;
 #[doc(hidden)]
 pub mod table;
 
+mod scan_since;
 mod seqno;
 mod slice;
 mod slice_windows;
@@ -400,6 +401,7 @@ pub use {
     memtable::{Memtable, MemtableId},
     merge_operator::MergeOperator,
     prefix::PrefixExtractor,
+    scan_since::ScanSinceEvent,
     seqno::{
         MAX_SEQNO, SequenceNumberCounter, SequenceNumberGenerator, SharedSequenceNumberGenerator,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ pub(crate) mod range_tombstone_filter;
 #[doc(hidden)]
 pub mod table;
 
+mod background_deleter;
 mod scan_since;
 mod seqno;
 mod slice;
@@ -380,6 +381,9 @@ pub use encryption::EncryptionProvider;
 #[cfg(feature = "encryption")]
 pub use encryption::Aes256GcmProvider;
 
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub use background_deleter::BackgroundDeleter;
 pub use pinnable_slice::PinnableSlice;
 #[cfg(feature = "std")]
 pub use repair::RepairReport;

--- a/src/scan_since.rs
+++ b/src/scan_since.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024-present, fjall-rs
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Change-data-capture event stream for [`Tree::scan_since_seqno`].
+//!
+//! [`Tree::scan_since_seqno`]: crate::Tree::scan_since_seqno
+
+use crate::{SeqNo, Slice};
+
+/// A single change event emitted by [`Tree::scan_since_seqno`].
+///
+/// Each event carries the sequence number at which the change was committed.
+/// Events are emitted in increasing seqno order, so a downstream consumer
+/// (replica, Kafka connector, Debezium-style pipeline) can replay them in
+/// order to reconstruct the source's history. Superseded versions are **not**
+/// collapsed: a key updated three times after the target seqno yields three
+/// events, mirroring the source's full change history rather than just its
+/// latest visible state.
+///
+/// # Replay semantics
+///
+/// Applying events in seqno order reconstructs the state delta. An
+/// `Insert(K, V1, s=150)` followed by a `PointTombstone(K, s=200)` means "K was
+/// inserted with V1 at 150, then deleted at 200" — the net effect on a replica
+/// starting before 150 is "create K with V1, then delete K", matching the
+/// source.
+///
+/// # Merge operands
+///
+/// A store using a [`MergeOperator`](crate::MergeOperator) records partial
+/// updates as [`MergeOperand`](Self::MergeOperand) events rather than resolved
+/// values: the consumer applies the same merge operator to reproduce the
+/// source's state. Emitting a merge as an `Insert` would make a replica
+/// overwrite instead of merge, diverging from the source; resolving the merge
+/// chain here would require reading the full base+operand history and defeat
+/// the block-skip optimization, so the raw operand is surfaced instead.
+///
+/// # KV-separated (blob) values
+///
+/// When a value is stored out-of-line in a blob file, the blob is resolved and
+/// the real value is carried in the [`Insert`](Self::Insert) event, so the
+/// consumer never needs access to the source's blob files to replicate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ScanSinceEvent {
+    /// A record was written (or overwritten) at `seqno`.
+    ///
+    /// Covers both inline values and values resolved from a blob file.
+    Insert {
+        /// User key that was written.
+        key: Slice,
+        /// Value written at `seqno` (resolved from a blob file if the entry
+        /// was KV-separated).
+        value: Slice,
+        /// Sequence number at which the write was committed.
+        seqno: SeqNo,
+    },
+
+    /// A merge operand was written at `seqno`.
+    ///
+    /// The consumer must apply the source's [`MergeOperator`](crate::MergeOperator)
+    /// to combine this operand with the prior value / operands, exactly as the
+    /// source does.
+    MergeOperand {
+        /// User key the operand applies to.
+        key: Slice,
+        /// Raw merge operand bytes, to be combined via the merge operator.
+        operand: Slice,
+        /// Sequence number at which the operand was committed.
+        seqno: SeqNo,
+    },
+
+    /// A single key was deleted at `seqno`.
+    ///
+    /// Covers both regular and weak (single-delete) tombstones; both reduce to
+    /// "this key is gone as of `seqno`" for replay purposes.
+    PointTombstone {
+        /// User key that was deleted.
+        key: Slice,
+        /// Sequence number at which the deletion was committed.
+        seqno: SeqNo,
+    },
+
+    /// A half-open key range `[start_key, end_key)` was deleted at `seqno`.
+    RangeTombstone {
+        /// Inclusive lower bound of the deleted range.
+        start_key: Slice,
+        /// Exclusive upper bound of the deleted range.
+        end_key: Slice,
+        /// Sequence number at which the range deletion was committed.
+        seqno: SeqNo,
+    },
+}
+
+impl ScanSinceEvent {
+    /// Sequence number at which this change was committed.
+    ///
+    /// Events from [`Tree::scan_since_seqno`](crate::Tree::scan_since_seqno)
+    /// arrive in increasing order of this value.
+    #[must_use]
+    pub fn seqno(&self) -> SeqNo {
+        match self {
+            Self::Insert { seqno, .. }
+            | Self::MergeOperand { seqno, .. }
+            | Self::PointTombstone { seqno, .. }
+            | Self::RangeTombstone { seqno, .. } => *seqno,
+        }
+    }
+}

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -133,6 +133,17 @@ impl KeyedBlockHandle {
         self.seqno
     }
 
+    /// Per-block seqno bounds `(min, max)` if this entry uses the
+    /// seqno-bounded wire format (markers 2 / 3), else `None` (legacy entry).
+    ///
+    /// A seqno-scoped scan skips the referenced data block without reading it
+    /// when `max < target`; `None` means the bounds are unavailable on disk and
+    /// the caller must fall back to reading and filtering the block.
+    #[must_use]
+    pub fn seqno_bounds(&self) -> Option<(SeqNo, SeqNo)> {
+        self.seqno_bounds
+    }
+
     pub fn shift(&mut self, delta: BlockOffset) {
         self.inner.offset += delta;
     }

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -116,6 +116,20 @@ pub struct Inner {
     // compaction and read on every Drop; CAS-based race semantics are
     // fine for this single-publisher, many-reader pattern.
     pub(crate) deletion_pause: once_cell::race::OnceBox<Arc<DeletionPause>>,
+
+    /// Tree-wide background file deleter. Installed once by
+    /// [`Table::install_background_deleter`](super::Table::install_background_deleter)
+    /// after the table is registered with a tree. When present (and no
+    /// checkpoint pause is active), the [`Drop`] impl reclaims the SST's blocks
+    /// synchronously via [`Fs::truncate_file`](crate::fs::Fs::truncate_file) and
+    /// hands the directory-entry `unlink` to this deleter's worker, off the
+    /// foreground path. Absent (e.g. orphan cleanup before a tree owns the
+    /// table) the Drop falls back to a synchronous `remove_file`.
+    // std-only (the deleter spawns a thread); `no_std` builds never install
+    // one and keep the synchronous Drop path. OnceBox keeps the field itself
+    // alloc-friendly, matching `deletion_pause`.
+    #[cfg(feature = "std")]
+    pub(crate) background_deleter: once_cell::race::OnceBox<Arc<crate::BackgroundDeleter>>,
 }
 
 impl Inner {
@@ -168,6 +182,23 @@ impl Drop for Inner {
                     "Deferred deletion of table {global_id:?} at {:?} (checkpoint active)",
                     self.path,
                 );
+                return;
+            }
+
+            // Off-foreground reclaim: return the SST's blocks to the filesystem
+            // synchronously (so a footprint scan reflects the reclaim at once)
+            // and hand the directory-entry unlink to the background deleter.
+            // Falls through to a synchronous remove_file when no deleter is
+            // installed (e.g. orphan cleanup before a tree owns the table).
+            #[cfg(feature = "std")]
+            if let Some(deleter) = self.background_deleter.get() {
+                if let Err(e) = self.fs.truncate_file(&self.path) {
+                    log::warn!(
+                        "Failed to truncate deleted table {global_id:?} at {:?}: {e:?}",
+                        self.path,
+                    );
+                }
+                deleter.enqueue(Arc::clone(&self.fs), (*self.path).clone());
                 return;
             }
 

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -192,7 +192,17 @@ impl Drop for Inner {
             // installed (e.g. orphan cleanup before a tree owns the table).
             #[cfg(feature = "std")]
             if let Some(deleter) = self.background_deleter.get() {
-                if let Err(e) = self.fs.truncate_file(&self.path) {
+                // Truncate (instant block-free) only when we own the sole hard
+                // link. A completed checkpoint may have hard-linked this SST;
+                // truncating the shared inode would zero the checkpoint's copy
+                // too. When the link is shared (or the count is unknown), skip
+                // the truncate and just unlink our directory entry — the data
+                // survives via the other link and its blocks free once the last
+                // link is gone. (An in-progress checkpoint is already handled by
+                // the deletion-pause branch above.)
+                if self.fs.hard_link_count(&self.path).is_ok_and(|n| n <= 1)
+                    && let Err(e) = self.fs.truncate_file(&self.path)
+                {
                     log::warn!(
                         "Failed to truncate deleted table {global_id:?} at {:?}: {e:?}",
                         self.path,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -899,6 +899,23 @@ impl Table {
     /// Returns `Err` if reading the index or a data block fails.
     #[doc(hidden)]
     pub fn scan_since_seqno(&self, target_seqno: SeqNo) -> crate::Result<Vec<InternalValue>> {
+        self.scan_seqno_range(target_seqno, SeqNo::MAX)
+    }
+
+    /// Like [`Self::scan_since_seqno`] but also bounds the result above:
+    /// collects entries whose global seqno is in `[target_seqno, end_seqno)`.
+    /// The upper bound lets the tree-level scan pin a stable snapshot watermark
+    /// so a concurrent write cannot leak in mid-scan.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the index or a data block fails.
+    #[doc(hidden)]
+    pub fn scan_seqno_range(
+        &self,
+        target_seqno: SeqNo,
+        end_seqno: SeqNo,
+    ) -> crate::Result<Vec<InternalValue>> {
         // Bulk-ingested tables store entries at LOCAL seqno coordinates with a
         // `global_seqno` offset; the on-disk seqno bounds and per-entry seqnos
         // are all local. Translate the incoming global target down to local
@@ -908,17 +925,21 @@ impl Table {
         // no-ops.
         let global_seqno = self.global_seqno();
         let local_target = target_seqno.saturating_sub(global_seqno);
+        // Upper bound in local coords. `SeqNo::MAX` (the unbounded case) stays
+        // MAX so every entry passes; a real watermark maps below the offset to
+        // 0, correctly excluding the whole table.
+        let local_end = end_seqno.saturating_sub(global_seqno);
 
         let mut out = Vec::new();
 
         for handle in self.block_index.iter() {
             let handle = handle?;
 
-            // Block-skip: a seqno-bounded entry whose (local) max is below the
-            // (local) target cannot reference any qualifying record, so skip
-            // the data-block read.
-            if let Some((_, seqno_max)) = handle.seqno_bounds()
-                && seqno_max < local_target
+            // Block-skip: a seqno-bounded entry whose (local) min exceeds the
+            // upper bound, or whose (local) max is below the target, cannot
+            // reference any qualifying record — skip the data-block read.
+            if let Some((seqno_min, seqno_max)) = handle.seqno_bounds()
+                && (seqno_max < local_target || seqno_min >= local_end)
             {
                 continue;
             }
@@ -927,7 +948,7 @@ impl Table {
             let data = &block.inner.data;
             for item in block.iter(self.comparator.clone()) {
                 let mut value = item.materialize(data);
-                if value.key.seqno >= local_target {
+                if value.key.seqno >= local_target && value.key.seqno < local_end {
                     value.key.seqno = value.key.seqno.saturating_add(global_seqno);
                     out.push(value);
                 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -930,6 +930,14 @@ impl Table {
         // 0, correctly excluding the whole table.
         let local_end = end_seqno.saturating_sub(global_seqno);
 
+        // Empty window (e.g. a caught-up CDC poller whose target equals the
+        // current watermark): nothing can qualify, so skip walking the index
+        // entirely. Without this a legacy SST (no per-block seqno bounds) would
+        // load + filter every block to return nothing on every poll.
+        if local_target >= local_end {
+            return Ok(Vec::new());
+        }
+
         let mut out = Vec::new();
 
         for handle in self.block_index.iter() {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -882,6 +882,49 @@ impl Table {
         self.range(..)
     }
 
+    /// Collects every entry in this SST with `seqno >= target_seqno`,
+    /// applying the per-block seqno-bounds skip when the SST carries it.
+    ///
+    /// A data block whose index entry reports `seqno_max < target_seqno`
+    /// (seqno-bounded format, `Properties.index_format = 1`) cannot hold a
+    /// qualifying record, so it is skipped without being read. Blocks without
+    /// bounds on disk (legacy `index_format = 0`) are always read and filtered
+    /// per entry, so the result is correct regardless of the SST's index
+    /// format. Entries come back in the SST's stored order (key-ascending,
+    /// seqno-descending within a key); ordering across sources is the caller's
+    /// job.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the index or a data block fails.
+    #[doc(hidden)]
+    pub fn scan_since_seqno(&self, target_seqno: SeqNo) -> crate::Result<Vec<InternalValue>> {
+        let mut out = Vec::new();
+
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+
+            // Block-skip: a seqno-bounded entry whose max is below the target
+            // cannot reference any qualifying record, so skip the data-block read.
+            if let Some((_, seqno_max)) = handle.seqno_bounds()
+                && seqno_max < target_seqno
+            {
+                continue;
+            }
+
+            let block = self.load_data_block(handle.as_ref())?;
+            let data = &block.inner.data;
+            for item in block.iter(self.comparator.clone()) {
+                let value = item.materialize(data);
+                if value.key.seqno >= target_seqno {
+                    out.push(value);
+                }
+            }
+        }
+
+        Ok(out)
+    }
+
     /// Creates a ranged iterator over the `Table`.
     ///
     /// # Errors

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -899,15 +899,26 @@ impl Table {
     /// Returns `Err` if reading the index or a data block fails.
     #[doc(hidden)]
     pub fn scan_since_seqno(&self, target_seqno: SeqNo) -> crate::Result<Vec<InternalValue>> {
+        // Bulk-ingested tables store entries at LOCAL seqno coordinates with a
+        // `global_seqno` offset; the on-disk seqno bounds and per-entry seqnos
+        // are all local. Translate the incoming global target down to local
+        // for the comparisons, then translate matched record seqnos back up to
+        // global before returning — exactly as `Table::get` does. For a
+        // non-ingested table `global_seqno` is 0 and both translations are
+        // no-ops.
+        let global_seqno = self.global_seqno();
+        let local_target = target_seqno.saturating_sub(global_seqno);
+
         let mut out = Vec::new();
 
         for handle in self.block_index.iter() {
             let handle = handle?;
 
-            // Block-skip: a seqno-bounded entry whose max is below the target
-            // cannot reference any qualifying record, so skip the data-block read.
+            // Block-skip: a seqno-bounded entry whose (local) max is below the
+            // (local) target cannot reference any qualifying record, so skip
+            // the data-block read.
             if let Some((_, seqno_max)) = handle.seqno_bounds()
-                && seqno_max < target_seqno
+                && seqno_max < local_target
             {
                 continue;
             }
@@ -915,8 +926,9 @@ impl Table {
             let block = self.load_data_block(handle.as_ref())?;
             let data = &block.inner.data;
             for item in block.iter(self.comparator.clone()) {
-                let value = item.materialize(data);
-                if value.key.seqno >= target_seqno {
+                let mut value = item.materialize(data);
+                if value.key.seqno >= local_target {
+                    value.key.seqno = value.key.seqno.saturating_add(global_seqno);
                     out.push(value);
                 }
             }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1500,6 +1500,9 @@ impl Table {
             zstd_dictionary,
 
             deletion_pause: once_cell::race::OnceBox::new(),
+
+            #[cfg(feature = "std")]
+            background_deleter: once_cell::race::OnceBox::new(),
         })))
     }
 
@@ -1509,6 +1512,17 @@ impl Table {
     /// after recovery and after compaction registers freshly-built tables.
     pub(crate) fn install_deletion_pause(&self, pause: Arc<crate::deletion_pause::DeletionPause>) {
         let _ = self.0.deletion_pause.set(Box::new(pause));
+    }
+
+    /// Installs the tree-wide background file deleter.
+    ///
+    /// Idempotent: a second call is a no-op. Called by the owning tree after
+    /// recovery and after compaction registers freshly-built tables, so an
+    /// obsolete SST's `unlink` runs off the foreground path while its blocks
+    /// are reclaimed synchronously at Drop.
+    #[cfg(feature = "std")]
+    pub(crate) fn install_background_deleter(&self, deleter: Arc<crate::BackgroundDeleter>) {
+        let _ = self.0.background_deleter.set(Box::new(deleter));
     }
 
     #[must_use]

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -85,6 +85,17 @@ pub struct TreeInner {
     /// [`Table`](crate::Table) and [`BlobFile`](crate::BlobFile).
     pub(crate) deletion_pause: Arc<DeletionPause>,
 
+    /// Tree-wide background file deleter. Installed into every table / blob
+    /// file so an obsolete file's directory-entry `unlink` runs off the
+    /// foreground path (its blocks are freed synchronously at the Drop site).
+    /// Held here so the deleter — and its worker thread — outlives every table
+    /// (each table holds a clone, so the worker drains and joins only once the
+    /// last reference, including this one, is dropped).
+    // std-only: the deleter spawns a thread. A no_std build keeps the
+    // synchronous Drop path and never constructs one.
+    #[cfg(feature = "std")]
+    pub(crate) background_deleter: Arc<crate::BackgroundDeleter>,
+
     /// Runtime-toggleable configuration. Lockless atomic snapshot.
     ///
     /// Reachable through the public Tree API
@@ -168,6 +179,8 @@ impl TreeInner {
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: DeletionPause::new_shared(),
+            #[cfg(feature = "std")]
+            background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
 
             #[cfg(feature = "metrics")]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -384,6 +384,10 @@ impl AbstractTree for Tree {
         let config = self.tree_config();
         let mut versions = self.get_version_history_lock();
 
+        // Pre-clear snapshot: every table + blob file it references becomes
+        // garbage the moment the new empty version is installed.
+        let prior = versions.latest_version();
+
         versions.upgrade_version(
             &config.path,
             |v| {
@@ -401,7 +405,29 @@ impl AbstractTree for Tree {
             &*config.fs,
             self.0.runtime_config.load_full(),
             self.0.config.encryption.clone(),
-        )
+        )?;
+
+        // Release the history's hold on the now-obsolete versions; only the new
+        // empty version remains. `prior` still holds them, so nothing reaches
+        // refcount zero yet.
+        versions.drain_obsolete_to_latest();
+        drop(versions); // release the version-history lock before any fs work
+
+        // Mark every obsolete table / blob file deleted so the file is
+        // reclaimed (Inner::Drop) once its last reference is released. A
+        // concurrent reader still holding the pre-clear snapshot keeps its own
+        // clone alive, deferring physical deletion until it finishes — the
+        // version-history Arc refcount is the MVCC guard, so reclaim never
+        // races a live read. Tables with no other live reference are reclaimed
+        // as `prior` drops at the end of this call.
+        for table in prior.version.iter_tables() {
+            table.mark_as_deleted();
+        }
+        for blob_file in prior.version.blob_files.iter() {
+            blob_file.mark_as_deleted();
+        }
+
+        Ok(())
     }
 
     #[doc(hidden)]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -17,6 +17,8 @@ use crate::{
     key::InternalKey,
     manifest::Manifest,
     memtable::Memtable,
+    range_tombstone::RangeTombstone,
+    scan_since::ScanSinceEvent,
     slice::Slice,
     table::Table,
     value::InternalValue,
@@ -1036,6 +1038,130 @@ impl AbstractTree for Tree {
 }
 
 impl Tree {
+    /// Maps a raw internal entry to its change-data-capture event.
+    ///
+    /// `Indirection` (KV-separated) values are not resolvable at this level
+    /// because the blob files live above the standard tree; the blob-tree scan
+    /// path resolves them into [`ScanSinceEvent::Insert`]. A standard tree
+    /// never stores `Indirection`, so this arm is unreachable there.
+    fn point_event(entry: InternalValue) -> crate::Result<ScanSinceEvent> {
+        let seqno = entry.key.seqno;
+        let key = entry.key.user_key;
+        Ok(match entry.key.value_type {
+            ValueType::Value => ScanSinceEvent::Insert {
+                key,
+                value: entry.value,
+                seqno,
+            },
+            ValueType::MergeOperand => ScanSinceEvent::MergeOperand {
+                key,
+                operand: entry.value,
+                seqno,
+            },
+            ValueType::Tombstone | ValueType::WeakTombstone => {
+                ScanSinceEvent::PointTombstone { key, seqno }
+            }
+            ValueType::Indirection => {
+                return Err(crate::Error::FeatureUnsupported(
+                    "scan_since_seqno on KV-separated values requires the blob-tree scan path",
+                ));
+            }
+        })
+    }
+
+    /// Iterate change events with `seqno >= target_seqno`.
+    ///
+    /// Returns every change committed at or after `target_seqno` as a stream
+    /// of [`ScanSinceEvent`]s in increasing seqno order. This is the canonical
+    /// change-data-capture primitive: a downstream consumer (replica, Kafka
+    /// connector, Debezium-style pipeline) replays the events in order to
+    /// reconstruct the source's history. Superseded versions are not collapsed
+    /// (a key written three times after the target yields three events).
+    ///
+    /// # Block-skip
+    ///
+    /// On SSTs written in the seqno-bounded index format (`seqno_in_index`),
+    /// data blocks whose `seqno_max < target_seqno` are skipped without being
+    /// read; legacy SSTs are read and filtered per entry, so mixed-format trees
+    /// are handled transparently.
+    ///
+    /// # KV-separation
+    ///
+    /// Standard trees never store blob-indirected values. On the inner tree of
+    /// a KV-separated (blob) tree this returns an `Err` for indirected entries:
+    /// blob resolution into [`ScanSinceEvent::Insert`] is provided by the
+    /// blob-tree scan path, which owns the blob files.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal version-history lock is poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the index or a data block fails, or if an entry
+    /// is a KV-separated value (see above).
+    pub fn scan_since_seqno(
+        &self,
+        target_seqno: SeqNo,
+    ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
+        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+        let super_version = self
+            .version_history
+            .read()
+            .expect("lock is poisoned")
+            .latest_version();
+
+        let mut events: Vec<ScanSinceEvent> = Vec::new();
+
+        // Point entries: active + sealed memtables, then SSTs (block-skip).
+        for entry in super_version.active_memtable.iter() {
+            if entry.key.seqno >= target_seqno {
+                events.push(Self::point_event(entry)?);
+            }
+        }
+        for memtable in super_version.sealed_memtables.iter() {
+            for entry in memtable.iter() {
+                if entry.key.seqno >= target_seqno {
+                    events.push(Self::point_event(entry)?);
+                }
+            }
+        }
+        for table in super_version.version.iter_tables() {
+            for entry in table.scan_since_seqno(target_seqno)? {
+                events.push(Self::point_event(entry)?);
+            }
+        }
+
+        // Range tombstones from the same sources, carrying their own seqno.
+        let mut push_range_tombstone = |rt: &RangeTombstone| {
+            if rt.seqno >= target_seqno {
+                events.push(ScanSinceEvent::RangeTombstone {
+                    start_key: rt.start.clone(),
+                    end_key: rt.end.clone(),
+                    seqno: rt.seqno,
+                });
+            }
+        };
+        for rt in super_version.active_memtable.range_tombstones_sorted() {
+            push_range_tombstone(&rt);
+        }
+        for memtable in super_version.sealed_memtables.iter() {
+            for rt in memtable.range_tombstones_sorted() {
+                push_range_tombstone(&rt);
+            }
+        }
+        for table in super_version.version.iter_tables() {
+            for rt in table.range_tombstones() {
+                push_range_tombstone(rt);
+            }
+        }
+
+        // Replay order is increasing seqno across every source.
+        events.sort_by_key(ScanSinceEvent::seqno);
+
+        Ok(events.into_iter())
+    }
+
     /// Update the live [`crate::runtime_config::RuntimeConfig`].
     ///
     /// Mutator runs on a clone of the current snapshot; the new snapshot

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1136,30 +1136,56 @@ impl Tree {
             .latest_version();
         let version = &super_version.version;
 
+        // Stable upper watermark, captured once before walking any source: the
+        // highest seqno present across every source at scan start (in global
+        // coordinates — `Table::get_highest_seqno` already adds the offset).
+        // The active memtable is shared and mutable, so without this cap a
+        // write committed mid-scan could leak in and break the "consistent
+        // snapshot of changes in [target, watermark]" contract. The seqno
+        // counter is not a reliable bound here because callers may assign
+        // seqnos explicitly without advancing it, so derive it from the data.
+        let end_seqno = {
+            let active = super_version.active_memtable.get_highest_seqno();
+            let sealed = super_version
+                .sealed_memtables
+                .iter()
+                .map(|mt| mt.get_highest_seqno())
+                .max()
+                .flatten();
+            let tables = version.iter_tables().map(Table::get_highest_seqno).max();
+            active.max(sealed).max(tables)
+        };
+        // No entries anywhere ⇒ nothing qualifies, regardless of target.
+        let Some(end_seqno) = end_seqno else {
+            return Ok(Vec::new().into_iter());
+        };
+
         let mut events: Vec<ScanSinceEvent> = Vec::new();
 
         // Point entries: active + sealed memtables, then SSTs (block-skip).
         for entry in super_version.active_memtable.iter() {
-            if entry.key.seqno >= target_seqno {
+            if entry.key.seqno >= target_seqno && entry.key.seqno <= end_seqno {
                 events.push(Self::map_event(entry, version, &resolve_indirection)?);
             }
         }
         for memtable in super_version.sealed_memtables.iter() {
             for entry in memtable.iter() {
-                if entry.key.seqno >= target_seqno {
+                if entry.key.seqno >= target_seqno && entry.key.seqno <= end_seqno {
                     events.push(Self::map_event(entry, version, &resolve_indirection)?);
                 }
             }
         }
         for table in version.iter_tables() {
-            for entry in table.scan_since_seqno(target_seqno)? {
+            // `scan_seqno_range` upper bound is exclusive; `end_seqno` is the
+            // inclusive max, so add one (saturating for the MAX edge).
+            for entry in table.scan_seqno_range(target_seqno, end_seqno.saturating_add(1))? {
                 events.push(Self::map_event(entry, version, &resolve_indirection)?);
             }
         }
 
         // Range tombstones from the same sources, carrying their own seqno.
         let mut push_range_tombstone = |rt: &RangeTombstone| {
-            if rt.seqno >= target_seqno {
+            if rt.seqno >= target_seqno && rt.seqno <= end_seqno {
                 events.push(ScanSinceEvent::RangeTombstone {
                     start_key: rt.start.clone(),
                     end_key: rt.end.clone(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -656,10 +656,14 @@ impl AbstractTree for Tree {
         // later get marked `is_deleted` by compaction.
         for table in tables {
             table.install_deletion_pause(Arc::clone(&self.deletion_pause));
+            #[cfg(feature = "std")]
+            table.install_background_deleter(Arc::clone(&self.background_deleter));
         }
         if let Some(bfs) = blob_files {
             for bf in bfs {
                 bf.install_deletion_pause(Arc::clone(&self.deletion_pause));
+                #[cfg(feature = "std")]
+                bf.install_background_deleter(Arc::clone(&self.background_deleter));
             }
         }
 
@@ -2317,6 +2321,8 @@ impl Tree {
         let comparator = config.comparator.clone();
 
         let deletion_pause = crate::deletion_pause::DeletionPause::new_shared();
+        #[cfg(feature = "std")]
+        let background_deleter = Arc::new(crate::BackgroundDeleter::new(None));
 
         // Clone the seed snapshot BEFORE moving config into the Arc
         // below — the runtime handle initializer needs it after the
@@ -2346,6 +2352,8 @@ impl Tree {
             flush_lock: Mutex::default(),
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: Arc::clone(&deletion_pause),
+            #[cfg(feature = "std")]
+            background_deleter: Arc::clone(&background_deleter),
             runtime_config: Arc::new(crate::runtime_config::handle::RuntimeConfigHandle::new(
                 initial_runtime,
             )),
@@ -2373,9 +2381,13 @@ impl Tree {
 
         for table in &recovered_tables {
             table.install_deletion_pause(Arc::clone(&deletion_pause));
+            #[cfg(feature = "std")]
+            table.install_background_deleter(Arc::clone(&background_deleter));
         }
         for blob_file in &recovered_blobs {
             blob_file.install_deletion_pause(Arc::clone(&deletion_pause));
+            #[cfg(feature = "std")]
+            blob_file.install_background_deleter(Arc::clone(&background_deleter));
         }
 
         Ok(Self(Arc::new(inner)))

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1038,13 +1038,23 @@ impl AbstractTree for Tree {
 }
 
 impl Tree {
-    /// Maps a raw internal entry to its change-data-capture event.
+    /// Maps a raw internal entry to its change-data-capture event, routing
+    /// `Indirection` (KV-separated) values through `resolve_indirection`.
     ///
-    /// `Indirection` (KV-separated) values are not resolvable at this level
-    /// because the blob files live above the standard tree; the blob-tree scan
-    /// path resolves them into [`ScanSinceEvent::Insert`]. A standard tree
-    /// never stores `Indirection`, so this arm is unreachable there.
-    fn point_event(entry: InternalValue) -> crate::Result<ScanSinceEvent> {
+    /// A standard tree never stores `Indirection` and supplies a resolver that
+    /// errors; the blob-tree scan path supplies one that reads the blob and
+    /// returns an [`ScanSinceEvent::Insert`].
+    fn map_event<F>(
+        entry: InternalValue,
+        version: &Version,
+        resolve_indirection: &F,
+    ) -> crate::Result<ScanSinceEvent>
+    where
+        F: Fn(&Version, InternalValue) -> crate::Result<ScanSinceEvent>,
+    {
+        if entry.key.value_type == ValueType::Indirection {
+            return resolve_indirection(version, entry);
+        }
         let seqno = entry.key.seqno;
         let key = entry.key.user_key;
         Ok(match entry.key.value_type {
@@ -1061,12 +1071,90 @@ impl Tree {
             ValueType::Tombstone | ValueType::WeakTombstone => {
                 ScanSinceEvent::PointTombstone { key, seqno }
             }
-            ValueType::Indirection => {
-                return Err(crate::Error::FeatureUnsupported(
-                    "scan_since_seqno on KV-separated values requires the blob-tree scan path",
-                ));
-            }
+            ValueType::Indirection => unreachable!("Indirection handled above"),
         })
+    }
+
+    /// Shared CDC aggregation behind [`Self::scan_since_seqno`] and the
+    /// blob-tree scan path: gathers qualifying entries (`seqno >= target`) plus
+    /// range tombstones from the active + sealed memtables and every SST (with
+    /// block-skip), maps each entry to a [`ScanSinceEvent`] — routing
+    /// `Indirection` values through `resolve_indirection` against the same
+    /// version snapshot — and returns them in increasing seqno order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal version-history lock is poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the index or a data block fails, or if
+    /// `resolve_indirection` errors.
+    pub(crate) fn scan_since_seqno_with<F>(
+        &self,
+        target_seqno: SeqNo,
+        resolve_indirection: F,
+    ) -> crate::Result<std::vec::IntoIter<ScanSinceEvent>>
+    where
+        F: Fn(&Version, InternalValue) -> crate::Result<ScanSinceEvent>,
+    {
+        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
+        let super_version = self
+            .version_history
+            .read()
+            .expect("lock is poisoned")
+            .latest_version();
+        let version = &super_version.version;
+
+        let mut events: Vec<ScanSinceEvent> = Vec::new();
+
+        // Point entries: active + sealed memtables, then SSTs (block-skip).
+        for entry in super_version.active_memtable.iter() {
+            if entry.key.seqno >= target_seqno {
+                events.push(Self::map_event(entry, version, &resolve_indirection)?);
+            }
+        }
+        for memtable in super_version.sealed_memtables.iter() {
+            for entry in memtable.iter() {
+                if entry.key.seqno >= target_seqno {
+                    events.push(Self::map_event(entry, version, &resolve_indirection)?);
+                }
+            }
+        }
+        for table in version.iter_tables() {
+            for entry in table.scan_since_seqno(target_seqno)? {
+                events.push(Self::map_event(entry, version, &resolve_indirection)?);
+            }
+        }
+
+        // Range tombstones from the same sources, carrying their own seqno.
+        let mut push_range_tombstone = |rt: &RangeTombstone| {
+            if rt.seqno >= target_seqno {
+                events.push(ScanSinceEvent::RangeTombstone {
+                    start_key: rt.start.clone(),
+                    end_key: rt.end.clone(),
+                    seqno: rt.seqno,
+                });
+            }
+        };
+        for rt in super_version.active_memtable.range_tombstones_sorted() {
+            push_range_tombstone(&rt);
+        }
+        for memtable in super_version.sealed_memtables.iter() {
+            for rt in memtable.range_tombstones_sorted() {
+                push_range_tombstone(&rt);
+            }
+        }
+        for table in version.iter_tables() {
+            for rt in table.range_tombstones() {
+                push_range_tombstone(rt);
+            }
+        }
+
+        // Replay order is increasing seqno across every source.
+        events.sort_by_key(ScanSinceEvent::seqno);
+
+        Ok(events.into_iter())
     }
 
     /// Iterate change events with `seqno >= target_seqno`.
@@ -1104,62 +1192,14 @@ impl Tree {
         &self,
         target_seqno: SeqNo,
     ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version();
-
-        let mut events: Vec<ScanSinceEvent> = Vec::new();
-
-        // Point entries: active + sealed memtables, then SSTs (block-skip).
-        for entry in super_version.active_memtable.iter() {
-            if entry.key.seqno >= target_seqno {
-                events.push(Self::point_event(entry)?);
-            }
-        }
-        for memtable in super_version.sealed_memtables.iter() {
-            for entry in memtable.iter() {
-                if entry.key.seqno >= target_seqno {
-                    events.push(Self::point_event(entry)?);
-                }
-            }
-        }
-        for table in super_version.version.iter_tables() {
-            for entry in table.scan_since_seqno(target_seqno)? {
-                events.push(Self::point_event(entry)?);
-            }
-        }
-
-        // Range tombstones from the same sources, carrying their own seqno.
-        let mut push_range_tombstone = |rt: &RangeTombstone| {
-            if rt.seqno >= target_seqno {
-                events.push(ScanSinceEvent::RangeTombstone {
-                    start_key: rt.start.clone(),
-                    end_key: rt.end.clone(),
-                    seqno: rt.seqno,
-                });
-            }
-        };
-        for rt in super_version.active_memtable.range_tombstones_sorted() {
-            push_range_tombstone(&rt);
-        }
-        for memtable in super_version.sealed_memtables.iter() {
-            for rt in memtable.range_tombstones_sorted() {
-                push_range_tombstone(&rt);
-            }
-        }
-        for table in super_version.version.iter_tables() {
-            for rt in table.range_tombstones() {
-                push_range_tombstone(rt);
-            }
-        }
-
-        // Replay order is increasing seqno across every source.
-        events.sort_by_key(ScanSinceEvent::seqno);
-
-        Ok(events.into_iter())
+        // A standard tree never stores blob-indirected values; the resolver
+        // errors so an indirected entry (only reachable via a blob tree's inner
+        // index) surfaces as a clear error rather than a wrong event.
+        self.scan_since_seqno_with(target_seqno, |_version, _entry| {
+            Err(crate::Error::FeatureUnsupported(
+                "scan_since_seqno on KV-separated values requires the blob-tree scan path",
+            ))
+        })
     }
 
     /// Update the live [`crate::runtime_config::RuntimeConfig`].

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -193,6 +193,24 @@ impl SuperVersions {
         Ok(())
     }
 
+    /// Drops every retained version except the latest from the in-memory
+    /// history.
+    ///
+    /// Used by [`AbstractTree::clear`](crate::AbstractTree::clear): the new
+    /// (latest) version is empty and every prior version's tables / blob files
+    /// were just marked deleted, so releasing the history's hold lets
+    /// [`Inner::Drop`](crate::table::Table) reclaim their files once any
+    /// concurrent reader's own snapshot clone is released (MVCC-safe — a reader
+    /// keeps its clone alive, deferring deletion until it finishes). The
+    /// on-disk manifest already reflects the latest version (persisted by the
+    /// preceding `upgrade_version`); intermediate in-memory versions carry no
+    /// `v{id}` snapshot file, so there is nothing to unlink here.
+    pub(crate) fn drain_obsolete_to_latest(&mut self) {
+        while self.versions.len() > 1 {
+            self.versions.pop_front();
+        }
+    }
+
     /// Modifies the level manifest atomically.
     ///
     /// The function accepts a transition function that receives the current version

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -60,6 +60,16 @@ pub struct Inner {
     // `once_cell::race::OnceBox` — see Table::Inner::deletion_pause
     // for the rationale (no-std-friendly one-shot slot).
     pub(crate) deletion_pause: once_cell::race::OnceBox<Arc<DeletionPause>>,
+
+    /// Tree-wide background file deleter. See
+    /// [`Table::install_background_deleter`](crate::Table) for the contract:
+    /// when present (and no checkpoint pause is active) the [`Drop`] impl frees
+    /// the blob file's blocks synchronously via
+    /// [`Fs::truncate_file`](crate::fs::Fs::truncate_file) and hands the
+    /// directory-entry `unlink` to this deleter, off the foreground path.
+    // std-only (the deleter spawns a thread); see Table::Inner for rationale.
+    #[cfg(feature = "std")]
+    pub(crate) background_deleter: once_cell::race::OnceBox<Arc<crate::BackgroundDeleter>>,
 }
 
 impl Inner {
@@ -127,7 +137,26 @@ impl Drop for Inner {
                     self.id,
                     self.path.display(),
                 );
-            } else if let Err(e) = self.fs.remove_file(&self.path) {
+                return;
+            }
+
+            // Off-foreground reclaim: free the blocks synchronously (accurate
+            // footprint scan) and hand the unlink to the background deleter.
+            // Falls through to a synchronous remove_file when none installed.
+            #[cfg(feature = "std")]
+            if let Some(deleter) = self.background_deleter.get() {
+                if let Err(e) = self.fs.truncate_file(&self.path) {
+                    log::warn!(
+                        "Failed to truncate deleted blob file {:?} at {}: {e:?}",
+                        self.id,
+                        self.path.display(),
+                    );
+                }
+                deleter.enqueue(Arc::clone(&self.fs), self.path.clone());
+                return;
+            }
+
+            if let Err(e) = self.fs.remove_file(&self.path) {
                 log::warn!(
                     "Failed to cleanup deleted blob file {:?} at {}: {e:?}",
                     self.id,
@@ -167,6 +196,12 @@ impl BlobFile {
     /// Idempotent: a second call is a no-op.
     pub(crate) fn install_deletion_pause(&self, pause: Arc<DeletionPause>) {
         let _ = self.0.deletion_pause.set(Box::new(pause));
+    }
+
+    /// Installs the tree-wide background file deleter. Idempotent.
+    #[cfg(feature = "std")]
+    pub(crate) fn install_background_deleter(&self, deleter: Arc<crate::BackgroundDeleter>) {
+        let _ = self.0.background_deleter.set(Box::new(deleter));
     }
 
     /// Returns the blob file ID.

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -145,7 +145,13 @@ impl Drop for Inner {
             // Falls through to a synchronous remove_file when none installed.
             #[cfg(feature = "std")]
             if let Some(deleter) = self.background_deleter.get() {
-                if let Err(e) = self.fs.truncate_file(&self.path) {
+                // Truncate only when we own the sole hard link — a checkpoint
+                // may have hard-linked this blob file, and truncating the shared
+                // inode would zero the checkpoint's copy. Otherwise skip the
+                // truncate and just unlink (data survives via the other link).
+                if self.fs.hard_link_count(&self.path).is_ok_and(|n| n <= 1)
+                    && let Err(e) = self.fs.truncate_file(&self.path)
+                {
                     log::warn!(
                         "Failed to truncate deleted blob file {:?} at {}: {e:?}",
                         self.id,

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -221,6 +221,9 @@ impl MultiWriter {
                 },
                 fs: fs.clone(),
                 deletion_pause: once_cell::race::OnceBox::new(),
+
+                #[cfg(feature = "std")]
+                background_deleter: once_cell::race::OnceBox::new(),
             }));
 
             Ok(Some(blob_file))

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -1051,6 +1051,9 @@ mod tests {
             file_accessor: FileAccessor::File(Arc::new(file2)),
             fs: Arc::new(crate::fs::StdFs),
             deletion_pause: once_cell::race::OnceBox::new(),
+
+            #[cfg(feature = "std")]
+            background_deleter: once_cell::race::OnceBox::new(),
         }));
 
         let reader = Reader::new(&blob_file, &file);

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -137,6 +137,9 @@ pub fn recover_blob_files(
                 tree_id,
                 fs: fs.clone(),
                 deletion_pause: once_cell::race::OnceBox::new(),
+
+                #[cfg(feature = "std")]
+                background_deleter: once_cell::race::OnceBox::new(),
             })));
 
             if idx % progress_mod == 0 {

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -905,7 +905,8 @@ fn clear_does_not_truncate_checkpoint_hardlinked_ssts() -> lsm_tree::Result<()> 
     let mut shared = false;
     let mut stack = vec![dst_path.clone()];
     while let Some(d) = stack.pop() {
-        for e in std::fs::read_dir(&d)?.flatten() {
+        for entry in std::fs::read_dir(&d)? {
+            let e = entry?;
             let m = e.metadata()?;
             if m.is_dir() {
                 stack.push(e.path());

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -860,3 +860,78 @@ fn checkpoint_survives_concurrent_manifest_gc_of_captured_version() -> lsm_tree:
     }
     Ok(())
 }
+
+/// A checkpoint hard-links the source SST/blob files (shared inode). Reclaiming
+/// the source (e.g. `clear()`) must NOT truncate those inodes, or it would zero
+/// the checkpoint's copy too. Regression guard for the truncate-based reclaim.
+#[cfg(unix)]
+#[test_log::test]
+fn clear_does_not_truncate_checkpoint_hardlinked_ssts() -> lsm_tree::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let dst_path = dst_dir.path().join("checkpoint");
+
+    let any = open_tree(src_dir.path())?;
+    let tree = match &any {
+        AnyTree::Standard(t) => t.clone(),
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    // Force the hard-link checkpoint path (shared inode) instead of reflink
+    // (independent CoW inode), so the truncate-vs-shared-inode hazard is
+    // exercised on every filesystem, not only non-reflink ones.
+    tree.update_runtime_config(|c| {
+        c.use_reflink_for_checkpoint = false;
+    })?;
+    for i in 0u32..500 {
+        tree.insert(
+            format!("k{i:04}"),
+            b"payload-value-data".as_slice(),
+            u64::from(i),
+        );
+    }
+    tree.flush_active_memtable(0)?;
+
+    let info = any.create_checkpoint(&dst_path)?;
+    assert!(
+        info.sst_files >= 1,
+        "checkpoint must capture at least one SST"
+    );
+
+    // Precondition: the checkpoint must have hard-linked (shared inode) for this
+    // test to exercise the bug. If the platform fell back to a copy, nlink == 1
+    // and there is nothing to corrupt — fail loudly so the gap is visible.
+    let mut shared = false;
+    let mut stack = vec![dst_path.clone()];
+    while let Some(d) = stack.pop() {
+        for e in std::fs::read_dir(&d)?.flatten() {
+            let m = e.metadata()?;
+            if m.is_dir() {
+                stack.push(e.path());
+            } else if m.nlink() > 1 {
+                shared = true;
+            }
+        }
+    }
+    assert!(
+        shared,
+        "checkpoint must hard-link a source file (same-fs) to test this"
+    );
+
+    // Reclaim the source: marks the SSTs deleted and runs the truncate path.
+    tree.clear()?;
+
+    // The checkpoint must still be fully readable.
+    let restored = open_tree(&dst_path)?;
+    for i in 0u32..500 {
+        let key = format!("k{i:04}");
+        assert!(
+            restored
+                .get(key.as_bytes(), lsm_tree::SeqNo::MAX)?
+                .is_some(),
+            "checkpoint key {key} must survive source clear() — inode was truncated",
+        );
+    }
+    Ok(())
+}

--- a/tests/clear_reclaim.rs
+++ b/tests/clear_reclaim.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! `clear()` must reclaim the obsolete SST files synchronously enough that a
+//! caller measuring on-disk footprint right after it returns sees the drop.
+//! Regression guard for the v5 deferred-cleanup gap: `clear()` upgraded the
+//! version but left the old SSTs referenced by stale version-history entries,
+//! so a directory scan still saw the pre-clear bytes.
+
+use lsm_tree::{AbstractTree, Config, SequenceNumberCounter, get_tmp_folder};
+use std::path::Path;
+use test_log::test;
+
+/// Total bytes of every regular file under `path` (mirrors a capacity
+/// scanner's `walkdir + sum(metadata.len())`).
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let meta = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+#[test]
+fn clear_reclaims_sst_disk_footprint_synchronously() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+    let tree = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    let tree = match tree {
+        lsm_tree::AnyTree::Standard(t) => t,
+        lsm_tree::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+
+    for i in 0..20_000u64 {
+        tree.insert(
+            format!("key:{i:010}").as_bytes(),
+            b"payload-bytes-padding-padding-padding",
+            i,
+        );
+    }
+    tree.flush_active_memtable(0)?;
+
+    let before = dir_size(path);
+    assert!(
+        before > 200_000,
+        "flushed tree should occupy real disk, got {before} bytes",
+    );
+
+    tree.clear()?;
+
+    let after = dir_size(path);
+    assert!(
+        after * 10 < before,
+        "clear() must reclaim the SST footprint synchronously: before={before}, after={after}",
+    );
+    Ok(())
+}

--- a/tests/clear_reclaim.rs
+++ b/tests/clear_reclaim.rs
@@ -75,3 +75,50 @@ fn clear_reclaims_sst_disk_footprint_synchronously() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn clear_reclaims_blob_files_synchronously() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(lsm_tree::KvSeparationOptions::default()))
+    .open()?;
+    let tree = match any {
+        lsm_tree::AnyTree::Blob(t) => t,
+        lsm_tree::AnyTree::Standard(_) => panic!("expected Blob tree"),
+    };
+
+    // Large values are stored out-of-line; clear() must reclaim both the SSTs
+    // and the blob files.
+    let big = b"blobby-payload".repeat(8_000);
+    for i in 0..40u64 {
+        tree.insert(format!("k{i:04}").as_bytes(), &big, i);
+    }
+    tree.flush_active_memtable(0)?;
+    assert!(tree.blob_file_count() > 0, "values must be blob-separated");
+
+    // The repetitive payload compresses hard, so the on-disk footprint is far
+    // below the logical size; the floor is just a sanity that blob + SST data
+    // landed — the relative drop below is the real reclaim assertion.
+    let before = dir_size(path);
+    assert!(
+        before > 20_000,
+        "blob tree should occupy real disk, got {before}"
+    );
+
+    tree.clear()?;
+
+    // Drop > 50%: the blob + SST bytes are reclaimed; what remains is the
+    // small manifest baseline (snapshot + CURRENT + edit log), which is a
+    // larger fraction here precisely because the payload compressed so well.
+    let after = dir_size(path);
+    assert!(
+        after * 2 < before,
+        "clear() must reclaim SST + blob footprint: before={before}, after={after}",
+    );
+    Ok(())
+}

--- a/tests/clear_reclaim.rs
+++ b/tests/clear_reclaim.rs
@@ -6,6 +6,13 @@
 //! Regression guard for the v5 deferred-cleanup gap: `clear()` upgraded the
 //! version but left the old SSTs referenced by stale version-history entries,
 //! so a directory scan still saw the pre-clear bytes.
+//!
+//! Unix-only: the *synchronous* footprint drop relies on `Fs::truncate_file`,
+//! which only runs when the inode link count can be confirmed as 1 (via
+//! `nlink`). On platforms without a link-count primitive the reclaim is correct
+//! but lands via the asynchronous unlink alone, so the right-after-`clear()`
+//! footprint assertion does not hold deterministically.
+#![cfg(unix)]
 
 use lsm_tree::{AbstractTree, Config, SequenceNumberCounter, get_tmp_folder};
 use std::path::Path;

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -9,7 +9,7 @@
 //! SSTs must scan correctly).
 
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, ScanSinceEvent, SeqNo, SequenceNumberCounter, Tree,
+    AbstractTree, AnyTree, BlobTree, Config, ScanSinceEvent, SeqNo, SequenceNumberCounter, Tree,
     get_tmp_folder,
 };
 use test_log::test;
@@ -33,6 +33,22 @@ fn events(tree: &Tree, target: SeqNo) -> Vec<ScanSinceEvent> {
     tree.scan_since_seqno(target)
         .expect("scan_since_seqno should succeed")
         .collect()
+}
+
+fn open_blob_tree(path: &std::path::Path) -> BlobTree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(lsm_tree::KvSeparationOptions::default()))
+    .open()
+    .expect("BlobTree open should succeed");
+
+    match any {
+        AnyTree::Blob(t) => t,
+        AnyTree::Standard(_) => panic!("expected Blob tree, got Standard"),
+    }
 }
 
 #[test]
@@ -214,5 +230,42 @@ fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
     let mut sorted = seqnos.clone();
     sorted.sort_unstable();
     assert_eq!(seqnos, sorted, "merged output stays seqno-ordered");
+    Ok(())
+}
+
+#[test]
+fn scan_since_resolves_blob_values_on_blob_tree() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_blob_tree(folder.path());
+
+    // A large value is stored out-of-line in a blob file (KV-separation); the
+    // index entry becomes an indirection pointer. A small value stays inline.
+    let big = b"blobby".repeat(40_000);
+    tree.insert(b"big", &big, 0);
+    tree.insert(b"small", b"inline", 1);
+    tree.flush_active_memtable(0)?;
+    assert!(tree.blob_file_count() > 0, "the big value must be separated");
+
+    let got: Vec<ScanSinceEvent> = tree
+        .scan_since_seqno(0)
+        .expect("blob-tree scan_since_seqno should succeed")
+        .collect();
+
+    // The blob-indirected entry must come back as an Insert carrying the real
+    // resolved value, not a pointer.
+    let big_value = got
+        .iter()
+        .find_map(|e| match e {
+            ScanSinceEvent::Insert { key, value, .. } if &**key == b"big" => Some(value.to_vec()),
+            _ => None,
+        })
+        .expect("an Insert for the blob-separated key must be emitted");
+    assert_eq!(big_value, big, "blob value must be resolved, not a handle");
+
+    let small_value = got.iter().find_map(|e| match e {
+        ScanSinceEvent::Insert { key, value, .. } if &**key == b"small" => Some(value.to_vec()),
+        _ => None,
+    });
+    assert_eq!(small_value.as_deref(), Some(b"inline" as &[u8]));
     Ok(())
 }

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -323,3 +323,28 @@ fn scan_since_seqno_translates_ingested_global_seqno() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn scan_since_caught_up_target_returns_empty() -> lsm_tree::Result<()> {
+    // A caught-up CDC poller scans at (or beyond) the current watermark; the
+    // window is empty and the scan must return nothing without re-reading the
+    // legacy/mixed-format portion of the tree.
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path())?;
+
+    for i in 0..10u64 {
+        tree.insert(format!("k{i:02}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Highest seqno present is 9; scanning since 10 (one past it) yields nothing.
+    assert!(
+        events(&tree, 10)?.is_empty(),
+        "an empty seqno window must yield no events"
+    );
+    assert!(
+        events(&tree, 100)?.is_empty(),
+        "a far-future target must yield no events"
+    );
+    Ok(())
+}

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -272,3 +272,55 @@ fn scan_since_resolves_blob_values_on_blob_tree() -> lsm_tree::Result<()> {
     assert_eq!(small_value.as_deref(), Some(b"inline" as &[u8]));
     Ok(())
 }
+
+#[test]
+fn scan_since_seqno_translates_ingested_global_seqno() -> lsm_tree::Result<()> {
+    // Bulk-ingested tables store entries at LOCAL seqno 0 but carry a
+    // global_seqno offset; reads translate (target down, results up) the way
+    // Table::get does. scan_since_seqno must do the same: comparing a global
+    // target against the table's LOCAL seqno bounds would block-skip the whole
+    // table (local max 0 < global target) and silently drop ingested changes.
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let visible = SequenceNumberCounter::default();
+    let any = Config::new(folder.path(), seqno.clone(), visible.clone()).open()?;
+    // `ingestion()` lives on AnyTree; `scan_since_seqno` on the concrete Tree.
+    // Tree is an Arc handle, so this clone shares state with `any`.
+    let tree = match &any {
+        AnyTree::Standard(t) => t.clone(),
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+
+    // A regular flushed table at global_seqno 0.
+    let s0 = seqno.next();
+    tree.insert(b"x", b"x", s0);
+    visible.fetch_max(s0 + 1);
+    tree.flush_active_memtable(0)?;
+
+    // Bulk-ingest: ingested table carries a nonzero global_seqno offset.
+    let global = seqno.get();
+    assert!(
+        global > 0,
+        "ingest must carry a nonzero global_seqno offset"
+    );
+    let mut ing = any.ingestion()?;
+    ing.write("a", "a")?;
+    ing.finish()?;
+
+    // Scanning at the ingest's global seqno must surface the ingested entry,
+    // in GLOBAL coordinates.
+    let events: Vec<ScanSinceEvent> = tree.scan_since_seqno(global)?.collect();
+    let a = events
+        .iter()
+        .find(|e| matches!(e, ScanSinceEvent::Insert { key, .. } if &**key == b"a"));
+    assert!(
+        a.is_some(),
+        "ingested entry must not be block-skipped by a global/local seqno mismatch",
+    );
+    assert_eq!(
+        a.unwrap().seqno(),
+        global,
+        "event seqno must be reported in GLOBAL coordinates",
+    );
+    Ok(())
+}

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -14,54 +14,50 @@ use lsm_tree::{
 };
 use test_log::test;
 
-fn open_tree(path: &std::path::Path) -> Tree {
+fn open_tree(path: &std::path::Path) -> lsm_tree::Result<Tree> {
     let any = Config::new(
         path,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
-    .open()
-    .expect("Tree open should succeed");
+    .open()?;
 
-    match any {
+    Ok(match any {
         AnyTree::Standard(t) => t,
         AnyTree::Blob(_) => panic!("expected Standard tree, got Blob"),
-    }
+    })
 }
 
-fn events(tree: &Tree, target: SeqNo) -> Vec<ScanSinceEvent> {
-    tree.scan_since_seqno(target)
-        .expect("scan_since_seqno should succeed")
-        .collect()
+fn events(tree: &Tree, target: SeqNo) -> lsm_tree::Result<Vec<ScanSinceEvent>> {
+    Ok(tree.scan_since_seqno(target)?.collect())
 }
 
-fn open_blob_tree(path: &std::path::Path) -> BlobTree {
+fn open_blob_tree(path: &std::path::Path) -> lsm_tree::Result<BlobTree> {
     let any = Config::new(
         path,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
     .with_kv_separation(Some(lsm_tree::KvSeparationOptions::default()))
-    .open()
-    .expect("BlobTree open should succeed");
+    .open()?;
 
-    match any {
+    Ok(match any {
         AnyTree::Blob(t) => t,
         AnyTree::Standard(_) => panic!("expected Blob tree, got Standard"),
-    }
+    })
 }
 
 #[test]
 fn scan_since_returns_only_entries_at_or_after_target() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     for i in 0..10u64 {
         tree.insert(format!("k{i:02}").as_bytes(), b"v", i);
     }
     tree.flush_active_memtable(0)?;
 
-    let got = events(&tree, 5);
+    let got = events(&tree, 5)?;
     assert_eq!(got.len(), 5, "only seqnos 5..10 qualify");
     assert!(
         got.iter().all(|e| e.seqno() >= 5),
@@ -73,7 +69,7 @@ fn scan_since_returns_only_entries_at_or_after_target() -> lsm_tree::Result<()> 
 #[test]
 fn scan_since_emits_events_in_increasing_seqno_order() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     // Insert in a deliberately scrambled key order; seqnos still rise.
     for (i, k) in ["m", "a", "z", "c", "q"].iter().enumerate() {
@@ -81,7 +77,10 @@ fn scan_since_emits_events_in_increasing_seqno_order() -> lsm_tree::Result<()> {
     }
     tree.flush_active_memtable(0)?;
 
-    let seqnos: Vec<SeqNo> = events(&tree, 0).iter().map(ScanSinceEvent::seqno).collect();
+    let seqnos: Vec<SeqNo> = events(&tree, 0)?
+        .iter()
+        .map(ScanSinceEvent::seqno)
+        .collect();
     let mut sorted = seqnos.clone();
     sorted.sort_unstable();
     assert_eq!(
@@ -94,13 +93,13 @@ fn scan_since_emits_events_in_increasing_seqno_order() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_maps_value_and_point_tombstone() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     tree.insert(b"key", b"val", 0);
     tree.remove(b"key", 1);
     tree.flush_active_memtable(0)?;
 
-    let got = events(&tree, 0);
+    let got = events(&tree, 0)?;
     assert_eq!(got.len(), 2, "the write and the delete are distinct events");
 
     // Replay order: insert before delete.
@@ -125,13 +124,13 @@ fn scan_since_maps_value_and_point_tombstone() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_emits_range_tombstone() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     tree.insert(b"a", b"v", 0);
     tree.remove_range(b"a", b"m", 1);
     tree.flush_active_memtable(0)?;
 
-    let got = events(&tree, 0);
+    let got = events(&tree, 0)?;
     let range = got
         .iter()
         .find_map(|e| match e {
@@ -152,7 +151,7 @@ fn scan_since_emits_range_tombstone() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_spans_memtable_and_sst() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     // Flushed to an SST.
     for i in 0..5u64 {
@@ -165,7 +164,7 @@ fn scan_since_spans_memtable_and_sst() -> lsm_tree::Result<()> {
         tree.insert(format!("m{i}").as_bytes(), b"v", i);
     }
 
-    let got = events(&tree, 0);
+    let got = events(&tree, 0)?;
     assert_eq!(
         got.len(),
         10,
@@ -177,7 +176,7 @@ fn scan_since_spans_memtable_and_sst() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_block_skip_on_seqno_indexed_sst() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
     tree.update_runtime_config(|cfg| {
         cfg.seqno_in_index = true;
     })?;
@@ -195,7 +194,7 @@ fn scan_since_block_skip_on_seqno_indexed_sst() -> lsm_tree::Result<()> {
         .sum();
     assert!(data_blocks > 1, "need >1 data block to exercise block-skip");
 
-    let got = events(&tree, 450);
+    let got = events(&tree, 450)?;
     assert_eq!(got.len(), 50, "only seqnos 450..500 qualify");
     assert!(got.iter().all(|e| e.seqno() >= 450));
     Ok(())
@@ -204,7 +203,7 @@ fn scan_since_block_skip_on_seqno_indexed_sst() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_tree(folder.path());
+    let tree = open_tree(folder.path())?;
 
     // First SST: legacy index_format=0 (seqno_in_index defaults off).
     for i in 0..250u64 {
@@ -223,7 +222,7 @@ fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
 
     // Target straddles both SSTs: the legacy one falls back to a full filter,
     // the seqno-bounded one uses block-skip; the union must be exact.
-    let got = events(&tree, 200);
+    let got = events(&tree, 200)?;
     assert_eq!(got.len(), 300, "seqnos 200..500 across both formats");
     assert!(got.iter().all(|e| e.seqno() >= 200));
     let seqnos: Vec<SeqNo> = got.iter().map(ScanSinceEvent::seqno).collect();
@@ -236,7 +235,7 @@ fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
 #[test]
 fn scan_since_resolves_blob_values_on_blob_tree() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
-    let tree = open_blob_tree(folder.path());
+    let tree = open_blob_tree(folder.path())?;
 
     // A large value is stored out-of-line in a blob file (KV-separation); the
     // index entry becomes an indirection pointer. A small value stays inline.

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -244,7 +244,10 @@ fn scan_since_resolves_blob_values_on_blob_tree() -> lsm_tree::Result<()> {
     tree.insert(b"big", &big, 0);
     tree.insert(b"small", b"inline", 1);
     tree.flush_active_memtable(0)?;
-    assert!(tree.blob_file_count() > 0, "the big value must be separated");
+    assert!(
+        tree.blob_file_count() > 0,
+        "the big value must be separated"
+    );
 
     let got: Vec<ScanSinceEvent> = tree
         .scan_since_seqno(0)

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -248,10 +248,7 @@ fn scan_since_resolves_blob_values_on_blob_tree() -> lsm_tree::Result<()> {
         "the big value must be separated"
     );
 
-    let got: Vec<ScanSinceEvent> = tree
-        .scan_since_seqno(0)
-        .expect("blob-tree scan_since_seqno should succeed")
-        .collect();
+    let got: Vec<ScanSinceEvent> = tree.scan_since_seqno(0)?.collect();
 
     // The blob-indirected entry must come back as an Insert carrying the real
     // resolved value, not a pointer.

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end coverage for `Tree::scan_since_seqno` (CDC event stream):
+//! target filtering, increasing-seqno replay order, event-type mapping
+//! (Insert / PointTombstone / RangeTombstone), coverage across memtable and
+//! SSTs, the seqno-bounded block-skip path, and mixed-format trees (a tree
+//! that holds both legacy `index_format=0` and seqno-bounded `index_format=1`
+//! SSTs must scan correctly).
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, ScanSinceEvent, SeqNo, SequenceNumberCounter, Tree,
+    get_tmp_folder,
+};
+use test_log::test;
+
+fn open_tree(path: &std::path::Path) -> Tree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("Tree open should succeed");
+
+    match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree, got Blob"),
+    }
+}
+
+fn events(tree: &Tree, target: SeqNo) -> Vec<ScanSinceEvent> {
+    tree.scan_since_seqno(target)
+        .expect("scan_since_seqno should succeed")
+        .collect()
+}
+
+#[test]
+fn scan_since_returns_only_entries_at_or_after_target() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    for i in 0..10u64 {
+        tree.insert(format!("k{i:02}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let got = events(&tree, 5);
+    assert_eq!(got.len(), 5, "only seqnos 5..10 qualify");
+    assert!(
+        got.iter().all(|e| e.seqno() >= 5),
+        "no event below the target seqno may be emitted",
+    );
+    Ok(())
+}
+
+#[test]
+fn scan_since_emits_events_in_increasing_seqno_order() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Insert in a deliberately scrambled key order; seqnos still rise.
+    for (i, k) in ["m", "a", "z", "c", "q"].iter().enumerate() {
+        tree.insert(k.as_bytes(), b"v", i as u64);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let seqnos: Vec<SeqNo> = events(&tree, 0).iter().map(ScanSinceEvent::seqno).collect();
+    let mut sorted = seqnos.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        seqnos, sorted,
+        "events must arrive in increasing seqno order"
+    );
+    Ok(())
+}
+
+#[test]
+fn scan_since_maps_value_and_point_tombstone() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.insert(b"key", b"val", 0);
+    tree.remove(b"key", 1);
+    tree.flush_active_memtable(0)?;
+
+    let got = events(&tree, 0);
+    assert_eq!(got.len(), 2, "the write and the delete are distinct events");
+
+    // Replay order: insert before delete.
+    match &got[0] {
+        ScanSinceEvent::Insert { key, value, seqno } => {
+            assert_eq!(&**key, b"key");
+            assert_eq!(&**value, b"val");
+            assert_eq!(*seqno, 0);
+        }
+        other => panic!("expected Insert first, got {other:?}"),
+    }
+    match &got[1] {
+        ScanSinceEvent::PointTombstone { key, seqno } => {
+            assert_eq!(&**key, b"key");
+            assert_eq!(*seqno, 1);
+        }
+        other => panic!("expected PointTombstone second, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn scan_since_emits_range_tombstone() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    tree.insert(b"a", b"v", 0);
+    tree.remove_range(b"a", b"m", 1);
+    tree.flush_active_memtable(0)?;
+
+    let got = events(&tree, 0);
+    let range = got
+        .iter()
+        .find_map(|e| match e {
+            ScanSinceEvent::RangeTombstone {
+                start_key,
+                end_key,
+                seqno,
+            } => Some((start_key.to_vec(), end_key.to_vec(), *seqno)),
+            _ => None,
+        })
+        .expect("a RangeTombstone event must be emitted");
+    assert_eq!(range.0, b"a");
+    assert_eq!(range.1, b"m");
+    assert_eq!(range.2, 1);
+    Ok(())
+}
+
+#[test]
+fn scan_since_spans_memtable_and_sst() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Flushed to an SST.
+    for i in 0..5u64 {
+        tree.insert(format!("s{i}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Still in the active memtable.
+    for i in 5..10u64 {
+        tree.insert(format!("m{i}").as_bytes(), b"v", i);
+    }
+
+    let got = events(&tree, 0);
+    assert_eq!(
+        got.len(),
+        10,
+        "scan must cover both the flushed SST and the live memtable",
+    );
+    Ok(())
+}
+
+#[test]
+fn scan_since_block_skip_on_seqno_indexed_sst() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+
+    // Enough keys to spill multiple data blocks so per-block bounds matter.
+    for i in 0..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let data_blocks: u64 = tree
+        .current_version()
+        .iter_tables()
+        .map(|t| t.metadata.data_block_count)
+        .sum();
+    assert!(data_blocks > 1, "need >1 data block to exercise block-skip");
+
+    let got = events(&tree, 450);
+    assert_eq!(got.len(), 50, "only seqnos 450..500 qualify");
+    assert!(got.iter().all(|e| e.seqno() >= 450));
+    Ok(())
+}
+
+#[test]
+fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // First SST: legacy index_format=0 (seqno_in_index defaults off).
+    for i in 0..250u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Toggle on, second SST: seqno-bounded index_format=1.
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+    for i in 250..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Target straddles both SSTs: the legacy one falls back to a full filter,
+    // the seqno-bounded one uses block-skip; the union must be exact.
+    let got = events(&tree, 200);
+    assert_eq!(got.len(), 300, "seqnos 200..500 across both formats");
+    assert!(got.iter().all(|e| e.seqno() >= 200));
+    let seqnos: Vec<SeqNo> = got.iter().map(ScanSinceEvent::seqno).collect();
+    let mut sorted = seqnos.clone();
+    sorted.sort_unstable();
+    assert_eq!(seqnos, sorted, "merged output stays seqno-ordered");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Three related workstreams on the read / reclaim path.

### 1. `scan_since_seqno` — CDC event stream (Part of #224)

`Tree::scan_since_seqno(target)` (and `BlobTree::scan_since_seqno`) streams every change committed at or after a sequence number as `ScanSinceEvent`s (`Insert` / `MergeOperand` / `PointTombstone` / `RangeTombstone`) in increasing seqno order — the canonical CDC primitive for replicas / Kafka connectors / Debezium-style pipelines. Superseded versions are preserved (no MVCC collapse), tombstones are exposed for faithful replay.

- Block-skip: builds on the per-block seqno bounds (#371). On SSTs written with `seqno_in_index`, data blocks whose `seqno_max < target` are skipped unread; legacy SSTs fall back to a per-entry filter, so mixed-format trees scan transparently.
- KV-separation: blob-indirected values are resolved into `Insert` carrying the real value, so a downstream consumer needs no access to the source's blob files.
- New public surface: `ScanSinceEvent` enum + `KeyedBlockHandle::seqno_bounds()`.

### 2. Synchronous `clear()` disk reclaim

`clear()` (standard + blob trees) upgraded the version but left the old SSTs / blob files pinned by stale version-history entries, so a caller measuring on-disk footprint right after it returned still saw the pre-clear bytes. Now:

- **MVCC-safe mark + prune:** marks every obsolete table / blob file deleted and drains the obsolete versions from the history; a concurrent reader holding the pre-clear snapshot keeps its own clone alive, so the Arc refcount remains the MVCC guard.
- **Off-foreground reclaim:** a rate-limited `BackgroundDeleter` (RocksDB `DeleteScheduler` model) drains unlinks on a worker thread; the Drop site frees the blocks synchronously via the new `Fs::truncate_file` hook (instant, accurate footprint scan) and hands the directory-entry unlink to the deleter. Arc refcounting keeps the worker alive until the last table reference drops — no leaked files, no field-ordering dependency.
- **`Fs::truncate_file`:** the per-filesystem-pluggable reclaim hook (portable `set_len(0)` default; a backend whose FS offers a cheaper primitive, reported via `Fs::capabilities`, can override).

### 3. aarch64/x86_64-musl portability fix

The Linux FS-capability path assumed glibc libc types (`statfs.f_type` is `c_long` on glibc / `c_ulong` on musl; `ioctl`'s request is `c_ulong` / `c_int`), breaking the musl cross builds. Normalized.

## no_std

All background-deleter surface is gated behind `std`; a `no_std` build keeps the synchronous Drop reclaim. The no-std-check error count is unchanged (the sole remaining blocker is `quick_cache`, tracked in #429).

## Testing

- Full suite green (2004 tests); `clippy --all-targets --all-features`, `fmt`, doc-tests clean.
- New: `scan_since_seqno` end-to-end (target filter, seqno order, event mapping, block-skip, mixed-format, blob resolution) + `clear()` footprint-reclaim (SST + blob) + background-deleter drain-on-drop.
- Cross-checked on `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-gnu`.

Benches (sparse-scan ≥10×, write-throughput, point-lookup) are a follow-up.

Part of #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Change-data-capture "scan since" that replays committed changes in seqno order (public API)
  * Optional background file deleter to offload unlink work (std feature)
  * Seqno-based block skipping to speed scans and preserve checkpoints during clear

* **Documentation**
  * README: incremental scan / CDC usage, trade-offs, comparisons, and checkpoint guidance

* **Tests**
  * End-to-end CDC tests, clear/reclaim and checkpoint regression tests verifying behavior and on-disk reclamation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->