### PR TITLE
refactor(no-std): make the core LSM path no_std + alloc capable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ std = [
     "dep:arc-swap",
     "dep:parking_lot",
     "dep:tempfile",
-    "byteorder/std",
     "rustc-hash/std",
     "varint-rs/std",
 ]
@@ -114,7 +113,6 @@ ribbon-serde = ["dep:serde"]
 
 [dependencies]
 bytes = { version = "1", optional = true }
-byteorder = { package = "byteorder-lite", version = "0.1.0", default-features = false }
 # Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
 # Lock-free atomic Arc swap. `arc-swap` 1.x is NOT `#![no_std]` (it requires
 # `std`), so it stays an optional dependency enabled only by the `std`
@@ -135,7 +133,7 @@ spin = { version = "0.12", default-features = false, features = ["mutex", "spin_
 hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }
 parking_lot = { version = "0.12", optional = true }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.33", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.34", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is
@@ -148,8 +146,19 @@ structured-zstd = { version = "0.0.33", optional = true, default-features = fals
 #     across racers, no auxiliary `Mutex`)
 #   - `deletion_pause` slot on tables / blob files (one-shot install of
 #     the shared `Arc<DeletionPause>` after recovery / compaction).
-once_cell = { version = "1", default-features = false, features = ["race"] }
+once_cell = { version = "1", default-features = false, features = ["race", "alloc"] }
 rustc-hash = { version = "2.1.1", default-features = false }
+# `portable-atomic` supplies `AtomicU64` on targets without native 64-bit
+# atomics (e.g. `thumbv7em-none-eabihf`, where the seqno counter would not
+# otherwise compile). On `std` / 64-bit targets it resolves to the native
+# atomic with zero overhead, so the std hot path is unchanged. The default
+# `fallback` feature implements the wide atomic via the target's native
+# 32-bit CAS, so no `critical-section` impl is required to compile-check.
+portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
+# Pure-Rust libm — supplies f64 ceil/round on `no_std` targets, which lack the
+# float-math intrinsics std provides. Used only on the no_std path (filter
+# sizing); std keeps the native `f64::ceil` / `f64::round`.
+libm = { version = "0.2", default-features = false }
 self_cell = "1.2.0"
 # Optional — only pulled in by the vendored Ribbon filter under the
 # `ribbon-serde` feature flag (off by default).
@@ -215,6 +224,10 @@ io-uring = { version = "0.7", optional = true }
 libc = "0.2"
 
 [dev-dependencies]
+# Integration tests assemble their own wire fixtures with byteorder; the
+# library itself no longer depends on it (its `ReadBytesExt`/`WriteBytesExt`
+# now live in the in-tree, no_std-capable `crate::io`).
+byteorder = { package = "byteorder-lite", version = "0.1.0" }
 criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"
 nanoid = "0.5.0"

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::ops::RangeBounds;
 
 pub type RangeItem = crate::Result<KvPair>;

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -2,14 +2,15 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::tree::inner::{FlushGuard, VersionsWriteGuard};
 use crate::{
     AnyTree, BlobTree, Config, Guard, InternalValue, KvPair, Memtable, SeqNo, TableId, Tree,
     UserKey, UserValue, iter_guard::IterGuardImpl, table::Table, version::Version, vlog::BlobFile,
 };
-use std::{
-    ops::RangeBounds,
-    sync::{Arc, MutexGuard, RwLockWriteGuard},
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::RangeBounds;
 
 pub type RangeItem = crate::Result<KvPair>;
 
@@ -137,7 +138,7 @@ pub trait AbstractTree: sealed::Sealed {
     }
 
     #[doc(hidden)]
-    fn get_version_history_lock(&self) -> RwLockWriteGuard<'_, crate::version::SuperVersions>;
+    fn get_version_history_lock(&self) -> VersionsWriteGuard<'_>;
 
     /// Creates a hard-linked checkpoint of the tree's on-disk state in
     /// `target_path` for point-in-time recovery (PITR) backup.
@@ -192,7 +193,9 @@ pub trait AbstractTree: sealed::Sealed {
     ///
     /// On error any partial checkpoint files are removed automatically
     /// (best-effort) so callers can safely retry against the same path.
-    fn create_checkpoint(&self, target_path: &std::path::Path) -> crate::Result<CheckpointInfo>;
+    // std-only: checkpoint creation hard-links / copies files via std::fs.
+    #[cfg(feature = "std")]
+    fn create_checkpoint(&self, target_path: &crate::path::Path) -> crate::Result<CheckpointInfo>;
 
     /// Seals the active memtable and flushes to table(s).
     ///
@@ -216,11 +219,7 @@ pub trait AbstractTree: sealed::Sealed {
     /// # Errors
     ///
     /// Will return `Err` if an IO error occurs.
-    fn flush(
-        &self,
-        _lock: &MutexGuard<'_, ()>,
-        seqno_threshold: SeqNo,
-    ) -> crate::Result<Option<u64>> {
+    fn flush(&self, _lock: &FlushGuard<'_>, seqno_threshold: SeqNo) -> crate::Result<Option<u64>> {
         use crate::{
             compaction::stream::CompactionStream, merge::Merger, range_tombstone::RangeTombstone,
         };
@@ -387,7 +386,7 @@ pub trait AbstractTree: sealed::Sealed {
     fn metrics(&self) -> &Arc<crate::Metrics>;
 
     /// Acquires the flush lock which is required to call [`Tree::flush`].
-    fn get_flush_lock(&self) -> MutexGuard<'_, ()>;
+    fn get_flush_lock(&self) -> FlushGuard<'_>;
 
     /// Synchronously flushes a memtable to a table.
     ///
@@ -1016,7 +1015,7 @@ pub trait AbstractTree: sealed::Sealed {
     /// Returns 0 for empty prefixes or all-`0xFF` prefixes (cannot form valid half-open range).
     fn remove_prefix<K: AsRef<[u8]>>(&self, prefix: K, seqno: SeqNo) -> u64 {
         use crate::range::prefix_to_range;
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         let (lo, hi) = prefix_to_range(prefix.as_ref());
 

--- a/src/active_tombstone_set.rs
+++ b/src/active_tombstone_set.rs
@@ -15,7 +15,7 @@
 use crate::{SeqNo, UserKey, comparator::SharedComparator, range_tombstone::RangeTombstone};
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Tracks active range tombstones during forward iteration.
 ///

--- a/src/active_tombstone_set.rs
+++ b/src/active_tombstone_set.rs
@@ -13,7 +13,9 @@
 //! when multiple tombstones share the same boundary key.
 
 use crate::{SeqNo, UserKey, comparator::SharedComparator, range_tombstone::RangeTombstone};
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Tracks active range tombstones during forward iteration.
 ///
@@ -103,7 +105,7 @@ impl ActiveTombstoneSet {
     /// Panics if an expiry pop has no matching activation in the seqno multiset.
     pub fn expire_until(&mut self, current_key: &[u8]) {
         while let Some((end, _, seqno)) = self.pending_expiry.last() {
-            if self.comparator.compare(end, current_key) == std::cmp::Ordering::Greater {
+            if self.comparator.compare(end, current_key) == core::cmp::Ordering::Greater {
                 break;
             }
             let seqno = *seqno;
@@ -252,7 +254,7 @@ impl ActiveTombstoneSetReverse {
     /// Panics if an expiry pop has no matching activation in the seqno multiset.
     pub fn expire_until(&mut self, current_key: &[u8]) {
         while let Some((start, _, seqno)) = self.pending_expiry.last() {
-            if self.comparator.compare(current_key, start) == std::cmp::Ordering::Less {
+            if self.comparator.compare(current_key, start) == core::cmp::Ordering::Less {
                 let seqno = *seqno;
                 self.pending_expiry.pop();
                 #[expect(

--- a/src/blob_tree/gc.rs
+++ b/src/blob_tree/gc.rs
@@ -35,7 +35,7 @@ impl FragmentationEntry {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FragmentationMap(crate::HashMap<BlobFileId, FragmentationEntry>);
 
-impl std::ops::Deref for FragmentationMap {
+impl core::ops::Deref for FragmentationMap {
     type Target = crate::HashMap<BlobFileId, FragmentationEntry>;
 
     fn deref(&self) -> &Self::Target {
@@ -43,7 +43,7 @@ impl std::ops::Deref for FragmentationMap {
     }
 }
 
-impl std::ops::DerefMut for FragmentationMap {
+impl core::ops::DerefMut for FragmentationMap {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -82,8 +82,8 @@ impl FragmentationMap {
 }
 
 impl crate::coding::Encode for FragmentationMap {
-    fn encode_into<W: std::io::Write>(&self, writer: &mut W) -> Result<(), crate::Error> {
-        use byteorder::{LE, WriteBytesExt};
+    fn encode_into<W: crate::io::Write>(&self, writer: &mut W) -> Result<(), crate::Error> {
+        use crate::io::{LE, WriteBytesExt};
 
         #[expect(
             clippy::cast_possible_truncation,
@@ -110,11 +110,11 @@ impl crate::coding::Encode for FragmentationMap {
 }
 
 impl crate::coding::Decode for FragmentationMap {
-    fn decode_from<R: std::io::Read>(reader: &mut R) -> Result<Self, crate::Error>
+    fn decode_from<R: crate::io::Read>(reader: &mut R) -> Result<Self, crate::Error>
     where
         Self: Sized,
     {
-        use byteorder::{LE, ReadBytesExt};
+        use crate::io::{LE, ReadBytesExt};
 
         let len = reader.read_u32::<LE>()?;
         let mut map =
@@ -167,6 +167,7 @@ impl DroppedKvCallback for FragmentationMap {
 #[expect(clippy::expect_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
+    use crate::HashMap;
     use crate::{
         ValueType,
         coding::{Decode, Encode},
@@ -174,7 +175,6 @@ mod tests {
         value::InternalValue,
         vlog::ValueHandle,
     };
-    use std::collections::HashMap;
     use test_log::test;
 
     #[test]

--- a/src/blob_tree/handle.rs
+++ b/src/blob_tree/handle.rs
@@ -2,11 +2,17 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
+#[cfg(not(feature = "std"))]
+use crate::io::{VarintReader, VarintWriter};
 use crate::{
     coding::{Decode, Encode},
     vlog::ValueHandle,
 };
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
+#[cfg(feature = "std")]
 use varint_rs::{VarintReader, VarintWriter};
 
 #[derive(Copy, Clone, Debug)]

--- a/src/blob_tree/ingest.rs
+++ b/src/blob_tree/ingest.rs
@@ -6,7 +6,13 @@ use crate::{
     SeqNo, UserKey, UserValue, blob_tree::handle::BlobIndirection, file::BLOBS_FOLDER,
     table::Table, tree::ingest::Ingestion as TableIngestion, vlog::BlobFileWriter,
 };
-use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::cmp::Ordering;
 
 /// Bulk ingestion for [`BlobTree`](crate::BlobTree)
 ///
@@ -199,10 +205,8 @@ impl<'a> BlobIngestion<'a> {
         // Acquire locks for version registration on the index tree. We must
         // hold both the compaction state lock and version history lock to
         // safely modify the tree's version.
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut _compaction_state = index.compaction_state.lock().expect("lock is poisoned");
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut version_lock = index.version_history.write().expect("lock is poisoned");
+        let mut _compaction_state = index.compaction_state.lock();
+        let mut version_lock = index.version_history.write();
 
         // Allocate the next global sequence number. This seqno will be shared
         // by all ingested tables, blob files, and the version that registers

--- a/src/blob_tree/ingest.rs
+++ b/src/blob_tree/ingest.rs
@@ -7,11 +7,7 @@ use crate::{
     table::Table, tree::ingest::Ingestion as TableIngestion, vlog::BlobFileWriter,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::ToString, vec::Vec};
 use core::cmp::Ordering;
 
 /// Bulk ingestion for [`BlobTree`](crate::BlobTree)

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -9,6 +9,8 @@ pub mod ingest;
 #[doc(hidden)]
 pub use gc::{FragmentationEntry, FragmentationMap};
 
+use crate::path::{Path, PathBuf};
+use crate::tree::inner::{FlushGuard, VersionsWriteGuard};
 use crate::{
     Cache, Config, Memtable, ScanSinceEvent, SeqNo, TableId, TreeId, UserKey, UserValue,
     abstract_tree::{AbstractTree, RangeItem},
@@ -20,12 +22,15 @@ use crate::{
     version::Version,
     vlog::{Accessor, BlobFile, BlobFileWriter},
 };
-use handle::BlobIndirection;
-use std::{
-    ops::RangeBounds,
-    path::{Path, PathBuf},
-    sync::{Arc, MutexGuard},
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
 };
+use core::ops::RangeBounds;
+use handle::BlobIndirection;
 
 /// Iterator value guard
 pub struct Guard {
@@ -70,7 +75,7 @@ impl IterGuard for Guard {
         let kv = self.kv?;
 
         if kv.key.value_type.is_indirection() {
-            let mut cursor = std::io::Cursor::new(kv.value);
+            let mut cursor = crate::io::Cursor::new(kv.value);
             Ok(BlobIndirection::decode_from(&mut cursor)?.size)
         } else {
             #[expect(clippy::cast_possible_truncation, reason = "values are u32 max length")]
@@ -105,7 +110,7 @@ fn resolve_value_handle(
     #[cfg(zstd_any)] zstd_dictionary: Option<&crate::compression::ZstdDictionary>,
 ) -> RangeItem {
     if item.key.value_type.is_indirection() {
-        let mut cursor = std::io::Cursor::new(item.value);
+        let mut cursor = crate::io::Cursor::new(item.value);
         let vptr = BlobIndirection::decode_from(&mut cursor)?;
 
         // Resolve indirection using value log
@@ -267,9 +272,10 @@ impl BlobTree {
 impl crate::abstract_tree::sealed::Sealed for BlobTree {}
 
 impl AbstractTree for BlobTree {
+    #[cfg(feature = "std")]
     fn create_checkpoint(
         &self,
-        target_path: &std::path::Path,
+        target_path: &crate::path::Path,
     ) -> crate::Result<crate::CheckpointInfo> {
         crate::checkpoint::run_checkpoint(
             self,
@@ -295,9 +301,7 @@ impl AbstractTree for BlobTree {
         self.index.table_file_cache_size()
     }
 
-    fn get_version_history_lock(
-        &self,
-    ) -> std::sync::RwLockWriteGuard<'_, crate::version::SuperVersions> {
+    fn get_version_history_lock(&self) -> VersionsWriteGuard<'_> {
         self.index.get_version_history_lock()
     }
 
@@ -481,7 +485,7 @@ impl AbstractTree for BlobTree {
         };
 
         Ok(Some(if item.key.value_type.is_indirection() {
-            let mut cursor = std::io::Cursor::new(item.value);
+            let mut cursor = crate::io::Cursor::new(item.value);
             let vptr = BlobIndirection::decode_from(&mut cursor)?;
             vptr.size
         } else {
@@ -512,7 +516,7 @@ impl AbstractTree for BlobTree {
         self.index.sealed_memtable_count()
     }
 
-    fn get_flush_lock(&self) -> MutexGuard<'_, ()> {
+    fn get_flush_lock(&self) -> FlushGuard<'_> {
         self.index.get_flush_lock()
     }
 
@@ -524,7 +528,7 @@ impl AbstractTree for BlobTree {
     ) -> crate::Result<Option<(Vec<Table>, Option<Vec<BlobFile>>)>> {
         use crate::{coding::Encode, file::BLOBS_FOLDER, table::multi_writer::MultiWriter};
 
-        let start = std::time::Instant::now();
+        let start = crate::time::Instant::now();
 
         let (table_folder, level_fs) = self.index.config.tables_folder_for_level(0);
 

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -24,11 +24,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::ops::RangeBounds;
 use handle::BlobIndirection;
 

--- a/src/byteview/byteview.rs
+++ b/src/byteview/byteview.rs
@@ -3,11 +3,9 @@
 // (found in the LICENSE-* files in the repository)
 
 use alloc::{string::String, sync::Arc, vec::Vec};
-use core::{
-    mem::ManuallyDrop,
-    ops::Deref,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use core::{mem::ManuallyDrop, ops::Deref, sync::atomic::Ordering};
+
+use portable_atomic::AtomicU64;
 
 pub use super::builder::Builder;
 
@@ -273,6 +271,21 @@ impl ByteView {
         // NOTE: We can use _unzeroed to skip zeroing of the heap allocated slice
         // because we receive the `len` parameter
         // If the reader does not give us exactly `len` bytes, `read_exact` fails anyway
+        let mut s = unsafe { Self::with_size_unzeroed(len) };
+        {
+            let mut builder = Mutator(&mut s);
+            reader.read_exact(&mut builder)?;
+        }
+        Ok(s)
+    }
+
+    /// `no_std` mirror of [`ByteView::from_reader`] over [`crate::io::Read`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurred.
+    #[cfg(not(feature = "std"))]
+    pub fn from_reader<R: crate::io::Read>(reader: &mut R, len: usize) -> crate::io::Result<Self> {
         let mut s = unsafe { Self::with_size_unzeroed(len) };
         {
             let mut builder = Mutator(&mut s);
@@ -858,18 +871,18 @@ mod tests {
         use super::{LongRepr, ShortRepr, Trailer};
 
         assert_eq!(
-            std::mem::size_of::<ShortRepr>(),
-            std::mem::size_of::<LongRepr>()
+            core::mem::size_of::<ShortRepr>(),
+            core::mem::size_of::<LongRepr>()
         );
         assert_eq!(
-            std::mem::size_of::<Trailer>(),
-            std::mem::size_of::<LongRepr>()
+            core::mem::size_of::<Trailer>(),
+            core::mem::size_of::<LongRepr>()
         );
 
-        assert_eq!(24, std::mem::size_of::<ByteView>());
+        assert_eq!(24, core::mem::size_of::<ByteView>());
         assert_eq!(
             32,
-            std::mem::size_of::<ByteView>() + std::mem::size_of::<HeapAllocationHeader>()
+            core::mem::size_of::<ByteView>() + core::mem::size_of::<HeapAllocationHeader>()
         );
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -48,7 +48,7 @@ pub struct PartialBlockEntry {
     pub hits: u32,
 }
 
-#[derive(Clone, Copy, Eq, std::hash::Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, core::hash::Hash, PartialEq)]
 struct CacheKey(u8, u64, u64, u64);
 
 impl From<(u8, u64, u64, u64)> for CacheKey {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -31,6 +31,8 @@ use crate::{
     version::Version,
     vlog::BlobFile,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use alloc::{sync::Arc, vec};
 use std::{
     io::{Read, Write},
@@ -69,9 +71,9 @@ pub fn prepare_target(target: &Path, include_blobs: bool, target_fs: &dyn Fs) ->
     // Atomic claim — fails with AlreadyExists if any other process /
     // thread / prior checkpoint already created the directory.
     target_fs.create_dir(target).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::AlreadyExists {
-            std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
+        if e.kind() == crate::io::ErrorKind::AlreadyExists {
+            crate::io::Error::new(
+                crate::io::ErrorKind::AlreadyExists,
                 format!(
                     "checkpoint target {} already exists; refusing to overwrite",
                     target.display(),
@@ -203,7 +205,7 @@ pub fn link_or_copy_cross_fs(
             // link itself.
             Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
             Err(e)
-                if crate::fs::is_cross_device(&e) || e.kind() == std::io::ErrorKind::NotFound =>
+                if crate::fs::is_cross_device(&e) || e.kind() == crate::io::ErrorKind::NotFound =>
             {
                 // The link didn't take, for one of:
                 //   - cross-device (EXDEV / CrossesDevices) — src and dst
@@ -226,7 +228,7 @@ pub fn link_or_copy_cross_fs(
                     e.kind(),
                 );
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(e.into()),
         }
     } else {
         // Backends do not share a namespace (e.g. MemFs source vs
@@ -386,7 +388,7 @@ fn copy_metadata_file_optional(
     let src = src_root.join(file_name);
     let mut src_file = match src_fs.open(&src, &FsOpenOptions::new().read(true)) {
         Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e.into()),
     };
     let dst = target_root.join(file_name);
@@ -430,8 +432,8 @@ fn write_current_for_version(
 ) -> crate::Result<()> {
     use crate::checksum::ChecksumType;
     use crate::file::rewrite_atomic;
+    use crate::io::{LittleEndian, WriteBytesExt};
     use crate::manifest_blocks::{current_digest, reader::ManifestArchiveReader};
-    use byteorder::{LittleEndian, WriteBytesExt};
 
     let manifest_path = target_root.join(format!("v{version_id}"));
     // Open the freshly-written manifest through the same reader
@@ -663,7 +665,7 @@ pub fn run_checkpoint<T: AbstractTree>(
         .filter(|c| !matches!(c, std::path::Component::CurDir))
         .collect();
     if normalized_target.as_os_str().is_empty() {
-        return Err(crate::Error::Io(std::io::Error::new(
+        return Err(crate::Error::from(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "checkpoint target_root must name at least one path component",
         )));

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -205,7 +205,9 @@ pub fn link_or_copy_cross_fs(
             // link itself.
             Ok(()) => return Ok(dst_fs.metadata(dst)?.len),
             Err(e)
-                if crate::fs::is_cross_device(&e) || e.kind() == crate::io::ErrorKind::NotFound =>
+                if crate::fs::is_cross_device(&e)
+                    || e.kind() == crate::io::ErrorKind::Unsupported
+                    || e.kind() == crate::io::ErrorKind::NotFound =>
             {
                 // The link didn't take, for one of:
                 //   - cross-device (EXDEV / CrossesDevices) — src and dst

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -25,8 +25,8 @@ impl From<crate::sfa::Checksum> for Checksum {
     }
 }
 
-impl std::fmt::Display for Checksum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Checksum {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{self:?}")
     }
 }
@@ -56,18 +56,30 @@ impl Checksum {
     }
 }
 
-pub struct ChecksummedWriter<W: std::io::Write> {
+pub struct ChecksummedWriter<W: crate::io::Write> {
     inner: W,
     hasher: xxhash_rust::xxh3::Xxh3Default,
 }
 
-impl<W: std::io::Write + std::io::Seek> std::io::Seek for ChecksummedWriter<W> {
+// `crate::io::{Write,Seek}` is the std trait (via the std-mode supertrait
+// blanket) under `std` and the native trait under `no_std`; the two impls
+// differ only in the trait path and the `Result`/`SeekFrom` type they name,
+// so each is gated to its build.
+#[cfg(feature = "std")]
+impl<W: crate::io::Write + crate::io::Seek> std::io::Seek for ChecksummedWriter<W> {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
         self.inner.seek(pos)
     }
 }
 
-impl<W: std::io::Write> ChecksummedWriter<W> {
+#[cfg(not(feature = "std"))]
+impl<W: crate::io::Write + crate::io::Seek> crate::io::Seek for ChecksummedWriter<W> {
+    fn seek(&mut self, pos: crate::io::SeekFrom) -> crate::io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+impl<W: crate::io::Write> ChecksummedWriter<W> {
     pub fn new(writer: W) -> Self {
         Self {
             inner: writer,
@@ -84,12 +96,25 @@ impl<W: std::io::Write> ChecksummedWriter<W> {
     }
 }
 
-impl<W: std::io::Write> std::io::Write for ChecksummedWriter<W> {
+#[cfg(feature = "std")]
+impl<W: crate::io::Write> std::io::Write for ChecksummedWriter<W> {
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }
 
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.hasher.update(buf);
+        self.inner.write(buf)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: crate::io::Write> crate::io::Write for ChecksummedWriter<W> {
+    fn flush(&mut self) -> crate::io::Result<()> {
+        self.inner.flush()
+    }
+
+    fn write(&mut self, buf: &[u8]) -> crate::io::Result<usize> {
         self.hasher.update(buf);
         self.inner.write(buf)
     }

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -4,7 +4,7 @@
 
 use crate::io::{Read, Write};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Trait to serialize stuff
 pub trait Encode {

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use std::io::{Read, Write};
+use crate::io::{Read, Write};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Trait to serialize stuff
 pub trait Encode {

--- a/src/compaction/drop_range.rs
+++ b/src/compaction/drop_range.rs
@@ -7,7 +7,7 @@ use crate::compaction::state::CompactionState;
 use crate::version::Version;
 use crate::{HashSet, Table};
 use crate::{KeyRange, config::Config, slice::Slice, version::run::Ranged};
-use std::ops::{Bound, RangeBounds};
+use core::ops::{Bound, RangeBounds};
 
 #[derive(Clone, Debug)]
 pub struct OwnedBounds {
@@ -38,7 +38,7 @@ impl OwnedBounds {
     /// using the given comparator for key ordering.
     #[must_use]
     pub fn contains(&self, range: &KeyRange, cmp: &dyn crate::comparator::UserComparator) -> bool {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         let lower_ok = match &self.start {
             Bound::Unbounded => true,

--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -8,7 +8,7 @@ use crate::{
     version::Version,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[doc(hidden)]
 pub const NAME: &str = "FifoCompaction";

--- a/src/compaction/fifo.rs
+++ b/src/compaction/fifo.rs
@@ -7,6 +7,8 @@ use crate::{
     HashSet, KvPair, compaction::state::CompactionState, config::Config, time::unix_timestamp,
     version::Version,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[doc(hidden)]
 pub const NAME: &str = "FifoCompaction";

--- a/src/compaction/filter.rs
+++ b/src/compaction/filter.rs
@@ -15,7 +15,7 @@ use crate::{
     vlog::{Accessor, BlobFileWriter, ValueHandle},
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::boxed::Box;
 use core::panic::RefUnwindSafe;
 
 /// Verdict returned by a [`CompactionFilter`].

--- a/src/compaction/filter.rs
+++ b/src/compaction/filter.rs
@@ -2,6 +2,7 @@
 //!
 //! Compaction filters allow users to run custom logic during compactions, e.g. custom cleanup rules such as TTL.
 //! Because compactions run in background workers, using compactions filters instead of scans can massively increase the efficiency of the storage engine.
+use crate::path::Path;
 use crate::{
     BlobIndirection, InternalValue, KvSeparationOptions, SeqNo, UserKey, UserValue, ValueType,
     coding::{Decode, Encode},
@@ -13,7 +14,9 @@ use crate::{
     version::Version,
     vlog::{Accessor, BlobFileWriter, ValueHandle},
 };
-use std::{panic::RefUnwindSafe, path::Path};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::panic::RefUnwindSafe;
 
 /// Verdict returned by a [`CompactionFilter`].
 #[non_exhaustive]

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -9,12 +9,18 @@ use crate::compaction::Input as CompactionPayload;
 use crate::compaction::worker::Options;
 use crate::range_tombstone::RangeTombstone;
 use crate::table::multi_writer::MultiWriter;
+use crate::time::Instant;
 use crate::version::{SuperVersions, Version};
 use crate::vlog::blob_file::scanner::ScanEntry;
 use crate::vlog::{BlobFileId, BlobFileMergeScanner, BlobFileWriter};
 use crate::{BlobFile, HashSet, InternalValue, Table};
-use std::iter::Peekable;
-use std::time::Instant;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::iter::Peekable;
 
 /// Drains all blobs that come "before" the given vptr.
 fn drain_blobs<I: Iterator<Item = crate::Result<(ScanEntry, BlobFileId)>>>(
@@ -339,7 +345,7 @@ pub struct RelocatingCompaction {
     /// encoded handle in `item.value`; the real payload moved here is
     /// debited at the relocation write site so KV-separated compactions
     /// are throttled by their actual bandwidth.
-    rate_limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+    rate_limiter: alloc::sync::Arc<crate::rate_limiter::RateLimiter>,
     /// Polled by the blob throttle so a long wait under a low limit stays
     /// interruptible by tree drop / shutdown.
     stop_signal: crate::stop_signal::StopSignal,
@@ -351,7 +357,7 @@ impl RelocatingCompaction {
         blob_scanner: Peekable<BlobFileMergeScanner>,
         blob_writer: BlobFileWriter,
         rewriting_blob_files: Vec<BlobFile>,
-        rate_limiter: std::sync::Arc<crate::rate_limiter::RateLimiter>,
+        rate_limiter: alloc::sync::Arc<crate::rate_limiter::RateLimiter>,
         stop_signal: crate::stop_signal::StopSignal,
     ) -> Self {
         Self {
@@ -491,7 +497,7 @@ impl CompactionFlavour for RelocatingCompaction {
             self.inner.start.elapsed(),
         );
 
-        let tables_to_delete = std::mem::take(&mut self.inner.tables_to_rewrite);
+        let tables_to_delete = core::mem::take(&mut self.inner.tables_to_rewrite);
 
         let created_tables = self.inner.consume_writer(opts, dst_lvl)?;
         // The output SSTs are already finalized; if blob finalization fails the
@@ -596,7 +602,7 @@ impl CompactionFlavour for StandardCompaction {
     ) -> crate::Result<ProducedOutput> {
         log::debug!("Compaction done in {:?}", self.start.elapsed());
 
-        let tables_to_delete = std::mem::take(&mut self.tables_to_rewrite);
+        let tables_to_delete = core::mem::take(&mut self.tables_to_rewrite);
         let created_tables = self.consume_writer(opts, dst_lvl)?;
 
         Ok(ProducedOutput {

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -15,11 +15,7 @@ use crate::vlog::blob_file::scanner::ScanEntry;
 use crate::vlog::{BlobFileId, BlobFileMergeScanner, BlobFileWriter};
 use crate::{BlobFile, HashSet, InternalValue, Table};
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::iter::Peekable;
 
 /// Drains all blobs that come "before" the given vptr.

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -169,8 +169,7 @@ mod tests {
             }
             tree.flush_active_memtable(2_000)?;
 
-            #[expect(clippy::expect_used, reason = "test asserts the tree shape")]
-            let versions = tree.version_history.read().expect("lock not poisoned");
+            let versions = tree.version_history.read();
             let binding = versions.latest_version();
             #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
             let table = binding.version.iter_tables().next().expect("one table");
@@ -301,8 +300,7 @@ mod tests {
             }
             tree.flush_active_memtable(0)?;
 
-            #[expect(clippy::expect_used, reason = "test asserts the tree shape")]
-            let versions = tree.version_history.read().expect("lock not poisoned");
+            let versions = tree.version_history.read();
             let binding = versions.latest_version();
             #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
             let table = binding.version.iter_tables().next().expect("one table");

--- a/src/compaction/leveled/mod.rs
+++ b/src/compaction/leveled/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     version::{Level, Version, run::Ranged},
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Tries to find the most optimal compaction set from one level into the other.
 ///

--- a/src/compaction/leveled/mod.rs
+++ b/src/compaction/leveled/mod.rs
@@ -21,6 +21,8 @@ use crate::{
     table::{Table, util::aggregate_run_key_range},
     version::{Level, Version, run::Ranged},
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Tries to find the most optimal compaction set from one level into the other.
 ///
@@ -433,7 +435,7 @@ impl CompactionStrategy for Strategy {
             (
                 crate::UserKey::from("leveled_level_ratio_policy"),
                 crate::UserValue::from({
-                    use byteorder::{LittleEndian, WriteBytesExt};
+                    use crate::io::{LittleEndian, WriteBytesExt};
 
                     let mut v = vec![];
 
@@ -714,7 +716,7 @@ impl CompactionStrategy for Strategy {
             .max_by(|(_, (score_a, _)), (_, (score_b, _))| {
                 score_a
                     .partial_cmp(score_b)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .unwrap_or(core::cmp::Ordering::Equal)
             })
             .expect("should have highest score somewhere");
 

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     HashSet, KvPair, TableId, compaction::state::CompactionState, config::Config, version::Version,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// The action taken during a compaction run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -44,6 +44,8 @@ pub use pulldown::Strategy as PullDown;
 use crate::{
     HashSet, KvPair, TableId, compaction::state::CompactionState, config::Config, version::Version,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// The action taken during a compaction run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/compaction/state/mod.rs
+++ b/src/compaction/state/mod.rs
@@ -26,7 +26,6 @@ impl CompactionState {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used)]
 mod tests {
     use crate::{AbstractTree, SequenceNumberCounter};
     use test_log::test;

--- a/src/compaction/state/mod.rs
+++ b/src/compaction/state/mod.rs
@@ -98,13 +98,7 @@ mod tests {
 
         assert!(tree.major_compact(u64::MAX, 4).is_err());
 
-        assert!(
-            tree.compaction_state
-                .lock()
-                .expect("lock is poisoned")
-                .hidden_set()
-                .is_empty()
-        );
+        assert!(tree.compaction_state.lock().hidden_set().is_empty());
 
         assert_eq!(table_count_before_major_compact, tree.table_count());
 

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -9,7 +9,7 @@ use crate::{InternalValue, SeqNo, UserKey, UserValue, ValueType, merge_operator:
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::iter::Peekable;
 
 type Item = crate::Result<InternalValue>;

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -6,7 +6,11 @@ use crate::active_tombstone_set::ActiveTombstoneSet;
 use crate::comparator::SharedComparator;
 use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, UserKey, UserValue, ValueType, merge_operator::MergeOperator};
-use std::{collections::VecDeque, iter::Peekable, sync::Arc};
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::iter::Peekable;
 
 type Item = crate::Result<InternalValue>;
 
@@ -206,7 +210,7 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
             self.rt_sorted = true;
         }
         while let Some(rt) = self.rt_apply.get(self.rt_idx) {
-            if comparator.compare(&rt.start, user_key) == std::cmp::Ordering::Greater {
+            if comparator.compare(&rt.start, user_key) == core::cmp::Ordering::Greater {
                 break;
             }
             // cutoff = MAX: every applicable tombstone is active; `is_suppressed`
@@ -979,7 +983,7 @@ mod tests {
 
     pub mod custom_mvcc {
         use super::*;
-        use byteorder::{BE, ReadBytesExt, WriteBytesExt};
+        use crate::io::{BE, ReadBytesExt, WriteBytesExt};
         use test_log::test;
 
         /// MVCC trailer size (anything but user key)

--- a/src/compaction/tiered/mod.rs
+++ b/src/compaction/tiered/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     version::Version,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[cfg(test)]
 mod tests;

--- a/src/compaction/tiered/mod.rs
+++ b/src/compaction/tiered/mod.rs
@@ -7,6 +7,8 @@ use crate::{
     HashSet, KvPair, TableId, compaction::state::CompactionState, config::Config, table::Table,
     version::Version,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[cfg(test)]
 mod tests;
@@ -191,7 +193,7 @@ impl CompactionStrategy for Strategy {
     }
 
     fn get_config(&self) -> Vec<KvPair> {
-        use byteorder::{LittleEndian, WriteBytesExt};
+        use crate::io::{LittleEndian, WriteBytesExt};
 
         let mut size_ratio_bytes = vec![];
         #[expect(clippy::expect_used, reason = "writing into Vec should not fail")]

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -3,6 +3,8 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use super::{CompactionAction, CompactionResult, CompactionStrategy, Input as CompactionPayload};
+use crate::time::Instant;
+use crate::tree::inner::{CompactionGuard, VersionsReadGuard};
 use crate::{
     BlobFile, Config, HashSet, InternalValue, SeqNo, SequenceNumberCounter,
     SharedSequenceNumberGenerator, Table, TableId, UserKey,
@@ -22,10 +24,14 @@ use crate::{
     version::{Run, SuperVersions, Version},
     vlog::{BlobFileMergeScanner, BlobFileScanner, BlobFileWriter},
 };
-use std::{
-    sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard},
-    time::Instant,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+// no-std: spin mirrors parking_lot's Mutex/RwLock API without an allocator.
+#[cfg(feature = "std")]
+use parking_lot::{Mutex, RwLock};
+#[cfg(not(feature = "std"))]
+use spin::{Mutex, RwLock};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
@@ -123,11 +129,9 @@ impl Options {
 ///
 /// This will block until the compactor is fully finished.
 pub fn do_compaction(opts: &Options) -> crate::Result<CompactionResult> {
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let compaction_state = opts.compaction_state.lock().expect("lock is poisoned");
+    let compaction_state = opts.compaction_state.lock();
 
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let version_history_lock = opts.version_history.read().expect("lock is poisoned");
+    let version_history_lock = opts.version_history.read();
 
     let start = Instant::now();
     log::trace!(
@@ -250,7 +254,7 @@ fn create_compaction_stream<'a>(
 fn create_bounded_compaction_stream<'a>(
     version: &'a Version,
     to_compact: &HashSet<TableId>,
-    bounds: (std::ops::Bound<UserKey>, std::ops::Bound<UserKey>),
+    bounds: (core::ops::Bound<UserKey>, core::ops::Bound<UserKey>),
     eviction_seqno: SeqNo,
     merge_operator: Option<Arc<dyn crate::merge_operator::MergeOperator>>,
     comparator: crate::comparator::SharedComparator,
@@ -333,8 +337,8 @@ fn range_tombstones_after_gc(
                 .any(|t| {
                     let kr = &t.metadata.key_range;
                     // [rt.start, rt.end) overlaps [kr.min, kr.max].
-                    cmp.compare(&rt.start, kr.max()) != std::cmp::Ordering::Greater
-                        && cmp.compare(kr.min(), &rt.end) == std::cmp::Ordering::Less
+                    cmp.compare(&rt.start, kr.max()) != core::cmp::Ordering::Greater
+                        && cmp.compare(kr.min(), &rt.end) == core::cmp::Ordering::Less
                 })
         })
         .cloned()
@@ -408,8 +412,8 @@ fn subcompaction_boundaries(
 #[cfg(feature = "std")]
 fn ranges_from_boundaries(
     boundaries: &[UserKey],
-) -> Vec<(std::ops::Bound<UserKey>, std::ops::Bound<UserKey>)> {
-    use std::ops::Bound::{Excluded, Included, Unbounded};
+) -> Vec<(core::ops::Bound<UserKey>, core::ops::Bound<UserKey>)> {
+    use core::ops::Bound::{Excluded, Included, Unbounded};
     let mut ranges = Vec::with_capacity(boundaries.len() + 1);
     let mut lo = Unbounded;
     for b in boundaries {
@@ -425,8 +429,8 @@ fn ranges_from_boundaries(
 /// of committing a truncated sub-range.
 #[cfg(feature = "std")]
 fn cancelled_compaction() -> crate::Error {
-    crate::Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Interrupted,
+    crate::Error::from(crate::io::Error::new(
+        crate::io::ErrorKind::Interrupted,
         "sub-compaction cancelled by stop signal",
     ))
 }
@@ -452,7 +456,7 @@ fn run_subcompaction(
     version: &Version,
     tables_for_deletion: Vec<Table>,
     input_range_tombstones: &[crate::range_tombstone::RangeTombstone],
-    bounds: (std::ops::Bound<UserKey>, std::ops::Bound<UserKey>),
+    bounds: (core::ops::Bound<UserKey>, core::ops::Bound<UserKey>),
     dst_lvl: usize,
     is_last_level: bool,
     blobs_folder: &std::path::Path,
@@ -487,7 +491,7 @@ fn run_subcompaction(
         // the source tables (this range may own input deletion) while producing
         // no replacement SSTs. Returning an error makes the parallel caller
         // re-show the inputs and skip the install entirely.
-        return Err(crate::Error::Io(std::io::Error::other(
+        return Err(crate::Error::from(crate::io::Error::other(
             "sub-compaction input tables disappeared mid-flight",
         )));
     };
@@ -618,12 +622,11 @@ fn run_subcompaction(
     reason = "version_history_lock must be held across upgrade_version and maintenance"
 )]
 fn move_tables(
-    compaction_state: &MutexGuard<'_, CompactionState>,
+    compaction_state: &CompactionGuard<'_>,
     opts: &Options,
     payload: &CompactionPayload,
 ) -> crate::Result<CompactionResult> {
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let mut version_history_lock = opts.version_history.write().expect("lock is poisoned");
+    let mut version_history_lock = opts.version_history.write();
 
     // Fail-safe for buggy compaction strategies
     if compaction_state
@@ -766,8 +769,7 @@ fn hidden_guard<T>(
         log::error!("Compaction failed: {e:?}");
 
         // IMPORTANT: We need to show tables again on error
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut compaction_state = opts.compaction_state.lock().expect("lock is poisoned");
+        let mut compaction_state = opts.compaction_state.lock();
 
         compaction_state
             .hidden_set_mut()
@@ -777,8 +779,8 @@ fn hidden_guard<T>(
 
 #[expect(clippy::too_many_lines)]
 fn merge_tables(
-    mut compaction_state: MutexGuard<'_, CompactionState>,
-    version_history_lock: RwLockReadGuard<'_, SuperVersions>,
+    mut compaction_state: CompactionGuard<'_>,
+    version_history_lock: VersionsReadGuard<'_>,
     opts: &Options,
     payload: &CompactionPayload,
 ) -> crate::Result<CompactionResult> {
@@ -939,7 +941,7 @@ fn merge_tables(
                             slot.unwrap_or_else(|| {
                                 // A worker panicked before sending: treat as a
                                 // failed sub-compaction so install is skipped.
-                                Err(crate::Error::Io(std::io::Error::other(
+                                Err(crate::Error::from(crate::io::Error::other(
                                     "sub-compaction worker did not report a result",
                                 )))
                             })
@@ -991,8 +993,7 @@ fn merge_tables(
                     done.rollback_uninstalled();
                 }
                 {
-                    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-                    let mut state = opts.compaction_state.lock().expect("lock is poisoned");
+                    let mut state = opts.compaction_state.lock();
                     state
                         .hidden_set_mut()
                         .show(payload.table_ids.iter().copied());
@@ -1002,10 +1003,8 @@ fn merge_tables(
             let outputs = committed;
 
             // Re-acquire locks and install one atomic version edit for all outputs.
-            #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-            let mut compaction_state = opts.compaction_state.lock().expect("lock is poisoned");
-            #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-            let mut version_history_lock = opts.version_history.write().expect("lock is poisoned");
+            let mut compaction_state = opts.compaction_state.lock();
+            let mut version_history_lock = opts.version_history.write();
 
             let tables_out =
                 super::flavour::install_merge(&mut version_history_lock, opts, payload, outputs)
@@ -1140,7 +1139,7 @@ fn merge_tables(
                 let scanner = BlobFileMergeScanner::new(
                     blob_files_to_rewrite
                         .iter()
-                        .map(|bf| BlobFileScanner::new(&bf.0.path, bf.id()))
+                        .map(|bf| BlobFileScanner::new(&bf.0.path, &*bf.0.fs, bf.id()))
                         .collect::<crate::Result<Vec<_>>>()?,
                 );
 
@@ -1265,12 +1264,10 @@ fn merge_tables(
         filter.finish();
     }
 
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let mut compaction_state = opts.compaction_state.lock().expect("lock is poisoned");
+    let mut compaction_state = opts.compaction_state.lock();
 
     log::trace!("Acquiring super version write lock");
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let mut version_history_lock = opts.version_history.write().expect("lock is poisoned");
+    let mut version_history_lock = opts.version_history.write();
     log::trace!("Acquired super version write lock");
 
     log::trace!("Blob fragmentation diff: {blob_frag_map:#?}");
@@ -1355,12 +1352,11 @@ fn merge_tables(
 }
 
 fn drop_tables(
-    compaction_state: MutexGuard<'_, CompactionState>,
+    compaction_state: CompactionGuard<'_>,
     opts: &Options,
     ids_to_drop: &[TableId],
 ) -> crate::Result<CompactionResult> {
-    #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-    let mut version_history_lock = opts.version_history.write().expect("lock is poisoned");
+    let mut version_history_lock = opts.version_history.write();
 
     // Fail-safe for buggy compaction strategies
     if compaction_state
@@ -1474,7 +1470,7 @@ mod tests {
             "test-first-byte"
         }
 
-        fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+        fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
             a.first().cmp(&b.first())
         }
     }
@@ -1512,7 +1508,7 @@ mod tests {
     #[cfg(feature = "parallel")]
     #[test]
     fn failed_subcompaction_rolls_back_and_restores_inputs() -> crate::Result<()> {
-        use std::sync::atomic::Ordering;
+        use core::sync::atomic::Ordering;
 
         const N: u64 = 4_000;
         let key = |i: u64| format!("key_{i:08}");

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 // no-std: spin mirrors parking_lot's Mutex/RwLock API without an allocator.
 #[cfg(feature = "std")]
 use parking_lot::{Mutex, RwLock};

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use std::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use alloc::sync::Arc;
 
 /// Trait for custom user key comparison.
 ///
@@ -37,7 +39,7 @@ use std::sync::Arc;
 ///
 /// ```
 /// use lsm_tree::UserComparator;
-/// use std::cmp::Ordering;
+/// use core::cmp::Ordering;
 ///
 /// /// Comparator that orders u64 keys stored as big-endian bytes.
 /// struct U64Comparator;
@@ -61,7 +63,7 @@ use std::sync::Arc;
 ///     }
 /// }
 /// ```
-pub trait UserComparator: Send + Sync + std::panic::RefUnwindSafe + 'static {
+pub trait UserComparator: Send + Sync + core::panic::RefUnwindSafe + 'static {
     /// Returns a stable identifier for this comparator.
     ///
     /// The name is persisted when a tree is first created. On subsequent
@@ -78,7 +80,7 @@ pub trait UserComparator: Send + Sync + std::panic::RefUnwindSafe + 'static {
     fn name(&self) -> &'static str;
 
     /// Compares two user keys, returning their ordering.
-    fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering;
+    fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering;
 
     /// Returns `true` if this comparator is lexicographic byte ordering.
     ///
@@ -103,7 +105,7 @@ impl UserComparator for DefaultUserComparator {
     }
 
     #[inline]
-    fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+    fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         a.cmp(b)
     }
 
@@ -129,7 +131,7 @@ impl<T: UserComparator + ?Sized> UserComparator for Arc<T> {
         (**self).name()
     }
     #[inline]
-    fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+    fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         (**self).compare(a, b)
     }
     #[inline]
@@ -148,10 +150,13 @@ pub const MAX_COMPARATOR_NAME_BYTES: usize = 256;
 /// Uses a shared static instance to avoid repeated allocations.
 #[must_use]
 pub fn default_comparator() -> SharedComparator {
-    // LazyLock creates the Arc once; subsequent calls just clone the Arc (ref-count bump).
-    static DEFAULT: std::sync::LazyLock<SharedComparator> =
-        std::sync::LazyLock::new(|| Arc::new(DefaultUserComparator));
-    DEFAULT.clone()
+    // OnceBox builds the Arc once; subsequent calls just clone it (ref-count
+    // bump). `once_cell::race::OnceBox` is lock-free (atomic pointer) and
+    // no_std + alloc, so this path is identical under std and no_std.
+    static DEFAULT: once_cell::race::OnceBox<SharedComparator> = once_cell::race::OnceBox::new();
+    DEFAULT
+        .get_or_init(|| Box::new(Arc::new(DefaultUserComparator)))
+        .clone()
 }
 
 #[cfg(test)]

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -6,11 +6,10 @@
 mod zstd_backend;
 
 use crate::coding::{Decode, Encode};
-use byteorder::{ReadBytesExt, WriteBytesExt};
-use std::io::{Read, Write};
+use crate::io::{Read, ReadBytesExt, Write, WriteBytesExt};
 
 #[cfg(zstd_any)]
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[cfg(feature = "zstd")]
 use once_cell::race::OnceBox;
@@ -212,7 +211,7 @@ impl ZstdDictionary {
             .get_or_try_init(|| -> crate::Result<Box<DictionaryHandle>> {
                 let handle = if self.raw.starts_with(&DICT_MAGIC) {
                     DictionaryHandle::decode_dict(&self.raw)
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+                        .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?
                 } else {
                     #[expect(
                         clippy::cast_possible_truncation,
@@ -220,7 +219,7 @@ impl ZstdDictionary {
                     )]
                     let raw_content_id = (self.id as u32).max(1);
                     let dict = Dictionary::from_raw_content(raw_content_id, self.raw.to_vec())
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                        .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
                     DictionaryHandle::from_dictionary(dict)
                 };
                 Ok(Box::new(handle))
@@ -266,8 +265,8 @@ impl ZstdDictionary {
 }
 
 #[cfg(zstd_any)]
-impl std::fmt::Debug for ZstdDictionary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ZstdDictionary {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ZstdDictionary")
             .field("id", &format_args!("{:#018x}", self.id))
             .field("size", &self.raw.len())
@@ -362,7 +361,7 @@ impl CompressionType {
         if !(1..=22).contains(&level) {
             // NOTE: Uses Error::other (not ErrorKind::InvalidInput) to match
             // upstream's error style and minimize fork divergence.
-            return Err(crate::Error::Io(std::io::Error::other(format!(
+            return Err(crate::Error::Io(crate::io::Error::other(format!(
                 "invalid zstd compression level {level}, expected 1..=22"
             ))));
         }
@@ -399,8 +398,8 @@ impl CompressionType {
     }
 }
 
-impl std::fmt::Display for CompressionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for CompressionType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}",
@@ -460,7 +459,7 @@ impl Encode for CompressionType {
                     reason = "level range 1..=22 fits i8"
                 )]
                 writer.write_i8(*level as i8)?;
-                byteorder::WriteBytesExt::write_u32::<byteorder::LittleEndian>(writer, *dict_id)?;
+                crate::io::WriteBytesExt::write_u32::<crate::io::LittleEndian>(writer, *dict_id)?;
             }
         }
 
@@ -490,7 +489,7 @@ impl Decode for CompressionType {
             4 => {
                 let level = i32::from(reader.read_i8()?);
                 Self::validate_zstd_level(level)?;
-                let dict_id = byteorder::ReadBytesExt::read_u32::<byteorder::LittleEndian>(reader)?;
+                let dict_id = crate::io::ReadBytesExt::read_u32::<crate::io::LittleEndian>(reader)?;
                 Ok(Self::ZstdDict { level, dict_id })
             }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -43,7 +43,7 @@ fn bounded_read(reader: &mut impl Read, capacity: usize) -> crate::Result<Vec<u8
         match reader.read(dest) {
             Ok(0) => break,
             Ok(n) => filled += n,
-            Err(e) => return Err(crate::Error::Io(e)),
+            Err(e) => return Err(crate::Error::from(e)),
         }
     }
 
@@ -58,7 +58,7 @@ fn bounded_read(reader: &mut impl Read, capacity: usize) -> crate::Result<Vec<u8
                 limit: capacity as u64,
             });
         }
-        Err(e) => return Err(crate::Error::Io(e)),
+        Err(e) => return Err(crate::Error::from(e)),
     }
 
     output.truncate(filled);
@@ -106,7 +106,7 @@ fn decode_raw_content_bounded(
                     &mut *cursor,
                     BlockDecodingStrategy::UptoBytes(remaining.max(1)),
                 )
-                .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
         }
 
         // Drain collectible bytes from the decoder's internal buffer.
@@ -138,7 +138,7 @@ fn decode_raw_content_bounded(
             // `read_exact` ensures all `can` bytes are drained in one call.
             // `Read::read` may do short reads, which would leave zero-filled
             // slack and corrupt capacity accounting on the next iteration.
-            decoder.read_exact(dest).map_err(crate::Error::Io)?;
+            decoder.read_exact(dest).map_err(crate::Error::from)?;
         }
 
         if decoder.is_finished() && decoder.can_collect() == 0 {
@@ -215,7 +215,7 @@ fn do_decompress_with_dict(
                     dict_id: raw_content_id,
                 })
             } else {
-                crate::Error::Io(std::io::Error::other(e))
+                crate::Error::Io(crate::io::Error::other(e.to_string()))
             }
         })?;
 
@@ -236,7 +236,7 @@ fn do_decompress_with_dict(
         // reusing the cached xxh3 fingerprint without re-hashing dict_raw.
         decoder
             .force_dict(raw_content_id)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
 
         decode_raw_content_bounded(decoder, &mut cursor, capacity)
     } else {
@@ -258,7 +258,7 @@ fn do_decompress_with_dict(
                     limit: capacity as u64,
                 }
             } else {
-                crate::Error::Io(std::io::Error::other(e))
+                crate::Error::Io(crate::io::Error::other(e.to_string()))
             }
         })?;
         // `decode_all_to_vec` returns `TargetTooSmall` if the frame would exceed
@@ -364,7 +364,7 @@ impl CompressionProvider for ZstdProvider {
 
     fn decompress(data: &[u8], capacity: usize) -> crate::Result<Vec<u8>> {
         let mut decoder = structured_zstd::decoding::StreamingDecoder::new(data)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
         bounded_read(&mut decoder, capacity)
     }
 
@@ -456,7 +456,7 @@ impl CompressionProvider for ZstdProvider {
                     // dictionary parsing dominates the miss-path cost.
                     compressor
                         .set_dictionary_from_bytes(dict_raw)
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                        .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
                 } else {
                     // Raw-content dict (no magic header): there is no serialized
                     // dictionary blob to parse for encoding, so wrap the
@@ -471,10 +471,10 @@ impl CompressionProvider for ZstdProvider {
                         h.max(1) // id=0 is rejected by the attach path; internal use only
                     };
                     let dictionary = Dictionary::from_raw_content(id, dict_raw.to_vec())
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                        .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
                     compressor
                         .set_encoder_dictionary(EncoderDictionary::from_dictionary(dictionary))
-                        .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                        .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
                 }
                 *state = Some((dict_key, level, compressor));
             }
@@ -584,7 +584,7 @@ impl CompressionProvider for ZstdProvider {
                 let mut decoder = FrameDecoder::new();
                 decoder
                     .add_dict_handle(handle)
-                    .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+                    .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
                 *state = Some((dict.id64(), decoder));
             }
 

--- a/src/config/block_size.rs
+++ b/src/config/block_size.rs
@@ -2,11 +2,14 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Block size policy
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BlockSizePolicy(Vec<u32>);
 
-impl std::ops::Deref for BlockSizePolicy {
+impl core::ops::Deref for BlockSizePolicy {
     type Target = [u32];
 
     fn deref(&self) -> &Self::Target {

--- a/src/config/compression.rs
+++ b/src/config/compression.rs
@@ -3,12 +3,14 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::CompressionType;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Compression policy
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CompressionPolicy(Vec<CompressionType>);
 
-impl std::ops::Deref for CompressionPolicy {
+impl core::ops::Deref for CompressionPolicy {
     type Target = [CompressionType];
 
     fn deref(&self) -> &Self::Target {

--- a/src/config/compression.rs
+++ b/src/config/compression.rs
@@ -4,7 +4,7 @@
 
 use crate::CompressionType;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Compression policy
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/config/filter.rs
+++ b/src/config/filter.rs
@@ -2,6 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 pub use crate::table::filter::BloomConstructionPolicy;
 
 /// Filter policy entry
@@ -20,7 +23,7 @@ pub enum FilterPolicyEntry {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FilterPolicy(Vec<FilterPolicyEntry>);
 
-impl std::ops::Deref for FilterPolicy {
+impl core::ops::Deref for FilterPolicy {
     type Target = [FilterPolicyEntry];
 
     fn deref(&self) -> &Self::Target {

--- a/src/config/hash_ratio.rs
+++ b/src/config/hash_ratio.rs
@@ -2,11 +2,14 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Hash ratio policy
 #[derive(Debug, Clone, PartialEq)]
 pub struct HashRatioPolicy(Vec<f32>);
 
-impl std::ops::Deref for HashRatioPolicy {
+impl core::ops::Deref for HashRatioPolicy {
     type Target = [f32];
 
     fn deref(&self) -> &Self::Target {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,23 +21,26 @@ pub type PartitioningPolicy = PinningPolicy;
 
 #[cfg(feature = "std")]
 use crate::fs::StdFs;
-use crate::path::{Path, PathBuf};
+use crate::path::PathBuf;
 use crate::{
-    AnyTree, BlobTree, Cache, CompressionType, DescriptorTable, SequenceNumberCounter,
-    SharedSequenceNumberGenerator, Tree,
+    AnyTree, BlobTree, Cache, CompressionType, DescriptorTable, SharedSequenceNumberGenerator,
+    Tree,
     compaction::filter::Factory,
-    comparator::{self, SharedComparator},
+    comparator::SharedComparator,
     encryption::EncryptionProvider,
     file::TABLES_FOLDER,
     fs::{Fs, SyncMode},
     merge_operator::MergeOperator,
     path::absolute_path,
     prefix::PrefixExtractor,
-    version::DEFAULT_LEVEL_COUNT,
 };
+// std-only: used solely by the std-gated `Config::default` / `Config::new`
+// constructors (the no_std path builds `Config` field-by-field).
+#[cfg(feature = "std")]
+use crate::{SequenceNumberCounter, comparator, path::Path, version::DEFAULT_LEVEL_COUNT};
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::Range;
 
 /// Per-level filesystem routing entry for tiered storage.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,6 +19,9 @@ pub use restart_interval::RestartIntervalPolicy;
 /// Partitioning policy for indexes and filters
 pub type PartitioningPolicy = PinningPolicy;
 
+#[cfg(feature = "std")]
+use crate::fs::StdFs;
+use crate::path::{Path, PathBuf};
 use crate::{
     AnyTree, BlobTree, Cache, CompressionType, DescriptorTable, SequenceNumberCounter,
     SharedSequenceNumberGenerator, Tree,
@@ -26,17 +29,16 @@ use crate::{
     comparator::{self, SharedComparator},
     encryption::EncryptionProvider,
     file::TABLES_FOLDER,
-    fs::{Fs, StdFs, SyncMode},
+    fs::{Fs, SyncMode},
     merge_operator::MergeOperator,
     path::absolute_path,
     prefix::PrefixExtractor,
     version::DEFAULT_LEVEL_COUNT,
 };
-use std::{
-    ops::Range,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::Range;
 
 /// Per-level filesystem routing entry for tiered storage.
 ///
@@ -76,8 +78,8 @@ pub struct LevelRoute {
     pub fs: Arc<dyn Fs>,
 }
 
-impl std::fmt::Debug for LevelRoute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LevelRoute {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("LevelRoute")
             .field("levels", &self.levels)
             .field("path", &self.path)
@@ -245,7 +247,7 @@ pub struct KvSeparationOptions {
     /// The `dict_id` in the compression type must match [`ZstdDictionary::id`](crate::ZstdDictionary::id).
     #[cfg(zstd_any)]
     #[doc(hidden)]
-    pub zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+    pub zstd_dictionary: Option<alloc::sync::Arc<crate::compression::ZstdDictionary>>,
 }
 
 impl Default for KvSeparationOptions {
@@ -335,7 +337,10 @@ impl KvSeparationOptions {
     /// they disagree.
     #[cfg(zstd_any)]
     #[must_use]
-    pub fn dict(mut self, dictionary: std::sync::Arc<crate::compression::ZstdDictionary>) -> Self {
+    pub fn dict(
+        mut self,
+        dictionary: alloc::sync::Arc<crate::compression::ZstdDictionary>,
+    ) -> Self {
         self.zstd_dictionary = Some(dictionary);
         self
     }
@@ -569,7 +574,7 @@ pub struct Config {
     /// rollback paths (sibling output rollback, input restore) can be exercised
     /// deterministically. Behind `cfg(test)`, never compiled into release builds.
     #[cfg(all(test, feature = "std"))]
-    pub(crate) fail_one_subcompaction: Arc<std::sync::atomic::AtomicBool>,
+    pub(crate) fail_one_subcompaction: Arc<core::sync::atomic::AtomicBool>,
 
     /// Pre-trained zstd dictionary for dictionary compression.
     ///
@@ -594,6 +599,10 @@ pub struct Config {
 }
 
 // TODO: remove default?
+// std-only: the default backend is `StdFs` and the default path is resolved
+// via std::path::absolute. no_std callers construct `Config` explicitly with a
+// caller-provided `Fs`.
+#[cfg(feature = "std")]
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -691,13 +700,17 @@ impl Default for Config {
             #[cfg(feature = "std")]
             subcompaction_min_bytes: crate::compaction::worker::SUBCOMPACTION_MIN_INPUT_BYTES,
             #[cfg(all(test, feature = "std"))]
-            fail_one_subcompaction: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            fail_one_subcompaction: Arc::new(core::sync::atomic::AtomicBool::new(false)),
         }
     }
 }
 
 impl Config {
     /// Initializes a new config
+    // std-only: seeds the remaining fields from `Config::default`, whose
+    // default `Fs` is `StdFs`. no_std callers build `Config` field-by-field
+    // with a caller-provided `Fs`.
+    #[cfg(feature = "std")]
     pub fn new<P: AsRef<Path>>(
         path: P,
         seqno: SequenceNumberCounter,
@@ -852,6 +865,8 @@ impl Config {
     /// This is useful when the caller already has
     /// [`SharedSequenceNumberGenerator`] instances (e.g., from a higher-level
     /// database that shares generators across multiple trees).
+    // std-only: see [`Config::new`] — seeds via `Config::default` (`StdFs`).
+    #[cfg(feature = "std")]
     pub fn new_with_generators<P: AsRef<Path>>(
         path: P,
         seqno: SharedSequenceNumberGenerator,
@@ -870,7 +885,7 @@ impl Config {
 mod tests {
     use super::*;
     use crate::{CompressionType, SequenceNumberCounter, compression::ZstdDictionary};
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     #[test]
     fn blob_zstd_dict_no_dict_is_rejected() {

--- a/src/config/pinning.rs
+++ b/src/config/pinning.rs
@@ -2,11 +2,14 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Pinning policy
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PinningPolicy(Vec<bool>);
 
-impl std::ops::Deref for PinningPolicy {
+impl core::ops::Deref for PinningPolicy {
     type Target = [bool];
 
     fn deref(&self) -> &Self::Target {

--- a/src/config/restart_interval.rs
+++ b/src/config/restart_interval.rs
@@ -2,11 +2,14 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Restart interval policy
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RestartIntervalPolicy(Vec<u8>);
 
-impl std::ops::Deref for RestartIntervalPolicy {
+impl core::ops::Deref for RestartIntervalPolicy {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -39,7 +39,7 @@
 use crate::fs::Fs;
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::path::PathBuf;

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -38,9 +38,12 @@
 // `Fs::remove_file(&Path)` anyway.
 use crate::fs::Fs;
 use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::sync::atomic::{AtomicU32, Ordering};
+
+use crate::path::PathBuf;
 use spin::Mutex;
-use std::path::PathBuf;
 
 /// Shared state controlling whether file deletions are deferred.
 ///

--- a/src/descriptor_table.rs
+++ b/src/descriptor_table.rs
@@ -3,15 +3,16 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::sharded_cache::{ShardedCache, UnitWeighter};
+use alloc::sync::Arc;
+
 use crate::{GlobalTableId, fs::FsFile};
-use std::sync::Arc;
 
 const TAG_BLOCK: u8 = 0;
 const TAG_BLOB: u8 = 1;
 
 type Item = Arc<dyn FsFile>;
 
-#[derive(Clone, Copy, Eq, std::hash::Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, core::hash::Hash, PartialEq)]
 struct CacheKey(u8, u64, u64);
 
 /// Number of shards in the FD cache. Smaller than the block cache: the FD cache

--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -27,8 +27,8 @@
 
 use std::io::Cursor;
 
+use crate::io::{BigEndian, ReadBytesExt};
 use aes_gcm::aead::Generate;
-use byteorder::{BigEndian, ReadBytesExt};
 use structured_zstd::skippable::SkippableFrame;
 
 use super::aad::{AAD_LEN, BlockIdentity, EncryptionContext, FORMAT_VERSION_V1, SuiteId, build};

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -66,6 +66,9 @@ pub mod block;
 pub mod error;
 pub mod key_chain;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 // Top-level re-exports so callers can spell `crate::encryption::
 // encrypt_block` / `decrypt_block` / `DecryptedBlock` /
 // `KeyChain` / `DecryptError` directly, instead of paging
@@ -95,7 +98,7 @@ pub use key_chain::StaticKeyChain;
 ///   sequence returned by `encrypt` and recover the original plaintext.
 /// - Both methods must be safe to call concurrently from multiple threads.
 pub trait EncryptionProvider:
-    Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe
+    Send + Sync + core::panic::UnwindSafe + core::panic::RefUnwindSafe
 {
     /// Encrypt `plaintext`, returning an opaque ciphertext blob.
     ///
@@ -309,29 +312,45 @@ fn new_chacha_rng() -> rand_chacha::ChaCha20Rng {
     rand_chacha::ChaCha20Rng::from_seed(seed)
 }
 
+/// Current process id for fork detection. Under `std` this is the real PID;
+/// under `no_std` there is no process/fork concept, so it is a constant — the
+/// PID never "changes", the reseed branch never fires, and the RNG behaves as
+/// a plain thread-local CSPRNG.
+#[cfg(feature = "encryption")]
+fn process_pid() -> u32 {
+    #[cfg(feature = "std")]
+    {
+        std::process::id()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        0
+    }
+}
+
 /// Thread-local CSPRNG wrapper with fork-aware PID tracking.
 ///
-/// On each access, compares the stored PID with `std::process::id()`.
-/// If they differ (i.e. the process was forked), the RNG is reseeded
-/// from the OS RNG to avoid nonce reuse across processes.
+/// On each access, compares the stored PID with [`process_pid`]. If they
+/// differ (i.e. the process was forked), the RNG is reseeded from the OS RNG
+/// to avoid nonce reuse across processes.
 #[cfg(feature = "encryption")]
 struct ForkAwareRng {
-    pid: std::cell::Cell<u32>,
-    rng: std::cell::RefCell<rand_chacha::ChaCha20Rng>,
+    pid: core::cell::Cell<u32>,
+    rng: core::cell::RefCell<rand_chacha::ChaCha20Rng>,
 }
 
 #[cfg(feature = "encryption")]
 impl ForkAwareRng {
     fn new() -> Self {
         Self {
-            pid: std::cell::Cell::new(std::process::id()),
-            rng: std::cell::RefCell::new(new_chacha_rng()),
+            pid: core::cell::Cell::new(process_pid()),
+            rng: core::cell::RefCell::new(new_chacha_rng()),
         }
     }
 
     fn with_rng<R>(&self, f: impl FnOnce(&mut rand_chacha::ChaCha20Rng) -> R) -> R {
         let mut rng_ref = self.rng.borrow_mut();
-        let current_pid = std::process::id();
+        let current_pid = process_pid();
         if self.pid.get() != current_pid {
             // Process was forked; reseed RNG to avoid nonce reuse across PIDs.
             self.pid.set(current_pid);
@@ -589,8 +608,8 @@ mod tests {
     /// exercising the default `encrypt_vec/decrypt_vec` implementations.
     struct XorProvider;
 
-    impl std::panic::UnwindSafe for XorProvider {}
-    impl std::panic::RefUnwindSafe for XorProvider {}
+    impl core::panic::UnwindSafe for XorProvider {}
+    impl core::panic::RefUnwindSafe for XorProvider {}
 
     impl EncryptionProvider for XorProvider {
         fn encrypt(&self, plaintext: &[u8]) -> crate::Result<Vec<u8>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 
 use crate::{Checksum, CompressionType};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::string::String;
 
 /// Represents errors that can occur in the LSM-tree
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,13 +3,15 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::{Checksum, CompressionType};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Represents errors that can occur in the LSM-tree
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// I/O error
-    Io(std::io::Error),
+    Io(crate::io::Error),
 
     /// Decompression failed
     Decompress(CompressionType),
@@ -61,7 +63,7 @@ pub enum Error {
     },
 
     /// UTF-8 error
-    Utf8(std::str::Utf8Error),
+    Utf8(core::str::Utf8Error),
 
     /// Merge operator failed.
     ///
@@ -309,14 +311,14 @@ pub enum Error {
     },
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "LsmTreeError: {self:?}")
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Io(e) => Some(e),
             _ => None,
@@ -351,11 +353,21 @@ impl From<crate::sfa::Error> for Error {
     }
 }
 
-impl From<std::io::Error> for Error {
-    fn from(value: std::io::Error) -> Self {
+// The `Io` variant carries `crate::io::Error` (the no_std-capable I/O error),
+// so this bridge is a direct wrap. Std file-I/O paths surface `std::io::Error`;
+// the std-gated bridge below folds those through `crate::io::Error`.
+impl From<crate::io::Error> for Error {
+    fn from(value: crate::io::Error) -> Self {
         Self::Io(value)
     }
 }
 
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value.into())
+    }
+}
+
 /// Tree result
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,11 +2,15 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use crate::io::Write;
+use crate::path::Path;
 use crate::{
     Slice,
     fs::{Fs, FsFile, SyncMode},
 };
-use std::{io::Write, path::Path};
+#[cfg(feature = "std")]
+use std::io::Write;
 
 // The trailing byte is bumped on every wire-format break of the block
 // header. Pre-V5 readers see `4` and reject the header immediately
@@ -24,7 +28,7 @@ pub const CURRENT_VERSION_FILE: &str = "current";
 ///
 /// Uses [`FsFile::read_at`] (equivalent to `pread(2)`) so multiple threads
 /// can call this concurrently on the same file handle.
-pub fn read_exact(file: &dyn FsFile, offset: u64, size: usize) -> std::io::Result<Slice> {
+pub fn read_exact(file: &dyn FsFile, offset: u64, size: usize) -> crate::io::Result<Slice> {
     // SAFETY: This slice builder starts uninitialized, but we know its length
     //
     // We use FsFile::read_at which gives us the number of bytes read.
@@ -41,8 +45,8 @@ pub fn read_exact(file: &dyn FsFile, offset: u64, size: usize) -> std::io::Resul
     let bytes_read = file.read_at(&mut builder, offset)?;
 
     if bytes_read != size {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
+        return Err(crate::io::Error::new(
+            crate::io::ErrorKind::UnexpectedEof,
             format!(
                 "read_exact({bytes_read}) at {offset} did not read enough bytes {size}; file has length {}",
                 file.metadata()?.len
@@ -62,9 +66,10 @@ pub fn rewrite_atomic(
     content: &[u8],
     fs: &dyn Fs,
     mode: SyncMode,
-) -> std::io::Result<()> {
+) -> crate::io::Result<()> {
     use crate::fs::FsOpenOptions;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use core::sync::atomic::Ordering;
+    use portable_atomic::AtomicU64;
 
     static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -74,7 +79,12 @@ pub fn rewrite_atomic(
     )]
     let folder = path.parent().expect("should have a parent");
 
+    // no-std: no process model — a fixed id is fine, the seq counter
+    // disambiguates temp names within a process.
+    #[cfg(feature = "std")]
     let pid = std::process::id();
+    #[cfg(not(feature = "std"))]
+    let pid = 0u32;
 
     // Retry with incrementing seq on AlreadyExists — handles leftover temp
     // files from a previous crash (PID can be reused, especially in containers).
@@ -88,7 +98,8 @@ pub fn rewrite_atomic(
             Ok(mut file) => {
                 let write_result = file
                     .write_all(content)
-                    .and_then(|()| file.flush())
+                    .map_err(crate::io::Error::from)
+                    .and_then(|()| file.flush().map_err(crate::io::Error::from))
                     .and_then(|()| FsFile::sync_all_with(&*file, mode));
                 if let Err(e) = write_result {
                     drop(file);
@@ -98,7 +109,7 @@ pub fn rewrite_atomic(
                 break candidate;
             }
             // Leftover temp file from a previous crash — retry with next seq.
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) if e.kind() == crate::io::ErrorKind::AlreadyExists => {}
             Err(e) => return Err(e),
         }
     };
@@ -119,7 +130,7 @@ pub fn rewrite_atomic(
 /// On Windows, `StdFs::sync_directory` already returns `Ok(())` (directory
 /// fsync is unsupported), but non-`StdFs` backends (e.g., `MemFs`) may use
 /// this call for path validation. Always delegate rather than short-circuiting.
-pub fn fsync_directory(path: &Path, fs: &dyn Fs, mode: SyncMode) -> std::io::Result<()> {
+pub fn fsync_directory(path: &Path, fs: &dyn Fs, mode: SyncMode) -> crate::io::Result<()> {
     fs.sync_directory_with(path, mode)
 }
 
@@ -149,7 +160,7 @@ mod tests {
         let file = File::open(&path)?;
         // Request 10 bytes from a 5-byte file → short read → UnexpectedEof
         let err = read_exact(&file, 0, 10).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert_eq!(err.kind(), crate::io::ErrorKind::UnexpectedEof);
 
         Ok(())
     }

--- a/src/file_accessor.rs
+++ b/src/file_accessor.rs
@@ -4,9 +4,10 @@
 
 use crate::GlobalTableId;
 use crate::descriptor_table::DescriptorTable;
+use alloc::sync::Arc;
+
 use crate::fs::{Fs, FsFile, FsOpenOptions};
-use std::path::Path;
-use std::sync::Arc;
+use crate::path::Path;
 
 /// Allows accessing a file (either cached or pinned)
 #[derive(Clone)]
@@ -49,7 +50,7 @@ impl FileAccessor {
         &self,
         table_id: &GlobalTableId,
         path: &Path,
-    ) -> std::io::Result<(Arc<dyn FsFile>, Option<bool>)> {
+    ) -> crate::io::Result<(Arc<dyn FsFile>, Option<bool>)> {
         match self {
             Self::File(fd) => Ok((fd.clone(), None)),
             Self::DescriptorTable { table, fs } => {
@@ -61,7 +62,7 @@ impl FileAccessor {
                 table.insert_for_table(*table_id, fd.clone());
                 Ok((fd, Some(false)))
             }
-            Self::Closed => Err(std::io::Error::other("file accessor closed")),
+            Self::Closed => Err(crate::io::Error::other("file accessor closed")),
         }
     }
 
@@ -73,7 +74,7 @@ impl FileAccessor {
         &self,
         table_id: &GlobalTableId,
         path: &Path,
-    ) -> std::io::Result<(Arc<dyn FsFile>, Option<bool>)> {
+    ) -> crate::io::Result<(Arc<dyn FsFile>, Option<bool>)> {
         match self {
             Self::File(fd) => Ok((fd.clone(), None)),
             Self::DescriptorTable { table, fs } => {
@@ -85,7 +86,7 @@ impl FileAccessor {
                 table.insert_for_blob_file(*table_id, fd.clone());
                 Ok((fd, Some(false)))
             }
-            Self::Closed => Err(std::io::Error::other("file accessor closed")),
+            Self::Closed => Err(crate::io::Error::other("file accessor closed")),
         }
     }
 
@@ -115,8 +116,8 @@ impl FileAccessor {
     }
 }
 
-impl std::fmt::Debug for FileAccessor {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for FileAccessor {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             Self::File(_) => write!(f, "FileAccessor::Pinned"),
             Self::DescriptorTable { .. } => {

--- a/src/format_version.rs
+++ b/src/format_version.rs
@@ -100,8 +100,8 @@ pub enum FormatVersion {
     V5,
 }
 
-impl std::fmt::Display for FormatVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for FormatVersion {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", u8::from(*self))
     }
 }

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -1163,7 +1163,8 @@ mod tests {
 
         match fs.sync_directory(&path) {
             Ok(()) => panic!("sync_directory on a file should fail"),
-            Err(err) => assert_eq!(err.kind(), io::ErrorKind::InvalidInput),
+            // sync_directory is an `Fs` method → returns `crate::io::Result`.
+            Err(err) => assert_eq!(err.kind(), crate::io::ErrorKind::InvalidInput),
         }
 
         Ok(())

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -110,7 +110,7 @@ impl std::fmt::Debug for IoUringFs {
 // ---------------------------------------------------------------------------
 
 impl Fs for IoUringFs {
-    fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
+    fn open(&self, path: &Path, opts: &FsOpenOptions) -> crate::io::Result<Box<dyn FsFile>> {
         let mut builder = OpenOptions::new();
         builder
             .read(opts.read)
@@ -156,15 +156,15 @@ impl Fs for IoUringFs {
         }))
     }
 
-    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
-        std::fs::create_dir_all(path)
+    fn create_dir_all(&self, path: &Path) -> crate::io::Result<()> {
+        std::fs::create_dir_all(path).map_err(crate::io::Error::from)
     }
 
-    fn create_dir(&self, path: &Path) -> io::Result<()> {
-        std::fs::create_dir(path)
+    fn create_dir(&self, path: &Path) -> crate::io::Result<()> {
+        std::fs::create_dir(path).map_err(crate::io::Error::from)
     }
 
-    fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
+    fn read_dir(&self, path: &Path) -> crate::io::Result<Vec<FsDirEntry>> {
         // Delegate to std::fs — directory listing doesn't benefit from io_uring.
         std::fs::read_dir(path)?
             .map(|res| {
@@ -185,22 +185,23 @@ impl Fs for IoUringFs {
                     is_dir: file_type.is_dir(),
                 })
             })
-            .collect()
+            .collect::<io::Result<Vec<_>>>()
+            .map_err(crate::io::Error::from)
     }
 
-    fn remove_file(&self, path: &Path) -> io::Result<()> {
-        std::fs::remove_file(path)
+    fn remove_file(&self, path: &Path) -> crate::io::Result<()> {
+        std::fs::remove_file(path).map_err(crate::io::Error::from)
     }
 
-    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
-        std::fs::remove_dir_all(path)
+    fn remove_dir_all(&self, path: &Path) -> crate::io::Result<()> {
+        std::fs::remove_dir_all(path).map_err(crate::io::Error::from)
     }
 
-    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
-        std::fs::rename(from, to)
+    fn rename(&self, from: &Path, to: &Path) -> crate::io::Result<()> {
+        std::fs::rename(from, to).map_err(crate::io::Error::from)
     }
 
-    fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
+    fn metadata(&self, path: &Path) -> crate::io::Result<FsMetadata> {
         let m = std::fs::metadata(path)?;
         Ok(FsMetadata {
             len: m.len(),
@@ -209,11 +210,11 @@ impl Fs for IoUringFs {
         })
     }
 
-    fn sync_directory(&self, path: &Path) -> io::Result<()> {
+    fn sync_directory(&self, path: &Path) -> crate::io::Result<()> {
         let dir = File::open(path)?;
         if !dir.metadata()?.is_dir() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+            return Err(crate::io::Error::new(
+                crate::io::ErrorKind::InvalidInput,
                 "sync_directory: path is not a directory",
             ));
         }
@@ -221,11 +222,11 @@ impl Fs for IoUringFs {
         Ok(())
     }
 
-    fn exists(&self, path: &Path) -> io::Result<bool> {
-        path.try_exists()
+    fn exists(&self, path: &Path) -> crate::io::Result<bool> {
+        path.try_exists().map_err(crate::io::Error::from)
     }
 
-    fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+    fn hard_link(&self, src: &Path, dst: &Path) -> crate::io::Result<()> {
         // Hard linking is a metadata-only operation; io_uring offers no
         // throughput benefit, so delegate to [`StdFs`] for the EXDEV
         // fallback logic.
@@ -271,17 +272,17 @@ pub struct IoUringFile {
 }
 
 impl FsFile for IoUringFile {
-    fn sync_all(&self) -> io::Result<()> {
+    fn sync_all(&self) -> crate::io::Result<()> {
         self.ring.submit_fsync(self.file.as_raw_fd(), false)?;
         Ok(())
     }
 
-    fn sync_data(&self) -> io::Result<()> {
+    fn sync_data(&self) -> crate::io::Result<()> {
         self.ring.submit_fsync(self.file.as_raw_fd(), true)?;
         Ok(())
     }
 
-    fn metadata(&self) -> io::Result<FsMetadata> {
+    fn metadata(&self) -> crate::io::Result<FsMetadata> {
         let m = self.file.metadata()?;
         Ok(FsMetadata {
             len: m.len(),
@@ -290,13 +291,13 @@ impl FsFile for IoUringFile {
         })
     }
 
-    fn set_len(&self, size: u64) -> io::Result<()> {
-        self.file.set_len(size)
+    fn set_len(&self, size: u64) -> crate::io::Result<()> {
+        self.file.set_len(size).map_err(crate::io::Error::from)
     }
 
     // Fill-or-EOF: loop until buf is full or we hit EOF (0-byte read).
     // Retries on EINTR internally so callers can rely on short read = EOF.
-    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> crate::io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
         }
@@ -316,7 +317,7 @@ impl FsFile for IoUringFile {
                 match self.ring.submit_read(fd, remaining, current_offset) {
                     Ok(n) => break n,
                     Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             };
 
@@ -329,7 +330,7 @@ impl FsFile for IoUringFile {
         Ok(total_read)
     }
 
-    fn lock_exclusive(&self) -> io::Result<()> {
+    fn lock_exclusive(&self) -> crate::io::Result<()> {
         // Delegate to the platform-specific FsFile impl for std::fs::File.
         FsFile::lock_exclusive(&self.file)
     }

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -16,12 +16,12 @@
 
 use super::{Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
 use crate::HashMap;
+use core::sync::atomic::AtomicU64;
 use io_uring::{IoUring, opcode, types};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -14,10 +14,24 @@
 //!   may fail with `ENOENT` on virtual paths.
 
 use super::{Fs, FsCapabilities, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
-use std::collections::{HashMap, HashSet};
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use crate::io::{self, SeekFrom};
+// Trait names referenced only by the no_std trait impls below (the std impls
+// target `std::io::*` directly, so these would be unused under `std`).
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Seek, Write};
+use crate::path::{Path, PathBuf};
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
+// no_std-capable primitives so this reference backend compiles on
+// `--no-default-features --features alloc` (it's the template a no_std
+// consumer copies for a real backend, e.g. WASM/IndexedDB): `spin` locks
+// (no poisoning, userspace), `hashbrown` maps. The locks see no real
+// contention here — a single ephemeral in-memory tree — so spin is fine.
+use hashbrown::{HashMap, HashSet};
+use spin::{Mutex, RwLock};
 
 // ---------------------------------------------------------------------------
 // MemFs
@@ -74,10 +88,13 @@ impl MemFs {
 /// values never collide; cloned `MemFs` instances reuse the same ID
 /// because `MemFs` derives `Clone`.
 fn next_mem_fs_namespace_id() -> u64 {
-    use core::sync::atomic::{AtomicU64, Ordering};
+    use core::sync::atomic::{AtomicU32, Ordering};
+    // `AtomicU32`, not `AtomicU64`: 64-bit atomics are unavailable on some
+    // no_std targets (e.g. thumbv7em). u32 IDs are ample for distinct
+    // in-memory backends in one process; widened to u64 at the call site.
     // Start at 1 so a future `0` sentinel stays available if needed.
-    static COUNTER: AtomicU64 = AtomicU64::new(1);
-    COUNTER.fetch_add(1, Ordering::Relaxed)
+    static COUNTER: AtomicU32 = AtomicU32::new(1);
+    u64::from(COUNTER.fetch_add(1, Ordering::Relaxed))
 }
 
 impl Default for MemFs {
@@ -109,8 +126,13 @@ fn copy_from_data(buf: &mut [u8], data: &[u8], pos: usize) -> usize {
     n
 }
 
-impl Read for MemFile {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+// Bodies live on inherent `*_impl` methods returning `crate::io::Result`; the
+// trait impls are dual-gated thin wrappers. Under `std`, `crate::io::{Read,
+// Write,Seek}` are method-less supertrait aliases (blanket-impl'd for
+// `std::io::*`), so the real impl must target `std::io::*` there and bridge the
+// error back via `Into`; under `no_std` it targets the native `crate::io::*`.
+impl MemFile {
+    fn read_impl(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if !self.readable {
             return Err(io::Error::other("file not opened for reading"));
         }
@@ -126,10 +148,8 @@ impl Read for MemFile {
         self.cursor += n as u64;
         Ok(n)
     }
-}
 
-impl Write for MemFile {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write_impl(&mut self, buf: &[u8]) -> io::Result<usize> {
         if !self.writable {
             return Err(io::Error::other("file not opened for writing"));
         }
@@ -163,13 +183,7 @@ impl Write for MemFile {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl Seek for MemFile {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+    fn seek_impl(&mut self, pos: SeekFrom) -> io::Result<u64> {
         let new_pos: u64 = match pos {
             SeekFrom::Start(n) => n,
             SeekFrom::End(n) => {
@@ -206,6 +220,51 @@ impl Seek for MemFile {
 
         self.cursor = new_pos;
         Ok(self.cursor)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Read for MemFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.read_impl(buf).map_err(Into::into)
+    }
+}
+#[cfg(not(feature = "std"))]
+impl Read for MemFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read_impl(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for MemFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.write_impl(buf).map_err(Into::into)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+#[cfg(not(feature = "std"))]
+impl Write for MemFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_impl(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Seek for MemFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.seek_impl(pos.into()).map_err(Into::into)
+    }
+}
+#[cfg(not(feature = "std"))]
+impl Seek for MemFile {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.seek_impl(pos)
     }
 }
 
@@ -299,10 +358,6 @@ fn ensure_parent_dir(path: &Path, state: &State) -> io::Result<()> {
 // Fs for MemFs
 // ---------------------------------------------------------------------------
 
-#[expect(
-    clippy::significant_drop_tightening,
-    reason = "RwLock guards are intentionally held for the duration of each method"
-)]
 impl Fs for MemFs {
     fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
         ensure_non_empty_path(path)?;
@@ -492,6 +547,7 @@ impl Fs for MemFs {
                 && let Some(name) = file_path.file_name()
             {
                 // Match StdFs contract: reject non-UTF-8 names with InvalidData.
+                #[cfg(feature = "std")]
                 let file_name = name.to_str().ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -502,6 +558,9 @@ impl Fs for MemFs {
                         ),
                     )
                 })?;
+                // no_std: keys are UTF-8 `&str` by construction.
+                #[cfg(not(feature = "std"))]
+                let file_name = name;
                 entries.push(FsDirEntry {
                     path: file_path.clone(),
                     file_name: file_name.to_owned(),
@@ -515,6 +574,7 @@ impl Fs for MemFs {
                 && dir_path != path
                 && let Some(name) = dir_path.file_name()
             {
+                #[cfg(feature = "std")]
                 let file_name = name.to_str().ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -525,6 +585,9 @@ impl Fs for MemFs {
                         ),
                     )
                 })?;
+                // no_std: keys are UTF-8 `&str` by construction.
+                #[cfg(not(feature = "std"))]
+                let file_name = name;
                 entries.push(FsDirEntry {
                     path: dir_path.clone(),
                     file_name: file_name.to_owned(),
@@ -720,16 +783,34 @@ impl Fs for MemFs {
 // Lock helpers - convert PoisonError to io::Error
 // ---------------------------------------------------------------------------
 
-fn lock<T>(m: &Mutex<T>) -> io::Result<std::sync::MutexGuard<'_, T>> {
-    m.lock().map_err(|_| io::Error::other("mutex poisoned"))
+// `spin` locks cannot be poisoned (no unwind-during-hold concept), so these
+// always succeed; the `io::Result` return is kept so the `?`-using call sites
+// stay unchanged.
+// Kept returning `io::Result` (always `Ok`) so the `?`-using call sites are
+// untouched — spin locks never poison, but a future fallible lock layer would
+// slot in here without churning every caller.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Result kept for ?-compatible call sites and future fallible-lock parity"
+)]
+fn lock<T>(m: &Mutex<T>) -> io::Result<impl core::ops::DerefMut<Target = T> + '_> {
+    Ok(m.lock())
 }
 
-fn read_state(rw: &RwLock<State>) -> io::Result<std::sync::RwLockReadGuard<'_, State>> {
-    rw.read().map_err(|_| io::Error::other("rwlock poisoned"))
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Result kept for ?-compatible call sites and future fallible-lock parity"
+)]
+fn read_state(rw: &RwLock<State>) -> io::Result<impl core::ops::Deref<Target = State> + '_> {
+    Ok(rw.read())
 }
 
-fn write_state(rw: &RwLock<State>) -> io::Result<std::sync::RwLockWriteGuard<'_, State>> {
-    rw.write().map_err(|_| io::Error::other("rwlock poisoned"))
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Result kept for ?-compatible call sites and future fallible-lock parity"
+)]
+fn write_state(rw: &RwLock<State>) -> io::Result<impl core::ops::DerefMut<Target = State> + '_> {
+    Ok(rw.write())
 }
 
 // ---------------------------------------------------------------------------
@@ -1048,10 +1129,10 @@ mod tests {
         let mut file = fs.open(path, &opts)?;
         file.write_all(b"hello world")?;
 
-        file.seek(SeekFrom::Start(6))?;
+        file.seek(std::io::SeekFrom::Start(6))?;
         file.write_all(b"rust!")?;
 
-        file.seek(SeekFrom::Start(0))?;
+        file.seek(std::io::SeekFrom::Start(0))?;
         let mut buf = String::new();
         file.read_to_string(&mut buf)?;
         assert_eq!(buf, "hello rust!");

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -36,7 +36,12 @@ mod aligned_buf;
 // gate is the first concrete step.
 #[cfg(feature = "std")]
 mod direct_io;
+// `std_fs` (std::fs) is genuinely std-bound and gated out of a `no_std` build.
+// `mem_fs` is the no_std-capable reference backend (spin + hashbrown over the
+// `crate::io` `Fs` trait): it stays unconditional so a `no_std` consumer has a
+// working `Fs` implementation to use and to copy for a real backend.
 mod mem_fs;
+#[cfg(feature = "std")]
 mod std_fs;
 
 pub use aligned_buf::AlignedBuf;
@@ -45,7 +50,9 @@ pub use aligned_buf::AlignedBuf;
 mod io_uring_fs;
 
 pub use mem_fs::MemFs;
+#[cfg(feature = "std")]
 pub use std_fs::StdFs;
+#[cfg(feature = "std")]
 pub(crate) use std_fs::is_cross_device;
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
@@ -57,17 +64,15 @@ pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 // existing std-backed backends (`std_fs`, `io_uring_fs`) satisfy
 // these bounds without any change to their own impls.
 //
-// `io::{Result, Error, ErrorKind}` still come from `std::io` here
-// (no public re-export - `use std::io;` is a local module alias).
-// The trait *bounds* are what blocked no-std for this module; the
-// surrounding `io::Result<T>` return type still resolves to
-// `std::io::Result<T>` and will be migrated to `crate::io::Result<T>`
-// in a follow-up so we keep the diff scoped to what this issue
-// actually unblocks. `std::path::Path` likewise stays for now -
-// the path migration is the second blocker tracked separately.
-use crate::io::{Read, Seek, Write};
-use std::io;
-use std::path::{Path, PathBuf};
+// `io::{Result, Error, ErrorKind}` come from `crate::io` (the local mirror of
+// `std::io`): under `std` they bridge to/from `std::io` via `From`, so std
+// backends' `?`-chains convert transparently; under `no_std` they are the
+// native types. `Path`/`PathBuf` come from `crate::path` (a re-export of
+// `std::path` under `std`, a `str`-key newtype under `no_std`).
+use crate::io::{self, Read, Seek, Write};
+use crate::path::{Path, PathBuf};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Options for opening a file through the [`Fs`] trait.
 ///
@@ -850,8 +855,11 @@ pub(crate) fn copy_file_streamed<F: Fs + ?Sized>(fs: &F, src: &Path, dst: &Path)
             let n = match src_file.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => n,
+                #[cfg(feature = "std")]
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                #[cfg(not(feature = "std"))]
                 Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                Err(e) => return Err(e),
+                Err(e) => return Err(e.into()),
             };
             let chunk = buf.get(..n).ok_or_else(|| {
                 io::Error::other("read returned more bytes than the buffer holds")

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -606,7 +606,7 @@ mod sys {
         if ret == 0 || ret == EINVAL {
             Ok(())
         } else {
-            Err(std::io::Error::from_raw_os_error(ret).into())
+            Err(std::io::Error::from_raw_os_error(ret))
         }
     }
 

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -3,9 +3,11 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use super::{FileHint, Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions, SyncMode};
+use crate::io;
+use crate::path::Path;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use std::fs::{File, OpenOptions};
-use std::io;
-use std::path::Path;
 
 /// Plain `fsync` (no `F_FULLFSYNC`) for [`SyncMode::Normal`].
 ///
@@ -22,7 +24,7 @@ fn normal_fsync(file: &File) -> io::Result<()> {
     if rc == 0 {
         Ok(())
     } else {
-        Err(io::Error::last_os_error())
+        Err(std::io::Error::last_os_error().into())
     }
 }
 
@@ -46,24 +48,24 @@ pub struct StdFs;
 
 impl FsFile for File {
     fn sync_all(&self) -> io::Result<()> {
-        Self::sync_all(self)
+        Self::sync_all(self).map_err(io::Error::from)
     }
 
     fn sync_data(&self) -> io::Result<()> {
-        Self::sync_data(self)
+        Self::sync_data(self).map_err(io::Error::from)
     }
 
     fn sync_all_with(&self, mode: SyncMode) -> io::Result<()> {
         match mode {
             // `File::sync_all` is `fcntl(F_FULLFSYNC)` on macOS.
-            SyncMode::Full => Self::sync_all(self),
+            SyncMode::Full => Self::sync_all(self).map_err(io::Error::from),
             SyncMode::Normal => normal_fsync(self),
         }
     }
 
     fn sync_data_with(&self, mode: SyncMode) -> io::Result<()> {
         match mode {
-            SyncMode::Full => Self::sync_data(self),
+            SyncMode::Full => Self::sync_data(self).map_err(io::Error::from),
             // Normal data-sync collapses to plain `fsync`: on macOS
             // `sync_data` is also `F_FULLFSYNC`, and a plain `fsync` already
             // covers the data, so there is no cheaper data-only barrier to
@@ -82,7 +84,7 @@ impl FsFile for File {
     }
 
     fn set_len(&self, size: u64) -> io::Result<()> {
-        Self::set_len(self, size)
+        Self::set_len(self, size).map_err(io::Error::from)
     }
 
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
@@ -102,8 +104,8 @@ impl FsFile for File {
                     use std::os::unix::fs::FileExt;
                     match FileExt::read_at(self, remaining, off) {
                         Ok(n) => n,
-                        Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                        Err(e) => return Err(e),
+                        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Err(e) => return Err(e.into()),
                     }
                 }
 
@@ -112,8 +114,8 @@ impl FsFile for File {
                     use std::os::windows::fs::FileExt;
                     match FileExt::seek_read(self, remaining, off) {
                         Ok(n) => n,
-                        Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-                        Err(e) => return Err(e),
+                        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Err(e) => return Err(e.into()),
                     }
                 }
 
@@ -137,11 +139,11 @@ impl FsFile for File {
     }
 
     fn lock_exclusive(&self) -> io::Result<()> {
-        sys::lock_exclusive(self)
+        sys::lock_exclusive(self).map_err(io::Error::from)
     }
 
     fn hint(&self, hint: FileHint) -> io::Result<()> {
-        sys::fadvise(self, hint)
+        sys::fadvise(self, hint).map_err(io::Error::from)
     }
 }
 
@@ -176,11 +178,11 @@ impl Fs for StdFs {
     }
 
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
-        std::fs::create_dir_all(path)
+        std::fs::create_dir_all(path).map_err(io::Error::from)
     }
 
     fn create_dir(&self, path: &Path) -> io::Result<()> {
-        std::fs::create_dir(path)
+        std::fs::create_dir(path).map_err(io::Error::from)
     }
 
     fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
@@ -209,15 +211,15 @@ impl Fs for StdFs {
     }
 
     fn remove_file(&self, path: &Path) -> io::Result<()> {
-        std::fs::remove_file(path)
+        std::fs::remove_file(path).map_err(io::Error::from)
     }
 
     fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
-        std::fs::remove_dir_all(path)
+        std::fs::remove_dir_all(path).map_err(io::Error::from)
     }
 
     fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
-        std::fs::rename(from, to)
+        std::fs::rename(from, to).map_err(io::Error::from)
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
@@ -239,7 +241,7 @@ impl Fs for StdFs {
                     "sync_directory: path is not a directory",
                 ));
             }
-            dir.sync_all()
+            dir.sync_all().map_err(io::Error::from)
         }
 
         // Windows cannot fsync directories - no-op, same as crate::file::fsync_directory.
@@ -261,7 +263,7 @@ impl Fs for StdFs {
                 ));
             }
             match mode {
-                SyncMode::Full => dir.sync_all(),
+                SyncMode::Full => dir.sync_all().map_err(io::Error::from),
                 SyncMode::Normal => normal_fsync(&dir),
             }
         }
@@ -275,7 +277,7 @@ impl Fs for StdFs {
     }
 
     fn exists(&self, path: &Path) -> io::Result<bool> {
-        path.try_exists()
+        path.try_exists().map_err(io::Error::from)
     }
 
     fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
@@ -287,7 +289,19 @@ impl Fs for StdFs {
         // SyncMode-aware streamed copy. Keeping the copy in one place means
         // the copied file's durability honors `Config::sync_mode` instead
         // of always paying `F_FULLFSYNC` here.
-        std::fs::hard_link(src, dst)
+        //
+        // Normalise a cross-device failure to `ErrorKind::CrossesDevices`
+        // while the errno is still readable on the std error: once it folds
+        // into `crate::io::Error` at this trait boundary the errno is gone,
+        // so the caller's kind-based `is_cross_device` would otherwise miss
+        // the platforms where std reports EXDEV without the matching kind.
+        std::fs::hard_link(src, dst).map_err(|e| {
+            if is_std_cross_device(&e) {
+                io::Error::from_kind(io::ErrorKind::CrossesDevices)
+            } else {
+                e.into()
+            }
+        })
     }
 
     fn backend_id(&self) -> Option<u64> {
@@ -340,7 +354,7 @@ impl Fs for StdFs {
             Err(e) if macos_caps::clone_should_fall_back(&e) => {
                 super::copy_file_streamed(self, src, dst)
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -408,11 +422,12 @@ pub const KERNEL_BACKEND_ID: u64 = 0x4b45_524e_454c_5f46; // "KERNEL_F"
 // surface even if `std_fs` is ever exported. clippy's `redundant_pub_crate`
 // fires only because the enclosing module is currently private; the re-export
 // genuinely needs crate visibility, so the lint is a false positive here.
-#[expect(
-    clippy::redundant_pub_crate,
-    reason = "re-exported crate-wide via fs::mod; pub(crate) communicates the intended scope"
-)]
-pub(crate) fn is_cross_device(err: &io::Error) -> bool {
+/// Cross-device detection on a raw `std::io::Error`, where the errno is still
+/// available. Used by [`StdFs::hard_link`] to NORMALISE a cross-device link
+/// failure into [`crate::io::ErrorKind::CrossesDevices`] before the error
+/// crosses the `Fs` trait boundary into [`crate::io::Error`] (which carries no
+/// errno). After normalisation the kind-based [`is_cross_device`] is enough.
+fn is_std_cross_device(err: &std::io::Error) -> bool {
     #[cfg(unix)]
     {
         // POSIX `EXDEV` ("invalid cross-device link"). The raw value is
@@ -427,6 +442,20 @@ pub(crate) fn is_cross_device(err: &io::Error) -> bool {
             return true;
         }
     }
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::CrossesDevices | std::io::ErrorKind::Unsupported
+    )
+}
+
+/// Cross-device detection on a [`crate::io::Error`] (post-`Fs`-boundary, no
+/// errno). [`StdFs::hard_link`] normalises the raw errno case to the
+/// `CrossesDevices` kind, so a kind check is authoritative here.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "re-exported crate-wide via fs::mod; pub(crate) communicates the intended scope"
+)]
+pub(crate) fn is_cross_device(err: &io::Error) -> bool {
     matches!(
         err.kind(),
         io::ErrorKind::CrossesDevices | io::ErrorKind::Unsupported
@@ -465,8 +494,8 @@ mod sys {
                 return Ok(());
             }
 
-            let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::Interrupted {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
                 continue;
             }
             return Err(err);
@@ -577,7 +606,7 @@ mod sys {
         if ret == 0 || ret == EINVAL {
             Ok(())
         } else {
-            Err(io::Error::from_raw_os_error(ret))
+            Err(std::io::Error::from_raw_os_error(ret).into())
         }
     }
 
@@ -620,7 +649,7 @@ mod sys {
     }
 
     pub(super) fn lock_exclusive(file: &File) -> io::Result<()> {
-        use std::ptr;
+        use core::ptr;
 
         // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
         const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
@@ -674,7 +703,7 @@ mod sys {
         };
 
         if ret == 0 {
-            return Err(io::Error::last_os_error());
+            return Err(std::io::Error::last_os_error().into());
         }
         Ok(())
     }
@@ -710,9 +739,9 @@ mod sys {
 #[cfg(target_os = "macos")]
 mod macos_caps {
     use crate::fs::FsCapabilities;
+    use core::mem::MaybeUninit;
     use std::ffi::{CStr, CString};
     use std::io;
-    use std::mem::MaybeUninit;
     use std::os::unix::ffi::OsStrExt;
     use std::path::Path;
 
@@ -735,7 +764,7 @@ mod macos_caps {
         #[expect(unsafe_code, reason = "statfs FFI to read the filesystem type name")]
         let rc = unsafe { libc::statfs(c.as_ptr(), buf.as_mut_ptr()) };
         if rc != 0 {
-            return Err(io::Error::last_os_error());
+            return Err(std::io::Error::last_os_error());
         }
         // SAFETY: statfs returned 0, so `buf` is initialized; `f_fstypename`
         // is a NUL-terminated `c_char` array.
@@ -774,7 +803,7 @@ mod macos_caps {
         #[expect(unsafe_code, reason = "clonefile FFI for an O(1) APFS clone")]
         let rc = unsafe { libc::clonefile(s.as_ptr(), d.as_ptr(), 0) };
         if rc != 0 {
-            return Err(io::Error::last_os_error());
+            return Err(std::io::Error::last_os_error());
         }
         Ok(())
     }
@@ -810,9 +839,9 @@ mod linux_caps {
     // numbers exceed i32::MAX); these imports + helper feed only that path, so
     // gate them to avoid unused-import / dead_code warnings on 32-bit targets.
     #[cfg(target_pointer_width = "64")]
-    use std::ffi::CString;
+    use core::mem::MaybeUninit;
     #[cfg(target_pointer_width = "64")]
-    use std::mem::MaybeUninit;
+    use std::ffi::CString;
     #[cfg(target_pointer_width = "64")]
     use std::os::unix::ffi::OsStrExt;
 
@@ -910,7 +939,7 @@ mod linux_caps {
             )
         };
         if rc != 0 {
-            let err = io::Error::last_os_error();
+            let err = std::io::Error::last_os_error();
             drop(dst_f);
             // Best-effort cleanup of the empty target so the copy fallback's
             // `create_new` does not trip over it.
@@ -967,7 +996,7 @@ mod linux_caps {
         )]
         let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_GETFLAGS as _, &raw mut flags) };
         if rc != 0 {
-            return ignore_if_unsupported(io::Error::last_os_error());
+            return ignore_if_unsupported(std::io::Error::last_os_error());
         }
         if flags & FS_NOCOW_FL != 0 {
             return Ok(()); // already NoCoW
@@ -983,7 +1012,7 @@ mod linux_caps {
         )]
         let rc = unsafe { libc::ioctl(f.as_raw_fd(), FS_IOC_SETFLAGS as _, &raw const flags) };
         if rc != 0 {
-            return ignore_if_unsupported(io::Error::last_os_error());
+            return ignore_if_unsupported(std::io::Error::last_os_error());
         }
         Ok(())
     }
@@ -1476,8 +1505,9 @@ mod tests {
         {
             // Matches the `EXDEV` constant inside `is_cross_device`.
             const EXDEV: i32 = 18;
-            let exdev = io::Error::from_raw_os_error(EXDEV);
-            assert!(is_cross_device(&exdev), "raw EXDEV must be recognised");
+            // Raw EXDEV (no matching kind) is detected by the std-side helper.
+            let exdev = std::io::Error::from_raw_os_error(EXDEV);
+            assert!(is_std_cross_device(&exdev), "raw EXDEV must be recognised");
         }
 
         // ErrorKind::CrossesDevices is the modern stable variant (Rust 1.85+).

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -31,7 +31,7 @@ fn normal_fsync(file: &File) -> io::Result<()> {
 #[cfg(not(target_os = "macos"))]
 fn normal_fsync(file: &File) -> io::Result<()> {
     // No `F_FULLFSYNC` distinction off macOS - `sync_all` is plain `fsync`.
-    File::sync_all(file)
+    File::sync_all(file).map_err(io::Error::from)
 }
 
 /// Default [`Fs`] implementation backed by [`std::fs`].
@@ -379,7 +379,7 @@ impl Fs for StdFs {
             Err(e) if linux_caps::clone_should_fall_back(&e) => {
                 super::copy_file_streamed(self, src, dst)
             }
-            Err(e) => Err(e),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -391,7 +391,7 @@ impl Fs for StdFs {
     /// filesystems that do not support the inode-flags ioctl.
     #[cfg(target_os = "linux")]
     fn try_disable_cow(&self, path: &Path) -> io::Result<()> {
-        linux_caps::try_disable_cow(path)
+        linux_caps::try_disable_cow(path).map_err(io::Error::from)
     }
 }
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -22,7 +22,7 @@
 use crate::InternalValue;
 use crate::comparator::SharedComparator;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 /// A single entry in the merge heap.

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -21,7 +21,9 @@
 
 use crate::InternalValue;
 use crate::comparator::SharedComparator;
-use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::cmp::Ordering;
 
 /// A single entry in the merge heap.
 ///
@@ -140,7 +142,7 @@ impl MergeHeap {
     pub fn replace_min(&mut self, entry: HeapEntry) -> HeapEntry {
         debug_assert!(!self.data.is_empty());
 
-        let old = std::mem::replace(&mut self.data[0], entry);
+        let old = core::mem::replace(&mut self.data[0], entry);
 
         // Slide right until in sorted position.
         let cmp = self.comparator.as_ref();
@@ -172,7 +174,7 @@ impl MergeHeap {
         debug_assert!(!self.data.is_empty());
 
         let last = self.data.len() - 1;
-        let old = std::mem::replace(&mut self.data[last], entry);
+        let old = core::mem::replace(&mut self.data[last], entry);
 
         // Slide left until in sorted position.
         let cmp = self.comparator.as_ref();

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -773,7 +773,7 @@ pub fn iter_data_block_entries(path: &Path) -> crate::Result<DataBlockEntryIter>
     let regions = ParsedRegions::parse_from_toc(toc)?;
 
     if regions.index.is_some() {
-        return Err(crate::Error::Io(std::io::Error::new(
+        return Err(crate::Error::from(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "partitioned-index SST (separate `index` section present) is not yet supported \
              by iter_data_block_entries; walking sub-index leaves to enumerate data blocks \

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -82,6 +82,12 @@ impl ErrorKind {
     }
 }
 
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// I/O error mirroring [`std::io::Error`].
 ///
 /// Carries an [`ErrorKind`] plus an optional message string for
@@ -154,6 +160,12 @@ impl Error {
     pub const fn kind(&self) -> ErrorKind {
         self.kind
     }
+
+    /// Construct an [`ErrorKind::Other`] error carrying `message`.
+    /// Mirrors [`std::io::Error::other`].
+    pub fn other<M: Into<String>>(message: M) -> Self {
+        Self::new(ErrorKind::Other, message)
+    }
 }
 
 impl From<ErrorKind> for Error {
@@ -182,8 +194,11 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+// `core::error::Error` (stable since 1.81, MSRV here is 1.92) so this error
+// is usable as a trait-object source under both `std` and `no_std`. Under
+// `std`, `std::error::Error` re-exports `core::error::Error`, so this is the
+// same impl std callers have always seen.
+impl core::error::Error for Error {}
 
 /// Bridge from `std::io::Error`. Maps the std `ErrorKind` to
 /// this crate's [`ErrorKind`] when a variant exists for it, and
@@ -322,7 +337,7 @@ impl From<std::io::SeekFrom> for SeekFrom {
 // this module are supertrait aliases over `std::io::{Read,Write,
 // Seek}`. Any `T: std::io::Read` automatically implements
 // `crate::io::Read` via the blanket below — AND `T: crate::io::Read`
-// implies `T: std::io::Read` (because std::io::Read is a supertrait).
+// implies `T: std::io::Read` (because crate::io::Read is a supertrait).
 // This second direction is what lets `dyn FsFile` (bounded on
 // `crate::io::Read`) flow into `std::io::BufReader`, `byteorder`,
 // and the rest of the std ecosystem without any explicit adapter.
@@ -362,6 +377,14 @@ impl<W: std::io::Write + ?Sized> Write for W {}
 pub trait Seek: std::io::Seek {}
 #[cfg(feature = "std")]
 impl<S: std::io::Seek + ?Sized> Seek for S {}
+
+/// Buffered-read trait. Under `std` this is a supertrait alias of
+/// [`std::io::BufRead`] (blanket-implemented), so std readers satisfy it
+/// directly; under `no_std` it is the native trait defined below.
+#[cfg(feature = "std")]
+pub trait BufRead: std::io::BufRead {}
+#[cfg(feature = "std")]
+impl<B: std::io::BufRead + ?Sized> BufRead for B {}
 
 /// Read trait mirroring [`std::io::Read`]. Only the methods this
 /// crate depends on are surfaced; default implementations follow the
@@ -416,6 +439,59 @@ pub trait Read {
             ))
         }
     }
+
+    /// Adapter that reads at most `limit` bytes from this reader, mirroring
+    /// [`std::io::Read::take`]. Used to bound a parser against a forged length
+    /// prefix.
+    fn take(self, limit: u64) -> Take<Self>
+    where
+        Self: Sized,
+    {
+        Take { inner: self, limit }
+    }
+}
+
+/// Limit-bounded reader returned by [`Read::take`], mirroring
+/// [`std::io::Take`].
+#[cfg(not(feature = "std"))]
+pub struct Take<R> {
+    inner: R,
+    limit: u64,
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> Read for Take<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        if self.limit == 0 {
+            return Ok(0);
+        }
+        // Cap this read at the remaining limit; `min` keeps `max <= buf.len()`.
+        let max = (buf.len() as u64).min(self.limit) as usize;
+        // `split_at_mut` instead of `&mut buf[..max]` to satisfy the crate's
+        // `deny(clippy::indexing_slicing)` on the no_std build.
+        let (head, _) = buf.split_at_mut(max);
+        let n = self.inner.read(head)?;
+        self.limit -= n as u64;
+        Ok(n)
+    }
+}
+
+/// Buffered-read trait mirroring the [`std::io::BufRead`] subset the storage
+/// layer uses (`fill_buf` + `consume`). Lets a record reader peek at the next
+/// bytes — and detect a clean EOF via an empty fill — without consuming them.
+#[cfg(not(feature = "std"))]
+pub trait BufRead: Read {
+    /// Return the buffer's current contents, refilling from the underlying
+    /// reader when empty. An empty return means EOF.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying reader.
+    fn fill_buf(&mut self) -> Result<&[u8]>;
+
+    /// Mark `amt` bytes from the start of the buffer as consumed so they are
+    /// not returned by the next [`fill_buf`](Self::fill_buf)/[`read`](Read::read).
+    fn consume(&mut self, amt: usize);
 }
 
 /// Write trait mirroring [`std::io::Write`].
@@ -482,6 +558,828 @@ pub trait Seek {
     ///
     /// Returns any I/O error from the underlying seeker.
     fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+
+    /// Current stream position (offset from the start). Mirrors
+    /// [`std::io::Seek::stream_position`].
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying seeker.
+    fn stream_position(&mut self) -> Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
+    /// Seek relative to the current position. Mirrors
+    /// [`std::io::Seek::seek_relative`].
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying seeker.
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        self.seek(SeekFrom::Current(offset))?;
+        Ok(())
+    }
+}
+
+// Blanket forwarding impls so readers/writers behind a reference or a box
+// (e.g. `&mut R`, `Box<dyn FsFile>`) satisfy the io traits — std provides the
+// equivalent blankets for its own io traits, so this only fills the no_std gap.
+#[cfg(not(feature = "std"))]
+impl<R: Read + ?Sized> Read for &mut R {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        (**self).read(buf)
+    }
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read + ?Sized> Read for alloc::boxed::Box<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        (**self).read(buf)
+    }
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write + ?Sized> Write for &mut W {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (**self).write(buf)
+    }
+    fn flush(&mut self) -> Result<()> {
+        (**self).flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (**self).write_all(buf)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write + ?Sized> Write for alloc::boxed::Box<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (**self).write(buf)
+    }
+    fn flush(&mut self) -> Result<()> {
+        (**self).flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (**self).write_all(buf)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<S: Seek + ?Sized> Seek for &mut S {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        (**self).seek(pos)
+    }
+    fn stream_position(&mut self) -> Result<u64> {
+        (**self).stream_position()
+    }
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        (**self).seek_relative(offset)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<S: Seek + ?Sized> Seek for alloc::boxed::Box<S> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        (**self).seek(pos)
+    }
+    fn stream_position(&mut self) -> Result<u64> {
+        (**self).stream_position()
+    }
+    fn seek_relative(&mut self, offset: i64) -> Result<()> {
+        (**self).seek_relative(offset)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<B: BufRead + ?Sized> BufRead for &mut B {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        (**self).fill_buf()
+    }
+    fn consume(&mut self, amt: usize) {
+        (**self).consume(amt);
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<B: BufRead + ?Sized> BufRead for alloc::boxed::Box<B> {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        (**self).fill_buf()
+    }
+    fn consume(&mut self, amt: usize) {
+        (**self).consume(amt);
+    }
+}
+
+// `varint-rs` only blankets its traits over `std::io` (under its `std`
+// feature), and a foreign trait cannot be blanket-impl'd here (orphan rule).
+// So `no_std` builds get crate-local varint extension traits with the same
+// method surface, blanketed over this module's `Read`/`Write`. The encoding is
+// canonical unsigned LEB128 — byte-identical to `varint-rs` — so frames written
+// under `std` and `no_std` interoperate. Call sites swap only the import path.
+/// Writes unsigned integers as canonical LEB128 varints over a [`Write`].
+///
+/// The `no_std` counterpart of `varint-rs`'s `VarintWriter`; the encoding is
+/// identical so frames interoperate across `std` / `no_std` builds.
+#[cfg(not(feature = "std"))]
+pub trait VarintWriter: Write {
+    /// Writes `value` as canonical unsigned LEB128.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u64_varint(&mut self, mut value: u64) -> Result<()> {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            self.write_all(&[byte])?;
+            if value == 0 {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Writes `value` as canonical unsigned LEB128.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u32_varint(&mut self, value: u32) -> Result<()> {
+        self.write_u64_varint(u64::from(value))
+    }
+
+    /// Writes `value` as canonical unsigned LEB128.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u16_varint(&mut self, value: u16) -> Result<()> {
+        self.write_u64_varint(u64::from(value))
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write + ?Sized> VarintWriter for W {}
+
+/// Reads canonical LEB128 varints over a [`Read`].
+///
+/// The `no_std` counterpart of `varint-rs`'s `VarintReader`; the encoding is
+/// identical so frames interoperate across `std` / `no_std` builds.
+#[cfg(not(feature = "std"))]
+pub trait VarintReader: Read {
+    /// Reads a canonical unsigned LEB128 value.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on a truncated value, or
+    /// [`ErrorKind::InvalidData`] on an overlong encoding; plus any underlying
+    /// reader error.
+    fn read_u64_varint(&mut self) -> Result<u64> {
+        let mut result: u64 = 0;
+        let mut shift: u32 = 0;
+        loop {
+            let mut byte = [0u8; 1];
+            self.read_exact(&mut byte)?;
+            // 10 groups of 7 bits cover a full u64; reject overlong encodings.
+            if shift >= 64 {
+                return Err(Error::new(ErrorKind::InvalidData, "varint overflows u64"));
+            }
+            result |= (u64::from(byte[0] & 0x7f)) << shift;
+            if byte[0] & 0x80 == 0 {
+                return Ok(result);
+            }
+            shift += 7;
+        }
+    }
+
+    /// Reads a canonical unsigned LEB128 value, narrowed to `u32`.
+    ///
+    /// # Errors
+    /// As [`Self::read_u64_varint`], plus [`ErrorKind::InvalidData`] if the
+    /// value does not fit `u32`.
+    fn read_u32_varint(&mut self) -> Result<u32> {
+        let v = self.read_u64_varint()?;
+        u32::try_from(v).map_err(|_| Error::new(ErrorKind::InvalidData, "varint exceeds u32"))
+    }
+
+    /// Reads a canonical unsigned LEB128 value, narrowed to `u16`.
+    ///
+    /// # Errors
+    /// As [`Self::read_u64_varint`], plus [`ErrorKind::InvalidData`] if the
+    /// value does not fit `u16`.
+    fn read_u16_varint(&mut self) -> Result<u16> {
+        let v = self.read_u64_varint()?;
+        u16::try_from(v).map_err(|_| Error::new(ErrorKind::InvalidData, "varint exceeds u16"))
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read + ?Sized> VarintReader for R {}
+
+// ---------------------------------------------------------------------------
+// Fixed-width integer I/O — a `no_std`-capable, drop-in replacement for
+// `byteorder`'s `WriteBytesExt` / `ReadBytesExt` / `ByteOrder` over this
+// module's `Read` / `Write` (which is `std::io` under `std` and the native
+// traits under `no_std`). The API mirrors `byteorder` exactly — same
+// `w.write_u32::<LittleEndian>(x)` / `r.read_u32::<LittleEndian>()` call
+// shape — so migrating a wire-format module off `byteorder` is just an
+// import swap, and the encoding is byte-identical (`to_le_bytes` /
+// `to_be_bytes`). High-level round-trip tests cover correctness; no
+// low-level duplication here.
+// ---------------------------------------------------------------------------
+
+/// Byte-order marker for fixed-width integer encoding.
+///
+/// Mirrors `byteorder::ByteOrder`. Implemented by [`LittleEndian`] /
+/// [`BigEndian`]; methods convert between fixed-size byte arrays and integers
+/// so call sites stay free of slice indexing.
+pub trait ByteOrder {
+    /// Decode a `u16` from its 2-byte representation.
+    fn u16_from(b: [u8; 2]) -> u16;
+    /// Decode a `u32` from its 4-byte representation.
+    fn u32_from(b: [u8; 4]) -> u32;
+    /// Decode a `u64` from its 8-byte representation.
+    fn u64_from(b: [u8; 8]) -> u64;
+    /// Decode a `u128` from its 16-byte representation.
+    fn u128_from(b: [u8; 16]) -> u128;
+    /// Encode a `u16` to its 2-byte representation.
+    fn u16_to(n: u16) -> [u8; 2];
+    /// Encode a `u32` to its 4-byte representation.
+    fn u32_to(n: u32) -> [u8; 4];
+    /// Encode a `u64` to its 8-byte representation.
+    fn u64_to(n: u64) -> [u8; 8];
+    /// Encode a `u128` to its 16-byte representation.
+    fn u128_to(n: u128) -> [u8; 16];
+
+    // Static slice helpers matching `byteorder::ByteOrder`'s API, so call
+    // sites of the form `LittleEndian::write_u32(buf, n)` / `read_u32(buf)`
+    // migrate unchanged. `split_at[_mut]` (not indexing) keeps the crate-level
+    // `deny(indexing_slicing)` happy; like byteorder, they panic if `buf` is
+    // shorter than the integer width (a caller bug, not a data condition).
+    /// Read a `u16` from the first 2 bytes of `buf`.
+    #[must_use]
+    fn read_u16(buf: &[u8]) -> u16 {
+        let (head, _) = buf.split_at(2);
+        let mut a = [0u8; 2];
+        a.copy_from_slice(head);
+        Self::u16_from(a)
+    }
+    /// Read a `u32` from the first 4 bytes of `buf`.
+    #[must_use]
+    fn read_u32(buf: &[u8]) -> u32 {
+        let (head, _) = buf.split_at(4);
+        let mut a = [0u8; 4];
+        a.copy_from_slice(head);
+        Self::u32_from(a)
+    }
+    /// Read a `u64` from the first 8 bytes of `buf`.
+    #[must_use]
+    fn read_u64(buf: &[u8]) -> u64 {
+        let (head, _) = buf.split_at(8);
+        let mut a = [0u8; 8];
+        a.copy_from_slice(head);
+        Self::u64_from(a)
+    }
+    /// Write `n` into the first 2 bytes of `buf`.
+    fn write_u16(buf: &mut [u8], n: u16) {
+        let (head, _) = buf.split_at_mut(2);
+        head.copy_from_slice(&Self::u16_to(n));
+    }
+    /// Write `n` into the first 4 bytes of `buf`.
+    fn write_u32(buf: &mut [u8], n: u32) {
+        let (head, _) = buf.split_at_mut(4);
+        head.copy_from_slice(&Self::u32_to(n));
+    }
+    /// Write `n` into the first 8 bytes of `buf`.
+    fn write_u64(buf: &mut [u8], n: u64) {
+        let (head, _) = buf.split_at_mut(8);
+        head.copy_from_slice(&Self::u64_to(n));
+    }
+}
+
+/// Little-endian [`ByteOrder`] (matches `byteorder::LittleEndian`).
+#[derive(Clone, Copy, Debug)]
+pub enum LittleEndian {}
+/// Big-endian [`ByteOrder`] (matches `byteorder::BigEndian`).
+#[derive(Clone, Copy, Debug)]
+pub enum BigEndian {}
+
+/// Short alias for [`LittleEndian`] (matches `byteorder::LE`).
+pub type LE = LittleEndian;
+/// Short alias for [`BigEndian`] (matches `byteorder::BE`).
+pub type BE = BigEndian;
+
+impl ByteOrder for LittleEndian {
+    fn u16_from(b: [u8; 2]) -> u16 {
+        u16::from_le_bytes(b)
+    }
+    fn u32_from(b: [u8; 4]) -> u32 {
+        u32::from_le_bytes(b)
+    }
+    fn u64_from(b: [u8; 8]) -> u64 {
+        u64::from_le_bytes(b)
+    }
+    fn u128_from(b: [u8; 16]) -> u128 {
+        u128::from_le_bytes(b)
+    }
+    fn u16_to(n: u16) -> [u8; 2] {
+        n.to_le_bytes()
+    }
+    fn u32_to(n: u32) -> [u8; 4] {
+        n.to_le_bytes()
+    }
+    fn u64_to(n: u64) -> [u8; 8] {
+        n.to_le_bytes()
+    }
+    fn u128_to(n: u128) -> [u8; 16] {
+        n.to_le_bytes()
+    }
+}
+
+impl ByteOrder for BigEndian {
+    fn u16_from(b: [u8; 2]) -> u16 {
+        u16::from_be_bytes(b)
+    }
+    fn u32_from(b: [u8; 4]) -> u32 {
+        u32::from_be_bytes(b)
+    }
+    fn u64_from(b: [u8; 8]) -> u64 {
+        u64::from_be_bytes(b)
+    }
+    fn u128_from(b: [u8; 16]) -> u128 {
+        u128::from_be_bytes(b)
+    }
+    fn u16_to(n: u16) -> [u8; 2] {
+        n.to_be_bytes()
+    }
+    fn u32_to(n: u32) -> [u8; 4] {
+        n.to_be_bytes()
+    }
+    fn u64_to(n: u64) -> [u8; 8] {
+        n.to_be_bytes()
+    }
+    fn u128_to(n: u128) -> [u8; 16] {
+        n.to_be_bytes()
+    }
+}
+
+/// Fixed-width integer writes over [`Write`], mirroring
+/// `byteorder::WriteBytesExt`. Blanket-implemented for every [`Write`].
+pub trait WriteBytesExt: Write {
+    /// Write a single byte.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u8(&mut self, n: u8) -> Result<()> {
+        self.write_all(&[n])?;
+        Ok(())
+    }
+    /// Write a signed byte.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_i8(&mut self, n: i8) -> Result<()> {
+        self.write_all(&n.to_le_bytes())?;
+        Ok(())
+    }
+    /// Write a `u16` in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u16<T: ByteOrder>(&mut self, n: u16) -> Result<()> {
+        self.write_all(&T::u16_to(n))?;
+        Ok(())
+    }
+    /// Write a `u32` in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u32<T: ByteOrder>(&mut self, n: u32) -> Result<()> {
+        self.write_all(&T::u32_to(n))?;
+        Ok(())
+    }
+    /// Write a `u64` in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u64<T: ByteOrder>(&mut self, n: u64) -> Result<()> {
+        self.write_all(&T::u64_to(n))?;
+        Ok(())
+    }
+    /// Write a `u128` in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_u128<T: ByteOrder>(&mut self, n: u128) -> Result<()> {
+        self.write_all(&T::u128_to(n))?;
+        Ok(())
+    }
+    /// Write an `f32` (IEEE-754 bit pattern) in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_f32<T: ByteOrder>(&mut self, n: f32) -> Result<()> {
+        self.write_u32::<T>(n.to_bits())
+    }
+    /// Write an `f64` (IEEE-754 bit pattern) in the byte order `T`.
+    ///
+    /// # Errors
+    /// Propagates the underlying writer's error.
+    fn write_f64<T: ByteOrder>(&mut self, n: f64) -> Result<()> {
+        self.write_u64::<T>(n.to_bits())
+    }
+}
+impl<W: Write + ?Sized> WriteBytesExt for W {}
+
+/// Fixed-width integer reads over [`Read`], mirroring
+/// `byteorder::ReadBytesExt`. Blanket-implemented for every [`Read`].
+pub trait ReadBytesExt: Read {
+    /// Read a single byte.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_u8(&mut self) -> Result<u8> {
+        let mut b = [0u8; 1];
+        self.read_exact(&mut b)?;
+        Ok(u8::from_le_bytes(b))
+    }
+    /// Read a signed byte.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_i8(&mut self) -> Result<i8> {
+        let mut b = [0u8; 1];
+        self.read_exact(&mut b)?;
+        Ok(i8::from_le_bytes(b))
+    }
+    /// Read a `u16` in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_u16<T: ByteOrder>(&mut self) -> Result<u16> {
+        let mut b = [0u8; 2];
+        self.read_exact(&mut b)?;
+        Ok(T::u16_from(b))
+    }
+    /// Read a `u32` in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_u32<T: ByteOrder>(&mut self) -> Result<u32> {
+        let mut b = [0u8; 4];
+        self.read_exact(&mut b)?;
+        Ok(T::u32_from(b))
+    }
+    /// Read a `u64` in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_u64<T: ByteOrder>(&mut self) -> Result<u64> {
+        let mut b = [0u8; 8];
+        self.read_exact(&mut b)?;
+        Ok(T::u64_from(b))
+    }
+    /// Read a `u128` in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_u128<T: ByteOrder>(&mut self) -> Result<u128> {
+        let mut b = [0u8; 16];
+        self.read_exact(&mut b)?;
+        Ok(T::u128_from(b))
+    }
+    /// Read an `f32` (IEEE-754 bit pattern) in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_f32<T: ByteOrder>(&mut self) -> Result<f32> {
+        Ok(f32::from_bits(self.read_u32::<T>()?))
+    }
+    /// Read an `f64` (IEEE-754 bit pattern) in the byte order `T`.
+    ///
+    /// # Errors
+    /// [`ErrorKind::UnexpectedEof`] on short read, or the reader's error.
+    fn read_f64<T: ByteOrder>(&mut self) -> Result<f64> {
+        Ok(f64::from_bits(self.read_u64::<T>()?))
+    }
+}
+impl<R: Read + ?Sized> ReadBytesExt for R {}
+
+// `no_std` concrete impls so wire-format code that writes into a `Vec<u8>` or
+// reads from a `&[u8]` keeps compiling once it moves off `byteorder` (under
+// `std` these come from `std::io`'s own impls via the supertrait aliases).
+#[cfg(not(feature = "std"))]
+impl Write for alloc::vec::Vec<u8> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Read for &[u8] {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let n = buf.len().min(self.len());
+        let (head, rest) = self.split_at(n);
+        let (dst, _) = buf.split_at_mut(n);
+        dst.copy_from_slice(head);
+        *self = rest;
+        Ok(n)
+    }
+}
+
+// In-memory cursor, mirroring `crate::io::Cursor`. Under `std` it IS
+// `crate::io::Cursor` (re-export); under `no_std` it's a local equivalent so
+// wire-format code reading/seeking over a `&[u8]` or writing into a `Vec<u8>`
+// keeps compiling. Same API surface (`new` / `position` / `set_position` /
+// `into_inner` / `get_ref`) so call sites are identical across both builds.
+#[cfg(feature = "std")]
+pub use std::io::Cursor;
+
+/// In-memory `Read` + `Seek` (and `Write` for `Vec` inner) cursor over a
+/// byte buffer, mirroring [`crate::io::Cursor`] for `no_std` builds.
+#[cfg(not(feature = "std"))]
+pub struct Cursor<T> {
+    inner: T,
+    pos: u64,
+}
+
+#[cfg(not(feature = "std"))]
+impl<T> Cursor<T> {
+    /// Wraps `inner`, starting the cursor at position 0.
+    pub const fn new(inner: T) -> Self {
+        Self { inner, pos: 0 }
+    }
+    /// Current byte position.
+    #[must_use]
+    pub const fn position(&self) -> u64 {
+        self.pos
+    }
+    /// Sets the byte position.
+    pub const fn set_position(&mut self, pos: u64) {
+        self.pos = pos;
+    }
+    /// Consumes the cursor, returning the wrapped buffer.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+    /// Borrows the wrapped buffer.
+    pub const fn get_ref(&self) -> &T {
+        &self.inner
+    }
+    /// Mutably borrows the wrapped buffer.
+    pub const fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<T: AsRef<[u8]>> Read for Cursor<T> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let inner = self.inner.as_ref();
+        // Position past end → 0 bytes (matches std).
+        let start = (self.pos as usize).min(inner.len());
+        let (_, remaining) = inner.split_at(start);
+        let n = buf.len().min(remaining.len());
+        let (src, _) = remaining.split_at(n);
+        let (dst, _) = buf.split_at_mut(n);
+        dst.copy_from_slice(src);
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<T: AsRef<[u8]>> Seek for Cursor<T> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        let len = self.inner.as_ref().len() as u64;
+        let new = match pos {
+            SeekFrom::Start(n) => n,
+            SeekFrom::End(off) => len.saturating_add_signed(off),
+            SeekFrom::Current(off) => self.pos.saturating_add_signed(off),
+        };
+        self.pos = new;
+        Ok(new)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Write for Cursor<alloc::vec::Vec<u8>> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Like std: writing at `pos` overwrites in place and extends the Vec
+        // when the write runs past the current end.
+        let pos = self.pos as usize;
+        if pos > self.inner.len() {
+            self.inner.resize(pos, 0);
+        }
+        let end = pos + buf.len();
+        if end > self.inner.len() {
+            self.inner.resize(end, 0);
+        }
+        let (_, tail) = self.inner.split_at_mut(pos);
+        let (dst, _) = tail.split_at_mut(buf.len());
+        dst.copy_from_slice(buf);
+        self.pos = end as u64;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+pub use std::io::BufReader;
+
+/// Buffering reader, mirroring the subset of [`std::io::BufReader`] the storage
+/// layer uses (record framing reads), for `no_std` builds. Coalesces small
+/// reads and exposes [`BufRead`] so a record parser can peek for a clean EOF.
+#[cfg(not(feature = "std"))]
+pub struct BufReader<R: Read> {
+    inner: R,
+    // `capacity`-sized; the valid (filled, not-yet-consumed) window is
+    // `buf[pos..cap]`.
+    buf: alloc::vec::Vec<u8>,
+    pos: usize,
+    cap: usize,
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> BufReader<R> {
+    /// Wraps `inner` with the default 8 KiB buffer.
+    pub fn new(inner: R) -> Self {
+        Self::with_capacity(8 * 1024, inner)
+    }
+
+    /// Wraps `inner` with a `capacity`-byte buffer.
+    pub fn with_capacity(capacity: usize, inner: R) -> Self {
+        Self {
+            inner,
+            buf: alloc::vec![0u8; capacity],
+            pos: 0,
+            cap: 0,
+        }
+    }
+
+    /// Mutable access to the inner reader. Bypasses the buffer — mixing direct
+    /// inner reads with buffered ones loses buffered bytes, like std.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Shared access to the inner reader.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> Read for BufReader<R> {
+    fn read(&mut self, dest: &mut [u8]) -> Result<usize> {
+        // A read at least as large as the buffer, with nothing buffered, goes
+        // straight to the inner reader (buffering would just add a copy).
+        if self.pos >= self.cap && dest.len() >= self.buf.len() {
+            return self.inner.read(dest);
+        }
+        let n = {
+            let available = self.fill_buf()?;
+            let n = available.len().min(dest.len());
+            let (src, _) = available.split_at(n);
+            let (dst, _) = dest.split_at_mut(n);
+            dst.copy_from_slice(src);
+            n
+        };
+        self.consume(n);
+        Ok(n)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> BufRead for BufReader<R> {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        if self.pos >= self.cap {
+            self.cap = self.inner.read(&mut self.buf)?;
+            self.pos = 0;
+        }
+        // Return `buf[pos..cap]` via split_at to keep `deny(indexing_slicing)`.
+        let (_, rest) = self.buf.split_at(self.pos);
+        let (out, _) = rest.split_at(self.cap - self.pos);
+        Ok(out)
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.pos = (self.pos + amt).min(self.cap);
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read + Seek> Seek for BufReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        // The buffered bytes belong to the old position; drop them.
+        self.pos = 0;
+        self.cap = 0;
+        self.inner.seek(pos)
+    }
+}
+
+#[cfg(feature = "std")]
+pub use std::io::BufWriter;
+
+/// Buffering writer, mirroring the subset of [`std::io::BufWriter`] the
+/// storage layer uses, for `no_std` builds. Coalesces small writes into one
+/// `capacity`-sized buffer and flushes it to the inner writer on overflow,
+/// explicit [`flush`](Write::flush), [`seek`](Seek::seek), or drop.
+#[cfg(not(feature = "std"))]
+pub struct BufWriter<W: Write> {
+    inner: W,
+    buf: alloc::vec::Vec<u8>,
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write> BufWriter<W> {
+    /// Wraps `inner` with the default 8 KiB buffer.
+    pub fn new(inner: W) -> Self {
+        Self::with_capacity(8 * 1024, inner)
+    }
+
+    /// Wraps `inner` with a `capacity`-byte buffer.
+    pub fn with_capacity(capacity: usize, inner: W) -> Self {
+        Self {
+            inner,
+            buf: alloc::vec::Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Mutable access to the inner writer. Does NOT flush the buffer first —
+    /// matches [`std::io::BufWriter::get_mut`].
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Shared access to the inner writer.
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    fn flush_buf(&mut self) -> Result<()> {
+        if !self.buf.is_empty() {
+            self.inner.write_all(&self.buf)?;
+            self.buf.clear();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write> Write for BufWriter<W> {
+    fn write(&mut self, data: &[u8]) -> Result<usize> {
+        // Flush first if this write wouldn't fit alongside what's buffered.
+        if self.buf.len() + data.len() > self.buf.capacity() {
+            self.flush_buf()?;
+        }
+        // A write at least as large as the whole buffer bypasses it entirely
+        // (buffering it would just add a copy), matching std::io::BufWriter.
+        if data.len() >= self.buf.capacity() {
+            self.inner.write(data)
+        } else {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.flush_buf()?;
+        self.inner.flush()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write + Seek> Seek for BufWriter<W> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        // Buffered bytes belong before the seek target, so flush them out
+        // before moving the inner cursor (matches std::io::BufWriter).
+        self.flush_buf()?;
+        self.inner.seek(pos)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write> Drop for BufWriter<W> {
+    fn drop(&mut self) {
+        // Best-effort flush, like std: a drop can't surface an error, and the
+        // storage writer always flushes explicitly before teardown anyway.
+        let _ = self.flush_buf();
+    }
 }
 
 #[cfg(test)]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -748,6 +748,15 @@ pub trait VarintReader: Read {
             if shift >= 64 {
                 return Err(Error::new(ErrorKind::InvalidData, "varint overflows u64"));
             }
+            // 10th byte (shift == 63): only bit 0 fits in u64. Any higher bit
+            // set is a non-canonical / overflowing encoding — reject it rather
+            // than silently shifting those bits away.
+            if shift == 63 && byte[0] & 0xFE != 0 {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "non-canonical varint overflow",
+                ));
+            }
             result |= (u64::from(byte[0] & 0x7f)) << shift;
             if byte[0] & 0x80 == 0 {
                 return Ok(result);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1559,4 +1559,124 @@ mod tests {
         assert_eq!(sink, b"hello");
         Ok(())
     }
+
+    /// Every `ErrorKind` discriminant — kept in one place so the
+    /// exhaustive bridge tests below stay total. A new variant added
+    /// to the enum without a row here fails the per-arm assertions
+    /// (the std round trip would not preserve it).
+    #[cfg(feature = "std")]
+    const ALL_KINDS: [ErrorKind; 12] = [
+        ErrorKind::AlreadyExists,
+        ErrorKind::BrokenPipe,
+        ErrorKind::CrossesDevices,
+        ErrorKind::Interrupted,
+        ErrorKind::InvalidData,
+        ErrorKind::InvalidInput,
+        ErrorKind::NotFound,
+        ErrorKind::Other,
+        ErrorKind::PermissionDenied,
+        ErrorKind::UnexpectedEof,
+        ErrorKind::Unsupported,
+        ErrorKind::WriteZero,
+    ];
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn every_kind_only_error_round_trips_through_std() {
+        // Exercises EVERY arm of both `From` match tables in one
+        // sweep: a kind-only `Error` (no message) crosses to
+        // `std::io::Error` (hitting that kind's arm in
+        // `From<Error> for std::io::Error`, plus the `None` message
+        // branch) and back (hitting the corresponding forward arm in
+        // `From<std::io::Error> for Error`, plus the kind-only mapped
+        // branch). The kind must survive both crossings unchanged —
+        // a dropped or mis-paired arm in either table fails here.
+        for kind in ALL_KINDS {
+            let original = Error::from_kind(kind);
+            let as_std: std::io::Error = original.into();
+            let back: Error = as_std.into();
+            assert_eq!(back.kind(), kind, "kind {kind:?} did not round-trip");
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn every_kind_only_std_error_maps_to_matching_kind() {
+        // Forward direction in isolation: a kind-only
+        // `std::io::Error` for each kind our table maps explicitly
+        // must produce the matching `ErrorKind`. Hits each mapped arm
+        // of `From<std::io::Error> for Error` directly (the prior test
+        // reaches them via produced std kinds; this asserts the mapping
+        // from the std side, where a future std-kind rename would bite).
+        let mapped = [
+            (std::io::ErrorKind::AlreadyExists, ErrorKind::AlreadyExists),
+            (std::io::ErrorKind::BrokenPipe, ErrorKind::BrokenPipe),
+            (
+                std::io::ErrorKind::CrossesDevices,
+                ErrorKind::CrossesDevices,
+            ),
+            (std::io::ErrorKind::Interrupted, ErrorKind::Interrupted),
+            (std::io::ErrorKind::InvalidData, ErrorKind::InvalidData),
+            (std::io::ErrorKind::InvalidInput, ErrorKind::InvalidInput),
+            (std::io::ErrorKind::NotFound, ErrorKind::NotFound),
+            (
+                std::io::ErrorKind::PermissionDenied,
+                ErrorKind::PermissionDenied,
+            ),
+            (std::io::ErrorKind::UnexpectedEof, ErrorKind::UnexpectedEof),
+            (std::io::ErrorKind::Unsupported, ErrorKind::Unsupported),
+            (std::io::ErrorKind::WriteZero, ErrorKind::WriteZero),
+        ];
+        for (std_kind, want) in mapped {
+            let ours: Error = std::io::Error::from(std_kind).into();
+            assert_eq!(ours.kind(), want, "std {std_kind:?} mis-mapped");
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn from_raw_os_error_preserves_os_detail_as_message() {
+        // A `std::io::Error::from_raw_os_error` carries an errno but no
+        // kind tag we mapped — `raw_os_error().is_some()` selects the
+        // message-attachment branch, so the OS-level Display text must
+        // survive into our message field rather than being dropped.
+        let std_err = std::io::Error::from_raw_os_error(2); // ENOENT
+        let ours: Error = std_err.into();
+        let rendered = alloc::format!("{ours}");
+        assert!(
+            rendered.contains(':'),
+            "os-detail error must attach a message, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn debug_renders_kind_always_and_message_when_present() {
+        // The custom `Debug` impl omits the `message` field entirely
+        // when none is set (it is not `Option`-wrapped in the output).
+        let kind_only = Error::from_kind(ErrorKind::NotFound);
+        let dbg = alloc::format!("{kind_only:?}");
+        assert!(dbg.contains("NotFound"), "missing kind in {dbg:?}");
+        assert!(
+            !dbg.contains("message"),
+            "kind-only must omit message: {dbg:?}"
+        );
+
+        let with_msg = Error::new(ErrorKind::InvalidData, "bad magic");
+        let dbg = alloc::format!("{with_msg:?}");
+        assert!(dbg.contains("message"), "expected message field in {dbg:?}");
+        assert!(dbg.contains("bad magic"), "expected payload in {dbg:?}");
+    }
+
+    #[test]
+    fn other_constructor_and_kind_from_conversion() {
+        // `Error::other` is the `ErrorKind::Other` shortcut; the
+        // `From<ErrorKind>` impl is the kind-only `?`-coercion path.
+        let e = Error::other("boom");
+        assert_eq!(e.kind(), ErrorKind::Other);
+        assert_eq!(alloc::format!("{e}"), "other error: boom");
+
+        let e: Error = ErrorKind::PermissionDenied.into();
+        assert_eq!(e.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(alloc::format!("{e}"), "permission denied");
+    }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::{SeqNo, UserKey, ValueType, comparator::UserComparator};
-use std::cmp::Reverse;
+use core::cmp::Reverse;
 
 #[derive(Clone, Eq)]
 pub struct InternalKey {
@@ -19,8 +19,8 @@ impl PartialEq for InternalKey {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-impl std::fmt::Debug for InternalKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InternalKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{:?}:{}:{}",
@@ -74,14 +74,14 @@ impl InternalKey {
         &self,
         other: &Self,
         cmp: &C,
-    ) -> std::cmp::Ordering {
+    ) -> core::cmp::Ordering {
         cmp.compare(&self.user_key, &other.user_key)
             .then_with(|| Reverse(self.seqno).cmp(&Reverse(other.seqno)))
     }
 }
 
 impl PartialOrd for InternalKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -90,7 +90,7 @@ impl PartialOrd for InternalKey {
 // This is one of the most important functions
 // Otherwise queries will not match expected behaviour
 impl Ord for InternalKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         (&self.user_key, Reverse(self.seqno)).cmp(&(&other.user_key, Reverse(other.seqno)))
     }
 }

--- a/src/key_range.rs
+++ b/src/key_range.rs
@@ -4,7 +4,7 @@
 
 use crate::{Slice, UserKey};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::Bound;
 
 /// A key range in the format of [min, max] (inclusive on both sides)

--- a/src/key_range.rs
+++ b/src/key_range.rs
@@ -3,7 +3,9 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::{Slice, UserKey};
-use std::ops::Bound;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::Bound;
 
 /// A key range in the format of [min, max] (inclusive on both sides)
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -80,8 +82,8 @@ impl KeyRange {
     ) -> bool {
         let (start1, end1) = self.as_tuple();
         let (start2, end2) = other.as_tuple();
-        cmp.compare(start1, start2) != std::cmp::Ordering::Greater
-            && cmp.compare(end1, end2) != std::cmp::Ordering::Less
+        cmp.compare(start1, start2) != core::cmp::Ordering::Greater
+            && cmp.compare(end1, end2) != core::cmp::Ordering::Less
     }
 
     /// Returns `true` if the `other` overlaps at least partially with this range.
@@ -101,8 +103,8 @@ impl KeyRange {
     ) -> bool {
         let (start1, end1) = self.as_tuple();
         let (start2, end2) = other.as_tuple();
-        cmp.compare(end1, start2) != std::cmp::Ordering::Less
-            && cmp.compare(start1, end2) != std::cmp::Ordering::Greater
+        cmp.compare(end1, start2) != core::cmp::Ordering::Less
+            && cmp.compare(start1, end2) != core::cmp::Ordering::Greater
     }
 
     /// Like [`Self::overlaps_with_bounds`], but uses a custom comparator for key ordering.
@@ -112,7 +114,7 @@ impl KeyRange {
         bounds: &(Bound<&[u8]>, Bound<&[u8]>),
         cmp: &dyn crate::comparator::UserComparator,
     ) -> bool {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         let (lo, hi) = bounds;
         let (my_lo, my_hi) = self.as_tuple();
@@ -217,7 +219,7 @@ impl KeyRange {
                 debug_assert!(
                     prev_min
                         .as_ref()
-                        .is_none_or(|pm| cmp.compare(pm, r.min()) != std::cmp::Ordering::Greater),
+                        .is_none_or(|pm| cmp.compare(pm, r.min()) != core::cmp::Ordering::Greater),
                     "merge_sorted_cmp: input ranges must be sorted by min key in comparator order",
                 );
                 prev_min = Some(r.min().clone());
@@ -225,9 +227,9 @@ impl KeyRange {
 
             if let Some(last) = out.last_mut() {
                 // Ranges overlap or are adjacent when last.max >= r.min
-                if cmp.compare(last.max(), r.min()) != std::cmp::Ordering::Less {
+                if cmp.compare(last.max(), r.min()) != core::cmp::Ordering::Less {
                     // Extend the current interval if r.max is beyond last.max
-                    if cmp.compare(r.max(), last.max()) == std::cmp::Ordering::Greater {
+                    if cmp.compare(r.max(), last.max()) == core::cmp::Ordering::Greater {
                         last.1 = r.1;
                     }
                     continue;
@@ -277,12 +279,12 @@ impl KeyRange {
 
         for other in iter {
             let x = other.min();
-            if cmp.compare(x, min) == std::cmp::Ordering::Less {
+            if cmp.compare(x, min) == core::cmp::Ordering::Less {
                 min = x;
             }
 
             let x = other.max();
-            if cmp.compare(x, max) == std::cmp::Ordering::Greater {
+            if cmp.compare(x, max) == core::cmp::Ordering::Greater {
                 max = x;
             }
         }
@@ -388,7 +390,7 @@ mod tests {
 
     mod overlaps_with_bounds {
         use super::*;
-        use std::ops::Bound::{Excluded, Included, Unbounded};
+        use core::ops::Bound::{Excluded, Included, Unbounded};
         use test_log::test;
 
         #[test]
@@ -479,7 +481,7 @@ mod tests {
     mod overlaps_with_bounds_cmp {
         use super::*;
         use crate::comparator::UserComparator;
-        use std::ops::Bound::{Excluded, Included, Unbounded};
+        use core::ops::Bound::{Excluded, Included, Unbounded};
         use test_log::test;
 
         struct ReverseComparator;
@@ -489,7 +491,7 @@ mod tests {
                 "reverse"
             }
 
-            fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+            fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
                 b.cmp(a)
             }
         }
@@ -670,7 +672,7 @@ mod tests {
                 fn name(&self) -> &'static str {
                     "reverse"
                 }
-                fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+                fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
                     b.cmp(a)
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,12 +121,72 @@
 // `Box`, and other heap types throughout. `extern crate alloc` makes the
 // `alloc` crate root visible to `no_std` builds; under `std` it is a
 // no-op alias because the standard library re-exports the same types.
+#[macro_use]
 extern crate alloc;
 
-#[doc(hidden)]
-pub type HashMap<K, V> = std::collections::HashMap<K, V, rustc_hash::FxBuildHasher>;
+// f64 ceil / round: the native `f64` methods are std-only (they bind to
+// platform float intrinsics), so the `no_std` build routes through `libm`.
+// std keeps the native path (equal or faster); the results are identical.
+#[cfg(feature = "std")]
+#[inline]
+pub(crate) fn f64_ceil(x: f64) -> f64 {
+    x.ceil()
+}
+#[cfg(not(feature = "std"))]
+#[inline]
+pub(crate) fn f64_ceil(x: f64) -> f64 {
+    libm::ceil(x)
+}
+#[cfg(feature = "std")]
+#[inline]
+pub(crate) fn f32_round(x: f32) -> f32 {
+    x.round()
+}
+#[cfg(not(feature = "std"))]
+#[inline]
+pub(crate) fn f32_round(x: f32) -> f32 {
+    libm::roundf(x)
+}
+#[cfg(feature = "std")]
+#[inline]
+pub(crate) fn f32_ceil(x: f32) -> f32 {
+    x.ceil()
+}
+#[cfg(not(feature = "std"))]
+#[inline]
+pub(crate) fn f32_ceil(x: f32) -> f32 {
+    libm::ceilf(x)
+}
+#[cfg(feature = "std")]
+#[inline]
+pub(crate) fn f64_log2(x: f64) -> f64 {
+    x.log2()
+}
+#[cfg(not(feature = "std"))]
+#[inline]
+pub(crate) fn f64_log2(x: f64) -> f64 {
+    libm::log2(x)
+}
+#[cfg(feature = "std")]
+#[inline]
+pub(crate) fn f32_log2(x: f32) -> f32 {
+    x.log2()
+}
+#[cfg(not(feature = "std"))]
+#[inline]
+pub(crate) fn f32_log2(x: f32) -> f32 {
+    libm::log2f(x)
+}
 
-pub(crate) type HashSet<K> = std::collections::HashSet<K, rustc_hash::FxBuildHasher>;
+// `hashbrown` (not `std::collections`) so the crate-wide map / set aliases
+// compile on `no_std + alloc`. hashbrown IS the implementation std's HashMap
+// wraps, so the API and performance match; using it directly just drops the
+// std dependency. Hasher stays `FxHasher` (fast, non-DoS — internal keys are
+// not attacker-controlled).
+#[doc(hidden)]
+pub type HashMap<K, V> = hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>;
+
+pub(crate) type HashSet<K> = hashbrown::HashSet<K, rustc_hash::FxBuildHasher>;
 
 macro_rules! fail_iter {
     ($e:expr) => {
@@ -154,6 +214,7 @@ pub mod heal_hints;
 // it via `pub` (even with `#[doc(hidden)]`) would lock the helpers into
 // the stable surface; tests that need to exercise them live inline as
 // unit tests inside `src/checkpoint.rs`.
+#[cfg(feature = "std")]
 pub(crate) mod checkpoint;
 
 #[doc(hidden)]
@@ -240,17 +301,6 @@ mod key;
 mod key_range;
 mod loser_tree;
 mod manifest;
-// Unconditional today. Gating behind `feature = "std"` requires
-// cascading `#[cfg]` onto every consumer that imports from this
-// module — `manifest`, `version::{persist,recovery}`, `tree::inner`,
-// `checkpoint`, plus their downstream re-exports — none of which are
-// themselves cfg-gated yet (they're std-bound through `fs::Fs` /
-// `Box<dyn FsFile>` for unrelated reasons). A naive gate here adds
-// hundreds of unresolved-module errors to the `no-std-check` job
-// before unblocking any of them. The cascade migration of this whole
-// std-bound layer (manifest + version + tree + checkpoint) is tracked
-// as issue #358; gating `manifest_blocks` in isolation is not cheap
-// and is the wrong sequencing.
 #[doc(hidden)]
 pub mod manifest_blocks;
 mod memtable;
@@ -297,6 +347,7 @@ pub mod range;
 pub mod runtime_config;
 
 /// Disaster-recovery: rebuild a missing/corrupt manifest from on-disk SSTs.
+// std-only: scans table folders and rewrites the manifest via std::fs.
 #[cfg(feature = "std")]
 pub mod repair;
 
@@ -377,7 +428,6 @@ pub type KvPair = (UserKey, UserValue);
 // rustdoc output; only intra-crate test/bench code is expected to use them.
 #[doc(hidden)]
 pub use {
-    blob_tree::{Guard as BlobGuard, handle::BlobIndirection},
     checksum::Checksum,
     iter_guard::IterGuardImpl,
     key_range::KeyRange,
@@ -386,9 +436,14 @@ pub use {
     // Re-exported for `benches/lsp.rs` only — see hidden-block contract above.
     table::util::longest_shared_prefix_length,
     table::{GlobalTableId, Table, TableId},
+    value::InternalValue,
+};
+
+#[doc(hidden)]
+pub use {
+    blob_tree::{Guard as BlobGuard, handle::BlobIndirection},
     tree::Guard as StandardGuard,
     tree::inner::TreeId,
-    value::InternalValue,
 };
 
 pub use encryption::EncryptionProvider;
@@ -396,8 +451,8 @@ pub use encryption::EncryptionProvider;
 #[cfg(feature = "encryption")]
 pub use encryption::Aes256GcmProvider;
 
-#[cfg(feature = "std")]
 #[doc(hidden)]
+#[cfg(feature = "std")]
 pub use background_deleter::BackgroundDeleter;
 pub use pinnable_slice::PinnableSlice;
 #[cfg(feature = "std")]
@@ -405,29 +460,32 @@ pub use repair::RepairReport;
 pub use write_batch::WriteBatch;
 
 pub use {
-    abstract_tree::{AbstractTree, CheckpointInfo},
-    any_tree::AnyTree,
-    blob_tree::BlobTree,
     cache::Cache,
     comparator::{DefaultUserComparator, SharedComparator, UserComparator},
     compression::CompressionType,
     config::{Config, KvSeparationOptions, TreeType},
-    descriptor_table::DescriptorTable,
     error::{Error, Result},
     format_version::FormatVersion,
-    ingestion::AnyIngestion,
     iter_guard::IterGuard as Guard,
     memtable::{Memtable, MemtableId},
     merge_operator::MergeOperator,
     prefix::PrefixExtractor,
-    scan_since::ScanSinceEvent,
     seqno::{
         MAX_SEQNO, SequenceNumberCounter, SequenceNumberGenerator, SharedSequenceNumberGenerator,
     },
     slice::Slice,
-    tree::Tree,
     value::SeqNo,
     value_type::ValueType,
+};
+
+pub use {
+    abstract_tree::{AbstractTree, CheckpointInfo},
+    any_tree::AnyTree,
+    blob_tree::BlobTree,
+    descriptor_table::DescriptorTable,
+    ingestion::AnyIngestion,
+    scan_since::ScanSinceEvent,
+    tree::Tree,
     vlog::BlobFile,
 };
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,9 +8,7 @@ use crate::{
 #[cfg(not(feature = "std"))]
 use alloc::{
     borrow::ToOwned,
-    boxed::Box,
     string::{String, ToString},
-    vec::Vec,
 };
 
 pub struct Manifest {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,6 +5,13 @@
 use crate::{
     FormatVersion, TreeType, checksum::ChecksumType, manifest_blocks::reader::ManifestArchiveReader,
 };
+#[cfg(not(feature = "std"))]
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 pub struct Manifest {
     pub version: FormatVersion,
@@ -133,11 +140,11 @@ impl Manifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::WriteBytesExt;
     use crate::{
         fs::{Fs, MemFs, StdFs},
         manifest_blocks::writer::ManifestArchiveWriter,
     };
-    use byteorder::WriteBytesExt;
     use std::{io::Write, path::Path};
 
     /// Write a minimal valid Blocks-based manifest with all four

--- a/src/manifest_blocks/current_digest.rs
+++ b/src/manifest_blocks/current_digest.rs
@@ -63,7 +63,7 @@ use crate::io::Write;
 use crate::io::{LittleEndian, WriteBytesExt};
 use crate::manifest_blocks::footer::{FooterPayload, TocEntry};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::io::Write;
 

--- a/src/manifest_blocks/current_digest.rs
+++ b/src/manifest_blocks/current_digest.rs
@@ -58,8 +58,13 @@
 //!   a MAC. AEAD (`Config::with_encryption(...)`) provides the
 //!   per-Block authenticated-encryption layer for that threat.
 
+#[cfg(not(feature = "std"))]
+use crate::io::Write;
+use crate::io::{LittleEndian, WriteBytesExt};
 use crate::manifest_blocks::footer::{FooterPayload, TocEntry};
-use byteorder::{LittleEndian, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "std")]
 use std::io::Write;
 
 /// Compute the canonical XXH3-128 digest a CURRENT pointer carries

--- a/src/manifest_blocks/footer.rs
+++ b/src/manifest_blocks/footer.rs
@@ -40,7 +40,7 @@ use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crate::io::{Read, Write};
 use crate::manifest_blocks::{MANIFEST_LAYOUT_VERSION_V1, MAX_SECTION_NAME_BYTES};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::io::{Read, Write};
 

--- a/src/manifest_blocks/footer.rs
+++ b/src/manifest_blocks/footer.rs
@@ -35,8 +35,13 @@
 //! validates structural invariants (UTF-8, non-empty names, no
 //! duplicates, bounded sizes).
 
+use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
 use crate::manifest_blocks::{MANIFEST_LAYOUT_VERSION_V1, MAX_SECTION_NAME_BYTES};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
 
 /// One entry in the footer's table of contents — locates a single

--- a/src/manifest_blocks/reader.rs
+++ b/src/manifest_blocks/reader.rs
@@ -59,7 +59,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 #[cfg(feature = "std")]
 use std::io::{Cursor, Read, Seek, SeekFrom};
 

--- a/src/manifest_blocks/reader.rs
+++ b/src/manifest_blocks/reader.rs
@@ -42,6 +42,10 @@
 //! [`FooterPayload`]: crate::manifest_blocks::footer::FooterPayload
 //! [`HEAD_FOOTER_RESERVED_SIZE`]: crate::manifest_blocks::HEAD_FOOTER_RESERVED_SIZE
 
+#[cfg(not(feature = "std"))]
+use crate::io::{Cursor, Read, Seek, SeekFrom};
+use crate::io::{LittleEndian, ReadBytesExt};
+use crate::path::{Path, PathBuf};
 use crate::{
     encryption::EncryptionProvider,
     fs::{Fs, FsFile, FsOpenOptions},
@@ -53,12 +57,11 @@ use crate::{
     runtime_config::RuntimeConfig,
     table::block::{Block, BlockIdentity, BlockTransform, BlockType, Header},
 };
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::{
-    io::{Cursor, Read, Seek, SeekFrom},
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::io::{Cursor, Read, Seek, SeekFrom};
 
 /// Reader over an already-validated manifest file: holds the parsed
 /// footer payload and an open file handle for on-demand section

--- a/src/manifest_blocks/writer.rs
+++ b/src/manifest_blocks/writer.rs
@@ -21,6 +21,10 @@
 //! [`start`]: ManifestArchiveWriter::start
 //! [`finish`]: ManifestArchiveWriter::finish
 
+#[cfg(not(feature = "std"))]
+use crate::io::{self, Seek, SeekFrom, Write};
+use crate::io::{LittleEndian, WriteBytesExt};
+use crate::path::Path;
 use crate::{
     encryption::EncryptionProvider,
     fs::{Fs, FsFile, FsOpenOptions, SyncMode},
@@ -32,13 +36,16 @@ use crate::{
     runtime_config::RuntimeConfig,
     table::block::{Block, BlockIdentity, BlockTransform, BlockType},
 };
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::{
-    collections::BTreeSet,
-    io::{self, Seek, SeekFrom, Write},
-    path::Path,
-    sync::Arc,
+use alloc::collections::BTreeSet;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
 };
+#[cfg(feature = "std")]
+use std::io::{self, Seek, SeekFrom, Write};
 
 /// Streaming writer for V5-2 manifest files. See module docs.
 pub struct ManifestArchiveWriter {
@@ -256,7 +263,7 @@ impl ManifestArchiveWriter {
         } else {
             0
         };
-        let payload = FooterPayload::new(flags, std::mem::take(&mut self.toc));
+        let payload = FooterPayload::new(flags, core::mem::take(&mut self.toc));
         let mut payload_bytes = Vec::new();
         payload.encode(&mut payload_bytes)?;
 
@@ -433,7 +440,7 @@ impl ManifestArchiveWriter {
         let section_checksum = {
             use crate::coding::Decode;
             use crate::table::block::Header;
-            let mut cursor = std::io::Cursor::new(block_bytes.as_slice());
+            let mut cursor = crate::io::Cursor::new(block_bytes.as_slice());
             Header::decode_from(&mut cursor)?.checksum.into_u128()
         };
 

--- a/src/memtable/arena.rs
+++ b/src/memtable/arena.rs
@@ -23,7 +23,7 @@
 //! longer eagerly zeroes its arena block).
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 

--- a/src/memtable/arena.rs
+++ b/src/memtable/arena.rs
@@ -12,7 +12,7 @@
 //!
 //! # Memory is uninitialized
 //!
-//! Blocks are allocated with [`alloc`](std::alloc::alloc), NOT `alloc_zeroed`
+//! Blocks are allocated with [`alloc`](alloc::alloc::alloc), NOT `alloc_zeroed`
 //! (same as the `RocksDB` arena, which uses an uninitialized `new char[]`). The
 //! caller MUST fully initialize every byte it later reads before publishing the
 //! allocation to other threads — the arena makes no zeroing guarantee. The
@@ -22,8 +22,10 @@
 //! creation. This removes the per-flush zeroing cost (a fresh memtable no
 //! longer eagerly zeroes its arena block).
 
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ptr;
+use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
 /// Bits used for the within-block offset.
 ///
@@ -170,7 +172,7 @@ impl Arena {
             "get_bytes: off={off} + len={len} exceeds BLOCK_SIZE={BLOCK_SIZE} (offset={offset})",
         );
         // SAFETY: caller guarantees the range is allocated and initialised.
-        unsafe { std::slice::from_raw_parts(ptr.add(off), len as usize) }
+        unsafe { core::slice::from_raw_parts(ptr.add(off), len as usize) }
     }
 
     /// Returns an exclusive reference to `len` bytes at the encoded `offset`.
@@ -186,7 +188,7 @@ impl Arena {
         let (ptr, off) = unsafe { self.decode(offset) };
         // SAFETY: caller guarantees exclusive access (typically right after alloc,
         // before the node offset is published to other threads).
-        unsafe { std::slice::from_raw_parts_mut(ptr.add(off), len as usize) }
+        unsafe { core::slice::from_raw_parts_mut(ptr.add(off), len as usize) }
     }
 
     /// Interprets 4 bytes at `offset` as an [`AtomicU32`] reference.
@@ -235,7 +237,7 @@ impl Arena {
             // Spin briefly — ensure_block uses CAS with AcqRel, so the
             // pointer will become visible after a few iterations.
             for _ in 0..1000 {
-                std::hint::spin_loop();
+                core::hint::spin_loop();
                 ptr = self.blocks[block_idx].load(Ordering::Acquire);
                 if !ptr.is_null() {
                     return (ptr, off);
@@ -273,9 +275,9 @@ impl Arena {
             // SAFETY: layout is non-zero (BLOCK_SIZE > 0). Visibility: the CAS
             // below (AcqRel) makes the block pointer (and the writes the caller
             // makes into it before publishing a node) visible to readers.
-            let raw = unsafe { std::alloc::alloc(layout) };
+            let raw = unsafe { alloc::alloc::alloc(layout) };
             if raw.is_null() {
-                std::alloc::handle_alloc_error(layout);
+                alloc::alloc::handle_alloc_error(layout);
             }
 
             // CAS null → raw.  If another thread won, free our block.
@@ -285,7 +287,7 @@ impl Arena {
             {
                 // SAFETY: raw was just allocated with `layout`.
                 unsafe {
-                    std::alloc::dealloc(raw, layout);
+                    alloc::alloc::dealloc(raw, layout);
                 }
             }
         }
@@ -293,9 +295,9 @@ impl Arena {
 
     /// Layout for arena blocks: `BLOCK_SIZE` bytes with 4-byte alignment
     /// (required for `AtomicU32` tower pointers).
-    fn block_layout() -> std::alloc::Layout {
+    fn block_layout() -> alloc::alloc::Layout {
         // SAFETY: BLOCK_SIZE > 0 and align (4) is a power of two.
-        unsafe { std::alloc::Layout::from_size_align_unchecked(BLOCK_SIZE as usize, 4) }
+        unsafe { alloc::alloc::Layout::from_size_align_unchecked(BLOCK_SIZE as usize, 4) }
     }
 }
 
@@ -314,7 +316,7 @@ impl Drop for Arena {
                 // SAFETY: `ptr` was allocated for this arena using `block_layout()`,
                 // so deallocating with the same layout is valid.
                 unsafe {
-                    std::alloc::dealloc(ptr, layout);
+                    alloc::alloc::dealloc(ptr, layout);
                 }
             }
         }

--- a/src/memtable/interval_tree.rs
+++ b/src/memtable/interval_tree.rs
@@ -11,7 +11,7 @@ use crate::range_tombstone::CoveringRt;
 use crate::range_tombstone::RangeTombstone;
 use crate::{SeqNo, UserKey, comparator::SharedComparator};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::cmp::Ordering;
 
 /// An AVL-balanced BST keyed by range tombstone `start`, augmented with

--- a/src/memtable/interval_tree.rs
+++ b/src/memtable/interval_tree.rs
@@ -10,7 +10,9 @@
 use crate::range_tombstone::CoveringRt;
 use crate::range_tombstone::RangeTombstone;
 use crate::{SeqNo, UserKey, comparator::SharedComparator};
-use std::cmp::Ordering;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::cmp::Ordering;
 
 /// An AVL-balanced BST keyed by range tombstone `start`, augmented with
 /// subtree-level metadata for efficient interval queries.

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     value::{InternalValue, SeqNo},
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::RangeBounds;
 use core::sync::atomic::AtomicBool;
 use portable_atomic::AtomicU64;

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -14,9 +14,18 @@ use crate::{
     UserKey, ValueType,
     value::{InternalValue, SeqNo},
 };
-use std::ops::RangeBounds;
-use std::sync::RwLock;
-use std::sync::atomic::{AtomicBool, AtomicU64};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::RangeBounds;
+use core::sync::atomic::AtomicBool;
+use portable_atomic::AtomicU64;
+// `parking_lot::RwLock` (std: small, userspace fast-path, no poisoning) /
+// `spin::RwLock` (no_std). Neither poisons on a panicked holder, so the read/
+// write guards are taken without a `LockResult` unwrap.
+#[cfg(feature = "std")]
+use parking_lot::RwLock;
+#[cfg(not(feature = "std"))]
+use spin::RwLock;
 
 pub use crate::tree::inner::MemtableId;
 
@@ -74,13 +83,13 @@ impl Memtable {
     /// Returns `true` if the memtable was already flagged for rotation.
     pub fn is_flagged_for_rotation(&self) -> bool {
         self.requested_rotation
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(core::sync::atomic::Ordering::Relaxed)
     }
 
     /// Flags the memtable as requested for rotation.
     pub fn flag_rotated(&self) {
         self.requested_rotation
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+            .store(true, core::sync::atomic::Ordering::Relaxed);
     }
 
     // `pub` + `#[doc(hidden)]`: used by the host crate (fjall) to construct
@@ -159,7 +168,7 @@ impl Memtable {
         let cmp = self.comparator.as_ref();
 
         let mut iter = self.items.range(lower_bound..).take_while(|entry| {
-            cmp.compare(entry.user_key_bytes(), key) == std::cmp::Ordering::Equal
+            cmp.compare(entry.user_key_bytes(), key) == core::cmp::Ordering::Equal
         });
 
         iter.next().map(|entry| InternalValue {
@@ -171,7 +180,7 @@ impl Memtable {
     /// Gets approximate size of memtable in bytes.
     pub fn size(&self) -> u64 {
         self.approximate_size
-            .load(std::sync::atomic::Ordering::Acquire)
+            .load(core::sync::atomic::Ordering::Acquire)
     }
 
     /// Counts the number of items in the memtable.
@@ -197,7 +206,7 @@ impl Memtable {
         if items.is_empty() {
             let size = self
                 .approximate_size
-                .load(std::sync::atomic::Ordering::Acquire);
+                .load(core::sync::atomic::Ordering::Acquire);
             return (0, size);
         }
 
@@ -205,7 +214,7 @@ impl Memtable {
         let mut max_seqno: u64 = 0;
 
         let overhead =
-            std::mem::size_of::<InternalValue>() + std::mem::size_of::<SharedComparator>();
+            core::mem::size_of::<InternalValue>() + core::mem::size_of::<SharedComparator>();
 
         for item in &items {
             #[expect(
@@ -225,7 +234,7 @@ impl Memtable {
 
         let size_before = self
             .approximate_size
-            .fetch_add(total_size, std::sync::atomic::Ordering::AcqRel);
+            .fetch_add(total_size, core::sync::atomic::Ordering::AcqRel);
 
         for item in items {
             let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
@@ -233,7 +242,7 @@ impl Memtable {
         }
 
         self.highest_seqno
-            .fetch_max(max_seqno, std::sync::atomic::Ordering::AcqRel);
+            .fetch_max(max_seqno, core::sync::atomic::Ordering::AcqRel);
 
         // fetch_add returns value BEFORE the add, so size_before + total_size
         // = value AFTER add = new memtable size. Same pattern as Memtable::insert().
@@ -250,20 +259,20 @@ impl Memtable {
         // Account for MemtableKey overhead (InternalKey + Arc<dyn UserComparator>)
         let item_size = (item.key.user_key.len()
             + item.value.len()
-            + std::mem::size_of::<InternalValue>()
-            + std::mem::size_of::<SharedComparator>())
+            + core::mem::size_of::<InternalValue>()
+            + core::mem::size_of::<SharedComparator>())
         .try_into()
         .expect("should fit into u64");
 
         let size_before = self
             .approximate_size
-            .fetch_add(item_size, std::sync::atomic::Ordering::AcqRel);
+            .fetch_add(item_size, core::sync::atomic::Ordering::AcqRel);
 
         let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
         self.items.insert(&key, &item.value);
 
         self.highest_seqno
-            .fetch_max(item.key.seqno, std::sync::atomic::Ordering::AcqRel);
+            .fetch_max(item.key.seqno, core::sync::atomic::Ordering::AcqRel);
 
         (item_size, size_before + item_size)
     }
@@ -292,7 +301,7 @@ impl Memtable {
         );
 
         // Reject invalid intervals in release builds (debug_assert is not enough)
-        if self.comparator.compare(&start, &end) != std::cmp::Ordering::Less {
+        if self.comparator.compare(&start, &end) != core::cmp::Ordering::Less {
             return 0;
         }
 
@@ -309,71 +318,43 @@ impl Memtable {
             return 0;
         }
 
-        let size = (start.len() + end.len() + std::mem::size_of::<RangeTombstone>()) as u64;
+        let size = (start.len() + end.len() + core::mem::size_of::<RangeTombstone>()) as u64;
 
-        // Panic on poison is intentional — a poisoned lock indicates a prior panic
-        // during a write, leaving the tree in an unknown state. Recovery would
-        // require validating AVL invariants which is not worth the complexity.
-        // This pattern is consistent with the original Mutex implementation.
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         self.range_tombstones
             .write()
-            .expect("lock is poisoned")
             .insert(RangeTombstone::new(start, end, seqno));
 
         self.approximate_size
-            .fetch_add(size, std::sync::atomic::Ordering::AcqRel);
+            .fetch_add(size, core::sync::atomic::Ordering::AcqRel);
 
         self.highest_seqno
-            .fetch_max(seqno, std::sync::atomic::Ordering::AcqRel);
+            .fetch_max(seqno, core::sync::atomic::Ordering::AcqRel);
 
         size
     }
 
     /// Returns `true` if the key at `key_seqno` is suppressed by a range tombstone
     /// visible at `read_seqno`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal `RwLock` is poisoned.
     pub(crate) fn is_key_suppressed_by_range_tombstone(
         &self,
         key: &[u8],
         key_seqno: SeqNo,
         read_seqno: SeqNo,
     ) -> bool {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         self.range_tombstones
             .read()
-            .expect("lock is poisoned")
             .query_suppression(key, key_seqno, read_seqno)
     }
 
     /// Returns all range tombstones in sorted order (for flush).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal `RwLock` is poisoned.
     pub(crate) fn range_tombstones_sorted(&self) -> Vec<RangeTombstone> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.range_tombstones
-            .read()
-            .expect("lock is poisoned")
-            .iter_sorted()
+        self.range_tombstones.read().iter_sorted()
     }
 
     /// Returns the number of range tombstones.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal `RwLock` is poisoned.
     #[must_use]
     pub fn range_tombstone_count(&self) -> usize {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.range_tombstones
-            .read()
-            .expect("lock is poisoned")
-            .len()
+        self.range_tombstones.read().len()
     }
 
     /// Returns the highest sequence number in the memtable.
@@ -383,7 +364,7 @@ impl Memtable {
         } else {
             Some(
                 self.highest_seqno
-                    .load(std::sync::atomic::Ordering::Acquire),
+                    .load(core::sync::atomic::Ordering::Acquire),
             )
         }
     }
@@ -418,7 +399,7 @@ mod tests {
         let rt_ref = &mt.range_tombstones;
         std::thread::scope(|s| {
             s.spawn(move || {
-                let _guard = rt_ref.read().expect("lock is poisoned");
+                let _guard = rt_ref.read();
                 let _ = held_tx.send(()); // signal: guard held
                 let _ = release_rx.recv(); // wait: main thread done
             });
@@ -428,7 +409,7 @@ mod tests {
                 .expect("spawned thread panicked before acquiring guard");
             let guard2 = mt.range_tombstones.try_read();
             assert!(
-                guard2.is_ok(),
+                guard2.is_some(),
                 "second read lock must succeed while first is held"
             );
             drop(guard2);

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -21,9 +21,10 @@ use crate::key::InternalKey;
 use crate::value::{SeqNo, UserValue};
 use crate::{UserKey, ValueType};
 
-use std::cmp::Ordering as CmpOrdering;
-use std::ops::{Bound, RangeBounds};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::cmp::Ordering as CmpOrdering;
+use core::ops::{Bound, RangeBounds};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use portable_atomic::AtomicU64;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -470,7 +471,7 @@ impl SkipMap {
         clippy::cast_possible_truncation,
         reason = "level < MAX_HEIGHT (20), fits in u32"
     )]
-    unsafe fn tower_atomic(&self, node: u32, level: usize) -> &std::sync::atomic::AtomicU32 {
+    unsafe fn tower_atomic(&self, node: u32, level: usize) -> &core::sync::atomic::AtomicU32 {
         // SAFETY: caller guarantees level < node height; node + OFF_TOWER + level*4
         // is within the node's arena allocation and 4-byte aligned.
         unsafe {

--- a/src/memtable/value_store.rs
+++ b/src/memtable/value_store.rs
@@ -13,9 +13,11 @@
 //! and caused 15-27% throughput regression under concurrent reads.
 
 use crate::value::UserValue;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
+use core::ptr;
+use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
 
 /// Number of entries per segment.  2^16 = 65 536.
 const SEGMENT_SHIFT: u32 = 16;
@@ -154,7 +156,7 @@ impl ValueStore {
                 reason = "Layout::array with compile-time-known size cannot fail"
             )]
             let layout =
-                std::alloc::Layout::array::<UserValue>(SEGMENT_SIZE).expect("segment layout");
+                alloc::alloc::Layout::array::<UserValue>(SEGMENT_SIZE).expect("segment layout");
 
             // SAFETY: layout is non-zero (SEGMENT_SIZE > 0, UserValue is non-ZST).
             // The cast to *mut UserValue is safe because alloc_zeroed returns
@@ -164,9 +166,9 @@ impl ValueStore {
                 clippy::cast_ptr_alignment,
                 reason = "Layout::array ensures correct alignment"
             )]
-            let raw = unsafe { std::alloc::alloc_zeroed(layout) }.cast::<UserValue>();
+            let raw = unsafe { alloc::alloc::alloc_zeroed(layout) }.cast::<UserValue>();
             if raw.is_null() {
-                std::alloc::handle_alloc_error(layout);
+                alloc::alloc::handle_alloc_error(layout);
             }
 
             // CAS null → raw.  Loser frees its allocation.
@@ -177,7 +179,7 @@ impl ValueStore {
                 // SAFETY: raw was just allocated with the same layout; no
                 // slots were initialised (we lost the race before any append).
                 unsafe {
-                    std::alloc::dealloc(raw.cast::<u8>(), layout);
+                    alloc::alloc::dealloc(raw.cast::<u8>(), layout);
                 }
             }
         }
@@ -236,13 +238,13 @@ impl Drop for ValueStore {
                 reason = "Layout::array with compile-time-known size cannot fail"
             )]
             let layout =
-                std::alloc::Layout::array::<UserValue>(SEGMENT_SIZE).expect("segment layout");
+                alloc::alloc::Layout::array::<UserValue>(SEGMENT_SIZE).expect("segment layout");
             // SAFETY: `seg_ptr` came from `alloc_zeroed(layout)` in
             // `ensure_segment()`, all initialised entries were dropped above,
             // and `Drop` has exclusive access — so this frees that allocation
             // exactly once with the original layout.
             unsafe {
-                std::alloc::dealloc(seg_ptr.cast::<u8>(), layout);
+                alloc::alloc::dealloc(seg_ptr.cast::<u8>(), layout);
             }
         }
     }

--- a/src/memtable/value_store.rs
+++ b/src/memtable/value_store.rs
@@ -14,7 +14,7 @@
 
 use crate::value::UserValue;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 use core::ptr;
 use core::sync::atomic::{AtomicPtr, AtomicU32, Ordering};

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -5,6 +5,8 @@
 use crate::InternalValue;
 use crate::comparator::SharedComparator;
 use crate::heap::{HeapEntry, MergeHeap};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 type IterItem = crate::Result<InternalValue>;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -6,7 +6,7 @@ use crate::InternalValue;
 use crate::comparator::SharedComparator;
 use crate::heap::{HeapEntry, MergeHeap};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 type IterItem = crate::Result<InternalValue>;
 

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::UserValue;
-use std::panic::RefUnwindSafe;
+use core::panic::RefUnwindSafe;
 
 /// A user-defined merge operator for commutative LSM operations.
 ///

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,8 +2,8 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use core::sync::atomic::Ordering::Relaxed;
+use core::sync::atomic::{AtomicU64, AtomicUsize};
 
 /// Runtime metrics
 ///
@@ -262,7 +262,7 @@ impl Metrics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering::Relaxed;
+    use core::sync::atomic::Ordering::Relaxed;
 
     #[test]
     fn range_tombstone_counters_default_zero() {

--- a/src/mvcc_stream.rs
+++ b/src/mvcc_stream.rs
@@ -8,7 +8,7 @@ use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, UserKey, UserValue, ValueType, comparator::SharedComparator};
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Consumes a stream of KVs and emits a new stream according to MVCC and tombstone rules
 ///

--- a/src/mvcc_stream.rs
+++ b/src/mvcc_stream.rs
@@ -6,7 +6,9 @@ use crate::double_ended_peekable::{DoubleEndedPeekable, DoubleEndedPeekableExt};
 use crate::merge_operator::MergeOperator;
 use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, UserKey, UserValue, ValueType, comparator::SharedComparator};
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Consumes a stream of KVs and emits a new stream according to MVCC and tombstone rules
 ///
@@ -326,7 +328,7 @@ impl<I: DoubleEndedIterator<Item = crate::Result<InternalValue>>> DoubleEndedIte
                     && !self.is_rt_suppressed(&tail)
                 {
                     self.key_entries_buf.push(tail);
-                    let entries = std::mem::take(&mut self.key_entries_buf);
+                    let entries = core::mem::take(&mut self.key_entries_buf);
                     return Some(self.resolve_merge_buffered(entries));
                 }
                 return Some(Ok(tail));
@@ -416,7 +418,7 @@ mod tests {
                     999,
                     ValueType::Value,
                 )),
-                Err(crate::Error::Io(std::io::Error::other("test error"))),
+                Err(crate::Error::Io(crate::io::Error::other("test error"))),
             ];
 
             let iter = Box::new(vec.into_iter());
@@ -436,7 +438,7 @@ mod tests {
                     999,
                     ValueType::Value,
                 )),
-                Err(crate::Error::Io(std::io::Error::other("test error"))),
+                Err(crate::Error::Io(crate::io::Error::other("test error"))),
             ];
 
             let iter = Box::new(vec.into_iter());

--- a/src/path.rs
+++ b/src/path.rs
@@ -2,10 +2,374 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use std::path::{Path, PathBuf};
+//! Path types for the storage layer.
+//!
+//! Dual, mirroring [`crate::io`]: under `std` these ARE
+//! [`std::path::Path`] / [`std::path::PathBuf`] (re-export), so the default
+//! `StdFs` backend and existing call sites are unchanged. Under
+//! `no_std + alloc` they are thin newtypes over `str` / `String` — a storage
+//! "path" is an object KEY (e.g. `"tables/123"`, `"MANIFEST"`), not a
+//! filesystem path, which is exactly what an embedded / WASM-IndexedDB backend
+//! addresses by. Components are `/`-separated.
+//!
+//! Filesystem *queries* (`exists` / `is_file` / `is_dir`) are deliberately NOT
+//! on these types — under `no_std` there is no ambient filesystem; the engine
+//! routes those through the injected [`crate::fs::Fs`] backend instead.
 
+#[cfg(feature = "std")]
+pub use std::path::{Path, PathBuf};
+
+/// Absolute-path helper. Identity under `no_std` (object keys have no
+/// process-relative ambiguity to resolve); canonicalises against the process
+/// CWD under `std`.
+#[cfg(feature = "std")]
+#[must_use]
 pub fn absolute_path(path: &Path) -> PathBuf {
     // Not sure if this can even fail realistically
     #[expect(clippy::expect_used, reason = "not much we can do about it")]
     std::path::absolute(path).expect("should be absolute path")
+}
+
+#[cfg(not(feature = "std"))]
+pub use nostd::{Path, PathBuf};
+
+/// Identity under `no_std`: an object key is already absolute (no CWD).
+#[cfg(not(feature = "std"))]
+#[must_use]
+pub fn absolute_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+#[cfg(not(feature = "std"))]
+mod nostd {
+    use alloc::borrow::ToOwned;
+    use alloc::string::String;
+    use core::fmt;
+    use core::ops::Deref;
+
+    /// Borrowed path slice, mirroring the subset of [`std::path::Path`] the
+    /// storage layer uses. `/`-separated object key. `#[repr(transparent)]`
+    /// over `str` so `&str ⇄ &Path` is a zero-cost reference cast.
+    #[repr(transparent)]
+    pub struct Path {
+        inner: str,
+    }
+
+    impl Path {
+        /// Wraps a string slice as a `Path` (zero-cost).
+        pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> &Self {
+            // SAFETY: `Path` is `#[repr(transparent)]` over `str`, so a
+            // `&str` and a `&Path` have identical layout; the cast only
+            // re-labels the reference type.
+            unsafe { &*(core::ptr::from_ref::<str>(s.as_ref()) as *const Self) }
+        }
+
+        /// The underlying string slice.
+        #[must_use]
+        pub const fn as_str(&self) -> &str {
+            &self.inner
+        }
+
+        /// Always `Some` (the whole key is valid UTF-8 by construction);
+        /// mirrors [`std::path::Path::to_str`].
+        #[must_use]
+        pub const fn to_str(&self) -> Option<&str> {
+            Some(&self.inner)
+        }
+
+        /// Lossless owned form; mirrors [`std::path::Path::to_string_lossy`]
+        /// (always lossless here).
+        #[must_use]
+        pub fn to_string_lossy(&self) -> &str {
+            &self.inner
+        }
+
+        /// Owned copy.
+        #[must_use]
+        pub fn to_path_buf(&self) -> PathBuf {
+            PathBuf {
+                inner: self.inner.to_owned(),
+            }
+        }
+
+        /// Identity (already a `&Path`); mirrors
+        /// [`std::path::Path::as_path`] on `PathBuf`-like deref chains.
+        #[must_use]
+        pub const fn as_path(&self) -> &Self {
+            self
+        }
+
+        /// Appends `component`, inserting a `/` separator as needed.
+        #[must_use]
+        pub fn join<S: AsRef<str>>(&self, component: S) -> PathBuf {
+            let mut buf = self.to_path_buf();
+            buf.push(component);
+            buf
+        }
+
+        /// Parent key (everything before the last `/`), or `None` at the root.
+        #[must_use]
+        pub fn parent(&self) -> Option<&Self> {
+            self.inner
+                .rfind('/')
+                .map(|idx| Self::new(self.inner.split_at(idx).0))
+        }
+
+        /// Final `/`-separated component, or `None` if empty.
+        #[must_use]
+        pub fn file_name(&self) -> Option<&str> {
+            if self.inner.is_empty() {
+                return None;
+            }
+            Some(self.inner.rsplit('/').next().unwrap_or(&self.inner))
+        }
+
+        /// Whether this key begins with `base` on a component boundary.
+        #[must_use]
+        pub fn starts_with<S: AsRef<str>>(&self, base: S) -> bool {
+            let base = base.as_ref().trim_end_matches('/');
+            if base.is_empty() {
+                return true;
+            }
+            &self.inner == base
+                || self
+                    .inner
+                    .strip_prefix(base)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        }
+
+        /// Strips a leading `base` component prefix.
+        ///
+        /// # Errors
+        /// Returns `Err(StripPrefixError)` if `self` does not start with `base`.
+        pub fn strip_prefix<S: AsRef<str>>(&self, base: S) -> Result<&Self, StripPrefixError> {
+            let base = base.as_ref().trim_end_matches('/');
+            if base.is_empty() {
+                return Ok(self);
+            }
+            self.inner
+                .strip_prefix(base)
+                .map(|rest| Self::new(rest.trim_start_matches('/')))
+                .ok_or(StripPrefixError(()))
+        }
+
+        /// `/`-separated components, skipping empty segments.
+        pub fn components(&self) -> impl Iterator<Item = &str> {
+            self.inner.split('/').filter(|s| !s.is_empty())
+        }
+
+        /// `Display`-able view (the raw key).
+        #[must_use]
+        pub const fn display(&self) -> &str {
+            &self.inner
+        }
+
+        /// Underlying bytes view; mirrors [`std::path::Path::as_os_str`].
+        /// The key is always valid UTF-8 here, so this is the raw `str`.
+        #[must_use]
+        pub const fn as_os_str(&self) -> &str {
+            &self.inner
+        }
+    }
+
+    impl alloc::borrow::ToOwned for Path {
+        type Owned = PathBuf;
+        fn to_owned(&self) -> PathBuf {
+            self.to_path_buf()
+        }
+    }
+
+    impl fmt::Debug for Path {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt::Debug::fmt(&self.inner, f)
+        }
+    }
+
+    impl fmt::Display for Path {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.inner)
+        }
+    }
+
+    impl PartialEq for Path {
+        fn eq(&self, other: &Self) -> bool {
+            self.inner == other.inner
+        }
+    }
+
+    impl Eq for Path {}
+
+    impl PartialOrd for Path {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for Path {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+            self.inner.cmp(&other.inner)
+        }
+    }
+
+    impl core::hash::Hash for Path {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            self.inner.hash(state);
+        }
+    }
+
+    impl AsRef<Path> for Path {
+        fn as_ref(&self) -> &Path {
+            self
+        }
+    }
+
+    impl AsRef<str> for Path {
+        fn as_ref(&self) -> &str {
+            &self.inner
+        }
+    }
+
+    /// Owned path key, mirroring the subset of [`std::path::PathBuf`] used.
+    #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct PathBuf {
+        inner: String,
+    }
+
+    impl PathBuf {
+        /// Empty path.
+        #[must_use]
+        pub const fn new() -> Self {
+            Self {
+                inner: String::new(),
+            }
+        }
+
+        /// Borrow as a [`Path`].
+        #[must_use]
+        pub fn as_path(&self) -> &Path {
+            Path::new(&self.inner)
+        }
+
+        /// Appends `component`, inserting a `/` separator when neither side
+        /// already supplies one. An absolute `component` (leading `/`)
+        /// replaces the buffer, matching `std`'s root-push semantics.
+        pub fn push<S: AsRef<str>>(&mut self, component: S) {
+            let c = component.as_ref();
+            if c.starts_with('/') {
+                self.inner.clear();
+                self.inner.push_str(c);
+                return;
+            }
+            if !self.inner.is_empty() && !self.inner.ends_with('/') {
+                self.inner.push('/');
+            }
+            self.inner.push_str(c);
+        }
+
+        /// Removes the last component; returns `false` at the root.
+        pub fn pop(&mut self) -> bool {
+            match self.inner.rfind('/') {
+                Some(idx) => {
+                    self.inner.truncate(idx);
+                    true
+                }
+                None if self.inner.is_empty() => false,
+                None => {
+                    self.inner.clear();
+                    true
+                }
+            }
+        }
+
+        /// `Display`-able view.
+        #[must_use]
+        pub fn display(&self) -> &str {
+            &self.inner
+        }
+    }
+
+    impl Deref for PathBuf {
+        type Target = Path;
+        fn deref(&self) -> &Path {
+            self.as_path()
+        }
+    }
+
+    impl PartialEq<Path> for PathBuf {
+        fn eq(&self, other: &Path) -> bool {
+            self.as_path() == other
+        }
+    }
+
+    impl PartialEq<PathBuf> for Path {
+        fn eq(&self, other: &PathBuf) -> bool {
+            self == other.as_path()
+        }
+    }
+
+    impl PartialEq<&Path> for PathBuf {
+        fn eq(&self, other: &&Path) -> bool {
+            self.as_path() == *other
+        }
+    }
+
+    impl alloc::borrow::Borrow<Path> for PathBuf {
+        fn borrow(&self) -> &Path {
+            self.as_path()
+        }
+    }
+
+    impl AsRef<Path> for PathBuf {
+        fn as_ref(&self) -> &Path {
+            self.as_path()
+        }
+    }
+
+    impl From<String> for PathBuf {
+        fn from(inner: String) -> Self {
+            Self { inner }
+        }
+    }
+
+    impl From<&str> for PathBuf {
+        fn from(s: &str) -> Self {
+            Self {
+                inner: s.to_owned(),
+            }
+        }
+    }
+
+    impl From<&Path> for PathBuf {
+        fn from(p: &Path) -> Self {
+            p.to_path_buf()
+        }
+    }
+
+    impl AsRef<str> for PathBuf {
+        fn as_ref(&self) -> &str {
+            &self.inner
+        }
+    }
+
+    impl fmt::Debug for PathBuf {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt::Debug::fmt(&self.inner, f)
+        }
+    }
+
+    impl fmt::Display for PathBuf {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.inner)
+        }
+    }
+
+    /// Error returned by [`Path::strip_prefix`] when the prefix does not match.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StripPrefixError(());
+
+    impl fmt::Display for StripPrefixError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("prefix not found")
+        }
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -25,9 +25,11 @@ pub use std::path::{Path, PathBuf};
 #[cfg(feature = "std")]
 #[must_use]
 pub fn absolute_path(path: &Path) -> PathBuf {
-    // Not sure if this can even fail realistically
-    #[expect(clippy::expect_used, reason = "not much we can do about it")]
-    std::path::absolute(path).expect("should be absolute path")
+    // `std::path::absolute` only fails on a degenerate input (e.g. an empty
+    // path). Rather than abort the process, fall back to the path as given so
+    // a caller-supplied path can never trigger a panic; an already-relative
+    // path simply stays relative, which the caller resolves against its cwd.
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(not(feature = "std"))]
@@ -149,6 +151,10 @@ mod nostd {
             }
             self.inner
                 .strip_prefix(base)
+                // Match only on a component boundary: "tables" must not strip
+                // the prefix of "tables10". The remainder is either empty
+                // (exact match) or begins with the `/` separator.
+                .filter(|rest| rest.is_empty() || rest.starts_with('/'))
                 .map(|rest| Self::new(rest.trim_start_matches('/')))
                 .ok_or(StripPrefixError(()))
         }

--- a/src/pinnable_slice.rs
+++ b/src/pinnable_slice.rs
@@ -103,8 +103,8 @@ impl PinnableSlice {
     }
 }
 
-impl std::fmt::Debug for PinnableSlice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PinnableSlice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Pinned { value, .. } => {
                 f.debug_struct("Pinned").field("len", &value.len()).finish()

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -2,6 +2,9 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 /// Extracts prefixes from keys for prefix bloom filter indexing.
 ///
 /// When a `PrefixExtractor` is configured on a tree, the bloom filter indexes
@@ -39,7 +42,7 @@
 /// }
 /// ```
 pub trait PrefixExtractor:
-    Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe
+    Send + Sync + core::panic::UnwindSafe + core::panic::RefUnwindSafe
 {
     /// Returns an iterator of prefixes to index for the given key.
     ///
@@ -106,7 +109,7 @@ pub trait PrefixExtractor:
 /// Used by both `Tree::create_prefix` and `BlobTree::prefix` to avoid
 /// duplicating the boundary-check + hashing logic.
 pub fn compute_prefix_hash(
-    extractor: Option<&std::sync::Arc<dyn PrefixExtractor>>,
+    extractor: Option<&alloc::sync::Arc<dyn PrefixExtractor>>,
     prefix_bytes: &[u8],
 ) -> Option<u64> {
     if prefix_bytes.is_empty() {

--- a/src/range.rs
+++ b/src/range.rs
@@ -17,11 +17,12 @@ use crate::{
     value::{SeqNo, UserKey},
     version::{Run, SuperVersion},
 };
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::{Bound, RangeBounds};
+
 use self_cell::self_cell;
-use std::{
-    ops::{Bound, RangeBounds},
-    sync::Arc,
-};
 
 #[must_use]
 pub fn seqno_filter(item_seqno: SeqNo, seqno: SeqNo) -> bool {
@@ -65,7 +66,7 @@ fn build_seeking<'a>(
 ///
 /// Panics if the prefix is empty.
 pub(crate) fn prefix_upper_range(prefix: &[u8]) -> Bound<UserKey> {
-    use std::ops::Bound::{Excluded, Unbounded};
+    use core::ops::Bound::{Excluded, Unbounded};
 
     assert!(!prefix.is_empty(), "prefix may not be empty");
 
@@ -89,7 +90,7 @@ pub(crate) fn prefix_upper_range(prefix: &[u8]) -> Bound<UserKey> {
 #[must_use]
 #[expect(clippy::module_name_repetitions)]
 pub fn prefix_to_range(prefix: &[u8]) -> (Bound<UserKey>, Bound<UserKey>) {
-    use std::ops::Bound::{Included, Unbounded};
+    use core::ops::Bound::{Included, Unbounded};
 
     if prefix.is_empty() {
         return (Unbounded, Unbounded);
@@ -169,14 +170,14 @@ fn range_tombstone_overlaps_bounds(
 ) -> bool {
     let overlaps_lo = match &bounds.0 {
         Bound::Included(key) | Bound::Excluded(key) => {
-            comparator.compare(&rt.end, key) == std::cmp::Ordering::Greater
+            comparator.compare(&rt.end, key) == core::cmp::Ordering::Greater
         }
         Bound::Unbounded => true,
     };
 
     let overlaps_hi = match &bounds.1 {
-        Bound::Included(key) => comparator.compare(&rt.start, key) != std::cmp::Ordering::Greater,
-        Bound::Excluded(key) => comparator.compare(&rt.start, key) == std::cmp::Ordering::Less,
+        Bound::Included(key) => comparator.compare(&rt.start, key) != core::cmp::Ordering::Greater,
+        Bound::Excluded(key) => comparator.compare(&rt.start, key) == core::cmp::Ordering::Less,
         Bound::Unbounded => true,
     };
 
@@ -194,7 +195,7 @@ fn bloom_passes(state: &IterState, table: &crate::table::Table) -> bool {
                 #[cfg(feature = "metrics")]
                 if let Some(m) = &state.metrics {
                     m.prefix_bloom_skips
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
                 }
                 return false;
             }
@@ -278,8 +279,8 @@ impl TreeIter {
             // Constant for a point key — computed once and reused for
             // key-range overlap checks and bloom filtering across all runs.
             let bounds = (
-                user_range.0.as_ref().map(std::convert::AsRef::as_ref),
-                user_range.1.as_ref().map(std::convert::AsRef::as_ref),
+                user_range.0.as_ref().map(core::convert::AsRef::as_ref),
+                user_range.1.as_ref().map(core::convert::AsRef::as_ref),
             );
 
             for run in lock
@@ -562,8 +563,8 @@ impl TreeIter {
                         // running the O(rt_count) table-skip scan.
                         if table.check_key_range_overlap_cmp(
                             &(
-                                user_range.0.as_ref().map(std::convert::AsRef::as_ref),
-                                user_range.1.as_ref().map(std::convert::AsRef::as_ref),
+                                user_range.0.as_ref().map(core::convert::AsRef::as_ref),
+                                user_range.1.as_ref().map(core::convert::AsRef::as_ref),
                             ),
                             lock.comparator.as_ref(),
                         ) && bloom_passes(lock, table)
@@ -597,8 +598,8 @@ impl TreeIter {
                         // and point-read merge pipelines (key_hash).
                         if lock.prefix_hash.is_some() || lock.key_hash.is_some() {
                             let bounds = (
-                                user_range.0.as_ref().map(std::convert::AsRef::as_ref),
-                                user_range.1.as_ref().map(std::convert::AsRef::as_ref),
+                                user_range.0.as_ref().map(core::convert::AsRef::as_ref),
+                                user_range.1.as_ref().map(core::convert::AsRef::as_ref),
                             );
 
                             let surviving: Vec<_> = run
@@ -675,7 +676,7 @@ impl TreeIter {
                 let table_kv_seqno = table.get_highest_kv_seqno();
 
                 let candidate_end = all_range_tombstones.partition_point(|(rt, _)| {
-                    lock.comparator.compare(&rt.start, table_min) != std::cmp::Ordering::Greater
+                    lock.comparator.compare(&rt.start, table_min) != core::cmp::Ordering::Greater
                 });
 
                 let is_covered =
@@ -843,7 +844,7 @@ impl TreeIter {
 mod tests {
     use super::*;
     use crate::Slice;
-    use std::ops::Bound::{Excluded, Included, Unbounded};
+    use core::ops::Bound::{Excluded, Included, Unbounded};
     use test_log::test;
 
     fn test_prefix(prefix: &[u8], upper_bound: Bound<&[u8]>) {

--- a/src/range.rs
+++ b/src/range.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::ops::{Bound, RangeBounds};
 
 use self_cell::self_cell;

--- a/src/range_tombstone.rs
+++ b/src/range_tombstone.rs
@@ -2,8 +2,11 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::{SeqNo, UserKey, comparator::UserComparator};
-use std::cmp::Reverse;
+use core::cmp::Reverse;
 
 /// A range tombstone that deletes all keys in `[start, end)` at a given sequence number.
 ///
@@ -44,8 +47,8 @@ impl RangeTombstone {
     /// Returns `true` if `key` is within `[start, end)` using the tree comparator.
     #[must_use]
     pub fn contains_key_with(&self, key: &[u8], comparator: &dyn UserComparator) -> bool {
-        comparator.compare(&self.start, key) != std::cmp::Ordering::Greater
-            && comparator.compare(key, &self.end) == std::cmp::Ordering::Less
+        comparator.compare(&self.start, key) != core::cmp::Ordering::Greater
+            && comparator.compare(key, &self.end) == core::cmp::Ordering::Less
     }
 
     /// Returns `true` if this tombstone is visible at the given read seqno.
@@ -102,18 +105,19 @@ impl RangeTombstone {
         max: &[u8],
         comparator: &dyn UserComparator,
     ) -> Option<Self> {
-        let new_start_ref = if comparator.compare(&self.start, min) == std::cmp::Ordering::Greater {
+        let new_start_ref = if comparator.compare(&self.start, min) == core::cmp::Ordering::Greater
+        {
             self.start.as_ref()
         } else {
             min
         };
-        let new_end_ref = if comparator.compare(&self.end, max) == std::cmp::Ordering::Less {
+        let new_end_ref = if comparator.compare(&self.end, max) == core::cmp::Ordering::Less {
             self.end.as_ref()
         } else {
             max
         };
 
-        if comparator.compare(new_start_ref, new_end_ref) == std::cmp::Ordering::Less {
+        if comparator.compare(new_start_ref, new_end_ref) == core::cmp::Ordering::Less {
             Some(Self {
                 start: UserKey::from(new_start_ref),
                 end: UserKey::from(new_end_ref),
@@ -142,8 +146,8 @@ impl RangeTombstone {
         max: &[u8],
         comparator: &dyn UserComparator,
     ) -> bool {
-        comparator.compare(&self.start, min) != std::cmp::Ordering::Greater
-            && comparator.compare(max, &self.end) == std::cmp::Ordering::Less
+        comparator.compare(&self.start, min) != core::cmp::Ordering::Greater
+            && comparator.compare(max, &self.end) == core::cmp::Ordering::Less
     }
 
     /// Comparator-aware ordering for range tombstone processing.
@@ -155,7 +159,7 @@ impl RangeTombstone {
         &self,
         other: &Self,
         comparator: &dyn UserComparator,
-    ) -> std::cmp::Ordering {
+    ) -> core::cmp::Ordering {
         comparator
             .compare(&self.start, &other.start)
             .then_with(|| other.seqno.cmp(&self.seqno))
@@ -168,7 +172,7 @@ impl RangeTombstone {
 /// The `end` tiebreaker ensures deterministic ordering for debug output
 /// and property tests.
 impl Ord for RangeTombstone {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         (&self.start, Reverse(self.seqno), &self.end).cmp(&(
             &other.start,
             Reverse(other.seqno),
@@ -178,7 +182,7 @@ impl Ord for RangeTombstone {
 }
 
 impl PartialOrd for RangeTombstone {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -221,8 +225,8 @@ impl CoveringRt {
         table_max_seqno: SeqNo,
         comparator: &dyn UserComparator,
     ) -> bool {
-        comparator.compare(&self.start, table_min) != std::cmp::Ordering::Greater
-            && comparator.compare(table_max, &self.end) == std::cmp::Ordering::Less
+        comparator.compare(&self.start, table_min) != core::cmp::Ordering::Greater
+            && comparator.compare(table_max, &self.end) == core::cmp::Ordering::Less
             && self.seqno > table_max_seqno
     }
 }

--- a/src/range_tombstone_filter.rs
+++ b/src/range_tombstone_filter.rs
@@ -13,6 +13,8 @@
 use crate::active_tombstone_set::{ActiveTombstoneSet, ActiveTombstoneSetReverse};
 use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, comparator::SharedComparator};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Wraps a bidirectional KV stream and suppresses entries covered by range tombstones.
 ///
@@ -110,7 +112,7 @@ impl<I> RangeTombstoneFilter<I> {
     /// Activates forward tombstones whose start <= `current_key`.
     fn fwd_activate_up_to(&mut self, key: &[u8]) {
         while let Some((rt, cutoff)) = self.fwd_tombstones.get(self.fwd_idx) {
-            if self.comparator.compare(&rt.start, key) == std::cmp::Ordering::Greater {
+            if self.comparator.compare(&rt.start, key) == core::cmp::Ordering::Greater {
                 break;
             }
             self.fwd_active.activate(rt, *cutoff);
@@ -121,7 +123,7 @@ impl<I> RangeTombstoneFilter<I> {
     /// Activates reverse tombstones whose end > `current_key`.
     fn rev_activate_up_to(&mut self, key: &[u8]) {
         while let Some((rt, cutoff)) = self.rev_tombstones.get(self.rev_idx) {
-            if self.comparator.compare(&rt.end, key) == std::cmp::Ordering::Greater {
+            if self.comparator.compare(&rt.end, key) == core::cmp::Ordering::Greater {
                 self.rev_active.activate(rt, *cutoff);
                 self.rev_idx += 1;
             } else {

--- a/src/range_tombstone_filter.rs
+++ b/src/range_tombstone_filter.rs
@@ -14,7 +14,7 @@ use crate::active_tombstone_set::{ActiveTombstoneSet, ActiveTombstoneSetReverse}
 use crate::range_tombstone::RangeTombstone;
 use crate::{InternalValue, SeqNo, comparator::SharedComparator};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Wraps a bidirectional KV stream and suppresses entries covered by range tombstones.
 ///

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -33,8 +33,10 @@
 //! but draining ahead of compaction) is a planned refinement; this
 //! revision throttles compaction alone.
 
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::Ordering;
 use core::time::Duration;
+
+use portable_atomic::AtomicU64;
 
 use spin::Mutex;
 
@@ -189,6 +191,16 @@ impl RateLimiter {
             remaining = remaining.saturating_sub(chunk);
         }
         false
+    }
+
+    /// `no_std` variant: there is no ambient monotonic clock to throttle
+    /// against, so this never sleeps. It still honors the caller's stop signal
+    /// so a shutdown is observed promptly; rate limiting itself is a no-op.
+    // no-std: wire a caller-provided clock + `acquire_wait` poll loop to restore
+    // throttling.
+    #[cfg(not(feature = "std"))]
+    pub fn request_interruptible(&self, _bytes: u64, should_stop: impl Fn() -> bool) -> bool {
+        should_stop()
     }
 
     /// Maximum single sleep span inside

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -354,7 +354,7 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         }
         match config.fs.remove_file(&dirent.path) {
             Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == crate::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e.into()),
         }
     }

--- a/src/run_reader.rs
+++ b/src/run_reader.rs
@@ -3,10 +3,10 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::{BoxedIterator, InternalValue, Table, UserKey, version::Run};
-use std::{
-    ops::{Bound, Deref, RangeBounds},
-    sync::Arc,
-};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::ops::{Bound, Deref, RangeBounds};
 
 type OwnedRange = (Bound<UserKey>, Bound<UserKey>);
 

--- a/src/run_scanner.rs
+++ b/src/run_scanner.rs
@@ -2,8 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use alloc::sync::Arc;
+
 use crate::{InternalValue, Table, table::Scanner, version::Run};
-use std::sync::Arc;
 
 /// Scans through a disjoint run
 ///

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -23,8 +23,14 @@
 //!   at the call site (see [`RuntimeConfigHandle::update`]).
 
 use super::types::RuntimeConfig;
+use alloc::sync::Arc;
+#[cfg(feature = "std")]
 use arc_swap::ArcSwap;
-use std::sync::Arc;
+// no-std: arc-swap 1.x is not no_std; spin::RwLock<Arc<_>> gives the same
+// snapshot-swap semantics (serialized writers, consistent readers) without an
+// allocator. parking_lot/arc-swap win the std hot path, so keep them there.
+#[cfg(not(feature = "std"))]
+use spin::RwLock;
 
 /// Lockless atomic snapshot of [`RuntimeConfig`].
 ///
@@ -37,7 +43,13 @@ use std::sync::Arc;
 /// need an owned reference from a `Guard` can clone the inner
 /// `Arc` out of it via `Arc::clone(&*guard)`.
 pub struct RuntimeConfigHandle {
+    /// `std`: lock-free `ArcSwap` (single atomic load on the read hot path).
+    #[cfg(feature = "std")]
     inner: ArcSwap<RuntimeConfig>,
+    /// `no_std`: `spin::RwLock<Arc<_>>` — reads take a brief read lock, writes
+    /// serialize. Slower than `ArcSwap` but allocator-only.
+    #[cfg(not(feature = "std"))]
+    inner: RwLock<Arc<RuntimeConfig>>,
 }
 
 impl RuntimeConfigHandle {
@@ -45,16 +57,27 @@ impl RuntimeConfigHandle {
     #[must_use]
     pub fn new(initial: RuntimeConfig) -> Self {
         Self {
+            #[cfg(feature = "std")]
             inner: ArcSwap::from_pointee(initial),
+            #[cfg(not(feature = "std"))]
+            inner: RwLock::new(Arc::new(initial)),
         }
     }
 
-    /// Load the current snapshot — lockless single atomic load.
-    /// The returned guard is cheap to drop; for longer-lived
-    /// references use [`Self::load_full`] which returns an
-    /// owned `Arc<RuntimeConfig>`.
+    /// Load the current snapshot — lockless single atomic load under `std`
+    /// (`no_std` takes a brief read lock). The returned guard is cheap to
+    /// drop; for longer-lived references use [`Self::load_full`] which returns
+    /// an owned `Arc<RuntimeConfig>`.
+    #[cfg(feature = "std")]
     pub fn load(&self) -> arc_swap::Guard<Arc<RuntimeConfig>> {
         self.inner.load()
+    }
+
+    /// See the `std` variant. Under `no_std` the guard borrows the handle via
+    /// the read lock; deref reaches `RuntimeConfig` through the inner `Arc`.
+    #[cfg(not(feature = "std"))]
+    pub fn load(&self) -> spin::RwLockReadGuard<'_, Arc<RuntimeConfig>> {
+        self.inner.read()
     }
 
     /// Load the current snapshot as an owned `Arc`.
@@ -62,7 +85,14 @@ impl RuntimeConfigHandle {
     /// increment) but the result outlives the handle.
     #[must_use]
     pub fn load_full(&self) -> Arc<RuntimeConfig> {
-        self.inner.load_full()
+        #[cfg(feature = "std")]
+        {
+            self.inner.load_full()
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            self.inner.read().clone()
+        }
     }
 
     /// Apply `mutator` to a clone of the current snapshot, then
@@ -112,7 +142,7 @@ impl RuntimeConfigHandle {
     where
         F: FnOnce(&mut RuntimeConfig),
     {
-        let current = self.inner.load_full();
+        let current = self.load_full();
         let mut next = (*current).clone();
         mutator(&mut next);
         // Validate the EFFECTIVE ECC state, not just the global `page_ecc`
@@ -173,7 +203,14 @@ impl RuntimeConfigHandle {
                 "kv_checksum_compute_point=AtInsert",
             ));
         }
-        self.inner.store(Arc::new(next));
+        #[cfg(feature = "std")]
+        {
+            self.inner.store(Arc::new(next));
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            *self.inner.write() = Arc::new(next);
+        }
         Ok(())
     }
 }

--- a/src/runtime_config/mod.rs
+++ b/src/runtime_config/mod.rs
@@ -56,7 +56,6 @@
 
 pub mod types;
 
-#[cfg(feature = "std")]
 pub(crate) mod handle;
 
 pub use types::{

--- a/src/seqno.rs
+++ b/src/seqno.rs
@@ -2,17 +2,12 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use alloc::sync::Arc;
+use core::fmt::Debug;
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
+
 use crate::SeqNo;
-use std::{
-    fmt::Debug,
-    sync::{
-        Arc,
-        atomic::{
-            AtomicU64,
-            Ordering::{AcqRel, Acquire, Release},
-        },
-    },
-};
+use portable_atomic::AtomicU64;
 
 /// The maximum allowed sequence number value.
 ///
@@ -71,7 +66,7 @@ pub const MAX_SEQNO: SeqNo = 0x7FFF_FFFF_FFFF_FFFF;
 /// MSB boundary in `new`, `set`, and `fetch_max` (via assert/clamp),
 /// and panics in `next` if the counter reaches the reserved range.
 pub trait SequenceNumberGenerator:
-    Send + Sync + Debug + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static
+    Send + Sync + Debug + core::panic::UnwindSafe + core::panic::RefUnwindSafe + 'static
 {
     /// Gets the next sequence number, atomically incrementing the counter.
     ///

--- a/src/sfa/checksum_writer.rs
+++ b/src/sfa/checksum_writer.rs
@@ -4,12 +4,12 @@
 
 use crate::sfa::Checksum;
 
-pub struct ChecksummedWriter<W: std::io::Write> {
+pub struct ChecksummedWriter<W: crate::io::Write> {
     inner: W,
     hasher: xxhash_rust::xxh3::Xxh3Default,
 }
 
-impl<W: std::io::Write> ChecksummedWriter<W> {
+impl<W: crate::io::Write> ChecksummedWriter<W> {
     pub fn new(writer: W) -> Self {
         Self {
             inner: writer,
@@ -22,7 +22,11 @@ impl<W: std::io::Write> ChecksummedWriter<W> {
     }
 }
 
-impl<W: std::io::Write> std::io::Write for ChecksummedWriter<W> {
+// `crate::io::Write` is the std trait (via the std-mode supertrait blanket)
+// under `std` and the native trait under `no_std`; the impls differ only in
+// the trait path and `Result` type, so each is gated to its build.
+#[cfg(feature = "std")]
+impl<W: crate::io::Write> std::io::Write for ChecksummedWriter<W> {
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
     }
@@ -36,11 +40,29 @@ impl<W: std::io::Write> std::io::Write for ChecksummedWriter<W> {
         // `inner.write` first so a failed write does not corrupt
         // the hasher state.
         let n = self.inner.write(buf)?;
-        // Safe slice: `n <= buf.len()` per `std::io::Write::write`
-        // contract.
+        // Safe slice: `n <= buf.len()` per the `Write::write` contract.
         #[expect(
             clippy::indexing_slicing,
-            reason = "n bounded by buf.len() per std::io::Write::write contract"
+            reason = "n bounded by buf.len() per Write::write contract"
+        )]
+        self.hasher.update(&buf[..n]);
+        Ok(n)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: crate::io::Write> crate::io::Write for ChecksummedWriter<W> {
+    fn flush(&mut self) -> crate::io::Result<()> {
+        self.inner.flush()
+    }
+
+    fn write(&mut self, buf: &[u8]) -> crate::io::Result<usize> {
+        // See the std impl above: hash only accepted bytes, inner.write
+        // first so a failed write cannot corrupt the hasher state.
+        let n = self.inner.write(buf)?;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "n bounded by buf.len() per Write::write contract"
         )]
         self.hasher.update(&buf[..n]);
         Ok(n)

--- a/src/sfa/error.rs
+++ b/src/sfa/error.rs
@@ -8,7 +8,7 @@ use crate::sfa::checksum::Checksum;
 #[derive(Debug)]
 pub enum Error {
     /// IO error
-    Io(std::io::Error),
+    Io(crate::io::Error),
 
     /// Invalid header
     InvalidHeader,
@@ -29,20 +29,30 @@ pub enum Error {
     },
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "SfaError: {self:?}")
     }
 }
 
-impl From<std::io::Error> for Error {
-    fn from(inner: std::io::Error) -> Self {
+impl From<crate::io::Error> for Error {
+    fn from(inner: crate::io::Error) -> Self {
         Self::Io(inner)
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+// Std file-I/O paths (the archive reader/writer over `std::fs`) surface
+// `std::io::Error`; bridge it through `crate::io::Error` so `?` keeps working
+// in those call sites.
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(inner: std::io::Error) -> Self {
+        Self::Io(inner.into())
+    }
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Io(inner) => Some(inner),
             _ => None,

--- a/src/sfa/error.rs
+++ b/src/sfa/error.rs
@@ -59,3 +59,45 @@ impl core::error::Error for Error {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::error::Error as _;
+
+    #[test]
+    fn from_crate_io_error_wraps_io_variant() {
+        let inner = crate::io::Error::from_kind(crate::io::ErrorKind::UnexpectedEof);
+        let err = Error::from(inner);
+        assert!(matches!(err, Error::Io(_)));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn from_std_io_error_bridges_through_crate_io() {
+        let std_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let err = Error::from(std_err);
+        match err {
+            Error::Io(inner) => assert_eq!(inner.kind(), crate::io::ErrorKind::NotFound),
+            other => panic!("expected Io variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn source_is_some_only_for_io_variant() {
+        let io = Error::Io(crate::io::Error::from_kind(crate::io::ErrorKind::Other));
+        assert!(io.source().is_some(), "Io must expose its inner as source");
+
+        let non_io = Error::InvalidHeader;
+        assert!(non_io.source().is_none(), "non-Io variants have no source");
+    }
+
+    #[test]
+    fn display_prefixes_sfa_error() {
+        // Display defers to the Debug rendering behind a fixed prefix.
+        assert_eq!(
+            alloc::format!("{}", Error::InvalidVersion),
+            "SfaError: InvalidVersion"
+        );
+    }
+}

--- a/src/sfa/mod.rs
+++ b/src/sfa/mod.rs
@@ -39,6 +39,9 @@
 mod checksum;
 mod checksum_writer;
 mod error;
+// The archive `Reader` opens a file by path (std::fs + BufReader), so it is
+// genuinely std-bound; the wire codec (toc / trailer / writer over generic
+// Read/Write) is no_std-capable and stays ungated.
 mod reader;
 mod toc;
 mod trailer;
@@ -51,7 +54,7 @@ mod writer;
 // outside the crate, so any type in their signatures must be at least
 // as visible as the fn. The alias stays doc-hidden via the parent
 // module's `#[doc(hidden)]`.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 pub use checksum::Checksum;
 pub use error::Error;

--- a/src/sfa/reader.rs
+++ b/src/sfa/reader.rs
@@ -2,10 +2,13 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Seek};
 use crate::sfa::{
     toc::{Toc, reader::TocReader},
     trailer::reader::TrailerReader,
 };
+#[cfg(feature = "std")]
 use std::io::{BufReader, Read, Seek};
 
 /// Archive reader
@@ -19,6 +22,9 @@ impl Reader {
     /// # Errors
     ///
     /// Returns error, if an IO error occurred.
+    // std-only: opens the path via std::fs. no_std callers use
+    // [`Reader::from_reader`] with a caller-provided Fs-backed reader.
+    #[cfg(feature = "std")]
     pub fn new(path: impl AsRef<std::path::Path>) -> crate::sfa::Result<Self> {
         let file = std::fs::File::open(path)?;
         let mut file = BufReader::with_capacity(4_096, file);

--- a/src/sfa/toc/entry.rs
+++ b/src/sfa/toc/entry.rs
@@ -2,13 +2,20 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use byteorder::ReadBytesExt;
-use byteorder::WriteBytesExt;
-use std::{
-    fs::File,
-    io::{BufReader, Read, Seek, Write},
-    path::Path,
-};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::io::{ReadBytesExt, WriteBytesExt};
+// Codec `impl Read`/`impl Write` bounds resolve to std under `std` and to the
+// native `crate::io` traits under `no_std`. The `reader`/`buf_reader` helpers
+// are std-only (they open a file), so `File`/`BufReader`/`Path` plus the
+// `Seek` trait for `file.seek` live behind the std gate.
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
+#[cfg(feature = "std")]
+use std::io::{Read, Seek, Write};
+#[cfg(feature = "std")]
+use std::{fs::File, io::BufReader, path::Path};
 
 pub type SectionName = Vec<u8>;
 
@@ -41,6 +48,7 @@ impl TocEntry {
     }
 
     #[doc(hidden)]
+    #[cfg(feature = "std")]
     pub fn reader(&self, path: &Path) -> std::io::Result<impl std::io::Read> {
         let mut file = File::open(path)?;
         file.seek(std::io::SeekFrom::Start(self.pos))?;
@@ -48,6 +56,7 @@ impl TocEntry {
     }
 
     #[doc(hidden)]
+    #[cfg(feature = "std")]
     pub fn buf_reader(&self, path: &Path) -> std::io::Result<impl std::io::BufRead> {
         let mut file = BufReader::new(File::open(path)?);
         file.seek(std::io::SeekFrom::Start(self.pos))?;
@@ -55,7 +64,7 @@ impl TocEntry {
     }
 
     pub(crate) fn write_into(&self, mut writer: impl Write) -> crate::sfa::Result<()> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         writer.write_u64::<LE>(self.pos())?;
         writer.write_u64::<LE>(self.len())?;
@@ -73,7 +82,7 @@ impl TocEntry {
     }
 
     pub(crate) fn read_from_file(reader: &mut impl Read) -> crate::sfa::Result<Self> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         let pos = reader.read_u64::<LE>()?;
         let len = reader.read_u64::<LE>()?;

--- a/src/sfa/toc/mod.rs
+++ b/src/sfa/toc/mod.rs
@@ -2,6 +2,9 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use crate::sfa::TocEntry;
 
 pub mod entry;
@@ -19,7 +22,7 @@ impl Toc {
     }
 }
 
-impl std::ops::Deref for Toc {
+impl core::ops::Deref for Toc {
     type Target = [TocEntry];
 
     fn deref(&self) -> &Self::Target {

--- a/src/sfa/toc/reader.rs
+++ b/src/sfa/toc/reader.rs
@@ -2,21 +2,30 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::writer::TOC_MAGIC;
+use crate::io::ReadBytesExt;
 use crate::sfa::{
     Result,
     checksum::Checksum,
     toc::{Toc, entry::TocEntry},
 };
-use byteorder::ReadBytesExt;
+// `Read`/`Seek`/`SeekFrom` resolve to std under `std` and to the native
+// `crate::io` types under `no_std`; the `take`/`seek` calls and the `SeekFrom`
+// value below track whichever is in play.
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Seek, SeekFrom};
+#[cfg(feature = "std")]
 use std::io::{Read, Seek, SeekFrom};
 
-struct ChecksummedReader<R: std::io::Read> {
+struct ChecksummedReader<R: crate::io::Read> {
     inner: R,
     hasher: xxhash_rust::xxh3::Xxh3Default,
 }
 
-impl<R: std::io::Read> ChecksummedReader<R> {
+impl<R: crate::io::Read> ChecksummedReader<R> {
     pub fn new(reader: R) -> Self {
         Self {
             inner: reader,
@@ -29,8 +38,24 @@ impl<R: std::io::Read> ChecksummedReader<R> {
     }
 }
 
-impl<R: std::io::Read> std::io::Read for ChecksummedReader<R> {
+// `crate::io::Read` is the std trait (via the std-mode supertrait blanket)
+// under `std` and the native trait under `no_std`; gated impls differ only
+// in the trait path and `Result` type.
+#[cfg(feature = "std")]
+impl<R: crate::io::Read> std::io::Read for ChecksummedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        #[expect(clippy::indexing_slicing)]
+        self.hasher.update(&buf[..n]);
+
+        Ok(n)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: crate::io::Read> crate::io::Read for ChecksummedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> crate::io::Result<usize> {
         let n = self.inner.read(buf)?;
 
         #[expect(clippy::indexing_slicing)]
@@ -49,7 +74,7 @@ impl TocReader {
         toc_len: u64,
         toc_checksum: Checksum,
     ) -> Result<Toc> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         log::trace!("Reading ToC");
 

--- a/src/sfa/toc/writer.rs
+++ b/src/sfa/toc/writer.rs
@@ -2,8 +2,13 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+use crate::io::WriteBytesExt;
 use crate::sfa::{checksum::Checksum, checksum_writer::ChecksummedWriter, toc::entry::TocEntry};
-use byteorder::WriteBytesExt;
+// `Write` is the std trait under `std` (so the concrete `ChecksummedWriter`'s
+// `write_all` resolves from `std::io`) and the native trait under `no_std`.
+#[cfg(not(feature = "std"))]
+use crate::io::Write;
+#[cfg(feature = "std")]
 use std::io::Write;
 
 pub const TOC_MAGIC: &[u8] = b"TOC!";
@@ -15,7 +20,7 @@ impl TocWriter {
         mut writer: impl Write,
         entries: &[TocEntry],
     ) -> crate::sfa::Result<Checksum> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         log::trace!("Writing ToC");
         log::trace!("ToC: {entries:#?}");

--- a/src/sfa/trailer/reader.rs
+++ b/src/sfa/trailer/reader.rs
@@ -3,8 +3,15 @@
 // (found in the LICENSE-* files in the repository)
 
 use super::writer::TRAILER_MAGIC;
+use crate::io::ReadBytesExt;
 use crate::sfa::{Result, checksum::Checksum};
-use byteorder::ReadBytesExt;
+// `Read`/`Seek`/`SeekFrom` resolve to std under `std` and to the native
+// `crate::io` types under `no_std`; gated together so the `SeekFrom` value
+// matches whichever `Seek::seek` is in play (crate::io::SeekFrom is a distinct
+// type from std's, not a re-export).
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Seek, SeekFrom};
+#[cfg(feature = "std")]
 use std::io::{Read, Seek, SeekFrom};
 
 #[expect(
@@ -35,7 +42,7 @@ pub struct TrailerReader;
 
 impl TrailerReader {
     pub fn from_reader<R: Read + Seek>(reader: &mut R) -> Result<ParsedTrailer> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         log::trace!("Reading trailer");
 

--- a/src/sfa/trailer/writer.rs
+++ b/src/sfa/trailer/writer.rs
@@ -2,21 +2,21 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+use crate::io::WriteBytesExt;
 use crate::sfa::checksum::Checksum;
-use byteorder::WriteBytesExt;
 
 pub const TRAILER_MAGIC: &[u8] = b"SFA!";
 
 pub struct TrailerWriter;
 
 impl TrailerWriter {
-    pub fn write_into<W: std::io::Write>(
+    pub fn write_into<W: crate::io::Write>(
         mut writer: W,
         toc_checksum: Checksum,
         toc_pos: u64,
         toc_len: u64,
     ) -> crate::sfa::Result<()> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         log::trace!("Writing trailer");
 

--- a/src/sfa/writer.rs
+++ b/src/sfa/writer.rs
@@ -2,6 +2,10 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::io::{Seek, Write};
 use crate::sfa::{
     toc::{
         entry::{SectionName, TocEntry},
@@ -9,7 +13,6 @@ use crate::sfa::{
     },
     trailer::writer::TrailerWriter,
 };
-use std::io::{Seek, Write};
 
 /// Archive writer
 #[expect(
@@ -42,6 +45,10 @@ impl<W: Write + Seek> Writer<W> {
     }
 }
 
+// `crate::io::Write` is the std trait (via the std-mode supertrait blanket)
+// under `std` and the native trait under `no_std`; gated impls differ only in
+// the trait path and `Result` type.
+#[cfg(feature = "std")]
 impl<W: Write + Seek> std::io::Write for Writer<W> {
     fn flush(&mut self) -> std::io::Result<()> {
         self.writer.flush()
@@ -52,23 +59,34 @@ impl<W: Write + Seek> std::io::Write for Writer<W> {
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl<W: Write + Seek> crate::io::Write for Writer<W> {
+    fn flush(&mut self) -> crate::io::Result<()> {
+        self.writer.flush()
+    }
+
+    fn write(&mut self, buf: &[u8]) -> crate::io::Result<usize> {
+        self.writer.write(buf)
+    }
+}
+
 impl<W: Write + Seek> Writer<W> {
     /// Starts the first named section.
     ///
     /// # Errors
     ///
     /// Returns error, if an IO error occurred.
-    pub fn start(&mut self, name: impl Into<SectionName>) -> std::io::Result<()> {
+    pub fn start(&mut self, name: impl Into<SectionName>) -> crate::io::Result<()> {
         self.append_toc_entry()?;
         self.section_name = name.into();
         Ok(())
     }
 
-    fn append_toc_entry(&mut self) -> std::io::Result<()> {
+    fn append_toc_entry(&mut self) -> crate::io::Result<()> {
         let file_pos = self.writer.stream_position()?;
 
         if file_pos > 0 {
-            let name = std::mem::take(&mut self.section_name);
+            let name = core::mem::take(&mut self.section_name);
             self.toc.push(TocEntry {
                 name,
                 pos: self.last_section_pos,

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -12,7 +12,7 @@ mod slice_default;
 
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use crate::path::{Path, PathBuf};
 

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -10,10 +10,11 @@ mod slice_bytes;
 #[cfg(not(feature = "bytes_1"))]
 mod slice_default;
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+use crate::path::{Path, PathBuf};
 
 #[cfg(not(feature = "bytes_1"))]
 pub use slice_default::{Builder, Slice};
@@ -67,13 +68,29 @@ impl From<&String> for Slice {
 
 impl From<&Path> for Slice {
     fn from(value: &Path) -> Self {
-        Self::from(value.as_os_str().as_encoded_bytes())
+        // std: `OsStr::as_encoded_bytes`. no_std: the key is UTF-8, so
+        // `as_os_str()` is a `&str` and `as_bytes()` yields the same bytes.
+        #[cfg(feature = "std")]
+        {
+            Self::from(value.as_os_str().as_encoded_bytes())
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            Self::from(value.as_os_str().as_bytes())
+        }
     }
 }
 
 impl From<PathBuf> for Slice {
     fn from(value: PathBuf) -> Self {
-        Self::from(value.as_os_str().as_encoded_bytes())
+        #[cfg(feature = "std")]
+        {
+            Self::from(value.as_os_str().as_encoded_bytes())
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            Self::from(value.as_os_str().as_bytes())
+        }
     }
 }
 
@@ -104,7 +121,7 @@ impl FromIterator<u8> for Slice {
     }
 }
 
-impl std::ops::Deref for Slice {
+impl core::ops::Deref for Slice {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -112,7 +129,7 @@ impl std::ops::Deref for Slice {
     }
 }
 
-impl std::borrow::Borrow<[u8]> for Slice {
+impl core::borrow::Borrow<[u8]> for Slice {
     fn borrow(&self) -> &[u8] {
         self
     }
@@ -137,13 +154,13 @@ impl<T> PartialOrd<T> for Slice
 where
     T: AsRef<[u8]>,
 {
-    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &T) -> Option<core::cmp::Ordering> {
         self.as_ref().partial_cmp(other.as_ref())
     }
 }
 
 impl PartialOrd<Slice> for &[u8] {
-    fn partial_cmp(&self, other: &Slice) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Slice) -> Option<core::cmp::Ordering> {
         (*self).partial_cmp(other.as_ref())
     }
 }

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::byteview::ByteView;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 pub use crate::byteview::Builder;
 

--- a/src/slice/slice_default/mod.rs
+++ b/src/slice/slice_default/mod.rs
@@ -3,6 +3,8 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::byteview::ByteView;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 pub use crate::byteview::Builder;
 
@@ -33,7 +35,7 @@ impl Slice {
         unsafe { ByteView::builder_unzeroed(len) }
     }
 
-    pub(crate) fn slice(&self, range: impl std::ops::RangeBounds<usize>) -> Self {
+    pub(crate) fn slice(&self, range: impl core::ops::RangeBounds<usize>) -> Self {
         Self(self.0.slice(range))
     }
 
@@ -44,6 +46,17 @@ impl Slice {
     #[doc(hidden)]
     #[cfg(feature = "std")]
     pub fn from_reader<R: std::io::Read>(reader: &mut R, len: usize) -> std::io::Result<Self> {
+        ByteView::from_reader(reader, len).map(Self)
+    }
+
+    /// `no_std` mirror of [`Slice::from_reader`] over [`crate::io::Read`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurred.
+    #[doc(hidden)]
+    #[cfg(not(feature = "std"))]
+    pub fn from_reader<R: crate::io::Read>(reader: &mut R, len: usize) -> crate::io::Result<Self> {
         ByteView::from_reader(reader, len).map(Self)
     }
 }

--- a/src/stop_signal.rs
+++ b/src/stop_signal.rs
@@ -2,18 +2,19 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use std::sync::{Arc, atomic::AtomicBool};
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicBool;
 
 #[derive(Clone, Debug, Default)]
 pub struct StopSignal(Arc<AtomicBool>);
 
 impl StopSignal {
     pub fn send(&self) {
-        self.0.store(true, std::sync::atomic::Ordering::Release);
+        self.0.store(true, core::sync::atomic::Ordering::Release);
     }
 
     #[must_use]
     pub fn is_stopped(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Acquire)
+        self.0.load(core::sync::atomic::Ordering::Acquire)
     }
 }

--- a/src/table/block/binary_index/builder.rs
+++ b/src/table/block/binary_index/builder.rs
@@ -4,7 +4,7 @@
 
 use crate::io::{LittleEndian, WriteBytesExt};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub struct Builder(Vec<u32>);

--- a/src/table/block/binary_index/builder.rs
+++ b/src/table/block/binary_index/builder.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use byteorder::{LittleEndian, WriteBytesExt};
+use crate::io::{LittleEndian, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[derive(Debug)]
 pub struct Builder(Vec<u32>);
@@ -16,7 +18,7 @@ impl Builder {
         self.0.push(pos);
     }
 
-    pub fn write<W: std::io::Write>(&self, writer: &mut W) -> crate::Result<(u8, usize)> {
+    pub fn write<W: crate::io::Write>(&self, writer: &mut W) -> crate::Result<(u8, usize)> {
         // NOTE: We check if the pointers may fit in 16-bits
         // If so, we halve the index size by storing u16 instead of u32
         let step_size = {

--- a/src/table/block/binary_index/reader.rs
+++ b/src/table/block/binary_index/reader.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use byteorder::{LittleEndian, ReadBytesExt};
+use crate::io::{LittleEndian, ReadBytesExt};
 
 pub struct Reader<'a> {
     bytes: &'a [u8],

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -3,12 +3,16 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use super::{TRAILER_START_MARKER, binary_index::Reader as BinaryIndexReader};
+use crate::io::{LittleEndian, ReadBytesExt};
 use crate::{
     SeqNo, Slice,
     table::{Block, block::Trailer},
 };
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::{io::Cursor, marker::PhantomData};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::marker::PhantomData;
+
+use crate::io::Cursor;
 
 /// Validates that `restart_interval` and `binary_index_step_size` read from a
 /// block trailer are within their allowed ranges.
@@ -37,7 +41,7 @@ pub trait ParsedItem<M> {
         needle: &[u8],
         bytes: &[u8],
         cmp: &dyn crate::comparator::UserComparator,
-    ) -> std::cmp::Ordering;
+    ) -> core::cmp::Ordering;
 
     /// Returns the item's seqno.
     fn seqno(&self) -> SeqNo;
@@ -930,7 +934,10 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
         }
     }
 
-    pub fn trim_back_to_upper_bound(&mut self, cmp: impl Fn(&Parsed, &[u8]) -> std::cmp::Ordering) {
+    pub fn trim_back_to_upper_bound(
+        &mut self,
+        cmp: impl Fn(&Parsed, &[u8]) -> core::cmp::Ordering,
+    ) {
         let Some(entries_end) = self.entries_end() else {
             return;
         };
@@ -959,7 +966,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
                 break;
             };
 
-            if cmp(&item, self.entries()) != std::cmp::Ordering::Greater {
+            if cmp(&item, self.entries()) != core::cmp::Ordering::Greater {
                 break;
             }
 
@@ -989,7 +996,7 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
                 return;
             };
 
-            cmp(&item, self.entries()) == std::cmp::Ordering::Less
+            cmp(&item, self.entries()) == core::cmp::Ordering::Less
         } else {
             true
         };
@@ -1034,8 +1041,8 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     #[must_use]
     pub fn upper_stack_tail_cmp(
         &self,
-        cmp: impl Fn(&Parsed, &[u8]) -> std::cmp::Ordering,
-    ) -> Option<std::cmp::Ordering> {
+        cmp: impl Fn(&Parsed, &[u8]) -> core::cmp::Ordering,
+    ) -> Option<core::cmp::Ordering> {
         let &offset = self.hi_scanner.stack.last()?;
         let entries_end = self.entries_end()?;
         let is_restart = self.hi_scanner.stack.len() == 1;
@@ -1176,6 +1183,7 @@ impl<Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> DoubleEndedIterator
 )]
 mod tests {
     use super::Decoder;
+    use crate::io::{ByteOrder, LittleEndian};
     use crate::{
         InternalValue,
         table::{
@@ -1185,7 +1193,6 @@ mod tests {
             index_block::IndexBlockParsedItem,
         },
     };
-    use byteorder::{ByteOrder, LittleEndian};
 
     fn make_handles(count: usize) -> Vec<KeyedBlockHandle> {
         (0..count)
@@ -1206,7 +1213,7 @@ mod tests {
             header: Header::test_dummy(BlockType::Index),
         });
         let trailer_offset = Trailer::new(&trailer_probe.inner).trailer_offset();
-        trailer_offset + 1 + 1 + std::mem::size_of::<u32>()
+        trailer_offset + 1 + 1 + core::mem::size_of::<u32>()
     }
 
     fn binary_index_len_field_pos(bytes: &[u8]) -> usize {
@@ -1233,18 +1240,18 @@ mod tests {
             header: Header::test_dummy(BlockType::Index),
         });
         let trailer_offset = Trailer::new(&trailer_probe.inner).trailer_offset();
-        trailer_offset + 1 + 1 + (2 * std::mem::size_of::<u32>())
+        trailer_offset + 1 + 1 + (2 * core::mem::size_of::<u32>())
     }
 
     fn hash_index_offset_field_pos(bytes: &[u8]) -> usize {
-        hash_index_len_field_pos(bytes) + std::mem::size_of::<u32>()
+        hash_index_len_field_pos(bytes) + core::mem::size_of::<u32>()
     }
 
     fn first_restart_key_len_field_pos(bytes: &[u8]) -> usize {
         use crate::coding::Decode;
+        use crate::io::Cursor;
+        use crate::io::ReadBytesExt;
         use crate::table::BlockHandle;
-        use byteorder::ReadBytesExt;
-        use std::io::Cursor;
         use varint_rs::VarintReader;
 
         let mut cursor = Cursor::new(bytes);
@@ -1260,9 +1267,9 @@ mod tests {
 
     fn first_truncated_rest_key_len_field_pos(bytes: &[u8]) -> usize {
         use crate::coding::Decode;
+        use crate::io::Cursor;
+        use crate::io::ReadBytesExt;
         use crate::table::BlockHandle;
-        use byteorder::ReadBytesExt;
-        use std::io::Cursor;
         use varint_rs::VarintReader;
 
         let mut cursor = Cursor::new(bytes);
@@ -1285,9 +1292,9 @@ mod tests {
 
     fn nth_truncated_rest_key_len_field_pos(bytes: &[u8], ordinal: usize) -> usize {
         use crate::coding::Decode;
+        use crate::io::Cursor;
+        use crate::io::ReadBytesExt;
         use crate::table::BlockHandle;
-        use byteorder::ReadBytesExt;
-        use std::io::Cursor;
         use varint_rs::VarintReader;
 
         let mut cursor = Cursor::new(bytes);
@@ -1331,7 +1338,7 @@ mod tests {
         let invalid_binary_index_offset = (bytes.len() as u32).saturating_add(1);
         LittleEndian::write_u32(
             &mut bytes
-                [binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+                [binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
             invalid_binary_index_offset,
         );
 
@@ -1355,7 +1362,7 @@ mod tests {
         let binary_index_offset_pos = binary_index_offset_field_pos(&bytes);
         LittleEndian::write_u32(
             &mut bytes
-                [binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+                [binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
             0,
         );
 
@@ -1378,7 +1385,7 @@ mod tests {
         let mut bytes = IndexBlock::encode_into_vec_with_restart_interval(&handles, 8).unwrap();
         let binary_index_offset_pos = binary_index_offset_field_pos(&bytes);
         let binary_index_offset = LittleEndian::read_u32(
-            &bytes[binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         bytes[binary_index_offset - 1] = 0;
 
@@ -1401,11 +1408,11 @@ mod tests {
         let mut bytes = IndexBlock::encode_into_vec_with_restart_interval(&handles, 8).unwrap();
         let binary_index_len_pos = binary_index_len_field_pos(&bytes);
         let current_binary_index_len = LittleEndian::read_u32(
-            &bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
         );
         let inflated_binary_index_len = current_binary_index_len.saturating_add(10_000);
         LittleEndian::write_u32(
-            &mut bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
             inflated_binary_index_len,
         );
 
@@ -1436,14 +1443,14 @@ mod tests {
         let trailer_offset = Trailer::new(&trailer_probe.inner).trailer_offset();
 
         let binary_index_offset = LittleEndian::read_u32(
-            &bytes[binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let step_size = usize::from(bytes[binary_index_step_size_pos]);
         let entries_before_trailer = trailer_offset - binary_index_offset;
         let inflated_binary_index_len = u32::try_from((entries_before_trailer / step_size) + 1)
             .expect("test fixture expects u32 binary index len");
         LittleEndian::write_u32(
-            &mut bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
             inflated_binary_index_len,
         );
 
@@ -1466,11 +1473,11 @@ mod tests {
         let mut bytes = IndexBlock::encode_into_vec_with_restart_interval(&handles, 8).unwrap();
         let binary_index_len_pos = binary_index_len_field_pos(&bytes);
         let current_binary_index_len = LittleEndian::read_u32(
-            &bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
         );
         let shortened_binary_index_len = current_binary_index_len.saturating_sub(1);
         LittleEndian::write_u32(
-            &mut bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
             shortened_binary_index_len,
         );
 
@@ -1494,7 +1501,7 @@ mod tests {
 
         let binary_index_offset_pos = binary_index_offset_field_pos(&bytes);
         let binary_index_offset = LittleEndian::read_u32(
-            &bytes[binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let entries_end = binary_index_offset - 1;
 
@@ -1605,10 +1612,10 @@ mod tests {
         let binary_index_len_pos = binary_index_len_field_pos(&bytes);
         let binary_index_step_size_pos = binary_index_step_size_field_pos(&bytes);
         let binary_index_offset = LittleEndian::read_u32(
-            &bytes[binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let binary_index_len = LittleEndian::read_u32(
-            &bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let binary_index_step_size = usize::from(bytes[binary_index_step_size_pos]);
         let mid = binary_index_len / 2;
@@ -1627,13 +1634,13 @@ mod tests {
                 )]
                 let trailer_start_u16 = trailer_start_u32 as u16;
                 LittleEndian::write_u16(
-                    &mut bytes[mid_offset..mid_offset + std::mem::size_of::<u16>()],
+                    &mut bytes[mid_offset..mid_offset + core::mem::size_of::<u16>()],
                     trailer_start_u16,
                 );
             }
             4 => {
                 LittleEndian::write_u32(
-                    &mut bytes[mid_offset..mid_offset + std::mem::size_of::<u32>()],
+                    &mut bytes[mid_offset..mid_offset + core::mem::size_of::<u32>()],
                     trailer_start_u32,
                 );
             }
@@ -1669,10 +1676,10 @@ mod tests {
         let binary_index_len_pos = binary_index_len_field_pos(&bytes);
         let binary_index_step_size_pos = binary_index_step_size_field_pos(&bytes);
         let binary_index_offset = LittleEndian::read_u32(
-            &bytes[binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let binary_index_len = LittleEndian::read_u32(
-            &bytes[binary_index_len_pos..binary_index_len_pos + std::mem::size_of::<u32>()],
+            &bytes[binary_index_len_pos..binary_index_len_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let binary_index_step_size = usize::from(bytes[binary_index_step_size_pos]);
         let mid = binary_index_len / 2;
@@ -1691,13 +1698,13 @@ mod tests {
                 )]
                 let trailer_start_u16 = trailer_start_u32 as u16;
                 LittleEndian::write_u16(
-                    &mut bytes[mid_offset..mid_offset + std::mem::size_of::<u16>()],
+                    &mut bytes[mid_offset..mid_offset + core::mem::size_of::<u16>()],
                     trailer_start_u16,
                 );
             }
             4 => {
                 LittleEndian::write_u32(
-                    &mut bytes[mid_offset..mid_offset + std::mem::size_of::<u32>()],
+                    &mut bytes[mid_offset..mid_offset + core::mem::size_of::<u32>()],
                     trailer_start_u32,
                 );
             }
@@ -1827,10 +1834,13 @@ mod tests {
         };
 
         let trailer_offset = Trailer::new(&block).trailer_offset();
-        let hash_index_offset_pos =
-            trailer_offset + 1 + 1 + (2 * std::mem::size_of::<u32>()) + std::mem::size_of::<u32>();
+        let hash_index_offset_pos = trailer_offset
+            + 1
+            + 1
+            + (2 * core::mem::size_of::<u32>())
+            + core::mem::size_of::<u32>();
         let hash_index_offset = LittleEndian::read_u32(
-            &block.data[hash_index_offset_pos..hash_index_offset_pos + std::mem::size_of::<u32>()],
+            &block.data[hash_index_offset_pos..hash_index_offset_pos + core::mem::size_of::<u32>()],
         );
         assert!(hash_index_offset > 0, "fixture must encode a hash index");
 
@@ -1850,13 +1860,13 @@ mod tests {
         let mut bytes = DataBlock::encode_into_vec(&items, 1, 1.33).expect("encode data block");
         let hash_index_offset_pos = hash_index_offset_field_pos(&bytes);
         let hash_index_offset = LittleEndian::read_u32(
-            &bytes[hash_index_offset_pos..hash_index_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[hash_index_offset_pos..hash_index_offset_pos + core::mem::size_of::<u32>()],
         );
         assert!(hash_index_offset > 0, "fixture must encode a hash index");
 
         let hash_index_len_pos = hash_index_len_field_pos(&bytes);
         LittleEndian::write_u32(
-            &mut bytes[hash_index_len_pos..hash_index_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[hash_index_len_pos..hash_index_len_pos + core::mem::size_of::<u32>()],
             u32::MAX,
         );
 
@@ -1884,14 +1894,14 @@ mod tests {
         let mut bytes = DataBlock::encode_into_vec(&items, 1, 1.33).expect("encode data block");
         let hash_index_len_pos = hash_index_len_field_pos(&bytes);
         let hash_index_len = LittleEndian::read_u32(
-            &bytes[hash_index_len_pos..hash_index_len_pos + std::mem::size_of::<u32>()],
+            &bytes[hash_index_len_pos..hash_index_len_pos + core::mem::size_of::<u32>()],
         );
         assert!(
             hash_index_len > 0,
             "fixture must encode a non-empty hash index"
         );
         LittleEndian::write_u32(
-            &mut bytes[hash_index_len_pos..hash_index_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[hash_index_len_pos..hash_index_len_pos + core::mem::size_of::<u32>()],
             hash_index_len - 1,
         );
 
@@ -1916,7 +1926,7 @@ mod tests {
         // Zero out binary_index_len in the trailer
         let bi_len_pos = binary_index_len_field_pos(&bytes);
         LittleEndian::write_u32(
-            &mut bytes[bi_len_pos..bi_len_pos + std::mem::size_of::<u32>()],
+            &mut bytes[bi_len_pos..bi_len_pos + core::mem::size_of::<u32>()],
             0,
         );
 
@@ -1943,11 +1953,11 @@ mod tests {
         let bi_len_pos = binary_index_len_field_pos(&bytes);
         let bi_step_pos = binary_index_step_size_field_pos(&bytes);
         let bi_offset = LittleEndian::read_u32(
-            &bytes[bi_offset_pos..bi_offset_pos + std::mem::size_of::<u32>()],
+            &bytes[bi_offset_pos..bi_offset_pos + core::mem::size_of::<u32>()],
         ) as usize;
         let step = usize::from(bytes[bi_step_pos]);
         let bi_len =
-            LittleEndian::read_u32(&bytes[bi_len_pos..bi_len_pos + std::mem::size_of::<u32>()])
+            LittleEndian::read_u32(&bytes[bi_len_pos..bi_len_pos + core::mem::size_of::<u32>()])
                 as usize;
 
         // Write data.len() into every binary index slot so seek lands at EOF

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -9,7 +9,7 @@ use crate::{
     table::{Block, block::Trailer},
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use crate::io::Cursor;

--- a/src/table/block/encoder.rs
+++ b/src/table/block/encoder.rs
@@ -10,12 +10,14 @@ use super::{
     },
     Trailer,
 };
-use std::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::marker::PhantomData;
 
 pub trait Encodable<Context: Default> {
     fn key(&self) -> &[u8];
 
-    fn encode_full_into<W: std::io::Write>(
+    fn encode_full_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         state: &mut Context,
@@ -23,7 +25,7 @@ pub trait Encodable<Context: Default> {
     where
         Self: Sized;
 
-    fn encode_truncated_into<W: std::io::Write>(
+    fn encode_truncated_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         state: &mut Context,

--- a/src/table/block/encoder.rs
+++ b/src/table/block/encoder.rs
@@ -11,7 +11,7 @@ use super::{
     Trailer,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 pub trait Encodable<Context: Default> {

--- a/src/table/block/hash_index/builder.rs
+++ b/src/table/block/hash_index/builder.rs
@@ -5,7 +5,7 @@
 use super::{MARKER_CONFLICT, MARKER_FREE, calculate_bucket_position};
 use crate::io::WriteBytesExt;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// With 254, pointers [0 - 253] can be indexed.
 pub const MAX_POINTERS_FOR_HASH_INDEX: usize = 254;

--- a/src/table/block/hash_index/builder.rs
+++ b/src/table/block/hash_index/builder.rs
@@ -3,7 +3,9 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use super::{MARKER_CONFLICT, MARKER_FREE, calculate_bucket_position};
-use byteorder::WriteBytesExt;
+use crate::io::WriteBytesExt;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// With 254, pointers [0 - 253] can be indexed.
 pub const MAX_POINTERS_FOR_HASH_INDEX: usize = 254;
@@ -115,7 +117,7 @@ impl Builder {
     }
 
     /// Appends the raw index bytes to a writer.
-    pub fn write<W: std::io::Write>(self, writer: &mut W) -> std::io::Result<()> {
+    pub fn write<W: crate::io::Write>(self, writer: &mut W) -> crate::io::Result<()> {
         for byte in self.0 {
             writer.write_u8(byte)?;
         }

--- a/src/table/block/header.rs
+++ b/src/table/block/header.rs
@@ -6,16 +6,23 @@ use super::Checksum;
 use crate::checksum::ChecksummedWriter;
 use crate::coding::{Decode, Encode};
 use crate::file::MAGIC_BYTES;
+use crate::io::{ReadBytesExt, WriteBytesExt};
 use crate::table::block::BlockType;
-use byteorder::{ReadBytesExt, WriteBytesExt};
+// `Read`/`Write` resolve to the std traits under `std` (so raw
+// `write_all`/`read_exact` come from `std::io`) and to the native
+// `crate::io` traits under `no_std`; bounds below are written bare so
+// they track whichever is imported.
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
 
-struct ChecksummedReader<R: std::io::Read> {
+struct ChecksummedReader<R: Read> {
     inner: R,
     hasher: xxhash_rust::xxh3::Xxh3Default,
 }
 
-impl<R: std::io::Read> ChecksummedReader<R> {
+impl<R: Read> ChecksummedReader<R> {
     pub fn new(reader: R) -> Self {
         Self {
             inner: reader,
@@ -33,8 +40,21 @@ impl<R: std::io::Read> ChecksummedReader<R> {
     }
 }
 
-impl<R: std::io::Read> std::io::Read for ChecksummedReader<R> {
+#[cfg(feature = "std")]
+impl<R: Read> std::io::Read for ChecksummedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+
+        #[expect(clippy::indexing_slicing)]
+        self.hasher.update(&buf[..n]);
+
+        Ok(n)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> crate::io::Read for ChecksummedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> crate::io::Result<usize> {
         let n = self.inner.read(buf)?;
 
         #[expect(clippy::indexing_slicing)]
@@ -134,13 +154,13 @@ impl Header {
         // the wire format is the contract and that contract is 1 byte.
         + 1
         // Data checksum
-        + std::mem::size_of::<Checksum>()
+        + core::mem::size_of::<Checksum>()
         // On-disk size
-        + std::mem::size_of::<u32>()
+        + core::mem::size_of::<u32>()
         // Uncompressed data length
-        + std::mem::size_of::<u32>()
+        + core::mem::size_of::<u32>()
         // Header checksum
-        + std::mem::size_of::<u32>();
+        + core::mem::size_of::<u32>();
 
     /// Largest possible header size: [`Self::MIN_LEN`] plus the optional
     /// `block_flags` byte. Used as a pre-decode upper bound where the
@@ -254,7 +274,7 @@ impl Header {
 
 impl Encode for Header {
     fn encode_into<W: Write>(&self, mut writer: &mut W) -> Result<(), crate::Error> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         let checksum = {
             let mut writer = ChecksummedWriter::new(&mut writer);
@@ -298,7 +318,7 @@ impl Encode for Header {
 
 impl Decode for Header {
     fn decode_from<R: Read>(reader: &mut R) -> Result<Self, crate::Error> {
-        use byteorder::LE;
+        use crate::io::LE;
 
         let mut protected_reader = ChecksummedReader::new(reader);
 

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -314,8 +314,7 @@ impl PreparedBlock<'_> {
     /// Writes the framed block (header + payload + optional parity trailer)
     /// to `writer` and returns the header. This is the single point where
     /// block bytes hit the file, so it must run in on-disk order.
-    // no-std: core2::io::Write (whole block-write path migrates together)
-    pub(crate) fn write_to<W: std::io::Write>(self, mut writer: &mut W) -> crate::Result<Header> {
+    pub(crate) fn write_to<W: crate::io::Write>(self, mut writer: &mut W) -> crate::Result<Header> {
         self.header.encode_into(&mut writer)?;
         writer.write_all(&self.payload)?;
         if let Some(parity) = &self.parity {
@@ -399,7 +398,7 @@ impl Block {
     /// independently. When ECC recovery succeeds, the original
     /// checksum-mismatch is logged at WARN level — the block is
     /// returned to the caller as if no corruption ever happened.
-    fn read_payload_and_verify<R: std::io::Read>(
+    fn read_payload_and_verify<R: crate::io::Read>(
         reader: &mut R,
         data_length: u32,
         ecc_length: u32,
@@ -535,7 +534,7 @@ impl Block {
     /// the mismatch before the call reaches `write_into`, so the
     /// guard is unreachable from any in-tree caller and exists purely
     /// as a "should-never-fire" assertion.
-    pub fn write_into<W: std::io::Write>(
+    pub fn write_into<W: crate::io::Write>(
         writer: &mut W,
         data: &[u8],
         identity: BlockIdentity,
@@ -567,7 +566,7 @@ impl Block {
     /// caller could only guess magic values and a wrong bit would serialize
     /// a header claiming a transform the payload doesn't carry. External
     /// code uses the safe [`Self::write_into`] wrapper instead.
-    pub(crate) fn write_into_with_flags<W: std::io::Write>(
+    pub(crate) fn write_into_with_flags<W: crate::io::Write>(
         writer: &mut W,
         data: &[u8],
         identity: BlockIdentity,
@@ -860,7 +859,7 @@ impl Block {
         clippy::too_many_lines,
         reason = "encrypt/no-encrypt branches duplicate compression match — see comment above"
     )]
-    pub fn from_reader<R: std::io::Read>(
+    pub fn from_reader<R: crate::io::Read>(
         reader: &mut R,
         identity: BlockIdentity,
         transform: &BlockTransform<'_>,
@@ -1211,8 +1210,8 @@ impl Block {
             let mut buf = vec![0u8; block_size];
             let n = file.read_at(&mut buf, *handle.offset())?;
             if n != block_size {
-                return Err(crate::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
+                return Err(crate::Error::Io(crate::io::Error::new(
+                    crate::io::ErrorKind::UnexpectedEof,
                     format!(
                         "block read_at: expected {block_size} bytes, got {n} at offset {}",
                         *handle.offset(),
@@ -1300,7 +1299,7 @@ impl Block {
                 (buf, false)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
-                let mut cursor = std::io::Cursor::new(&buf[header_len..]);
+                let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
                 Self::read_payload_and_verify(
                     &mut cursor,
                     parsed_header.data_length,
@@ -1452,7 +1451,7 @@ impl Block {
                 (buf.slice(header_len..header_len + actual_data_len), false)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
-                let mut cursor = std::io::Cursor::new(&buf[header_len..]);
+                let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
                 let (payload, corrected) = Self::read_payload_and_verify(
                     &mut cursor,
                     parsed_header.data_length,
@@ -1576,7 +1575,7 @@ impl Block {
         transform: &BlockTransform<'_>,
     ) -> crate::Result<(Header, Slice, bool)> {
         if transform.encryption().is_some() {
-            return Err(crate::Error::Io(std::io::Error::other(
+            return Err(crate::Error::Io(crate::io::Error::other(
                 "read_data_frame: encrypted blocks are not supported on the lazy path",
             )));
         }
@@ -1644,7 +1643,7 @@ impl Block {
             (buf.slice(header_len..header_len + actual_data_len), false)
         } else {
             #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
-            let mut cursor = std::io::Cursor::new(&buf[header_len..]);
+            let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
             // `corrected` is surfaced so the partial-decode caller can schedule
             // auto-heal (the recovered bytes are correct but the on-disk copy is
             // still faulty); a heal is also logged inside read_payload_and_verify.

--- a/src/table/block/offset.rs
+++ b/src/table/block/offset.rs
@@ -3,10 +3,10 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 // TODO: rename FileOffset?
-#[derive(Copy, Clone, Default, Debug, std::hash::Hash, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Default, Debug, core::hash::Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct BlockOffset(pub u64);
 
-impl std::ops::Deref for BlockOffset {
+impl core::ops::Deref for BlockOffset {
     type Target = u64;
 
     fn deref(&self) -> &Self::Target {
@@ -14,13 +14,13 @@ impl std::ops::Deref for BlockOffset {
     }
 }
 
-impl std::ops::AddAssign<Self> for BlockOffset {
+impl core::ops::AddAssign<Self> for BlockOffset {
     fn add_assign(&mut self, rhs: Self) {
         *self += *rhs;
     }
 }
 
-impl std::ops::AddAssign<u64> for BlockOffset {
+impl core::ops::AddAssign<u64> for BlockOffset {
     fn add_assign(&mut self, rhs: u64) {
         self.0 += rhs;
     }

--- a/src/table/block/trailer.rs
+++ b/src/table/block/trailer.rs
@@ -6,21 +6,21 @@ use super::{
     Block,
     encoder::{Encodable, Encoder},
 };
+use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crate::table::block::hash_index::MAX_POINTERS_FOR_HASH_INDEX;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 pub const TRAILER_START_MARKER: u8 = 255;
 
-const TRAILER_SIZE: usize = 5 * std::mem::size_of::<u32>()
-    + (2 * std::mem::size_of::<u8>())
+const TRAILER_SIZE: usize = 5 * core::mem::size_of::<u32>()
+    + (2 * core::mem::size_of::<u8>())
     // Fixed key size (unused)
-    + std::mem::size_of::<u8>()
-    + std::mem::size_of::<u16>()
+    + core::mem::size_of::<u8>()
+    + core::mem::size_of::<u16>()
     // Prefix truncation on/off (always on)
-    + std::mem::size_of::<u8>()
+    + core::mem::size_of::<u8>()
     // Fixed value size (unused)
-    + std::mem::size_of::<u8>()
-    + std::mem::size_of::<u32>();
+    + core::mem::size_of::<u8>()
+    + core::mem::size_of::<u32>();
 
 /// Block trailer
 ///
@@ -72,7 +72,7 @@ impl<'a> Trailer<'a> {
             clippy::indexing_slicing,
             reason = "the item_count is at the end and is a u32"
         )]
-        let reader = &mut &reader[(TRAILER_SIZE - std::mem::size_of::<u32>())..];
+        let reader = &mut &reader[(TRAILER_SIZE - core::mem::size_of::<u32>())..];
 
         #[expect(
             clippy::expect_used,

--- a/src/table/block_index/iter.rs
+++ b/src/table/block_index/iter.rs
@@ -87,7 +87,7 @@ impl OwnedIndexBlockIter {
     ) -> crate::Result<Option<Self>> {
         // Short-circuit contradictory bounds: lo > hi means an empty range.
         if let (Some((lo_key, _)), Some((hi_key, _))) = (lo, hi)
-            && comparator.compare(lo_key, hi_key) == std::cmp::Ordering::Greater
+            && comparator.compare(lo_key, hi_key) == core::cmp::Ordering::Greater
         {
             return Ok(None);
         }

--- a/src/table/block_index/two_level.rs
+++ b/src/table/block_index/two_level.rs
@@ -15,7 +15,9 @@ use crate::{
         util::load_block,
     },
 };
-use std::{path::PathBuf, sync::Arc};
+use alloc::sync::Arc;
+
+use crate::path::PathBuf;
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;

--- a/src/table/block_index/volatile.rs
+++ b/src/table/block_index/volatile.rs
@@ -15,7 +15,9 @@ use crate::{
         util::load_block,
     },
 };
-use std::{path::PathBuf, sync::Arc};
+use alloc::sync::Arc;
+
+use crate::path::PathBuf;
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -25,6 +25,8 @@
 //! ```
 
 use crate::table::block::BlockOffset;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Serialize the per-block inner-block layouts into `out`.
 ///
@@ -74,7 +76,7 @@ impl BlockLayoutMap {
     /// the entries are not strictly ascending by offset (a corrupt section
     /// must surface rather than silently mis-map a range).
     pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
-        // Manual little-endian slice parsing (no `std::io::Read`), so the codec
+        // Manual little-endian slice parsing (no `crate::io::Read`), so the codec
         // stays `no_std + alloc`-clean. Any truncation or invariant violation
         // surfaces as a typed `InvalidHeader`, not a stringly-typed I/O error.
         const ERR: crate::Error = crate::Error::InvalidHeader("BlockLayout");

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -26,7 +26,7 @@
 
 use crate::table::block::BlockOffset;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Serialize the per-block inner-block layouts into `out`.
 ///

--- a/src/table/data_block/iter.rs
+++ b/src/table/data_block/iter.rs
@@ -64,18 +64,18 @@ impl<'a> Iter<'a> {
         if cmp.is_lexicographic() {
             self.decoder.inner_mut().seek(
                 |head_key, head_seqno| match head_key.cmp(needle) {
-                    std::cmp::Ordering::Less => true,
-                    std::cmp::Ordering::Equal => head_seqno >= seqno,
-                    std::cmp::Ordering::Greater => false,
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => head_seqno >= seqno,
+                    core::cmp::Ordering::Greater => false,
                 },
                 false,
             )
         } else {
             self.decoder.inner_mut().seek(
                 |head_key, head_seqno| match cmp.compare(head_key, needle) {
-                    std::cmp::Ordering::Less => true,
-                    std::cmp::Ordering::Equal => head_seqno >= seqno,
-                    std::cmp::Ordering::Greater => false,
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => head_seqno >= seqno,
+                    core::cmp::Ordering::Greater => false,
                 },
                 false,
             )
@@ -99,13 +99,13 @@ impl<'a> Iter<'a> {
             };
 
             match item.compare_key(needle, self.bytes, self.comparator.as_ref()) {
-                std::cmp::Ordering::Equal => {
+                core::cmp::Ordering::Equal => {
                     return true;
                 }
-                std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Greater => {
                     return false;
                 }
-                std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Less => {
                     // Continue
 
                     #[expect(
@@ -133,7 +133,7 @@ impl<'a> Iter<'a> {
                 .seek_upper(|head_key, _| head_key <= needle, false)
         } else {
             self.decoder.inner_mut().seek_upper(
-                |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
+                |head_key, _| cmp.compare(head_key, needle) != core::cmp::Ordering::Greater,
                 false,
             )
         };
@@ -148,13 +148,13 @@ impl<'a> Iter<'a> {
             };
 
             match item.compare_key(needle, self.bytes, self.comparator.as_ref()) {
-                std::cmp::Ordering::Equal => {
+                core::cmp::Ordering::Equal => {
                     return true;
                 }
-                std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Less => {
                     return false;
                 }
-                std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Greater => {
                     // Continue
 
                     #[expect(
@@ -180,10 +180,10 @@ impl<'a> Iter<'a> {
             };
 
             match item.compare_key(needle, self.bytes, self.comparator.as_ref()) {
-                std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Greater => {
                     return true;
                 }
-                std::cmp::Ordering::Equal | std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Equal | core::cmp::Ordering::Less => {
                     #[expect(
                         clippy::expect_used,
                         reason = "we peeked a value successfully, so there must be a next item in the stream"
@@ -206,7 +206,7 @@ impl<'a> Iter<'a> {
                 .seek_upper(|head_key, _| head_key <= needle, false)
         } else {
             self.decoder.inner_mut().seek_upper(
-                |head_key, _| cmp.compare(head_key, needle) != std::cmp::Ordering::Greater,
+                |head_key, _| cmp.compare(head_key, needle) != core::cmp::Ordering::Greater,
                 false,
             )
         };
@@ -220,10 +220,10 @@ impl<'a> Iter<'a> {
             };
 
             match item.compare_key(needle, self.bytes, self.comparator.as_ref()) {
-                std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Less => {
                     return true;
                 }
-                std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Equal | core::cmp::Ordering::Greater => {
                     #[expect(
                         clippy::expect_used,
                         reason = "we peeked a value successfully, so there must be a next item in the stream"

--- a/src/table/data_block/iter_test.rs
+++ b/src/table/data_block/iter_test.rs
@@ -1329,8 +1329,8 @@ mod tests {
                 block::{BlockType, Header, ParsedItem},
             },
         };
+        use core::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
         struct CountingComparator {
             /// Counts `compare()` invocations — proves the lex devirt path

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -13,14 +13,25 @@ use super::block::{
     Block, Decodable, Decoder, Encodable, Encoder, ParsedItem, TRAILER_START_MARKER, Trailer,
     binary_index::Reader as BinaryIndexReader, hash_index::Reader as HashIndexReader,
 };
+use crate::io::Cursor;
+use crate::io::WriteBytesExt;
+use crate::io::{LittleEndian, ReadBytesExt};
 use crate::key::InternalKey;
 use crate::table::block::hash_index::{MARKER_CONFLICT, MARKER_FREE};
 use crate::table::util::{SliceIndexes, compare_prefixed_slice};
 use crate::{InternalValue, SeqNo, Slice, ValueType};
-use byteorder::WriteBytesExt;
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::Cursor;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+// `Seek` resolves to std under `std` (so `seek_relative` on `Cursor` comes
+// from `std::io::Seek`) and to the native trait under `no_std`; written bare
+// so the `seek_relative` calls below track whichever is imported.
+#[cfg(not(feature = "std"))]
+use crate::io::Seek;
+#[cfg(not(feature = "std"))]
+use crate::io::{VarintReader, VarintWriter};
+#[cfg(feature = "std")]
 use std::io::Seek;
+#[cfg(feature = "std")]
 use varint_rs::{VarintReader, VarintWriter};
 
 impl Decodable<DataBlockParsedItem> for InternalValue {
@@ -235,7 +246,7 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
 }
 
 impl Encodable<()> for InternalValue {
-    fn encode_full_into<W: std::io::Write>(
+    fn encode_full_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         _state: &mut (),
@@ -261,7 +272,7 @@ impl Encodable<()> for InternalValue {
         Ok(())
     }
 
-    fn encode_truncated_into<W: std::io::Write>(
+    fn encode_truncated_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         _state: &mut (),
@@ -326,7 +337,7 @@ impl ParsedItem<InternalValue> for DataBlockParsedItem {
         needle: &[u8],
         bytes: &[u8],
         cmp: &dyn crate::comparator::UserComparator,
-    ) -> std::cmp::Ordering {
+    ) -> core::cmp::Ordering {
         // SAFETY: slice indexes come from the block parser which validates them
         // during decoding. The block format guarantees they are within bounds.
         if let Some(prefix) = &self.prefix {
@@ -466,7 +477,7 @@ impl DataBlock {
     }
 
     pub(crate) fn get_binary_index_reader(&self) -> BinaryIndexReader<'_> {
-        use std::mem::size_of;
+        use core::mem::size_of;
 
         let trailer = Trailer::new(&self.inner);
 
@@ -495,7 +506,7 @@ impl DataBlock {
 
     #[must_use]
     pub fn get_hash_index_reader(&self) -> Option<HashIndexReader<'_>> {
-        use std::mem::size_of;
+        use core::mem::size_of;
 
         let trailer = Trailer::new(&self.inner);
 
@@ -588,14 +599,14 @@ impl DataBlock {
         // Linear scan
         for item in iter {
             match item.compare_key(needle, &self.inner.data, comparator.as_ref()) {
-                std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Greater => {
                     // We are past our searched key
                     return Ok(None);
                 }
-                std::cmp::Ordering::Equal => {
+                core::cmp::Ordering::Equal => {
                     // If key is same as needle, check sequence number
                 }
-                std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Less => {
                     // We are before our searched key
                     continue;
                 }
@@ -655,7 +666,7 @@ impl DataBlock {
     /// The number of pointers is equal to the number of restart intervals.
     #[must_use]
     pub fn binary_index_len(&self) -> u32 {
-        use std::mem::size_of;
+        use core::mem::size_of;
 
         let trailer = Trailer::new(&self.inner);
 
@@ -874,6 +885,7 @@ impl DataBlock {
 mod tests {
     use super::DataBlockParsedItem;
     use crate::comparator::default_comparator;
+    use crate::io::ReadBytesExt;
     use crate::{
         InternalValue, SeqNo, Slice,
         ValueType::{Tombstone, Value},
@@ -882,7 +894,6 @@ mod tests {
             block::{BlockType, Decodable, Encodable, Header, ParsedItem},
         },
     };
-    use byteorder::ReadBytesExt;
     use std::io::{Cursor, Seek};
     use test_log::test;
     use varint_rs::VarintReader;

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -21,7 +21,7 @@ use crate::table::block::hash_index::{MARKER_CONFLICT, MARKER_FREE};
 use crate::table::util::{SliceIndexes, compare_prefixed_slice};
 use crate::{InternalValue, SeqNo, Slice, ValueType};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 // `Seek` resolves to std under `std` (so `seek_relative` on `Cursor` comes
 // from `std::io::Seek`) and to the native trait under `no_std`; written bare
 // so the `seek_relative` calls below track whichever is imported.

--- a/src/table/filter/mod.rs
+++ b/src/table/filter/mod.rs
@@ -5,9 +5,11 @@
 pub mod block;
 pub mod ribbon;
 
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::BuildHasherDefault;
 use ribbon::burr::{BurrBuilder, BurrParams};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::BuildHasherDefault;
+use rustc_hash::FxHasher;
 
 /// Hasher type embedded in `BuRR` filters. Only its type identity is used —
 /// the construction + probe paths in this crate go through
@@ -15,8 +17,12 @@ use std::hash::BuildHasherDefault;
 /// `BurrFilterReader::contains_hash`, all of which take pre-computed u64
 /// hashes (xxh3 via `crate::hash::hash64`) and never invoke the
 /// `BuildHasher`. The type slot exists only to satisfy the vendored
-/// ribbon-filter's generic `S: BuildHasher` bound.
-type FilterHasher = BuildHasherDefault<DefaultHasher>;
+/// ribbon-filter's generic `S: BuildHasher` bound; the concrete hasher is
+/// never constructed or called, so the choice has no on-disk or runtime
+/// effect. `FxHasher` (a no_std-capable hasher already in the dependency
+/// tree) replaces the std-only `DefaultHasher` purely to keep this module
+/// off `std`.
+type FilterHasher = BuildHasherDefault<FxHasher>;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BloomConstructionPolicy {

--- a/src/table/filter/mod.rs
+++ b/src/table/filter/mod.rs
@@ -6,7 +6,7 @@ pub mod block;
 pub mod ribbon;
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::BuildHasherDefault;
 use ribbon::burr::{BurrBuilder, BurrParams};
 use rustc_hash::FxHasher;

--- a/src/table/filter/ribbon/builder.rs
+++ b/src/table/filter/ribbon/builder.rs
@@ -1,4 +1,6 @@
-use std::hash::BuildHasher;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::BuildHasher;
 
 use super::error::{BuildError, ConstructionFailure};
 use super::filter::RibbonFilter;
@@ -64,7 +66,7 @@ where
     /// No retry budget: a single attempt with the given seed. Caller is
     /// responsible for sizing `m` (via `Params::m`) generously enough that
     /// the banded solver succeeds with the keys provided.
-    pub(crate) fn build_with_seed_verbatim<K: std::hash::Hash>(
+    pub(crate) fn build_with_seed_verbatim<K: core::hash::Hash>(
         &self,
         keys: &[K],
         seed: u64,
@@ -101,7 +103,7 @@ where
             })
     }
 
-    pub fn build<K: std::hash::Hash>(&self, keys: &[K]) -> Result<RibbonFilter<S>, BuildError> {
+    pub fn build<K: core::hash::Hash>(&self, keys: &[K]) -> Result<RibbonFilter<S>, BuildError> {
         self.params.validate().map_err(BuildError::InvalidParams)?;
 
         let mut attempts = 0usize;
@@ -162,7 +164,7 @@ where
         })
     }
 
-    fn build_once<K: std::hash::Hash>(
+    fn build_once<K: core::hash::Hash>(
         &self,
         keys: &[K],
         m: usize,

--- a/src/table/filter/ribbon/builder.rs
+++ b/src/table/filter/ribbon/builder.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::BuildHasher;
 
 use super::error::{BuildError, ConstructionFailure};

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -1,4 +1,6 @@
-use std::hash::{BuildHasher, Hash};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::{BuildHasher, Hash};
 
 use super::super::builder::RibbonBuilder;
 use super::super::hashing::{StandardEquation, standard_equation_w64};

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::{BuildHasher, Hash};
 
 use super::super::builder::RibbonBuilder;

--- a/src/table/filter/ribbon/burr/error.rs
+++ b/src/table/filter/ribbon/burr/error.rs
@@ -48,7 +48,7 @@ impl fmt::Display for BurrBuildError {
     }
 }
 
-impl std::error::Error for BurrBuildError {}
+impl core::error::Error for BurrBuildError {}
 
 /// Detailed construction failure for diagnostics.
 #[derive(Debug, Clone)]
@@ -77,7 +77,7 @@ impl fmt::Display for BurrConstructionFailure {
     }
 }
 
-impl std::error::Error for BurrConstructionFailure {}
+impl core::error::Error for BurrConstructionFailure {}
 
 #[cfg(test)]
 mod tests {
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn burr_build_error_implements_std_error() {
         let err = BurrBuildError::InvalidParams("x");
-        let _: &dyn std::error::Error = &err;
+        let _: &dyn core::error::Error = &err;
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod tests {
             layer_index: 0,
             block_index: 0,
         };
-        let _: &dyn std::error::Error = &err;
+        let _: &dyn core::error::Error = &err;
     }
 
     #[test]

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::{BuildHasher, Hash};
 
 use super::super::builder::Scratch;

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -1,4 +1,6 @@
-use std::hash::{BuildHasher, Hash};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::{BuildHasher, Hash};
 
 use super::super::builder::Scratch;
 use super::super::filter::RibbonFilter;

--- a/src/table/filter/ribbon/burr/params.rs
+++ b/src/table/filter/ribbon/burr/params.rs
@@ -61,7 +61,7 @@ impl BurrParams {
         if !(0.0 < fpr && fpr < 1.0) {
             return Err(BurrBuildError::InvalidParams("fpr must be in (0.0, 1.0)"));
         }
-        let r_f = (-fpr.log2()).ceil();
+        let r_f = crate::f32_ceil(-crate::f32_log2(fpr));
         if !r_f.is_finite() || r_f < 1.0 || r_f > 64.0 {
             return Err(BurrBuildError::InvalidParams(
                 "computed r out of supported range [1, 64]",
@@ -99,7 +99,7 @@ impl BurrParams {
             clippy::cast_sign_loss,
             reason = "bpk is validated to 1.0..=64.0 above, then clamped to the same range"
         )]
-        let r = bpk.round().clamp(1.0, 64.0) as u8;
+        let r = crate::f32_round(bpk).clamp(1.0, 64.0) as u8;
         Ok(Self {
             n,
             r,
@@ -144,7 +144,7 @@ impl BurrParams {
             clippy::cast_precision_loss,
             reason = "layer_input_keys is bounded by the filter capacity; ceil result fits usize on supported platforms"
         )]
-        let raw = ((layer_input_keys as f64) * (1.0 + overhead)).ceil() as usize;
+        let raw = crate::f64_ceil((layer_input_keys as f64) * (1.0 + overhead)) as usize;
         let raw = raw.max(usize::from(self.b)); // ≥ one block
         // Round UP to a multiple of b (so block_count = m / b is exact).
         // `raw.div_ceil(b) * b` can wrap on extreme inputs in release builds,

--- a/src/table/filter/ribbon/burr/tests.rs
+++ b/src/table/filter/ribbon/burr/tests.rs
@@ -27,8 +27,8 @@
     reason = "test code indexes into fixture buffers with known sizes"
 )]
 
+use core::hash::BuildHasherDefault;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::BuildHasherDefault;
 
 use super::{BurrBuilder, BurrParams};
 
@@ -86,7 +86,7 @@ fn burr_wire_format_round_trips() {
     // BurrFilterReader, and verify contains_hash answers match
     // BurrFilter::contains for every inserted key.
     use super::filter::BurrFilterReader;
-    use std::hash::BuildHasher;
+    use core::hash::BuildHasher;
 
     let n = 500_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");

--- a/src/table/filter/ribbon/burr/threshold.rs
+++ b/src/table/filter/ribbon/burr/threshold.rs
@@ -25,6 +25,8 @@
 //! warning.
 
 use super::super::hashing::StandardEquation;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Capacity numerator: per-block keep-capacity = `b * CAP_NUM / CAP_DEN`.
 /// 90% load factor (CAP_NUM=9, CAP_DEN=10) — leaves ~10% margin for the

--- a/src/table/filter/ribbon/burr/threshold.rs
+++ b/src/table/filter/ribbon/burr/threshold.rs
@@ -26,7 +26,7 @@
 
 use super::super::hashing::StandardEquation;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Capacity numerator: per-block keep-capacity = `b * CAP_NUM / CAP_DEN`.
 /// 90% load factor (CAP_NUM=9, CAP_DEN=10) — leaves ~10% margin for the

--- a/src/table/filter/ribbon/burr/wire.rs
+++ b/src/table/filter/ribbon/burr/wire.rs
@@ -34,7 +34,7 @@
 //! to drift seeds across encode/decode.
 
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::BuildHasher;
 
 use crate::io::Cursor;

--- a/src/table/filter/ribbon/burr/wire.rs
+++ b/src/table/filter/ribbon/burr/wire.rs
@@ -33,10 +33,19 @@
 //! at parse time. Keeps the format compact and removes the temptation
 //! to drift seeds across encode/decode.
 
-use std::hash::BuildHasher;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::BuildHasher;
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Cursor, Read};
+use crate::io::Cursor;
+use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
+// `Read` in scope for the raw `cursor.read_exact` below: the std trait under
+// `std` (where `crate::io::Read` is a method-less alias), the native one under
+// `no_std`.
+#[cfg(not(feature = "std"))]
+use crate::io::Read;
+#[cfg(feature = "std")]
+use std::io::Read;
 
 use super::super::hashing::{StandardEquation, standard_equation_from_hash};
 use super::super::params::{Mode, Params};

--- a/src/table/filter/ribbon/error.rs
+++ b/src/table/filter/ribbon/error.rs
@@ -37,7 +37,7 @@ impl fmt::Display for ParamError {
     }
 }
 
-impl std::error::Error for ParamError {}
+impl core::error::Error for ParamError {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConstructionFailure {
@@ -95,7 +95,7 @@ impl fmt::Display for ConstructionFailure {
     }
 }
 
-impl std::error::Error for ConstructionFailure {}
+impl core::error::Error for ConstructionFailure {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum BuildError {
@@ -123,7 +123,7 @@ impl fmt::Display for BuildError {
     }
 }
 
-impl std::error::Error for BuildError {}
+impl core::error::Error for BuildError {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterReprError {
@@ -162,7 +162,7 @@ impl fmt::Display for FilterReprError {
     }
 }
 
-impl std::error::Error for FilterReprError {}
+impl core::error::Error for FilterReprError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/table/filter/ribbon/filter.rs
+++ b/src/table/filter/ribbon/filter.rs
@@ -1,4 +1,6 @@
-use std::hash::{BuildHasher, Hash};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::hash::{BuildHasher, Hash};
 
 use super::builder::Scratch;
 #[cfg(feature = "ribbon-serde")]

--- a/src/table/filter/ribbon/filter.rs
+++ b/src/table/filter/ribbon/filter.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::hash::{BuildHasher, Hash};
 
 use super::builder::Scratch;

--- a/src/table/filter/ribbon/hashing.rs
+++ b/src/table/filter/ribbon/hashing.rs
@@ -1,5 +1,5 @@
+use core::hash::BuildHasher;
 use core::hash::Hash;
-use std::hash::BuildHasher;
 
 use super::params::{Mode, Params};
 

--- a/src/table/filter/ribbon/params.rs
+++ b/src/table/filter/ribbon/params.rs
@@ -96,7 +96,7 @@ impl Params {
         if !(0.0 < fpr && fpr < 1.0) {
             return Err(ParamError::InvalidFalsePositiveRate { fpr });
         }
-        let r = (-fpr.log2()).ceil() as usize;
+        let r = crate::f64_ceil(-crate::f64_log2(fpr)) as usize;
         Ok(r.max(1))
     }
 
@@ -114,7 +114,7 @@ impl Params {
             return Err(ParamError::InvalidOverhead { overhead });
         }
 
-        let m = ((n as f64) * (1.0 + overhead)).ceil() as usize;
+        let m = crate::f64_ceil((n as f64) * (1.0 + overhead)) as usize;
         Self::new(m.max(w), w, r, mode)
     }
 

--- a/src/table/filter/ribbon/tests.rs
+++ b/src/table/filter/ribbon/tests.rs
@@ -1,6 +1,6 @@
 use super::{BuildError, Mode, ParamError, Params, RibbonBuilder};
+use core::hash::BuildHasherDefault;
 use std::collections::hash_map::DefaultHasher;
-use std::hash::BuildHasherDefault;
 
 use super::hashing::{standard_equation_w64, start_position_from_stream};
 

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::io::Cursor;
+use crate::io::{ReadBytesExt, WriteBytesExt};
 use crate::{SeqNo, UserKey};
 use crate::{
     coding::{Decode, Encode},
@@ -11,8 +13,15 @@ use crate::{
         util::SliceIndexes,
     },
 };
-use byteorder::{ReadBytesExt, WriteBytesExt};
-use std::io::{Cursor, Seek};
+// `Seek` resolves to std under `std` (so `seek_relative` on `Cursor` comes
+// from `std::io::Seek`) and to the native trait under `no_std`.
+#[cfg(not(feature = "std"))]
+use crate::io::Seek;
+#[cfg(not(feature = "std"))]
+use crate::io::{VarintReader, VarintWriter};
+#[cfg(feature = "std")]
+use std::io::Seek;
+#[cfg(feature = "std")]
 use varint_rs::{VarintReader, VarintWriter};
 
 /// Points to a block on file
@@ -43,7 +52,7 @@ impl BlockHandle {
 }
 
 impl Encode for BlockHandle {
-    fn encode_into<W: std::io::Write>(&self, writer: &mut W) -> Result<(), crate::Error> {
+    fn encode_into<W: crate::io::Write>(&self, writer: &mut W) -> Result<(), crate::Error> {
         writer.write_u64_varint(*self.offset)?;
         writer.write_u32_varint(self.size)?;
         Ok(())
@@ -51,7 +60,7 @@ impl Encode for BlockHandle {
 }
 
 impl Decode for BlockHandle {
-    fn decode_from<R: std::io::Read>(reader: &mut R) -> Result<Self, crate::Error>
+    fn decode_from<R: crate::io::Read>(reader: &mut R) -> Result<Self, crate::Error>
     where
         Self: Sized,
     {
@@ -172,7 +181,7 @@ impl PartialEq for KeyedBlockHandle {
 }
 
 impl Encodable<BlockOffset> for KeyedBlockHandle {
-    fn encode_full_into<W: std::io::Write>(
+    fn encode_full_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         state: &mut BlockOffset,
@@ -210,7 +219,7 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
     }
 
     // TODO: see https://github.com/structured-world/coordinode-lsm-tree/issues/184
-    fn encode_truncated_into<W: std::io::Write>(
+    fn encode_truncated_into<W: crate::io::Write>(
         &self,
         writer: &mut W,
         _state: &mut BlockOffset,

--- a/src/table/index_block/iter.rs
+++ b/src/table/index_block/iter.rs
@@ -56,18 +56,18 @@ impl<'a> Iter<'a> {
         let landed = if cmp.is_lexicographic() {
             self.decoder.inner_mut().seek(
                 |end_key, s| match end_key.cmp(needle) {
-                    std::cmp::Ordering::Greater => false,
-                    std::cmp::Ordering::Less => true,
-                    std::cmp::Ordering::Equal => s >= seqno,
+                    core::cmp::Ordering::Greater => false,
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => s >= seqno,
                 },
                 true,
             )
         } else {
             self.decoder.inner_mut().seek(
                 |end_key, s| match cmp.compare(end_key, needle) {
-                    std::cmp::Ordering::Greater => false,
-                    std::cmp::Ordering::Less => true,
-                    std::cmp::Ordering::Equal => s >= seqno,
+                    core::cmp::Ordering::Greater => false,
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => s >= seqno,
                 },
                 true,
             )
@@ -79,9 +79,9 @@ impl<'a> Iter<'a> {
         if self.decoder.inner_mut().restart_interval() > 1 {
             self.decoder.inner_mut().advance_while(|item, bytes| {
                 match item.compare_key(needle, bytes, cmp.as_ref()) {
-                    std::cmp::Ordering::Greater => false,
-                    std::cmp::Ordering::Less => true,
-                    std::cmp::Ordering::Equal => item.seqno() >= seqno,
+                    core::cmp::Ordering::Greater => false,
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => item.seqno() >= seqno,
                 }
             });
         }
@@ -137,7 +137,7 @@ impl<'a> Iter<'a> {
                         .seek_upper(|end_key, _s| end_key < needle, true)
                 } else {
                     self.decoder.inner_mut().seek_upper(
-                        |end_key, _s| cmp.compare(end_key, needle) == std::cmp::Ordering::Less,
+                        |end_key, _s| cmp.compare(end_key, needle) == core::cmp::Ordering::Less,
                         true,
                     )
                 }
@@ -158,7 +158,7 @@ impl<'a> Iter<'a> {
                         .seek_upper(|end_key, _s| end_key <= needle, true)
                 } else {
                     self.decoder.inner_mut().seek_upper(
-                        |end_key, _s| cmp.compare(end_key, needle) != std::cmp::Ordering::Greater,
+                        |end_key, _s| cmp.compare(end_key, needle) != core::cmp::Ordering::Greater,
                         true,
                     )
                 }
@@ -169,7 +169,7 @@ impl<'a> Iter<'a> {
                 .seek_upper(|end_key, _s| end_key <= needle, true)
         } else {
             self.decoder.inner_mut().seek_upper(
-                |end_key, _s| cmp.compare(end_key, needle) != std::cmp::Ordering::Greater,
+                |end_key, _s| cmp.compare(end_key, needle) != core::cmp::Ordering::Greater,
                 true,
             )
         };
@@ -188,7 +188,7 @@ impl<'a> Iter<'a> {
                 .decoder
                 .inner_mut()
                 .upper_stack_tail_cmp(|item, bytes| item.compare_key(needle, bytes, cmp.as_ref()))
-                == Some(std::cmp::Ordering::Less)
+                == Some(core::cmp::Ordering::Less)
             {
                 if !self.decoder.inner_mut().advance_upper_restart_interval() {
                     break;
@@ -280,6 +280,8 @@ impl DoubleEndedIterator for Iter<'_> {
 )]
 mod tests {
     use super::*;
+    use crate::io::Cursor;
+    use crate::io::{ByteOrder, LittleEndian, ReadBytesExt};
     use crate::{
         coding::Decode,
         comparator::default_comparator,
@@ -288,8 +290,6 @@ mod tests {
             block::{BlockType, Header, ParsedItem, Trailer},
         },
     };
-    use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
-    use std::io::Cursor;
     use varint_rs::VarintReader;
 
     fn make_handles(count: usize) -> Vec<KeyedBlockHandle> {
@@ -346,7 +346,7 @@ mod tests {
             header: Header::test_dummy(BlockType::Index),
         });
         let trailer_offset = Trailer::new(&trailer_probe.inner).trailer_offset();
-        let binary_index_offset_pos = trailer_offset + 1 + 1 + std::mem::size_of::<u32>();
+        let binary_index_offset_pos = trailer_offset + 1 + 1 + core::mem::size_of::<u32>();
         #[expect(
             clippy::cast_possible_truncation,
             reason = "test block sizes stay well below u32::MAX"
@@ -354,7 +354,7 @@ mod tests {
         let invalid_binary_index_offset = (bytes.len() as u32).saturating_add(1);
         LittleEndian::write_u32(
             &mut bytes
-                [binary_index_offset_pos..binary_index_offset_pos + std::mem::size_of::<u32>()],
+                [binary_index_offset_pos..binary_index_offset_pos + core::mem::size_of::<u32>()],
             invalid_binary_index_offset,
         );
 

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub struct IndexBlockParsedItem {

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -13,6 +13,7 @@ use super::{
     block::{BlockOffset, Encoder, Trailer},
 };
 use crate::Slice;
+use crate::io::{Error, ErrorKind};
 use crate::{
     SeqNo,
     table::{
@@ -20,7 +21,8 @@ use crate::{
         util::{SliceIndexes, compare_prefixed_slice},
     },
 };
-use std::io::{Error, ErrorKind};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[derive(Debug)]
 pub struct IndexBlockParsedItem {
@@ -40,7 +42,7 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
         needle: &[u8],
         bytes: &[u8],
         cmp: &dyn crate::comparator::UserComparator,
-    ) -> std::cmp::Ordering {
+    ) -> core::cmp::Ordering {
         // SAFETY: slice indexes come from the block parser which validates them
         // during decoding. The block format guarantees they are within bounds.
         if let Some(prefix) = &self.prefix {
@@ -188,7 +190,7 @@ impl IndexBlock {
     ///
     /// # Errors
     ///
-    /// Returns [`std::io::ErrorKind::InvalidInput`] when `restart_interval == 0`.
+    /// Returns [`crate::io::ErrorKind::InvalidInput`] when `restart_interval == 0`.
     ///
     /// # Panics
     ///
@@ -217,7 +219,7 @@ impl IndexBlock {
     ///
     /// # Errors
     ///
-    /// Returns [`std::io::ErrorKind::InvalidInput`] when `restart_interval == 0`.
+    /// Returns [`crate::io::ErrorKind::InvalidInput`] when `restart_interval == 0`.
     ///
     /// # Panics
     ///
@@ -294,7 +296,9 @@ mod tests {
         let Err(err) = IndexBlock::encode_into_vec_with_restart_interval(&handles, 0) else {
             panic!("restart interval of zero must be rejected");
         };
-        assert!(matches!(err, crate::Error::Io(e) if e.kind() == ErrorKind::InvalidInput));
+        assert!(
+            matches!(err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::InvalidInput)
+        );
     }
 
     #[test]
@@ -340,8 +344,8 @@ mod tests {
         use super::*;
         use crate::comparator::UserComparator;
         use crate::table::BlockHandle;
+        use core::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
         struct CountingComparator {
             /// Counts `compare()` invocations — proves the lex devirt path
@@ -367,7 +371,7 @@ mod tests {
             fn name(&self) -> &'static str {
                 "counting"
             }
-            fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+            fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
                 self.count.fetch_add(1, AtomicOrdering::Relaxed);
                 a.cmp(b)
             }

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use super::{
     block_index::BlockIndexImpl, block_layout::BlockLayoutMap, meta::ParsedMeta,
@@ -80,11 +80,15 @@ pub struct Inner {
 
     /// Cached sum of referenced blob file bytes for this table.
     ///
-    /// Lazily computed on first access to avoid repeated I/O in compaction
-    /// decisions. `u64::MAX` is the "not yet computed" sentinel (a real sum
-    /// can never reach 18 EiB), so a single relaxed-ordered load resolves a
-    /// cache hit without a separate init flag. Concurrent computers race to
-    /// the same value, so the store is idempotent.
+    /// Initialized to `AtomicU64::new(u64::MAX)`, the "not yet computed"
+    /// sentinel (a real sum can never reach 18 EiB). Lazily computed on first
+    /// access to avoid repeated I/O in compaction decisions:
+    /// `Table::referenced_blob_bytes` does an `Acquire` load, returns early
+    /// when the value is not `u64::MAX`, otherwise sums the table's
+    /// `LinkedFile.on_disk_bytes` and publishes it with a `Release` store.
+    /// The store is idempotent under races because the table's linked-blob-file
+    /// region is immutable after open, so every racing computer re-reads the
+    /// same on-disk byte counts and computes the same sum.
     pub(crate) cached_blob_bytes: AtomicU64,
 
     /// Range tombstones stored in this table. Loaded on open.

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 use super::{
     block_index::BlockIndexImpl, block_layout::BlockLayoutMap, meta::ParsedMeta,
@@ -21,10 +23,11 @@ use crate::{
     table::{IndexBlock, filter::block::FilterBlock},
     tree::inner::TreeId,
 };
-use std::{
-    path::PathBuf,
-    sync::{Arc, OnceLock, atomic::AtomicBool},
-};
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicBool;
+
+use crate::path::PathBuf;
+use portable_atomic::AtomicU64;
 
 pub struct Inner {
     pub path: Arc<PathBuf>,
@@ -76,8 +79,13 @@ pub struct Inner {
     pub(crate) metrics: Arc<Metrics>,
 
     /// Cached sum of referenced blob file bytes for this table.
-    /// Lazily computed on first access to avoid repeated I/O in compaction decisions.
-    pub(crate) cached_blob_bytes: OnceLock<u64>,
+    ///
+    /// Lazily computed on first access to avoid repeated I/O in compaction
+    /// decisions. `u64::MAX` is the "not yet computed" sentinel (a real sum
+    /// can never reach 18 EiB), so a single relaxed-ordered load resolves a
+    /// cache hit without a separate init flag. Concurrent computers race to
+    /// the same value, so the store is idempotent.
+    pub(crate) cached_blob_bytes: AtomicU64,
 
     /// Range tombstones stored in this table. Loaded on open.
     pub(crate) range_tombstones: Vec<RangeTombstone>,
@@ -156,16 +164,16 @@ impl Drop for Inner {
     fn drop(&mut self) {
         let global_id = self.global_id();
 
-        if self.is_deleted.load(std::sync::atomic::Ordering::Acquire) {
+        if self.is_deleted.load(core::sync::atomic::Ordering::Acquire) {
             log::trace!("Cleanup deleted table {global_id:?} at {:?}", self.path);
 
             // Move the accessor and block index out so all file handles
             // (including clones held by the block index) are closed before
             // attempting deletion. On Windows, remove_file fails while any
             // handle is open.
-            let file_accessor = std::mem::replace(&mut self.file_accessor, FileAccessor::Closed);
+            let file_accessor = core::mem::replace(&mut self.file_accessor, FileAccessor::Closed);
             let block_index =
-                std::mem::replace(&mut self.block_index, Arc::new(BlockIndexImpl::Closed));
+                core::mem::replace(&mut self.block_index, Arc::new(BlockIndexImpl::Closed));
 
             // Evict cached FD from the descriptor table.
             file_accessor.as_descriptor_table().inspect(|d| {

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -17,8 +17,10 @@ use crate::{
         util::load_block,
     },
 };
+use alloc::sync::Arc;
+
+use crate::path::PathBuf;
 use self_cell::self_cell;
-use std::{path::PathBuf, sync::Arc};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;

--- a/src/table/lazy_block.rs
+++ b/src/table/lazy_block.rs
@@ -90,7 +90,7 @@ impl LazyBlock {
         let mut decoder = FrameDecoder::new();
         decoder
             .reset(&mut source)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
         Ok(Self {
             source,
             decoder,
@@ -190,7 +190,7 @@ impl LazyBlock {
         self.source.set_position(0);
         self.decoder
             .reset(&mut self.source)
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
 
         let resuming = self.resume_state.is_some();
         let pd = if let Some(state) = self.resume_state.as_deref() {
@@ -206,14 +206,14 @@ impl LazyBlock {
                     }),
                     true,
                 )
-                .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+                .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?
         } else {
             self.decoder
                 .decode_blocks_partial(&mut self.source, 0, end_block, None, true)
-                .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?
+                .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?
         };
         if let Some((idx, err)) = pd.stopped_at {
-            return Err(crate::Error::Io(std::io::Error::other(format!(
+            return Err(crate::Error::Io(crate::io::Error::other(format!(
                 "lazy partial decode stopped at inner block {idx}: {err:?}"
             ))));
         }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -8,7 +8,7 @@ use crate::{
     CompressionType, KeyRange, SeqNo, TableId, checksum::ChecksumType, coding::Decode,
     comparator::default_comparator, runtime_config::ChecksumAlgorithm, table::block::BlockType,
 };
-use std::ops::Deref;
+use core::ops::Deref;
 
 /// Nanosecond timestamp.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -163,8 +163,8 @@ macro_rules! read_u128 {
 /// A value above `max_seqno` indicates on-disk corruption.
 fn validated_kv_seqno(kv_seqno: SeqNo, max_seqno: SeqNo) -> crate::Result<SeqNo> {
     if kv_seqno > max_seqno {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+        return Err(crate::io::Error::new(
+            crate::io::ErrorKind::InvalidData,
             "seqno#kv_max exceeds seqno#max",
         )
         .into());
@@ -174,8 +174,8 @@ fn validated_kv_seqno(kv_seqno: SeqNo, max_seqno: SeqNo) -> crate::Result<SeqNo>
 
 fn validated_restart_interval_index(restart_interval: u8) -> crate::Result<u8> {
     if restart_interval == 0 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+        return Err(crate::io::Error::new(
+            crate::io::ErrorKind::InvalidData,
             "restart_interval#index must be greater than zero",
         )
         .into());
@@ -480,7 +480,9 @@ mod tests {
     #[test]
     fn validated_kv_seqno_exceeds_max_returns_error() {
         let err = validated_kv_seqno(11, 10).unwrap_err();
-        assert!(matches!(err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::InvalidData));
+        assert!(
+            matches!(err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::InvalidData)
+        );
     }
 
     #[test]
@@ -492,7 +494,9 @@ mod tests {
     #[test]
     fn validated_restart_interval_index_zero_returns_error() {
         let err = validated_restart_interval_index(0).unwrap_err();
-        assert!(matches!(err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::InvalidData));
+        assert!(
+            matches!(err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::InvalidData)
+        );
     }
 
     // ---------------------------------------------------------------

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -56,7 +56,7 @@ use crate::{
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use block_index::BlockIndexImpl;
 use core::ops::{Bound, RangeBounds};
 use inner::Inner;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -53,15 +53,17 @@ use crate::{
         writer::LinkedFile,
     },
 };
+use alloc::borrow::Cow;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use block_index::BlockIndexImpl;
+use core::ops::{Bound, RangeBounds};
 use inner::Inner;
 use iter::Iter;
-use std::{
-    borrow::Cow,
-    ops::{Bound, RangeBounds},
-    path::PathBuf,
-    sync::Arc,
-};
+
+use crate::path::PathBuf;
+use portable_atomic::AtomicU64;
 use util::load_block;
 
 #[cfg(feature = "metrics")]
@@ -81,7 +83,7 @@ pub type TableInner = Inner;
 #[derive(Clone)]
 pub struct Table(Arc<Inner>);
 
-impl std::ops::Deref for Table {
+impl core::ops::Deref for Table {
     type Target = Inner;
 
     fn deref(&self) -> &Self::Target {
@@ -90,8 +92,8 @@ impl std::ops::Deref for Table {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-impl std::fmt::Debug for Table {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Table {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Table:{}({:?})", self.id(), self.metadata.key_range)
     }
 }
@@ -132,8 +134,12 @@ impl Table {
     }
 
     pub fn referenced_blob_bytes(&self) -> crate::Result<u64> {
-        if let Some(v) = self.0.cached_blob_bytes.get() {
-            return Ok(*v);
+        let cached = self
+            .0
+            .cached_blob_bytes
+            .load(core::sync::atomic::Ordering::Acquire);
+        if cached != u64::MAX {
+            return Ok(cached);
         }
 
         let sum = self
@@ -141,12 +147,14 @@ impl Table {
             .map(|bf| bf.iter().map(|f| f.on_disk_bytes).sum::<u64>())
             .unwrap_or_default();
 
-        let _ = self.0.cached_blob_bytes.set(sum);
+        self.0
+            .cached_blob_bytes
+            .store(sum, core::sync::atomic::Ordering::Release);
         Ok(sum)
     }
 
     pub fn list_blob_file_references(&self) -> crate::Result<Option<Vec<LinkedFile>>> {
-        use byteorder::{LE, ReadBytesExt};
+        use crate::io::{LE, ReadBytesExt};
 
         Ok(if let Some(handle) = &self.regions.linked_blob_files {
             let table_id = self.global_id();
@@ -360,7 +368,7 @@ impl Table {
                 // Key sorts past the last filter partition — definite miss.
                 #[cfg(feature = "metrics")]
                 {
-                    use std::sync::atomic::Ordering::Relaxed;
+                    use core::sync::atomic::Ordering::Relaxed;
                     self.metrics.filter_queries.fetch_add(1, Relaxed);
                     self.metrics.io_skipped_by_filter.fetch_add(1, Relaxed);
                 }
@@ -388,7 +396,7 @@ impl Table {
         {
             #[cfg(feature = "metrics")]
             {
-                use std::sync::atomic::Ordering::Relaxed;
+                use core::sync::atomic::Ordering::Relaxed;
                 self.metrics.filter_queries.fetch_add(1, Relaxed);
                 self.metrics.io_skipped_by_filter.fetch_add(1, Relaxed);
             }
@@ -427,7 +435,7 @@ impl Table {
 
         #[cfg(feature = "metrics")]
         {
-            use std::sync::atomic::Ordering::Relaxed;
+            use core::sync::atomic::Ordering::Relaxed;
             // NOTE: `check_bloom()` accounts for lookups rejected by the filter
             // (skip I/O entirely). This path accounts for negative point lookups
             // that still reached storage even though a filter was present, so
@@ -473,7 +481,7 @@ impl Table {
 
         #[cfg(feature = "metrics")]
         {
-            use std::sync::atomic::Ordering::Relaxed;
+            use core::sync::atomic::Ordering::Relaxed;
             if result.is_none() && bloom.has_filter() {
                 self.metrics.filter_queries.fetch_add(1, Relaxed);
             }
@@ -858,6 +866,7 @@ impl Table {
             .expect("data block count should fit");
 
         Scanner::new(
+            &self.fs,
             &self.path,
             block_count,
             self.metadata.data_block_compression,
@@ -1151,9 +1160,9 @@ impl Table {
         comparator: SharedComparator,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
     ) -> crate::Result<Self> {
+        use core::sync::atomic::AtomicBool;
         use meta::ParsedMeta;
         use regions::ParsedRegions;
-        use std::sync::atomic::AtomicBool;
 
         log::debug!("Recovering table from file {}", file_path.display());
         let mut file = fs.open(&file_path, &FsOpenOptions::new().read(true))?;
@@ -1162,7 +1171,7 @@ impl Table {
         #[cfg(feature = "metrics")]
         metrics
             .table_file_opened_uncached
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
         let trailer = crate::sfa::Reader::from_reader(&mut file)?;
         let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
@@ -1534,7 +1543,7 @@ impl Table {
             #[cfg(feature = "metrics")]
             metrics,
 
-            cached_blob_bytes: std::sync::OnceLock::new(),
+            cached_blob_bytes: AtomicU64::new(u64::MAX),
             range_tombstones,
             block_layout,
             encryption,
@@ -1592,7 +1601,7 @@ impl Table {
         reason = "block sizes are bounded well within usize on all supported platforms"
     )]
     fn read_checked_slice(
-        cursor: &mut std::io::Cursor<&[u8]>,
+        cursor: &mut crate::io::Cursor<&[u8]>,
         field: &'static str,
         len: usize,
     ) -> crate::Result<Vec<u8>> {
@@ -1625,8 +1634,7 @@ impl Table {
         block: &Block,
         comparator: &dyn crate::comparator::UserComparator,
     ) -> crate::Result<Vec<RangeTombstone>> {
-        use byteorder::{LE, ReadBytesExt};
-        use std::io::Cursor;
+        use crate::io::{Cursor, LE, ReadBytesExt};
 
         let mut tombstones = Vec::new();
         let data = block.data.as_ref();
@@ -1729,7 +1737,7 @@ impl Table {
     pub(crate) fn mark_as_deleted(&self) {
         self.0
             .is_deleted
-            .store(true, std::sync::atomic::Ordering::Release);
+            .store(true, core::sync::atomic::Ordering::Release);
     }
 
     /// Checks if a key range overlaps (partially or fully) with this table's key range.

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -14,7 +14,15 @@ use crate::{
     value::InternalValue,
     vlog::BlobFileId,
 };
-use std::{path::PathBuf, sync::Arc};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use crate::path::PathBuf;
 
 /// Like `Writer` but will rotate to a new table, once a table grows larger than `target_size`
 ///
@@ -297,11 +305,11 @@ impl MultiWriter {
                             if let Some(existing) = &mut writer.meta.last_key {
                                 let safe = clip_upper.is_some_and(|upper| {
                                     comparator.compare(&clipped.end, upper.as_ref())
-                                        == std::cmp::Ordering::Less
+                                        == core::cmp::Ordering::Less
                                 });
                                 if safe
                                     && comparator.compare(&clipped.end, existing.as_ref())
-                                        == std::cmp::Ordering::Greater
+                                        == core::cmp::Ordering::Greater
                                 {
                                     *existing = clipped.end.clone();
                                 }
@@ -318,14 +326,14 @@ impl MultiWriter {
                     // disjoint-run invariant that point reads rely on.
                     for rt in tombstones {
                         let clipped_start = if comparator.compare(&rt.start, first_key.as_ref())
-                            == std::cmp::Ordering::Greater
+                            == core::cmp::Ordering::Greater
                         {
                             rt.start.as_ref()
                         } else {
                             first_key.as_ref()
                         };
 
-                        if comparator.compare(clipped_start, &rt.end) == std::cmp::Ordering::Less {
+                        if comparator.compare(clipped_start, &rt.end) == core::cmp::Ordering::Less {
                             writer.write_range_tombstone(RangeTombstone::new(
                                 UserKey::from(clipped_start),
                                 rt.end.clone(),
@@ -348,7 +356,7 @@ impl MultiWriter {
                     match &mut writer.meta.first_key {
                         Some(existing) => {
                             if comparator.compare(&rt.start, existing.as_ref())
-                                == std::cmp::Ordering::Less
+                                == core::cmp::Ordering::Less
                             {
                                 *existing = rt.start.clone();
                             }
@@ -360,7 +368,7 @@ impl MultiWriter {
                     match &mut writer.meta.last_key {
                         Some(existing) => {
                             if comparator.compare(&rt.end, existing.as_ref())
-                                == std::cmp::Ordering::Greater
+                                == core::cmp::Ordering::Greater
                             {
                                 *existing = rt.end.clone();
                             }
@@ -601,7 +609,7 @@ impl MultiWriter {
             new_writer = new_writer.use_parallel_compression(spawner, self.parallel_threads);
         }
 
-        let mut old_writer = std::mem::replace(&mut self.writer, new_writer);
+        let mut old_writer = core::mem::replace(&mut self.writer, new_writer);
         old_writer.spill_block()?;
 
         // Write range tombstones to the finishing writer.

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -16,11 +16,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::ToString, vec::Vec};
 
 use crate::path::PathBuf;
 

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -2,19 +2,23 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+
 use super::{Block, DataBlock};
+use crate::io::BufReader;
+use crate::path::Path;
 use crate::{
     CompressionType, InternalValue, SeqNo,
     comparator::SharedComparator,
     encryption::EncryptionProvider,
-    fs::{FileHint, FsFile},
+    fs::{FileHint, Fs, FsFile, FsOpenOptions},
     table::{block::BlockType, iter::OwnedDataBlockIter},
 };
-use std::{fs::File, io::BufReader, path::Path, sync::Arc};
 
 /// Table reader that is optimized for consuming an entire table
 pub struct Scanner {
-    reader: BufReader<File>,
+    reader: BufReader<Box<dyn FsFile>>,
     iter: OwnedDataBlockIter,
 
     compression: CompressionType,
@@ -51,6 +55,7 @@ impl Scanner {
                   makes about the values"
     )]
     pub fn new(
+        fs: &Arc<dyn Fs>,
         path: &Path,
         block_count: usize,
         compression: CompressionType,
@@ -73,7 +78,7 @@ impl Scanner {
         // tuning beyond this would benefit from a configurable knob,
         // tracked as the configurable-readahead follow-up under #133.
         const SCANNER_READAHEAD_BYTES: usize = 2 * 1024 * 1024;
-        let file = File::open(path)?;
+        let file = fs.open(path, &FsOpenOptions::new().read(true))?;
         // The scanner walks every block in order — tell the kernel so
         // it can ramp readahead aggressively and evict already-read
         // pages instead of pinning them. Best-effort: hint() is
@@ -119,7 +124,7 @@ impl Scanner {
     }
 
     fn fetch_next_block(
-        reader: &mut BufReader<File>,
+        reader: &mut BufReader<Box<dyn FsFile>>,
         table_id: crate::TableId,
         compression: CompressionType,
         encryption: Option<&dyn EncryptionProvider>,

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -865,7 +865,7 @@ fn table_point_read_zstd_dictionary() -> crate::Result<()> {
 
 #[test]
 fn table_range_exclusive_bounds() -> crate::Result<()> {
-    use std::ops::Bound::{Excluded, Included};
+    use core::ops::Bound::{Excluded, Included};
 
     let items = [
         crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
@@ -1955,7 +1955,7 @@ fn assert_rt_decode_error(data: Vec<u8>, expected_field: &str, expected_offset: 
 #[test]
 #[expect(clippy::unwrap_used)]
 fn decode_range_tombstones_invalid_interval_returns_error() {
-    use byteorder::{LE, WriteBytesExt};
+    use crate::io::{LE, WriteBytesExt};
 
     // Build a single tombstone where start ("z") >= end ("a")
     let mut buf = Vec::new();
@@ -1984,7 +1984,7 @@ fn decode_range_tombstones_empty_block_returns_error() {
 #[test]
 #[expect(clippy::unwrap_used)]
 fn decode_range_tombstones_start_len_exceeds_remaining_returns_error() {
-    use byteorder::{LE, WriteBytesExt};
+    use crate::io::{LE, WriteBytesExt};
 
     // start_len = 100 but only 1 byte of data follows; offset = 0 (entry start)
     let mut buf = Vec::new();
@@ -1997,7 +1997,7 @@ fn decode_range_tombstones_start_len_exceeds_remaining_returns_error() {
 #[test]
 #[expect(clippy::unwrap_used)]
 fn decode_range_tombstones_truncated_end_len_returns_error() {
-    use byteorder::{LE, WriteBytesExt};
+    use crate::io::{LE, WriteBytesExt};
 
     // Valid start_len + start, then truncated before end_len completes
     // offset = 3 (after u16 start_len + 1-byte key)
@@ -2012,7 +2012,7 @@ fn decode_range_tombstones_truncated_end_len_returns_error() {
 #[test]
 #[expect(clippy::unwrap_used)]
 fn decode_range_tombstones_end_len_exceeds_remaining_returns_error() {
-    use byteorder::{LE, WriteBytesExt};
+    use crate::io::{LE, WriteBytesExt};
 
     // Valid start, then end_len = 100 but only 1 byte follows
     // offset = 3 (after u16 start_len + 1-byte key)
@@ -2028,7 +2028,7 @@ fn decode_range_tombstones_end_len_exceeds_remaining_returns_error() {
 #[test]
 #[expect(clippy::unwrap_used)]
 fn decode_range_tombstones_truncated_seqno_returns_error() {
-    use byteorder::{LE, WriteBytesExt};
+    use crate::io::{LE, WriteBytesExt};
 
     // Valid start + end, but seqno truncated (only 4 of 8 bytes)
     // offset = 6 (after u16+1+u16+1 = 6 bytes for start/end fields)
@@ -2055,7 +2055,7 @@ fn load_block_range_tombstone_metrics() -> crate::Result<()> {
         range_tombstone::RangeTombstone,
         table::{block::BlockType, util::load_block},
     };
-    use std::sync::atomic::Ordering::Relaxed;
+    use core::sync::atomic::Ordering::Relaxed;
 
     let dir = tempdir()?;
     let file = dir.path().join("table");
@@ -2548,7 +2548,7 @@ fn meta_seqno_kv_max_corruption_returns_invalid_data() -> crate::Result<()> {
 
         let err = result.expect_err("corrupted seqno#kv_max should cause an error");
         assert!(
-            matches!(&err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::InvalidData),
+            matches!(&err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::InvalidData),
             "expected InvalidData, got: {err:?}",
         );
     }

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -392,7 +392,9 @@ fn reread_block_is_corrected(
 /// narrower hosts that fail the wider checks before taking their lane).
 #[must_use]
 pub fn longest_shared_prefix_length(s1: &[u8], s2: &[u8]) -> usize {
-    #[cfg(target_arch = "x86_64")]
+    // std-gated: `is_x86_feature_detected!` is std-only. Under no_std the
+    // scalar tail handles x86.
+    #[cfg(all(feature = "std", target_arch = "x86_64"))]
     {
         if std::is_x86_feature_detected!("avx512bw") {
             // SAFETY: AVX-512BW availability just verified via runtime CPU feature detection.
@@ -407,7 +409,7 @@ pub fn longest_shared_prefix_length(s1: &[u8], s2: &[u8]) -> usize {
         // attribute on `lsp_sse2` documents this contract explicitly.
         return unsafe { lsp_sse2(s1, s2) };
     }
-    #[cfg(target_arch = "x86")]
+    #[cfg(all(feature = "std", target_arch = "x86"))]
     {
         if std::is_x86_feature_detected!("avx512bw") {
             // SAFETY: AVX-512BW availability just verified via runtime CPU feature detection.
@@ -439,7 +441,7 @@ pub fn longest_shared_prefix_length(s1: &[u8], s2: &[u8]) -> usize {
     // riscv, powerpc, …), which is the whole point of having a portable fallback.
     #[cfg_attr(
         any(
-            target_arch = "x86_64",
+            all(feature = "std", target_arch = "x86_64"),
             all(target_arch = "aarch64", target_endian = "little")
         ),
         expect(

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -513,7 +513,13 @@ pub(crate) fn lsp_scalar(s1: &[u8], s2: &[u8]) -> usize {
 /// # Safety
 ///
 /// Caller must ensure the host CPU supports AVX2 (`is_x86_feature_detected!("avx2")`).
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+// Exists only where it is used: the std-gated runtime dispatch above, or the
+// #[cfg(test)] kernel tests below (kept alive under `--all-targets` clippy on
+// the no-default-features build, where the std dispatch is compiled out).
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(feature = "std", test)
+))]
 #[target_feature(enable = "avx2")]
 #[expect(unsafe_code, reason = "intrinsics require unsafe")]
 #[must_use]
@@ -581,7 +587,11 @@ unsafe fn lsp_avx2(s1: &[u8], s2: &[u8]) -> usize {
 /// Caller must ensure the host CPU supports AVX-512BW
 /// (`is_x86_feature_detected!("avx512bw")`). BW implies the F subset, so the
 /// 512-bit load and the byte-granular compare-mask are both available.
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+// See `lsp_avx2`: gated to where it is used (std dispatch or kernel tests).
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(feature = "std", test)
+))]
 // List both ISA features the body relies on: `_mm512_loadu_si512` is AVX-512F,
 // `_mm512_cmpeq_epi8_mask` is AVX-512BW. BW implies F (so `avx512bw` alone would
 // compile), but naming both keeps the gate matching the actual requirements and
@@ -648,7 +658,11 @@ unsafe fn lsp_avx512(s1: &[u8], s2: &[u8]) -> usize {
 /// Caller must ensure the host supports SSE2. On `x86_64` this is the mandatory
 /// ISA baseline (always true); on 32-bit `x86` it must be runtime-detected via
 /// `is_x86_feature_detected!("sse2")` because pre-Pentium-4 CPUs lack it.
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+// See `lsp_avx2`: gated to where it is used (std dispatch or kernel tests).
+#[cfg(all(
+    any(target_arch = "x86_64", target_arch = "x86"),
+    any(feature = "std", test)
+))]
 #[target_feature(enable = "sse2")]
 #[expect(unsafe_code, reason = "intrinsics require unsafe")]
 #[must_use]

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -2,12 +2,15 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use super::{Block, BlockHandle, GlobalTableId};
+use crate::path::Path;
 use crate::{
     Cache, CompressionType, KeyRange, Table, encryption::EncryptionProvider,
     file_accessor::FileAccessor, table::block::BlockType, version::run::Ranged,
 };
-use std::path::Path;
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
@@ -62,7 +65,7 @@ pub fn load_block(
     #[cfg(feature = "metrics")] metrics: &Metrics,
 ) -> crate::Result<Block> {
     #[cfg(feature = "metrics")]
-    use std::sync::atomic::Ordering::Relaxed;
+    use core::sync::atomic::Ordering::Relaxed;
 
     log::trace!("load {block_type:?} block {handle:?}");
 
@@ -265,7 +268,7 @@ pub(crate) fn maybe_record_persistent_heal(
                 #[cfg(feature = "metrics")]
                 metrics
                     .ecc_auto_heal_scheduled
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
                 log::warn!(
                     "Persistent ECC correction on table {table_id:?} block {handle:?}; \
                      queued for healing recompaction"
@@ -514,9 +517,11 @@ pub(crate) fn lsp_scalar(s1: &[u8], s2: &[u8]) -> usize {
 #[must_use]
 unsafe fn lsp_avx2(s1: &[u8], s2: &[u8]) -> usize {
     #[cfg(target_arch = "x86")]
-    use std::arch::x86::{__m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8};
+    use core::arch::x86::{__m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8};
     #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::{__m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8};
+    use core::arch::x86_64::{
+        __m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8,
+    };
 
     let min_len = s1.len().min(s2.len());
     let mut i = 0;
@@ -586,9 +591,9 @@ unsafe fn lsp_avx2(s1: &[u8], s2: &[u8]) -> usize {
 #[must_use]
 unsafe fn lsp_avx512(s1: &[u8], s2: &[u8]) -> usize {
     #[cfg(target_arch = "x86")]
-    use std::arch::x86::{__m512i, _mm512_cmpeq_epi8_mask, _mm512_loadu_si512};
+    use core::arch::x86::{__m512i, _mm512_cmpeq_epi8_mask, _mm512_loadu_si512};
     #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::{__m512i, _mm512_cmpeq_epi8_mask, _mm512_loadu_si512};
+    use core::arch::x86_64::{__m512i, _mm512_cmpeq_epi8_mask, _mm512_loadu_si512};
 
     let min_len = s1.len().min(s2.len());
     let mut i = 0;
@@ -647,9 +652,9 @@ unsafe fn lsp_avx512(s1: &[u8], s2: &[u8]) -> usize {
 #[must_use]
 unsafe fn lsp_sse2(s1: &[u8], s2: &[u8]) -> usize {
     #[cfg(target_arch = "x86")]
-    use std::arch::x86::{__m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8};
+    use core::arch::x86::{__m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8};
     #[cfg(target_arch = "x86_64")]
-    use std::arch::x86_64::{__m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8};
+    use core::arch::x86_64::{__m128i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8};
 
     let min_len = s1.len().min(s2.len());
     let mut i = 0;
@@ -710,7 +715,7 @@ unsafe fn lsp_sse2(s1: &[u8], s2: &[u8]) -> usize {
 #[expect(unsafe_code, reason = "intrinsics require unsafe")]
 #[must_use]
 unsafe fn lsp_neon(s1: &[u8], s2: &[u8]) -> usize {
-    use std::arch::aarch64::{
+    use core::arch::aarch64::{
         vandq_u8, vceqq_u8, vdupq_n_u8, vgetq_lane_u64, vld1q_u8, vreinterpretq_u64_u8,
     };
 
@@ -768,7 +773,7 @@ pub fn compare_prefixed_slice(
     suffix: &[u8],
     needle: &[u8],
     cmp: &dyn crate::comparator::UserComparator,
-) -> std::cmp::Ordering {
+) -> core::cmp::Ordering {
     // Fast path: zero-allocation bytewise comparison for the default
     // (lexicographic) comparator. This is the hot path for block index
     // and data block binary searches.
@@ -809,8 +814,8 @@ fn compare_prefixed_slice_lexicographic(
     prefix: &[u8],
     suffix: &[u8],
     needle: &[u8],
-) -> std::cmp::Ordering {
-    use std::cmp::Ordering::{Equal, Greater};
+) -> core::cmp::Ordering {
+    use core::cmp::Ordering::{Equal, Greater};
 
     if needle.is_empty() {
         let combined_len = prefix.len() + suffix.len();
@@ -1124,7 +1129,7 @@ mod tests {
 
     #[test]
     fn test_compare_prefixed_slice() {
-        use std::cmp::Ordering::{Equal, Greater, Less};
+        use core::cmp::Ordering::{Equal, Greater, Less};
 
         assert_eq!(
             Greater,
@@ -1241,14 +1246,14 @@ mod tests {
             "test-reverse"
         }
 
-        fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+        fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
             b.cmp(a)
         }
     }
 
     #[test]
     fn test_compare_prefixed_slice_custom_comparator() {
-        use std::cmp::Ordering::{Equal, Greater, Less};
+        use core::cmp::Ordering::{Equal, Greater, Less};
 
         use crate::comparator::UserComparator as _;
         assert_eq!(ReverseComparator.name(), "test-reverse");

--- a/src/table/writer/filter/full.rs
+++ b/src/table/writer/filter/full.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 pub struct FullFilterWriter {
     /// Key hashes for AMQ filter

--- a/src/table/writer/filter/full.rs
+++ b/src/table/writer/filter/full.rs
@@ -11,7 +11,9 @@ use crate::{
     prefix::PrefixExtractor,
     table::{Block, filter::build_burr_filter_bytes},
 };
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 pub struct FullFilterWriter {
     /// Key hashes for AMQ filter
@@ -46,7 +48,7 @@ impl FullFilterWriter {
     }
 }
 
-impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
+impl<W: crate::io::Write + crate::io::Seek> FilterWriter<W> for FullFilterWriter {
     fn use_partition_size(self: Box<Self>, _: u32) -> Box<dyn FilterWriter<W>> {
         self
     }
@@ -124,6 +126,8 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
             self.bloom_policy,
         );
 
+        // no-std: caller-provided Clock trait (timing is trace-only here)
+        #[cfg(feature = "std")]
         let start = std::time::Instant::now();
         // Build BEFORE opening the archive section. An invalid policy
         // can produce empty bytes; opening start("filter") and then
@@ -141,11 +145,14 @@ impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for FullFilterWriter {
 
         file_writer.start("filter")?;
 
+        #[cfg(feature = "std")]
         log::trace!(
             "Built BuRR filter ({}B) in {:?}",
             filter_bytes.len(),
             start.elapsed(),
         );
+        #[cfg(not(feature = "std"))]
+        log::trace!("Built BuRR filter ({}B)", filter_bytes.len());
 
         Block::write_into(
             file_writer,

--- a/src/table/writer/filter/mod.rs
+++ b/src/table/writer/filter/mod.rs
@@ -12,11 +12,13 @@ use crate::{
     CompressionType, UserKey, checksum::ChecksummedWriter, config::BloomConstructionPolicy,
     encryption::EncryptionProvider, prefix::PrefixExtractor,
 };
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 // All methods are required (no defaults) by design so that implementations must
 // explicitly handle configuration changes (e.g., filter policies, prefix extractors).
-pub trait FilterWriter<W: std::io::Write + std::io::Seek> {
+pub trait FilterWriter<W: crate::io::Write + crate::io::Seek> {
     // NOTE: We purposefully use a UserKey instead of &[u8]
     // so we can clone it without heap allocation, if needed
     /// Registers a key in the block index.

--- a/src/table/writer/filter/mod.rs
+++ b/src/table/writer/filter/mod.rs
@@ -12,9 +12,9 @@ use crate::{
     CompressionType, UserKey, checksum::ChecksummedWriter, config::BloomConstructionPolicy,
     encryption::EncryptionProvider, prefix::PrefixExtractor,
 };
-use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::boxed::Box;
+use alloc::sync::Arc;
 
 // All methods are required (no defaults) by design so that implementations must
 // explicitly handle configuration changes (e.g., filter policies, prefix extractors).

--- a/src/table/writer/filter/partitioned.rs
+++ b/src/table/writer/filter/partitioned.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 // Concrete writers (sfa::Writer / ChecksummedWriter) carry the io trait via
 // their own impls; the defining trait must be in scope for raw method calls.

--- a/src/table/writer/filter/partitioned.rs
+++ b/src/table/writer/filter/partitioned.rs
@@ -14,10 +14,16 @@ use crate::{
         filter::build_burr_filter_bytes,
     },
 };
-use std::{
-    io::{Seek, Write},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+// Concrete writers (sfa::Writer / ChecksummedWriter) carry the io trait via
+// their own impls; the defining trait must be in scope for raw method calls.
+#[cfg(not(feature = "std"))]
+use crate::io::{Seek, Write};
+#[cfg(feature = "std")]
+use std::io::{Seek, Write};
 
 pub struct PartitionedFilterWriter {
     final_filter_buffer: Vec<u8>,
@@ -92,7 +98,7 @@ impl PartitionedFilterWriter {
         // flush/compaction, so the saved reallocations matter on the
         // write hot path.
         let old_cap = self.bloom_hash_buffer.capacity();
-        let hashes = std::mem::replace(&mut self.bloom_hash_buffer, Vec::with_capacity(old_cap));
+        let hashes = core::mem::replace(&mut self.bloom_hash_buffer, Vec::with_capacity(old_cap));
         let filter_bytes = build_burr_filter_bytes(self.bloom_policy, hashes)?;
 
         // An empty BuRR build result means the policy is inactive for
@@ -216,7 +222,7 @@ impl PartitionedFilterWriter {
     }
 }
 
-impl<W: std::io::Write + std::io::Seek> FilterWriter<W> for PartitionedFilterWriter {
+impl<W: crate::io::Write + crate::io::Seek> FilterWriter<W> for PartitionedFilterWriter {
     fn use_encryption(
         mut self: Box<Self>,
         encryption: Option<Arc<dyn EncryptionProvider>>,

--- a/src/table/writer/index/adaptive.rs
+++ b/src/table/writer/index/adaptive.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 use crate::io::{Seek, Write};
 

--- a/src/table/writer/index/adaptive.rs
+++ b/src/table/writer/index/adaptive.rs
@@ -39,10 +39,11 @@ use crate::{
         writer::index::{BlockIndexWriter, FullIndexWriter, PartitionedIndexWriter},
     },
 };
-use std::{
-    io::{Seek, Write},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+use crate::io::{Seek, Write};
 
 /// Index-size threshold (bytes) at or below which the index is written
 /// single-level. The estimate mirrors [`PartitionedIndexWriter`]'s own
@@ -133,7 +134,7 @@ impl<W: Write + Seek + 'static> BlockIndexWriter<W> for AdaptiveIndexWriter<W> {
         // Mirror PartitionedIndexWriter's per-entry size estimate so the
         // threshold compares like-for-like against the partition logic.
         let entry_size =
-            (block_handle.end_key().len() + std::mem::size_of::<KeyedBlockHandle>()) as u64;
+            (block_handle.end_key().len() + core::mem::size_of::<KeyedBlockHandle>()) as u64;
         self.buffered_bytes += entry_size;
         self.buffer.push(block_handle);
 

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 pub struct FullIndexWriter {
     compression: CompressionType,

--- a/src/table/writer/index/full.rs
+++ b/src/table/writer/index/full.rs
@@ -8,7 +8,9 @@ use crate::{
     encryption::EncryptionProvider,
     table::{Block, IndexBlock, index_block::KeyedBlockHandle, writer::index::BlockIndexWriter},
 };
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 pub struct FullIndexWriter {
     compression: CompressionType,
@@ -40,7 +42,7 @@ impl FullIndexWriter {
     }
 }
 
-impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for FullIndexWriter {
+impl<W: crate::io::Write + crate::io::Seek> BlockIndexWriter<W> for FullIndexWriter {
     fn use_encryption(
         mut self: Box<Self>,
         encryption: Option<Arc<dyn EncryptionProvider>>,

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -14,9 +14,11 @@ use crate::{
     CompressionType, checksum::ChecksummedWriter, encryption::EncryptionProvider,
     table::index_block::KeyedBlockHandle,
 };
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
-pub trait BlockIndexWriter<W: std::io::Write + std::io::Seek> {
+pub trait BlockIndexWriter<W: crate::io::Write + crate::io::Seek> {
     /// Registers a data block in the block index.
     fn register_data_block(&mut self, block_handle: KeyedBlockHandle) -> crate::Result<()>;
 

--- a/src/table/writer/index/mod.rs
+++ b/src/table/writer/index/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 pub trait BlockIndexWriter<W: crate::io::Write + crate::io::Seek> {
     /// Registers a data block in the block index.

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -11,10 +11,16 @@ use crate::{
         writer::index::BlockIndexWriter,
     },
 };
-use std::{
-    io::{Seek, Write},
-    sync::Arc,
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+// Concrete writers (sfa::Writer / ChecksummedWriter) carry the io trait via
+// their own impls; the defining trait must be in scope for raw method calls.
+#[cfg(not(feature = "std"))]
+use crate::io::{Seek, Write};
+#[cfg(feature = "std")]
+use std::io::{Seek, Write};
 
 pub struct PartitionedIndexWriter {
     relative_file_pos: u64,
@@ -206,7 +212,7 @@ impl PartitionedIndexWriter {
     }
 }
 
-impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndexWriter {
+impl<W: crate::io::Write + crate::io::Seek> BlockIndexWriter<W> for PartitionedIndexWriter {
     fn use_encryption(
         mut self: Box<Self>,
         encryption: Option<Arc<dyn EncryptionProvider>>,
@@ -259,7 +265,7 @@ impl<W: std::io::Write + std::io::Seek> BlockIndexWriter<W> for PartitionedIndex
             reason = "key is u16 max, so we can not exceed u32::MAX"
         )]
         let block_handle_size =
-            (block_handle.end_key().len() + std::mem::size_of::<KeyedBlockHandle>()) as u32;
+            (block_handle.end_key().len() + core::mem::size_of::<KeyedBlockHandle>()) as u32;
 
         self.buffer_size += block_handle_size;
 

--- a/src/table/writer/index/partitioned.rs
+++ b/src/table/writer/index/partitioned.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 // Concrete writers (sfa::Writer / ChecksummedWriter) carry the io trait via
 // their own impls; the defining trait must be in scope for raw method calls.

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use index::BlockIndexWriter;
 
 use crate::io::BufWriter;

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -33,8 +33,13 @@ use crate::{
     time::unix_timestamp,
     vlog::BlobFileId,
 };
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use index::BlockIndexWriter;
-use std::{io::BufWriter, path::PathBuf, sync::Arc};
+
+use crate::io::BufWriter;
+use crate::path::PathBuf;
 
 #[cfg(feature = "std")] // no-std: parallel compaction unavailable (no threads)
 use {parallel_compressor::BlockCompressor, std::collections::VecDeque};
@@ -50,7 +55,7 @@ struct HandleMeta {
     item_count: usize,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, std::hash::Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, core::hash::Hash)]
 pub struct LinkedFile {
     pub blob_file_id: BlobFileId,
     pub bytes: u64,
@@ -221,6 +226,8 @@ impl Writer {
     ) -> crate::Result<Self> {
         // Normalize path once so open(), remove_file(), and fsync_directory()
         // all see the same absolute path.
+        // no-std: caller must pass an already-absolute path (no cwd concept)
+        #[cfg(feature = "std")]
         let path = std::path::absolute(path)?;
 
         let file = fs.open(&path, &FsOpenOptions::new().write(true).create_new(true))?;
@@ -827,7 +834,7 @@ impl Writer {
             &transform,
             kv_flags,
         )?;
-        let layout = std::mem::take(&mut prepared.layout);
+        let layout = core::mem::take(&mut prepared.layout);
         let header = prepared.write_to(&mut self.file_writer)?;
 
         self.register_written_block(
@@ -957,12 +964,12 @@ impl Writer {
         };
         let mut prepared = prepared?;
         let Some(meta) = self.pending_meta.pop_front() else {
-            return Err(crate::Error::Io(std::io::Error::other(
+            return Err(crate::Error::Io(crate::io::Error::other(
                 "parallel block pipeline meta desync",
             )));
         };
         // Take the inner-block layout before `write_to` consumes the block.
-        let layout = std::mem::take(&mut prepared.layout);
+        let layout = core::mem::take(&mut prepared.layout);
         let header = prepared.write_to(&mut self.file_writer)?;
         // Header is Copy; read the in-flight size before handing it off.
         self.parallel_pending_bytes = self
@@ -982,6 +989,9 @@ impl Writer {
     #[expect(clippy::too_many_lines)]
     /// Finishes the table, making sure all data is written durably
     pub fn finish(mut self) -> crate::Result<Option<(TableId, Checksum)>> {
+        #[cfg(not(feature = "std"))]
+        use crate::io::Write;
+        #[cfg(feature = "std")]
         use std::io::Write;
 
         self.spill_block()?;
@@ -1128,7 +1138,7 @@ impl Writer {
 
         // Write range tombstones block (if any)
         if !self.range_tombstones.is_empty() {
-            use byteorder::{LE, WriteBytesExt};
+            use crate::io::{LE, WriteBytesExt};
 
             self.file_writer.start("range_tombstones")?;
 
@@ -1136,14 +1146,14 @@ impl Writer {
             self.block_buffer.clear();
             for rt in &self.range_tombstones {
                 let start_len = u16::try_from(rt.start.len()).map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    crate::io::Error::new(
+                        crate::io::ErrorKind::InvalidData,
                         "range tombstone start key length exceeds u16::MAX",
                     )
                 })?;
                 let end_len = u16::try_from(rt.end.len()).map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    crate::io::Error::new(
+                        crate::io::ErrorKind::InvalidData,
                         "range tombstone end key length exceeds u16::MAX",
                     )
                 })?;
@@ -1273,7 +1283,7 @@ impl Writer {
         )?;
 
         if !self.linked_blob_files.is_empty() {
-            use byteorder::{LE, WriteBytesExt};
+            use crate::io::{LE, WriteBytesExt};
 
             self.file_writer.start("linked_blob_files")?;
 
@@ -1527,7 +1537,7 @@ fn meta_kv(key: &str, value: &[u8]) -> InternalValue {
     InternalValue::from_components(key, value, 0, crate::ValueType::Value)
 }
 
-fn write_meta_section<W: std::io::Write + std::io::Seek>(
+fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
     file_writer: &mut crate::sfa::Writer<ChecksummedWriter<W>>,
     block_buffer: &mut Vec<u8>,
     encryption: Option<&dyn EncryptionProvider>,

--- a/src/table/writer/parallel_compressor.rs
+++ b/src/table/writer/parallel_compressor.rs
@@ -27,18 +27,25 @@
 //! never buffers its entire compressed output: when the cap is reached it
 //! drains (and writes) one block before submitting the next.
 
+// `Box` for the (no_std-able) CompactionSpawner trait; under std it's in the
+// prelude. Everything below the trait is the std-only parallel pipeline.
+#[cfg(feature = "std")]
 use crate::{
     CompressionType, TableId,
     table::block::{Block, BlockIdentity, BlockTransform, BlockType, PreparedBlock},
 };
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(feature = "std")]
 use std::{
     collections::BTreeMap,
     sync::{Arc, Condvar, Mutex, PoisonError},
 };
 
-#[cfg(zstd_any)]
+#[cfg(all(feature = "std", zstd_any))]
 use crate::compression::ZstdDictionary;
 
+#[cfg(feature = "std")]
 use crate::encryption::EncryptionProvider;
 
 /// Caller-injectable execution backend for parallel block compression.
@@ -76,7 +83,7 @@ impl RayonSpawner {
             .num_threads(threads)
             .thread_name(|i| format!("lsm-compress-{i}"))
             .build()
-            .map_err(|e| crate::Error::Io(std::io::Error::other(e)))?;
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
         Ok(Self {
             pool: Arc::new(pool),
         })
@@ -97,6 +104,7 @@ impl CompactionSpawner for RayonSpawner {
 }
 
 /// Shared reorder slot: finished blocks keyed by submission sequence number.
+#[cfg(feature = "std")]
 struct Shared {
     ready: Mutex<BTreeMap<u64, crate::Result<PreparedBlock<'static>>>>,
     woke: Condvar,
@@ -108,6 +116,7 @@ struct Shared {
 /// shared reorder slot. The writer feeds encoded block buffers in via
 /// [`Self::submit`] and pulls finished blocks back out, in submission order,
 /// via [`Self::take_next`].
+#[cfg(feature = "std")]
 pub struct BlockCompressor {
     spawner: Arc<dyn CompactionSpawner>,
     shared: Arc<Shared>,
@@ -124,6 +133,7 @@ pub struct BlockCompressor {
     next_drain: u64,
 }
 
+#[cfg(feature = "std")]
 impl BlockCompressor {
     pub fn new(
         spawner: Arc<dyn CompactionSpawner>,
@@ -221,6 +231,7 @@ impl BlockCompressor {
 
 /// Worker-side block preparation: rebuild the transform from owned parts, run
 /// the pipeline, and detach the result from the borrowed `encoded` buffer.
+#[cfg(feature = "std")]
 fn prepare_owned(
     encoded: &[u8],
     table_id: TableId,

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,8 +2,13 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-/// Gets the unix timestamp as a duration
-pub fn unix_timestamp() -> std::time::Duration {
+/// Gets the unix timestamp as a duration (wall-clock time since the epoch).
+///
+/// Under `std` this reads the system clock. Under `no_std` there is no ambient
+/// clock, so the value comes from a caller-registered hook (see
+/// [`set_clock`]); until one is registered it is [`core::time::Duration::ZERO`]
+/// (epoch), which disables TTL expiry rather than expiring everything.
+pub fn unix_timestamp() -> core::time::Duration {
     #[cfg(test)]
     #[allow(clippy::significant_drop_in_scrutinee, clippy::expect_used)]
     {
@@ -14,11 +19,77 @@ pub fn unix_timestamp() -> std::time::Duration {
         }
     }
 
-    let now = std::time::SystemTime::now();
+    #[cfg(feature = "std")]
+    {
+        let now = std::time::SystemTime::now();
+        #[expect(clippy::expect_used, reason = "trivial")]
+        now.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("time went backwards")
+    }
 
-    #[expect(clippy::expect_used, reason = "trivial")]
-    now.duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .expect("time went backwards")
+    #[cfg(not(feature = "std"))]
+    {
+        nostd_clock::now()
+    }
+}
+
+/// Monotonic instant used for elapsed-time logging on the compaction / flush
+/// paths.
+///
+/// Under `std` this is a re-export of [`std::time::Instant`]. Under `no_std`
+/// there is no ambient monotonic clock, so this is a zero-sized stub whose
+/// [`elapsed`](Instant::elapsed) always reports [`core::time::Duration::ZERO`]
+/// — the timing logs degrade to `0ns` rather than failing to compile.
+// no-std: wire a caller-provided monotonic Clock hook (mirroring the
+// `unix_timestamp` wall-clock hook) if real elapsed timing is needed.
+#[cfg(feature = "std")]
+pub use std::time::Instant;
+
+/// See the `std` variant — a no-op monotonic-instant stub for `no_std`.
+#[cfg(not(feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Instant;
+
+#[cfg(not(feature = "std"))]
+impl Instant {
+    /// Returns the (stub) current instant.
+    #[must_use]
+    pub const fn now() -> Self {
+        Self
+    }
+
+    /// Always [`core::time::Duration::ZERO`] under `no_std` (no monotonic clock).
+    #[must_use]
+    pub const fn elapsed(&self) -> core::time::Duration {
+        core::time::Duration::ZERO
+    }
+}
+
+/// Registers the wall-clock source used by [`unix_timestamp`] under `no_std`
+/// (e.g. a WASM host's `Date.now()`). Idempotent — the first registration
+/// wins; later calls are ignored. A no-op under `std`, where the system clock
+/// is always available.
+#[cfg(not(feature = "std"))]
+pub fn set_clock(clock: fn() -> core::time::Duration) {
+    nostd_clock::set(clock);
+}
+
+#[cfg(not(feature = "std"))]
+mod nostd_clock {
+    use alloc::boxed::Box;
+    use core::time::Duration;
+    use once_cell::race::OnceBox;
+
+    // Caller-injected wall-clock. Lock-free (atomic pointer), set once.
+    static CLOCK: OnceBox<fn() -> Duration> = OnceBox::new();
+
+    pub fn set(clock: fn() -> Duration) {
+        let _ = CLOCK.set(Box::new(clock));
+    }
+
+    pub fn now() -> Duration {
+        CLOCK.get().map_or(Duration::ZERO, |clock| clock())
+    }
 }
 
 #[cfg(test)]

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -7,9 +7,16 @@ use crate::{
     BlobIndirection, SeqNo, UserKey, UserValue, config::FilterPolicyEntry, fs::Fs,
     table::multi_writer::MultiWriter,
 };
-use std::cmp::Ordering;
-use std::path::PathBuf;
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::cmp::Ordering;
+
+use crate::path::PathBuf;
 
 pub const INITIAL_CANONICAL_LEVEL: usize = 1;
 
@@ -319,11 +326,9 @@ impl<'a> Ingestion<'a> {
         // Acquire locks for version registration. We must hold both the
         // compaction state lock and version history lock to safely modify
         // the tree's version.
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut _compaction_state = self.tree.compaction_state.lock().expect("lock is poisoned");
+        let mut _compaction_state = self.tree.compaction_state.lock();
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut version_lock = self.tree.version_history.write().expect("lock is poisoned");
+        let mut version_lock = self.tree.version_history.write();
 
         // Allocate the next global sequence number. This seqno will be shared
         // by all ingested tables and the version that registers them, ensuring

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -9,11 +9,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::ToString, vec::Vec};
 use core::cmp::Ordering;
 
 use crate::path::PathBuf;

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -11,7 +11,40 @@ use crate::{
     stop_signal::StopSignal,
     version::{SuperVersions, Version, persist_version},
 };
-use std::sync::{Arc, Mutex, RwLock, atomic::AtomicU64};
+use alloc::sync::Arc;
+use portable_atomic::AtomicU64;
+// no-std: parking_lot is std-only; spin provides the same Mutex/RwLock API
+// without an allocator. parking_lot wins on the std hot path (8-byte,
+// userspace fast path), so keep it for std and fall back to spin for no_std.
+#[cfg(feature = "std")]
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+#[cfg(not(feature = "std"))]
+use spin::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+// RwLock guard aliases: parking_lot's and spin's read/write guards both take
+// `<'a, T>` (spin defaults its relax-strategy param to `Spin`), so one alias
+// per guard covers both backends.
+/// Write guard over the tree's version history. Backend-specific guard type
+/// (`parking_lot` under std, `spin` under `no_std`), aliased so
+/// [`crate::AbstractTree`] and its impls share one signature.
+pub type VersionsWriteGuard<'a> = RwLockWriteGuard<'a, SuperVersions>;
+/// Read guard over the tree's version history. See [`VersionsWriteGuard`].
+pub type VersionsReadGuard<'a> = RwLockReadGuard<'a, SuperVersions>;
+
+// spin's `MutexGuard` (unlike its RwLock guards) has no default relax-strategy
+// param, so the Mutex-based aliases name the backend guard explicitly.
+/// Guard over the tree's compaction state. See [`VersionsWriteGuard`].
+#[cfg(feature = "std")]
+pub type CompactionGuard<'a> = parking_lot::MutexGuard<'a, CompactionState>;
+/// Guard over the tree's compaction state. See [`VersionsWriteGuard`].
+#[cfg(not(feature = "std"))]
+pub type CompactionGuard<'a> = spin::MutexGuard<'a, CompactionState, spin::Spin>;
+/// Guard over the tree's flush-serialization mutex. See [`VersionsWriteGuard`].
+#[cfg(feature = "std")]
+pub type FlushGuard<'a> = parking_lot::MutexGuard<'a, ()>;
+/// Guard over the tree's flush-serialization mutex. See [`VersionsWriteGuard`].
+#[cfg(not(feature = "std"))]
+pub type FlushGuard<'a> = spin::MutexGuard<'a, (), spin::Spin>;
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
@@ -29,7 +62,7 @@ pub type MemtableId = u64;
 /// Hands out a unique (monotonically increasing) tree ID.
 pub fn get_next_tree_id() -> TreeId {
     static TREE_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
-    TREE_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    TREE_ID_COUNTER.fetch_add(1, core::sync::atomic::Ordering::Relaxed)
 }
 
 pub struct TreeInner {
@@ -145,13 +178,13 @@ impl TreeInner {
         // `Config::with_runtime_config`). Reused below to initialize
         // the Tree's `RuntimeConfigHandle` so the on-disk manifest
         // bytes and the live runtime handle agree on byte zero.
-        let initial_runtime = std::sync::Arc::new(config.initial_runtime_config.clone());
+        let initial_runtime = Arc::new(config.initial_runtime_config.clone());
         persist_version(
             &config.path,
             &version,
             config.comparator.name(),
             &*config.fs,
-            std::sync::Arc::clone(&initial_runtime),
+            Arc::clone(&initial_runtime),
             config.encryption.clone(),
             config.sync_mode,
         )?;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -28,11 +28,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::ops::{Bound, RangeBounds};
 use inner::{FlushGuard, TreeId, TreeInner, VersionsWriteGuard};
 // no-std: spin mirrors parking_lot's Mutex/RwLock API without an allocator.

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -6,6 +6,7 @@ pub mod ingest;
 pub mod inner;
 pub mod sealed;
 
+use crate::path::Path;
 use crate::{
     AbstractTree, Checksum, KvPair, SeqNo, SequenceNumberCounter, TableId, UserKey, UserValue,
     ValueType,
@@ -25,12 +26,21 @@ use crate::{
     version::{SuperVersion, SuperVersions, Version, recovery::recover},
     vlog::BlobFile,
 };
-use inner::{TreeId, TreeInner};
-use std::{
-    ops::{Bound, RangeBounds},
-    path::Path,
-    sync::{Arc, Mutex, RwLock},
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
 };
+use core::ops::{Bound, RangeBounds};
+use inner::{FlushGuard, TreeId, TreeInner, VersionsWriteGuard};
+// no-std: spin mirrors parking_lot's Mutex/RwLock API without an allocator.
+// parking_lot wins on the std hot path, so keep it for std.
+#[cfg(feature = "std")]
+use parking_lot::{Mutex, RwLock};
+#[cfg(not(feature = "std"))]
+use spin::{Mutex, RwLock};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
@@ -138,7 +148,7 @@ fn ignore_tombstone_value(item: InternalValue) -> Option<InternalValue> {
 #[derive(Clone)]
 pub struct Tree(#[doc(hidden)] pub Arc<TreeInner>);
 
-impl std::ops::Deref for Tree {
+impl core::ops::Deref for Tree {
     type Target = TreeInner;
 
     fn deref(&self) -> &Self::Target {
@@ -156,11 +166,8 @@ impl AbstractTree for Tree {
             .map_or(0, |dt| dt.len())
     }
 
-    fn get_version_history_lock(
-        &self,
-    ) -> std::sync::RwLockWriteGuard<'_, crate::version::SuperVersions> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.version_history.write().expect("lock is poisoned")
+    fn get_version_history_lock(&self) -> VersionsWriteGuard<'_> {
+        self.version_history.write()
     }
 
     fn next_table_id(&self) -> TableId {
@@ -175,9 +182,10 @@ impl AbstractTree for Tree {
         0
     }
 
+    #[cfg(feature = "std")]
     fn create_checkpoint(
         &self,
-        target_path: &std::path::Path,
+        target_path: &crate::path::Path,
     ) -> crate::Result<crate::CheckpointInfo> {
         crate::checkpoint::run_checkpoint(
             self,
@@ -196,12 +204,7 @@ impl AbstractTree for Tree {
     }
 
     fn print_trace(&self, key: &[u8]) -> crate::Result<()> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version();
+        let super_version = self.version_history.read().latest_version();
 
         let key = Slice::from(key);
 
@@ -268,12 +271,7 @@ impl AbstractTree for Tree {
 
         // Historical snapshot read (seqno <= latest.seqno): consult the locked
         // version history for the correct point-in-time SuperVersion.
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno);
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
 
         Self::get_internal_entry_from_version(
             &super_version,
@@ -284,17 +282,11 @@ impl AbstractTree for Tree {
     }
 
     fn current_version(&self) -> Version {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.version_history
-            .read()
-            .expect("poisoned")
-            .latest_version()
-            .version
+        self.version_history.read().latest_version().version
     }
 
-    fn get_flush_lock(&self) -> std::sync::MutexGuard<'_, ()> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.flush_lock.lock().expect("lock is poisoned")
+    fn get_flush_lock(&self) -> FlushGuard<'_> {
+        self.flush_lock.lock()
     }
 
     #[cfg(feature = "metrics")]
@@ -303,11 +295,7 @@ impl AbstractTree for Tree {
     }
 
     fn version_free_list_len(&self) -> usize {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.version_history
-            .read()
-            .expect("lock is poisoned")
-            .free_list_len()
+        self.version_history.read().free_list_len()
     }
 
     fn prefix<K: AsRef<[u8]>>(
@@ -368,12 +356,7 @@ impl AbstractTree for Tree {
         let strategy = Arc::new(crate::compaction::drop_range::Strategy::new(bounds));
 
         // IMPORTANT: Write lock so we can be the only compaction going on
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let _lock = self
-            .0
-            .major_compaction_lock
-            .write()
-            .expect("lock is poisoned");
+        let _lock = self.0.major_compaction_lock.write();
 
         log::info!("Starting drop_range compaction");
         self.inner_compact(strategy, 0)?;
@@ -439,12 +422,7 @@ impl AbstractTree for Tree {
         let strategy = Arc::new(crate::compaction::major::Strategy::new(target_size));
 
         // IMPORTANT: Write lock so we can be the only compaction going on
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let _lock = self
-            .0
-            .major_compaction_lock
-            .write()
-            .expect("lock is poisoned");
+        let _lock = self.0.major_compaction_lock.write();
 
         log::info!("Starting major compaction");
         self.inner_compact(strategy, seqno_threshold)
@@ -485,10 +463,8 @@ impl AbstractTree for Tree {
     }
 
     fn sealed_memtable_count(&self) -> usize {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         self.version_history
             .read()
-            .expect("lock is poisoned")
             .latest_version()
             .sealed_memtables
             .len()
@@ -500,7 +476,7 @@ impl AbstractTree for Tree {
         range_tombstones: Vec<crate::range_tombstone::RangeTombstone>,
     ) -> crate::Result<Option<(Vec<Table>, Option<Vec<BlobFile>>)>> {
         use crate::table::multi_writer::MultiWriter;
-        use std::time::Instant;
+        use crate::time::Instant;
 
         let start = Instant::now();
 
@@ -668,10 +644,8 @@ impl AbstractTree for Tree {
             }
         }
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut _compaction_state = self.compaction_state.lock().expect("lock is poisoned");
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut version_lock = self.version_history.write().expect("lock is poisoned");
+        let mut _compaction_state = self.compaction_state.lock();
+        let mut version_lock = self.version_history.write();
 
         version_lock.upgrade_version(
             &self.config.path,
@@ -711,8 +685,7 @@ impl AbstractTree for Tree {
     fn clear_active_memtable(&self) {
         use crate::tree::sealed::SealedMemtables;
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut version_history_lock = self.version_history.write().expect("lock is poisoned");
+        let mut version_history_lock = self.version_history.write();
         let super_version = version_history_lock.latest_version();
 
         if super_version.active_memtable.is_empty() {
@@ -742,12 +715,7 @@ impl AbstractTree for Tree {
         // NOTE: Read lock major compaction lock
         // That way, if a major compaction is running, we cannot proceed
         // But in general, parallel (non-major) compactions can occur
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let _lock = self
-            .0
-            .major_compaction_lock
-            .read()
-            .expect("lock is poisoned");
+        let _lock = self.0.major_compaction_lock.read();
 
         self.inner_compact(strategy, seqno_threshold)
     }
@@ -761,18 +729,12 @@ impl AbstractTree for Tree {
     }
 
     fn active_memtable(&self) -> Arc<Memtable> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version()
-            .active_memtable
+        self.version_history.read().latest_version().active_memtable
     }
 
     #[expect(clippy::significant_drop_tightening)]
     fn rotate_memtable(&self) -> Option<Arc<Memtable>> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let mut version_history_lock = self.version_history.write().expect("lock is poisoned");
+        let mut version_history_lock = self.version_history.write();
         let super_version = version_history_lock.latest_version();
 
         if super_version.active_memtable.is_empty() {
@@ -811,12 +773,7 @@ impl AbstractTree for Tree {
     }
 
     fn approximate_len(&self) -> usize {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version();
+        let super_version = self.version_history.read().latest_version();
 
         let tables_item_count = self
             .current_version()
@@ -845,12 +802,7 @@ impl AbstractTree for Tree {
     }
 
     fn get_highest_memtable_seqno(&self) -> Option<SeqNo> {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version();
+        let version = self.version_history.read().latest_version();
 
         let active = version.active_memtable.get_highest_seqno();
 
@@ -874,12 +826,7 @@ impl AbstractTree for Tree {
     fn get<K: AsRef<[u8]>>(&self, key: K, seqno: SeqNo) -> crate::Result<Option<UserValue>> {
         let key = key.as_ref();
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno);
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
 
         Self::resolve_or_passthrough(
             &super_version,
@@ -897,12 +844,7 @@ impl AbstractTree for Tree {
     ) -> crate::Result<Option<crate::PinnableSlice>> {
         let key = key.as_ref();
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno);
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
 
         Self::resolve_or_passthrough_pinned(
             &super_version,
@@ -1054,15 +996,7 @@ impl AbstractTree for Tree {
     }
 
     fn remove_range<K: Into<UserKey>>(&self, start: K, end: K, seqno: SeqNo) -> u64 {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let memtable = Arc::clone(
-            &self
-                .version_history
-                .read()
-                .expect("lock is poisoned")
-                .latest_version()
-                .active_memtable,
-        );
+        let memtable = Arc::clone(&self.version_history.read().latest_version().active_memtable);
 
         memtable.insert_range_tombstone(start.into(), end.into(), seqno)
     }
@@ -1125,16 +1059,11 @@ impl Tree {
         &self,
         target_seqno: SeqNo,
         resolve_indirection: F,
-    ) -> crate::Result<std::vec::IntoIter<ScanSinceEvent>>
+    ) -> crate::Result<alloc::vec::IntoIter<ScanSinceEvent>>
     where
         F: Fn(&Version, InternalValue) -> crate::Result<ScanSinceEvent>,
     {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .latest_version();
+        let super_version = self.version_history.read().latest_version();
         let version = &super_version.version;
 
         // Stable upper watermark, captured once before walking any source: the
@@ -1622,7 +1551,7 @@ impl Tree {
         prefix_hash: Option<u64>,
     ) -> impl DoubleEndedIterator<Item = crate::Result<InternalValue>> + 'static {
         use crate::range::{IterState, TreeIter};
-        use std::ops::Bound::{self, Excluded, Included, Unbounded};
+        use core::ops::Bound::{self, Excluded, Included, Unbounded};
 
         let lo: Bound<UserKey> = match range.start_bound() {
             Included(x) => Included(x.as_ref().into()),
@@ -1760,8 +1689,8 @@ impl Tree {
             .filter(|t| {
                 // Early reject: skip tables whose key range doesn't contain the key.
                 let kr = &t.metadata.key_range;
-                comparator.compare(kr.min(), key) != std::cmp::Ordering::Greater
-                    && comparator.compare(key, kr.max()) != std::cmp::Ordering::Greater
+                comparator.compare(kr.min(), key) != core::cmp::Ordering::Greater
+                    && comparator.compare(key, kr.max()) != core::cmp::Ordering::Greater
             })
         {
             let rts = table.range_tombstones();
@@ -1769,14 +1698,14 @@ impl Tree {
             // Binary search: find the first RT whose start is > key (in comparator order).
             // All RTs before that index have start <= key and are candidates.
             let candidate_end = rts.partition_point(|rt| {
-                comparator.compare(&rt.start, key) != std::cmp::Ordering::Greater
+                comparator.compare(&rt.start, key) != core::cmp::Ordering::Greater
             });
 
             for rt in rts.iter().take(candidate_end) {
                 // Check: start <= key < end (in comparator order) AND seqno visibility.
                 if rt.visible_at(read_seqno)
-                    && comparator.compare(&rt.start, key) != std::cmp::Ordering::Greater
-                    && comparator.compare(key, &rt.end) == std::cmp::Ordering::Less
+                    && comparator.compare(&rt.start, key) != core::cmp::Ordering::Greater
+                    && comparator.compare(key, &rt.end) == core::cmp::Ordering::Less
                     && key_seqno < rt.seqno
                 {
                     return true;
@@ -2002,11 +1931,7 @@ impl Tree {
     }
 
     pub(crate) fn get_version_for_snapshot(&self, seqno: SeqNo) -> SuperVersion {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        self.version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno)
+        self.version_history.read().get_version_for_snapshot(seqno)
     }
 
     /// Normalizes a user-provided range into owned `Bound<Slice>` values.
@@ -2111,7 +2036,7 @@ impl Tree {
             config.encryption.clone(),
         ) {
             Ok(_) => Self::recover(config),
-            Err(crate::Error::Io(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(crate::Error::Io(e)) if e.kind() == crate::io::ErrorKind::NotFound => {
                 // Missing CURRENT MUST coincide with a directory that
                 // has no version artifacts; otherwise we are looking at
                 // a half-written checkpoint (or other interrupted
@@ -2137,8 +2062,8 @@ impl Tree {
                         config.path.display(),
                     );
                     log::error!("{msg}");
-                    return Err(crate::Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
+                    return Err(crate::Error::from(crate::io::Error::new(
+                        crate::io::ErrorKind::InvalidData,
                         msg,
                     )));
                 }
@@ -2154,13 +2079,7 @@ impl Tree {
     #[doc(hidden)]
     #[must_use]
     pub fn is_compacting(&self) -> bool {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        !self
-            .compaction_state
-            .lock()
-            .expect("lock is poisoned")
-            .hidden_set()
-            .is_empty()
+        !self.compaction_state.lock().hidden_set().is_empty()
     }
 
     fn inner_compact(
@@ -2197,12 +2116,7 @@ impl Tree {
         seqno: SeqNo,
         ephemeral: Option<(Arc<Memtable>, SeqNo)>,
     ) -> impl DoubleEndedIterator<Item = crate::Result<KvPair>> + 'static {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno);
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
 
         Self::create_internal_range(
             super_version,
@@ -2234,12 +2148,7 @@ impl Tree {
 
         let range = prefix_to_range(prefix_bytes);
 
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let super_version = self
-            .version_history
-            .read()
-            .expect("lock is poisoned")
-            .get_version_for_snapshot(seqno);
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
 
         let iter_state = IterState {
             version: super_version,
@@ -2265,10 +2174,8 @@ impl Tree {
     #[doc(hidden)]
     #[must_use]
     pub fn append_entry(&self, value: InternalValue) -> (u64, u64) {
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         self.version_history
             .read()
-            .expect("lock is poisoned")
             .latest_version()
             .active_memtable
             .insert(value)
@@ -2286,10 +2193,8 @@ impl Tree {
         // Hold the read guard for the entire insert to prevent rotate_memtable()
         // from sealing this memtable mid-batch (which could cause data loss if
         // a concurrent flush persists only a prefix of the batch).
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
         self.version_history
             .read()
-            .expect("lock is poisoned")
             .latest_version()
             .active_memtable
             .insert_batch(items)
@@ -2343,7 +2248,7 @@ impl Tree {
             let mut archive_reader = crate::manifest_blocks::reader::ManifestArchiveReader::open(
                 &manifest_path,
                 &*config.fs,
-                std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
+                alloc::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
                 config.encryption.clone(),
             )?;
             let manifest = Manifest::decode_from(&mut archive_reader)?;
@@ -2454,18 +2359,11 @@ impl Tree {
         // Drop impls consult it when a checkpoint is in flight. Snapshot
         // the Arc handles into owned collections so the read lock is
         // released before iterating (avoids `significant_drop_tightening`).
-        #[expect(clippy::expect_used, reason = "lock is expected to not be poisoned")]
-        let (recovered_tables, recovered_blobs): (Vec<Table>, Vec<BlobFile>) = inner
-            .version_history
-            .read()
-            .map(|lock| {
-                let version = &lock.latest_version().version;
-                (
-                    version.iter_tables().cloned().collect(),
-                    version.blob_files.iter().cloned().collect(),
-                )
-            })
-            .expect("lock is poisoned");
+        // Snapshot the version under the read lock, then drop the lock before
+        // collecting so the version_history lock isn't held across the clones.
+        let version = inner.version_history.read().latest_version().version;
+        let recovered_tables: Vec<Table> = version.iter_tables().cloned().collect();
+        let recovered_blobs: Vec<BlobFile> = version.blob_files.iter().cloned().collect();
 
         for table in &recovered_tables {
             table.install_deletion_pause(Arc::clone(&deletion_pause));
@@ -2589,7 +2487,7 @@ impl Tree {
         // junctions, or case-insensitive aliases of the same directory) are
         // skipped rather than orphan-deleted.
         let mut recovered_table_ids: crate::HashSet<TableId> = crate::HashSet::default();
-        let mut orphaned_tables: Vec<(std::path::PathBuf, Arc<dyn crate::fs::Fs>)> = vec![];
+        let mut orphaned_tables: Vec<(crate::path::PathBuf, Arc<dyn crate::fs::Fs>)> = vec![];
 
         // Scan all configured table folders (primary + level routes).
         let all_folders = config.all_tables_folders();
@@ -2794,7 +2692,7 @@ impl Tree {
                 log::trace!("Cleanup orphaned manifest file {name}");
                 match fs.remove_file(&dirent.path) {
                     Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) if e.kind() == crate::io::ErrorKind::NotFound => {}
                     Err(e) => return Err(e.into()),
                 }
             }
@@ -2822,7 +2720,7 @@ fn has_existing_version_state(folder: &Path, fs: &dyn Fs) -> crate::Result<bool>
     }
     let entries = match fs.read_dir(folder) {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => return Ok(false),
         Err(e) => return Err(e.into()),
     };
     for entry in entries {

--- a/src/tree/sealed.rs
+++ b/src/tree/sealed.rs
@@ -5,7 +5,7 @@
 use crate::{Memtable, tree::inner::MemtableId};
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// Stores references to all sealed memtables
 ///

--- a/src/tree/sealed.rs
+++ b/src/tree/sealed.rs
@@ -3,7 +3,9 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 use crate::{Memtable, tree::inner::MemtableId};
-use std::sync::Arc;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// Stores references to all sealed memtables
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@
 
 use crate::UserKey;
 use crate::range::prefix_upper_range;
-use std::ops::RangeBounds;
+use core::ops::RangeBounds;
 
 pub use crate::range::prefix_to_range;
 
@@ -19,7 +19,7 @@ pub fn prefixed_range<P: AsRef<[u8]>, K: AsRef<[u8]>, R: RangeBounds<K>>(
     prefix: P,
     range: R,
 ) -> impl RangeBounds<UserKey> {
-    use std::ops::Bound::{Excluded, Included, Unbounded};
+    use core::ops::Bound::{Excluded, Included, Unbounded};
 
     let prefix = prefix.as_ref();
 
@@ -65,8 +65,8 @@ pub fn prefixed_range<P: AsRef<[u8]>, K: AsRef<[u8]>, R: RangeBounds<K>>(
 mod tests {
     use super::prefixed_range;
     use crate::UserKey;
-    use std::ops::Bound::{Excluded, Included};
-    use std::ops::RangeBounds;
+    use core::ops::Bound::{Excluded, Included};
+    use core::ops::RangeBounds;
     use test_log::test;
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -116,8 +116,8 @@ impl PartialEq for InternalValue {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-impl std::fmt::Debug for InternalValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InternalValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{:?} => {:?}",

--- a/src/version/blob_file_list.rs
+++ b/src/version/blob_file_list.rs
@@ -4,7 +4,7 @@ use crate::{
     vlog::{BlobFile, BlobFileId},
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[derive(Clone, Default)]
 pub struct BlobFileList(HashMap<BlobFileId, BlobFile>);

--- a/src/version/blob_file_list.rs
+++ b/src/version/blob_file_list.rs
@@ -3,6 +3,8 @@ use crate::{
     blob_tree::FragmentationMap,
     vlog::{BlobFile, BlobFileId},
 };
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 #[derive(Clone, Default)]
 pub struct BlobFileList(HashMap<BlobFileId, BlobFile>);

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -13,6 +13,8 @@
 use super::Version;
 use super::edit::{AddedBlobFile, ChangedLevel, TableDesc, VersionEdit};
 use crate::coding::Encode;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 impl Version {
     /// Computes the edit that turns `prior` into `self`.

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -14,7 +14,7 @@ use super::Version;
 use super::edit::{AddedBlobFile, ChangedLevel, TableDesc, VersionEdit};
 use crate::coding::Encode;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 impl Version {
     /// Computes the edit that turns `prior` into `self`.

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -60,7 +60,7 @@
 use super::framing;
 use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use crate::io::{Read, Write};

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -58,7 +58,13 @@
 //! record shape is recognised on both paths.
 
 use super::framing;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
 
 /// One table in a run: the snapshot's per-table record minus the positional
@@ -321,7 +327,10 @@ pub fn replay_edits<R: Read>(
     mode: crate::config::ManifestRecoveryMode,
 ) -> crate::Result<Vec<VersionEdit>> {
     use crate::config::ManifestRecoveryMode;
+    #[cfg(not(feature = "std"))]
+    use crate::io::BufRead;
     use framing::FramedRecordOutcome;
+    #[cfg(feature = "std")]
     use std::io::BufRead;
 
     // Only AbsoluteConsistency refuses to roll back a writer-incomplete tail.
@@ -335,14 +344,14 @@ pub fn replay_edits<R: Read>(
 
     // Buffer the reader so a clean record boundary can be detected (empty fill)
     // without consuming bytes from a genuine trailing record.
-    let mut reader = std::io::BufReader::new(reader);
+    let mut reader = crate::io::BufReader::new(reader);
     let mut edits = Vec::new();
     let mut scratch = Vec::new();
     loop {
         // No bytes left at a record boundary: the normal end of the log. A crash
         // exactly at a boundary is indistinguishable from a pristine close, so
         // this is always a successful end — never a "torn tail", in any mode.
-        if reader.fill_buf().map_err(crate::Error::Io)?.is_empty() {
+        if reader.fill_buf().map_err(crate::Error::from)?.is_empty() {
             break;
         }
         let outcome = framing::read_framed_record(&mut reader, u64::MAX, None, &mut scratch)?;

--- a/src/version/edit_log.rs
+++ b/src/version/edit_log.rs
@@ -18,8 +18,14 @@
 
 use super::edit::{VersionEdit, replay_edits};
 use crate::fs::{Fs, FsOpenOptions, SyncMode};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use crate::io::{Seek, SeekFrom};
+use crate::path::Path;
+#[cfg(feature = "std")]
 use std::io::{Seek, SeekFrom};
-use std::path::Path;
 
 /// Appends one framed [`VersionEdit`] to the log at `path` (created on first
 /// write) and fsyncs per `sync_mode`, so the edit is durable before the caller
@@ -42,9 +48,9 @@ pub fn append_edit(
             path,
             &FsOpenOptions::new().write(true).create(true).append(true),
         )
-        .map_err(crate::Error::Io)?;
+        .map_err(crate::Error::from)?;
     edit.append_to(&mut file, scratch)?;
-    file.sync_all_with(sync_mode).map_err(crate::Error::Io)?;
+    file.sync_all_with(sync_mode).map_err(crate::Error::from)?;
     Ok(())
 }
 
@@ -69,8 +75,8 @@ pub fn replay_log(
 ) -> crate::Result<Vec<VersionEdit>> {
     match fs.open(path, &FsOpenOptions::new().read(true)) {
         Ok(mut file) => replay_edits(&mut file, mode),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
-        Err(e) => Err(crate::Error::Io(e)),
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(e) => Err(crate::Error::from(e)),
     }
 }
 
@@ -83,9 +89,9 @@ pub fn replay_log(
 /// Returns an I/O error if the open (other than not-found) or the seek fails.
 pub fn log_size(fs: &dyn Fs, path: &Path) -> crate::Result<u64> {
     match fs.open(path, &FsOpenOptions::new().read(true)) {
-        Ok(mut file) => file.seek(SeekFrom::End(0)).map_err(crate::Error::Io),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
-        Err(e) => Err(crate::Error::Io(e)),
+        Ok(mut file) => file.seek(SeekFrom::End(0)).map_err(crate::Error::from),
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => Ok(0),
+        Err(e) => Err(crate::Error::from(e)),
     }
 }
 

--- a/src/version/edit_log.rs
+++ b/src/version/edit_log.rs
@@ -19,7 +19,7 @@
 use super::edit::{VersionEdit, replay_edits};
 use crate::fs::{Fs, FsOpenOptions, SyncMode};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use crate::io::{Seek, SeekFrom};

--- a/src/version/framing.rs
+++ b/src/version/framing.rs
@@ -346,6 +346,10 @@ pub fn read_framed_record<R: Read>(
     payload_scratch.resize(len as usize, 0);
     match reader.read_exact(payload_scratch) {
         Ok(()) => {}
+        // Two cfg arms, not one: under `std`, `crate::io::Read` is a method-less
+        // supertrait alias, so `read_exact` resolves to `std::io::Read` and
+        // `e.kind()` is `std::io::ErrorKind`; under no_std it is
+        // `crate::io::ErrorKind`. A single arm would not type-check on both.
         #[cfg(feature = "std")]
         Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
             return Ok(FramedRecordOutcome::TailTruncation);

--- a/src/version/framing.rs
+++ b/src/version/framing.rs
@@ -66,8 +66,11 @@
 //! [`ManifestRecoveryMode::PointInTimeRecovery`]: crate::config::ManifestRecoveryMode::PointInTimeRecovery
 //! [`ManifestRecoveryMode::SkipAnyCorruptedRecords`]: crate::config::ManifestRecoveryMode::SkipAnyCorruptedRecords
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Read, Write};
+use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+use crate::io::{Read, Write};
 
 /// Size of the framing header in bytes (4 B `len` + 8 B `xxh3_64`).
 pub const FRAME_HEADER_LEN: usize = 4 + 8;
@@ -276,7 +279,7 @@ pub fn read_framed_record<R: Read>(
 ) -> crate::Result<FramedRecordOutcome> {
     let len = match reader.read_u32::<LittleEndian>() {
         Ok(n) => n,
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+        Err(e) if e.kind() == crate::io::ErrorKind::UnexpectedEof => {
             return Ok(FramedRecordOutcome::TailTruncation);
         }
         Err(e) => return Err(e.into()),
@@ -329,7 +332,7 @@ pub fn read_framed_record<R: Read>(
 
     let digest_expected = match reader.read_u64::<LittleEndian>() {
         Ok(d) => d,
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+        Err(e) if e.kind() == crate::io::ErrorKind::UnexpectedEof => {
             return Ok(FramedRecordOutcome::TailTruncation);
         }
         Err(e) => return Err(e.into()),
@@ -343,7 +346,12 @@ pub fn read_framed_record<R: Read>(
     payload_scratch.resize(len as usize, 0);
     match reader.read_exact(payload_scratch) {
         Ok(()) => {}
+        #[cfg(feature = "std")]
         Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            return Ok(FramedRecordOutcome::TailTruncation);
+        }
+        #[cfg(not(feature = "std"))]
+        Err(e) if e.kind() == crate::io::ErrorKind::UnexpectedEof => {
             return Ok(FramedRecordOutcome::TailTruncation);
         }
         Err(e) => return Err(e.into()),

--- a/src/version/framing.rs
+++ b/src/version/framing.rs
@@ -68,7 +68,7 @@
 
 use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use crate::io::{Read, Write};
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -51,9 +51,13 @@ use crate::{
     comparator::UserComparator,
     vlog::{BlobFile, BlobFileId},
 };
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::Deref;
+
 use optimize::optimize_runs;
 use run::Ranged;
-use std::{ops::Deref, sync::Arc};
 
 /// Context threaded through [`Version`] transformation methods.
 ///
@@ -92,7 +96,7 @@ pub struct GenericLevel<T: Ranged> {
     runs: Vec<Arc<Run<T>>>,
 }
 
-impl<T: Ranged> std::ops::Deref for GenericLevel<T> {
+impl<T: Ranged> core::ops::Deref for GenericLevel<T> {
     type Target = [Arc<Run<T>>];
 
     fn deref(&self) -> &Self::Target {
@@ -129,7 +133,7 @@ impl<T: Ranged> GenericLevel<T> {
 #[derive(Clone)]
 pub struct Level(Arc<GenericLevel<Table>>);
 
-impl std::ops::Deref for Level {
+impl core::ops::Deref for Level {
     type Target = GenericLevel<Table>;
 
     fn deref(&self) -> &Self::Target {
@@ -244,7 +248,7 @@ pub struct Version {
     inner: Arc<VersionInner>,
 }
 
-impl std::ops::Deref for Version {
+impl core::ops::Deref for Version {
     type Target = VersionInner;
 
     fn deref(&self) -> &Self::Target {
@@ -730,7 +734,10 @@ impl Version {
         comparator_name: &str,
     ) -> Result<(), crate::Error> {
         use crate::FormatVersion;
-        use byteorder::{LittleEndian, WriteBytesExt};
+        #[cfg(not(feature = "std"))]
+        use crate::io::Write;
+        use crate::io::{LittleEndian, WriteBytesExt};
+        #[cfg(feature = "std")]
         use std::io::Write;
 
         //

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -53,7 +53,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::Deref;
 
 use optimize::optimize_runs;

--- a/src/version/optimize.rs
+++ b/src/version/optimize.rs
@@ -5,6 +5,8 @@
 use super::run::Ranged;
 use crate::comparator::UserComparator;
 use crate::version::Run;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 pub fn optimize_runs<T: Clone + Ranged>(
     runs: Vec<Run<T>>,

--- a/src/version/optimize.rs
+++ b/src/version/optimize.rs
@@ -6,7 +6,7 @@ use super::run::Ranged;
 use crate::comparator::UserComparator;
 use crate::version::Run;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 pub fn optimize_runs<T: Clone + Ranged>(
     runs: Vec<Run<T>>,

--- a/src/version/persist.rs
+++ b/src/version/persist.rs
@@ -1,3 +1,4 @@
+use crate::io::{LittleEndian, WriteBytesExt};
 use crate::{
     encryption::EncryptionProvider,
     file::{CURRENT_VERSION_FILE, fsync_directory, rewrite_atomic},
@@ -6,8 +7,9 @@ use crate::{
     runtime_config::RuntimeConfig,
     version::Version,
 };
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::{path::Path, sync::Arc};
+use alloc::sync::Arc;
+
+use crate::path::Path;
 
 /// Crate-internal (version module is not exported).
 ///
@@ -28,8 +30,8 @@ pub fn persist_version(
     sync_mode: SyncMode,
 ) -> crate::Result<()> {
     if comparator_name.len() > crate::comparator::MAX_COMPARATOR_NAME_BYTES {
-        return Err(crate::Error::from(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
+        return Err(crate::Error::from(crate::io::Error::new(
+            crate::io::ErrorKind::InvalidInput,
             format!(
                 "comparator name is {} bytes (max {})",
                 comparator_name.len(),

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -13,7 +13,7 @@ use crate::{
     vlog::BlobFileId,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use crate::path::Path;
 

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::io::{LittleEndian, ReadBytesExt};
 use crate::{
     Checksum, SeqNo, TableId, TreeType,
     coding::Decode,
@@ -11,8 +12,10 @@ use crate::{
     version::VersionId,
     vlog::BlobFileId,
 };
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::path::Path;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+use crate::path::Path;
 
 /// Exact on-disk size of a `tables`-section record payload (post-framing):
 /// `id: u64 (8) | checksum_type: u8 (1) | checksum: u128 (16) | global_seqno: u64 (8)`.
@@ -48,7 +51,7 @@ fn decode_table_entry_payload(payload: &[u8]) -> crate::Result<RecoveredTable> {
     if payload.len() != TABLE_ENTRY_PAYLOAD_LEN as usize {
         return Err(crate::Error::InvalidHeader("tables record payload length"));
     }
-    let mut cursor = std::io::Cursor::new(payload);
+    let mut cursor = crate::io::Cursor::new(payload);
     let id = cursor.read_u64::<LittleEndian>()?;
     let checksum_type = cursor.read_u8()?;
     if checksum_type != 0 {
@@ -72,7 +75,7 @@ fn decode_blob_entry_payload(payload: &[u8]) -> crate::Result<(BlobFileId, Check
             "blob_files record payload length",
         ));
     }
-    let mut cursor = std::io::Cursor::new(payload);
+    let mut cursor = crate::io::Cursor::new(payload);
     let id = cursor.read_u64::<LittleEndian>()?;
     let checksum_type = cursor.read_u8()?;
     if checksum_type != 0 {
@@ -116,9 +119,9 @@ fn decode_blob_entry_payload(payload: &[u8]) -> crate::Result<(BlobFileId, Check
 pub fn get_current_version(
     folder: &Path,
     fs: &dyn Fs,
-    encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+    encryption: Option<alloc::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
 ) -> crate::Result<VersionId> {
-    use byteorder::{LittleEndian, ReadBytesExt};
+    use crate::io::{LittleEndian, ReadBytesExt};
 
     let path = folder.join(CURRENT_VERSION_FILE);
     let mut file = fs.open(&path, &FsOpenOptions::new().read(true))?;
@@ -154,11 +157,11 @@ pub fn get_current_version(
     let archive = crate::manifest_blocks::reader::ManifestArchiveReader::open(
         &manifest_path,
         fs,
-        std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
+        alloc::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
         encryption,
     )
     .map_err(|e| match e {
-        crate::Error::Io(io) if io.kind() == std::io::ErrorKind::NotFound => {
+        crate::Error::Io(io) if io.kind() == crate::io::ErrorKind::NotFound => {
             crate::Error::ManifestFooterInvalid(
                 "manifest file referenced by CURRENT does not exist",
             )
@@ -346,7 +349,7 @@ pub fn recover(
     folder: &Path,
     fs: &dyn Fs,
     mode: ManifestRecoveryMode,
-    encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+    encryption: Option<alloc::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
 ) -> crate::Result<Recovery> {
     // Per-record framing constants used by both the tables and
     // blob_files sections. Each on-disk record is a
@@ -372,7 +375,7 @@ pub fn recover(
     let mut archive = crate::manifest_blocks::reader::ManifestArchiveReader::open(
         &version_file_path,
         fs,
-        std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
+        alloc::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
         encryption,
     )?;
 
@@ -447,7 +450,7 @@ pub fn recover(
         }
         let section_bytes = archive.read_section("tables")?;
         let section_len: u64 = section_bytes.len() as u64;
-        let mut reader = std::io::Cursor::new(section_bytes);
+        let mut reader = crate::io::Cursor::new(section_bytes);
 
         // Wrap the level-count read in tail tolerance too: a manifest
         // truncated before the first byte of `tables` (or right after
@@ -473,7 +476,7 @@ pub fn recover(
                 tables_bytes_consumed += 1;
                 n
             }
-            Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            Err(e) if tolerate_tail && e.kind() == crate::io::ErrorKind::UnexpectedEof => {
                 log::warn!(
                     "tables section truncated before level_count byte in version \
                      #{curr_version_id}; tail-tolerant mode produces 0 levels"
@@ -506,7 +509,7 @@ pub fn recover(
                     tables_bytes_consumed += 1;
                     n
                 }
-                Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                Err(e) if tolerate_tail && e.kind() == crate::io::ErrorKind::UnexpectedEof => {
                     // No runs in this level had a chance to start;
                     // pushing the empty `level` keeps the level slot
                     // visible to downstream code (instead of silently
@@ -536,7 +539,7 @@ pub fn recover(
                         tables_bytes_consumed += 4;
                         n
                     }
-                    Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    Err(e) if tolerate_tail && e.kind() == crate::io::ErrorKind::UnexpectedEof => {
                         // Push the partial `level` so any fully
                         // decoded runs earlier in this level survive
                         // — breaking out of `'levels` without this
@@ -778,8 +781,8 @@ pub fn recover(
                         // corruption that the operator needs to know
                         // about as such).
                         FramedRecordOutcome::TailTruncation => {
-                            return Err(crate::Error::Io(std::io::Error::new(
-                                std::io::ErrorKind::UnexpectedEof,
+                            return Err(crate::Error::from(crate::io::Error::new(
+                                crate::io::ErrorKind::UnexpectedEof,
                                 "manifest tables record truncated mid-frame",
                             )));
                         }
@@ -877,11 +880,11 @@ pub fn recover(
         }
         let section_bytes = archive.read_section("blob_files")?;
         let section_len: u64 = section_bytes.len() as u64;
-        let mut reader = std::io::Cursor::new(section_bytes);
+        let mut reader = crate::io::Cursor::new(section_bytes);
 
         let blob_file_count = match reader.read_u32::<LittleEndian>() {
             Ok(n) => n,
-            Err(e) if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            Err(e) if tolerate_tail && e.kind() == crate::io::ErrorKind::UnexpectedEof => {
                 log::warn!(
                     "blob_files section truncated before count header in version \
                      #{curr_version_id}; tail-tolerant mode produces 0 blob files"
@@ -1027,8 +1030,8 @@ pub fn recover(
                 // because the writer never produces a header above
                 // MAX_FRAME_PAYLOAD on its own.
                 FramedRecordOutcome::TailTruncation => {
-                    return Err(crate::Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
+                    return Err(crate::Error::from(crate::io::Error::new(
+                        crate::io::ErrorKind::UnexpectedEof,
                         "manifest blob_files record truncated mid-frame",
                     )));
                 }
@@ -1090,7 +1093,7 @@ pub fn recover(
             return Err(crate::Error::Unrecoverable);
         }
         let section_bytes = archive.read_section("blob_gc_stats")?;
-        let mut reader = std::io::Cursor::new(section_bytes);
+        let mut reader = crate::io::Cursor::new(section_bytes);
 
         // Same tail-tolerance contract as the record-list sections:
         // a power-loss between the `blob_files` commit and the
@@ -1103,7 +1106,7 @@ pub fn recover(
         match crate::blob_tree::FragmentationMap::decode_from(&mut reader) {
             Ok(m) => m,
             Err(crate::Error::Io(e))
-                if tolerate_tail && e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                if tolerate_tail && e.kind() == crate::io::ErrorKind::UnexpectedEof =>
             {
                 log::warn!(
                     "blob_gc_stats section truncated in version #{curr_version_id}; \
@@ -1181,8 +1184,8 @@ mod tests {
     use super::*;
     use crate::coding::Encode;
     use crate::fs::{FsOpenOptions, MemFs};
+    use crate::io::{LittleEndian, WriteBytesExt};
     use crate::version::edit::{AddedBlobFile, ChangedLevel, TableDesc, VersionEdit};
-    use byteorder::{LittleEndian, WriteBytesExt};
     use std::io::Write;
 
     /// A snapshot-state `Recovery` with the given level layout and no blobs /
@@ -1371,7 +1374,7 @@ mod tests {
         let archive = crate::manifest_blocks::reader::ManifestArchiveReader::open(
             &manifest_path,
             fs,
-            std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
+            alloc::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
             None,
         )?;
         let checksum =
@@ -1398,7 +1401,7 @@ mod tests {
         FixtureWriter::create(
             &path,
             fs,
-            std::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
+            alloc::sync::Arc::new(crate::runtime_config::RuntimeConfig::default()),
             None,
             crate::fs::SyncMode::Normal,
         )
@@ -1576,7 +1579,7 @@ mod tests {
         // acceptable strict-mode failures. The contract is: SOMETHING
         // surfaces, the open does not silently succeed with partial data.
         assert!(
-            matches!(&err, crate::Error::Io(e) if e.kind() == std::io::ErrorKind::UnexpectedEof)
+            matches!(&err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::UnexpectedEof)
                 || matches!(err, crate::Error::Unrecoverable),
             "expected UnexpectedEof or Unrecoverable, got: {err:?}",
         );

--- a/src/version/run.rs
+++ b/src/version/run.rs
@@ -4,7 +4,9 @@
 
 use crate::KeyRange;
 use crate::comparator::UserComparator;
-use std::ops::{Bound, RangeBounds};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::ops::{Bound, RangeBounds};
 
 pub trait Ranged {
     fn key_range(&self) -> &KeyRange;
@@ -42,7 +44,7 @@ impl<T: Ranged> Ranged for Indexed<T> {
     }
 }
 
-impl<T: Ranged> std::ops::Deref for Indexed<T> {
+impl<T: Ranged> core::ops::Deref for Indexed<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -54,7 +56,7 @@ impl<T: Ranged> std::ops::Deref for Indexed<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Run<T: Ranged>(Vec<T>);
 
-impl<T: Ranged> std::ops::Deref for Run<T> {
+impl<T: Ranged> core::ops::Deref for Run<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
@@ -161,12 +163,13 @@ impl<T: Ranged> Run<T> {
         key: &[u8],
         cmp: &dyn crate::comparator::UserComparator,
     ) -> Option<&T> {
-        let idx = self
-            .partition_point(|x| cmp.compare(x.key_range().max(), key) == std::cmp::Ordering::Less);
+        let idx = self.partition_point(|x| {
+            cmp.compare(x.key_range().max(), key) == core::cmp::Ordering::Less
+        });
 
         self.0
             .get(idx)
-            .filter(|x| cmp.compare(x.key_range().min(), key) != std::cmp::Ordering::Greater)
+            .filter(|x| cmp.compare(x.key_range().min(), key) != core::cmp::Ordering::Greater)
     }
 
     /// Returns the run's key range.
@@ -304,7 +307,7 @@ impl<T: Ranged> Run<T> {
         key_range: &R,
         cmp: &dyn UserComparator,
     ) -> Option<(usize, usize)> {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         let level = &self.0;
 
@@ -396,7 +399,7 @@ mod tests {
             "reverse"
         }
 
-        fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+        fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
             b.cmp(a)
         }
     }
@@ -572,7 +575,7 @@ mod tests {
             fn name(&self) -> &'static str {
                 "reverse"
             }
-            fn compare(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+            fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
                 b.cmp(a)
             }
         }

--- a/src/version/run.rs
+++ b/src/version/run.rs
@@ -5,7 +5,7 @@
 use crate::KeyRange;
 use crate::comparator::UserComparator;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::{Bound, RangeBounds};
 
 pub trait Ranged {

--- a/src/version/super_version.rs
+++ b/src/version/super_version.rs
@@ -16,13 +16,18 @@ use crate::{
 fn remove_if_present(fs: &dyn Fs, path: &Path) -> crate::Result<()> {
     match fs.remove_file(path) {
         Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e.into()),
     }
 }
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use arc_swap::ArcSwap;
-use std::{collections::VecDeque, path::Path, sync::Arc};
+
+use crate::path::Path;
 
 /// A super version is a point-in-time snapshot of memtables and a [`Version`] (list of disk files)
 #[derive(Clone)]
@@ -176,7 +181,7 @@ impl SuperVersions {
                     let path = folder.join(format!("v{evicted_id}"));
                     match fs.remove_file(&path) {
                         Ok(()) => {}
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => {}
                         Err(e) => return Err(e.into()),
                     }
                 }
@@ -232,8 +237,8 @@ impl SuperVersions {
         seqno: &SharedSequenceNumberGenerator,
         visible_seqno: &SharedSequenceNumberGenerator,
         fs: &dyn Fs,
-        runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
-        encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+        runtime: Arc<crate::runtime_config::RuntimeConfig>,
+        encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
     ) -> crate::Result<()> {
         self.upgrade_version_with_seqno(
             tree_path,
@@ -265,8 +270,8 @@ impl SuperVersions {
         seqno: SeqNo,
         visible_seqno: &SharedSequenceNumberGenerator,
         fs: &dyn Fs,
-        runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
-        encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+        runtime: Arc<crate::runtime_config::RuntimeConfig>,
+        encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
     ) -> crate::Result<()> {
         let prior = self.latest_version();
         let mut next_version = f(&prior)?;
@@ -309,8 +314,8 @@ impl SuperVersions {
         prior: &Version,
         next: &Version,
         fs: &dyn Fs,
-        runtime: std::sync::Arc<crate::runtime_config::RuntimeConfig>,
-        encryption: Option<std::sync::Arc<dyn crate::encryption::EncryptionProvider>>,
+        runtime: Arc<crate::runtime_config::RuntimeConfig>,
+        encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
     ) -> crate::Result<()> {
         let log_path = tree_path.join(format!("edits-{}", self.snapshot_id));
 

--- a/src/vlog/accessor.rs
+++ b/src/vlog/accessor.rs
@@ -2,12 +2,14 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::path::Path;
 use crate::{
     Cache, GlobalTableId, TreeId, UserValue,
     version::BlobFileList,
     vlog::{ValueHandle, blob_file::reader::Reader},
 };
-use std::path::Path;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 pub struct Accessor<'a> {
     blob_files: &'a BlobFileList,

--- a/src/vlog/blob_file/merge.rs
+++ b/src/vlog/blob_file/merge.rs
@@ -132,7 +132,7 @@ mod tests {
         }
 
         {
-            let mut merger = MergeScanner::new(vec![Scanner::new(&blob_file_path, 0)?]);
+            let mut merger = MergeScanner::new(vec![Scanner::new(&blob_file_path, &StdFs, 0)?]);
 
             assert_eq!(
                 (Slice::from(b"a"), Slice::from(b"1".repeat(100))),
@@ -192,8 +192,8 @@ mod tests {
 
         {
             let mut merger = MergeScanner::new(vec![
-                Scanner::new(&blob_file_0_path, 0)?,
-                Scanner::new(&blob_file_1_path, 1)?,
+                Scanner::new(&blob_file_0_path, &StdFs, 0)?,
+                Scanner::new(&blob_file_1_path, &StdFs, 1)?,
             ]);
 
             let merged_keys = [b"a", b"b", b"c", b"d", b"e"];

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -2,6 +2,9 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use crate::io::{LittleEndian, ReadBytesExt};
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
 use crate::{
     CompressionType, InternalValue, KeyRange, SeqNo, Slice,
     checksum::ChecksumType,
@@ -10,7 +13,7 @@ use crate::{
     table::{Block, DataBlock},
     vlog::BlobFileId,
 };
-use byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "std")]
 use std::io::{Read, Write};
 
 macro_rules! read_u64 {

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -9,15 +9,16 @@ pub mod reader;
 pub mod scanner;
 pub mod writer;
 
+use crate::path::{Path, PathBuf};
 use crate::{
     Checksum, GlobalTableId, TreeId, blob_tree::FragmentationMap, deletion_pause::DeletionPause,
     file_accessor::FileAccessor, fs::Fs, vlog::BlobFileId,
 };
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::sync::atomic::AtomicBool;
 pub use meta::Metadata;
-use std::{
-    path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
-};
 
 /// A blob file is an immutable, sorted, contiguous file that contains large key-value pairs (blobs)
 //
@@ -86,7 +87,7 @@ impl core::fmt::Debug for Inner {
             .field("path", &self.path)
             .field(
                 "is_deleted",
-                &self.is_deleted.load(std::sync::atomic::Ordering::Relaxed),
+                &self.is_deleted.load(core::sync::atomic::Ordering::Relaxed),
             )
             .field("meta", &self.meta)
             .finish_non_exhaustive()
@@ -95,7 +96,7 @@ impl core::fmt::Debug for Inner {
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        if self.is_deleted.load(std::sync::atomic::Ordering::Acquire) {
+        if self.is_deleted.load(core::sync::atomic::Ordering::Acquire) {
             log::trace!(
                 "Cleanup deleted blob file {:?} at {}",
                 self.id,
@@ -111,7 +112,7 @@ impl Drop for Inner {
             // table::Inner::drop. Eviction from the descriptor table
             // happens through the same accessor before the drop.
             let global_id = self.global_id();
-            let file_accessor = std::mem::replace(&mut self.file_accessor, FileAccessor::Closed);
+            let file_accessor = core::mem::replace(&mut self.file_accessor, FileAccessor::Closed);
             file_accessor
                 .as_descriptor_table()
                 .inspect(|d| d.remove_for_blob_file(&global_id));
@@ -185,8 +186,8 @@ impl PartialEq for BlobFile {
     }
 }
 
-impl std::hash::Hash for BlobFile {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for BlobFile {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.id().hash(state);
     }
 }
@@ -195,7 +196,7 @@ impl BlobFile {
     pub(crate) fn mark_as_deleted(&self) {
         self.0
             .is_deleted
-            .store(true, std::sync::atomic::Ordering::Release);
+            .store(true, core::sync::atomic::Ordering::Release);
     }
 
     /// Installs the tree-wide deletion pause used by checkpoints.

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -4,6 +4,7 @@
 
 use super::writer::Writer;
 use crate::fs::FsFile;
+use crate::path::{Path, PathBuf};
 use crate::{
     BlobFile, CompressionType, DescriptorTable, SeqNo, SequenceNumberCounter, TreeId,
     file_accessor::FileAccessor,
@@ -13,10 +14,14 @@ use crate::{
         blob_file::{Inner as BlobFileInner, Metadata},
     },
 };
-use std::{
-    path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
 };
+use core::sync::atomic::AtomicBool;
 
 /// Blob file writer, may write multiple blob files
 pub struct MultiWriter {
@@ -40,7 +45,7 @@ pub struct MultiWriter {
 
     /// Dictionary for `ZstdDict` compression, shared across all rotated writers.
     #[cfg(zstd_any)]
-    zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+    zstd_dictionary: Option<alloc::sync::Arc<crate::compression::ZstdDictionary>>,
 
     tree_id: TreeId,
     descriptor_table: Option<Arc<DescriptorTable>>,
@@ -130,7 +135,7 @@ impl MultiWriter {
     #[must_use]
     pub fn use_zstd_dictionary(
         mut self,
-        dict: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+        dict: Option<alloc::sync::Arc<crate::compression::ZstdDictionary>>,
     ) -> Self {
         self.active_writer = self.active_writer.use_zstd_dictionary(dict.clone());
         self.zstd_dictionary = dict;
@@ -153,7 +158,7 @@ impl MultiWriter {
             w
         };
 
-        let old_writer = std::mem::replace(&mut self.active_writer, new_writer);
+        let old_writer = core::mem::replace(&mut self.active_writer, new_writer);
         let blob_file = Self::consume_writer(
             old_writer,
             self.passthrough_compression,

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -16,11 +16,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::ToString, vec::Vec};
 use core::sync::atomic::AtomicBool;
 
 /// Blob file writer, may write multiple blob files

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -5,6 +5,9 @@
 #[cfg(zstd_any)]
 use crate::compression::CompressionProvider as _;
 
+#[cfg(not(feature = "std"))]
+use crate::io::{Cursor, Read};
+use crate::io::{LittleEndian, ReadBytesExt};
 use crate::{
     BlobFile, Checksum, CompressionType, UserValue,
     fs::FsFile,
@@ -15,7 +18,7 @@ use crate::{
         },
     },
 };
-use byteorder::{LittleEndian, ReadBytesExt};
+#[cfg(feature = "std")]
 use std::io::{Cursor, Read};
 
 /// Safety cap on blob value size (256 MiB).
@@ -425,7 +428,7 @@ mod tests {
     #[test]
     #[cfg(feature = "lz4")]
     fn blob_reader_lz4_corrupted_real_val_len_triggers_header_crc_mismatch() -> crate::Result<()> {
-        use byteorder::WriteBytesExt;
+        use crate::io::WriteBytesExt;
 
         let id_generator = SequenceNumberCounter::default();
 
@@ -503,7 +506,7 @@ mod tests {
     #[test]
     #[cfg(zstd_any)]
     fn blob_reader_zstd_corrupted_real_val_len_triggers_header_crc_mismatch() -> crate::Result<()> {
-        use byteorder::WriteBytesExt;
+        use crate::io::WriteBytesExt;
 
         let id_generator = SequenceNumberCounter::default();
 
@@ -965,8 +968,8 @@ mod tests {
     #[test]
     fn blob_reader_v3_backward_compat_roundtrip() -> crate::Result<()> {
         use crate::file_accessor::FileAccessor;
+        use crate::io::WriteBytesExt;
         use crate::vlog::{ValueHandle, blob_file::Inner as BlobFileInner};
-        use byteorder::WriteBytesExt;
         use std::io::Write;
         use std::sync::{Arc, atomic::AtomicBool};
 
@@ -992,23 +995,23 @@ mod tests {
 
             // V3 frame: BLOB magic, no header_crc
             sfa_writer.write_all(b"BLOB")?;
-            sfa_writer.write_u128::<byteorder::LittleEndian>(checksum)?;
-            sfa_writer.write_u64::<byteorder::LittleEndian>(42)?; // seqno
+            sfa_writer.write_u128::<crate::io::LittleEndian>(checksum)?;
+            sfa_writer.write_u64::<crate::io::LittleEndian>(42)?; // seqno
             #[expect(
                 clippy::cast_possible_truncation,
                 reason = "test key length fits in u16"
             )]
-            sfa_writer.write_u16::<byteorder::LittleEndian>(key.len() as u16)?;
+            sfa_writer.write_u16::<crate::io::LittleEndian>(key.len() as u16)?;
             #[expect(
                 clippy::cast_possible_truncation,
                 reason = "test value length fits in u32"
             )]
-            sfa_writer.write_u32::<byteorder::LittleEndian>(value.len() as u32)?;
+            sfa_writer.write_u32::<crate::io::LittleEndian>(value.len() as u32)?;
             #[expect(
                 clippy::cast_possible_truncation,
                 reason = "test value length fits in u32"
             )]
-            sfa_writer.write_u32::<byteorder::LittleEndian>(value.len() as u32)?;
+            sfa_writer.write_u32::<crate::io::LittleEndian>(value.len() as u32)?;
             sfa_writer.write_all(key)?;
             sfa_writer.write_all(value)?;
 

--- a/src/vlog/blob_file/scanner.rs
+++ b/src/vlog/blob_file/scanner.rs
@@ -5,13 +5,17 @@
 // Format constants live in writer (the format definition site).
 // Extracting to a shared module is an upstream structural decision.
 use super::writer::{BLOB_HEADER_MAGIC_V3, BLOB_HEADER_MAGIC_V4, validate_header_crc};
+use crate::fs::{Fs, FsFile, FsOpenOptions};
+use crate::io::BufReader;
+use crate::io::{LittleEndian, ReadBytesExt};
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Seek, SeekFrom};
+use crate::path::Path;
 use crate::{Checksum, SeqNo, UserKey, UserValue, vlog::BlobFileId};
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::{
-    fs::File,
-    io::{BufReader, Read, Seek},
-    path::Path,
-};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(feature = "std")]
+use std::io::{Read, Seek, SeekFrom};
 
 /// Reads through a blob file in order.
 ///
@@ -22,7 +26,7 @@ use std::{
 /// magic (`META`).
 pub struct Scanner {
     pub(crate) blob_file_id: BlobFileId, // TODO: remove unused?
-    inner: BufReader<File>,
+    inner: BufReader<Box<dyn FsFile>>,
     is_terminated: bool,
 
     /// Byte offset where the "data" section ends (from the SFA TOC).
@@ -40,10 +44,14 @@ impl Scanner {
     ///
     /// Will return `Err` if an IO error occurs or the blob file lacks
     /// a "data" section.
-    pub fn new<P: AsRef<Path>>(path: P, blob_file_id: BlobFileId) -> crate::Result<Self> {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        fs: &dyn Fs,
+        blob_file_id: BlobFileId,
+    ) -> crate::Result<Self> {
         let path = path.as_ref();
 
-        let mut file = File::open(path)?;
+        let mut file = fs.open(path, &FsOpenOptions::new().read(true))?;
         let sfa_reader = crate::sfa::Reader::from_reader(&mut file)?;
         let data_section = sfa_reader.toc().section(b"data").ok_or_else(|| {
             log::error!("BlobFile: SFA TOC has no \"data\" section");
@@ -58,7 +66,7 @@ impl Scanner {
             crate::Error::InvalidHeader("BlobFile")
         })?;
 
-        file.seek(std::io::SeekFrom::Start(data_start))?;
+        file.seek(SeekFrom::Start(data_start))?;
         let file_reader = BufReader::with_capacity(32_000, file);
 
         Ok(Self {
@@ -223,7 +231,7 @@ mod tests {
         }
 
         {
-            let mut scanner = Scanner::new(&blob_file_path, 0)?;
+            let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
 
             for key in keys {
                 assert_eq!(
@@ -268,7 +276,7 @@ mod tests {
             .copy_from_slice(&99u64.to_le_bytes()[..seqno_len]);
         std::fs::write(&blob_file_path, &raw)?;
 
-        let mut scanner = Scanner::new(&blob_file_path, 0)?;
+        let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
         let result = scanner.next().unwrap();
         assert!(
             matches!(result, Err(crate::Error::HeaderCrcMismatch { .. })),
@@ -304,7 +312,7 @@ mod tests {
         raw[value_offset] ^= 0xFF;
         std::fs::write(&blob_file_path, &raw)?;
 
-        let mut scanner = Scanner::new(&blob_file_path, 0)?;
+        let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
         let result = scanner.next().unwrap();
         assert!(
             matches!(result, Err(crate::Error::ChecksumMismatch { .. })),
@@ -318,7 +326,7 @@ mod tests {
     /// then verify the scanner can read it with V3 backward compat path.
     #[test]
     fn blob_scanner_reads_v3_format() -> crate::Result<()> {
-        use byteorder::{LittleEndian, WriteBytesExt};
+        use crate::io::{LittleEndian, WriteBytesExt};
         use std::io::Write;
 
         let dir = tempdir()?;
@@ -381,7 +389,7 @@ mod tests {
         }
 
         // Scanner should read the V3 frame successfully
-        let mut scanner = Scanner::new(&blob_file_path, 0)?;
+        let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
         let entry = scanner.next().unwrap()?;
         assert_eq!(entry.key, Slice::from(&key[..]));
         assert_eq!(entry.value, Slice::from(&value[..]));
@@ -409,7 +417,7 @@ mod tests {
         raw[0..4].copy_from_slice(b"XXXX");
         std::fs::write(&blob_file_path, &raw)?;
 
-        let mut scanner = Scanner::new(&blob_file_path, 0)?;
+        let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
         let result = scanner.next().unwrap();
         assert!(
             matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
@@ -467,7 +475,7 @@ mod tests {
             .copy_from_slice(b"META");
         std::fs::write(&blob_file_path, &raw)?;
 
-        let mut scanner = Scanner::new(&blob_file_path, 0)?;
+        let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
 
         // First frame should still be readable (it's intact).
         let first = scanner.next().unwrap();
@@ -501,7 +509,7 @@ mod tests {
             sfa_writer.finish()?;
         }
 
-        let result = Scanner::new(&blob_file_path, 0);
+        let result = Scanner::new(&blob_file_path, &StdFs, 0);
         assert!(result.is_err(), "expected error for missing data section");
         let err = result.err().unwrap();
         assert!(
@@ -516,7 +524,7 @@ mod tests {
     /// section whose pos + len overflows u64.
     #[test]
     fn blob_scanner_rejects_data_section_offset_overflow() -> crate::Result<()> {
-        use byteorder::{LittleEndian, WriteBytesExt};
+        use crate::io::{LittleEndian, WriteBytesExt};
         use std::io::Write;
 
         let dir = tempdir()?;
@@ -568,7 +576,7 @@ mod tests {
             file.sync_all()?;
         }
 
-        let result = Scanner::new(&blob_file_path, 0);
+        let result = Scanner::new(&blob_file_path, &StdFs, 0);
         assert!(
             result.is_err(),
             "expected error for overflowing data section"

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -4,8 +4,15 @@
 
 #[cfg(zstd_any)]
 use crate::compression::CompressionProvider as _;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 use super::meta::Metadata;
+use crate::io::BufWriter;
+#[cfg(not(feature = "std"))]
+use crate::io::Write;
+use crate::io::{LittleEndian, WriteBytesExt};
+use crate::path::{Path, PathBuf};
 use crate::{
     Checksum, CompressionType, KeyRange, SeqNo, TreeId, UserKey,
     checksum::ChecksummedWriter,
@@ -13,11 +20,8 @@ use crate::{
     time::unix_timestamp,
     vlog::BlobFileId,
 };
-use byteorder::{LittleEndian, WriteBytesExt};
-use std::{
-    io::{BufWriter, Write},
-    path::{Path, PathBuf},
-};
+#[cfg(feature = "std")]
+use std::io::Write;
 
 /// Safety cap on blob value size (256 MiB).
 ///
@@ -51,14 +55,14 @@ pub const BLOB_HEADER_MAGIC_V4: &[u8] = b"BLO4";
 
 /// V3 blob frame header length (38 bytes, no `header_crc`).
 pub const BLOB_HEADER_LEN_V3: usize = BLOB_HEADER_MAGIC_V3.len()
-    + std::mem::size_of::<u128>() // Checksum
-    + std::mem::size_of::<u64>() // SeqNo
-    + std::mem::size_of::<u16>() // Key length
-    + std::mem::size_of::<u32>() // Real value length
-    + std::mem::size_of::<u32>(); // On-disk value length
+    + core::mem::size_of::<u128>() // Checksum
+    + core::mem::size_of::<u64>() // SeqNo
+    + core::mem::size_of::<u16>() // Key length
+    + core::mem::size_of::<u32>() // Real value length
+    + core::mem::size_of::<u32>(); // On-disk value length
 
 /// V4 blob frame header length (42 bytes, includes `header_crc`).
-pub const BLOB_HEADER_LEN_V4: usize = BLOB_HEADER_LEN_V3 + std::mem::size_of::<u32>(); // Header CRC
+pub const BLOB_HEADER_LEN_V4: usize = BLOB_HEADER_LEN_V3 + core::mem::size_of::<u32>(); // Header CRC
 
 /// Compute V4 header CRC from header fields.
 /// Returns a 4-byte truncated xxh3 hash.
@@ -129,7 +133,7 @@ pub struct Writer {
     /// Dictionary for `ZstdDict` compression.  Must be supplied when
     /// `compression` is [`CompressionType::ZstdDict`].
     #[cfg(zstd_any)]
-    pub(crate) zstd_dictionary: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+    pub(crate) zstd_dictionary: Option<alloc::sync::Arc<crate::compression::ZstdDictionary>>,
 }
 
 impl Writer {
@@ -200,7 +204,7 @@ impl Writer {
     #[must_use]
     pub fn use_zstd_dictionary(
         mut self,
-        dict: Option<std::sync::Arc<crate::compression::ZstdDictionary>>,
+        dict: Option<alloc::sync::Arc<crate::compression::ZstdDictionary>>,
     ) -> Self {
         self.zstd_dictionary = dict;
         self
@@ -238,20 +242,20 @@ impl Writer {
         // the cap applies uniformly to all blob data regardless of
         // compression state).
         let value = match &self.compression {
-            CompressionType::None => std::borrow::Cow::Borrowed(value),
+            CompressionType::None => alloc::borrow::Cow::Borrowed(value),
 
             #[cfg(feature = "lz4")]
             CompressionType::Lz4 => {
                 let compressed = lz4_flex::compress(value);
                 check_size_cap(compressed.len())?;
-                std::borrow::Cow::Owned(compressed)
+                alloc::borrow::Cow::Owned(compressed)
             }
 
             #[cfg(zstd_any)]
             CompressionType::Zstd(level) => {
                 let compressed = crate::compression::ZstdBackend::compress(value, *level)?;
                 check_size_cap(compressed.len())?;
-                std::borrow::Cow::Owned(compressed)
+                alloc::borrow::Cow::Owned(compressed)
             }
 
             #[cfg(zstd_any)]
@@ -272,7 +276,7 @@ impl Writer {
                 let compressed =
                     crate::compression::ZstdBackend::compress_with_dict(value, *level, dict.raw())?;
                 check_size_cap(compressed.len())?;
-                std::borrow::Cow::Owned(compressed)
+                alloc::borrow::Cow::Owned(compressed)
             }
         };
 
@@ -280,7 +284,7 @@ impl Writer {
         // to disk as a 32-bit length. This prevents truncation if compression
         // expands the payload (possible for incompressible data near u32 boundary).
         let compressed_len_u32 = u32::try_from(value.len())
-            .map_err(|_| std::io::Error::other("compressed value length exceeds u32::MAX"))?;
+            .map_err(|_| crate::io::Error::other("compressed value length exceeds u32::MAX"))?;
 
         if self.first_key.is_none() {
             self.first_key = Some(key.into());
@@ -535,7 +539,7 @@ mod tests {
         };
         let mut writer = Writer::new(&path, 0, 0, &StdFs)?
             .use_compression(compression)
-            .use_zstd_dictionary(Some(std::sync::Arc::new(dict)));
+            .use_zstd_dictionary(Some(alloc::sync::Arc::new(dict)));
 
         let result = writer.write(b"key", 0, b"hello world blob value");
         assert!(

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -5,7 +5,7 @@
 #[cfg(zstd_any)]
 use crate::compression::CompressionProvider as _;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::boxed::Box;
 
 use super::meta::Metadata;
 use crate::io::BufWriter;

--- a/src/vlog/handle.rs
+++ b/src/vlog/handle.rs
@@ -2,14 +2,18 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(not(feature = "std"))]
+use crate::io::{Read, Write};
+#[cfg(not(feature = "std"))]
+use crate::io::{VarintReader, VarintWriter};
 use crate::{
     coding::{Decode, Encode},
     vlog::BlobFileId,
 };
-use std::{
-    hash::Hash,
-    io::{Read, Write},
-};
+use core::hash::Hash;
+#[cfg(feature = "std")]
+use std::io::{Read, Write};
+#[cfg(feature = "std")]
 use varint_rs::{VarintReader, VarintWriter};
 
 /// A value handle points into the value log

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -13,16 +13,17 @@ pub use {
     blob_file::scanner::Scanner as BlobFileScanner, handle::ValueHandle,
 };
 
+use crate::path::{Path, PathBuf};
 use crate::{
     Checksum, DescriptorTable, TreeId,
     file_accessor::FileAccessor,
     fs::Fs,
     vlog::blob_file::{Inner as BlobFileInner, Metadata},
 };
-use std::{
-    path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
-};
+use alloc::sync::Arc;
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::sync::atomic::AtomicBool;
 
 pub fn recover_blob_files(
     folder: &Path,
@@ -37,7 +38,7 @@ pub fn recover_blob_files(
     // is missing, that is unrecoverable corruption — fail fast.
     let entries = match fs.read_dir(folder) {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => {
             if ids.is_empty() {
                 return Ok((vec![], vec![]));
             }

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::sync::atomic::AtomicBool;
 
 pub fn recover_blob_files(

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -20,6 +20,8 @@
 //! fjall's keyspace for single-writer batches.
 
 use crate::{UserKey, UserValue, ValueType, value::InternalValue};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 /// A single entry in a [`WriteBatch`].
 #[derive(Clone, Debug)]
@@ -151,8 +153,8 @@ impl WriteBatch {
         // ties on `(user_key, seqno)` without `value_type` as tie-breaker,
         // making the read/compaction outcome ambiguous.
         {
-            let mut seen: std::collections::HashMap<&[u8], ValueType, rustc_hash::FxBuildHasher> =
-                std::collections::HashMap::with_capacity_and_hasher(
+            let mut seen: crate::HashMap<&[u8], ValueType> =
+                crate::HashMap::with_capacity_and_hasher(
                     self.entries.len(),
                     rustc_hash::FxBuildHasher,
                 );

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -21,7 +21,7 @@
 
 use crate::{UserKey, UserValue, ValueType, value::InternalValue};
 #[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::vec::Vec;
 
 /// A single entry in a [`WriteBatch`].
 #[derive(Clone, Debug)]

--- a/tests/checkpoint_pitr.rs
+++ b/tests/checkpoint_pitr.rs
@@ -570,7 +570,8 @@ fn second_checkpoint_into_same_target_rejected() -> lsm_tree::Result<()> {
     // surface `Io(NotFound | AlreadyExists)`-class refusal so callers
     // can detect double-target programmatically.
     match err {
-        lsm_tree::Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::AlreadyExists => {}
+        lsm_tree::Error::Io(ref io_err)
+            if io_err.kind() == lsm_tree::io::ErrorKind::AlreadyExists => {}
         other => panic!("expected Io(AlreadyExists) on second checkpoint, got {other:?}"),
     }
     Ok(())
@@ -608,7 +609,7 @@ fn checkpoint_failure_leaves_source_intact() -> lsm_tree::Result<()> {
         matches!(
             &err,
             lsm_tree::Error::Io(io_err)
-                if io_err.kind() == std::io::ErrorKind::AlreadyExists,
+                if io_err.kind() == lsm_tree::io::ErrorKind::AlreadyExists,
         ),
         "expected Io(AlreadyExists) on early reject, got {err:?}",
     );
@@ -742,7 +743,9 @@ fn checkpoint_open_rejects_missing_current_pointer() -> lsm_tree::Result<()> {
         Err(e) => e,
     };
     match err {
-        lsm_tree::Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::InvalidData => {
+        lsm_tree::Error::Io(ref io_err)
+            if io_err.kind() == lsm_tree::io::ErrorKind::InvalidData =>
+        {
             let msg = io_err.to_string();
             assert!(
                 msg.contains("current") && msg.contains("version artifacts"),

--- a/tests/custom_comparator.rs
+++ b/tests/custom_comparator.rs
@@ -419,7 +419,7 @@ fn oversized_comparator_name_rejected_on_create() {
 
     match result {
         Err(lsm_tree::Error::Io(e)) => {
-            assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            assert_eq!(e.kind(), lsm_tree::io::ErrorKind::InvalidInput);
         }
         Ok(_) => panic!("expected InvalidInput error for oversized comparator name"),
         Err(e) => panic!("expected InvalidInput Io error, got {e:?}"),

--- a/tests/tree_non_utf8.rs
+++ b/tests/tree_non_utf8.rs
@@ -69,7 +69,7 @@ fn tree_reopen_rejects_non_utf8_filename_in_data_dir() -> lsm_tree::Result<()> {
         lsm_tree::Error::Io(ref io_err) => {
             assert_eq!(
                 io_err.kind(),
-                std::io::ErrorKind::InvalidData,
+                lsm_tree::io::ErrorKind::InvalidData,
                 "expected InvalidData, got: {err:?}"
             );
         }

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -582,7 +582,9 @@ fn run_dump(
         // value byte count.
         Ok(it) if keys_only => it.keys_only(),
         Ok(it) => it,
-        Err(lsm_tree::Error::Io(io_err)) if io_err.kind() == std::io::ErrorKind::Unsupported => {
+        Err(lsm_tree::Error::Io(io_err))
+            if io_err.kind() == lsm_tree::io::ErrorKind::Unsupported =>
+        {
             // Partitioned-index SSTs surface here. Same pattern as
             // `filter-stats` for partitioned filters: print a
             // user-facing "not supported" message that names the


### PR DESCRIPTION
## Summary

Makes the **entire crate** compile on `thumbv7em-none-eabihf --no-default-features --features alloc` with **zero errors**. The core LSM path is fully no_std; the std::fs-bound diagnostic / maintenance tools are gated behind `std`.

## What changed

**Core path → core/alloc/crate mirrors**
- `cmp`/`mem`/`ops`/`hash`/`fmt` → `core`; `Arc`/`Vec`/`VecDeque`/`Cow` → `alloc`; `path` → `crate::path`; `io::{Read,Write,Seek,Error,Cursor,BufReader,BufWriter}` → `crate::io` (gated-import where concrete writers call the trait methods).

**Dual-backend (std hot path unchanged)**
- Tree-level locks + `RuntimeConfigHandle`: `parking_lot` / `arc-swap` under std, `spin` / `spin::RwLock` under no_std. `AtomicU64` via `portable-atomic`. Guard return types centralized as aliases so `AbstractTree` and its impls share one signature per build.

**io plumbing**
- Blanket `Read`/`Write`/`Seek`/`BufRead` impls for `&mut R` / `Box<R>` so `Box<dyn FsFile>` satisfies the io traits the way std's blankets do.
- Crate-local LEB128 `VarintReader`/`VarintWriter` for no_std (byte-identical to `varint-rs`, which only blankets `std::io`). Call sites swap only the import path.

**Fs-routed file access** — blob-file `Scanner` opens via `fs.open`; `sfa::Reader`'s wire codec is un-gated (only its path constructor stays std-only).

**Float / time / path primitives**
- `crate::time::Instant` shim (std re-export / no_std ZST). `libm`-backed f32/f64 `ceil`/`round`/`log2` for targets without float intrinsics.
- no_std `Path`/`PathBuf` gain `Ord`/`Hash`/`Borrow`/`PartialEq` + `as_os_str`, so the in-memory `MemFs` backend compiles unchanged.

**std-only surface gated behind `std`**
- The std::fs-bound diagnostic / maintenance tools: `verify` (bit-rot scrub), `repair` (last-resort manifest rebuild), `checkpoint` (PITR backup), `inspect` (forensic dump). These need real filesystem syscalls (dir-walk, hard-link, `std::path::absolute`) with no `Fs`-trait equivalent yet.
- `Config::default` / `Config::new` (StdFs default), `BackgroundDeleter`, thread-pool defaults, `RateLimiter::request_interruptible` (no_std gets a non-throttling, stop-aware variant).

> The **normal crash-recovery-on-open** path (`version::recovery` — manifest / version replay) is no_std-capable. What no_std loses is the manual disaster-recovery (`repair`) and PITR (`checkpoint`) tooling, not the everyday open-after-crash path.

## Testing

- `cargo check --all-features` — green
- `cargo clippy --all-features` — clean
- `cargo nextest run --all-features` — **2060 passed**, 2 skipped
- `cargo test --doc --all-features` — **49 passed**
- `cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc` — **0 errors**

Part of #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved portability: broad no-std + alloc support across the library while preserving std behavior
  * Unified I/O, error, and formatting surfaces for consistent behavior across targets
  * Pluggable filesystem and synchronization backends for more deployment flexibility

* **Build & Infrastructure**
  * Adjusted dependency wiring to support both std and no-std builds and internal I/O helpers
  * Optional compression dependency version bumped; test/dev dependency adjustments for integration tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->