### PR TITLE
feat(tooling): reconstruct block AAD for offline tag verification

### DIFF
--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -444,6 +444,65 @@ pub fn parse_encrypted_block_metadata(
     })
 }
 
+/// Reconstructs the [`AAD_LEN`]-byte AAD an AEAD verify of this block would
+/// use, from the on-disk `MetadataFrame` plus the caller-supplied `table_id`,
+/// WITHOUT the key.
+///
+/// For offline forensic AEAD verification with an externally-held key: the AAD
+/// is never written to disk, so a key holder needs to rebuild it to check the
+/// tag. The on-disk-mirrored fields (header byte, key epoch, block type, suite,
+/// compression type, dict id, window log, block flags) come from the block;
+/// `table_id` is an AAD-binding field that is NOT stored on disk and must be
+/// supplied from read context (the owning SST's table id).
+///
+/// Note: the block's byte offset and owning tree id are intentionally NOT
+/// bound in the AAD (see [`build`]), so they are not required here — only
+/// `table_id` is.
+///
+/// # Errors
+///
+/// Same envelope-structure errors as [`parse_encrypted_block_metadata`] for a
+/// malformed `MetadataFrame`, plus [`DecryptError::MalformedMetadataFrame`] if
+/// the on-disk block-type byte is not a known [`crate::table::block::BlockType`].
+///
+/// # Examples
+///
+/// ```
+/// use lsm_tree::encryption::{
+///     StaticKeyChain, encrypt_block, reconstruct_block_aad,
+///     aad::{BlockIdentity, BlockType, EncryptionContext, SuiteId},
+/// };
+///
+/// let chain = StaticKeyChain::new().with_key(1, [0x42; 32]);
+/// let ctx = EncryptionContext::v1(1, SuiteId::Aes256Gcm, 0, 0);
+/// let id = BlockIdentity { table_id: 7, block_type: BlockType::Data, dict_id: 0, window_log: 0 };
+/// let sealed = encrypt_block(b"payload bytes", &id, &ctx, &chain).unwrap();
+///
+/// // Reconstruct the AAD with the owning table id (the only AAD field not on disk).
+/// let aad = reconstruct_block_aad(&sealed, 7).unwrap();
+/// assert_eq!(aad.len(), 23);
+/// ```
+pub fn reconstruct_block_aad(bytes: &[u8], table_id: u64) -> Result<[u8; AAD_LEN], DecryptError> {
+    let mut cursor = Cursor::new(bytes);
+    let metadata_payload = read_framed_payload(
+        &mut cursor,
+        Some(METADATA_VARIANT),
+        METADATA_PAYLOAD_LEN_V1,
+        METADATA_PAYLOAD_LEN_V1,
+        DecryptError::MalformedMetadataFrame,
+    )?;
+    let parsed = decode_metadata_payload(&metadata_payload)?;
+    let block_type = crate::table::block::BlockType::try_from(parsed.block_type_byte)
+        .map_err(|_| DecryptError::MalformedMetadataFrame("unknown BlockType byte"))?;
+    let identity = BlockIdentity {
+        table_id,
+        block_type,
+        dict_id: parsed.dict_id,
+        window_log: parsed.window_log,
+    };
+    Ok(build(&parsed.ctx, &identity))
+}
+
 /// Seals `plaintext` into the AAD-bound `MetadataFrame ‖ BodyFrame`
 /// byte sequence.
 ///
@@ -869,6 +928,28 @@ mod tests {
             matches!(err, DecryptError::MalformedBodyFrame(_)),
             "expected MalformedBodyFrame for a truncated body, got {err:?}",
         );
+    }
+
+    #[test]
+    fn reconstruct_aad_matches_seal_with_correct_table_id() {
+        // The AAD is never on disk; offline AEAD verification needs it rebuilt.
+        // Reconstructing with the SAME table_id the block was sealed under must
+        // yield byte-for-byte the AAD encrypt_block used.
+        let sealed = encrypt_block(b"forensic payload bytes", &id(), &ctx(), &chain()).unwrap();
+        let expected = build(&ctx(), &id());
+        let got = reconstruct_block_aad(&sealed, id().table_id).unwrap();
+        assert_eq!(got.len(), AAD_LEN);
+        assert_eq!(
+            got, expected,
+            "reconstructed AAD must match the sealing AAD"
+        );
+
+        // A different table_id binds to a different AAD (table_id IS in the AAD).
+        let other = reconstruct_block_aad(&sealed, id().table_id ^ 1).unwrap();
+        assert_ne!(got, other, "table_id must affect the reconstructed AAD");
+
+        // Malformed input is a typed error, not a panic.
+        assert!(reconstruct_block_aad(b"not a frame", 0).is_err());
     }
 
     #[test]

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -74,7 +74,7 @@ pub mod key_chain;
 #[cfg(all(feature = "encryption", zstd_any))]
 pub use block::{
     DecryptedBlock, EncryptedBlockMetadata, decrypt_block, encrypt_block,
-    parse_encrypted_block_metadata,
+    parse_encrypted_block_metadata, reconstruct_block_aad,
 };
 pub use error::DecryptError;
 pub use key_chain::KeyChain;

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -11,7 +11,7 @@
 
 use clap::{Parser, Subcommand};
 use lsm_tree::coding::Decode;
-use lsm_tree::encryption::parse_encrypted_block_metadata;
+use lsm_tree::encryption::{parse_encrypted_block_metadata, reconstruct_block_aad};
 use lsm_tree::inspect::{
     iter_data_block_entries, read_filter_stats, read_table_properties, read_top_level_index_entries,
 };
