### PR TITLE
feat(ecc): self-heal SSTs after a parity-corrected read

### DIFF
--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Compaction strategy that rewrites SSTs flagged for ECC self-healing.
+//!
+//! A block read that recovers its payload from Page-ECC parity returns correct
+//! bytes but leaves the fault on disk (SSTs are immutable, so the block cannot
+//! be patched). The read path records the owning SST in the tree's
+//! [`HealHints`]; this strategy claims one such SST per pass and emits a
+//! single-table [`Merge`](super::Choice::Merge) back into its own level. The
+//! merge re-reads the block (correcting it once more on the way in) and writes a
+//! fresh SST with newly computed parity, so subsequent reads need no correction.
+//!
+//! Run it repeatedly (from the compaction loop, leader-only in a clustered
+//! deployment) until [`HealHints::is_empty`] reports the queue drained.
+
+use super::{Choice, CompactionStrategy, Input as CompactionInput};
+use crate::{
+    HashSet, compaction::state::CompactionState, config::Config, heal_hints::HealHints,
+    version::Version,
+};
+use alloc::sync::Arc;
+
+/// Name reported by [`CompactionStrategy::get_name`].
+pub const NAME: &str = "EccHealCompaction";
+
+/// Rewrites one ECC-flagged SST per invocation to clear a latent parity fault.
+///
+/// Holds a shared handle to the tree's [`HealHints`]; obtain it from
+/// [`Tree::heal_hints`](crate::Tree::heal_hints).
+pub struct Strategy {
+    hints: Arc<HealHints>,
+    target_size: u64,
+}
+
+impl Strategy {
+    /// Builds a heal strategy over `hints`.
+    ///
+    /// `target_size` caps the rewritten output run's table size (use the level's
+    /// target, or [`u64::MAX`] to keep the SST a single table).
+    #[must_use]
+    pub fn new(hints: Arc<HealHints>, target_size: u64) -> Self {
+        Self { hints, target_size }
+    }
+}
+
+impl CompactionStrategy for Strategy {
+    fn get_name(&self) -> &'static str {
+        NAME
+    }
+
+    fn choose(&self, version: &Version, _cfg: &Config, state: &CompactionState) -> Choice {
+        // Claim flagged SSTs one at a time. An id no longer in the tree (already
+        // compacted away since the hint) is dropped; one currently hidden in
+        // another compaction is re-queued for the next pass.
+        while let Some(global_id) = self.hints.pop() {
+            let table_id = global_id.table_id();
+
+            let Some(level_idx) = version
+                .iter_levels()
+                .position(|level| level.list_ids().contains(&table_id))
+            else {
+                // Gone — nothing left to heal for this id.
+                continue;
+            };
+
+            if state.hidden_set().is_hidden(table_id) {
+                // Busy in another compaction; put it back and try next pass.
+                self.hints.record(global_id);
+                return Choice::DoNothing;
+            }
+
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "level index is bounded by level_count, which is a u8"
+            )]
+            let level = level_idx as u8;
+
+            return Choice::Merge(CompactionInput {
+                table_ids: core::iter::once(table_id).collect::<HashSet<_>>(),
+                dest_level: level,
+                canonical_level: level,
+                target_size: self.target_size,
+            });
+        }
+
+        Choice::DoNothing
+    }
+}
+
+#[cfg(all(test, feature = "page_ecc"))]
+mod tests {
+    use crate::{
+        AbstractTree, Config, MAX_SEQNO, SequenceNumberCounter,
+        runtime_config::EccScheme,
+        table::{block::Header, block_index::BlockIndex},
+    };
+    use alloc::sync::Arc;
+
+    /// Full self-heal cycle: a read that recovers a corrupted data block via RS
+    /// parity records the SST; running [`super::Strategy`] rewrites that SST so
+    /// the re-read is clean and records no further hint.
+    #[test]
+    fn ecc_heal_strategy_rewrites_flagged_sst_so_reread_is_clean() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        // Write one SST whose data blocks carry RS(8,2) parity, then capture the
+        // first data block's on-disk offset before dropping the tree.
+        let (sst_path, corrupt_pos) = {
+            let tree = Config::new(
+                dir.path(),
+                SequenceNumberCounter::default(),
+                SequenceNumberCounter::default(),
+            )
+            .page_ecc(true)
+            .ecc_scheme(EccScheme::ReedSolomon {
+                data_shards: 8,
+                parity_shards: 2,
+            })
+            .open()?;
+            let crate::AnyTree::Standard(tree) = tree else {
+                unreachable!("standard tree configured (no kv separation)");
+            };
+            for i in 0u64..2_000 {
+                tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+            }
+            tree.flush_active_memtable(2_000)?;
+
+            #[expect(clippy::expect_used, reason = "test asserts the tree shape")]
+            let versions = tree.version_history.read().expect("lock not poisoned");
+            let binding = versions.latest_version();
+            #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
+            let table = binding.version.iter_tables().next().expect("one table");
+            #[expect(clippy::expect_used, reason = "table has at least one data block")]
+            let keyed = table.block_index.iter().next().expect("a data block")?;
+            let off = keyed.offset().0 as usize;
+            ((*table.path).clone(), off + Header::MIN_LEN + 3)
+        };
+
+        // Flip one payload byte of the first data block (RS-correctable).
+        let mut bytes = std::fs::read(&sst_path)?;
+        bytes[corrupt_pos] ^= 0x80;
+        std::fs::write(&sst_path, &bytes)?;
+
+        // Reopen (fresh caches + fds) so the read hits the tampered bytes.
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .page_ecc(true)
+        .ecc_scheme(EccScheme::ReedSolomon {
+            data_shards: 8,
+            parity_shards: 2,
+        })
+        .open()?;
+        let crate::AnyTree::Standard(tree) = tree else {
+            unreachable!("standard tree configured (no kv separation)");
+        };
+        assert!(tree.heal_hints().is_empty(), "fresh tree has no hints");
+
+        // A read of a key in the corrupted block repairs it (correct value) and
+        // records the SST for healing.
+        #[expect(clippy::expect_used, reason = "key was inserted before flush")]
+        let got = tree.get(b"key-000000", MAX_SEQNO)?.expect("key present");
+        assert_eq!(&*got, b"v000000", "ECC must repair the value on read");
+        assert!(
+            !tree.heal_hints().is_empty(),
+            "a persistent ECC correction must record a heal hint",
+        );
+
+        // Run the heal strategy: it claims the SST and rewrites it clean.
+        let result = tree.compact(
+            Arc::new(super::Strategy::new(tree.heal_hints(), u64::MAX)),
+            0,
+        )?;
+        assert!(
+            tree.heal_hints().is_empty(),
+            "heal compaction must drain the hint queue, got {result:?}",
+        );
+
+        // The healed SST reads clean: correct value, no fresh correction hint.
+        #[expect(clippy::expect_used, reason = "key survives the rewrite")]
+        let got = tree
+            .get(b"key-000000", MAX_SEQNO)?
+            .expect("key present after heal");
+        assert_eq!(&*got, b"v000000", "healed value must still be correct");
+        assert!(
+            tree.heal_hints().is_empty(),
+            "the rewritten SST must read clean (no further correction)",
+        );
+
+        Ok(())
+    }
+}

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -88,6 +88,43 @@ impl CompactionStrategy for Strategy {
     }
 }
 
