### PR TITLE
feat(tooling): key-free forensic dump-block for encrypted SSTs

### DIFF
--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -66,13 +66,13 @@ const SKIPPABLE_MAGIC_START: u32 = 0x184D_2A50;
 ///   value (including out-of-range bytes) is rejected.
 /// - `None`: any variant in 0..=15 is acceptable; the variant byte
 ///   is returned alongside the payload so the caller can dispatch.
-fn read_framed_payload<R: std::io::Read>(
+fn read_framed_payload_len<R: std::io::Read>(
     reader: &mut R,
     expected_variant: Option<u8>,
     min_payload: u32,
     max_payload: u32,
     err_ctor: fn(&'static str) -> DecryptError,
-) -> Result<(u8, Vec<u8>), DecryptError> {
+) -> Result<u32, DecryptError> {
     let mut header = [0u8; 8];
     reader
         .read_exact(&mut header)
@@ -107,12 +107,28 @@ fn read_framed_payload<R: std::io::Read>(
     if payload_len > max_payload {
         return Err(err_ctor("PayloadLen exceeds cap"));
     }
+    Ok(payload_len)
+}
 
+/// Reads + validates the skippable-frame header (via
+/// [`read_framed_payload_len`]) and then reads exactly the declared
+/// payload bytes into a `Vec<u8>`. Use when the payload bytes are needed
+/// (decrypt); use [`read_framed_payload_len`] alone when only the length
+/// matters (forensic metadata parse), to skip the body allocation.
+fn read_framed_payload<R: std::io::Read>(
+    reader: &mut R,
+    expected_variant: Option<u8>,
+    min_payload: u32,
+    max_payload: u32,
+    err_ctor: fn(&'static str) -> DecryptError,
+) -> Result<Vec<u8>, DecryptError> {
+    let payload_len =
+        read_framed_payload_len(reader, expected_variant, min_payload, max_payload, err_ctor)?;
     let mut payload = vec![0u8; payload_len as usize];
     reader
         .read_exact(&mut payload)
         .map_err(|_| err_ctor("truncated frame payload"))?;
-    Ok((variant_byte, payload))
+    Ok(payload)
 }
 
 /// `MetadataPayload` size for v1 suites: 39 bytes
@@ -384,7 +400,7 @@ pub fn parse_encrypted_block_metadata(
     bytes: &[u8],
 ) -> Result<EncryptedBlockMetadata, DecryptError> {
     let mut cursor = Cursor::new(bytes);
-    let (_, metadata_payload) = read_framed_payload(
+    let metadata_payload = read_framed_payload(
         &mut cursor,
         Some(METADATA_VARIANT),
         METADATA_PAYLOAD_LEN_V1,
@@ -392,13 +408,16 @@ pub fn parse_encrypted_block_metadata(
         DecryptError::MalformedMetadataFrame,
     )?;
     let parsed = decode_metadata_payload(&metadata_payload)?;
-    let (_, ciphertext) = read_framed_payload(
+    // Forensic parse needs only the body LENGTH, not its bytes — read the
+    // BodyFrame header and validate its bounds without allocating / copying
+    // the ciphertext (which can be up to 256 MiB).
+    let ciphertext_len = read_framed_payload_len(
         &mut cursor,
         Some(BODY_VARIANT),
         1,
         MAX_BODY_LEN,
         DecryptError::MalformedBodyFrame,
-    )?;
+    )? as usize;
     Ok(EncryptedBlockMetadata {
         format_version: parsed.ctx.header_byte >> 4,
         key_epoch: parsed.ctx.key_epoch,
@@ -410,7 +429,7 @@ pub fn parse_encrypted_block_metadata(
         block_flags: parsed.ctx.block_flags,
         nonce: parsed.nonce,
         aead_tag: parsed.tag,
-        ciphertext_len: ciphertext.len(),
+        ciphertext_len,
     })
 }
 
@@ -681,7 +700,7 @@ pub fn decrypt_block(
     // v1 MetadataPayload is fixed at exactly 39 bytes; reject any
     // other declared length upfront so a forged `PayloadLen`
     // can't allocate-and-then-discard.
-    let (_, metadata_payload) = read_framed_payload(
+    let metadata_payload = read_framed_payload(
         &mut cursor,
         Some(METADATA_VARIANT),
         METADATA_PAYLOAD_LEN_V1,
@@ -695,7 +714,7 @@ pub fn decrypt_block(
     // PayloadLen": valid range `[1, 256 MiB]` for v1 suites.
     // Empty body is forbidden by spec — encrypt_block enforces
     // the matching rule on the write side.
-    let (_, mut ciphertext) = read_framed_payload(
+    let mut ciphertext = read_framed_payload(
         &mut cursor,
         Some(BODY_VARIANT),
         1,

--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -417,7 +417,18 @@ pub fn parse_encrypted_block_metadata(
         1,
         MAX_BODY_LEN,
         DecryptError::MalformedBodyFrame,
-    )? as usize;
+    )?;
+    // The length-only read does not consume the payload, so verify the input
+    // actually contains the advertised ciphertext bytes — otherwise a block cut
+    // off right after the BodyFrame header would be reported as structurally
+    // valid with a ciphertext_len for bytes that aren't there.
+    let remaining = u64::try_from(bytes.len())
+        .unwrap_or(u64::MAX)
+        .saturating_sub(cursor.position());
+    if u64::from(ciphertext_len) > remaining {
+        return Err(DecryptError::MalformedBodyFrame("truncated frame payload"));
+    }
+    let ciphertext_len = ciphertext_len as usize;
     Ok(EncryptedBlockMetadata {
         format_version: parsed.ctx.header_byte >> 4,
         key_epoch: parsed.ctx.key_epoch,
@@ -835,6 +846,29 @@ mod tests {
         // Garbage / truncated input is a typed error, never a panic.
         assert!(parse_encrypted_block_metadata(b"not a frame").is_err());
         assert!(parse_encrypted_block_metadata(&sealed[..10]).is_err());
+    }
+
+    #[test]
+    fn parse_metadata_rejects_truncated_body() {
+        // Regression: the forensic parser reads only the BodyFrame header (for
+        // ciphertext_len) without the payload. A block cut off right after that
+        // header — full MetadataFrame + BodyFrame header, but zero ciphertext
+        // bytes — must still be rejected, not reported as structurally valid
+        // with a ciphertext_len for bytes that aren't there.
+        let sealed = encrypt_block(b"forensic payload bytes", &id(), &ctx(), &chain()).unwrap();
+        // MetadataFrame = 8-byte SFA header + 39-byte payload; BodyFrame header
+        // = 8 bytes. Cut to exactly that boundary: header present, body absent.
+        let cut = 8 + METADATA_PAYLOAD_LEN_V1 as usize + 8;
+        assert!(
+            sealed.len() > cut,
+            "test setup: sealed block must extend past the body header",
+        );
+        let err = parse_encrypted_block_metadata(&sealed[..cut])
+            .expect_err("truncated body must be rejected");
+        assert!(
+            matches!(err, DecryptError::MalformedBodyFrame(_)),
+            "expected MalformedBodyFrame for a truncated body, got {err:?}",
+        );
     }
 
     #[test]

--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -301,6 +301,119 @@ fn decode_metadata_payload(payload: &[u8]) -> Result<ParsedMetadata, DecryptErro
     })
 }
 
+/// Key-free structural view of an AAD-bound encrypted block's metadata,
+/// parsed from the on-disk `MetadataFrame` WITHOUT the encryption key.
+///
+/// Produced by [`parse_encrypted_block_metadata`] for offline forensic
+/// inspection — e.g. an on-call engineer examining a block that fails to
+/// decode, with no live process and no key. Every field is read from the
+/// on-disk `MetadataFrame` mirror; nothing here requires decryption and the
+/// ciphertext body is never touched beyond bounds-checking its frame.
+///
+/// The three AAD-binding fields `tree_id`, `table_id` and `block_offset` are
+/// deliberately NOT stored on disk (they are supplied from read context at
+/// decrypt time), so they are absent here — reconstructing the AAD for offline
+/// verification requires the caller to supply them from the file path /
+/// inventory.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct EncryptedBlockMetadata {
+    /// Wire-format version (high nibble of the on-disk `HeaderByte`); `1` for v1.
+    pub format_version: u8,
+    /// Key epoch the block was sealed under (selects the key in the chain).
+    pub key_epoch: u8,
+    /// Raw `BlockType` discriminator byte (mirrors the block header).
+    pub block_type: u8,
+    /// AEAD suite the block was sealed with.
+    pub suite_id: SuiteId,
+    /// Raw `CompressionType` tag (`0` None, `1` Lz4, `3` Zstd, `4` `ZstdDict`).
+    pub compression_type: u8,
+    /// zstd dictionary id (non-zero only for `ZstdDict`).
+    pub dict_id: u32,
+    /// zstd window-log descriptor (`0`, or `10..=31`).
+    pub window_log: u8,
+    /// Transform-presence bitfield mirrored from the block header.
+    pub block_flags: u8,
+    /// 12-byte AEAD nonce.
+    pub nonce: [u8; 12],
+    /// 16-byte AEAD authentication tag.
+    pub aead_tag: [u8; TAG_LEN],
+    /// Length in bytes of the encrypted `BodyFrame` payload (the ciphertext).
+    pub ciphertext_len: usize,
+}
+
+/// Parses the metadata of an AAD-bound encrypted block WITHOUT decrypting it.
+///
+/// Walks the on-disk `MetadataFrame ‖ BodyFrame` envelope, validating the
+/// `MetadataFrame` structure (magic, length, codec-context invariants) and the
+/// `BodyFrame` bounds, and returns the [`EncryptedBlockMetadata`] view. No key
+/// is consulted and no plaintext is produced — this is the read-only structural
+/// parse a forensics tool uses to inspect a block that fails to decode.
+///
+/// Trailing bytes after the `BodyFrame` (e.g. a Page ECC parity trailer added
+/// outside the encryption envelope) are ignored, so this accepts either the
+/// bare envelope or an envelope followed by such a trailer.
+///
+/// # Errors
+///
+/// Returns [`DecryptError::MalformedMetadataFrame`] / [`DecryptError::MalformedBodyFrame`]
+/// for a structurally invalid envelope, [`DecryptError::UnsupportedFormatVersion`]
+/// for an unknown wire version, or [`DecryptError::UnsupportedSuite`] for an
+/// unregistered suite byte.
+///
+/// # Examples
+///
+/// ```
+/// use lsm_tree::encryption::{
+///     StaticKeyChain, encrypt_block, parse_encrypted_block_metadata,
+///     aad::{BlockIdentity, BlockType, EncryptionContext, SuiteId},
+/// };
+///
+/// let chain = StaticKeyChain::new().with_key(1, [0x42; 32]);
+/// let ctx = EncryptionContext::v1(1, SuiteId::Aes256Gcm, 0, 0);
+/// let id = BlockIdentity { table_id: 7, block_type: BlockType::Data, dict_id: 0, window_log: 0 };
+/// let sealed = encrypt_block(b"payload bytes", &id, &ctx, &chain).unwrap();
+///
+/// let meta = parse_encrypted_block_metadata(&sealed).unwrap();
+/// assert_eq!(meta.format_version, 1);
+/// assert_eq!(meta.key_epoch, 1);
+/// assert_eq!(meta.suite_id, SuiteId::Aes256Gcm);
+/// assert_eq!(meta.dict_id, 0);
+/// ```
+pub fn parse_encrypted_block_metadata(
+    bytes: &[u8],
+) -> Result<EncryptedBlockMetadata, DecryptError> {
+    let mut cursor = Cursor::new(bytes);
+    let (_, metadata_payload) = read_framed_payload(
+        &mut cursor,
+        Some(METADATA_VARIANT),
+        METADATA_PAYLOAD_LEN_V1,
+        METADATA_PAYLOAD_LEN_V1,
+        DecryptError::MalformedMetadataFrame,
+    )?;
+    let parsed = decode_metadata_payload(&metadata_payload)?;
+    let (_, ciphertext) = read_framed_payload(
+        &mut cursor,
+        Some(BODY_VARIANT),
+        1,
+        MAX_BODY_LEN,
+        DecryptError::MalformedBodyFrame,
+    )?;
+    Ok(EncryptedBlockMetadata {
+        format_version: parsed.ctx.header_byte >> 4,
+        key_epoch: parsed.ctx.key_epoch,
+        block_type: parsed.block_type_byte,
+        suite_id: parsed.suite_id,
+        compression_type: parsed.ctx.compression_type,
+        dict_id: parsed.dict_id,
+        window_log: parsed.window_log,
+        block_flags: parsed.ctx.block_flags,
+        nonce: parsed.nonce,
+        aead_tag: parsed.tag,
+        ciphertext_len: ciphertext.len(),
+    })
+}
+
 /// Seals `plaintext` into the AAD-bound `MetadataFrame ‖ BodyFrame`
 /// byte sequence.
 ///
@@ -673,6 +786,36 @@ mod tests {
 
     fn chain() -> StaticKeyChain {
         StaticKeyChain::new().with_key(0, TEST_KEY)
+    }
+
+    #[test]
+    fn parse_metadata_is_key_free_and_matches_seal() {
+        // Forensic parse needs no key: seal a block, then read its
+        // MetadataPayload structurally with `parse_encrypted_block_metadata`
+        // (no KeyChain) and confirm the fields mirror what was sealed.
+        let plaintext = b"forensic payload bytes";
+        let sealed = encrypt_block(plaintext, &id(), &ctx(), &chain()).unwrap();
+
+        let meta = parse_encrypted_block_metadata(&sealed).unwrap();
+        assert_eq!(meta.format_version, 1);
+        assert_eq!(meta.key_epoch, 0);
+        assert_eq!(meta.suite_id, SuiteId::Aes256Gcm);
+        assert_eq!(meta.block_type, u8::from(BlockType::Data));
+        assert_eq!(meta.compression_type, 0);
+        assert_eq!(meta.dict_id, 0);
+        assert_eq!(meta.window_log, 0);
+        assert!(meta.ciphertext_len > 0, "body must carry ciphertext");
+
+        // Suite is reflected for ChaCha too (proves it reads the on-disk
+        // SuiteID byte, not a hard-coded default).
+        let chacha_ctx = EncryptionContext::v1(0, SuiteId::ChaCha20Poly1305, 0, 0);
+        let sealed_cc = encrypt_block(plaintext, &id(), &chacha_ctx, &chain()).unwrap();
+        let meta_cc = parse_encrypted_block_metadata(&sealed_cc).unwrap();
+        assert_eq!(meta_cc.suite_id, SuiteId::ChaCha20Poly1305);
+
+        // Garbage / truncated input is a typed error, never a panic.
+        assert!(parse_encrypted_block_metadata(b"not a frame").is_err());
+        assert!(parse_encrypted_block_metadata(&sealed[..10]).is_err());
     }
 
     #[test]

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -72,7 +72,10 @@ pub mod key_chain;
 // through the submodule path each time. Matches the surface
 // shape #251's design discussion settled on.
 #[cfg(all(feature = "encryption", zstd_any))]
-pub use block::{DecryptedBlock, decrypt_block, encrypt_block};
+pub use block::{
+    DecryptedBlock, EncryptedBlockMetadata, decrypt_block, encrypt_block,
+    parse_encrypted_block_metadata,
+};
 pub use error::DecryptError;
 pub use key_chain::KeyChain;
 #[cfg(feature = "std")]

--- a/tools/sst-dump/Cargo.toml
+++ b/tools/sst-dump/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 # `lz4` + `zstd` features enabled because real production SSTs are
 # usually compressed; without them the tool refuses to walk
 # compressed blocks.
-lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["lz4", "zstd"] }
+lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["lz4", "zstd", "encryption"] }
 clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -813,9 +813,13 @@ fn hex_string(bytes: &[u8]) -> String {
 }
 
 /// Cap on the block payload the forensic dump will read, guarding against a
-/// forged `Header.data_length` triggering a multi-GiB allocation. 256 MiB
-/// matches the encrypted-body cap enforced on the read path.
-const DUMP_BLOCK_MAX_PAYLOAD: u64 = 256 * 1024 * 1024;
+/// forged `Header.data_length` triggering a multi-GiB allocation. This is
+/// compared against the full envelope length (`Header.data_length`), so it is
+/// the 256 MiB encrypted-body cap PLUS the envelope framing overhead: a 47-byte
+/// `MetadataFrame` (8-byte skippable header + 39-byte payload) and an 8-byte
+/// `BodyFrame` header. Without the +55 a maximum-sized valid block would be
+/// rejected.
+const DUMP_BLOCK_MAX_PAYLOAD: u64 = 256 * 1024 * 1024 + 55;
 
 /// Forensic structural dump of one encrypted block at `offset`, key-free.
 ///

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -11,6 +11,7 @@
 
 use clap::{Parser, Subcommand};
 use lsm_tree::coding::Decode;
+use lsm_tree::encryption::parse_encrypted_block_metadata;
 use lsm_tree::inspect::{
     iter_data_block_entries, read_filter_stats, read_table_properties, read_top_level_index_entries,
 };
@@ -181,6 +182,34 @@ enum Command {
     /// "not supported" error. Filter-less tables (no `filter`
     /// section at all) exit 0 with a "no filter installed" notice.
     FilterStats,
+
+    /// Forensic structural dump of a single encrypted block WITHOUT the
+    /// key. Reads the `Header` at `offset`, then parses the block's
+    /// AAD-bound `MetadataFrame` envelope (no decryption, no live
+    /// process) and prints the cryptographic parameters as YAML: format
+    /// version, suite, key epoch, block type, compression, dict id,
+    /// window log, block flags, nonce, AEAD tag, ciphertext length.
+    ///
+    /// Use when a production block fails to decode and on-call needs the
+    /// block's structure without the key. The AAD-binding fields
+    /// `tree_id` / `table_id` / `block_offset` are NOT stored on disk, so
+    /// they are shown only if supplied via `--tree-id` / `--table-id`
+    /// (block offset is the positional arg).
+    DumpBlock {
+        /// Byte offset of the block's `Header` in the file (e.g. a value
+        /// reported by `verify --verbose` or a TOC section start).
+        offset: u64,
+
+        /// Owning tree id — not stored on disk; supplied from read
+        /// context. Echoed in the output when provided.
+        #[arg(long)]
+        tree_id: Option<u64>,
+
+        /// Owning table id — not stored on disk; supplied from read
+        /// context. Echoed in the output when provided.
+        #[arg(long)]
+        table_id: Option<u64>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -203,6 +232,11 @@ fn main() -> ExitCode {
         } => run_dump(&cli.path, from.as_deref(), to.as_deref(), max, keys_only),
         Command::FilterStats => run_filter_stats(&cli.path),
         Command::Repair => run_repair(&cli.path),
+        Command::DumpBlock {
+            offset,
+            tree_id,
+            table_id,
+        } => run_dump_block(&cli.path, offset, tree_id, table_id),
     }
 }
 
@@ -764,4 +798,122 @@ fn format_key(key: &[u8]) -> String {
     }
     out.push('"');
     out
+}
+
+/// Lowercase hex string of `bytes`, no separators (for nonce / tag dumps).
+fn hex_string(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // Writing to a String is infallible; the Result is discarded
+        // deliberately rather than unwrapped (clippy::unwrap_used).
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Cap on the block payload the forensic dump will read, guarding against a
+/// forged `Header.data_length` triggering a multi-GiB allocation. 256 MiB
+/// matches the encrypted-body cap enforced on the read path.
+const DUMP_BLOCK_MAX_PAYLOAD: u64 = 256 * 1024 * 1024;
+
+/// Forensic structural dump of one encrypted block at `offset`, key-free.
+///
+/// Reads the block `Header` at `offset` (which leaves the cursor at the
+/// payload), reads `data_length` payload bytes, and parses them as the
+/// AAD-bound `MetadataFrame ‖ BodyFrame` envelope. Emits the cryptographic
+/// parameters as YAML. No key is used and no plaintext is produced.
+fn run_dump_block(
+    path: &std::path::Path,
+    offset: u64,
+    tree_id: Option<u64>,
+    table_id: Option<u64>,
+) -> ExitCode {
+    let mut file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: open {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(e) = file.seek(SeekFrom::Start(offset)) {
+        eprintln!("error: seek to {offset}: {e}");
+        return ExitCode::FAILURE;
+    }
+    let header = match Header::decode_from(&mut file) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("error: decode block header at offset {offset}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let data_len = u64::from(header.data_length);
+    if data_len > DUMP_BLOCK_MAX_PAYLOAD {
+        eprintln!(
+            "error: block data_length {data_len} exceeds cap {DUMP_BLOCK_MAX_PAYLOAD}; \
+             refusing to allocate (forged header?)"
+        );
+        return ExitCode::FAILURE;
+    }
+    // `Header::decode_from` consumed exactly the header bytes, so the file
+    // cursor now sits at the start of the block payload.
+    let mut payload = vec![0u8; data_len as usize];
+    if let Err(e) = file.read_exact(&mut payload) {
+        eprintln!("error: read {data_len}-byte block payload at offset {offset}: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    let meta = match parse_encrypted_block_metadata(&payload) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!(
+                "block at offset {offset} is not an AAD-bound encrypted block \
+                 (no MetadataFrame envelope): {e:?}"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Spec §5.1 CompressionType registry.
+    let compression = match meta.compression_type {
+        0 => "None",
+        1 => "Lz4",
+        3 => "Zstd",
+        4 => "ZstdDict",
+        _ => "unknown",
+    };
+
+    // YAML output (machine-parseable for incident postmortems).
+    println!("file: {}", format_key(path.to_string_lossy().as_bytes()));
+    println!("block_offset: {offset}");
+    println!("encrypted: true");
+    println!("header_block_type: {:?}", header.block_type);
+    println!("format_version: {}", meta.format_version);
+    println!("suite: {:?}", meta.suite_id);
+    println!("suite_byte: {}", meta.suite_id.as_byte());
+    println!("key_epoch: {}", meta.key_epoch);
+    println!("block_type_byte: {}", meta.block_type);
+    println!("compression_type: {compression}");
+    println!("compression_type_byte: {}", meta.compression_type);
+    println!("dict_id: {}", meta.dict_id);
+    println!("window_log: {}", meta.window_log);
+    println!("block_flags: 0x{:02x}", meta.block_flags);
+    println!("nonce: \"{}\"", hex_string(&meta.nonce));
+    println!("aead_tag: \"{}\"", hex_string(&meta.aead_tag));
+    println!("ciphertext_len: {}", meta.ciphertext_len);
+
+    // tree_id / table_id / block_offset are AAD-binding but NOT stored on
+    // disk (supplied from read context at decrypt time), so they are echoed
+    // only when the operator passes them.
+    println!("caller_supplied:");
+    match tree_id {
+        Some(t) => println!("  tree_id: {t}"),
+        None => println!("  tree_id: null  # not on disk; pass --tree-id"),
+    }
+    match table_id {
+        Some(t) => println!("  table_id: {t}"),
+        None => println!("  table_id: null  # not on disk; pass --table-id"),
+    }
+
+    ExitCode::SUCCESS
 }

--- a/tools/sst-dump/tests/dump_block_smoke.rs
+++ b/tools/sst-dump/tests/dump_block_smoke.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end smoke test for the `dump-block` forensic subcommand:
+//! build a real ENCRYPTED SST via `lsm-tree`, then drive `sst-dump
+//! dump-block` against the first block and confirm it prints the
+//! AAD-bound metadata WITHOUT the key. Also confirms a non-encrypted
+//! block is reported as such (no MetadataFrame envelope).
+
+use lsm_tree::{
+    AbstractTree, Aes256GcmProvider, Config, SequenceNumberCounter, compression::CompressionType,
+    config::CompressionPolicy,
+};
+use std::process::Command;
+use std::sync::Arc;
+
+const SST_DUMP_BIN: &str = env!("CARGO_BIN_EXE_sst-dump");
+
+fn first_sst(dir: &std::path::Path) -> std::path::PathBuf {
+    let tables = dir.join("tables");
+    std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path()
+}
+
+fn populate(tree: &impl AbstractTree) {
+    for i in 0u64..200 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+}
+
+/// Encrypted SST: uncompressed blocks sealed via the AAD-bound block path
+/// (`with_encryption`), so each block's payload is a `MetadataFrame ‖ BodyFrame`
+/// envelope the forensic parser can read key-free.
+fn build_encrypted_sst() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let key = [0x42u8; 32];
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .with_encryption(Some(Arc::new(Aes256GcmProvider::new(&key))))
+    .open()
+    .expect("open encrypted tree");
+    populate(&tree);
+    drop(tree);
+    let sst = first_sst(dir.path());
+    (dir, sst)
+}
+
+fn build_plain_sst() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .open()
+    .expect("open tree");
+    populate(&tree);
+    drop(tree);
+    let sst = first_sst(dir.path());
+    (dir, sst)
+}
+
+#[test]
+fn dump_block_on_encrypted_block_prints_metadata_key_free() {
+    let (_dir, sst) = build_encrypted_sst();
+
+    // Offset 0 is the first block's `Header`; for an encrypted SST its
+    // payload is the AAD-bound envelope. No key is passed to the tool.
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("dump-block")
+        .arg("0")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(stdout.contains("encrypted: true"), "got:\n{stdout}");
+    assert!(stdout.contains("format_version: 1"), "got:\n{stdout}");
+    assert!(stdout.contains("suite: Aes256Gcm"), "got:\n{stdout}");
+    // Nonce + tag are dumped as quoted hex.
+    assert!(stdout.contains("nonce: \""), "got:\n{stdout}");
+    assert!(stdout.contains("aead_tag: \""), "got:\n{stdout}");
+    // tree_id / table_id are not on disk and were not supplied.
+    assert!(stdout.contains("tree_id: null"), "got:\n{stdout}");
+}
+
+#[test]
+fn dump_block_echoes_caller_supplied_ids() {
+    let (_dir, sst) = build_encrypted_sst();
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("dump-block")
+        .arg("0")
+        .arg("--tree-id")
+        .arg("7")
+        .arg("--table-id")
+        .arg("42")
+        .output()
+        .expect("spawn sst-dump");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "expected exit 0; got:\n{stdout}");
+    assert!(stdout.contains("tree_id: 7"), "got:\n{stdout}");
+    assert!(stdout.contains("table_id: 42"), "got:\n{stdout}");
+}
+
+#[test]
+fn dump_block_on_plain_block_reports_not_encrypted() {
+    let (_dir, sst) = build_plain_sst();
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("dump-block")
+        .arg("0")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on a non-encrypted block",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not an AAD-bound encrypted block"),
+        "expected the not-encrypted notice; got:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

First slice of the forensic block inspector (#256): a key-free structural dump of an encrypted block's metadata, plus the `sst-dump dump-block` subcommand that drives it. For an on-call engineer inspecting a block that fails to decode — no key, no live process.

## What

**Library** (`coordinode-lsm-tree`):
- `parse_encrypted_block_metadata(bytes) -> EncryptedBlockMetadata`: walks the on-disk `MetadataFrame ‖ BodyFrame` envelope and returns format version, key epoch, block type, suite, compression type, dict id, window log, block flags, nonce, AEAD tag, and ciphertext length — **without the key**. Reuses the decrypt path's structural validation (frame magic/length, codec-context invariants, body bounds) but performs no AEAD work and produces no plaintext. Trailing bytes after the `BodyFrame` (e.g. a Page ECC parity trailer outside the envelope) are tolerated.

**CLI** (`sst-dump`):
- `sst-dump <file> dump-block <offset>`: reads the block `Header` at the offset, reads the `data_length` payload, and prints the parsed metadata as YAML. `data_length` is capped before allocation to guard a forged header. A non-encrypted block (no `MetadataFrame` envelope) is reported and exits non-zero.
- The AAD-binding `tree_id` / `table_id` / `block_offset` are **not stored on disk** (supplied from read context at decrypt time): `block_offset` is the positional arg; `tree_id` / `table_id` are echoed only when passed via `--tree-id` / `--table-id`.
- Enables the `encryption` feature on the tool's `lsm-tree` dependency.

## Design note

The body is ciphertext, so inner-zstd-block layout (`visit_blocks`) is only accessible for non-encrypted blocks — encrypted blocks dump the `MetadataPayload` structurally (the key-free value). The non-encrypted inner-block listing, `--reconstruct-aad`, the Page ECC trailer report, and the mixed-suite integration corpus are follow-up slices.

## Testing

- Library unit test + doctest: parse a real sealed block (AES + ChaCha) key-free and confirm fields; malformed/truncated input is a typed error.
- CLI smoke tests: key-free dump of a real encrypted block, `--tree-id`/`--table-id` echo, and the non-encrypted rejection.
- `clippy --lib --all-features` + `clippy` on the tool, `fmt --check`, lib full suite (2033) and full `sst-dump` suite (26) all green. No on-disk format change (decode-side only).

Part of #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Key-free metadata parsing for encrypted blocks to inspect block cryptographic parameters without decryption keys.
  * sst-dump gains a DumpBlock subcommand that prints block metadata (format, suite, nonce, tag, ciphertext length, caller hints).

* **Bug Fixes**
  * Safer payload handling with enforced size caps and explicit errors on malformed or truncated inputs.

* **Tests**
  * Added end-to-end smoke tests for encrypted and plain SST inspection.

* **Chores**
  * Metadata parsing APIs are exposed only when encryption support is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->