### PR TITLE
fix(manifest): reject torn edit-log tail under AbsoluteConsistency

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -272,6 +272,35 @@ pub enum Error {
     ///   this internally and the check here becomes belt-and-
     ///   braces.
     ManifestSectionInvalid(&'static str),
+
+    /// The trailing record of the incremental manifest edit log is
+    /// incomplete or corrupt, and the tree was opened under
+    /// [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency),
+    /// which refuses to silently roll back an unacknowledged or
+    /// bit-rotted edit.
+    ///
+    /// A clean end-of-log is never reported here: a crash exactly at a
+    /// record boundary is byte-identical to a pristine close, so that
+    /// case is always tolerated. This fires only when bytes of a
+    /// trailing record are present but the record fails framing (a
+    /// power-loss-truncated append), a fully-framed record's checksum
+    /// doesn't match (bit-rot), or a framing header is forged.
+    ///
+    /// Recover by truncating the torn tail: run
+    /// [`Config::repair`](crate::Config::repair), which rebuilds a clean
+    /// standalone snapshot (dropping the edit log), or re-open under a tolerant
+    /// [`ManifestRecoveryMode`](crate::config::ManifestRecoveryMode) to
+    /// roll the unacknowledged tail back.
+    TornManifestEditLog {
+        /// The trailing defect detected: `"truncated"` (partial record
+        /// from a power-loss-interrupted append), `"checksum-mismatch"`
+        /// (fully-framed record whose payload bit-rotted),
+        /// `"bad-header"` (implausible framing length), or
+        /// `"len-mismatch"` (record length disagrees with the expected
+        /// fixed size). Static so callers can branch without parsing
+        /// the message string.
+        kind: &'static str,
+    },
 }
 
 impl std::fmt::Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -274,23 +274,29 @@ pub enum Error {
     ManifestSectionInvalid(&'static str),
 
     /// The trailing record of the incremental manifest edit log is
-    /// incomplete or corrupt, and the tree was opened under
-    /// [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency),
-    /// which refuses to silently roll back an unacknowledged or
-    /// bit-rotted edit.
+    /// incomplete or corrupt, and the active
+    /// [`ManifestRecoveryMode`](crate::config::ManifestRecoveryMode) does
+    /// not tolerate that defect, so the open aborts rather than silently
+    /// rolling the edit back.
     ///
     /// A clean end-of-log is never reported here: a crash exactly at a
     /// record boundary is byte-identical to a pristine close, so that
-    /// case is always tolerated. This fires only when bytes of a
-    /// trailing record are present but the record fails framing (a
-    /// power-loss-truncated append), a fully-framed record's checksum
-    /// doesn't match (bit-rot), or a framing header is forged.
+    /// case is always tolerated. This fires when bytes of a trailing
+    /// record are present but the record fails framing — a
+    /// power-loss-truncated append (only
+    /// [`AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency)
+    /// rejects it; other modes roll it back), or a fully-framed record
+    /// whose checksum doesn't match (bit-rot) / whose header is forged
+    /// (rejected by both `AbsoluteConsistency` and
+    /// [`TolerateCorruptedTailRecords`](crate::config::ManifestRecoveryMode::TolerateCorruptedTailRecords),
+    /// which salvages writer-incomplete tails only; rolled back under
+    /// `PointInTimeRecovery` / `SkipAnyCorruptedRecords`).
     ///
     /// Recover by truncating the torn tail: run
     /// [`Config::repair`](crate::Config::repair), which rebuilds a clean
-    /// standalone snapshot (dropping the edit log), or re-open under a tolerant
-    /// [`ManifestRecoveryMode`](crate::config::ManifestRecoveryMode) to
-    /// roll the unacknowledged tail back.
+    /// standalone snapshot (dropping the edit log), or re-open under a
+    /// [`ManifestRecoveryMode`](crate::config::ManifestRecoveryMode) that
+    /// tolerates the defect to roll the trailing edit back.
     TornManifestEditLog {
         /// The trailing defect detected: `"truncated"` (partial record
         /// from a power-loss-interrupted append), `"checksum-mismatch"`

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -283,32 +283,55 @@ fn tail_defect_kind(outcome: &framing::FramedRecordOutcome) -> &'static str {
 /// The edit log has no count header and no terminator: a clean end-of-log is a
 /// record boundary with no further bytes, which is byte-identical to a crash
 /// that landed exactly at a boundary. That clean boundary always ends replay
-/// successfully (in either mode) — otherwise a pristine database would fail to
+/// successfully in every mode — otherwise a pristine database would fail to
 /// open.
 ///
-/// `strict` mirrors [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency):
-/// - `false` (tolerant modes): a *partial* or corrupt trailing record (bytes
-///   present but framing not `Ok`) is dropped along with anything after it; that
-///   tail was never acknowledged upward, so a higher-level journal replays its
-///   data.
-/// - `true` (AbsoluteConsistency): the same partial / bit-rotted / mis-framed
-///   trailing record is surfaced as [`crate::Error::TornManifestEditLog`] rather
-///   than silently rolled back, so an operator truncates the tail (via
-///   [`Config::repair`](crate::Config::repair)) deliberately.
+/// For a trailing record with bytes present, the policy follows `mode` and the
+/// kind of defect, mirroring how the snapshot sections route the same
+/// [`ManifestRecoveryMode`](crate::config::ManifestRecoveryMode) variants:
+///
+/// - **Truncated tail** (`TailTruncation`): the writer never finished the
+///   record, so the operation was never acknowledged upward. Rolled back (and
+///   the durable prefix recovered) under every mode except
+///   [`AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency),
+///   which surfaces [`crate::Error::TornManifestEditLog`] so an operator
+///   truncates the tail deliberately (via [`Config::repair`](crate::Config::repair)).
+/// - **Corrupt fully-framed tail** (`ChecksumMismatch` / `BadHeader` /
+///   `LenMismatch`): bit-rot or forgery of already-committed bytes, not an
+///   incomplete write. Rolled back only under the corruption-tolerant modes
+///   ([`PointInTimeRecovery`](crate::config::ManifestRecoveryMode::PointInTimeRecovery)
+///   / [`SkipAnyCorruptedRecords`](crate::config::ManifestRecoveryMode::SkipAnyCorruptedRecords)).
+///   Both [`AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency)
+///   and [`TolerateCorruptedTailRecords`](crate::config::ManifestRecoveryMode::TolerateCorruptedTailRecords)
+///   abort with [`crate::Error::TornManifestEditLog`] — the latter salvages
+///   writer-incomplete tails only, never arbitrary bit-rot.
 ///
 /// A record whose framing is `Ok` (full payload + matching checksum) but whose
 /// payload fails to decode is a genuine format error, not power loss, and is
-/// surfaced as an error in both modes rather than silently truncating the log.
+/// surfaced as an error in every mode rather than silently truncating the log.
 ///
 /// # Errors
 ///
 /// Returns an I/O error from `reader`, [`crate::Error::InvalidHeader`] if a
 /// checksum-valid record fails to decode, or
-/// [`crate::Error::TornManifestEditLog`] when `strict` and the trailing record
-/// is torn / bit-rotted / mis-framed.
-pub fn replay_edits<R: Read>(reader: &mut R, strict: bool) -> crate::Result<Vec<VersionEdit>> {
+/// [`crate::Error::TornManifestEditLog`] when the trailing record is
+/// torn / bit-rotted / mis-framed and `mode` does not tolerate that defect.
+pub fn replay_edits<R: Read>(
+    reader: &mut R,
+    mode: crate::config::ManifestRecoveryMode,
+) -> crate::Result<Vec<VersionEdit>> {
+    use crate::config::ManifestRecoveryMode;
     use framing::FramedRecordOutcome;
     use std::io::BufRead;
+
+    // Only AbsoluteConsistency refuses to roll back a writer-incomplete tail.
+    let abort_on_truncation = matches!(mode, ManifestRecoveryMode::AbsoluteConsistency);
+    // Only PIT / SkipAny roll back a fully-framed but corrupt trailing record;
+    // AbsoluteConsistency and TolerateCorruptedTailRecords abort on it.
+    let tolerate_corruption = matches!(
+        mode,
+        ManifestRecoveryMode::PointInTimeRecovery | ManifestRecoveryMode::SkipAnyCorruptedRecords
+    );
 
     // Buffer the reader so a clean record boundary can be detected (empty fill)
     // without consuming bytes from a genuine trailing record.
@@ -318,27 +341,33 @@ pub fn replay_edits<R: Read>(reader: &mut R, strict: bool) -> crate::Result<Vec<
     loop {
         // No bytes left at a record boundary: the normal end of the log. A crash
         // exactly at a boundary is indistinguishable from a pristine close, so
-        // this is always a successful end — never a "torn tail", in either mode.
+        // this is always a successful end — never a "torn tail", in any mode.
         if reader.fill_buf().map_err(crate::Error::Io)?.is_empty() {
             break;
         }
         let outcome = framing::read_framed_record(&mut reader, u64::MAX, None, &mut scratch)?;
         match outcome {
             FramedRecordOutcome::Ok => edits.push(VersionEdit::decode_payload(&scratch)?),
-            // Bytes were present but the trailing record isn't a clean `Ok`:
-            // a power-loss-truncated append, in-record bit-rot, or a forged
-            // header. Tolerant modes recover the durable prefix; strict mode
-            // refuses to roll the unacknowledged / corrupt tail back silently.
-            FramedRecordOutcome::TailTruncation
-            | FramedRecordOutcome::ChecksumMismatch { .. }
-            | FramedRecordOutcome::BadHeader
-            | FramedRecordOutcome::LenMismatch { .. } => {
-                if strict {
-                    return Err(crate::Error::TornManifestEditLog {
-                        kind: tail_defect_kind(&outcome),
-                    });
+            // Writer-incomplete tail (power loss mid-append): unacknowledged, so
+            // tolerant modes drop it; AbsoluteConsistency surfaces it.
+            FramedRecordOutcome::TailTruncation => {
+                if abort_on_truncation {
+                    return Err(crate::Error::TornManifestEditLog { kind: "truncated" });
                 }
                 break;
+            }
+            // Fully-framed but corrupt: bit-rot / forgery of committed bytes.
+            // PIT / SkipAny roll it back; AbsoluteConsistency and
+            // TolerateCorruptedTailRecords (truncation-salvage only) abort.
+            FramedRecordOutcome::ChecksumMismatch { .. }
+            | FramedRecordOutcome::BadHeader
+            | FramedRecordOutcome::LenMismatch { .. } => {
+                if tolerate_corruption {
+                    break;
+                }
+                return Err(crate::Error::TornManifestEditLog {
+                    kind: tail_defect_kind(&outcome),
+                });
             }
         }
     }
@@ -361,6 +390,7 @@ fn cap(count: u32) -> usize {
 #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
     use super::*;
+    use crate::config::ManifestRecoveryMode;
 
     fn sample() -> VersionEdit {
         VersionEdit {
@@ -502,7 +532,8 @@ mod tests {
         for e in &edits {
             e.append_to(&mut log, &mut scratch).expect("append");
         }
-        let replayed = replay_edits(&mut &log[..], false).expect("replay");
+        let replayed =
+            replay_edits(&mut &log[..], ManifestRecoveryMode::AbsoluteConsistency).expect("replay");
         assert_eq!(replayed, edits, "replay must recover every edit in order");
     }
 
@@ -524,13 +555,22 @@ mod tests {
         e2.append_to(&mut log, &mut scratch).expect("append e2");
         log.truncate(clean_len + 6); // partial third record
 
-        let replayed = replay_edits(&mut &log[..], false).expect("replay");
+        // A writer-incomplete (truncated) tail is rolled back under every mode
+        // except AbsoluteConsistency; TolerateCorruptedTailRecords is the mode
+        // dedicated to exactly this salvage.
+        let replayed = replay_edits(
+            &mut &log[..],
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )
+        .expect("replay");
         assert_eq!(replayed, vec![e0, e1], "torn tail dropped, prefix kept");
     }
 
     #[test]
-    fn replay_stops_at_bitflipped_record() {
-        // A bit-flip in the second record stops replay after the first.
+    fn replay_stops_at_bitflipped_record_under_corruption_tolerant_mode() {
+        // A bit-flip in the second record is corruption of committed bytes (a
+        // fully-framed record with a bad checksum), not a writer-incomplete tail.
+        // Only the corruption-tolerant modes (PIT / SkipAny) roll it back.
         let mut log = Vec::new();
         let mut scratch = Vec::new();
         let mut e0 = sample();
@@ -544,13 +584,50 @@ mod tests {
         let target = after_e0 + framing::FRAME_HEADER_LEN + 2;
         log[target] ^= 0xFF;
 
-        let replayed = replay_edits(&mut &log[..], false).expect("replay");
-        assert_eq!(replayed, vec![e0], "replay stops at the corrupted record");
+        let replayed =
+            replay_edits(&mut &log[..], ManifestRecoveryMode::PointInTimeRecovery).expect("replay");
+        assert_eq!(replayed, vec![e0], "PIT drops the corrupted record");
+    }
+
+    #[test]
+    fn bitflipped_tail_aborts_under_tolerate_corrupted_tail() {
+        // The mode distinction the bool collapsed: TolerateCorruptedTailRecords
+        // salvages writer-incomplete tails ONLY, so a fully-framed but bit-rotted
+        // trailing record (corruption of committed bytes) must abort, not roll
+        // back. PIT / SkipAny roll it back (covered above); this guards the
+        // boundary so the two policies never merge again.
+        let mut log = Vec::new();
+        let mut scratch = Vec::new();
+        let mut e0 = sample();
+        e0.new_version_id = 1;
+        let mut e1 = sample();
+        e1.new_version_id = 2;
+        e0.append_to(&mut log, &mut scratch).expect("append e0");
+        let after_e0 = log.len();
+        e1.append_to(&mut log, &mut scratch).expect("append e1");
+        let target = after_e0 + framing::FRAME_HEADER_LEN + 2;
+        log[target] ^= 0xFF;
+
+        let err = replay_edits(
+            &mut &log[..],
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )
+        .expect_err("tolerate-tail must reject committed bit-rot");
+        assert!(
+            matches!(
+                err,
+                crate::Error::TornManifestEditLog {
+                    kind: "checksum-mismatch"
+                }
+            ),
+            "expected TornManifestEditLog(checksum-mismatch), got {err:?}",
+        );
     }
 
     #[test]
     fn replay_of_empty_log_is_empty() {
-        let replayed = replay_edits(&mut &[][..], false).expect("replay");
+        let replayed =
+            replay_edits(&mut &[][..], ManifestRecoveryMode::AbsoluteConsistency).expect("replay");
         assert!(replayed.is_empty(), "empty log → no edits");
     }
 

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -261,37 +261,86 @@ impl VersionEdit {
     }
 }
 
+/// Maps a non-`Ok` trailing-record outcome to the static `kind` carried by
+/// [`crate::Error::TornManifestEditLog`].
+fn tail_defect_kind(outcome: &framing::FramedRecordOutcome) -> &'static str {
+    use framing::FramedRecordOutcome;
+    match outcome {
+        FramedRecordOutcome::TailTruncation => "truncated",
+        FramedRecordOutcome::ChecksumMismatch { .. } => "checksum-mismatch",
+        FramedRecordOutcome::BadHeader => "bad-header",
+        FramedRecordOutcome::LenMismatch { .. } => "len-mismatch",
+        // The caller only routes non-`Ok` outcomes here.
+        FramedRecordOutcome::Ok => "ok",
+    }
+}
+
 /// Replays an edit log: reads framed `VersionEdit` records from `reader` in
-/// order and returns the durable prefix. Replay STOPS at the first record that
-/// is not cleanly `Ok` (torn tail, bad checksum, bad/short header) — under the
-/// append-only invariant a crash can only ever truncate or corrupt the trailing
-/// record, so the clean prefix is exactly the set of durably-committed edits.
-/// The dropped tail (and anything after it) was never acknowledged upward, so a
-/// higher-level journal replays that data.
+/// order and returns the durable prefix. Under the append-only invariant a
+/// crash can only ever truncate or corrupt the trailing record, so the clean
+/// prefix is exactly the set of durably-committed edits.
+///
+/// The edit log has no count header and no terminator: a clean end-of-log is a
+/// record boundary with no further bytes, which is byte-identical to a crash
+/// that landed exactly at a boundary. That clean boundary always ends replay
+/// successfully (in either mode) — otherwise a pristine database would fail to
+/// open.
+///
+/// `strict` mirrors [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency):
+/// - `false` (tolerant modes): a *partial* or corrupt trailing record (bytes
+///   present but framing not `Ok`) is dropped along with anything after it; that
+///   tail was never acknowledged upward, so a higher-level journal replays its
+///   data.
+/// - `true` (AbsoluteConsistency): the same partial / bit-rotted / mis-framed
+///   trailing record is surfaced as [`crate::Error::TornManifestEditLog`] rather
+///   than silently rolled back, so an operator truncates the tail (via
+///   [`Config::repair`](crate::Config::repair)) deliberately.
 ///
 /// A record whose framing is `Ok` (full payload + matching checksum) but whose
 /// payload fails to decode is a genuine format error, not power loss, and is
-/// surfaced as an error rather than silently truncating the log.
+/// surfaced as an error in both modes rather than silently truncating the log.
 ///
 /// # Errors
 ///
-/// Returns an I/O error from `reader` (other than EOF, which ends replay), or
-/// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode.
-pub fn replay_edits<R: Read>(reader: &mut R) -> crate::Result<Vec<VersionEdit>> {
+/// Returns an I/O error from `reader`, [`crate::Error::InvalidHeader`] if a
+/// checksum-valid record fails to decode, or
+/// [`crate::Error::TornManifestEditLog`] when `strict` and the trailing record
+/// is torn / bit-rotted / mis-framed.
+pub fn replay_edits<R: Read>(reader: &mut R, strict: bool) -> crate::Result<Vec<VersionEdit>> {
     use framing::FramedRecordOutcome;
+    use std::io::BufRead;
 
+    // Buffer the reader so a clean record boundary can be detected (empty fill)
+    // without consuming bytes from a genuine trailing record.
+    let mut reader = std::io::BufReader::new(reader);
     let mut edits = Vec::new();
     let mut scratch = Vec::new();
-    // Loop until the first non-`Ok` outcome: under the append-only invariant a
-    // crash truncates / corrupts only the trailing record, so the first
-    // TailTruncation / ChecksumMismatch / Bad-or-LenMismatch header ends the
-    // durable prefix. A clean record that fails to *decode* is a real format
-    // error and propagates via `?`.
-    while matches!(
-        framing::read_framed_record(reader, u64::MAX, None, &mut scratch)?,
-        FramedRecordOutcome::Ok
-    ) {
-        edits.push(VersionEdit::decode_payload(&scratch)?);
+    loop {
+        // No bytes left at a record boundary: the normal end of the log. A crash
+        // exactly at a boundary is indistinguishable from a pristine close, so
+        // this is always a successful end — never a "torn tail", in either mode.
+        if reader.fill_buf().map_err(crate::Error::Io)?.is_empty() {
+            break;
+        }
+        let outcome = framing::read_framed_record(&mut reader, u64::MAX, None, &mut scratch)?;
+        match outcome {
+            FramedRecordOutcome::Ok => edits.push(VersionEdit::decode_payload(&scratch)?),
+            // Bytes were present but the trailing record isn't a clean `Ok`:
+            // a power-loss-truncated append, in-record bit-rot, or a forged
+            // header. Tolerant modes recover the durable prefix; strict mode
+            // refuses to roll the unacknowledged / corrupt tail back silently.
+            FramedRecordOutcome::TailTruncation
+            | FramedRecordOutcome::ChecksumMismatch { .. }
+            | FramedRecordOutcome::BadHeader
+            | FramedRecordOutcome::LenMismatch { .. } => {
+                if strict {
+                    return Err(crate::Error::TornManifestEditLog {
+                        kind: tail_defect_kind(&outcome),
+                    });
+                }
+                break;
+            }
+        }
     }
     Ok(edits)
 }
@@ -453,7 +502,7 @@ mod tests {
         for e in &edits {
             e.append_to(&mut log, &mut scratch).expect("append");
         }
-        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        let replayed = replay_edits(&mut &log[..], false).expect("replay");
         assert_eq!(replayed, edits, "replay must recover every edit in order");
     }
 
@@ -475,7 +524,7 @@ mod tests {
         e2.append_to(&mut log, &mut scratch).expect("append e2");
         log.truncate(clean_len + 6); // partial third record
 
-        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        let replayed = replay_edits(&mut &log[..], false).expect("replay");
         assert_eq!(replayed, vec![e0, e1], "torn tail dropped, prefix kept");
     }
 
@@ -495,13 +544,13 @@ mod tests {
         let target = after_e0 + framing::FRAME_HEADER_LEN + 2;
         log[target] ^= 0xFF;
 
-        let replayed = replay_edits(&mut &log[..]).expect("replay");
+        let replayed = replay_edits(&mut &log[..], false).expect("replay");
         assert_eq!(replayed, vec![e0], "replay stops at the corrupted record");
     }
 
     #[test]
     fn replay_of_empty_log_is_empty() {
-        let replayed = replay_edits(&mut &[][..]).expect("replay");
+        let replayed = replay_edits(&mut &[][..], false).expect("replay");
         assert!(replayed.is_empty(), "empty log → no edits");
     }
 

--- a/src/version/edit_log.rs
+++ b/src/version/edit_log.rs
@@ -8,8 +8,9 @@
 //! one framed edit and fsyncs, so the structural change is durable before the
 //! operation is acknowledged upward (the engine has no WAL — durability of data
 //! lives a layer above, but the manifest is the crash anchor for the LSM's own
-//! structure). On recovery the snapshot is loaded and the log replayed; a
-//! power-loss-truncated trailing record is dropped (see [`replay_log`]).
+//! structure). On recovery the snapshot is loaded and the log replayed; under
+//! tolerant modes a power-loss-truncated trailing record is dropped, while
+//! `AbsoluteConsistency` surfaces it for deliberate repair (see [`replay_log`]).
 //!
 //! Rotation (writing a fresh snapshot and starting a new log) is driven by
 //! [`log_size`] exceeding a threshold; the snapshot switch is done atomically
@@ -48,16 +49,22 @@ pub fn append_edit(
 }
 
 /// Replays the durable prefix of the log at `path`. An absent log is an empty
-/// edit list (a snapshot with no edits yet). Replay stops at the first
-/// torn / bad-checksum trailing record (see [`replay_edits`]).
+/// edit list (a snapshot with no edits yet).
+///
+/// `strict` mirrors [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency):
+/// when `true`, an incomplete or corrupt trailing record is surfaced as
+/// [`crate::Error::TornManifestEditLog`] instead of being rolled back. A clean
+/// end-of-log is always tolerated (see [`replay_edits`]).
 ///
 /// # Errors
 ///
-/// Returns an I/O error if the open (other than not-found) or a read fails, or
-/// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode.
-pub fn replay_log(fs: &dyn Fs, path: &Path) -> crate::Result<Vec<VersionEdit>> {
+/// Returns an I/O error if the open (other than not-found) or a read fails,
+/// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode,
+/// or [`crate::Error::TornManifestEditLog`] when `strict` and the trailing
+/// record is torn / bit-rotted / mis-framed.
+pub fn replay_log(fs: &dyn Fs, path: &Path, strict: bool) -> crate::Result<Vec<VersionEdit>> {
     match fs.open(path, &FsOpenOptions::new().read(true)) {
-        Ok(mut file) => replay_edits(&mut file),
+        Ok(mut file) => replay_edits(&mut file, strict),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(e) => Err(crate::Error::Io(e)),
     }
@@ -79,7 +86,7 @@ pub fn log_size(fs: &dyn Fs, path: &Path) -> crate::Result<u64> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "test code")]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
     use super::super::edit::{ChangedLevel, TableDesc, VersionEdit};
     use super::*;
@@ -109,7 +116,7 @@ mod tests {
         for e in &edits {
             append_edit(&StdFs, &path, e, &mut scratch, SyncMode::Normal).expect("append");
         }
-        let replayed = replay_log(&StdFs, &path).expect("replay");
+        let replayed = replay_log(&StdFs, &path, false).expect("replay");
         assert_eq!(replayed, edits, "append+replay must round-trip in order");
     }
 
@@ -117,36 +124,115 @@ mod tests {
     fn replay_absent_log_is_empty() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("edits-missing");
-        assert!(replay_log(&StdFs, &path).expect("replay").is_empty());
+        assert!(replay_log(&StdFs, &path, false).expect("replay").is_empty());
         assert_eq!(log_size(&StdFs, &path).expect("size"), 0);
     }
 
-    #[test]
-    fn torn_tail_record_is_dropped_on_replay() {
-        // Append three edits, then truncate the file mid-third record (simulated
-        // power loss): replay keeps the first two, drops the torn tail.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("edits-torn");
+    /// Appends `count` clean edits, then truncates the file to `clean + 5`
+    /// bytes past the durable prefix so the trailing record is partial
+    /// (a power-loss-interrupted append). Returns the path.
+    fn log_with_torn_tail(dir: &std::path::Path, count: u64) -> std::path::PathBuf {
+        let path = dir.join("edits-torn");
         let mut scratch = Vec::new();
-        for i in 1..=2 {
+        for i in 1..=count {
             append_edit(&StdFs, &path, &edit(i), &mut scratch, SyncMode::Normal).expect("append");
         }
         let clean = log_size(&StdFs, &path).expect("size");
-        append_edit(&StdFs, &path, &edit(3), &mut scratch, SyncMode::Normal).expect("append");
-
-        // Truncate to a few bytes past the clean prefix → partial third record.
+        append_edit(
+            &StdFs,
+            &path,
+            &edit(count + 1),
+            &mut scratch,
+            SyncMode::Normal,
+        )
+        .expect("append");
         let f = std::fs::OpenOptions::new()
             .write(true)
             .open(&path)
             .expect("open");
         f.set_len(clean + 5).expect("truncate");
         drop(f);
+        path
+    }
 
-        let replayed = replay_log(&StdFs, &path).expect("replay");
+    #[test]
+    fn torn_tail_record_is_dropped_on_replay() {
+        // Lenient mode: a partial trailing record (simulated power loss mid-append)
+        // is dropped, keeping the durable prefix.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = log_with_torn_tail(dir.path(), 2);
+        let replayed = replay_log(&StdFs, &path, false).expect("replay");
         assert_eq!(
             replayed,
             vec![edit(1), edit(2)],
             "torn tail dropped, clean prefix kept",
+        );
+    }
+
+    #[test]
+    fn torn_tail_record_aborts_under_strict() {
+        // AbsoluteConsistency (strict): a partial trailing record is NOT silently
+        // rolled back — replay surfaces TornManifestEditLog so an operator must
+        // truncate the tail (Tree::repair) before the tree opens.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = log_with_torn_tail(dir.path(), 2);
+        let err = replay_log(&StdFs, &path, true).expect_err("strict must reject torn tail");
+        assert!(
+            matches!(err, crate::Error::TornManifestEditLog { kind: "truncated" }),
+            "expected TornManifestEditLog(truncated), got {err:?}",
+        );
+    }
+
+    #[test]
+    fn clean_log_replays_under_strict() {
+        // A pristine log (every record fully fsynced) ends in a clean record
+        // boundary, which the trailing read sees as EOF — byte-identical to a
+        // crash exactly at a boundary. Strict mode MUST tolerate this, else every
+        // healthy open would fail under the default AbsoluteConsistency mode.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-clean");
+        let mut scratch = Vec::new();
+        let edits: Vec<VersionEdit> = (1..=3).map(edit).collect();
+        for e in &edits {
+            append_edit(&StdFs, &path, e, &mut scratch, SyncMode::Normal).expect("append");
+        }
+        let replayed = replay_log(&StdFs, &path, true).expect("strict must accept a clean log");
+        assert_eq!(replayed, edits, "clean log replays fully under strict");
+    }
+
+    #[test]
+    fn checksum_mismatch_tail_aborts_under_strict() {
+        // A fully-framed trailing record whose payload bit-rotted (length and
+        // digest intact, bytes flipped) is corruption, not an unacknowledged
+        // write. Strict mode rejects it; lenient mode drops it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("edits-bitrot");
+        let mut scratch = Vec::new();
+        for i in 1..=3 {
+            append_edit(&StdFs, &path, &edit(i), &mut scratch, SyncMode::Normal).expect("append");
+        }
+        // Flip the last payload byte of the final (fully written) record.
+        let mut bytes = std::fs::read(&path).expect("read");
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        std::fs::write(&path, &bytes).expect("write");
+
+        let err = replay_log(&StdFs, &path, true).expect_err("strict must reject bit-rot");
+        assert!(
+            matches!(
+                err,
+                crate::Error::TornManifestEditLog {
+                    kind: "checksum-mismatch"
+                }
+            ),
+            "expected TornManifestEditLog(checksum-mismatch), got {err:?}",
+        );
+
+        let replayed = replay_log(&StdFs, &path, false).expect("lenient drops bit-rotted tail");
+        assert_eq!(
+            replayed,
+            vec![edit(1), edit(2)],
+            "lenient: bit-rotted tail dropped, prefix kept",
         );
     }
 

--- a/src/version/edit_log.rs
+++ b/src/version/edit_log.rs
@@ -51,20 +51,24 @@ pub fn append_edit(
 /// Replays the durable prefix of the log at `path`. An absent log is an empty
 /// edit list (a snapshot with no edits yet).
 ///
-/// `strict` mirrors [`ManifestRecoveryMode::AbsoluteConsistency`](crate::config::ManifestRecoveryMode::AbsoluteConsistency):
-/// when `true`, an incomplete or corrupt trailing record is surfaced as
-/// [`crate::Error::TornManifestEditLog`] instead of being rolled back. A clean
-/// end-of-log is always tolerated (see [`replay_edits`]).
+/// `mode` selects the trailing-record policy (see [`replay_edits`]): a clean
+/// end-of-log is always tolerated, a writer-incomplete tail is rolled back in
+/// every mode except `AbsoluteConsistency`, and a fully-framed corrupt tail is
+/// rolled back only under `PointInTimeRecovery` / `SkipAnyCorruptedRecords`.
 ///
 /// # Errors
 ///
 /// Returns an I/O error if the open (other than not-found) or a read fails,
 /// [`crate::Error::InvalidHeader`] if a checksum-valid record fails to decode,
-/// or [`crate::Error::TornManifestEditLog`] when `strict` and the trailing
-/// record is torn / bit-rotted / mis-framed.
-pub fn replay_log(fs: &dyn Fs, path: &Path, strict: bool) -> crate::Result<Vec<VersionEdit>> {
+/// or [`crate::Error::TornManifestEditLog`] when the trailing record is
+/// torn / bit-rotted / mis-framed and `mode` does not tolerate that defect.
+pub fn replay_log(
+    fs: &dyn Fs,
+    path: &Path,
+    mode: crate::config::ManifestRecoveryMode,
+) -> crate::Result<Vec<VersionEdit>> {
     match fs.open(path, &FsOpenOptions::new().read(true)) {
-        Ok(mut file) => replay_edits(&mut file, strict),
+        Ok(mut file) => replay_edits(&mut file, mode),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(e) => Err(crate::Error::Io(e)),
     }
@@ -90,6 +94,7 @@ pub fn log_size(fs: &dyn Fs, path: &Path) -> crate::Result<u64> {
 mod tests {
     use super::super::edit::{ChangedLevel, TableDesc, VersionEdit};
     use super::*;
+    use crate::config::ManifestRecoveryMode;
     use crate::fs::StdFs;
 
     fn edit(id: u64) -> VersionEdit {
@@ -116,7 +121,8 @@ mod tests {
         for e in &edits {
             append_edit(&StdFs, &path, e, &mut scratch, SyncMode::Normal).expect("append");
         }
-        let replayed = replay_log(&StdFs, &path, false).expect("replay");
+        let replayed =
+            replay_log(&StdFs, &path, ManifestRecoveryMode::AbsoluteConsistency).expect("replay");
         assert_eq!(replayed, edits, "append+replay must round-trip in order");
     }
 
@@ -124,7 +130,11 @@ mod tests {
     fn replay_absent_log_is_empty() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("edits-missing");
-        assert!(replay_log(&StdFs, &path, false).expect("replay").is_empty());
+        assert!(
+            replay_log(&StdFs, &path, ManifestRecoveryMode::AbsoluteConsistency)
+                .expect("replay")
+                .is_empty()
+        );
         assert_eq!(log_size(&StdFs, &path).expect("size"), 0);
     }
 
@@ -161,7 +171,12 @@ mod tests {
         // is dropped, keeping the durable prefix.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = log_with_torn_tail(dir.path(), 2);
-        let replayed = replay_log(&StdFs, &path, false).expect("replay");
+        let replayed = replay_log(
+            &StdFs,
+            &path,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        )
+        .expect("replay");
         assert_eq!(
             replayed,
             vec![edit(1), edit(2)],
@@ -176,7 +191,8 @@ mod tests {
         // truncate the tail (Tree::repair) before the tree opens.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = log_with_torn_tail(dir.path(), 2);
-        let err = replay_log(&StdFs, &path, true).expect_err("strict must reject torn tail");
+        let err = replay_log(&StdFs, &path, ManifestRecoveryMode::AbsoluteConsistency)
+            .expect_err("strict must reject torn tail");
         assert!(
             matches!(err, crate::Error::TornManifestEditLog { kind: "truncated" }),
             "expected TornManifestEditLog(truncated), got {err:?}",
@@ -196,15 +212,18 @@ mod tests {
         for e in &edits {
             append_edit(&StdFs, &path, e, &mut scratch, SyncMode::Normal).expect("append");
         }
-        let replayed = replay_log(&StdFs, &path, true).expect("strict must accept a clean log");
+        let replayed = replay_log(&StdFs, &path, ManifestRecoveryMode::AbsoluteConsistency)
+            .expect("strict must accept a clean log");
         assert_eq!(replayed, edits, "clean log replays fully under strict");
     }
 
     #[test]
-    fn checksum_mismatch_tail_aborts_under_strict() {
+    fn checksum_mismatch_tail_aborts_under_strict_and_tolerate_tail() {
         // A fully-framed trailing record whose payload bit-rotted (length and
-        // digest intact, bytes flipped) is corruption, not an unacknowledged
-        // write. Strict mode rejects it; lenient mode drops it.
+        // digest intact, bytes flipped) is corruption of committed bytes, not an
+        // unacknowledged write. AbsoluteConsistency AND TolerateCorruptedTailRecords
+        // (writer-incomplete salvage only) must both reject it; only the
+        // corruption-tolerant modes (PIT / SkipAny) drop it.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("edits-bitrot");
         let mut scratch = Vec::new();
@@ -217,22 +236,28 @@ mod tests {
         bytes[last] ^= 0xFF;
         std::fs::write(&path, &bytes).expect("write");
 
-        let err = replay_log(&StdFs, &path, true).expect_err("strict must reject bit-rot");
-        assert!(
-            matches!(
-                err,
-                crate::Error::TornManifestEditLog {
-                    kind: "checksum-mismatch"
-                }
-            ),
-            "expected TornManifestEditLog(checksum-mismatch), got {err:?}",
-        );
+        for mode in [
+            ManifestRecoveryMode::AbsoluteConsistency,
+            ManifestRecoveryMode::TolerateCorruptedTailRecords,
+        ] {
+            let err = replay_log(&StdFs, &path, mode).expect_err("must reject committed bit-rot");
+            assert!(
+                matches!(
+                    err,
+                    crate::Error::TornManifestEditLog {
+                        kind: "checksum-mismatch"
+                    }
+                ),
+                "expected TornManifestEditLog(checksum-mismatch) under {mode:?}, got {err:?}",
+            );
+        }
 
-        let replayed = replay_log(&StdFs, &path, false).expect("lenient drops bit-rotted tail");
+        let replayed = replay_log(&StdFs, &path, ManifestRecoveryMode::PointInTimeRecovery)
+            .expect("PIT drops bit-rotted tail");
         assert_eq!(
             replayed,
             vec![edit(1), edit(2)],
-            "lenient: bit-rotted tail dropped, prefix kept",
+            "PIT: bit-rotted tail dropped, prefix kept",
         );
     }
 

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -1148,12 +1148,16 @@ pub fn recover(
     // Replay the incremental edit log layered on top of the snapshot. The log
     // `edits-{snapshot_id}` holds every VersionEdit appended since the snapshot
     // was written; applying them in order reconstructs the current version.
-    // `replay_log` returns only the durable prefix — a power-loss-truncated
-    // trailing edit is dropped (it was never acknowledged upward), which is the
-    // same tail-tolerance the snapshot sections already grant. Each applied edit
-    // advances `recovery.curr_version_id` past the snapshot's id.
+    // Under tolerant modes `replay_log` returns only the durable prefix — a
+    // power-loss-truncated trailing edit is dropped (it was never acknowledged
+    // upward). Under `AbsoluteConsistency` (`!tolerate_tail`, the default) it
+    // instead surfaces `TornManifestEditLog` so an incomplete or bit-rotted
+    // trailing edit is not silently rolled back: the operator truncates the tail
+    // (Tree::repair) deliberately. A clean end-of-log is always accepted in both
+    // modes. Each applied edit advances `recovery.curr_version_id` past the
+    // snapshot's id.
     let log_path = folder.join(format!("edits-{curr_version_id}"));
-    let edits = super::edit_log::replay_log(fs, &log_path)?;
+    let edits = super::edit_log::replay_log(fs, &log_path, !tolerate_tail)?;
     if !edits.is_empty() {
         log::info!(
             "Replaying {} manifest edit(s) on top of snapshot #{curr_version_id}",

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -1148,16 +1148,16 @@ pub fn recover(
     // Replay the incremental edit log layered on top of the snapshot. The log
     // `edits-{snapshot_id}` holds every VersionEdit appended since the snapshot
     // was written; applying them in order reconstructs the current version.
-    // Under tolerant modes `replay_log` returns only the durable prefix — a
-    // power-loss-truncated trailing edit is dropped (it was never acknowledged
-    // upward). Under `AbsoluteConsistency` (`!tolerate_tail`, the default) it
-    // instead surfaces `TornManifestEditLog` so an incomplete or bit-rotted
-    // trailing edit is not silently rolled back: the operator truncates the tail
-    // (Tree::repair) deliberately. A clean end-of-log is always accepted in both
-    // modes. Each applied edit advances `recovery.curr_version_id` past the
-    // snapshot's id.
+    // `replay_log` routes the same `mode` the snapshot sections use: a
+    // writer-incomplete trailing edit is rolled back in every mode except the
+    // default `AbsoluteConsistency` (which surfaces `TornManifestEditLog` so the
+    // operator truncates the tail via repair); a fully-framed but bit-rotted
+    // trailing edit is rolled back only under PIT / SkipAny, and aborts under
+    // AbsoluteConsistency and TolerateCorruptedTailRecords (truncation-salvage
+    // only). A clean end-of-log is always accepted. Each applied edit advances
+    // `recovery.curr_version_id` past the snapshot's id.
     let log_path = folder.join(format!("edits-{curr_version_id}"));
-    let edits = super::edit_log::replay_log(fs, &log_path, !tolerate_tail)?;
+    let edits = super::edit_log::replay_log(fs, &log_path, mode)?;
     if !edits.is_empty() {
         log::info!(
             "Replaying {} manifest edit(s) on top of snapshot #{curr_version_id}",

--- a/tests/tree_recovery_versions.rs
+++ b/tests/tree_recovery_versions.rs
@@ -310,17 +310,26 @@ fn tree_recovery_version_free_list() -> lsm_tree::Result<()> {
 
 /// Crash safety of the incremental manifest: a power-loss-truncated trailing
 /// edit in the log is dropped on recovery, and the tree recovers exactly the
-/// durable prefix — the state after the last fully-fsynced edit.
+/// durable prefix — but only when the recovery mode opts into tail tolerance.
 ///
 /// Two flushes append two edits to `edits-0`. Truncating the file mid-second
 /// record simulates a crash between the second flush's edit being partially
-/// written and its fsync completing. On reopen the snapshot (`v0`, empty) plus
-/// the first edit are replayed; the torn second edit is discarded. So `a` (first
-/// flush) is present and `b` (second flush) is gone — the second flush was never
-/// durably committed to the manifest, which is the contract: an unacknowledged
-/// write may be lost, but the recovered state is always internally consistent.
+/// written and its fsync completing.
+///
+/// Under the default [`ManifestRecoveryMode::AbsoluteConsistency`] the torn
+/// trailing edit must NOT be silently rolled back: reopen fails with
+/// [`lsm_tree::Error::TornManifestEditLog`] so an operator deliberately
+/// truncates the tail (e.g. via repair) rather than losing an edit unnoticed.
+///
+/// Under [`ManifestRecoveryMode::TolerateCorruptedTailRecords`] the snapshot
+/// (`v0`, empty) plus the first edit are replayed and the torn second edit is
+/// discarded. So `a` (first flush) is present and `b` (second flush) is gone:
+/// the second flush was never durably committed, an unacknowledged write may be
+/// lost, but the recovered state is always internally consistent.
 #[test]
 fn tree_recovers_durable_prefix_when_edit_log_tail_is_torn() -> lsm_tree::Result<()> {
+    use lsm_tree::config::ManifestRecoveryMode;
+
     let folder = get_tmp_folder();
     let path = folder.path();
 
@@ -359,12 +368,28 @@ fn tree_recovers_durable_prefix_when_edit_log_tail_is_torn() -> lsm_tree::Result
     log.sync_all()?;
     drop(log);
 
+    // Default (AbsoluteConsistency): the torn trailing edit aborts the open.
+    let strict = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open();
+    assert!(
+        matches!(strict, Err(lsm_tree::Error::TornManifestEditLog { .. })),
+        "default AbsoluteConsistency must reject a torn edit-log tail, got {:?}",
+        strict.map(|_| "Ok"),
+    );
+
+    // Tolerant mode: recover the durable prefix (first flush survives, torn
+    // second flush is dropped).
     {
         let tree = Config::new(
             path,
             SequenceNumberCounter::default(),
             SequenceNumberCounter::default(),
         )
+        .manifest_recovery_mode(ManifestRecoveryMode::TolerateCorruptedTailRecords)
         .open()?;
 
         assert!(
@@ -374,6 +399,87 @@ fn tree_recovers_durable_prefix_when_edit_log_tail_is_torn() -> lsm_tree::Result
         assert!(
             !tree.contains_key("b", 2)?,
             "the second flush's edit was torn off — its key must be dropped"
+        );
+    }
+
+    Ok(())
+}
+
+/// The prescribed operator fix for a torn edit-log tail under the default
+/// strict mode: run repair, which rebuilds a clean standalone snapshot from the
+/// on-disk SST files and sweeps the stale edit log. Because repair scans the
+/// `tables/` directory directly (not the manifest), it even salvages the SST
+/// the torn edit had dropped — so after repair the tree reopens cleanly under
+/// the default [`ManifestRecoveryMode::AbsoluteConsistency`] with BOTH keys.
+#[test]
+fn repair_clears_torn_edit_log_tail_and_reopens_under_default() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let path = folder.path();
+
+    let clean_after_first;
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        tree.insert("a", "a", 0);
+        tree.flush_active_memtable(0)?;
+        clean_after_first = std::fs::metadata(path.join("edits-0"))?.len();
+        tree.insert("b", "b", 1);
+        tree.flush_active_memtable(1)?;
+    }
+
+    // Tear the trailing (second) edit.
+    let full = std::fs::metadata(path.join("edits-0"))?.len();
+    let torn_len = clean_after_first + (full - clean_after_first) / 2;
+    let log = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path.join("edits-0"))?;
+    log.set_len(torn_len)?;
+    log.sync_all()?;
+    drop(log);
+
+    // Default open rejects it.
+    let strict = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open();
+    assert!(
+        matches!(strict, Err(lsm_tree::Error::TornManifestEditLog { .. })),
+        "torn tail must abort the default open before repair",
+    );
+
+    // Repair: rebuild the manifest from the SST files on disk, dropping the log.
+    Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+    assert!(
+        !path.join("edits-0").try_exists()?,
+        "repair must sweep the stale edit log",
+    );
+
+    // Default open now succeeds, and both SSTs were salvaged by the directory scan.
+    {
+        let tree = Config::new(
+            path,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        assert!(
+            tree.contains_key("a", 2)?,
+            "repair salvaged the first flush's table",
+        );
+        assert!(
+            tree.contains_key("b", 2)?,
+            "repair salvaged the orphaned SST the torn edit had dropped",
         );
     }
 


### PR DESCRIPTION
## Summary

The incremental manifest (snapshot + append-only edit log) replayed its log by always rolling back an incomplete or corrupt **trailing** edit, in **every** recovery mode. That silently collapsed `AbsoluteConsistency` (the default) into the tolerant modes for the edit-log tail: the documented contract of `AbsoluteConsistency` is that any truncation or corruption aborts the open, and the snapshot sections already honour it, but the edit-log tail did not.

This threads a `strict` flag through `replay_log` / `replay_edits`, set from the existing `tolerate_tail` flag at the recovery site.

## Behaviour

- **Clean end-of-log** is a record boundary with no further bytes, byte-identical to a crash exactly at a boundary, so it is **always accepted in every mode** (otherwise a pristine database would fail to open under the default). The reader is buffered so this boundary is detected via an empty fill without consuming bytes from a genuine trailing record.
- **Tolerant modes** keep dropping a partial / bit-rotted / mis-framed trailing record and recover the durable prefix, unchanged.
- **`AbsoluteConsistency`** now surfaces such a trailing record as the new `Error::TornManifestEditLog { kind }` (`truncated` / `checksum-mismatch` / `bad-header` / `len-mismatch`) instead of rolling it back silently. An unacknowledged or bit-rotted edit is no longer lost without an operator noticing.

## Operator fix

`repair` rebuilds a clean standalone snapshot by scanning the on-disk SST files and sweeps the stale edit log, so it is the prescribed fix and reopens cleanly afterward. Because repair scans `tables/` directly (not the manifest), it even salvages the SST the torn edit had dropped.

## On-disk format

No format change. New error variant only; existing manifests recover identically (clean logs always accepted; behaviour change is limited to a torn/corrupt tail under the strict default).

## Testing

- Codec: strict aborts on a partial trailing record and on a bit-rotted (fully-framed, checksum-mismatched) trailing record; strict accepts a clean log (pristine open); tolerant mode recovers the durable prefix.
- Integration: torn tail rejected under the default, recovered under `TolerateCorruptedTailRecords`, and the full operator workflow (torn tail -> strict abort -> repair -> clean reopen with both SSTs salvaged).
- `clippy --all-features` and `--no-default-features --features zstd,lz4` (lib + tests) clean; full suite green (2011 tests); doctests pass.

Closes #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced recovery modes: strict recovery now surfaces torn or corrupted manifest tails with clear defect categories; tolerant/PIT modes recover by dropping damaged trailing records as appropriate.
  * Repair now clears torn manifest tails so a subsequent open can succeed.

* **Tests**
  * Expanded crash-recovery tests to exercise truncated and corrupted manifest tails across recovery modes and verify repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->