+#[cfg(test)]
+mod strategy_tests {
+    use crate::{AbstractTree, AnyTree, Config, GlobalTableId, SequenceNumberCounter};
+    use alloc::sync::Arc;
+
+    /// A queued id that is no longer present in the tree (already compacted away
+    /// since the hint) is dropped: the strategy drains it and chooses nothing,
+    /// rather than emitting a merge for a missing table.
+    #[test]
+    fn ecc_heal_drops_ids_no_longer_in_the_tree() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let AnyTree::Standard(tree) = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?
+        else {
+            unreachable!("standard tree configured (no kv separation)");
+        };
+        tree.insert("k", "v", 1);
+        tree.flush_active_memtable(1)?;
+
+        // Flag an SST id that does not exist in this tree.
+        let hints = tree.heal_hints();
+        hints.record(GlobalTableId::from((tree.id(), 999_999)));
+        assert!(!hints.is_empty());
+
+        let result = tree.compact(Arc::new(super::Strategy::new(hints.clone(), u64::MAX)), 0)?;
+        assert!(
+            hints.is_empty(),
+            "a stale id must be drained, not left queued; got {result:?}",
+        );
+        Ok(())
+    }
+}
+
 #[cfg(all(test, feature = "page_ecc"))]
 mod tests {
     use crate::{

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -128,9 +128,15 @@ mod strategy_tests {
 #[cfg(all(test, feature = "page_ecc"))]
 mod tests {
     use crate::{
-        AbstractTree, Config, MAX_SEQNO, SequenceNumberCounter,
+        AbstractTree,
+        Config,
+        MAX_SEQNO,
+        SequenceNumberCounter,
         runtime_config::EccScheme,
-        table::{block::Header, block_index::BlockIndex},
+        // `BlockIndex` is imported only for its `.iter()` method on
+        // `table.block_index` (a trait method); `as _` keeps it in scope for
+        // method resolution without binding the unused type name.
+        table::{block::Header, block_index::BlockIndex as _},
     };
     use alloc::sync::Arc;
 

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -159,6 +159,14 @@ mod tests {
         };
         assert!(tree.heal_hints().is_empty(), "fresh tree has no hints");
 
+        // Opt into rewrite scheduling (default off). The gate tracks auto_heal.
+        assert!(!tree.heal_hints().is_enabled(), "auto_heal defaults off");
+        tree.update_runtime_config(|c| c.auto_heal = true)?;
+        assert!(
+            tree.heal_hints().is_enabled(),
+            "auto_heal toggle syncs the gate"
+        );
+
         // A read of a key in the corrupted block repairs it (correct value) and
         // records the SST for healing.
         #[expect(clippy::expect_used, reason = "key was inserted before flush")]

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -213,6 +213,12 @@ mod tests {
             !tree.heal_hints().is_empty(),
             "a persistent ECC correction must record a heal hint",
         );
+        #[cfg(feature = "metrics")]
+        assert_eq!(
+            tree.metrics().ecc_auto_heal_scheduled_count(),
+            1,
+            "the scheduled SST is counted once",
+        );
 
         // Run the heal strategy: it claims the SST and rewrites it clean.
         let result = tree.compact(

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -237,4 +237,95 @@ mod tests {
 
         Ok(())
     }
+
+    /// The zstd partial-decode read path also schedules auto-heal: a bounded
+    /// range scan that takes the partial path over a corrupted large block
+    /// recovers via parity and flags the SST, just like the full load path.
+    #[cfg(feature = "zstd")]
+    #[test]
+    fn ecc_heal_scheduled_on_partial_decode_corrected_read() -> crate::Result<()> {
+        use crate::{
+            CompressionType,
+            config::{BlockSizePolicy, CompressionPolicy},
+        };
+
+        // Opt into the partial-decode path for this test process (OnceLock-cached;
+        // nextest isolates each test in its own process so this does not leak).
+        // SAFETY: set before any tree in this process reads the env.
+        unsafe { std::env::set_var("LSM_PARTIAL_DECODE", "1") };
+
+        let dir = tempfile::tempdir()?;
+        let open = || {
+            Config::new(
+                dir.path(),
+                SequenceNumberCounter::default(),
+                SequenceNumberCounter::default(),
+            )
+            .page_ecc(true)
+            .ecc_scheme(EccScheme::ReedSolomon {
+                data_shards: 8,
+                parity_shards: 2,
+            })
+            .data_block_compression_policy(CompressionPolicy::all(
+                #[expect(clippy::expect_used, reason = "19 is a valid zstd level")]
+                CompressionType::zstd(19).expect("valid level"),
+            ))
+            .data_block_size_policy(BlockSizePolicy::all(512 * 1024))
+            .open()
+        };
+
+        // Build a large multi-inner-block zstd+ECC SST; capture the first data
+        // block's on-disk offset before dropping the tree.
+        let (sst_path, corrupt_pos) = {
+            let crate::AnyTree::Standard(tree) = open()? else {
+                unreachable!("standard tree configured");
+            };
+            for i in 0u64..20_000 {
+                tree.insert(
+                    format!("key-{i:08}"),
+                    format!("value-{i:08}-padding-padding"),
+                    0,
+                );
+            }
+            tree.flush_active_memtable(0)?;
+
+            #[expect(clippy::expect_used, reason = "test asserts the tree shape")]
+            let versions = tree.version_history.read().expect("lock not poisoned");
+            let binding = versions.latest_version();
+            #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
+            let table = binding.version.iter_tables().next().expect("one table");
+            #[expect(clippy::expect_used, reason = "table has at least one data block")]
+            let keyed = table.block_index.iter().next().expect("a data block")?;
+            let off = keyed.offset().0 as usize;
+            ((*table.path).clone(), off + Header::MIN_LEN + 8)
+        };
+
+        // Flip one byte of the first block's compressed frame (RS-correctable).
+        let mut bytes = std::fs::read(&sst_path)?;
+        bytes[corrupt_pos] ^= 0x01;
+        std::fs::write(&sst_path, &bytes)?;
+
+        // Reopen (fresh caches/fds), opt into healing, then run a bounded range
+        // scan whose upper bound falls inside the first block so the read takes
+        // the partial-decode path.
+        let crate::AnyTree::Standard(tree) = open()? else {
+            unreachable!("standard tree configured");
+        };
+        tree.update_runtime_config(|c| c.auto_heal = true)?;
+
+        let count = tree
+            .range(
+                b"key-00000000".to_vec()..b"key-00000050".to_vec(),
+                MAX_SEQNO,
+                None,
+            )
+            .count();
+        assert!(count > 0, "bounded range returned rows");
+        assert!(
+            !tree.heal_hints().is_empty(),
+            "a corrected read on the partial-decode path must schedule healing",
+        );
+
+        Ok(())
+    }
 }

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod leveled;
 pub(crate) mod drop_range;
 pub mod filter;
 mod flavour;
+pub(crate) mod heal;
 pub(crate) mod major;
 pub(crate) mod movedown;
 pub(crate) mod pulldown;
@@ -22,6 +23,7 @@ pub(crate) mod worker;
 
 pub use fifo::Strategy as Fifo;
 pub use filter::{CompactionFilter, Factory, ItemAccessor, Verdict};
+pub use heal::Strategy as EccHeal;
 pub use leveled::Strategy as Leveled;
 pub use tiered::Strategy as SizeTiered;
 

--- a/src/heal_hints.rs
+++ b/src/heal_hints.rs
@@ -28,6 +28,7 @@ use alloc::collections::BTreeSet;
 use alloc::sync::Arc;
 #[cfg(test)]
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
 
 /// Shared set of SSTs awaiting priority recompaction after a confirmed
@@ -44,13 +45,37 @@ use spin::Mutex;
 pub struct HealHints {
     /// SSTs queued for healing recompaction, deduped by id.
     pending: Mutex<BTreeSet<GlobalTableId>>,
+
+    /// Mirrors [`RuntimeConfig::auto_heal`](crate::runtime_config::RuntimeConfig::auto_heal).
+    /// When `false`, the read path skips the persistence re-read and records
+    /// nothing — correction-on-read still happens, only the rewrite scheduling
+    /// is suppressed. The owning tree keeps this in sync with its runtime
+    /// config. Default `false` (scheduling is opt-in).
+    enabled: AtomicBool,
 }
 
 impl HealHints {
-    /// Creates a fresh, empty shared hint set.
+    /// Creates a fresh, empty shared hint set with scheduling set to `enabled`
+    /// (mirrors the tree's initial `auto_heal`).
     #[must_use]
-    pub fn new_shared() -> Arc<Self> {
-        Arc::new(Self::default())
+    pub fn new_shared(enabled: bool) -> Arc<Self> {
+        let hints = Self::default();
+        hints.set_enabled(enabled);
+        Arc::new(hints)
+    }
+
+    /// Returns `true` when rewrite scheduling is enabled (mirrors
+    /// [`RuntimeConfig::auto_heal`](crate::runtime_config::RuntimeConfig::auto_heal)).
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Enables or disables rewrite scheduling. The owning tree calls this on open
+    /// and on every runtime-config update so the read-path gate tracks
+    /// `auto_heal`.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
     }
 
     /// Records `id` as needing a healing recompaction.

--- a/src/heal_hints.rs
+++ b/src/heal_hints.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Tree-wide queue of SSTs whose blocks were ECC-corrected on a read that was
+//! confirmed *persistent* (the on-disk bytes are still faulty after a
+//! cache-bypassing re-read).
+//!
+//! A block-read that finds a checksum mismatch but recovers the payload from
+//! its Page-ECC parity returns the *correct* bytes to the caller, yet leaves
+//! the faulty bytes on disk. Without intervention the same latent fault is
+//! re-corrected on every future read, and a second bit-flip in the same block
+//! could push it past the parity's correction budget into unrecoverable
+//! territory. Recording the SST here lets the compaction picker rewrite it
+//! clean (a new file + atomic manifest swap) instead.
+//!
+//! # Why a tree-wide set and not a per-table flag
+//!
+//! Tables only know their own id + [`crate::fs::Fs`]; they have no
+//! back-reference to the owning tree. Each table carries an
+//! [`Arc<HealHints>`] (installed once after it joins a tree, [`None`] before
+//! that) so the read path can record a hint in O(1), and the compaction picker
+//! drains the whole set in one place. The set dedups by
+//! [`GlobalTableId`](crate::GlobalTableId): many corrected block-reads against
+//! the same SST enqueue it once.
+
+use crate::GlobalTableId;
+use alloc::collections::BTreeSet;
+use alloc::sync::Arc;
+#[cfg(test)]
+use alloc::vec::Vec;
+use spin::Mutex;
+
+/// Shared set of SSTs awaiting priority recompaction after a confirmed
+/// persistent ECC correction.
+///
+/// Cheap to clone (it is always held behind an [`Arc`]). The inner mutex is
+/// only ever contended on the cold corrected-read path and the periodic
+/// compaction drain, never on a clean read.
+// `spin::Mutex` rather than `std::sync::Mutex` keeps this module's std
+// footprint at zero — it is `no_std` + `alloc` by construction, matching
+// `crate::deletion_pause`. The set is never touched on a clean read, so
+// spin contention is irrelevant in practice.
+#[derive(Default)]
+pub struct HealHints {
+    /// SSTs queued for healing recompaction, deduped by id.
+    pending: Mutex<BTreeSet<GlobalTableId>>,
+}
+
+impl HealHints {
+    /// Creates a fresh, empty shared hint set.
+    pub fn new_shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Records `id` as needing a healing recompaction.
+    ///
+    /// Returns `true` when the id was newly inserted, `false` when it was
+    /// already queued — callers use this to count each SST once.
+    pub fn record(&self, id: GlobalTableId) -> bool {
+        self.pending.lock().insert(id)
+    }
+
+    /// Returns a snapshot of the queued ids (test-only until the compaction
+    /// picker consumes the queue).
+    #[cfg(test)]
+    pub fn snapshot(&self) -> Vec<GlobalTableId> {
+        self.pending.lock().iter().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(tree: u64, table: u64) -> GlobalTableId {
+        GlobalTableId::from((tree, table))
+    }
+
+    #[test]
+    fn record_dedups_same_id_returns_false_on_repeat() {
+        let hints = HealHints::default();
+        assert!(hints.record(id(1, 7)));
+        assert!(!hints.record(id(1, 7)));
+        assert_eq!(hints.snapshot(), vec![id(1, 7)]);
+    }
+
+    #[test]
+    fn record_collects_distinct_ids() {
+        let hints = HealHints::default();
+        hints.record(id(1, 1));
+        hints.record(id(1, 2));
+        hints.record(id(1, 1));
+        let snapshot = hints.snapshot();
+        assert_eq!(snapshot, vec![id(1, 1), id(1, 2)]);
+    }
+}

--- a/src/heal_hints.rs
+++ b/src/heal_hints.rs
@@ -48,6 +48,7 @@ pub struct HealHints {
 
 impl HealHints {
     /// Creates a fresh, empty shared hint set.
+    #[must_use]
     pub fn new_shared() -> Arc<Self> {
         Arc::new(Self::default())
     }
@@ -60,9 +61,27 @@ impl HealHints {
         self.pending.lock().insert(id)
     }
 
-    /// Returns a snapshot of the queued ids (test-only until the compaction
-    /// picker consumes the queue).
+    /// Claims one queued id, removing and returning it (`None` when empty).
+    ///
+    /// The heal compaction strategy pops one SST per pass; losing a popped id to
+    /// a failed compaction is self-correcting (the next read re-records it).
+    #[must_use]
+    pub fn pop(&self) -> Option<GlobalTableId> {
+        self.pending.lock().pop_first()
+    }
+
+    /// Returns `true` when no SST is currently queued for healing.
+    ///
+    /// Lets a scheduler skip running the heal strategy when there is nothing to
+    /// do.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pending.lock().is_empty()
+    }
+
+    /// Returns a snapshot of the queued ids (test-only helper).
     #[cfg(test)]
+    #[must_use]
     pub fn snapshot(&self) -> Vec<GlobalTableId> {
         self.pending.lock().iter().copied().collect()
     }

--- a/src/heal_hints.rs
+++ b/src/heal_hints.rs
@@ -18,7 +18,8 @@
 //! Tables only know their own id + [`crate::fs::Fs`]; they have no
 //! back-reference to the owning tree. Each table carries an
 //! [`Arc<HealHints>`] (installed once after it joins a tree, [`None`] before
-//! that) so the read path can record a hint in O(1), and the compaction picker
+//! that) so the read path can record a hint in O(log n) (a `BTreeSet` insert,
+//! n = pending SSTs, only on the cold corrected path), and the compaction picker
 //! drains the whole set in one place. The set dedups by
 //! [`GlobalTableId`](crate::GlobalTableId): many corrected block-reads against
 //! the same SST enqueue it once.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ mod any_tree;
 mod abstract_tree;
 
 pub(crate) mod deletion_pause;
-pub(crate) mod heal_hints;
+pub mod heal_hints;
 
 // `checkpoint` is `pub(crate)`: it contains internal helpers
 // (`link_or_copy_cross_fs`, `prepare_target`, `run_checkpoint`) used by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ mod any_tree;
 mod abstract_tree;
 
 pub(crate) mod deletion_pause;
+pub(crate) mod heal_hints;
 
 // `checkpoint` is `pub(crate)`: it contains internal helpers
 // (`link_or_copy_cross_fs`, `prepare_target`, `run_checkpoint`) used by

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -65,6 +65,12 @@ pub struct Metrics {
 
     /// Number of range tombstone block bytes that were requested from OS or disk
     pub(crate) range_tombstone_block_io_requested: AtomicU64,
+
+    /// Number of SSTs flagged for a healing recompaction after a read recovered
+    /// a block from Page-ECC parity and confirmed the fault persistent (counted
+    /// only when `auto_heal` is enabled). Each SST is counted once per pending
+    /// schedule.
+    pub(crate) ecc_auto_heal_scheduled: AtomicUsize,
 }
 
 #[expect(
@@ -131,6 +137,12 @@ impl Metrics {
     pub fn range_tombstone_block_load_count(&self) -> usize {
         self.range_tombstone_block_load_cached.load(Relaxed)
             + self.range_tombstone_block_load_io.load(Relaxed)
+    }
+
+    /// Number of SSTs scheduled for a healing recompaction after a persistent
+    /// ECC correction on read (`auto_heal` enabled).
+    pub fn ecc_auto_heal_scheduled_count(&self) -> usize {
+        self.ecc_auto_heal_scheduled.load(Relaxed)
     }
 
     /// Number of blocks that were loaded from disk or OS page cache.

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -750,6 +750,20 @@ pub struct RuntimeConfig {
     /// SST; recorded per-SST alongside [`Self::ecc_scheme`].
     pub ecc_granularity: EccGranularity,
 
+    /// When `true`, a read that recovers a block from its Page-ECC parity, and
+    /// confirms the on-disk fault is persistent (via a cache-bypassing re-read),
+    /// flags the owning SST for a healing recompaction — the corrected data is
+    /// rewritten into a fresh SST so the latent fault is not re-corrected on
+    /// every subsequent read. Drive the rewrite with
+    /// [`compaction::EccHeal`](crate::compaction::EccHeal) over
+    /// [`Tree::heal_hints`](crate::Tree::heal_hints), leader-only in a clustered
+    /// deployment (compaction is a background mutation).
+    ///
+    /// Default `false`: correction-on-read still happens whenever ECC is
+    /// enabled; only the rewrite *scheduling* is opt-in, because it costs
+    /// compaction I/O. Toggling takes effect immediately for subsequent reads.
+    pub auto_heal: bool,
+
     /// Per-block seqno bounds in SST index entries (#224). When `true`,
     /// SSTs written by the next flush / compaction record each data
     /// block's `seqno_min` / `seqno_max` in its index entry
@@ -832,6 +846,7 @@ impl Default for RuntimeConfig {
             kv_checksums_ecc_override: None,
             ecc_scheme: EccScheme::Secded,
             ecc_granularity: EccGranularity::Block,
+            auto_heal: false,
             seqno_in_index: false,
             index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
             disable_cow_on_sst_files: true,

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -360,6 +360,14 @@ pub enum EccStatus {
     /// ECC trailer present but its scheme is unrecognized / unusable; the
     /// payload still verified by its checksum. Recommend recompaction.
     Unrecognized,
+    /// The on-disk payload failed its checksum and was REPAIRED by ECC
+    /// (SEC-DED single-bit heal or Reed-Solomon shard recovery): the bytes
+    /// returned to the caller are correct (they reproduce the stored
+    /// checksum), but the on-disk copy still holds the latent fault. A signal
+    /// for auto-heal — the caller may re-read to confirm the corruption is
+    /// persistent (not a transient read-path fault) and, if so, schedule a
+    /// recompaction so the corrected bytes are persisted to a fresh SST.
+    Corrected,
 }
 
 #[derive(Clone)]
@@ -396,7 +404,7 @@ impl Block {
             expect(unused_variables, reason = "recovery scheme only used under page_ecc")
         )]
         ecc_params: EccParams,
-    ) -> crate::Result<Vec<u8>> {
+    ) -> crate::Result<(Vec<u8>, bool)> {
         let mut data = vec![0u8; data_length as usize];
         reader.read_exact(&mut data)?;
 
@@ -408,7 +416,7 @@ impl Block {
                     "Checksum mismatch for block payload, got={computed}, expected={expected}",
                 );
             })?;
-            return Ok(data);
+            return Ok((data, false));
         }
 
         // ECC trailer present — always consume the parity bytes so
@@ -418,7 +426,7 @@ impl Block {
         reader.read_exact(&mut parity)?;
 
         if computed == expected {
-            return Ok(data);
+            return Ok((data, false));
         }
 
         // Mismatch — try ECC recovery before failing.
@@ -443,7 +451,7 @@ impl Block {
                          checksum mismatch (data_len={}, ecc_len={ecc_length})",
                         data.len(),
                     );
-                    return Ok(healed);
+                    return Ok((healed, true));
                 }
                 log::error!(
                     "Checksum mismatch on SEC-DED block, heal failed, \
@@ -469,7 +477,7 @@ impl Block {
                      (data_len={}, ecc_len={ecc_length})",
                     data.len(),
                 );
-                return Ok(recovered);
+                return Ok((recovered, true));
             }
             log::error!(
                 "Checksum mismatch on ECC-protected block, recovery failed, \
@@ -902,7 +910,10 @@ impl Block {
         let data = if let Some(enc) = encryption {
             // Read payload + optional ECC trailer, verify checksum
             // (with recovery on mismatch when parity is present).
-            let raw_vec = Self::read_payload_and_verify(
+            // `from_reader` returns no EccStatus, so a heal here is logged but
+            // not surfaced; the status-returning `from_file_with_status` path is
+            // what auto-heal observes.
+            let (raw_vec, _corrected) = Self::read_payload_and_verify(
                 reader,
                 header.data_length,
                 ecc_length,
@@ -1001,13 +1012,15 @@ impl Block {
                 })?;
                 s
             } else {
-                Slice::from(Self::read_payload_and_verify(
+                // from_reader has no EccStatus return; a heal is logged only.
+                let (payload, _corrected) = Self::read_payload_and_verify(
                     reader,
                     header.data_length,
                     ecc_length,
                     header.checksum,
                     block_ecc_params(&header, transform),
-                )?)
+                )?;
+                Slice::from(payload)
             };
 
             match compression {
@@ -1261,7 +1274,7 @@ impl Block {
             // unrecognized opaque trailer is excluded and discarded. With a
             // recognized scheme, run the shared helper against a cursor over
             // the post-header bytes so recovery is available on mismatch.
-            let buf = if ecc_length == 0 {
+            let (buf, payload_corrected) = if ecc_length == 0 {
                 #[expect(
                     clippy::indexing_slicing,
                     reason = "actual_data_len <= post-header len"
@@ -1279,7 +1292,7 @@ impl Block {
                 // Strip header prefix + any opaque trailer so buf is the payload.
                 buf.copy_within(header_len..header_len + actual_data_len, 0);
                 buf.truncate(actual_data_len);
-                buf
+                (buf, false)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
                 let mut cursor = std::io::Cursor::new(&buf[header_len..]);
@@ -1290,6 +1303,14 @@ impl Block {
                     parsed_header.checksum,
                     block_ecc_params(&parsed_header, transform),
                 )?
+            };
+
+            // Fold a successful ECC repair into the reported status (an
+            // unrecognized scheme never heals, so the two are exclusive).
+            let ecc_status = if payload_corrected {
+                EccStatus::Corrected
+            } else {
+                ecc_status
             };
 
             let decrypted = decrypt_block_payload(enc, buf, &identity)?;
@@ -1408,7 +1429,7 @@ impl Block {
             // opaque trailer); recognized-ECC blocks go through the
             // recovery-capable helper. The checksum covers exactly the
             // `data_length` payload bytes, so an opaque trailer is excluded.
-            let payload_slice: Slice = if ecc_length == 0 {
+            let (payload_slice, payload_corrected): (Slice, bool) = if ecc_length == 0 {
                 #[expect(
                     clippy::indexing_slicing,
                     reason = "actual_data_len <= post-header len"
@@ -1423,17 +1444,24 @@ impl Block {
                         parsed_header.checksum,
                     );
                 })?;
-                buf.slice(header_len..header_len + actual_data_len)
+                (buf.slice(header_len..header_len + actual_data_len), false)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
                 let mut cursor = std::io::Cursor::new(&buf[header_len..]);
-                Slice::from(Self::read_payload_and_verify(
+                let (payload, corrected) = Self::read_payload_and_verify(
                     &mut cursor,
                     parsed_header.data_length,
                     ecc_length,
                     parsed_header.checksum,
                     block_ecc_params(&parsed_header, transform),
-                )?)
+                )?;
+                (Slice::from(payload), corrected)
+            };
+            // Fold a successful ECC repair into the reported status.
+            let ecc_status = if payload_corrected {
+                EccStatus::Corrected
+            } else {
+                ecc_status
             };
 
             let data = match compression {
@@ -1612,13 +1640,15 @@ impl Block {
         } else {
             #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
             let mut cursor = std::io::Cursor::new(&buf[header_len..]);
-            Slice::from(Self::read_payload_and_verify(
+            // This frame-extraction path returns no EccStatus; a heal is logged.
+            let (frame, _corrected) = Self::read_payload_and_verify(
                 &mut cursor,
                 parsed_header.data_length,
                 ecc_length,
                 parsed_header.checksum,
                 block_ecc_params(&parsed_header, transform),
-            )?)
+            )?;
+            Slice::from(frame)
         };
 
         Ok((parsed_header, payload))
@@ -3531,6 +3561,54 @@ mod tests {
                 &BlockTransform::PlainEcc(EccParams::RS_4_2),
             )?;
             assert_eq!(&*block.data, PAYLOAD);
+            Ok(())
+        }
+
+        /// `from_file_with_status` reports `EccStatus::Corrected` when a read
+        /// repaired the block via ECC, and `EccStatus::Ok` for a clean read.
+        /// This is the auto-heal (#411) signal: a healed read returns the
+        /// correct bytes AND flags that the on-disk copy still holds the fault.
+        #[test]
+        fn from_file_with_status_reports_corrected_after_ecc_repair() -> crate::Result<()> {
+            let transform = BlockTransform::PlainEcc(EccParams::RS_4_2);
+            let tmp = super::write_block_to_tempfile(
+                PAYLOAD,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &transform,
+            )?;
+            let path = tmp.dir.path().join("block");
+
+            // Clean read first: no repair → EccStatus::Ok.
+            {
+                let file = std::fs::File::open(&path)?;
+                let (block, status) = Block::from_file_with_status(
+                    &file,
+                    tmp.handle,
+                    BlockIdentity::for_test(0, BlockType::Data),
+                    &transform,
+                )?;
+                assert_eq!(&*block.data, PAYLOAD);
+                assert_eq!(status, EccStatus::Ok, "clean read must not flag a repair");
+            }
+
+            // Flip one payload byte so the read must repair via RS parity.
+            let mut bytes = std::fs::read(&path)?;
+            bytes[Header::MIN_LEN + 3] ^= 0x80;
+            std::fs::write(&path, &bytes)?;
+
+            let file = std::fs::File::open(&path)?;
+            let (block, status) = Block::from_file_with_status(
+                &file,
+                tmp.handle,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &transform,
+            )?;
+            assert_eq!(&*block.data, PAYLOAD, "repaired bytes must equal original");
+            assert_eq!(
+                status,
+                EccStatus::Corrected,
+                "a read that repaired the block must report Corrected",
+            );
             Ok(())
         }
 

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -344,8 +344,13 @@ impl PreparedBlock<'_> {
 /// with no available recovery). When the read *succeeds*, this reports
 /// whether the block's ECC was usable:
 ///
-/// - [`Self::Ok`] — ECC absent, or a recognized scheme that verified (and
-///   recovered, if needed).
+/// - [`Self::Ok`] — the read returned correct bytes with no ECC intervention:
+///   ECC was absent, or a recognized scheme verified the payload as-is (no
+///   repair needed).
+/// - [`Self::Corrected`] — ECC repaired the on-disk payload (the caller saw
+///   correct bytes, but the on-disk copy still holds a latent fault). Treat as
+///   a signal to confirm persistence and potentially schedule an auto-heal
+///   recompaction.
 /// - [`Self::Unrecognized`] — the block carries an ECC trailer this build
 ///   cannot interpret (an unimplemented or non-canonical scheme: Secded,
 ///   page granularity, unknown kind, …). The payload was returned (its
@@ -1569,7 +1574,7 @@ impl Block {
         file: &dyn FsFile,
         handle: BlockHandle,
         transform: &BlockTransform<'_>,
-    ) -> crate::Result<(Header, Slice)> {
+    ) -> crate::Result<(Header, Slice, bool)> {
         if transform.encryption().is_some() {
             return Err(crate::Error::Io(std::io::Error::other(
                 "read_data_frame: encrypted blocks are not supported on the lazy path",
@@ -1627,7 +1632,7 @@ impl Block {
             &handle,
         )?;
 
-        let payload: Slice = if ecc_length == 0 {
+        let (payload, corrected): (Slice, bool) = if ecc_length == 0 {
             #[expect(
                 clippy::indexing_slicing,
                 reason = "actual_data_len <= post-header len, checked via classify_block_trailer"
@@ -1636,22 +1641,24 @@ impl Block {
                 &buf[header_len..header_len + actual_data_len],
             ));
             checksum.check(parsed_header.checksum)?;
-            buf.slice(header_len..header_len + actual_data_len)
+            (buf.slice(header_len..header_len + actual_data_len), false)
         } else {
             #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
             let mut cursor = std::io::Cursor::new(&buf[header_len..]);
-            // This frame-extraction path returns no EccStatus; a heal is logged.
-            let (frame, _corrected) = Self::read_payload_and_verify(
+            // `corrected` is surfaced so the partial-decode caller can schedule
+            // auto-heal (the recovered bytes are correct but the on-disk copy is
+            // still faulty); a heal is also logged inside read_payload_and_verify.
+            let (frame, corrected) = Self::read_payload_and_verify(
                 &mut cursor,
                 parsed_header.data_length,
                 ecc_length,
                 parsed_header.checksum,
                 block_ecc_params(&parsed_header, transform),
             )?;
-            Slice::from(frame)
+            (Slice::from(frame), corrected)
         };
 
-        Ok((parsed_header, payload))
+        Ok((parsed_header, payload, corrected))
     }
 }
 
@@ -1798,7 +1805,8 @@ mod tests {
             &transform,
         )?;
 
-        let (header, frame) = Block::read_data_frame(&tmp.file, tmp.handle, &transform)?;
+        let (header, frame, _corrected) =
+            Block::read_data_frame(&tmp.file, tmp.handle, &transform)?;
         // The returned bytes are the COMPRESSED frame: it must be smaller than
         // the payload and must decompress back to the original (proving
         // read_data_frame skipped decode yet returned a valid frame).

--- a/src/table/block_index/two_level.rs
+++ b/src/table/block_index/two_level.rs
@@ -172,6 +172,12 @@ impl Iterator for Iter {
                     self.ecc,
                     #[cfg(zstd_any)]
                     None,
+                    // Index-block ECC corrections are healed-on-read but not yet
+                    // scheduled for recompaction (the heal sink is threaded
+                    // through the data-block paths only). An index fault
+                    // resurfaces on the next read and is rewritten whenever the
+                    // SST is otherwise recompacted.
+                    None,
                     #[cfg(feature = "metrics")]
                     &self.metrics,
                 ) {
@@ -251,6 +257,12 @@ impl DoubleEndedIterator for Iter {
                     self.encryption.as_deref(),
                     self.ecc,
                     #[cfg(zstd_any)]
+                    None,
+                    // Index-block ECC corrections are healed-on-read but not yet
+                    // scheduled for recompaction (the heal sink is threaded
+                    // through the data-block paths only). An index fault
+                    // resurfaces on the next read and is rewritten whenever the
+                    // SST is otherwise recompacted.
                     None,
                     #[cfg(feature = "metrics")]
                     &self.metrics,

--- a/src/table/block_index/volatile.rs
+++ b/src/table/block_index/volatile.rs
@@ -123,6 +123,11 @@ impl Iter {
             self.ecc,
             #[cfg(zstd_any)]
             None,
+            // Index-block ECC corrections are healed-on-read but not yet
+            // scheduled for recompaction (the heal sink is threaded through the
+            // data-block paths only). An index fault resurfaces on the next read
+            // and is rewritten whenever the SST is otherwise recompacted.
+            None,
             #[cfg(feature = "metrics")]
             &self.metrics,
         )?;

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -130,6 +130,18 @@ pub struct Inner {
     // alloc-friendly, matching `deletion_pause`.
     #[cfg(feature = "std")]
     pub(crate) background_deleter: once_cell::race::OnceBox<Arc<crate::BackgroundDeleter>>,
+
+    /// Tree-wide ECC heal-hint sink. Installed once by
+    /// [`Table::install_heal_hints`](super::Table::install_heal_hints) after the
+    /// table joins a tree. When present, a block read that is ECC-corrected and
+    /// confirmed persistent (via a cache-bypassing re-read) records this SST's
+    /// id so the compaction picker can rewrite it clean. Absent before the table
+    /// is tree-owned: corrections are still returned to the caller, they are
+    /// just not scheduled for healing.
+    // alloc-friendly `OnceBox` (not `std::sync::OnceLock`) so the field does not
+    // pin `Inner` to std, matching `deletion_pause`. The hint set itself is
+    // `no_std` + alloc (see `crate::heal_hints`).
+    pub(crate) heal_hints: once_cell::race::OnceBox<Arc<crate::heal_hints::HealHints>>,
 }
 
 impl Inner {

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -162,6 +162,10 @@ pub struct Iter {
     /// Per-SST Page-ECC scheme from table metadata; the block reader needs
     /// it to size + recover the parity trailer. `None` = no parity.
     ecc: Option<crate::table::block::EccParams>,
+    /// Tree-wide ECC heal sink. A scan that recovers a data block from parity
+    /// records this SST here (on confirmed persistence) for a healing
+    /// recompaction. `None` before the table is tree-owned.
+    heal_hints: Option<Arc<crate::heal_hints::HealHints>>,
     /// Per-SST per-KV-footer flag from table metadata
     /// (`kv_checksum_algo.is_some()`); data blocks omit the `block_flags` byte,
     /// so `from_loaded` is told here whether to strip a footer.
@@ -215,6 +219,7 @@ impl Iter {
         compression: CompressionType,
         encryption: Option<Arc<dyn EncryptionProvider>>,
         ecc: Option<crate::table::block::EccParams>,
+        heal_hints: Option<Arc<crate::heal_hints::HealHints>>,
         has_kv_footer: bool,
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
@@ -234,6 +239,7 @@ impl Iter {
             compression,
             encryption,
             ecc,
+            heal_hints,
             has_kv_footer,
             #[cfg(zstd_any)]
             zstd_dictionary,
@@ -541,6 +547,7 @@ impl Iterator for Iter {
                     self.ecc,
                     #[cfg(zstd_any)]
                     self.zstd_dictionary.as_deref(),
+                    self.heal_hints.as_ref().map(AsRef::as_ref),
                     #[cfg(feature = "metrics")]
                     &self.metrics,
                 ) {
@@ -687,6 +694,7 @@ impl DoubleEndedIterator for Iter {
                     self.ecc,
                     #[cfg(zstd_any)]
                     self.zstd_dictionary.as_deref(),
+                    self.heal_hints.as_ref().map(AsRef::as_ref),
                     #[cfg(feature = "metrics")]
                     &self.metrics,
                 ) {

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -382,11 +382,29 @@ impl Iter {
             Some(ecc) => transform.with_ecc(ecc),
             None => transform,
         };
-        let (_header, frame) = crate::table::block::Block::read_data_frame(
-            fd.as_ref(),
-            BlockHandle::new(handle.offset(), handle.size()),
-            &transform,
-        )?;
+        let block_handle = BlockHandle::new(handle.offset(), handle.size());
+        let (_header, frame, corrected) =
+            crate::table::block::Block::read_data_frame(fd.as_ref(), block_handle, &transform)?;
+        // The partial path bypasses `load_block`, so schedule auto-heal here too:
+        // an ECC-corrected frame read flags the SST for a healing rewrite (the
+        // partial path is non-encrypted by the guard above).
+        if corrected {
+            crate::table::util::maybe_record_persistent_heal(
+                self.table_id,
+                &self.path,
+                &self.file_accessor,
+                &block_handle,
+                crate::table::block::BlockType::Data,
+                self.compression,
+                None,
+                self.ecc,
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+                self.heal_hints.as_ref().map(AsRef::as_ref),
+                #[cfg(feature = "metrics")]
+                &self.metrics,
+            );
+        }
         // Cold first touch (carried_resume None) or resume-grow from the cached
         // snapshot — either way only the new tail blocks are decompressed.
         let (block, covered_upper, payload) = crate::table::lazy_block::partial_data_block(

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -246,6 +246,7 @@ impl Table {
             self.metadata.ecc_params,
             #[cfg(zstd_any)]
             zstd_dict,
+            self.heal_hints.get().map(AsRef::as_ref),
             #[cfg(feature = "metrics")]
             &self.metrics,
         )
@@ -989,6 +990,7 @@ impl Table {
             self.metadata.data_block_compression,
             self.encryption.clone(),
             self.metadata.ecc_params,
+            self.heal_hints.get().cloned(),
             self.metadata.kv_checksum_algo.is_some(),
             #[cfg(zstd_any)]
             self.zstd_dictionary.clone(),
@@ -1544,6 +1546,8 @@ impl Table {
 
             #[cfg(feature = "std")]
             background_deleter: once_cell::race::OnceBox::new(),
+
+            heal_hints: once_cell::race::OnceBox::new(),
         })))
     }
 
@@ -1564,6 +1568,16 @@ impl Table {
     #[cfg(feature = "std")]
     pub(crate) fn install_background_deleter(&self, deleter: Arc<crate::BackgroundDeleter>) {
         let _ = self.0.background_deleter.set(Box::new(deleter));
+    }
+
+    /// Installs the tree-wide ECC heal-hint sink.
+    ///
+    /// Idempotent: a second call is a no-op. Called by the owning tree after
+    /// recovery and after compaction registers freshly-built tables, so a
+    /// confirmed-persistent ECC correction on a read can queue this SST for a
+    /// healing recompaction.
+    pub(crate) fn install_heal_hints(&self, hints: Arc<crate::heal_hints::HealHints>) {
+        let _ = self.0.heal_hints.set(Box::new(hints));
     }
 
     #[must_use]

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2131,6 +2131,7 @@ fn load_block_range_tombstone_metrics() -> crate::Result<()> {
         None,
         #[cfg(zstd_any)]
         None,
+        None,
         #[cfg(feature = "metrics")]
         &metrics,
     )?;
@@ -2152,6 +2153,7 @@ fn load_block_range_tombstone_metrics() -> crate::Result<()> {
         None,
         None,
         #[cfg(zstd_any)]
+        None,
         None,
         #[cfg(feature = "metrics")]
         &metrics,
@@ -2236,6 +2238,7 @@ fn load_block_cache_hit_rejects_wrong_block_type() -> crate::Result<()> {
         None,
         #[cfg(zstd_any)]
         None,
+        None,
         #[cfg(feature = "metrics")]
         &metrics,
     )?;
@@ -2255,6 +2258,7 @@ fn load_block_cache_hit_rejects_wrong_block_type() -> crate::Result<()> {
         None,
         #[cfg(zstd_any)]
         None,
+        None,
         #[cfg(feature = "metrics")]
         &metrics,
     );
@@ -2263,6 +2267,160 @@ fn load_block_cache_hit_rejects_wrong_block_type() -> crate::Result<()> {
         matches!(&result, Err(crate::Error::InvalidTag(("BlockType", _)))),
         "expected InvalidTag for block type mismatch on cache hit, got Ok or wrong Err",
     );
+
+    Ok(())
+}
+
+/// A read that recovers a data block from its Page-ECC parity, and confirms the
+/// on-disk fault persists across a cache-bypassing re-read, must record the SST
+/// in the heal sink for a healing recompaction. A clean read records nothing.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<()> {
+    use crate::{
+        Cache, InternalValue,
+        descriptor_table::DescriptorTable,
+        fs::StdFs,
+        heal_hints::HealHints,
+        table::{
+            BlockHandle,
+            block::{BlockType, EccParams, Header},
+            util::load_block,
+        },
+    };
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    // Build a table whose data blocks carry RS(4,2) parity.
+    let scheme = EccParams::RS_4_2;
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_ecc(Some(scheme));
+    for i in 0..200u32 {
+        let key = format!("key{i:05}");
+        writer.write(InternalValue::from_components(
+            key.as_bytes(),
+            b"value-payload-bytes",
+            u64::from(i) + 1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    #[expect(
+        clippy::unwrap_used,
+        reason = "finish() returns Some after writing items"
+    )]
+    let (_, checksum) = writer.finish()?.unwrap();
+
+    let metrics = Arc::new(crate::metrics::Metrics::default());
+    let table = Table::recover(
+        file.clone(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(10_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        metrics.clone(),
+    )?;
+
+    let table_id = table.global_id();
+    let compression = table.metadata.data_block_compression;
+
+    // First data block.
+    #[expect(clippy::unwrap_used, reason = "table has at least one data block")]
+    let keyed = table.block_index.iter().next().unwrap()?;
+    let handle = BlockHandle::new(keyed.offset(), keyed.size());
+
+    // Clean read with a sink installed: a non-corrected read records nothing.
+    {
+        let clean_sink = HealHints::default();
+        let fresh_cache = Cache::with_capacity_bytes(10_000_000);
+        let _block = load_block(
+            table_id,
+            &table.path,
+            &table.file_accessor,
+            &fresh_cache,
+            &handle,
+            BlockType::Data,
+            compression,
+            None,
+            table.metadata.ecc_params,
+            #[cfg(zstd_any)]
+            None,
+            Some(&clean_sink),
+            #[cfg(feature = "metrics")]
+            &metrics,
+        )?;
+        assert!(
+            clean_sink.snapshot().is_empty(),
+            "a clean read must not record a heal hint",
+        );
+    }
+
+    // Flip one payload byte of the first data block so the read must repair it
+    // via RS parity, and drop any cached fd so the re-read re-opens the tampered
+    // file from disk (confirming the fault is persistent).
+    let mut bytes = std::fs::read(&file)?;
+    let pos = handle.offset().0 as usize + Header::MIN_LEN + 3;
+    bytes[pos] ^= 0x80;
+    std::fs::write(&file, &bytes)?;
+    table.file_accessor.remove_for_table(&table_id);
+
+    let sink = HealHints::default();
+    let fresh_cache = Cache::with_capacity_bytes(10_000_000);
+    let block = load_block(
+        table_id,
+        &table.path,
+        &table.file_accessor,
+        &fresh_cache,
+        &handle,
+        BlockType::Data,
+        compression,
+        None,
+        table.metadata.ecc_params,
+        #[cfg(zstd_any)]
+        None,
+        Some(&sink),
+        #[cfg(feature = "metrics")]
+        &metrics,
+    )?;
+    assert_eq!(
+        block.header.block_type,
+        BlockType::Data,
+        "repaired read still yields a valid data block",
+    );
+    assert_eq!(
+        sink.snapshot(),
+        vec![table_id],
+        "a persistent ECC correction must queue the SST for healing",
+    );
+
+    // Passing no sink (None) must not panic and must still return repaired data.
+    table.file_accessor.remove_for_table(&table_id);
+    let fresh_cache = Cache::with_capacity_bytes(10_000_000);
+    let _block = load_block(
+        table_id,
+        &table.path,
+        &table.file_accessor,
+        &fresh_cache,
+        &handle,
+        BlockType::Data,
+        compression,
+        None,
+        table.metadata.ecc_params,
+        #[cfg(zstd_any)]
+        None,
+        None,
+        #[cfg(feature = "metrics")]
+        &metrics,
+    )?;
 
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2310,6 +2310,7 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     )]
     let (_, checksum) = writer.finish()?.unwrap();
 
+    #[cfg(feature = "metrics")]
     let metrics = Arc::new(crate::metrics::Metrics::default());
     let table = Table::recover(
         file.clone(),

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2338,9 +2338,10 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     let keyed = table.block_index.iter().next().unwrap()?;
     let handle = BlockHandle::new(keyed.offset(), keyed.size());
 
-    // Clean read with a sink installed: a non-corrected read records nothing.
+    // Clean read with an enabled sink: a non-corrected read records nothing.
     {
         let clean_sink = HealHints::default();
+        clean_sink.set_enabled(true);
         let fresh_cache = Cache::with_capacity_bytes(10_000_000);
         let _block = load_block(
             table_id,
@@ -2374,6 +2375,7 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     table.file_accessor.remove_for_table(&table_id);
 
     let sink = HealHints::default();
+    sink.set_enabled(true);
     let fresh_cache = Cache::with_capacity_bytes(10_000_000);
     let block = load_block(
         table_id,
@@ -2402,10 +2404,11 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
         "a persistent ECC correction must queue the SST for healing",
     );
 
-    // Passing no sink (None) must not panic and must still return repaired data.
+    // A DISABLED sink (auto_heal off) corrects on read but records nothing.
     table.file_accessor.remove_for_table(&table_id);
+    let off_sink = HealHints::default(); // enabled == false
     let fresh_cache = Cache::with_capacity_bytes(10_000_000);
-    let _block = load_block(
+    let block = load_block(
         table_id,
         &table.path,
         &table.file_accessor,
@@ -2417,10 +2420,19 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
         table.metadata.ecc_params,
         #[cfg(zstd_any)]
         None,
-        None,
+        Some(&off_sink),
         #[cfg(feature = "metrics")]
         &metrics,
     )?;
+    assert_eq!(
+        block.header.block_type,
+        BlockType::Data,
+        "disabled auto-heal still returns repaired data",
+    );
+    assert!(
+        off_sink.snapshot().is_empty(),
+        "auto_heal off must not schedule a rewrite",
+    );
 
     Ok(())
 }

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -191,17 +191,10 @@ pub fn load_block(
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below
-    // are correct, but the on-disk copy is still faulty. When auto-heal is on
-    // (sink installed and enabled), confirm the fault is persistent (a transient
-    // read-path glitch would re-read clean) and queue the SST for a healing
-    // recompaction. Gated by `is_enabled` so a disabled tree pays nothing beyond
-    // the correction itself; the whole block only runs on the cold corrected
-    // path anyway, so clean reads pay nothing.
-    if corrected
-        && let Some(hints) = heal_hints
-        && hints.is_enabled()
-    {
-        match reread_block_is_corrected(
+    // are correct, but the on-disk copy is still faulty: when auto-heal is on,
+    // confirm the fault is persistent and queue the SST for a healing rewrite.
+    if corrected {
+        maybe_record_persistent_heal(
             table_id,
             path,
             file_accessor,
@@ -212,30 +205,81 @@ pub fn load_block(
             ecc,
             #[cfg(zstd_any)]
             zstd_dict,
-        ) {
-            Ok(true) => {
-                if hints.record(table_id) {
-                    #[cfg(feature = "metrics")]
-                    metrics.ecc_auto_heal_scheduled.fetch_add(1, Relaxed);
-                    log::warn!(
-                        "Persistent ECC correction on table {table_id:?} block {handle:?}; \
-                         queued for healing recompaction"
-                    );
-                }
-            }
-            Ok(false) => log::debug!(
-                "Transient ECC correction on table {table_id:?} block {handle:?}; \
-                 re-read clean, not scheduling"
-            ),
-            Err(e) => log::debug!(
-                "ECC re-read confirmation for table {table_id:?} block {handle:?} failed: {e:?}"
-            ),
-        }
+            heal_hints,
+            #[cfg(feature = "metrics")]
+            metrics,
+        );
     }
 
     cache.insert_block(table_id, handle.offset(), block.clone());
 
     Ok(block)
+}
+
+/// Schedules a healing recompaction for `table_id` when a just-read block was
+/// ECC-corrected and the fault is confirmed persistent.
+///
+/// Call this on any read path that recovers a block from parity (full
+/// [`load_block`] and the zstd partial-decode path both feed it). No-op unless
+/// `heal_hints` is `Some` and enabled (`auto_heal`). On a corrected read it
+/// re-reads the block straight from disk (cache-bypassing) to tell a persistent
+/// medium fault from a transient read-path glitch, recording the SST only on
+/// confirmed persistence. A re-read error is treated as non-persistent: a
+/// genuinely faulty medium resurfaces on the next read, and this must never mask
+/// a live-path I/O failure.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors the block read context needed for the confirming re-read"
+)]
+pub(crate) fn maybe_record_persistent_heal(
+    table_id: GlobalTableId,
+    path: &Path,
+    file_accessor: &FileAccessor,
+    handle: &BlockHandle,
+    block_type: BlockType,
+    compression: CompressionType,
+    encryption: Option<&dyn EncryptionProvider>,
+    ecc: Option<crate::table::block::EccParams>,
+    #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
+    heal_hints: Option<&crate::heal_hints::HealHints>,
+    #[cfg(feature = "metrics")] metrics: &Metrics,
+) {
+    let Some(hints) = heal_hints else { return };
+    if !hints.is_enabled() {
+        return;
+    }
+    match reread_block_is_corrected(
+        table_id,
+        path,
+        file_accessor,
+        handle,
+        block_type,
+        compression,
+        encryption,
+        ecc,
+        #[cfg(zstd_any)]
+        zstd_dict,
+    ) {
+        Ok(true) => {
+            if hints.record(table_id) {
+                #[cfg(feature = "metrics")]
+                metrics
+                    .ecc_auto_heal_scheduled
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                log::warn!(
+                    "Persistent ECC correction on table {table_id:?} block {handle:?}; \
+                     queued for healing recompaction"
+                );
+            }
+        }
+        Ok(false) => log::debug!(
+            "Transient ECC correction on table {table_id:?} block {handle:?}; \
+             re-read clean, not scheduling"
+        ),
+        Err(e) => log::debug!(
+            "ECC re-read confirmation for table {table_id:?} block {handle:?} failed: {e:?}"
+        ),
+    }
 }
 
 /// Builds the [`BlockTransform`](crate::table::block::BlockTransform) for a

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -191,11 +191,16 @@ pub fn load_block(
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below
-    // are correct, but the on-disk copy is still faulty. When a heal sink is
-    // installed, confirm the fault is persistent (a transient read-path glitch
-    // would re-read clean) and queue the SST for a healing recompaction. This
-    // runs only on the cold corrected path, so clean reads pay nothing.
-    if corrected && let Some(hints) = heal_hints {
+    // are correct, but the on-disk copy is still faulty. When auto-heal is on
+    // (sink installed and enabled), confirm the fault is persistent (a transient
+    // read-path glitch would re-read clean) and queue the SST for a healing
+    // recompaction. Gated by `is_enabled` so a disabled tree pays nothing beyond
+    // the correction itself; the whole block only runs on the cold corrected
+    // path anyway, so clean reads pay nothing.
+    if corrected
+        && let Some(hints) = heal_hints
+        && hints.is_enabled()
+    {
         match reread_block_is_corrected(
             table_id,
             path,
@@ -210,6 +215,8 @@ pub fn load_block(
         ) {
             Ok(true) => {
                 if hints.record(table_id) {
+                    #[cfg(feature = "metrics")]
+                    metrics.ecc_auto_heal_scheduled.fetch_add(1, Relaxed);
                     log::warn!(
                         "Persistent ECC correction on table {table_id:?} block {handle:?}; \
                          queued for healing recompaction"

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -33,9 +33,19 @@ pub struct SliceIndexes(pub usize, pub usize);
 /// Loads a block from disk or block cache, if cached.
 ///
 /// Also handles file descriptor opening and caching.
+///
+/// When this read recovers the payload from its Page-ECC parity (a checksum
+/// mismatch the parity repaired) the returned bytes are correct, but the on-disk
+/// copy still carries the fault. If `heal_hints` is `Some`, the loader then
+/// re-reads the same block straight from disk to tell a persistent medium fault
+/// (re-read again recovers) from a transient read-path glitch (re-read clean),
+/// and records the SST in the sink on confirmed persistence so the compaction
+/// picker can rewrite it clean. `None` disables that scheduling (the payload is
+/// still healed and returned). A cache hit never triggers this path: the cached
+/// bytes were already verified on their original read.
 #[expect(
     clippy::too_many_arguments,
-    reason = "block loading requires table id, path, file accessor, cache, handle, block type, compression, and encryption context"
+    reason = "block loading requires table id, path, file accessor, cache, handle, block type, compression, and heal context"
 )]
 pub fn load_block(
     table_id: GlobalTableId,
@@ -48,6 +58,7 @@ pub fn load_block(
     encryption: Option<&dyn EncryptionProvider>,
     ecc: Option<crate::table::block::EccParams>,
     #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
+    heal_hints: Option<&crate::heal_hints::HealHints>,
     #[cfg(feature = "metrics")] metrics: &Metrics,
 ) -> crate::Result<Block> {
     #[cfg(feature = "metrics")]
@@ -116,7 +127,14 @@ pub fn load_block(
     #[cfg(not(feature = "metrics"))]
     let _ = cache_event;
 
-    let block = Block::from_file(
+    let transform = build_block_transform(
+        compression,
+        encryption,
+        ecc,
+        #[cfg(zstd_any)]
+        zstd_dict,
+    )?;
+    let (block, ecc_status) = Block::from_file_with_status(
         fd.as_ref(),
         *handle,
         crate::table::block::BlockIdentity {
@@ -125,29 +143,9 @@ pub fn load_block(
             dict_id: compression.dict_id(),
             window_log: 0,
         },
-        &{
-            // ECC presence is a per-SST descriptor property (passed in by
-            // the caller from table metadata): upgrade the transform to its
-            // `*Ecc` variant when this SST was written with a recognized Page
-            // ECC scheme. On a build WITHOUT the `page_ecc` feature `with_ecc`
-            // is the identity function — the parity trailer then reads as an
-            // unrecognized opaque trailer (the read frames the payload by
-            // `data_length`, verifies its checksum, and reports
-            // `EccStatus::Unrecognized`), so the data still loads without ECC
-            // recovery rather than failing closed.
-            let t = crate::table::block::BlockTransform::from_parts(
-                compression,
-                encryption,
-                #[cfg(zstd_any)]
-                zstd_dict,
-            )?;
-            if let Some(ecc) = ecc {
-                t.with_ecc(ecc)
-            } else {
-                t
-            }
-        },
+        &transform,
     )?;
+    let corrected = matches!(ecc_status, crate::table::block::EccStatus::Corrected);
 
     if block.header.block_type != block_type {
         return Err(crate::Error::InvalidTag((
@@ -192,9 +190,127 @@ pub fn load_block(
         BlockType::Manifest | BlockType::ManifestFooter | BlockType::BlockLayout => {}
     }
 
+    // ECC recovered this block's payload from parity. The bytes returned below
+    // are correct, but the on-disk copy is still faulty. When a heal sink is
+    // installed, confirm the fault is persistent (a transient read-path glitch
+    // would re-read clean) and queue the SST for a healing recompaction. This
+    // runs only on the cold corrected path, so clean reads pay nothing.
+    if corrected && let Some(hints) = heal_hints {
+        match reread_block_is_corrected(
+            table_id,
+            path,
+            file_accessor,
+            handle,
+            block_type,
+            compression,
+            encryption,
+            ecc,
+            #[cfg(zstd_any)]
+            zstd_dict,
+        ) {
+            Ok(true) => {
+                if hints.record(table_id) {
+                    log::warn!(
+                        "Persistent ECC correction on table {table_id:?} block {handle:?}; \
+                         queued for healing recompaction"
+                    );
+                }
+            }
+            Ok(false) => log::debug!(
+                "Transient ECC correction on table {table_id:?} block {handle:?}; \
+                 re-read clean, not scheduling"
+            ),
+            Err(e) => log::debug!(
+                "ECC re-read confirmation for table {table_id:?} block {handle:?} failed: {e:?}"
+            ),
+        }
+    }
+
     cache.insert_block(table_id, handle.offset(), block.clone());
 
     Ok(block)
+}
+
+/// Builds the [`BlockTransform`](crate::table::block::BlockTransform) for a
+/// block read from its per-SST codec context.
+///
+/// ECC presence is a per-SST descriptor property (`ecc`): the transform is
+/// upgraded to its `*Ecc` variant when this SST was written with a recognized
+/// Page ECC scheme. On a build WITHOUT the `page_ecc` feature `with_ecc` is the
+/// identity function — the parity trailer then reads as an unrecognized opaque
+/// trailer (the read frames the payload by `data_length`, verifies its
+/// checksum, and reports
+/// [`EccStatus::Unrecognized`](crate::table::block::EccStatus::Unrecognized)),
+/// so the data still loads without ECC recovery rather than failing closed.
+fn build_block_transform<'a>(
+    compression: CompressionType,
+    encryption: Option<&'a dyn EncryptionProvider>,
+    ecc: Option<crate::table::block::EccParams>,
+    #[cfg(zstd_any)] zstd_dict: Option<&'a crate::compression::ZstdDictionary>,
+) -> crate::Result<crate::table::block::BlockTransform<'a>> {
+    let t = crate::table::block::BlockTransform::from_parts(
+        compression,
+        encryption,
+        #[cfg(zstd_any)]
+        zstd_dict,
+    )?;
+    Ok(if let Some(ecc) = ecc {
+        t.with_ecc(ecc)
+    } else {
+        t
+    })
+}
+
+/// Re-reads a block straight from disk (bypassing the block cache) and reports
+/// whether its on-disk bytes are *still* ECC-corrected.
+///
+/// Used to confirm that a correction observed on a cache-miss read reflects a
+/// **persistent** on-disk fault rather than a transient read-path glitch (bad
+/// RAM / DMA / cable during the first read): a second independent read of the
+/// same offset that again recovers from parity proves the bytes on the medium
+/// are faulty. Returns `Ok(true)` when the re-read was itself ECC-corrected,
+/// `Ok(false)` when it read clean (transient) or carried no recognized parity.
+///
+/// Runs only on the cold corrected-read path, so the extra disk read costs
+/// nothing on clean reads.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors load_block's read context minus the cache"
+)]
+fn reread_block_is_corrected(
+    table_id: GlobalTableId,
+    path: &Path,
+    file_accessor: &FileAccessor,
+    handle: &BlockHandle,
+    block_type: BlockType,
+    compression: CompressionType,
+    encryption: Option<&dyn EncryptionProvider>,
+    ecc: Option<crate::table::block::EccParams>,
+    #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
+) -> crate::Result<bool> {
+    let (fd, _cache_event) = file_accessor.get_or_open_table(&table_id, path)?;
+    let transform = build_block_transform(
+        compression,
+        encryption,
+        ecc,
+        #[cfg(zstd_any)]
+        zstd_dict,
+    )?;
+    let (_block, ecc_status) = Block::from_file_with_status(
+        fd.as_ref(),
+        *handle,
+        crate::table::block::BlockIdentity {
+            table_id: table_id.table_id(),
+            block_type,
+            dict_id: compression.dict_id(),
+            window_log: 0,
+        },
+        &transform,
+    )?;
+    Ok(matches!(
+        ecc_status,
+        crate::table::block::EccStatus::Corrected
+    ))
 }
 
 /// Returns the length of the longest shared byte prefix of `s1` and `s2`.

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -96,6 +96,13 @@ pub struct TreeInner {
     #[cfg(feature = "std")]
     pub(crate) background_deleter: Arc<crate::BackgroundDeleter>,
 
+    /// Tree-wide ECC heal-hint sink. A block read that recovers a payload from
+    /// its Page-ECC parity, and confirms the on-disk fault is persistent via a
+    /// cache-bypassing re-read, records the SST id here. The compaction picker
+    /// drains it to rewrite the faulty file clean. Installed into every table so
+    /// the read path can record without a back-reference to the tree.
+    pub(crate) heal_hints: Arc<crate::heal_hints::HealHints>,
+
     /// Runtime-toggleable configuration. Lockless atomic snapshot.
     ///
     /// Reachable through the public Tree API
@@ -181,6 +188,7 @@ impl TreeInner {
             deletion_pause: DeletionPause::new_shared(),
             #[cfg(feature = "std")]
             background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
+            heal_hints: crate::heal_hints::HealHints::new_shared(),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
 
             #[cfg(feature = "metrics")]

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -188,7 +188,7 @@ impl TreeInner {
             deletion_pause: DeletionPause::new_shared(),
             #[cfg(feature = "std")]
             background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
-            heal_hints: crate::heal_hints::HealHints::new_shared(),
+            heal_hints: crate::heal_hints::HealHints::new_shared(initial_runtime.auto_heal),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
 
             #[cfg(feature = "metrics")]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1313,7 +1313,12 @@ impl Tree {
         // mutation (currently: `page_ecc = true` on a non-`page_ecc`
         // build) is rejected at update time, not silently swallowed
         // at the next manifest write.
-        self.0.runtime_config.try_update(mutator)
+        self.0.runtime_config.try_update(mutator)?;
+        // Keep the read-path heal gate in sync with `auto_heal`.
+        self.0
+            .heal_hints
+            .set_enabled(self.0.runtime_config.load_full().auto_heal);
+        Ok(())
     }
 
     /// Snapshot of the current runtime config. Cheap atomic load —
@@ -2364,7 +2369,8 @@ impl Tree {
         let deletion_pause = crate::deletion_pause::DeletionPause::new_shared();
         #[cfg(feature = "std")]
         let background_deleter = Arc::new(crate::BackgroundDeleter::new(None));
-        let heal_hints = crate::heal_hints::HealHints::new_shared();
+        let heal_hints =
+            crate::heal_hints::HealHints::new_shared(config.initial_runtime_config.auto_heal);
 
         // Clone the seed snapshot BEFORE moving config into the Arc
         // below — the runtime handle initializer needs it after the

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -658,6 +658,7 @@ impl AbstractTree for Tree {
             table.install_deletion_pause(Arc::clone(&self.deletion_pause));
             #[cfg(feature = "std")]
             table.install_background_deleter(Arc::clone(&self.background_deleter));
+            table.install_heal_hints(Arc::clone(&self.heal_hints));
         }
         if let Some(bfs) = blob_files {
             for bf in bfs {
@@ -2349,6 +2350,7 @@ impl Tree {
         let deletion_pause = crate::deletion_pause::DeletionPause::new_shared();
         #[cfg(feature = "std")]
         let background_deleter = Arc::new(crate::BackgroundDeleter::new(None));
+        let heal_hints = crate::heal_hints::HealHints::new_shared();
 
         // Clone the seed snapshot BEFORE moving config into the Arc
         // below — the runtime handle initializer needs it after the
@@ -2380,6 +2382,7 @@ impl Tree {
             deletion_pause: Arc::clone(&deletion_pause),
             #[cfg(feature = "std")]
             background_deleter: Arc::clone(&background_deleter),
+            heal_hints: Arc::clone(&heal_hints),
             runtime_config: Arc::new(crate::runtime_config::handle::RuntimeConfigHandle::new(
                 initial_runtime,
             )),
@@ -2409,6 +2412,7 @@ impl Tree {
             table.install_deletion_pause(Arc::clone(&deletion_pause));
             #[cfg(feature = "std")]
             table.install_background_deleter(Arc::clone(&background_deleter));
+            table.install_heal_hints(Arc::clone(&heal_hints));
         }
         for blob_file in &recovered_blobs {
             blob_file.install_deletion_pause(Arc::clone(&deletion_pause));

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1337,6 +1337,36 @@ impl Tree {
     /// clustered deployment — to rewrite the flagged SSTs clean. Check
     /// [`HealHints::is_empty`](crate::heal_hints::HealHints::is_empty) to skip
     /// the pass when nothing is queued.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lsm_tree::{AbstractTree, AnyTree, Config, SequenceNumberCounter, compaction::EccHeal};
+    /// use std::sync::Arc;
+    /// # fn main() -> lsm_tree::Result<()> {
+    /// let AnyTree::Standard(tree) = Config::new(
+    ///     "/tmp/db",
+    ///     SequenceNumberCounter::default(),
+    ///     SequenceNumberCounter::default(),
+    /// )
+    /// .open()?
+    /// else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// // Opt into rewrite scheduling; reads that recover a block from parity now
+    /// // flag its SST for healing.
+    /// tree.update_runtime_config(|c| c.auto_heal = true)?;
+    ///
+    /// // Drain the queue, rewriting each flagged SST clean (leader-only in a
+    /// // clustered deployment).
+    /// let hints = tree.heal_hints();
+    /// while !hints.is_empty() {
+    ///     tree.compact(Arc::new(EccHeal::new(tree.heal_hints(), u64::MAX)), 0)?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn heal_hints(&self) -> Arc<crate::heal_hints::HealHints> {
         Arc::clone(&self.0.heal_hints)

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1313,11 +1313,20 @@ impl Tree {
         // mutation (currently: `page_ecc = true` on a non-`page_ecc`
         // build) is rejected at update time, not silently swallowed
         // at the next manifest write.
-        self.0.runtime_config.try_update(mutator)?;
-        // Keep the read-path heal gate in sync with `auto_heal`.
-        self.0
-            .heal_hints
-            .set_enabled(self.0.runtime_config.load_full().auto_heal);
+        // Capture this update's `auto_heal` inside the mutation so the read-path
+        // heal gate reflects exactly the config THIS call commits, rather than a
+        // separate `load_full()` that could observe a different concurrent
+        // update's value. Concurrent `update_runtime_config` calls must be
+        // serialized by the caller (see the last-writer-wins note above); under
+        // that contract the gate and the committed config stay in sync. On a
+        // validation error `try_update` does not commit and `?` returns before
+        // the gate is touched, so it keeps tracking the unchanged config.
+        let mut auto_heal = false;
+        self.0.runtime_config.try_update(|c| {
+            mutator(c);
+            auto_heal = c.auto_heal;
+        })?;
+        self.0.heal_hints.set_enabled(auto_heal);
         Ok(())
     }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1323,6 +1323,20 @@ impl Tree {
         self.0.runtime_config.load_full()
     }
 
+    /// Shared handle to this tree's ECC heal-hint queue.
+    ///
+    /// A read that recovers a block from Page-ECC parity records the owning SST
+    /// here (when the on-disk fault is confirmed persistent). Pass the handle to
+    /// [`compaction::EccHeal`](crate::compaction::EccHeal) and run that strategy
+    /// via [`Tree::compact`](crate::AbstractTree::compact) — leader-only in a
+    /// clustered deployment — to rewrite the flagged SSTs clean. Check
+    /// [`HealHints::is_empty`](crate::heal_hints::HealHints::is_empty) to skip
+    /// the pass when nothing is queued.
+    #[must_use]
+    pub fn heal_hints(&self) -> Arc<crate::heal_hints::HealHints> {
+        Arc::clone(&self.0.heal_hints)
+    }
+
     /// Shared point-read logic for `get()` and `multi_get()`: finds the newest
     /// entry, applies merge resolution or RT suppression, and returns the value.
     fn resolve_or_passthrough(


### PR DESCRIPTION
## Summary

When a block read recovers its payload from Page-ECC parity, the returned bytes are correct but the on-disk copy is still faulty, so the same latent fault is re-corrected on every future read. This adds opt-in self-healing: a corrected read (confirmed persistent) flags the owning SST, and a compaction strategy rewrites it clean.

Because SSTs are immutable, "rewrite the corrected block" means recompacting the owning SST: the corrected data flows into a fresh SST with newly computed parity, and the faulty source is dropped. No in-place mutation.

## What's included

- **Correction signal** — block reads report `EccStatus::Corrected` when parity repaired the payload.
- **Persistence confirmation** — on a corrected read the loader re-reads the block straight from disk (cache-bypassing) to distinguish a persistent medium fault (re-read again recovers) from a transient read-path glitch (re-read clean), and flags the SST only on confirmed persistence. Transients cost no rewrite.
- **Heal queue** — `HealHints`, a tree-wide, dedup-by-SST set (no-std + alloc), installed into every table.
- **Heal strategy** — `compaction::EccHeal` claims one flagged SST per pass and merges it back into its own level; the merge re-reads (correcting on the way in) and writes fresh parity. Drive it via `Tree::heal_hints()` + `Tree::compact`, leader-only in a clustered deployment.
- **Opt-in gate** — `RuntimeConfig::auto_heal` (default **false**): correction-on-read still happens whenever ECC is enabled; only the persistence re-read + scheduling are gated. The gate tracks the runtime flag at open and on update.
- **Metric** — `ecc_auto_heal_scheduled` (+ accessor).

## Tests

- Persistent corrected read flags the SST; a disabled gate corrects but flags nothing.
- End-to-end (page_ecc): corrupt a data block, read repairs + flags, run `EccHeal`, then the re-read is clean and flags nothing.
- Queue dedup + drain.

Full lib suite green (1407).

## Follow-ups (not in this change)

- Scheduling on **index-block** corrections: the read path wires the heal sink through the data-block paths (point read + scan). Index-block readers are built before the tree installs the sink, so wiring them needs a live sink reference rather than a captured one; tracked separately. Index-block faults still heal on read, just without proactive scheduling.
- A transient-vs-persistent unit test needs a fault-injecting filesystem (the re-read currently can only be exercised for the persistent case).

Part of #411