@@ -209,6 +209,14 @@ enum Command {
         /// context. Echoed in the output when provided.
         #[arg(long)]
         table_id: Option<u64>,
+
+        /// Also emit the AAD bytes (hex) an AEAD verify of this block would
+        /// use, reconstructed from the on-disk metadata plus `--table-id`,
+        /// for offline tag verification with an externally-held key. Requires
+        /// `--table-id` (the only AAD-binding field not stored on disk; the
+        /// v1 AAD binds neither `tree_id` nor the block offset).
+        #[arg(long)]
+        reconstruct_aad: bool,
     },
 }
 
@@ -236,7 +244,8 @@ fn main() -> ExitCode {
             offset,
             tree_id,
             table_id,
-        } => run_dump_block(&cli.path, offset, tree_id, table_id),
+            reconstruct_aad,
+        } => run_dump_block(&cli.path, offset, tree_id, table_id, reconstruct_aad),
     }
 }
 
@@ -832,6 +841,7 @@ fn run_dump_block(
     offset: u64,
     tree_id: Option<u64>,
     table_id: Option<u64>,
+    reconstruct_aad: bool,
 ) -> ExitCode {
     let mut file = match File::open(path) {
         Ok(f) => f,
@@ -917,6 +927,25 @@ fn run_dump_block(
     match table_id {
         Some(t) => println!("  table_id: {t}"),
         None => println!("  table_id: null  # not on disk; pass --table-id"),
+    }
+
+    if reconstruct_aad {
+        // The v1 AAD binds table_id (not tree_id, not block offset), so the
+        // only caller-side input needed to rebuild it is --table-id.
+        let Some(tid) = table_id else {
+            eprintln!(
+                "error: --reconstruct-aad requires --table-id (the AAD binds table_id, \
+                 which is not stored on disk)"
+            );
+            return ExitCode::FAILURE;
+        };
+        match reconstruct_block_aad(&payload, tid) {
+            Ok(aad) => println!("reconstructed_aad: \"{}\"", hex_string(&aad)),
+            Err(e) => {
+                eprintln!("error: reconstruct AAD: {e:?}");
+                return ExitCode::FAILURE;
+            }
+        }
     }
 
     ExitCode::SUCCESS

--- a/tools/sst-dump/tests/dump_block_smoke.rs
+++ b/tools/sst-dump/tests/dump_block_smoke.rs
@@ -138,3 +138,57 @@ fn dump_block_on_plain_block_reports_not_encrypted() {
         "expected the not-encrypted notice; got:\n{stderr}",
     );
 }
+
+#[test]
+fn dump_block_reconstruct_aad_emits_hex() {
+    let (_dir, sst) = build_encrypted_sst();
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("dump-block")
+        .arg("0")
+        .arg("--table-id")
+        .arg("42")
+        .arg("--reconstruct-aad")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "got:\n{stdout}");
+    // The v1 AAD is 23 bytes → 46 lowercase hex chars between the quotes.
+    let hex = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("reconstructed_aad: \""))
+        .and_then(|rest| rest.strip_suffix('"'))
+        .unwrap_or_else(|| panic!("no reconstructed_aad line; got:\n{stdout}"));
+    assert_eq!(
+        hex.len(),
+        46,
+        "AAD must be 23 bytes (46 hex chars); got {hex:?}"
+    );
+    assert!(
+        hex.bytes().all(|b| b.is_ascii_hexdigit()),
+        "AAD must be lowercase hex; got {hex:?}",
+    );
+}
+
+#[test]
+fn dump_block_reconstruct_aad_requires_table_id() {
+    let (_dir, sst) = build_encrypted_sst();
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("dump-block")
+        .arg("0")
+        .arg("--reconstruct-aad")
+        .output()
+        .expect("spawn sst-dump");
+
+    assert!(
+        !out.status.success(),
+        "--reconstruct-aad without --table-id must exit non-zero",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("requires --table-id"),
+        "expected the requires-table-id error; got:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

Next slice of the forensic block inspector (#256): reconstruct the AAD an AEAD verify of an encrypted block would use, so a key holder can verify the tag offline with no live process.

## What

**Library**:
- `reconstruct_block_aad(bytes, table_id) -> [u8; 23]`: rebuilds the AAD from the on-disk `MetadataFrame` (header byte, key epoch, block type, suite, compression, dict id, window log, block flags) plus the caller-supplied `table_id`, WITHOUT the key. The AAD is never written to disk, so a key holder needs it rebuilt to check the AEAD tag.

**CLI**:
- `sst-dump <file> dump-block <offset> --table-id N --reconstruct-aad` prints the reconstructed AAD as hex. `--reconstruct-aad` requires `--table-id` and errors clearly otherwise.

## Note on the AAD shape

#256 was written before the change that dropped `tree_id` from the AAD (it is process-ephemeral, not durable across reopen). The current v1 AAD is **23 bytes** keyed on `table_id` (not the originally-specced 38 bytes with `tree_id`), and binds neither `tree_id` nor the block offset — so `--reconstruct-aad` needs only `--table-id`.

## Testing

- Library unit test (reconstructing with the correct `table_id` yields byte-for-byte the sealing AAD; a different `table_id` changes it; malformed input is a typed error) + a doctest.
- CLI smoke tests: `--reconstruct-aad` emits 46-hex-char (23-byte) AAD; requires `--table-id`.
- `clippy --lib --all-features` + tool clippy + fmt clean; lib suite (2036) + `sst-dump` suite (28) green. No on-disk format change.

Part of #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--reconstruct-aad` flag to `sst-dump dump-block` subcommand enabling offline AEAD-tag verification using external keys and block metadata.
  * Reconstructs block AAD without decrypting full block contents.

* **Tests**
  * Added smoke tests verifying successful AAD reconstruction with correct table ID and proper error handling for missing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->