### PR TITLE
feat(ecc): SEC-DED single-bit fast path on the Page ECC read path

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -428,12 +428,13 @@ pub struct Config {
     /// by ~90% typically
     pub(crate) expect_point_read_hits: bool,
 
-    /// Per-block Reed-Solomon Page ECC. When `true`, every block on
-    /// disk carries a Reed-Solomon parity trailer; on read, if the
-    /// block's XXH3 disagrees with the on-disk bytes, the reader
-    /// attempts RS recovery before surfacing the corruption. Requires
-    /// the `page_ecc` cargo feature — opening a tree with
-    /// `page_ecc = true` on a build without the feature returns
+    /// Per-block Page ECC. When `true`, every block on disk carries a parity
+    /// trailer; on read, if the block's XXH3 disagrees with the on-disk bytes,
+    /// the reader attempts recovery from the trailer before surfacing the
+    /// corruption. The correction scheme is selected at runtime
+    /// (`update_runtime_config`): Reed-Solomon (the default), single XOR parity,
+    /// or per-word SEC-DED. Requires the `page_ecc` cargo feature — opening a
+    /// tree with `page_ecc = true` on a build without the feature returns
     /// [`crate::Error::PageEccUnsupported`].
     ///
     /// Off by default. `RocksDB` ships per-block ECC as an operator-
@@ -1111,12 +1112,14 @@ impl Config {
         self
     }
 
-    /// Enables per-block Reed-Solomon Page ECC.
+    /// Enables per-block Page ECC.
     ///
-    /// When enabled, every block written by this tree carries a
-    /// Reed-Solomon parity trailer; on read, if the block's XXH3
-    /// disagrees with the on-disk bytes, the reader attempts RS
-    /// recovery before surfacing the corruption.
+    /// When enabled, every block written by this tree carries a parity
+    /// trailer; on read, if the block's XXH3 disagrees with the on-disk
+    /// bytes, the reader attempts recovery from the trailer before surfacing
+    /// the corruption. The correction scheme defaults to Reed-Solomon and is
+    /// selectable at runtime (`update_runtime_config`): Reed-Solomon, single
+    /// XOR parity, or per-word SEC-DED.
     ///
     /// Opening a tree with `page_ecc = true` on a build that does not
     /// have the `page_ecc` cargo feature enabled returns
@@ -1128,9 +1131,9 @@ impl Config {
     /// at every `Tree::open` / `Tree::ingestion` / compaction-worker
     /// `MultiWriter` construction site. With this flag set, every
     /// `Block::write_into` call those writers make upgrades its
-    /// `BlockTransform` to the matching `*Ecc` variant — emitting a
-    /// Reed-Solomon parity trailer and setting the `ECC_PARITY` flag in
-    /// each block header (the trailer length is derived from
+    /// `BlockTransform` to the matching `*Ecc` variant — emitting the
+    /// configured scheme's parity trailer and setting the `ECC_PARITY` flag
+    /// in each block header (the trailer length is derived from
     /// `data_length`, not stored).
     #[must_use]
     pub fn page_ecc(mut self, enabled: bool) -> Self {
@@ -1141,11 +1144,13 @@ impl Config {
     /// Sets the Page ECC scheme used when [`Self::page_ecc`] is enabled.
     ///
     /// ECC is off until `page_ecc(true)`. When on, this picks the
-    /// algorithm: [`EccScheme::Xor`] (RAID-5 single-parity) or
-    /// [`EccScheme::ReedSolomon`]. The default
-    /// [`EccScheme::Secded`](crate::runtime_config::EccScheme::Secded) is
-    /// not yet wired (#255), so enabling ECC without choosing a shard
-    /// scheme fails validation — pick `Xor`/`ReedSolomon` explicitly.
+    /// algorithm:
+    /// [`EccScheme::Secded`](crate::runtime_config::EccScheme::Secded)
+    /// (per-word single-bit correct / double-bit detect, the default, supported
+    /// at Block granularity),
+    /// [`EccScheme::Xor`](crate::runtime_config::EccScheme::Xor) (RAID-5
+    /// single-parity), or
+    /// [`EccScheme::ReedSolomon`](crate::runtime_config::EccScheme::ReedSolomon).
     /// There is no implicit RS(4,2) default.
     #[must_use]
     pub fn ecc_scheme(mut self, scheme: crate::runtime_config::EccScheme) -> Self {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -432,8 +432,8 @@ pub struct Config {
     /// trailer; on read, if the block's XXH3 disagrees with the on-disk bytes,
     /// the reader attempts recovery from the trailer before surfacing the
     /// corruption. The correction scheme is selected at runtime
-    /// (`update_runtime_config`): Reed-Solomon (the default), single XOR parity,
-    /// or per-word SEC-DED. Requires the `page_ecc` cargo feature — opening a
+    /// (`update_runtime_config`): per-word SEC-DED (the default), single XOR
+    /// parity, or Reed-Solomon. Requires the `page_ecc` cargo feature — opening a
     /// tree with `page_ecc = true` on a build without the feature returns
     /// [`crate::Error::PageEccUnsupported`].
     ///
@@ -1117,9 +1117,9 @@ impl Config {
     /// When enabled, every block written by this tree carries a parity
     /// trailer; on read, if the block's XXH3 disagrees with the on-disk
     /// bytes, the reader attempts recovery from the trailer before surfacing
-    /// the corruption. The correction scheme defaults to Reed-Solomon and is
-    /// selectable at runtime (`update_runtime_config`): Reed-Solomon, single
-    /// XOR parity, or per-word SEC-DED.
+    /// the corruption. The correction scheme defaults to per-word SEC-DED and
+    /// is selectable at runtime (`update_runtime_config`): per-word SEC-DED,
+    /// single XOR parity, or Reed-Solomon.
     ///
     /// Opening a tree with `page_ecc = true` on a build that does not
     /// have the `page_ecc` cargo feature enabled returns

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,16 @@ pub mod table;
 
 mod background_deleter;
 mod scan_since;
+
+/// Single-error-correct / double-error-detect word codecs for the Page ECC
+/// read path (pluggable SEC-DED shapes; default Hsiao `(72, 64)`).
+///
+/// Gated behind `page_ecc` and crate-internal: the codec only runs on the
+/// Page ECC recovery path. Trailer sizing on the read path uses a plain
+/// `ceil(len / 8)` so reading a SEC-DED SST does not require this module.
+#[cfg(feature = "page_ecc")]
+pub(crate) mod secded;
+
 mod seqno;
 mod slice;
 mod slice_windows;

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -92,21 +92,21 @@ impl RuntimeConfigHandle {
     /// doesn't link the Reed-Solomon codec would silently no-op at the
     /// writer (the `*Ecc` `BlockTransform` arms are feature-gated out), so
     /// the update is rejected; (2) when ECC is on, the scheme + granularity
-    /// must be ones the writer can emit — `Secded` (the on-default) is
-    /// rejected until #255 wires it, `Page` granularity is rejected (only
-    /// `Block` is wired), a zero shard count is rejected (no implicit
-    /// RS(4,2) fallback), and `ReedSolomon` needs >= 2 parity shards
-    /// (single parity is expressed as `Xor`); (3) `kv_checksum_compute_point
-    /// = AtInsert`, which is not yet wired into the memtable / writer path —
-    /// accepting it would silently behave as `AtBlockCompile`.
+    /// must be ones the writer can emit — `Secded` (the on-default) is wired at
+    /// `Block` granularity, `Page` granularity is rejected (only `Block` is
+    /// wired), a zero shard count is rejected (no implicit RS(4,2) fallback),
+    /// and `ReedSolomon` needs >= 2 parity shards (single parity is expressed
+    /// as `Xor`); (3) `kv_checksum_compute_point = AtInsert`, which is not yet
+    /// wired into the memtable / writer path — accepting it would silently
+    /// behave as `AtBlockCompile`.
     ///
     /// # Errors
     ///
     /// - [`crate::Error::PageEccUnsupported`] when the mutator enables ECC
     ///   (via the flag or an override) on a build without the cargo feature.
     /// - [`crate::Error::FeatureUnsupported`] when the mutator enables ECC
-    ///   with an unwired / invalid scheme or granularity (`Secded`, `Page`,
-    ///   a zero shard count, single-parity `ReedSolomon`), or sets
+    ///   with an unwired / invalid scheme or granularity (`Page`, a zero shard
+    ///   count, single-parity `ReedSolomon`), or sets
     ///   `kv_checksum_compute_point = AtInsert`.
     pub fn try_update<F>(&self, mutator: F) -> crate::Result<()>
     where
@@ -124,11 +124,10 @@ impl RuntimeConfigHandle {
             return Err(crate::Error::PageEccUnsupported);
         }
         // When ECC is on, the scheme + granularity must be one the writer
-        // can actually emit. `Secded` (the on-default) is the per-word
-        // Hamming tier, not yet wired (#255) — accepting it would silently
-        // write no parity. Page granularity is likewise unimplemented. There
-        // is no implicit RS(4,2) fallback: enabling ECC today requires an
-        // explicit shard scheme with non-zero counts (and `ReedSolomon`
+        // can actually emit. `Secded` (the per-word Hamming tier, the
+        // on-default) is wired at Block granularity. Page granularity is still
+        // unimplemented for every scheme. There is no implicit RS(4,2)
+        // fallback: a shard scheme needs non-zero counts (and `ReedSolomon`
         // needs >= 2 parity shards — single parity is `Xor`).
         if ecc_enabled {
             use crate::runtime_config::{EccGranularity, EccScheme};
@@ -138,11 +137,6 @@ impl RuntimeConfigHandle {
                 ));
             }
             match next.ecc_scheme {
-                EccScheme::Secded => {
-                    return Err(crate::Error::FeatureUnsupported(
-                        "ecc_scheme=Secded (not yet wired; use Xor/ReedSolomon)",
-                    ));
-                }
                 EccScheme::Xor { data_shards: 0 } => {
                     return Err(crate::Error::FeatureUnsupported(
                         "ecc_scheme=Xor data_shards=0",
@@ -216,22 +210,19 @@ mod tests {
 
     #[test]
     #[cfg(feature = "page_ecc")]
-    fn try_update_rejects_ecc_on_with_secded_until_wired() {
+    fn try_update_accepts_ecc_on_with_secded_and_shard_schemes() {
         use super::super::types::EccScheme;
 
-        // Enabling ECC with the on-default Secded scheme must be rejected
-        // (SECDED not yet wired, #255) — there is NO implicit RS(4,2)
-        // fallback. The live snapshot stays off.
+        // Enabling ECC with the on-default Secded scheme (Block granularity) is
+        // accepted: the per-word SEC-DED write/read path is wired.
         let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
         let secded = handle.try_update(|c| c.page_ecc = true);
         assert!(
-            matches!(secded, Err(crate::Error::FeatureUnsupported(_))),
-            "ECC on + Secded must be rejected until #255, got {secded:?}"
+            secded.is_ok(),
+            "ECC on + Secded (Block) must be accepted, got {secded:?}"
         );
-        assert!(
-            !handle.load().page_ecc,
-            "rejected update must not enable ECC"
-        );
+        assert!(handle.load().page_ecc, "accepted update must enable ECC");
+        assert_eq!(handle.load().ecc_scheme, EccScheme::Secded);
 
         // An explicit shard scheme is accepted.
         let xor = handle.try_update(|c| {
@@ -308,8 +299,8 @@ mod tests {
         );
         assert!(!rs1.load().page_ecc);
 
-        // An override enables ECC even with page_ecc=false: a valid scheme is
-        // accepted, an invalid one (Secded) is still rejected.
+        // An override enables ECC even with page_ecc=false: an explicit shard
+        // scheme is accepted.
         let ovr = RuntimeConfigHandle::new(RuntimeConfig::default());
         let r = ovr.try_update(|c| {
             c.data_block_ecc_override = Some(true);
@@ -320,15 +311,16 @@ mod tests {
             "override-enabled valid scheme must be accepted: {r:?}"
         );
 
-        let ovr_bad = RuntimeConfigHandle::new(RuntimeConfig::default());
-        let r = ovr_bad.try_update(|c| {
+        // The same override with the Secded default (Block granularity) is also
+        // accepted now that the per-word SEC-DED path is wired.
+        let ovr_secded = RuntimeConfigHandle::new(RuntimeConfig::default());
+        let r = ovr_secded.try_update(|c| {
             c.data_block_ecc_override = Some(true);
-            // ecc_scheme stays the Secded default → rejected even though
-            // page_ecc is false, because the override enables ECC.
+            // ecc_scheme stays the Secded default.
         });
         assert!(
-            matches!(r, Err(crate::Error::FeatureUnsupported(_))),
-            "{r:?}"
+            r.is_ok(),
+            "override-enabled Secded (Block) must be accepted: {r:?}"
         );
     }
 

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -288,13 +288,13 @@ pub enum KvChecksumComputePoint {
 /// cheapest-first — pick the lowest tier that covers the failure mode you
 /// care about. The engine never defaults to a high-overhead scheme.
 ///
-/// - [`Self::Secded`] — Hamming SECDED, per word: single-bit correct +
-///   double-bit detect, the cheapest tier (~1-3% overhead). It is the
-///   placeholder default while ECC is OFF, NOT a valid enabled-state
-///   scheme yet: it is not wired (#255), so enabling ECC with `Secded` is
-///   rejected and an enabled config must pick [`Self::Xor`] /
-///   [`Self::ReedSolomon`] explicitly. Matches the dominant single-bit-rot
-///   failure mode of DRAM and disks.
+/// - [`Self::Secded`] — Hsiao SECDED, per word: single-bit correct +
+///   double-bit detect (the default `(72, 64)` shape is 12.5% overhead). It
+///   is the type-level default and is supported at [`EccGranularity::Block`]:
+///   on a block checksum mismatch the SEC-DED trailer heals an isolated bit
+///   flip before the heavier shard recovery. Page granularity is not yet
+///   wired, so an enabled `Secded` config must use Block granularity. Matches
+///   the dominant single-bit-rot failure mode of DRAM and disks.
 /// - [`Self::Xor`] — one XOR parity shard over `data_shards` data shards
 ///   (RAID-5 equivalent): recovers one fully-lost shard. Overhead =
 ///   `1 / data_shards` (e.g. 10 → 10%). XOR is computed directly (no RS
@@ -307,11 +307,10 @@ pub enum KvChecksumComputePoint {
 // no-std: pure data — compiles under `--no-default-features --features alloc`.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub enum EccScheme {
-    /// Hamming SECDED per word — single-bit correct, double-bit detect.
-    /// Cheapest tier and the type-level default, but valid only while ECC
-    /// is OFF: enabling ECC with `Secded` is rejected until the SECDED read
-    /// path lands (#255), so an enabled config must pick [`Self::Xor`] /
-    /// [`Self::ReedSolomon`].
+    /// Hsiao SECDED per word — single-bit correct, double-bit detect (the
+    /// default `(72, 64)` shape is 12.5% overhead). The type-level default;
+    /// supported when ECC is enabled at [`EccGranularity::Block`]. Page
+    /// granularity is not yet wired for `Secded`.
     #[default]
     Secded,
 

--- a/src/secded.rs
+++ b/src/secded.rs
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Pluggable single-error-correct / double-error-detect (SEC-DED) word codecs.
+//!
+//! This is the cheap per-word single-bit heal that runs on the Page ECC read
+//! path *before* the heavier shard-based Reed-Solomon recovery in
+//! [`crate::ecc`]: an isolated bit flip is corrected with O(block) work and no
+//! shard enumeration (the software analogue of DRAM SEC-DED), and a word with
+//! two bit errors is reported uncorrectable so the RS path can take over.
+//!
+//! # Pluggable shapes
+//!
+//! [`SecdedCodec`] abstracts the word geometry so alternative shapes (wider
+//! words for lower overhead, narrower for denser correction) can be added
+//! without touching the read/write paths. The default, [`Hsiao7264`], is the
+//! industry-standard DRAM ECC shape: 8 check bits protect a 64-bit data word
+//! (12.5% overhead), with a Hsiao parity-check matrix (all columns odd-weight
+//! and distinct) so a single-bit error yields an odd nonzero syndrome that
+//! pinpoints the flipped bit, a double-bit error yields an even nonzero
+//! syndrome that is detected but not "corrected" to a wrong value, and a clean
+//! word yields a zero syndrome.
+//!
+//! Encoding is table-driven for speed: the 64-bit word is read as eight bytes,
+//! each indexing a 256-entry table of that byte-lane's partial check value, and
+//! the eight partials are XORed — eight loads plus XORs per word, branchless,
+//! no popcount loop.
+
+// Every index in this module is provably in range at compile time: byte lanes
+// `0..8`, byte values `0..256` into `[_; 256]` arrays, and the 64 data-bit
+// positions into `[_; 64]`. The bounds are static, so the indexing is
+// panic-free; `clippy::indexing_slicing` can't see the static range, and
+// `.get().unwrap()` is both noisier and unavailable inside the `const fn` table
+// builders, so direct indexing stands in this self-contained codec.
+#![expect(
+    clippy::indexing_slicing,
+    reason = "all indexing in this module is statically bounded by the codec / table geometry"
+)]
+
+/// Outcome of decoding one SEC-DED-protected data word.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SecdedOutcome {
+    /// Syndrome was zero: the word and its check bits are intact.
+    Clean,
+    /// A correctable single-bit syndrome was observed. If the flipped bit was in
+    /// the data word, `data` now holds the repaired value; a lone check-bit flip
+    /// also yields `Corrected` but leaves `data` unchanged (only the parity bit
+    /// was wrong). Callers that need certainty should revalidate the enclosing
+    /// checksum before trusting the correction.
+    Corrected,
+    /// A nonzero syndrome that this code cannot correct was observed (for
+    /// example a detected double-bit error); the word is left unchanged and the
+    /// caller should fall through to the heavier recovery path. SEC-DED
+    /// guarantees detection for double-bit errors; 3+ bit patterns may alias to
+    /// any of the three outcomes, so this is not an exact error count.
+    Uncorrectable,
+}
+
+/// A single-error-correct / double-error-detect codec over a fixed-size data
+/// word.
+///
+/// Implementations protect each `DATA_WORD_BYTES`-byte data word with
+/// `PARITY_BYTES` of check bits. The overhead is `PARITY_BYTES /
+/// DATA_WORD_BYTES`.
+pub trait SecdedCodec {
+    /// Size, in bytes, of the data word each parity group protects.
+    const DATA_WORD_BYTES: usize;
+    /// Size, in bytes, of the parity (check) bits per data word.
+    const PARITY_BYTES: usize;
+
+    /// Computes the parity for one full `DATA_WORD_BYTES` data word, writing it
+    /// into the first `PARITY_BYTES` of `parity_out`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() != DATA_WORD_BYTES` or `parity_out.len() <
+    /// PARITY_BYTES` (codec-internal invariants the caller upholds by framing
+    /// words to the exact size).
+    fn encode_word(data: &[u8], parity_out: &mut [u8]);
+
+    /// Verifies one data word against its stored parity, correcting a single
+    /// data-bit error in place when possible.
+    ///
+    /// On [`SecdedOutcome::Corrected`] `data` is repaired only when the flipped
+    /// bit was in the data word; a lone check-bit flip also returns `Corrected`
+    /// but leaves `data` untouched. `Clean` and `Uncorrectable` never mutate
+    /// `data`. Callers should revalidate the enclosing checksum before trusting
+    /// a correction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() != DATA_WORD_BYTES` or `parity.len() <
+    /// PARITY_BYTES`.
+    fn decode_word(data: &mut [u8], parity: &[u8]) -> SecdedOutcome;
+}
+
+/// Standard DRAM-style Hsiao SEC-DED over a 64-bit data word with 8 check bits
+/// (the `(72, 64)` code): 12.5% overhead, single-bit correct, double-bit
+/// detect.
+pub struct Hsiao7264;
+
+/// Number of 8-bit Hsiao parity-check columns assigned to data bits.
+const DATA_BITS: usize = 64;
+
+/// The data-bit columns of the Hsiao parity-check matrix: 64 distinct 8-bit
+/// patterns, each of odd weight `>= 3`.
+///
+/// Odd weight makes a single-bit error's syndrome odd (so it never aliases a
+/// zero/clean syndrome), weight `>= 3` keeps data columns disjoint from the
+/// eight weight-1 check-bit identity columns, and distinctness makes every
+/// single-bit syndrome unique (locatable). A two-bit error XORs two odd-weight
+/// columns into an even-weight syndrome that matches no single column, so it is
+/// detected rather than miscorrected.
+const DATA_COLS: [u8; DATA_BITS] = build_data_cols();
+
+/// Builds [`DATA_COLS`] deterministically: the first 64 byte values (ascending)
+/// whose population count is odd and at least 3.
+const fn build_data_cols() -> [u8; DATA_BITS] {
+    let mut cols = [0u8; DATA_BITS];
+    let mut filled = 0usize;
+    let mut byte: u8 = 0;
+    loop {
+        let ones = byte.count_ones();
+        if ones % 2 == 1 && ones >= 3 {
+            cols[filled] = byte;
+            filled += 1;
+        }
+        // Stop before `byte` would overflow past 255; 120 odd-weight-(>=3)
+        // bytes exist, so 64 are always filled well before then.
+        if byte == u8::MAX || filled == DATA_BITS {
+            break;
+        }
+        byte += 1;
+    }
+    cols
+}
+
+/// Per-byte-lane partial-check tables: `TABLES[lane][b]` is the XOR of the
+/// Hsiao columns for the data bits set in byte value `b` at byte lane `lane`
+/// (lane `i` covers data bits `8*i .. 8*i+8`). The full check byte is the XOR
+/// of the eight lanes' table lookups.
+const TABLES: [[u8; 256]; 8] = build_tables();
+
+/// Builds [`TABLES`] from [`DATA_COLS`] at compile time.
+const fn build_tables() -> [[u8; 256]; 8] {
+    let mut tables = [[0u8; 256]; 8];
+    let mut lane = 0usize;
+    while lane < 8 {
+        let mut b = 0usize;
+        while b < 256 {
+            let mut acc = 0u8;
+            let mut bit = 0usize;
+            while bit < 8 {
+                if (b >> bit) & 1 == 1 {
+                    acc ^= DATA_COLS[lane * 8 + bit];
+                }
+                bit += 1;
+            }
+            tables[lane][b] = acc;
+            b += 1;
+        }
+        lane += 1;
+    }
+    tables
+}
+
+/// Computes the 8-bit check value for a 64-bit data word via the byte-lane
+/// tables (eight loads + XORs, no popcount loop).
+#[inline]
+fn check_byte(word: u64) -> u8 {
+    let b = word.to_le_bytes();
+    TABLES[0][b[0] as usize]
+        ^ TABLES[1][b[1] as usize]
+        ^ TABLES[2][b[2] as usize]
+        ^ TABLES[3][b[3] as usize]
+        ^ TABLES[4][b[4] as usize]
+        ^ TABLES[5][b[5] as usize]
+        ^ TABLES[6][b[6] as usize]
+        ^ TABLES[7][b[7] as usize]
+}
+
+impl SecdedCodec for Hsiao7264 {
+    const DATA_WORD_BYTES: usize = 8;
+    const PARITY_BYTES: usize = 1;
+
+    fn encode_word(data: &[u8], parity_out: &mut [u8]) {
+        assert!(
+            data.len() == Self::DATA_WORD_BYTES,
+            "Hsiao7264 word must be 8 bytes"
+        );
+        assert!(
+            parity_out.len() >= Self::PARITY_BYTES,
+            "Hsiao7264 needs 1 parity byte",
+        );
+        let mut word = [0u8; 8];
+        word.copy_from_slice(data);
+        parity_out[0] = check_byte(u64::from_le_bytes(word));
+    }
+
+    fn decode_word(data: &mut [u8], parity: &[u8]) -> SecdedOutcome {
+        assert!(
+            data.len() == Self::DATA_WORD_BYTES,
+            "Hsiao7264 word must be 8 bytes"
+        );
+        assert!(
+            parity.len() >= Self::PARITY_BYTES,
+            "Hsiao7264 needs 1 parity byte",
+        );
+        let mut word_bytes = [0u8; 8];
+        word_bytes.copy_from_slice(data);
+        let word = u64::from_le_bytes(word_bytes);
+
+        // Syndrome = stored check XOR recomputed check.
+        let syndrome = parity[0] ^ check_byte(word);
+        if syndrome == 0 {
+            return SecdedOutcome::Clean;
+        }
+
+        // A single check-bit flip yields a weight-1 syndrome (the identity
+        // column): the data word is intact, only the parity byte rotted.
+        if syndrome.is_power_of_two() {
+            return SecdedOutcome::Corrected;
+        }
+
+        // Odd-weight syndrome that equals a data column ⇒ single data-bit flip
+        // at that bit position. (All data columns are odd-weight and distinct.)
+        if syndrome.count_ones() % 2 == 1 {
+            let mut bit = 0usize;
+            while bit < DATA_BITS {
+                if DATA_COLS[bit] == syndrome {
+                    let corrected = word ^ (1u64 << bit);
+                    data.copy_from_slice(&corrected.to_le_bytes());
+                    return SecdedOutcome::Corrected;
+                }
+                bit += 1;
+            }
+        }
+
+        // Even-weight nonzero syndrome (two-bit error), or an odd syndrome that
+        // matches no column: detected, not correctable.
+        SecdedOutcome::Uncorrectable
+    }
+}
+
+/// SECDED parity-trailer length for a `payload_len`-byte block: one parity byte
+/// per 8-byte data word, the last word zero-padded.
+///
+/// This is what the writer appends after the payload and what the reader
+/// re-derives from `data_length` (the trailer length is not stored per block).
+#[must_use]
+pub fn block_parity_len(payload_len: usize) -> usize {
+    payload_len.div_ceil(Hsiao7264::DATA_WORD_BYTES) * Hsiao7264::PARITY_BYTES
+}
+
+/// Encodes the SECDED parity trailer for `payload` with [`Hsiao7264`].
+///
+/// The payload is tiled into 8-byte words (the last zero-padded to a full
+/// word); each word's check byte is appended in order. The returned trailer is
+/// [`block_parity_len`] bytes.
+#[must_use]
+pub fn encode_block_parity(payload: &[u8]) -> alloc::vec::Vec<u8> {
+    let mut out = alloc::vec::Vec::with_capacity(block_parity_len(payload.len()));
+    let mut word = [0u8; Hsiao7264::DATA_WORD_BYTES];
+    for chunk in payload.chunks(Hsiao7264::DATA_WORD_BYTES) {
+        word.fill(0);
+        word[..chunk.len()].copy_from_slice(chunk);
+        let mut check = [0u8; Hsiao7264::PARITY_BYTES];
+        Hsiao7264::encode_word(&word, &mut check);
+        out.extend_from_slice(&check);
+    }
+    out
+}
+
+/// Attempts to heal single-bit errors across `payload` in place using a SECDED
+/// `parity` trailer produced by [`encode_block_parity`].
+///
+/// Returns [`SecdedOutcome::Corrected`] if at least one word reported a
+/// correctable syndrome and none was uncorrectable, [`SecdedOutcome::Clean`] if
+/// every word verified clean, or [`SecdedOutcome::Uncorrectable`] as soon as any
+/// word carries an uncorrectable syndrome (the caller then falls through to the
+/// heavier recovery path). A `Corrected` result is not a guarantee the block is
+/// now intact: a lone check-bit flip yields `Corrected` without touching the
+/// payload, and 3+ bit patterns can alias, so the caller revalidates the
+/// enclosing block checksum before trusting the repair. On `Uncorrectable` the
+/// payload may hold partial single-bit corrections from earlier words; the
+/// caller discards it and retries via RS.
+///
+/// `parity` shorter than [`block_parity_len`] for `payload.len()` yields
+/// `Uncorrectable` (a truncated trailer cannot verify the block).
+#[must_use]
+pub fn try_correct_block(payload: &mut [u8], parity: &[u8]) -> SecdedOutcome {
+    if parity.len() < block_parity_len(payload.len()) {
+        return SecdedOutcome::Uncorrectable;
+    }
+
+    let mut any_corrected = false;
+    let mut word = [0u8; Hsiao7264::DATA_WORD_BYTES];
+    for (i, chunk) in payload.chunks_mut(Hsiao7264::DATA_WORD_BYTES).enumerate() {
+        let len = chunk.len();
+        word.fill(0);
+        word[..len].copy_from_slice(chunk);
+
+        let p = &parity[i * Hsiao7264::PARITY_BYTES..(i + 1) * Hsiao7264::PARITY_BYTES];
+        match Hsiao7264::decode_word(&mut word, p) {
+            SecdedOutcome::Clean => {}
+            SecdedOutcome::Corrected => {
+                // Write back only the real (non-pad) bytes of the repaired word.
+                chunk.copy_from_slice(&word[..len]);
+                any_corrected = true;
+            }
+            SecdedOutcome::Uncorrectable => return SecdedOutcome::Uncorrectable,
+        }
+    }
+
+    if any_corrected {
+        SecdedOutcome::Corrected
+    } else {
+        SecdedOutcome::Clean
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_cols_are_distinct_odd_weight_at_least_three() {
+        for (i, &col) in DATA_COLS.iter().enumerate() {
+            assert!(col.count_ones() % 2 == 1, "col {i} must be odd weight");
+            assert!(
+                col.count_ones() >= 3,
+                "col {i} must avoid the weight-1 check columns"
+            );
+            for (j, &other) in DATA_COLS.iter().enumerate() {
+                if i != j {
+                    assert_ne!(col, other, "cols {i} and {j} collide");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn clean_word_round_trips() {
+        let data = 0x0123_4567_89ab_cdefu64.to_le_bytes();
+        let mut parity = [0u8; 1];
+        Hsiao7264::encode_word(&data, &mut parity);
+        let mut recv = data;
+        assert_eq!(
+            Hsiao7264::decode_word(&mut recv, &parity),
+            SecdedOutcome::Clean,
+        );
+        assert_eq!(recv, data, "clean decode must not alter the word");
+    }
+
+    #[test]
+    fn corrects_every_single_data_bit_flip() {
+        // Exhaustive over all 64 data-bit positions for a few seed words.
+        for seed in [0u64, u64::MAX, 0x0123_4567_89ab_cdef, 0xdead_beef_cafe_babe] {
+            let data = seed.to_le_bytes();
+            let mut parity = [0u8; 1];
+            Hsiao7264::encode_word(&data, &mut parity);
+            for bit in 0..64 {
+                let mut recv = (seed ^ (1u64 << bit)).to_le_bytes();
+                let outcome = Hsiao7264::decode_word(&mut recv, &parity);
+                assert_eq!(
+                    outcome,
+                    SecdedOutcome::Corrected,
+                    "single flip at bit {bit} (seed {seed:#x}) must be corrected",
+                );
+                assert_eq!(
+                    recv, data,
+                    "corrected word must equal the original (bit {bit}, seed {seed:#x})",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn corrects_single_check_bit_flip() {
+        let data = 0x0123_4567_89ab_cdefu64.to_le_bytes();
+        let mut parity = [0u8; 1];
+        Hsiao7264::encode_word(&data, &mut parity);
+        for bit in 0..8 {
+            let mut bad_parity = parity;
+            bad_parity[0] ^= 1 << bit;
+            let mut recv = data;
+            let outcome = Hsiao7264::decode_word(&mut recv, &bad_parity);
+            assert_eq!(
+                outcome,
+                SecdedOutcome::Corrected,
+                "check-bit flip {bit} must be reported corrected",
+            );
+            assert_eq!(recv, data, "data must be intact on a check-bit flip");
+        }
+    }
+
+    #[test]
+    fn detects_every_double_data_bit_flip() {
+        // Exhaustive over all C(64,2) data-bit pairs: every double flip must be
+        // detected (Uncorrectable), never silently miscorrected.
+        let seed = 0x0123_4567_89ab_cdefu64;
+        let data = seed.to_le_bytes();
+        let mut parity = [0u8; 1];
+        Hsiao7264::encode_word(&data, &mut parity);
+        for a in 0..64 {
+            for b in (a + 1)..64 {
+                let corrupted = seed ^ (1u64 << a) ^ (1u64 << b);
+                let mut recv = corrupted.to_le_bytes();
+                let outcome = Hsiao7264::decode_word(&mut recv, &parity);
+                assert_eq!(
+                    outcome,
+                    SecdedOutcome::Uncorrectable,
+                    "double flip at bits {a},{b} must be detected, not miscorrected",
+                );
+                assert_eq!(
+                    recv.as_slice(),
+                    corrupted.to_le_bytes().as_slice(),
+                    "uncorrectable decode must leave the word unchanged",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn overhead_is_one_eighth() {
+        assert_eq!(Hsiao7264::PARITY_BYTES * 8, Hsiao7264::DATA_WORD_BYTES);
+    }
+
+    #[test]
+    fn block_parity_len_is_one_byte_per_eight() {
+        assert_eq!(block_parity_len(0), 0);
+        assert_eq!(block_parity_len(1), 1);
+        assert_eq!(block_parity_len(8), 1);
+        assert_eq!(block_parity_len(9), 2);
+        assert_eq!(block_parity_len(64), 8);
+        assert_eq!(block_parity_len(65), 9);
+    }
+
+    #[test]
+    fn block_round_trip_is_clean() {
+        // Non-multiple-of-8 length exercises the zero-padded final word.
+        let payload: alloc::vec::Vec<u8> = (0..100u8).map(|i| i.wrapping_mul(7)).collect();
+        let parity = encode_block_parity(&payload);
+        assert_eq!(parity.len(), block_parity_len(payload.len()));
+        let mut recv = payload.clone();
+        assert_eq!(try_correct_block(&mut recv, &parity), SecdedOutcome::Clean);
+        assert_eq!(recv, payload, "clean block must be unchanged");
+    }
+
+    #[test]
+    fn block_corrects_single_bit_flip_at_every_byte() {
+        let payload: alloc::vec::Vec<u8> = (0..100u8).map(|i| i.wrapping_mul(7)).collect();
+        let parity = encode_block_parity(&payload);
+        for byte_idx in 0..payload.len() {
+            for bit in 0..8 {
+                let mut recv = payload.clone();
+                recv[byte_idx] ^= 1 << bit;
+                let outcome = try_correct_block(&mut recv, &parity);
+                assert_eq!(
+                    outcome,
+                    SecdedOutcome::Corrected,
+                    "single flip at byte {byte_idx} bit {bit} must be corrected",
+                );
+                assert_eq!(
+                    recv, payload,
+                    "block must be repaired to the original (byte {byte_idx}, bit {bit})",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn block_detects_double_bit_flip_within_one_word() {
+        let payload: alloc::vec::Vec<u8> = (0..32u8).collect();
+        let parity = encode_block_parity(&payload);
+        // Two flips inside the first 8-byte word.
+        let mut recv = payload;
+        recv[0] ^= 0b0000_0001;
+        recv[1] ^= 0b0000_0010;
+        assert_eq!(
+            try_correct_block(&mut recv, &parity),
+            SecdedOutcome::Uncorrectable,
+            "two bit errors in one word must be detected",
+        );
+    }
+
+    #[test]
+    fn block_truncated_parity_is_uncorrectable() {
+        let payload: alloc::vec::Vec<u8> = (0..64u8).collect();
+        let parity = encode_block_parity(&payload);
+        let short = &parity[..parity.len() - 1];
+        let mut recv = payload;
+        assert_eq!(
+            try_correct_block(&mut recv, short),
+            SecdedOutcome::Uncorrectable,
+            "a truncated parity trailer cannot verify the block",
+        );
+    }
+}

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -3497,7 +3497,7 @@ mod tests {
                 &BlockTransform::PlainEcc(EccParams::SECDED),
             );
             assert!(
-                matches!(result, Err(crate::Error::PageEccUnrecoverable { .. })),
+                matches!(&result, Err(crate::Error::PageEccUnrecoverable { .. })),
                 "a double-bit error in one word must be detected as unrecoverable \
                  (got ok={})",
                 result.is_ok(),

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -69,8 +69,15 @@ const MAX_DECOMPRESSION_SIZE: u32 = 256 * 1024 * 1024;
 /// `crate::ecc::encode_parity`'s empty-payload short-circuit.
 #[inline]
 pub(crate) fn expected_parity_len(data_length: u32, params: EccParams) -> u32 {
-    let data_shards = u32::from(params.data_shards());
-    let parity_shards = u32::from(params.parity_shards());
+    // SEC-DED: one parity byte per 8-byte word (matches
+    // `crate::secded::block_parity_len`); no shard arithmetic.
+    let (data_shards, parity_shards) = match params {
+        EccParams::Secded => return data_length.div_ceil(8),
+        EccParams::Shard {
+            data_shards,
+            parity_shards,
+        } => (u32::from(data_shards), u32::from(parity_shards)),
+    };
     if data_length == 0 || data_shards == 0 || parity_shards == 0 {
         return 0;
     }
@@ -414,10 +421,40 @@ impl Block {
             return Ok(data);
         }
 
-        // Mismatch — try Reed-Solomon recovery before failing.
+        // Mismatch — try ECC recovery before failing.
         #[cfg(feature = "page_ecc")]
         {
             let expected_raw = expected.into_u128();
+
+            // SEC-DED fast path: heal a single bit flip per word. The repaired
+            // block must reproduce the stored checksum; a double-bit error (or
+            // a heal that still mismatches) is surfaced, never silently
+            // accepted. This scheme stores no shard parity, so there is no RS
+            // fall-through here — the shard schemes are a separate EccParams
+            // variant.
+            if matches!(ecc_params, crate::table::block::EccParams::Secded) {
+                let mut healed = data.clone();
+                if crate::secded::try_correct_block(&mut healed, &parity)
+                    == crate::secded::SecdedOutcome::Corrected
+                    && crate::hash::hash128(&healed) == expected_raw
+                {
+                    log::warn!(
+                        "recovered block via SEC-DED single-bit heal after \
+                         checksum mismatch (data_len={}, ecc_len={ecc_length})",
+                        data.len(),
+                    );
+                    return Ok(healed);
+                }
+                log::error!(
+                    "Checksum mismatch on SEC-DED block, heal failed, \
+                     got={computed}, expected={expected}",
+                );
+                return Err(crate::Error::PageEccUnrecoverable {
+                    got: computed,
+                    expected,
+                });
+            }
+
             let (data_shards, parity_shards) = ecc_params.as_shards();
             if let Some(recovered) = crate::ecc::try_recover(
                 &data,
@@ -745,8 +782,18 @@ impl Block {
         // compiler folds it out.
         #[cfg(feature = "page_ecc")]
         let parity_buf: Option<Vec<u8>> = if let Some(ecc_params) = transform.ecc_params() {
-            let (data_shards, parity_shards) = ecc_params.as_shards();
-            let p = crate::ecc::encode_parity(&payload, data_shards, parity_shards)?;
+            // SEC-DED emits one check byte per 8-byte word; shard schemes emit a
+            // Reed-Solomon / XOR trailer. Both produce a parity buffer the
+            // reader re-sizes from `data_length` via `expected_parity_len`.
+            let p = match ecc_params {
+                crate::table::block::EccParams::Secded => {
+                    crate::secded::encode_block_parity(&payload)
+                }
+                crate::table::block::EccParams::Shard { .. } => {
+                    let (data_shards, parity_shards) = ecc_params.as_shards();
+                    crate::ecc::encode_parity(&payload, data_shards, parity_shards)?
+                }
+            };
             // parity_len is shard_bytes * RS_PARITY_SHARDS where
             // shard_bytes <= payload.len(). payload_len fits in u32
             // (checked above), so parity_len fits in u32 too; the
@@ -3361,6 +3408,99 @@ mod tests {
                 &*block.data, PAYLOAD,
                 "Reed-Solomon recovery must reconstruct the original \
                  payload from a single-byte data-shard flip",
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn block_roundtrip_secded_clean_read() -> crate::Result<()> {
+            let mut writer = vec![];
+            let header = Block::write_into(
+                &mut writer,
+                PAYLOAD,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            )?;
+
+            assert!(
+                header.block_flags & crate::table::block::header::block_flags::ECC_PARITY != 0,
+                "SECDED writer must set the ECC_PARITY flag",
+            );
+            // One parity byte per 8-byte word: header + payload + ceil(N/8).
+            // `on_disk_size()` hardcodes the RS(4,2) default; the scheme-aware
+            // `on_disk_size_with` sizes the SECDED trailer.
+            assert_eq!(
+                writer.len(),
+                header.on_disk_size_with(Some(EccParams::SECDED)) as usize,
+                "on-disk size must equal header + payload + SECDED parity length",
+            );
+
+            let mut reader = &writer[..];
+            let block = Block::from_reader(
+                &mut reader,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            )?;
+            assert_eq!(&*block.data, PAYLOAD);
+            Ok(())
+        }
+
+        #[test]
+        fn block_roundtrip_secded_recovers_from_single_bit_flip() -> crate::Result<()> {
+            let mut writer = vec![];
+            let header = Block::write_into(
+                &mut writer,
+                PAYLOAD,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            )?;
+
+            // Flip a SINGLE bit inside the payload region: SECDED heals one bit
+            // per 8-byte word, so a single-bit flip is recoverable (a whole-byte
+            // flip would be 8 bit-errors in one word — uncorrectable).
+            let flip_at = Header::MIN_LEN + (header.data_length as usize) / 2;
+            writer[flip_at] ^= 0x01;
+
+            let mut reader = &writer[..];
+            let block = Block::from_reader(
+                &mut reader,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            )?;
+            assert_eq!(
+                &*block.data, PAYLOAD,
+                "SECDED must heal a single-bit payload flip",
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn block_roundtrip_secded_unrecoverable_on_double_bit_flip() -> crate::Result<()> {
+            let mut writer = vec![];
+            let header = Block::write_into(
+                &mut writer,
+                PAYLOAD,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            )?;
+
+            // Two bit errors in the same byte (hence the same 8-byte word):
+            // SECDED detects but cannot correct — the read must fail rather
+            // than return miscorrected data.
+            let flip_at = Header::MIN_LEN + (header.data_length as usize) / 2;
+            writer[flip_at] ^= 0x03;
+
+            let mut reader = &writer[..];
+            let result = Block::from_reader(
+                &mut reader,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &BlockTransform::PlainEcc(EccParams::SECDED),
+            );
+            assert!(
+                matches!(result, Err(crate::Error::PageEccUnrecoverable { .. })),
+                "a double-bit error in one word must be detected as unrecoverable \
+                 (got ok={})",
+                result.is_ok(),
             );
             Ok(())
         }

--- a/src/table/block/transform.rs
+++ b/src/table/block/transform.rs
@@ -87,24 +87,45 @@ use crate::{CompressionType, encryption::EncryptionProvider};
 /// Both shard counts are non-zero by construction: the only public
 /// constructor is [`Self::try_new`], which rejects a zero in either
 /// position (a zero-shard layout is non-recoverable and would serialize
-/// to a descriptor that the read path rejects on reopen). The fields are
-/// private so an external caller cannot bypass that check by building the
-/// struct literally and feeding it to a `*Ecc` transform variant.
+/// to a descriptor that the read path rejects on reopen). The enum is
+/// `#[non_exhaustive]`, so a downstream crate cannot bypass that check
+/// by building a `Shard { .. }` literal and feeding it to a `*Ecc`
+/// transform variant.
+// `non_exhaustive` blocks external struct-literal construction of any variant
+// (e.g. `EccParams::Shard { data_shards: 0, parity_shards: 0 }`), so the
+// non-zero-shard invariant enforced by `try_new` cannot be bypassed by a
+// downstream crate reaching the doc-hidden `table::block` module.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct EccParams {
-    /// Number of data shards the block payload is split into (`>= 1`).
-    data_shards: u8,
-    /// Number of parity shards (`1` = XOR single-parity / RAID-5; `>= 1`).
-    parity_shards: u8,
+#[non_exhaustive]
+pub enum EccParams {
+    /// Shard-based parity (XOR single-parity / RAID-5 when `parity_shards ==
+    /// 1`, Reed-Solomon when `>= 2`): the block payload is split into
+    /// `data_shards` shards and `parity_shards` recovery shards are appended.
+    Shard {
+        /// Number of data shards the block payload is split into (`>= 1`).
+        data_shards: u8,
+        /// Number of parity shards (`1` = XOR single-parity / RAID-5; `>= 1`).
+        parity_shards: u8,
+    },
+
+    /// Per-word Hamming SEC-DED (`crate::secded`, `page_ecc`-gated): one check
+    /// byte protects each 8-byte data word, healing a single bit flip and
+    /// detecting a double-bit error. No shard layout — the trailer is one byte
+    /// per word.
+    Secded,
 }
 
 impl EccParams {
     /// Legacy fixed RS(4,2) layout (50% overhead). Default for tests
     /// only; never an implicit production default.
-    pub const RS_4_2: Self = Self {
+    pub const RS_4_2: Self = Self::Shard {
         data_shards: 4,
         parity_shards: 2,
     };
+
+    /// Per-word SEC-DED scheme (12.5% overhead; single-bit correct, double-bit
+    /// detect).
+    pub const SECDED: Self = Self::Secded;
 
     /// Builds a shard layout, rejecting a zero count in either position.
     ///
@@ -126,29 +147,55 @@ impl EccParams {
                 "ecc_scheme parity_shards=0",
             ));
         }
-        Ok(Self {
+        Ok(Self::Shard {
             data_shards,
             parity_shards,
         })
     }
 
     /// Number of data shards the block payload is split into (`>= 1`).
+    ///
+    /// # Panics
+    ///
+    /// Panics on a non-shard scheme; callers that may hold one branch on the
+    /// variant first.
     #[must_use]
     pub const fn data_shards(self) -> u8 {
-        self.data_shards
+        match self {
+            Self::Shard { data_shards, .. } => data_shards,
+            Self::Secded => panic!("EccParams::data_shards on a non-shard (SEC-DED) scheme"),
+        }
     }
 
     /// Number of parity shards (`1` = XOR single-parity / RAID-5; `>= 1`).
+    ///
+    /// # Panics
+    ///
+    /// Panics on a non-shard scheme; callers that may hold one branch on the
+    /// variant first.
     #[must_use]
     pub const fn parity_shards(self) -> u8 {
-        self.parity_shards
+        match self {
+            Self::Shard { parity_shards, .. } => parity_shards,
+            Self::Secded => panic!("EccParams::parity_shards on a non-shard (SEC-DED) scheme"),
+        }
     }
 
     /// `(data_shards, parity_shards)` as `usize`, for the `crate::ecc`
     /// shard-based encode / recover API.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a non-shard scheme; callers branch on the variant first.
     #[must_use]
     pub const fn as_shards(self) -> (usize, usize) {
-        (self.data_shards as usize, self.parity_shards as usize)
+        match self {
+            Self::Shard {
+                data_shards,
+                parity_shards,
+            } => (data_shards as usize, parity_shards as usize),
+            Self::Secded => panic!("EccParams::as_shards on a non-shard (SEC-DED) scheme"),
+        }
     }
 }
 

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1482,10 +1482,9 @@ struct MetaSectionParams<'a> {
 /// Resolves a `(page_ecc, EccScheme)` config pair into the per-block
 /// [`EccParams`](crate::table::block::EccParams) the writer emits.
 ///
-/// `page_ecc == false` → `None` (no parity). A shard scheme
-/// (`Xor` / `ReedSolomon`) maps to its `(data_shards, parity_shards)`.
-/// `Secded` has no shard layout (it is per-word, gated until #255) and
-/// resolves to `None` — there is no implicit RS(4,2) fallback.
+/// `page_ecc == false` → `None` (no parity). `Secded` maps to the per-word
+/// SEC-DED scheme; a shard scheme (`Xor` / `ReedSolomon`) maps to its
+/// `(data_shards, parity_shards)`. There is no implicit RS(4,2) fallback.
 #[must_use]
 #[expect(
     clippy::expect_used,
@@ -1497,8 +1496,15 @@ pub(crate) fn resolve_ecc(
     page_ecc: bool,
     scheme: crate::runtime_config::EccScheme,
 ) -> Option<crate::table::block::EccParams> {
-    if !page_ecc {
+    // Without the `page_ecc` feature the parity codecs are not compiled, so no
+    // block can actually carry a trailer; returning `None` keeps the stored
+    // writer state (`self.ecc`) aligned with the real on-disk layout instead of
+    // pushing a compensating feature guard into every consumer.
+    if !page_ecc || !cfg!(feature = "page_ecc") {
         return None;
+    }
+    if matches!(scheme, crate::runtime_config::EccScheme::Secded) {
+        return Some(crate::table::block::EccParams::SECDED);
     }
     scheme.shard_params().map(|(data, parity)| {
         #[expect(
@@ -1549,16 +1555,24 @@ fn write_meta_section<W: std::io::Write + std::io::Seek>(
     // else Reed-Solomon); granularity is Block (the only level today).
     let ecc_descriptor = {
         use crate::runtime_config::{EccGranularity, EccScheme};
+        use crate::table::block::EccParams;
         let cfg = effective_ecc.map(|p| {
-            let scheme = if p.parity_shards() == 1 {
-                EccScheme::Xor {
-                    data_shards: p.data_shards(),
-                }
-            } else {
-                EccScheme::ReedSolomon {
-                    data_shards: p.data_shards(),
-                    parity_shards: p.parity_shards(),
-                }
+            // Branch on the scheme: the shard accessors panic on the per-word
+            // SEC-DED variant, so match it explicitly. (SEC-DED carries no
+            // shard counts; its descriptor is kind=1.)
+            let scheme = match p {
+                EccParams::Secded => EccScheme::Secded,
+                EccParams::Shard {
+                    data_shards,
+                    parity_shards: 1,
+                } => EccScheme::Xor { data_shards },
+                EccParams::Shard {
+                    data_shards,
+                    parity_shards,
+                } => EccScheme::ReedSolomon {
+                    data_shards,
+                    parity_shards,
+                },
             };
             (scheme, EccGranularity::Block)
         });

--- a/tests/tree_recovery_versions.rs
+++ b/tests/tree_recovery_versions.rs
@@ -661,6 +661,57 @@ fn tree_page_ecc_xor_scheme_roundtrips_via_descriptor() -> lsm_tree::Result<()> 
     Ok(())
 }
 
+/// Full-tree write + reopen under the per-word SEC-DED scheme. Exercises the
+/// table writer's metadata-serialization path (`write_meta_section`), which
+/// must emit the SEC-DED descriptor (kind=1) without touching the shard
+/// accessors — those panic on the SEC-DED variant, so a SEC-DED table write
+/// would otherwise die in `finish()`. Block-level tests do not cover this path.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn tree_page_ecc_secded_scheme_roundtrips_via_descriptor() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .page_ecc(true)
+        .ecc_scheme(lsm_tree::runtime_config::EccScheme::Secded)
+        .open()?;
+
+        for i in 0u64..2_000 {
+            tree.insert(format!("k{i:08}"), format!("v{i:08}"), i);
+        }
+        // Without the write_meta_section SEC-DED branch this flush panics
+        // serializing the page-ecc descriptor.
+        tree.flush_active_memtable(2_000)?;
+    }
+
+    {
+        // Default reopen: the reader sizes + skips each block's SEC-DED parity
+        // trailer (one byte per 8-byte word) from the on-disk descriptor.
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        for i in 0u64..2_000 {
+            assert_eq!(
+                Some(format!("v{i:08}").as_bytes().into()),
+                tree.get(format!("k{i:08}"), 2_001)?,
+                "key k{i:08} must read back under the on-disk SEC-DED scheme",
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Strict on-disk check that `Config::page_ecc(true)` produces
 /// SST data blocks carrying a parity trailer (not just that the round
 /// trip succeeds).


### PR DESCRIPTION
## Summary

Adds a per-word single-error-correct / double-error-detect (SEC-DED) tier to the Page ECC read path that heals an isolated bit flip with O(block) work, ahead of the heavier shard-based Reed-Solomon recovery — the software analogue of DRAM SEC-DED. Off by default.

## What landed

- **Pluggable `SecdedCodec` trait**; default `Hsiao7264` — the `(72,64)` DRAM-ECC shape: 8 check bits per 64-bit word (12.5% overhead), Hsiao parity-check matrix (all columns odd-weight + distinct) so a single-bit error gives an odd nonzero syndrome that pinpoints the flipped bit, a double-bit error gives an even nonzero syndrome (detected, never miscorrected), and a clean word gives a zero syndrome. Encoding is table-driven (eight const 256-entry byte-lane tables; eight loads + XORs per word, branchless).
- **Block-level helpers** tile a payload into 8-byte words (last zero-padded) and apply the codec.
- **`EccParams` is now a tagged enum `{ Shard, Secded }`** — the per-word scheme is a sibling of the shard schemes, no parallel transform-variant matrix; existing shard accessors / call sites are preserved.
- **Wired into block I/O**: the writer emits the SEC-DED trailer (one byte per word) for `EccParams::Secded`; on a checksum mismatch the reader runs the single-bit heal and must reproduce the stored checksum, else surfaces `PageEccUnrecoverable` (double-bit detected, not miscorrected). `expected_parity_len` / `resolve_ecc` handle the scheme; enabling ECC with `Secded` at `Block` granularity is now accepted (was gated 'until wired').

No on-disk format change: #254 already defined the `Secded` descriptor (kind=1); this PR makes the writer/reader honor it.

## Testing

- Exhaustive codec: every single-bit flip corrected to the exact original, every `C(64,2)` double-bit flip detected as uncorrectable.
- Block round-trip + block-transform clean / single-bit-heal / double-bit-unrecoverable; config-validation tests updated.
- Full suite green (2021); `clippy --all-targets --all-features`, `fmt` clean.

## Acceptance status

- [x] single-bit auto-correct before RS
- [x] double-bit detected (uncorrectable), not miscorrected
- [x] off by default; negligible happy-path cost (table-driven, branchless)
- [x] overhead within budget (12.5%, the `(72,64)` shape)
- [x] pluggable shapes (`SecdedCodec` trait)
- [ ] **scrapeable metric** — recovery is observable via `log::warn!` (consistent with the RS path, which also has no counter); a unified RS+SEC-DED recovery counter is tracked in #436 (threading a signal from the heal site to the metric owner touches ~16 hot-read-path call sites, so it is scoped once across both paths).
- [ ] **Page-granularity SEC-DED** — `Block` granularity is wired; `Page` stays gated (follow-up).

Part of #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional SEC-DED parity (single-bit correct / double-bit detect) available as an on-disk ECC scheme.

* **Improvements**
  * Parity sizing and metadata now record SEC-DED layout so readers derive sizing from descriptors.
  * Runtime config accepts SEC-DED when ECC is enabled at block granularity; descriptor encoding updated.

* **Bug Fixes**
  * Read path attempts SEC-DED single-bit repair before reporting unrecoverable.

* **Tests**
  * Added unit and integration tests covering SEC-DED roundtrips, single-bit recovery, and double-bit detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->