### PR TITLE
feat(compression): pin inner-frame dict id as configurable-checksum defense-in-depth

### DIFF
--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -183,12 +183,24 @@ fn do_decompress_with_dict(
         // Inner-frame defense-in-depth: pin the frame's embedded Dictionary_ID
         // against the dictionary we are about to decode with. On the raw-content
         // path the frame carries the synthetic `raw_content_id` we wrote at
-        // compress time, so a genuine frame always matches; a spliced frame body
-        // compressed under a different dictionary (the dict-substitution attack —
-        // header kept valid to pass the block-header and AAD checks) diverges
-        // here and is rejected BEFORE `force_dict` blindly applies the wrong
-        // tables and yields silent garbage. `init` validates the pinned id
-        // against the parsed header before any block decode runs.
+        // compress time, so a genuine frame always matches; a frame body
+        // compressed under a different dictionary diverges here and is rejected
+        // BEFORE `force_dict` blindly applies the wrong tables and yields silent
+        // garbage. `init` validates the pinned id against the parsed header
+        // before any block decode runs.
+        //
+        // This is an INDEPENDENT check, not a duplicate of the block checksum.
+        // The block's integrity checksum is configurable
+        // (`ChecksumAlgorithm`: `Xxh3_64` / `Xxh3Low32` / `Crc32c`) and runs over
+        // the compressed bytes. Under a 32-bit choice — `Crc32c` (linear,
+        // adversarially forgeable to any target) or `Xxh3Low32` — that checksum
+        // is no longer an adversarial barrier, so on a NON-encrypted dict block
+        // the embedded Dictionary_ID is the one independent witness that the
+        // frame was produced under the expected dictionary. For ENCRYPTED blocks
+        // the AAD already binds `dict_id` (AEAD verify catches substitution), so
+        // here the gate is belt-and-suspenders; it also turns an honest
+        // wrong-dictionary misconfiguration into a clear typed error instead of
+        // decompressed garbage.
         decoder.expect_dict_id(Some(raw_content_id));
         decoder.init(&mut cursor).map_err(|e| {
             if matches!(

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -802,9 +802,17 @@ mod tests {
         // `force_dict` can apply A's tables to B's frame.
         let err = ZstdProvider::decompress_with_dict(&frame_b, &dict_a, payload.len() + 1)
             .expect_err("dict substitution must be rejected by the inner-frame gate");
+        // Lock down the exact mismatch payload the gate emits, not just any
+        // Decompress error: the id carried is the EXPECTED dict (the one we
+        // decoded with), so an unrelated decompression failure would not match.
+        let expected_dict_id = dict_a.id().max(1);
         assert!(
-            matches!(err, crate::Error::Decompress(_)),
-            "expected a typed Decompress error (never silent wrong output), got {err:?}"
+            matches!(
+                err,
+                crate::Error::Decompress(crate::CompressionType::ZstdDict { level: 0, dict_id })
+                    if dict_id == expected_dict_id
+            ),
+            "expected Decompress(ZstdDict {{ level: 0, dict_id: {expected_dict_id} }}), got {err:?}"
         );
     }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -180,9 +180,31 @@ fn do_decompress_with_dict(
         //   - older frames written before the id was retained (header
         //     omits it).
         let mut cursor = std::io::Cursor::new(data);
-        decoder
-            .init(&mut cursor)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+        // Inner-frame defense-in-depth: pin the frame's embedded Dictionary_ID
+        // against the dictionary we are about to decode with. On the raw-content
+        // path the frame carries the synthetic `raw_content_id` we wrote at
+        // compress time, so a genuine frame always matches; a spliced frame body
+        // compressed under a different dictionary (the dict-substitution attack —
+        // header kept valid to pass the block-header and AAD checks) diverges
+        // here and is rejected BEFORE `force_dict` blindly applies the wrong
+        // tables and yields silent garbage. `init` validates the pinned id
+        // against the parsed header before any block decode runs.
+        decoder.expect_dict_id(Some(raw_content_id));
+        decoder.init(&mut cursor).map_err(|e| {
+            if matches!(
+                e,
+                structured_zstd::decoding::errors::FrameDecoderError::UnexpectedDictId { .. }
+            ) {
+                // Typed signal: the inner frame was compressed under a different
+                // dictionary than this block claims. Never silent wrong output.
+                crate::Error::Decompress(crate::CompressionType::ZstdDict {
+                    level: 0,
+                    dict_id: raw_content_id,
+                })
+            } else {
+                crate::Error::Io(std::io::Error::other(e))
+            }
+        })?;
 
         // Decompression-bomb guard: if the frame header declares a
         // content size larger than `capacity`, reject before allocating
@@ -728,6 +750,48 @@ mod tests {
         assert_eq!(
             decompressed, PLAINTEXT,
             "round-trip with raw content dict must equal the original plaintext"
+        );
+    }
+
+    #[test]
+    fn raw_content_dict_substitution_rejected_by_inner_frame_gate() {
+        // Defense-in-depth for the dict-substitution threat (#253): the
+        // raw-content decode path applies the dictionary via `force_dict`, which
+        // ignores the inner zstd frame's embedded Dictionary_ID. Without the
+        // `expect_dict_id` gate, a frame body compressed under a DIFFERENT
+        // dictionary (spliced in while the block header + AAD dict_id are kept
+        // valid) would be decoded against the wrong tables and yield silent
+        // garbage. The gate pins the frame id to the decoding dict, so the
+        // substitution surfaces a typed error instead of wrong plaintext.
+        let dict_a_raw = b"raw content dictionary ALPHA for the substitution test".to_vec();
+        let dict_b_raw = b"raw content dictionary BRAVO for the substitution test".to_vec();
+        let dict_a = ZstdDictionary::new(&dict_a_raw);
+        let dict_b = ZstdDictionary::new(&dict_b_raw);
+        assert_ne!(
+            dict_a.id(),
+            dict_b.id(),
+            "distinct raw dicts must hash to distinct ids"
+        );
+
+        let payload = b"defense-in-depth payload bytes compressed under a raw dict";
+
+        // Frame genuinely compressed under dict B (carries dict B's synthetic id).
+        let frame_b =
+            ZstdProvider::compress_with_dict(payload, 3, &dict_b_raw).expect("compress under B");
+
+        // Matching dict B decodes cleanly (the gate's expectation == frame id).
+        let ok = ZstdProvider::decompress_with_dict(&frame_b, &dict_b, payload.len() + 1)
+            .expect("matching dict must decode");
+        assert_eq!(ok, payload, "matching-dict round-trip must be exact");
+
+        // Substitution: decode frame B against dict A. The inner-frame id (B)
+        // diverges from the expectation (A) and the gate rejects it before
+        // `force_dict` can apply A's tables to B's frame.
+        let err = ZstdProvider::decompress_with_dict(&frame_b, &dict_a, payload.len() + 1)
+            .expect_err("dict substitution must be rejected by the inner-frame gate");
+        assert!(
+            matches!(err, crate::Error::Decompress(_)),
+            "expected a typed Decompress error (never silent wrong output), got {err:?}"
         );
     }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -189,18 +189,19 @@ fn do_decompress_with_dict(
         // garbage. `init` validates the pinned id against the parsed header
         // before any block decode runs.
         //
-        // This is an INDEPENDENT check, not a duplicate of the block checksum.
-        // The block's integrity checksum is configurable
-        // (`ChecksumAlgorithm`: `Xxh3_64` / `Xxh3Low32` / `Crc32c`) and runs over
-        // the compressed bytes. Under a 32-bit choice — `Crc32c` (linear,
-        // adversarially forgeable to any target) or `Xxh3Low32` — that checksum
-        // is no longer an adversarial barrier, so on a NON-encrypted dict block
-        // the embedded Dictionary_ID is the one independent witness that the
-        // frame was produced under the expected dictionary. For ENCRYPTED blocks
-        // the AAD already binds `dict_id` (AEAD verify catches substitution), so
-        // here the gate is belt-and-suspenders; it also turns an honest
-        // wrong-dictionary misconfiguration into a clear typed error instead of
-        // decompressed garbage.
+        // Primary value is correctness, with defense-in-depth on top:
+        // - Correctness: `force_dict` applies the given dictionary REGARDLESS of
+        //   the frame's id, so a wrong-dictionary configuration would otherwise
+        //   decode to silent garbage. The gate turns that into a clear typed
+        //   error at the source.
+        // - Defense-in-depth: the block-level integrity checksum (a fixed
+        //   XXH3-128 over the compressed bytes, verified before we get here) and,
+        //   for encrypted blocks, the AAD `dict_id` binding (AEAD verify) already
+        //   reject a substituted frame; the embedded Dictionary_ID is an
+        //   independent third witness behind them.
+        // (Note: the configurable `ChecksumAlgorithm` — `Xxh3_64` / `Xxh3Low32`
+        // / `Crc32c` — is the per-KV / per-entry checksum, NOT this block
+        // checksum, which is unconditionally XXH3-128.)
         decoder.expect_dict_id(Some(raw_content_id));
         decoder.init(&mut cursor).map_err(|e| {
             if matches!(

--- a/tests/encryption_aad_threat_model.rs
+++ b/tests/encryption_aad_threat_model.rs
@@ -55,13 +55,16 @@
 //! live, since each is defended by an existing layer rather than a new gate in
 //! THIS file):
 //!
-//! - **Dict substitution.** AAD binds `dict_id`, so on an encrypted block AEAD
-//!   verify rejects a swap (covered here by `dict_id_*` tampers). The inner
-//!   zstd frame's embedded `Dictionary_ID` is independently pinned on the
-//!   compression read path via `FrameDecoder::expect_dict_id` — the one barrier
-//!   that still holds for a NON-encrypted dict block when the block checksum is
-//!   configured to a forgeable 32-bit algorithm (`Crc32c` / `Xxh3Low32`). That
-//!   gate + its unit test live in `crate::compression::zstd_backend`
+//! - **Dict substitution.** Two independent layers reject a substituted frame:
+//!   the block integrity checksum (fixed XXH3-128 over the compressed bytes,
+//!   verified before decode) and, on encrypted blocks, the AAD `dict_id` binding
+//!   (AEAD verify — covered here by `dict_id_*` tampers). On top, the inner zstd
+//!   frame's embedded `Dictionary_ID` is pinned on the compression read path via
+//!   `FrameDecoder::expect_dict_id`, which mainly converts a wrong-dictionary
+//!   configuration into a clear typed error (the raw-content `force_dict` path
+//!   would otherwise apply the wrong tables and decode to silent garbage) and
+//!   adds defense-in-depth behind the checksum + AAD. That gate + its unit test
+//!   live in `crate::compression::zstd_backend`
 //!   (`raw_content_dict_substitution_rejected_by_inner_frame_gate`).
 //! - **Decompression-bomb window swap.** Defended without a strict
 //!   window-descriptor gate: AAD binds `window_log` (AEAD verify catches the

--- a/tests/encryption_aad_threat_model.rs
+++ b/tests/encryption_aad_threat_model.rs
@@ -51,11 +51,36 @@
 //! 6. ChaCha20-Poly1305 cross-suite coverage of the most consequential
 //!    scenarios (round-trip, cross-table swap, ciphertext bit-flip).
 //!
-//! Out of first-wave (require structured-zstd integration):
-//! - Dict substitution (needs ZstdDict frame inner-id check)
-//! - Decompression-bomb window swap (needs zstd window-log inner check)
-//! - Suite downgrade beyond AAD coverage (needs key-chain suite metadata)
-//! - Codec / decompression library version drift (needs zstd content checksum)
+//! Coverage of the remaining structured-zstd-integration scenarios (where they
+//! live, since each is defended by an existing layer rather than a new gate in
+//! THIS file):
+//!
+//! - **Dict substitution.** AAD binds `dict_id`, so on an encrypted block AEAD
+//!   verify rejects a swap (covered here by `dict_id_*` tampers). The inner
+//!   zstd frame's embedded `Dictionary_ID` is independently pinned on the
+//!   compression read path via `FrameDecoder::expect_dict_id` — the one barrier
+//!   that still holds for a NON-encrypted dict block when the block checksum is
+//!   configured to a forgeable 32-bit algorithm (`Crc32c` / `Xxh3Low32`). That
+//!   gate + its unit test live in `crate::compression::zstd_backend`
+//!   (`raw_content_dict_substitution_rejected_by_inner_frame_gate`).
+//! - **Decompression-bomb window swap.** Defended without a strict
+//!   window-descriptor gate: AAD binds `window_log` (AEAD verify catches the
+//!   swap on encrypted blocks — covered here by `window_log_*` tampers), and the
+//!   decode path bounds the output allocation to the block's
+//!   `uncompressed_length` (`DecompressedSizeTooLarge`), which caps the bomb's
+//!   effect on every block regardless of segment type or checksum algorithm.
+//!   `expect_window_descriptor` is intentionally NOT wired: it is strict
+//!   equality, applies only to (non-single-segment) dict frames, and adds
+//!   nothing over the always-applicable capacity bound.
+//! - **Codec / decompression library version drift.** Not applicable: the codec
+//!   is a single pinned pure-Rust dependency (deterministic decode within a
+//!   build; cross-version divergence is a codec bug caught by round-trip tests,
+//!   not an at-rest tamper). A per-frame zstd content checksum would change the
+//!   on-disk frame format (+4 bytes / block) and is deferred to a separate,
+//!   benchmark-symmetry-gated decision rather than enabled here.
+//! - **Suite downgrade beyond AAD coverage.** Covered: `suite_id` tamper +
+//!   key-chain epoch/suite disagreement are exercised below (`suite_id_*`,
+//!   `key_epoch_*`).
 
 #![cfg(all(feature = "encryption", feature = "zstd"))]
 


### PR DESCRIPTION
## Summary

Adds an inner-frame Dictionary_ID gate on the zstd raw-content decode path (#253, E2) and documents how the remaining threat-model scenarios are covered.

## Why

The raw-content dictionary decode path applies the dictionary via `force_dict`, which ignores the inner zstd frame's embedded `Dictionary_ID`. A wrong-dictionary configuration — or a frame body produced under a different dictionary — would be decoded against the wrong tables and yield silent garbage.

The gate's value:

- **Correctness (primary):** turns a wrong-dictionary configuration into a clear typed `Decompress` error at the source, instead of silent garbage downstream.
- **Defense-in-depth:** the block integrity checksum (a fixed **XXH3-128** over the compressed bytes, verified before decode) and, on encrypted blocks, the AAD `dict_id` binding (AEAD verify) already reject a substituted frame. The embedded `Dictionary_ID` is an independent third witness behind them.

Note: the configurable `ChecksumAlgorithm` (`Xxh3_64` / `Xxh3Low32` / `Crc32c`) is the **per-KV / per-entry** checksum, not the block checksum — the block checksum is unconditionally XXH3-128. (An earlier revision of this description incorrectly conflated the two.)

The finalized-dict path already rejects a foreign frame via auto-load-by-id (the spliced frame's id is not registered), so the gate targets the previously-unprotected raw-content path.

## What

- `do_decompress_with_dict` (raw-content branch) pins `FrameDecoder::expect_dict_id(Some(raw_content_id))`, validated at `init` before any block decode; `UnexpectedDictId` maps to a typed `Decompress` error. A genuine raw-content frame carries the same synthetic id the compressor wrote, so the matching round-trip is unaffected.
- Threat-model suite header documents coverage of the remaining scenarios:
  - **window-swap**: bounded by AAD `window_log` binding + the output-capacity check (`DecompressedSizeTooLarge`); no strict window-descriptor gate (it would apply only to non-single-segment dict frames and adds nothing over the always-applicable capacity bound).
  - **codec/library version-drift**: not applicable to a single pinned pure-Rust codec; a per-frame content checksum is a frame-format change deferred to a benchmark-symmetry-gated (#353) decision.

## Testing

- New: `raw_content_dict_substitution_rejected_by_inner_frame_gate` (a frame compressed under raw dict B decoded against raw dict A is rejected; the matching dict B round-trips exactly).
- No regression: all existing dict round-trip + finalized-path tests pass (they never hit the raw-content branch).
- `clippy --lib --all-features` clean; `fmt --check` clean; full suite green (2008 tests).

## On-disk format

No format change. Decode-side gate only; existing frames decode identically.

Part of #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened decompression validation so frames encoded with one dictionary are rejected when decoded with a different dictionary, returning a typed decompression error.

* **Tests**
  * Added a test verifying mismatched-dictionary decompression is rejected rather than producing incorrect output.

* **Documentation**
  * Expanded threat-model documentation mapping remaining integration scenarios to defenses and corresponding tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->