### PR TITLE
fix(verify): don't sleep the scrub throttle after the last SST

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -101,12 +101,14 @@ pub trait AbstractTree: sealed::Sealed {
     /// the tree's current version — a scrubber for catching bit rot before it
     /// surfaces as a user-visible read failure (cron / scrub jobs).
     ///
-    /// Reports at block granularity: the returned
-    /// [`BlockVerifyReport`](crate::verify::BlockVerifyReport) lists every
-    /// finding as `(file, offset)` and never aborts early. It does not surface
-    /// per-entry indices or ECC-correction counts (when ECC-at-rest is enabled a
-    /// within-budget corrupt block may still be healed on read as a side effect
-    /// of the scan, but the report does not tally corrections).
+    /// Reports at block granularity and never aborts early. The returned
+    /// [`BlockVerifyReport`](crate::verify::BlockVerifyReport) records
+    /// block-corruption findings with `(file, offset)`, while file-level errors
+    /// (e.g. [`BlockVerifyError::SstFileUnreadable`](crate::verify::BlockVerifyError::SstFileUnreadable))
+    /// carry the file only (no offset). It does not surface per-entry indices or
+    /// ECC-correction counts (when ECC-at-rest is enabled a within-budget corrupt
+    /// block may still be healed on read as a side effect of the scan, but the
+    /// report does not tally corrections).
     ///
     /// Filesystems with native per-block integrity (ZFS, Btrfs, `ReFS`, S3 —
     /// see [`Fs::capabilities`](crate::fs::Fs::capabilities)) already detect

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -101,10 +101,12 @@ pub trait AbstractTree: sealed::Sealed {
     /// the tree's current version — a scrubber for catching bit rot before it
     /// surfaces as a user-visible read failure (cron / scrub jobs).
     ///
-    /// Per-KV-checked SSTs (footer digests) pinpoint a corrupt entry by index;
-    /// when ECC-at-rest is enabled a within-budget corrupt block may be
-    /// corrected on read. The returned [`BlockVerifyReport`](crate::verify::BlockVerifyReport)
-    /// lists every finding with `(file, offset)` and never aborts early.
+    /// Reports at block granularity: the returned
+    /// [`BlockVerifyReport`](crate::verify::BlockVerifyReport) lists every
+    /// finding as `(file, offset)` and never aborts early. It does not surface
+    /// per-entry indices or ECC-correction counts (when ECC-at-rest is enabled a
+    /// within-budget corrupt block may still be healed on read as a side effect
+    /// of the scan, but the report does not tally corrections).
     ///
     /// Filesystems with native per-block integrity (ZFS, Btrfs, `ReFS`, S3 —
     /// see [`Fs::capabilities`](crate::fs::Fs::capabilities)) already detect

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -613,9 +613,14 @@ pub fn verify_block_checksums_with(
     // Sequential fast path: no thread spawn, deterministic table order.
     if workers <= 1 {
         let mut report = BlockVerifyReport::default();
-        for table in &tables {
+        for (idx, table) in tables.iter().enumerate() {
             merge_report(&mut report, scan_one_table(table));
-            if let Some(delay) = options.throttle {
+            // Inter-SST pause only: skip the sleep after the final table so a
+            // finished scrub returns promptly instead of waiting one extra
+            // throttle interval (which makes a done single-table scrub look hung).
+            if idx + 1 < tables.len()
+                && let Some(delay) = options.throttle
+            {
                 std::thread::sleep(delay);
             }
         }
@@ -628,13 +633,16 @@ pub fn verify_block_checksums_with(
             .map(|_| {
                 scope.spawn(|| {
                     let mut local = BlockVerifyReport::default();
-                    loop {
-                        let idx = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let Some(table) = tables.get(idx) else {
-                            break;
-                        };
+                    let mut idx = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    while let Some(table) = tables.get(idx) {
                         merge_report(&mut local, scan_one_table(table));
-                        if let Some(delay) = options.throttle {
+                        // Claim the next SST first; only pause if this worker
+                        // actually has another table to scan, so no worker sleeps
+                        // after its final SST.
+                        idx = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if tables.get(idx).is_some()
+                            && let Some(delay) = options.throttle
+                        {
                             std::thread::sleep(delay);
                         }
                     }
@@ -2061,5 +2069,29 @@ mod block_verify_tests {
             "throttled scrub must still verify clean: {report:?}"
         );
         assert!(report.sst_files_scanned >= 2);
+    }
+
+    #[test]
+    fn verify_checksum_with_throttle_does_not_sleep_after_last_sst() {
+        // Regression: the throttle is an INTER-SST pause and must not fire after
+        // the final SST. A single-SST tree scrubbed with a large throttle must
+        // return promptly; the bug slept one full throttle interval after the
+        // only table, making a finished scrub look hung. Sequential path
+        // (parallelism 1, one table) so this pins the single-worker loop.
+        let dir = tempfile::tempdir().unwrap();
+        populate_multi_sst(dir.path(), 1, 50);
+        let tree = reopen_tree(dir.path());
+        let throttle = std::time::Duration::from_millis(400);
+        let opts = VerifyOptions::default().parallelism(1).throttle(throttle);
+        let start = std::time::Instant::now();
+        let report = tree.verify_checksum_with(&opts);
+        let elapsed = start.elapsed();
+        assert!(report.is_ok(), "clean single-SST scrub: {report:?}");
+        assert_eq!(report.sst_files_scanned, 1, "test needs exactly one SST");
+        assert!(
+            elapsed < throttle / 2,
+            "a single-SST scrub must not sleep the inter-SST throttle after the \
+             last table: took {elapsed:?} with a {throttle:?} throttle",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Post-merge follow-up to #435 (#300) addressing CodeRabbit review on the merged PR.

## Fixes

1. **Throttle sleeps after the last SST** (Major). The inter-SST scrub throttle slept unconditionally after every scan in both the sequential and worker loops, so a single-table scrub (or a worker after its final table) waited one extra throttle interval before returning — a finished scrub looked hung for large throttle values. Now the sleep fires only when another table remains: the sequential loop skips the final iteration; each worker claims its next index first and pauses only if that index still maps to a table.

2. **`verify_checksum` doc overpromise** (Minor). The docs claimed per-entry indices and ECC-correction counts, but `verify_block_checksums*` report at block granularity (`BlockVerifyReport`: file + offset). Docs corrected to match what the API actually returns.

## Testing

- New regression test `verify_checksum_with_throttle_does_not_sleep_after_last_sst`: a single-SST scrub under a 400ms throttle must return in under half an interval. Verified test-first — it failed at ~404ms against the pre-fix code and passes after.
- `clippy --lib --all-features` clean; `fmt --check` clean; full suite green (the only failure is the known `encryption_stress` SLOW test flaking under full-suite parallel load — passes in isolation, unrelated to this change).

Part of #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary throttling delay at the end of verification, improving completion time for final storage structures.

* **Tests**
  * Added a regression test ensuring verification completes quickly when only a single storage structure is processed.

* **Documentation**
  * Clarified verification and reporting behavior, including how block-level and file-level findings are represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->