### PR TITLE
refactor(filter): remove dead from-keys BuildHasher path from vendored ribbon

### DIFF
--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -226,7 +226,9 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy (strict)
         if: needs.changes.outputs.code != 'false'
-        run: cargo clippy --all-features -- -D warnings
+        # `--all-targets` lints tests + benches too, not just the lib; without
+        # it, test-harness code under `--all-features` is never clippy-checked.
+        run: cargo clippy --all-features --all-targets -- -D warnings
 
   test:
     needs: [changes, lint]

--- a/benches/bloom.rs
+++ b/benches/bloom.rs
@@ -20,11 +20,7 @@ use lsm_tree::table::filter::ribbon::burr::{
     BurrBuilder, BurrFilter, BurrFilterReader, BurrParams,
 };
 use rand::RngExt;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::BuildHasherDefault;
 use std::time::{Duration, Instant};
-
-type Hasher = BuildHasherDefault<DefaultHasher>;
 
 /// Cap on retained per-iteration duration samples. Criterion can pick
 /// very large `iters` counts for fast probe benches (millions); keeping
@@ -162,8 +158,8 @@ fn burr_filter_construction(c: &mut Criterion) {
 
             b.iter(|| {
                 let params = BurrParams::with_fp_rate(n, 0.01).expect("params");
-                let builder = BurrBuilder::new(params, Hasher::default()).expect("builder");
-                let filter: BurrFilter<Hasher> = builder.build_from_hashes(&keys).expect("build");
+                let builder = BurrBuilder::new(params).expect("builder");
+                let filter: BurrFilter = builder.build_from_hashes(&keys).expect("build");
                 std::hint::black_box(filter.layer_count());
             });
         });
@@ -187,7 +183,7 @@ fn burr_filter_contains(c: &mut Criterion) {
         }
 
         let params = BurrParams::with_fp_rate(n, fpr).expect("params");
-        let builder = BurrBuilder::new(params, Hasher::default()).expect("builder");
+        let builder = BurrBuilder::new(params).expect("builder");
         let filter = builder.build_from_hashes(&padded).expect("build");
         let filter_bytes = filter.to_wire_bytes();
 
@@ -246,74 +242,10 @@ fn burr_filter_contains(c: &mut Criterion) {
     }
 }
 
-/// Standard (single-layer) Ribbon contains_in bench — apples-to-apples
-/// against BuRR's contains_hash so the BuRR multi-layer overhead vs
-/// pure Ribbon stays visible.
-fn ribbon_filter_contains(c: &mut Criterion) {
-    use lsm_tree::table::filter::ribbon::{Mode, Params, RibbonBuilder};
-
-    let keys: Vec<u64> = (0..100_000_u64).collect();
-
-    for fpr in [0.01_f32, 0.001, 0.0001] {
-        let n = 1_000_000_usize;
-        // r = ceil(-log2(fpr)) — matches what BuRR picks internally.
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "r is derived from bounded FPR inputs for this benchmark"
-        )]
-        #[expect(
-            clippy::cast_sign_loss,
-            reason = "(-log2(fpr)).ceil() is non-negative for fpr in (0, 1)"
-        )]
-        let r = (-fpr.log2()).ceil() as usize;
-        let params = Params::new(n, 64, r, Mode::Standard)
-            .expect("ribbon params")
-            .with_seed(0);
-        let builder = RibbonBuilder::new(params, Hasher::default()).expect("builder");
-        // Pad the key set to n with random fillers so the Ribbon load
-        // factor matches the BuRR bench above. Without padding the
-        // Ribbon body would be ~10% loaded vs BuRR's ~70-90%, skewing
-        // probe-latency conclusions.
-        let mut rng = rand::rng();
-        let mut padded = keys.clone();
-        while padded.len() < n {
-            padded.push(rng.random::<u64>());
-        }
-        let filter = builder.build(&padded).expect("build");
-        let mut scratch = filter.new_scratch();
-
-        // Precompute the probe order outside the timed body. Round-
-        // robin over the key universe — same rationale as the BuRR
-        // probe benches above (keep RNG cost out of the percentile
-        // measurement). Borrow `keys` directly — no clone needed,
-        // it's not mutated.
-        let probe_keys: &[u64] = &keys;
-        let mut probe_idx = 0_usize;
-
-        let label = format!(
-            "standard ribbon contains, true positive (FPR={}%)",
-            fpr * 100.0
-        );
-        c.bench_function(&label, |b| {
-            b.iter_custom(|iters| {
-                measure_with_percentiles(&label, iters, || {
-                    let sample = probe_keys[probe_idx];
-                    probe_idx += 1;
-                    if probe_idx == probe_keys.len() {
-                        probe_idx = 0;
-                    }
-                    assert!(filter.contains_in(&sample, &mut scratch));
-                })
-            });
-        });
-    }
-}
-
 criterion_group!(
     benches,
     fast_block_index,
     burr_filter_construction,
     burr_filter_contains,
-    ribbon_filter_contains,
 );
 criterion_main!(benches);

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -174,9 +174,12 @@ mod tests {
             let table = binding.version.iter_tables().next().expect("one table");
             #[expect(clippy::expect_used, reason = "table has at least one data block")]
             let keyed = table.block_index.iter().next().expect("a data block")?;
-            #[expect(
+            // Target-conditional truncation: `as usize` only narrows on 32-bit
+            // pointer widths, so `allow` (not `expect`) keeps it clean on the
+            // 64-bit host where clippy frames it as a portability note.
+            #[allow(
                 clippy::cast_possible_truncation,
-                reason = "an in-file block offset fits usize on the 64-bit test host"
+                reason = "in-file block offset fits usize; only narrows on 32-bit targets"
             )]
             let off = keyed.offset().0 as usize;
             ((*table.path).clone(), off + Header::MIN_LEN + 3)
@@ -313,9 +316,12 @@ mod tests {
             let table = binding.version.iter_tables().next().expect("one table");
             #[expect(clippy::expect_used, reason = "table has at least one data block")]
             let keyed = table.block_index.iter().next().expect("a data block")?;
-            #[expect(
+            // Target-conditional truncation: `as usize` only narrows on 32-bit
+            // pointer widths, so `allow` (not `expect`) keeps it clean on the
+            // 64-bit host where clippy frames it as a portability note.
+            #[allow(
                 clippy::cast_possible_truncation,
-                reason = "an in-file block offset fits usize on the 64-bit test host"
+                reason = "in-file block offset fits usize; only narrows on 32-bit targets"
             )]
             let off = keyed.offset().0 as usize;
             ((*table.path).clone(), off + Header::MIN_LEN + 8)

--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -169,19 +169,27 @@ mod tests {
             }
             tree.flush_active_memtable(2_000)?;
 
-            let versions = tree.version_history.read();
-            let binding = versions.latest_version();
+            let binding = tree.version_history.read().latest_version();
             #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
             let table = binding.version.iter_tables().next().expect("one table");
             #[expect(clippy::expect_used, reason = "table has at least one data block")]
             let keyed = table.block_index.iter().next().expect("a data block")?;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "an in-file block offset fits usize on the 64-bit test host"
+            )]
             let off = keyed.offset().0 as usize;
             ((*table.path).clone(), off + Header::MIN_LEN + 3)
         };
 
         // Flip one payload byte of the first data block (RS-correctable).
         let mut bytes = std::fs::read(&sst_path)?;
-        bytes[corrupt_pos] ^= 0x80;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "corrupt_pos is an in-file block offset, in range for the SST bytes"
+        )]
+        let slot = &mut bytes[corrupt_pos];
+        *slot ^= 0x80;
         std::fs::write(&sst_path, &bytes)?;
 
         // Reopen (fresh caches + fds) so the read hits the tampered bytes.
@@ -300,19 +308,27 @@ mod tests {
             }
             tree.flush_active_memtable(0)?;
 
-            let versions = tree.version_history.read();
-            let binding = versions.latest_version();
+            let binding = tree.version_history.read().latest_version();
             #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
             let table = binding.version.iter_tables().next().expect("one table");
             #[expect(clippy::expect_used, reason = "table has at least one data block")]
             let keyed = table.block_index.iter().next().expect("a data block")?;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "an in-file block offset fits usize on the 64-bit test host"
+            )]
             let off = keyed.offset().0 as usize;
             ((*table.path).clone(), off + Header::MIN_LEN + 8)
         };
 
         // Flip one byte of the first block's compressed frame (RS-correctable).
         let mut bytes = std::fs::read(&sst_path)?;
-        bytes[corrupt_pos] ^= 0x01;
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "corrupt_pos is an in-file block offset, in range for the SST bytes"
+        )]
+        let slot = &mut bytes[corrupt_pos];
+        *slot ^= 0x01;
         std::fs::write(&sst_path, &bytes)?;
 
         // Reopen (fresh caches/fds), opt into healing, then run a bounded range

--- a/src/encryption/block.rs
+++ b/src/encryption/block.rs
@@ -922,6 +922,10 @@ mod tests {
             sealed.len() > cut,
             "test setup: sealed block must extend past the body header",
         );
+        #[expect(
+            clippy::expect_used,
+            reason = "test asserts the truncated frame is rejected"
+        )]
         let err = parse_encrypted_block_metadata(&sealed[..cut])
             .expect_err("truncated body must be rejected");
         assert!(

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -788,13 +788,22 @@ impl Drop for RingThread {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::expect_used,
+        reason = "test assertions over known-good fixtures; failure surfaces via panic"
+    )]
+    #![expect(
+        clippy::indexing_slicing,
+        reason = "test code indexes fixture buffers with known sizes"
+    )]
+
     use super::*;
     use std::io::{Read, Write};
     use std::sync::Arc;
     // Shadows #[test] to enable log capture in test output.
     use test_log::test;
 
-    /// Returns an `IoUringFs`, skipping only if the kernel lacks io_uring.
+    /// Returns an `IoUringFs`, skipping only if the kernel lacks `io_uring`.
     /// Constructor bugs (e.g. broken `RingThread::spawn`) will panic the
     /// test instead of silently skipping.
     fn try_io_uring() -> Option<IoUringFs> {
@@ -1063,7 +1072,7 @@ mod tests {
         let mut file = fs.open(&path, &opts)?;
         // Write 1000 bytes: each byte = (offset % 256)
         #[expect(clippy::cast_possible_truncation, reason = "% 256 guarantees 0..=255")]
-        let data: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
+        let data: Vec<u8> = (0u32..1000).map(|i| (i % 256) as u8).collect();
         file.write_all(&data)?;
         file.sync_all()?;
 
@@ -1088,7 +1097,7 @@ mod tests {
         for h in handles {
             match h.join() {
                 Ok(result) => result?,
-                Err(_) => return Err(io::Error::new(io::ErrorKind::Other, "thread panicked")),
+                Err(_) => return Err(io::Error::other("thread panicked")),
             }
         }
 

--- a/src/table/filter/mod.rs
+++ b/src/table/filter/mod.rs
@@ -7,22 +7,7 @@ pub mod ribbon;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::BuildHasherDefault;
 use ribbon::burr::{BurrBuilder, BurrParams};
-use rustc_hash::FxHasher;
-
-/// Hasher type embedded in `BuRR` filters. Only its type identity is used —
-/// the construction + probe paths in this crate go through
-/// `BurrBuilder::build_from_hashes` / `BurrFilter::contains_hash` /
-/// `BurrFilterReader::contains_hash`, all of which take pre-computed u64
-/// hashes (xxh3 via `crate::hash::hash64`) and never invoke the
-/// `BuildHasher`. The type slot exists only to satisfy the vendored
-/// ribbon-filter's generic `S: BuildHasher` bound; the concrete hasher is
-/// never constructed or called, so the choice has no on-disk or runtime
-/// effect. `FxHasher` (a no_std-capable hasher already in the dependency
-/// tree) replaces the std-only `DefaultHasher` purely to keep this module
-/// off `std`.
-type FilterHasher = BuildHasherDefault<FxHasher>;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BloomConstructionPolicy {
@@ -111,8 +96,7 @@ pub(crate) fn build_burr_filter_bytes(
     let Some(params) = policy.burr_params(hashes.len()) else {
         return Ok(Vec::new());
     };
-    let build_hasher = FilterHasher::default();
-    let builder = BurrBuilder::new(params, build_hasher).map_err(|e| {
+    let builder = BurrBuilder::new(params).map_err(|e| {
         log::error!("BuRR builder init failed: {e:?}");
         crate::Error::Unrecoverable
     })?;

--- a/src/table/filter/ribbon/builder.rs
+++ b/src/table/filter/ribbon/builder.rs
@@ -1,99 +1,41 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::BuildHasher;
 
 use super::error::{BuildError, ConstructionFailure};
 use super::filter::RibbonFilter;
 use super::hashing::{
-    SplitMix64, StandardEquation, derive_attempt_seed, for_each_set_bit_u128_parts,
-    standard_equation_from_hash, standard_equation_w64, xor_words,
+    SplitMix64, StandardEquation, for_each_set_bit_u128_parts, standard_equation_from_hash,
+    xor_words,
 };
 use super::params::{Mode, Params};
 
 #[derive(Debug, Clone)]
-pub struct Scratch {
-    pub(crate) fingerprint: Vec<u64>,
-    pub(crate) acc: Vec<u64>,
-}
-
-impl Scratch {
-    pub(crate) fn new(stride_words: usize) -> Self {
-        Self {
-            fingerprint: vec![0; stride_words],
-            acc: vec![0; stride_words],
-        }
-    }
-
-    pub(crate) fn reset(&mut self) {
-        self.fingerprint.fill(0);
-        self.acc.fill(0);
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RibbonBuilder<S> {
+pub struct RibbonBuilder {
     params: Params,
-    build_hasher: S,
 }
 
-impl<S> RibbonBuilder<S>
-where
-    S: BuildHasher + Clone,
-{
-    pub fn new(params: Params, build_hasher: S) -> Result<Self, BuildError> {
+impl RibbonBuilder {
+    pub fn new(params: Params) -> Result<Self, BuildError> {
         params.validate().map_err(BuildError::InvalidParams)?;
-        Ok(Self {
-            params,
-            build_hasher,
-        })
+        Ok(Self { params })
     }
 
     pub fn params(&self) -> Params {
         self.params
     }
 
-    pub fn hasher(&self) -> &S {
-        &self.build_hasher
-    }
-
-    /// Build a Ribbon filter using a CALLER-PROVIDED seed verbatim — no
-    /// `derive_attempt_seed` mixing on top. This is the entry point BuRR
-    /// uses to keep the threshold-decision seed and the actual
-    /// construction seed identical, so the per-block bump decisions made
-    /// from precomputed equations agree with the equations the ribbon
-    /// stores for its kept keys.
-    ///
-    /// No retry budget: a single attempt with the given seed. Caller is
-    /// responsible for sizing `m` (via `Params::m`) generously enough that
-    /// the banded solver succeeds with the keys provided.
-    pub(crate) fn build_with_seed_verbatim<K: core::hash::Hash>(
-        &self,
-        keys: &[K],
-        seed: u64,
-        m: usize,
-    ) -> Result<RibbonFilter<S>, BuildError> {
-        self.params.validate().map_err(BuildError::InvalidParams)?;
-        self.build_once(keys, m, seed)
-            .map_err(|failure| BuildError::ConstructionFailed {
-                final_m: m,
-                attempts: 1,
-                last_failure: failure,
-            })
-    }
-
-    /// Build a Ribbon filter from already-hashed keys (each `u64` is
-    /// treated as the value `BuildHasher::hash_one(key)` would have
-    /// produced). Verbatim seed, no retry.
+    /// Build a Ribbon filter from already-hashed keys (each `u64` is a
+    /// stable key hash the caller precomputed). Verbatim seed, no retry.
     ///
     /// Used by BuRR when the LSM has already computed a stable u64
-    /// hash for each key (via `crate::hash::hash64` / xxh3) — running
-    /// the BuildHasher again would just double-hash the same bytes.
+    /// hash for each key (via `crate::hash::hash64` / xxh3); the ribbon
+    /// feeds those hashes straight into the banded solver.
     pub(crate) fn build_with_seed_verbatim_from_hashes(
         &self,
         hashes: &[u64],
         seed: u64,
         m: usize,
-    ) -> Result<RibbonFilter<S>, BuildError> {
+    ) -> Result<RibbonFilter, BuildError> {
         self.params.validate().map_err(BuildError::InvalidParams)?;
         self.build_once_from_hashes(hashes, m, seed)
             .map_err(|failure| BuildError::ConstructionFailed {
@@ -103,235 +45,17 @@ where
             })
     }
 
-    pub fn build<K: core::hash::Hash>(&self, keys: &[K]) -> Result<RibbonFilter<S>, BuildError> {
-        self.params.validate().map_err(BuildError::InvalidParams)?;
-
-        let mut attempts = 0usize;
-        let mut current_m = self.params.m;
-        let mut last_failure = None;
-
-        for grow_step in 0..=self.params.grow_limit {
-            for retry_step in 0..self.params.retry_limit {
-                attempts += 1;
-                let attempt_index = ((grow_step as u64) << 32) | retry_step as u64;
-                let seed = derive_attempt_seed(self.params.seed, attempt_index);
-
-                match self.build_once(keys, current_m, seed) {
-                    Ok(filter) => return Ok(filter),
-                    Err(err) => last_failure = Some(err),
-                }
-
-                if matches!(self.params.mode, Mode::Homogeneous) {
-                    break;
-                }
-            }
-
-            if matches!(self.params.mode, Mode::Homogeneous) {
-                break;
-            }
-
-            if grow_step < self.params.grow_limit {
-                let w = self.params.w;
-                // Unchecked multiplication can wrap in release builds for
-                // caller-supplied `m` near usize::MAX, leaving `current_m`
-                // smaller than `w` and breaking later invariants. Fail
-                // construction explicitly when the grown size would
-                // overflow.
-                let Some(grown) = current_m.checked_mul(w + 1).map(|raw| raw.div_ceil(w)) else {
-                    return Err(BuildError::ConstructionFailed {
-                        final_m: current_m,
-                        attempts,
-                        last_failure: last_failure.unwrap_or(
-                            ConstructionFailure::InconsistentEquation {
-                                key_index: 0,
-                                row_index: 0,
-                            },
-                        ),
-                    });
-                };
-                current_m = grown;
-                debug_assert!(current_m >= self.params.w);
-            }
-        }
-
-        Err(BuildError::ConstructionFailed {
-            final_m: current_m,
-            attempts,
-            last_failure: last_failure.unwrap_or(ConstructionFailure::InconsistentEquation {
-                key_index: 0,
-                row_index: 0,
-            }),
-        })
-    }
-
-    fn build_once<K: core::hash::Hash>(
-        &self,
-        keys: &[K],
-        m: usize,
-        seed: u64,
-    ) -> Result<RibbonFilter<S>, ConstructionFailure> {
-        debug_assert!(m >= self.params.w);
-
-        let stride_words = self.params.fingerprint_words();
-        // `m * stride_words` would overflow `usize` if `m` is set
-        // unreasonably large; allocate via the checked product and bail
-        // before the vec! call panics.
-        let total_words = m
-            .checked_mul(stride_words)
-            .ok_or(ConstructionFailure::StorageLengthOverflow { m, stride_words })?;
-        let fp_last_mask = self.params.fingerprint_last_word_mask();
-        let mut occupied = vec![false; m];
-        let mut coeff_lo = vec![0u64; m];
-        let mut coeff_hi = vec![0u64; m];
-        let mut rhs = vec![0u64; total_words];
-
-        let mut key_fp = vec![0u64; stride_words];
-
-        for (key_index, key) in keys.iter().enumerate() {
-            key_fp.fill(0);
-            let equation = standard_equation_w64(
-                &self.build_hasher,
-                key,
-                seed,
-                &Params { m, ..self.params },
-                &mut key_fp,
-            );
-
-            let mut i = equation.start;
-            let mut c_lo = equation.coeff_lo;
-            let mut c_hi = equation.coeff_hi;
-            let mut b = key_fp.clone();
-
-            if i >= m {
-                return Err(ConstructionFailure::OutOfBounds {
-                    key_index: Some(key_index),
-                    row_index: i,
-                    m,
-                });
-            }
-
-            loop {
-                if !occupied[i] {
-                    occupied[i] = true;
-                    coeff_lo[i] = c_lo;
-                    coeff_hi[i] = c_hi;
-                    rhs[i * stride_words..(i + 1) * stride_words].copy_from_slice(&b);
-                    break;
-                }
-
-                c_lo ^= coeff_lo[i];
-                c_hi ^= coeff_hi[i];
-                xor_words(&mut b, &rhs[i * stride_words..(i + 1) * stride_words]);
-
-                if c_lo == 0 && c_hi == 0 {
-                    if b.iter().all(|&x| x == 0) {
-                        break;
-                    }
-                    return Err(ConstructionFailure::InconsistentEquation {
-                        key_index,
-                        row_index: i,
-                    });
-                }
-
-                let shift = if c_lo != 0 {
-                    c_lo.trailing_zeros() as usize
-                } else {
-                    64 + c_hi.trailing_zeros() as usize
-                };
-                i += shift;
-                if i >= m {
-                    return Err(ConstructionFailure::OutOfBounds {
-                        key_index: Some(key_index),
-                        row_index: i,
-                        m,
-                    });
-                }
-                if shift >= 64 {
-                    c_lo = c_hi >> (shift - 64);
-                    c_hi = 0;
-                } else if shift > 0 {
-                    c_lo = (c_lo >> shift) | (c_hi << (64 - shift));
-                    c_hi >>= shift;
-                }
-            }
-        }
-
-        let mut z = vec![0u64; total_words];
-        if matches!(self.params.mode, Mode::Homogeneous) {
-            let mut rng = SplitMix64::new(seed ^ 0xD1B5_4A32_D192_ED03);
-            for (i, is_occupied) in occupied.iter().enumerate().take(m) {
-                if *is_occupied {
-                    continue;
-                }
-
-                let row_start = i * stride_words;
-                let row_end = row_start + stride_words;
-                for word in &mut z[row_start..row_end] {
-                    *word = rng.next_u64();
-                }
-                z[row_end - 1] &= fp_last_mask;
-            }
-        }
-
-        for i in (0..m).rev() {
-            if !occupied[i] {
-                continue;
-            }
-
-            let row_start = i * stride_words;
-            let row_end = row_start + stride_words;
-
-            z[row_start..row_end].copy_from_slice(&rhs[row_start..row_end]);
-
-            let upper_lo = coeff_lo[i] & !1u64;
-            let upper_hi = coeff_hi[i];
-            let mut row_offsets = Vec::with_capacity(self.params.w.saturating_sub(1));
-            for_each_set_bit_u128_parts(upper_lo, upper_hi, |offset| {
-                row_offsets.push(offset);
-            });
-
-            for offset in row_offsets {
-                let row_index = i + offset;
-                if row_index >= m {
-                    return Err(ConstructionFailure::OutOfBounds {
-                        key_index: None,
-                        row_index,
-                        m,
-                    });
-                }
-                let other_start = row_index * stride_words;
-                let (left, right) = z.split_at_mut(other_start);
-                let row = &mut left[row_start..row_end];
-                let other = &right[..stride_words];
-                xor_words(row, other);
-            }
-
-            z[row_end - 1] &= fp_last_mask;
-        }
-        let mut built_params = self.params;
-        built_params.m = m;
-        built_params.seed = seed;
-
-        Ok(RibbonFilter::new(
-            built_params,
-            self.build_hasher.clone(),
-            z,
-        ))
-    }
-
-    /// Variant of [`Self::build_once`] that takes pre-computed key hashes
-    /// instead of `Hash` keys. Otherwise identical algorithm.
+    /// Build a single ribbon over pre-computed key hashes.
     ///
     /// Used by BuRR through `build_with_seed_verbatim_from_hashes` so the
     /// LSM-side stable u64 hash (xxh3 / `crate::hash::hash64`) flows
-    /// straight into the banded solver without re-hashing through the
-    /// `BuildHasher`.
+    /// straight into the banded solver.
     fn build_once_from_hashes(
         &self,
         hashes: &[u64],
         m: usize,
         seed: u64,
-    ) -> Result<RibbonFilter<S>, ConstructionFailure> {
+    ) -> Result<RibbonFilter, ConstructionFailure> {
         debug_assert!(m >= self.params.w);
 
         let stride_words = self.params.fingerprint_words();
@@ -461,10 +185,6 @@ where
         built_params.m = m;
         built_params.seed = seed;
 
-        Ok(RibbonFilter::new(
-            built_params,
-            self.build_hasher.clone(),
-            z,
-        ))
+        Ok(RibbonFilter::new(built_params, z))
     }
 }

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -1,9 +1,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::{BuildHasher, Hash};
 
 use super::super::builder::RibbonBuilder;
-use super::super::hashing::{StandardEquation, standard_equation_w64};
+use super::super::hashing::StandardEquation;
 use super::super::params::{Mode, Params};
 use super::error::BurrBuildError;
 use super::filter::{BurrFilter, BurrLayer};
@@ -33,12 +32,11 @@ use super::threshold::{compute_thresholds, partition_keys_by_threshold};
 /// `thresholds[..] = b` (accept everything) and is sized with an enlarged
 /// `m` and generous retry+grow budget so the Ribbon build is guaranteed
 /// to absorb its residual.
-pub struct BurrBuilder<S> {
+pub struct BurrBuilder {
     params: BurrParams,
-    hasher: S,
 }
 
-impl<S> core::fmt::Debug for BurrBuilder<S> {
+impl core::fmt::Debug for BurrBuilder {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("BurrBuilder")
             .field("params", &self.params)
@@ -46,11 +44,8 @@ impl<S> core::fmt::Debug for BurrBuilder<S> {
     }
 }
 
-impl<S> BurrBuilder<S>
-where
-    S: BuildHasher + Clone,
-{
-    pub fn new(params: BurrParams, hasher: S) -> Result<Self, BurrBuildError> {
+impl BurrBuilder {
+    pub fn new(params: BurrParams) -> Result<Self, BurrBuildError> {
         if params.n == 0 {
             return Err(BurrBuildError::InvalidParams("n must be > 0"));
         }
@@ -85,20 +80,16 @@ where
         if params.max_layers == 0 {
             return Err(BurrBuildError::InvalidParams("max_layers must be > 0"));
         }
-        Ok(Self { params, hasher })
+        Ok(Self { params })
     }
 
     /// Build from pre-computed u64 key hashes (e.g. xxh3 outputs from
-    /// `crate::hash::hash64`). Bypasses `BuildHasher::hash_one` — the
-    /// `S` parameter is only used as the type slot for the eventual
-    /// `BurrFilter<S>` return value (which carries it for API
-    /// compatibility with the key-based `contains_in`); no key →
-    /// hash work happens here.
+    /// `crate::hash::hash64`).
     ///
     /// This is the entry point the LSM filter writer uses: it has
     /// already hashed every key with xxh3 for filter-block indexing
     /// and pipes those u64s directly into BuRR.
-    pub fn build_from_hashes(&self, hashes: &[u64]) -> Result<BurrFilter<S>, BurrBuildError> {
+    pub fn build_from_hashes(&self, hashes: &[u64]) -> Result<BurrFilter, BurrBuildError> {
         // Borrowed-slice variant — copies the input into the per-layer
         // working buffer. Use [`Self::build_from_hashes_owned`] to move
         // an existing `Vec<u64>` instead, avoiding the up-front clone
@@ -111,10 +102,7 @@ where
     /// filter writer uses this on its accumulated `bloom_hash_buffer`
     /// so per-partition construction doesn't pay the copy cost twice
     /// (once here, once during the per-layer recursion).
-    pub fn build_from_hashes_owned(
-        &self,
-        hashes: Vec<u64>,
-    ) -> Result<BurrFilter<S>, BurrBuildError> {
+    pub fn build_from_hashes_owned(&self, hashes: Vec<u64>) -> Result<BurrFilter, BurrBuildError> {
         // Empty input would produce a zero-layer filter that
         // `to_wire_bytes` correctly serialises as an empty Vec, but
         // `BurrFilterReader::new` rejects num_layers == 0 — so the
@@ -125,7 +113,7 @@ where
             return Err(BurrBuildError::InvalidParams("key set must be non-empty"));
         }
         let mut remaining: Vec<u64> = hashes;
-        let mut layers: Vec<BurrLayer<S>> = Vec::with_capacity(usize::from(self.params.max_layers));
+        let mut layers: Vec<BurrLayer> = Vec::with_capacity(usize::from(self.params.max_layers));
 
         for layer_idx in 0..self.params.max_layers {
             if remaining.is_empty() {
@@ -175,13 +163,12 @@ where
             let (kept, bumped) =
                 partition_keys_by_threshold(&remaining, &equations, &thresholds, self.params.b);
 
-            let ribbon_builder =
-                RibbonBuilder::new(equation_params, self.hasher.clone()).map_err(|e| {
-                    BurrBuildError::RibbonLayerFailed {
-                        layer_index: usize::from(layer_idx),
-                        ribbon_error: e,
-                    }
-                })?;
+            let ribbon_builder = RibbonBuilder::new(equation_params).map_err(|e| {
+                BurrBuildError::RibbonLayerFailed {
+                    layer_index: usize::from(layer_idx),
+                    ribbon_error: e,
+                }
+            })?;
 
             let ribbon = ribbon_builder
                 .build_with_seed_verbatim_from_hashes(&kept, layer_seed, m)
@@ -207,149 +194,8 @@ where
             });
         }
 
-        Ok(BurrFilter::from_layers(
-            self.params,
-            self.hasher.clone(),
-            layers,
-        ))
+        Ok(BurrFilter::from_layers(self.params, layers))
     }
-
-    pub fn build<K: Hash + Clone>(&self, keys: &[K]) -> Result<BurrFilter<S>, BurrBuildError> {
-        // Same empty-input rejection as `build_from_hashes_owned` —
-        // builder is the right place to surface "no keys, no filter"
-        // rather than letting the read path fail later.
-        if keys.is_empty() {
-            return Err(BurrBuildError::InvalidParams("key set must be non-empty"));
-        }
-        let mut remaining: Vec<K> = keys.to_vec();
-        let mut layers: Vec<BurrLayer<S>> = Vec::with_capacity(usize::from(self.params.max_layers));
-
-        for layer_idx in 0..self.params.max_layers {
-            if remaining.is_empty() {
-                break;
-            }
-
-            let is_last_layer = layer_idx + 1 == self.params.max_layers;
-            let layer_seed = derive_layer_seed(self.params.seed, layer_idx);
-            let layer_input = remaining.len();
-
-            // Last layer: enlarge m to guarantee success even at full load
-            // (no next layer to absorb spillover).
-            let m_target = self.params.layer_m(layer_input);
-            let m = if is_last_layer {
-                let doubled = m_target.saturating_mul(2);
-                doubled.max(usize::from(self.params.b) * 4)
-            } else {
-                m_target
-            };
-
-            // Build a Params instance reflecting THIS layer's slot count,
-            // seed, and (later) retry budget — used both for equation
-            // computation and for the inner RibbonBuilder.
-            let layer_w = usize::from(self.params.w);
-            let layer_r = usize::from(self.params.r);
-            let equation_params = Params::new(m, layer_w, layer_r, Mode::Standard)
-                .map_err(static_param_err)?
-                .with_seed(layer_seed);
-
-            // (1) Equations for every key in `remaining` under this
-            // layer's seed/m/w/r.
-            let equations =
-                compute_layer_equations(&self.hasher, &remaining, &equation_params, layer_r);
-
-            // (2) Decide per-block thresholds. Last layer uses
-            // all-accepting thresholds: `b` everywhere.
-            let thresholds = if is_last_layer {
-                let block_count = m.div_ceil(usize::from(self.params.b));
-                vec![self.params.b; block_count]
-            } else {
-                compute_thresholds(&equations, m, self.params.b)
-            };
-
-            // (3) Partition into kept / bumped.
-            let (kept, bumped) =
-                partition_keys_by_threshold(&remaining, &equations, &thresholds, self.params.b);
-
-            // (4) Build Ribbon for kept. Use `build_with_seed_verbatim`
-            // so the construction seed matches `layer_seed` exactly —
-            // otherwise the vendored `RibbonBuilder.build` would mix it
-            // through `derive_attempt_seed`, which would make the
-            // ribbon's internal `start` values disagree with the start
-            // values we used for threshold decisions (= correctness bug
-            // surfaced as wire-format probe misses).
-            //
-            // No retry budget: the threshold scheme caps per-block load
-            // at ~90%, so single-attempt construction succeeds in
-            // practice. If it doesn't (parameter mistuning), the
-            // resulting `RibbonLayerFailed` is the diagnostic — we
-            // don't silently retry with a different seed because that
-            // would invalidate the thresholds we just computed.
-            let ribbon_builder =
-                RibbonBuilder::new(equation_params, self.hasher.clone()).map_err(|e| {
-                    BurrBuildError::RibbonLayerFailed {
-                        layer_index: usize::from(layer_idx),
-                        ribbon_error: e,
-                    }
-                })?;
-
-            let ribbon = ribbon_builder
-                .build_with_seed_verbatim(&kept, layer_seed, m)
-                .map_err(|e| BurrBuildError::RibbonLayerFailed {
-                    layer_index: usize::from(layer_idx),
-                    ribbon_error: e,
-                })?;
-
-            layers.push(BurrLayer {
-                m,
-                seed: layer_seed,
-                thresholds,
-                ribbon,
-            });
-
-            // (5) Recurse with bumped keys.
-            remaining = bumped;
-        }
-
-        if !remaining.is_empty() {
-            return Err(BurrBuildError::LayerExhaustion {
-                layers_attempted: usize::from(self.params.max_layers),
-                remaining_keys: remaining.len(),
-            });
-        }
-
-        Ok(BurrFilter::from_layers(
-            self.params,
-            self.hasher.clone(),
-            layers,
-        ))
-    }
-}
-
-/// Compute the equation each key would generate under the given params.
-///
-/// The fingerprint side-output is discarded — we only need `start` for
-/// the threshold decision. The ribbon build that follows will recompute
-/// equations (incl. fingerprints) using the same hasher + seed, so the
-/// `start` values agree by construction.
-fn compute_layer_equations<K, S>(
-    hasher: &S,
-    keys: &[K],
-    params: &Params,
-    r: usize,
-) -> Vec<StandardEquation>
-where
-    K: Hash,
-    S: BuildHasher,
-{
-    let stride = r.div_ceil(64);
-    let mut fp_throwaway = vec![0_u64; stride];
-    let mut out = Vec::with_capacity(keys.len());
-    for key in keys {
-        fp_throwaway.fill(0);
-        let eq = standard_equation_w64(hasher, key, params.seed, params, &mut fp_throwaway);
-        out.push(eq);
-    }
-    out
 }
 
 /// Derive a per-layer seed from the root seed.

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -1,16 +1,14 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::{BuildHasher, Hash};
 
-use super::super::builder::Scratch;
 use super::super::filter::RibbonFilter;
-use super::super::hashing::{standard_equation_from_hash, standard_equation_w64};
+use super::super::hashing::standard_equation_from_hash;
 use super::super::params::{Mode, Params};
 use super::params::BurrParams;
 use super::threshold::is_bumped;
 
 /// One layer of a built BuRR filter.
-pub(crate) struct BurrLayer<S> {
+pub(crate) struct BurrLayer {
     /// Slot count for this layer (== ribbon's m). Kept here so we don't
     /// have to reach into ribbon.params() on every probe.
     pub(crate) m: usize,
@@ -25,10 +23,10 @@ pub(crate) struct BurrLayer<S> {
     /// Length = `m.div_ceil(b)`.
     pub(crate) thresholds: Vec<u8>,
     /// The vendored Ribbon filter holding this layer's KEPT keys.
-    pub(crate) ribbon: RibbonFilter<S>,
+    pub(crate) ribbon: RibbonFilter,
 }
 
-impl<S> core::fmt::Debug for BurrLayer<S> {
+impl core::fmt::Debug for BurrLayer {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("BurrLayer")
             .field("m", &self.m)
@@ -43,31 +41,14 @@ impl<S> core::fmt::Debug for BurrLayer<S> {
 /// (the bumped-from-layer-0 set), etc. A key is "present" if any layer's
 /// Ribbon body reports a match. False positives carry the FPR ≈ 2⁻ʳ of
 /// the underlying Ribbon layers.
-///
-/// The probe path is allocation-free after the initial `new_scratch` call
-/// (one `Scratch` is reused across layers — the largest layer's stride is
-/// used).
-pub struct BurrFilter<S> {
+pub struct BurrFilter {
     params: BurrParams,
-    /// Hasher used by the probe-time equation re-compute for the per-
-    /// layer bump-check. All `BurrLayer::ribbon`s were given clones of
-    /// this same hasher at build time, so hashes agree at the boundary
-    /// (`BuildHasher::hash_one` is deterministic for a given hasher
-    /// state).
-    hasher: S,
-    layers: Vec<BurrLayer<S>>,
+    layers: Vec<BurrLayer>,
 }
 
-impl<S> BurrFilter<S>
-where
-    S: BuildHasher + Clone,
-{
-    pub(crate) fn from_layers(params: BurrParams, hasher: S, layers: Vec<BurrLayer<S>>) -> Self {
-        Self {
-            params,
-            hasher,
-            layers,
-        }
+impl BurrFilter {
+    pub(crate) fn from_layers(params: BurrParams, layers: Vec<BurrLayer>) -> Self {
+        Self { params, layers }
     }
 
     /// Returns the layer count after construction. Useful for diagnostics
@@ -81,7 +62,7 @@ where
     /// wire-format encoder; `pub(crate)` so it doesn't leak into the
     /// public API.
     #[must_use]
-    pub(crate) fn layers_inner(&self) -> &[BurrLayer<S>] {
+    pub(crate) fn layers_inner(&self) -> &[BurrLayer] {
         &self.layers
     }
 
@@ -111,58 +92,11 @@ where
         self.params
     }
 
-    /// Returns a fresh `Scratch` sized for the largest layer's stride.
-    #[must_use]
-    pub fn new_scratch(&self) -> Scratch {
-        // All layers share the same r (fingerprint stride), so any
-        // layer's scratch is interchangeable.
-        match self.layers.first() {
-            Some(layer) => layer.ribbon.new_scratch(),
-            None => Scratch::new(0),
-        }
-    }
-
-    /// Returns `true` if the key may be present.
-    ///
-    /// MUST be paired with [`BurrBuilder::build`] (the key-based build
-    /// path): the probe hashes `key` via the filter's `BuildHasher` and
-    /// looks the hash up under the same hashing the builder used.
-    /// Calling `contains(&k)` on a filter built via
-    /// [`BurrBuilder::build_from_hashes`] is NOT valid — those filters
-    /// were built from caller-supplied u64 hashes that, in general, do
-    /// not equal `BuildHasher::hash_one(&k)`, and the probe will report
-    /// inserted keys as absent (false negative). Use
-    /// [`Self::contains_hash`] with the same u64 hashing the builder
-    /// used in that case.
-    pub fn contains<Q: Hash + ?Sized>(&self, key: &Q) -> bool {
-        let mut scratch = self.new_scratch();
-        self.contains_in(key, &mut scratch)
-    }
-
     /// Probe with a pre-computed u64 hash (e.g. xxh3 output from
-    /// `crate::hash::hash64`). Equivalent to `contains` when the caller
-    /// has already hashed the key — avoids re-running the
-    /// `BuildHasher` on the hot path.
-    ///
-    /// MUST be paired with [`BurrBuilder::build_from_hashes`]: a filter
-    /// built via `build(keys)` (which hashes with `BuildHasher`) is NOT
-    /// queryable by `contains_hash(h)` unless `h` is the
-    /// `BuildHasher::hash_one(key)` value. The on-disk LSM filter
-    /// always uses the hash-based build + probe pair so the two stay
+    /// `crate::hash::hash64`). The hash must be produced the same way
+    /// the builder's input hashes were (the on-disk LSM filter uses
+    /// `crate::hash::hash64` on both build and probe), so the two stay
     /// consistent.
-    ///
-    /// Note on probe-mode tagging: a previous reviewer asked whether
-    /// the construction mode (keyed vs hashed) should be encoded in
-    /// the type so that mismatched pairs fail fast at runtime. The
-    /// trade-off was considered and rejected: the in-tree LSM caller
-    /// uses [`BurrBuilder::build_from_hashes`] + `contains_hash`
-    /// exclusively (see the table filter pipeline), so the keyed API
-    /// has a single, well-defined call site (this crate's own tests
-    /// plus external callers who explicitly opt in). Adding a runtime
-    /// mode tag would cost an extra branch on every probe; splitting
-    /// into two filter types would bifurcate every consumer (writer,
-    /// reader, builder, wire codec) for no in-tree benefit. The
-    /// doc-comment contract above is the canonical guarantee.
     #[inline]
     #[expect(
         clippy::indexing_slicing,
@@ -226,82 +160,9 @@ where
         }
         false
     }
-
-    /// Allocation-free probe using a caller-provided scratch.
-    ///
-    /// Same pairing contract as [`Self::contains`]: only valid when
-    /// the filter was built via [`BurrBuilder::build`] (key-based
-    /// path). A filter built via [`BurrBuilder::build_from_hashes`]
-    /// must be probed with [`Self::contains_hash`] instead, otherwise
-    /// the probe reports inserted keys as absent.
-    ///
-    /// Walks layers descend-only: for each layer, recompute the equation
-    /// under that layer's seed+m and check the per-block threshold. If
-    /// the key would have been BUMPED at construction time
-    /// (`offset >= thresholds[block]`), continue to the next layer. Else
-    /// delegate to the layer's `RibbonFilter::contains_in` — which
-    /// re-derives the same equation internally and runs the GF(2) XOR-
-    /// reduce against the stored solution.
-    ///
-    /// The double equation work per kept-layer is the MVP cost
-    /// (correctness first); a follow-up can expose a `contains_with_eq`
-    /// path on `RibbonFilter` that reuses our pre-computed equation.
-    pub fn contains_in<Q: Hash + ?Sized>(&self, key: &Q, scratch: &mut Scratch) -> bool {
-        // Stack-sized throwaway fingerprint buffer reused across layers.
-        // `BurrParams::with_*` clamp `r` to 1..=64 so `stride` is 1; the
-        // assert pins the invariant.
-        debug_assert!(self.params.r <= 64, "BuRR params pin r <= 64");
-        let mut fp_throwaway = [0_u64; 1];
-        for layer in &self.layers {
-            // Build a Params reflecting this layer's m/w/r/seed so the
-            // equation-computation matches what the builder did.
-            let layer_params = match Params::new(
-                layer.m,
-                usize::from(self.params.w),
-                usize::from(self.params.r),
-                Mode::Standard,
-            ) {
-                Ok(p) => p.with_seed(layer.seed),
-                // Unreachable for built filters; fail closed defensively
-                // so a future param-validation regression yields a
-                // false positive (caller does an index lookup) rather
-                // than a false negative.
-                Err(_) => return true,
-            };
-
-            // Re-hash to learn this layer's `start` and decide bump.
-            // Throwaway fingerprint; the real probe uses `scratch`
-            // inside `ribbon.contains_in`. The hasher is the one
-            // BurrFilter holds — all layers' RibbonFilters were given
-            // clones of THIS hasher at build time, so hashes agree by
-            // construction (BuildHasher is deterministic).
-            fp_throwaway[0] = 0;
-            let equation = standard_equation_w64(
-                &self.hasher,
-                key,
-                layer.seed,
-                &layer_params,
-                &mut fp_throwaway,
-            );
-
-            if is_bumped(&equation, &layer.thresholds, self.params.b) {
-                // Bumped at build time → not in this layer's ribbon;
-                // continue to the next layer.
-                continue;
-            }
-
-            // Kept at this layer → ribbon authoritatively decides.
-            return layer.ribbon.contains_in(key, scratch);
-        }
-        // Walked all layers without finding a non-bumped layer — would
-        // only happen if the input was never inserted in any layer
-        // (i.e. a non-member key whose hash always lands at a bumped
-        // offset). Definite-not-present.
-        false
-    }
 }
 
-impl<S> core::fmt::Debug for BurrFilter<S> {
+impl core::fmt::Debug for BurrFilter {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("BurrFilter")
             .field("params", &self.params)
@@ -360,7 +221,7 @@ impl<'a> BurrFilterReader<'a> {
     /// Probe with a pre-computed key hash. Used by the LSM filter
     /// framework's `block::FilterBlock` — the table read path already
     /// computes a u64 hash for block indexing, and the filter consumes
-    /// that same hash directly (no re-hash via `BuildHasher`).
+    /// that same hash directly (no re-hashing).
     #[inline]
     #[must_use]
     pub fn contains_hash(&self, hash: u64) -> bool {

--- a/src/table/filter/ribbon/burr/params.rs
+++ b/src/table/filter/ribbon/burr/params.rs
@@ -18,7 +18,7 @@ pub struct BurrParams {
     /// `w=64` band assumes single-word `b` vectors).
     pub r: u8,
     /// Band width — fixed at 64 to match the vendored Ribbon
-    /// `standard_equation_w64` solver.
+    /// `standard_equation_from_hash` solver.
     pub w: u8,
     /// Block size (rows per block, drives the per-block threshold byte).
     /// Default 64; must be ≤ 255 so the threshold fits one byte.

--- a/src/table/filter/ribbon/burr/tests.rs
+++ b/src/table/filter/ribbon/burr/tests.rs
@@ -27,26 +27,23 @@
     reason = "test code indexes into fixture buffers with known sizes"
 )]
 
-use core::hash::BuildHasherDefault;
-use std::collections::hash_map::DefaultHasher;
-
 use super::{BurrBuilder, BurrParams};
-
-type DefaultBuildHasher = BuildHasherDefault<DefaultHasher>;
 
 #[test]
 fn burr_builds_and_reports_inserted_keys_present() {
     let n = 1_000_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
-    let keys: Vec<u64> = (0..n as u64).collect();
-    let filter = builder.build(&keys).expect("build");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder.build_from_hashes(&hashes).expect("build");
 
-    // Every inserted key must report as present (no false negatives).
-    for key in &keys {
+    // Every inserted hash must report as present (no false negatives).
+    for h in &hashes {
         assert!(
-            filter.contains(key),
-            "inserted key {key} reported absent — BuRR must be FN-free",
+            filter.contains_hash(*h),
+            "inserted hash {h} reported absent — BuRR must be FN-free",
         );
     }
 }
@@ -58,14 +55,17 @@ fn burr_fpr_at_one_percent_is_within_envelope() {
     // sample size some slack.
     let n = 1_000_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
-    let keys: Vec<u64> = (0..n as u64).collect();
-    let filter = builder.build(&keys).expect("build");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder.build_from_hashes(&hashes).expect("build");
 
     let probe_count = 10_000_usize;
     let mut false_positives = 0_usize;
-    for key in (n as u64)..(n as u64 + probe_count as u64) {
-        if filter.contains(&key) {
+    for i in (n as u64)..(n as u64 + probe_count as u64) {
+        let h = crate::hash::hash64(&i.to_le_bytes());
+        if filter.contains_hash(h) {
             false_positives += 1;
         }
     }
@@ -81,51 +81,13 @@ fn burr_fpr_at_one_percent_is_within_envelope() {
 }
 
 #[test]
-fn burr_wire_format_round_trips() {
-    // Build a BuRR, serialize to wire bytes, parse via
-    // BurrFilterReader, and verify contains_hash answers match
-    // BurrFilter::contains for every inserted key.
-    use super::filter::BurrFilterReader;
-    use core::hash::BuildHasher;
-
-    let n = 500_usize;
-    let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let hasher = DefaultBuildHasher::default();
-    let builder = BurrBuilder::new(params, hasher.clone()).expect("builder");
-    let keys: Vec<u64> = (0..n as u64).collect();
-    let filter = builder.build(&keys).expect("build");
-
-    let bytes = filter.to_wire_bytes();
-    assert!(bytes.len() > 20, "wire buffer too small ({})", bytes.len());
-
-    let reader = BurrFilterReader::new(&bytes).expect("parse");
-    assert_eq!(
-        reader.layer_count(),
-        filter.layer_count(),
-        "decoded layer count must match",
-    );
-
-    // The reader's contains_hash takes a pre-computed u64. We must
-    // use the SAME hasher state the BurrFilter was built with so the
-    // base_hash matches. BuildHasher::hash_one is the convention used
-    // by both sides.
-    for key in &keys {
-        let h = hasher.hash_one(key);
-        assert!(
-            reader.contains_hash(h),
-            "inserted key {key} not found in decoded reader (hash {h})",
-        );
-    }
-}
-
-#[test]
 fn burr_build_from_hashes_and_contains_hash_round_trip() {
     // The hash-based build + probe pair is what the LSM filter writer
     // and reader use. Insert n xxh3-hashed u64s and verify
     // contains_hash reports each as present.
     let n = 500_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
 
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
@@ -166,7 +128,7 @@ fn burr_hash_build_wire_format_round_trips() {
 
     let n = 500_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -191,7 +153,7 @@ fn burr_wire_rejects_bad_magic() {
     // arbitrary zeros could also fail later in decode (e.g. on the
     // version byte) and mask whether the magic check fires at all.
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -210,7 +172,7 @@ fn burr_single_key_round_trips() {
     // Smallest possible filter. Last-layer enlargement must accommodate
     // n=1 without LayerExhaustion. Hash-based + key-based both work.
     let params = BurrParams::with_fp_rate(1, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let key_hash = crate::hash::hash64(b"only-one");
     let filter = builder
         .build_from_hashes(&[key_hash])
@@ -232,14 +194,14 @@ fn burr_build_is_deterministic_for_fixed_seed() {
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
     let bytes_a = {
-        let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+        let builder = BurrBuilder::new(params).expect("builder");
         builder
             .build_from_hashes(&hashes)
             .expect("build")
             .to_wire_bytes()
     };
     let bytes_b = {
-        let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+        let builder = BurrBuilder::new(params).expect("builder");
         builder
             .build_from_hashes(&hashes)
             .expect("build")
@@ -266,7 +228,7 @@ fn burr_wire_rejects_unknown_version() {
     // Build a real filter, mutate the version byte, decode must fail.
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -286,7 +248,7 @@ fn burr_wire_rejects_unknown_version() {
 fn burr_wire_rejects_unknown_filter_type() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -307,7 +269,7 @@ fn burr_negative_keys_obey_fpr_envelope_at_low_target() {
     // probes must stay within a safety envelope around the target.
     let n = 2_000_usize;
     let params = BurrParams::with_fp_rate(n, 0.001).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -337,7 +299,7 @@ fn burr_negative_keys_obey_fpr_envelope_at_very_low_target() {
     // sample should be well below the 1‰ ceiling we accept here.
     let n = 5_000_usize;
     let params = BurrParams::with_fp_rate(n, 0.0001).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -365,31 +327,10 @@ fn burr_negative_keys_obey_fpr_envelope_at_very_low_target() {
 }
 
 #[test]
-fn burr_contains_in_matches_contains_with_external_scratch() {
-    // The allocation-free probe path (contains_in with caller scratch)
-    // must agree with the convenience contains for every key in the set.
-    let n = 300_usize;
-    let params = BurrParams::with_fp_rate(n, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
-    let keys: Vec<u64> = (0..n as u64).collect();
-    let filter = builder.build(&keys).expect("build");
-    let mut scratch = filter.new_scratch();
-    for key in &keys {
-        let via_contains = filter.contains(key);
-        let via_contains_in = filter.contains_in(key, &mut scratch);
-        assert_eq!(
-            via_contains, via_contains_in,
-            "probe paths disagree on {key}"
-        );
-        assert!(via_contains, "inserted key {key} not present");
-    }
-}
-
-#[test]
 fn burr_wire_rejects_zero_b() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -410,7 +351,7 @@ fn burr_wire_rejects_zero_b() {
 fn burr_wire_rejects_zero_num_layers() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -430,7 +371,7 @@ fn burr_wire_rejects_zero_num_layers() {
 fn burr_wire_rejects_out_of_range_r() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -458,7 +399,7 @@ fn burr_wire_rejects_out_of_range_r() {
 fn burr_wire_rejects_corrupted_num_blocks() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -481,7 +422,7 @@ fn burr_wire_rejects_corrupted_num_blocks() {
 fn burr_wire_rejects_corrupted_z_byte_len() {
     use super::filter::BurrFilterReader;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -502,9 +443,11 @@ fn burr_wire_rejects_corrupted_z_byte_len() {
 fn burr_settles_in_few_layers() {
     let n = 5_000_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("valid params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
-    let keys: Vec<u64> = (0..n as u64).collect();
-    let filter = builder.build(&keys).expect("build");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder.build_from_hashes(&hashes).expect("build");
 
     // BuRR's design target is 1-3 layers for well-tuned parameters.
     // Each layer absorbs ~90% of incoming keys; 3 layers reach ≈
@@ -581,8 +524,7 @@ fn burr_params_with_seed_sets_seed_field() {
 fn burr_builder_rejects_n_zero() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).unwrap();
     params.n = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default())
-        .expect_err("builder must reject n=0");
+    let err = BurrBuilder::new(params).expect_err("builder must reject n=0");
     let msg = format!("{err}");
     assert!(msg.contains("n must be > 0"), "got: {msg}");
 }
@@ -591,8 +533,7 @@ fn burr_builder_rejects_n_zero() {
 fn burr_builder_rejects_zero_r() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).unwrap();
     params.r = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default())
-        .expect_err("builder must reject r=0");
+    let err = BurrBuilder::new(params).expect_err("builder must reject r=0");
     let msg = format!("{err}");
     assert!(msg.contains("r must be in 1..=64"), "got: {msg}");
 }
@@ -601,8 +542,7 @@ fn burr_builder_rejects_zero_r() {
 fn burr_builder_rejects_zero_b() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).unwrap();
     params.b = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default())
-        .expect_err("builder must reject b=0");
+    let err = BurrBuilder::new(params).expect_err("builder must reject b=0");
     let msg = format!("{err}");
     assert!(msg.contains("b must be > 0"), "got: {msg}");
 }
@@ -611,8 +551,7 @@ fn burr_builder_rejects_zero_b() {
 fn burr_builder_rejects_zero_max_layers() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).unwrap();
     params.max_layers = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default())
-        .expect_err("builder must reject max_layers=0");
+    let err = BurrBuilder::new(params).expect_err("builder must reject max_layers=0");
     let msg = format!("{err}");
     assert!(msg.contains("max_layers"), "got: {msg}");
 }
@@ -624,7 +563,7 @@ fn burr_layer_count_for_tiny_input_is_at_most_one() {
     // is now rejected by the builder; see
     // burr_builder_rejects_empty_input_via_build_from_hashes.)
     let params = BurrParams::with_fp_rate(100, 0.01).unwrap();
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).unwrap();
+    let builder = BurrBuilder::new(params).unwrap();
     let hashes: Vec<u64> = (0..4_u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -635,7 +574,7 @@ fn burr_layer_count_for_tiny_input_is_at_most_one() {
 #[test]
 fn burr_filter_debug_format_includes_layer_count() {
     let params = BurrParams::with_fp_rate(100, 0.01).unwrap();
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).unwrap();
+    let builder = BurrBuilder::new(params).unwrap();
     let hashes: Vec<u64> = (0..100_u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -648,7 +587,7 @@ fn burr_filter_debug_format_includes_layer_count() {
 #[test]
 fn burr_filter_params_accessor() {
     let params = BurrParams::with_fp_rate(500, 0.01).unwrap();
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).unwrap();
+    let builder = BurrBuilder::new(params).unwrap();
     let hashes: Vec<u64> = (0..500_u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -664,7 +603,7 @@ fn burr_filter_contains_returns_false_for_definitely_absent() {
     // for inserted; some false-positive is expected for non-inserted).
     let n = 64_usize;
     let params = BurrParams::with_fp_rate(n, 0.001).unwrap();
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).unwrap();
+    let builder = BurrBuilder::new(params).unwrap();
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -692,7 +631,7 @@ fn contains_hash_from_bytes_round_trips_against_decoded() {
 
     let n = 500_usize;
     let params = BurrParams::with_fp_rate(n, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -735,7 +674,7 @@ fn contains_hash_from_bytes_rejects_short_buffer() {
 fn contains_hash_from_bytes_rejects_bad_magic() {
     use super::contains_hash_from_bytes;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -753,7 +692,7 @@ fn contains_hash_from_bytes_rejects_bad_magic() {
 fn contains_hash_from_bytes_rejects_bad_version() {
     use super::contains_hash_from_bytes;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -772,7 +711,7 @@ fn contains_hash_from_bytes_rejects_bad_version() {
 fn contains_hash_from_bytes_rejects_bad_filter_type() {
     use super::contains_hash_from_bytes;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -791,7 +730,7 @@ fn contains_hash_from_bytes_rejects_bad_filter_type() {
 fn contains_hash_from_bytes_rejects_bad_params() {
     use super::contains_hash_from_bytes;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -814,7 +753,7 @@ fn contains_hash_from_bytes_rejects_corrupted_layer_payload() {
     // reaching the slice.
     use super::contains_hash_from_bytes;
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -843,7 +782,7 @@ fn contains_hash_from_bytes_returns_false_for_non_inserted() {
     use super::filter::BurrFilterReader;
     let n = 200_usize;
     let params = BurrParams::with_fp_rate(n, 0.001).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..n as u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
@@ -879,7 +818,7 @@ fn burr_wire_rejects_corrupted_m_below_w() {
     use super::filter::BurrFilterReader;
     // Build a single-layer filter (n = 50 → one layer).
     let params = BurrParams::with_fp_rate(50, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..50_u64)
         .map(|i| crate::hash::hash64(&[i as u8]))
         .collect();
@@ -913,7 +852,7 @@ fn burr_wire_rejects_corrupted_m_below_w() {
 #[test]
 fn burr_builder_rejects_empty_input_via_build_from_hashes() {
     let params = BurrParams::with_fp_rate(100, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let err = builder
         .build_from_hashes(&[])
         .expect_err("empty hash input must error");
@@ -925,25 +864,10 @@ fn burr_builder_rejects_empty_input_via_build_from_hashes() {
 }
 
 #[test]
-fn burr_builder_rejects_empty_input_via_build_keys() {
-    let params = BurrParams::with_fp_rate(100, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
-    let keys: [u64; 0] = [];
-    let err = builder
-        .build(&keys)
-        .expect_err("empty key input must error");
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("non-empty"),
-        "expected non-empty mention: {msg}"
-    );
-}
-
-#[test]
 fn burr_builder_new_rejects_zero_n() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.n = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("n=0 must reject");
+    let err = BurrBuilder::new(params).expect_err("n=0 must reject");
     assert!(format!("{err}").contains("n must be > 0"));
 }
 
@@ -951,13 +875,12 @@ fn burr_builder_new_rejects_zero_n() {
 fn burr_builder_new_rejects_r_out_of_range() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.r = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("r=0 must reject");
+    let err = BurrBuilder::new(params).expect_err("r=0 must reject");
     assert!(format!("{err}").contains("r must be in 1..=64"));
 
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.r = 65;
-    let err =
-        BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("r=65 must reject");
+    let err = BurrBuilder::new(params).expect_err("r=65 must reject");
     assert!(format!("{err}").contains("r must be in 1..=64"));
 }
 
@@ -965,8 +888,7 @@ fn burr_builder_new_rejects_r_out_of_range() {
 fn burr_builder_new_rejects_non_64_w() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.w = 32;
-    let err =
-        BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("w=32 must reject");
+    let err = BurrBuilder::new(params).expect_err("w=32 must reject");
     assert!(format!("{err}").contains("w must be exactly 64"));
 }
 
@@ -974,7 +896,7 @@ fn burr_builder_new_rejects_non_64_w() {
 fn burr_builder_new_rejects_zero_b() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.b = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("b=0 must reject");
+    let err = BurrBuilder::new(params).expect_err("b=0 must reject");
     assert!(format!("{err}").contains("b must be > 0"));
 }
 
@@ -984,7 +906,7 @@ fn burr_builder_new_rejects_b_below_w() {
     // invariant: the builder must reject hand-built params with b < w.
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.b = 32; // < w (= 64)
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default()).expect_err("b<w must reject");
+    let err = BurrBuilder::new(params).expect_err("b<w must reject");
     let msg = format!("{err}");
     assert!(msg.contains("b must be >= w"), "got: {msg}");
 }
@@ -993,15 +915,14 @@ fn burr_builder_new_rejects_b_below_w() {
 fn burr_builder_new_rejects_zero_max_layers() {
     let mut params = BurrParams::with_fp_rate(100, 0.01).expect("params");
     params.max_layers = 0;
-    let err = BurrBuilder::new(params, DefaultBuildHasher::default())
-        .expect_err("max_layers=0 must reject");
+    let err = BurrBuilder::new(params).expect_err("max_layers=0 must reject");
     assert!(format!("{err}").contains("max_layers must be > 0"));
 }
 
 #[test]
 fn burr_builder_debug_includes_params() {
     let params = BurrParams::with_fp_rate(100, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let debug = format!("{builder:?}");
     assert!(debug.contains("BurrBuilder"), "got: {debug}");
     assert!(debug.contains("params"), "got: {debug}");
@@ -1010,7 +931,7 @@ fn burr_builder_debug_includes_params() {
 #[test]
 fn burr_filter_debug_includes_layer_count() {
     let params = BurrParams::with_fp_rate(100, 0.01).expect("params");
-    let builder = BurrBuilder::new(params, DefaultBuildHasher::default()).expect("builder");
+    let builder = BurrBuilder::new(params).expect("builder");
     let hashes: Vec<u64> = (0..100_u64)
         .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();

--- a/src/table/filter/ribbon/burr/wire.rs
+++ b/src/table/filter/ribbon/burr/wire.rs
@@ -35,7 +35,6 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::BuildHasher;
 
 use crate::io::Cursor;
 use crate::io::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -70,10 +69,7 @@ const HEADER_LEN: usize = MAGIC_BYTES.len() + 6 + 8;
 const LAYER_HEADER_LEN: usize = 12;
 
 /// Serialize a built [`BurrFilter`] into the wire format.
-pub(crate) fn encode<S>(filter: &BurrFilter<S>) -> Vec<u8>
-where
-    S: BuildHasher + Clone,
-{
+pub(crate) fn encode(filter: &BurrFilter) -> Vec<u8> {
     let params = filter.params();
     let layers = filter.layers_inner();
 
@@ -507,7 +503,7 @@ pub(crate) fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result
 /// This is the hot path for the LSM filter framework: the table read
 /// path already computes the key's u64 hash for hash-table indexing
 /// elsewhere; the filter consumes that same hash directly instead of
-/// re-hashing via a `BuildHasher`.
+/// re-hashing.
 #[inline]
 pub(crate) fn contains_hash(decoded: &DecodedFilter<'_>, hash: u64) -> bool {
     // r is validated to 1..=64 in decode, so stride_words is always 1

--- a/src/table/filter/ribbon/filter.rs
+++ b/src/table/filter/ribbon/filter.rs
@@ -1,11 +1,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::hash::{BuildHasher, Hash};
 
-use super::builder::Scratch;
 #[cfg(feature = "ribbon-serde")]
 use super::error::FilterReprError;
-use super::hashing::{for_each_set_bit_u128_parts, standard_equation_w64, xor_words};
 use super::params::Params;
 
 #[cfg(feature = "ribbon-serde")]
@@ -30,82 +27,18 @@ pub struct RibbonFilterRepr {
 }
 
 #[derive(Debug, Clone)]
-pub struct RibbonFilter<S> {
+pub struct RibbonFilter {
     params: Params,
-    build_hasher: S,
     z: Vec<u64>,
-    stride_words: usize,
 }
 
-impl<S> RibbonFilter<S>
-where
-    S: BuildHasher + Clone,
-{
-    pub(crate) fn new(params: Params, build_hasher: S, z: Vec<u64>) -> Self {
-        let stride_words = params.fingerprint_words();
-        Self {
-            params,
-            build_hasher,
-            z,
-            stride_words,
-        }
+impl RibbonFilter {
+    pub(crate) fn new(params: Params, z: Vec<u64>) -> Self {
+        Self { params, z }
     }
 
     pub fn params(&self) -> Params {
         self.params
-    }
-
-    pub fn new_scratch(&self) -> Scratch {
-        Scratch::new(self.stride_words)
-    }
-
-    pub fn contains<Q: Hash + ?Sized>(&self, key: &Q) -> bool {
-        let mut scratch = self.new_scratch();
-        self.contains_in(key, &mut scratch)
-    }
-
-    pub fn contains_in<Q: Hash + ?Sized>(&self, key: &Q, scratch: &mut Scratch) -> bool {
-        // Hard runtime check, not debug_assert: a mismatched Scratch in
-        // release would silently truncate via `xor_words` (shorter slice
-        // wins the zip) and could produce false negatives. The caller
-        // contract is "Scratch came from RibbonFilter::new_scratch on
-        // this same filter" — violating it is a programmer error worth
-        // panicking on in production.
-        assert_eq!(
-            scratch.fingerprint.len(),
-            self.stride_words,
-            "scratch fingerprint width mismatch; use RibbonFilter::new_scratch() from this filter",
-        );
-        assert_eq!(
-            scratch.acc.len(),
-            self.stride_words,
-            "scratch accumulator width mismatch; use RibbonFilter::new_scratch() from this filter",
-        );
-        scratch.reset();
-
-        let equation = standard_equation_w64(
-            &self.build_hasher,
-            key,
-            self.params.seed,
-            &self.params,
-            &mut scratch.fingerprint,
-        );
-
-        for_each_set_bit_u128_parts(equation.coeff_lo, equation.coeff_hi, |offset| {
-            let row_index = equation.start + offset;
-            if row_index < self.params.m {
-                let row = self.z_row(row_index);
-                xor_words(&mut scratch.acc, row);
-            }
-        });
-
-        scratch.acc == scratch.fingerprint
-    }
-
-    fn z_row(&self, row: usize) -> &[u64] {
-        let start = row * self.stride_words;
-        let end = start + self.stride_words;
-        &self.z[start..end]
     }
 
     /// Borrowed access to the raw solution-matrix words.
@@ -128,7 +61,7 @@ where
     }
 
     #[cfg(feature = "ribbon-serde")]
-    pub fn from_repr(repr: RibbonFilterRepr, build_hasher: S) -> Result<Self, FilterReprError> {
+    pub fn from_repr(repr: RibbonFilterRepr) -> Result<Self, FilterReprError> {
         if repr.version != RIBBON_FILTER_FORMAT_VERSION {
             return Err(FilterReprError::UnsupportedVersion {
                 found: repr.version,
@@ -156,8 +89,6 @@ where
 
         Ok(Self {
             params: repr.params,
-            build_hasher,
-            stride_words,
             z: repr.z,
         })
     }

--- a/src/table/filter/ribbon/hashing.rs
+++ b/src/table/filter/ribbon/hashing.rs
@@ -1,6 +1,3 @@
-use core::hash::BuildHasher;
-use core::hash::Hash;
-
 use super::params::{Mode, Params};
 
 const MIX_CONST: u64 = 0x9E37_79B9_7F4A_7C15;
@@ -64,28 +61,11 @@ pub(crate) fn start_position_from_stream(next_word: u64, m: usize, w: usize) -> 
     fastrange_u64(next_word, start_range)
 }
 
-pub(crate) fn derive_attempt_seed(base_seed: u64, attempt_index: u64) -> u64 {
-    let mut sm = SplitMix64::new(base_seed ^ attempt_index.wrapping_mul(MIX_CONST));
-    sm.next_u64().wrapping_mul(MIX_CONST)
-}
-
-pub(crate) fn standard_equation_w64<S: BuildHasher, Q: Hash + ?Sized>(
-    build_hasher: &S,
-    key: &Q,
-    seed: u64,
-    params: &Params,
-    fingerprint: &mut [u64],
-) -> StandardEquation {
-    let base_hash = build_hasher.hash_one(key);
-    standard_equation_from_hash(base_hash, seed, params, fingerprint)
-}
-
 /// Compute the equation directly from a pre-computed key hash.
 ///
-/// This is the inner loop of [`standard_equation_w64`], factored out so
-/// the BuRR wire-format probe path (which consumes pre-hashed inputs from
-/// the LSM filter framework) can skip the `build_hasher.hash_one(key)`
-/// step entirely.
+/// The LSM filter framework hands in keys already hashed to a stable
+/// `u64` (xxh3 / `crate::hash::hash64`), so the ribbon never hashes keys
+/// itself — this is the sole equation entry point.
 #[expect(
     clippy::inline_always,
     reason = "called per layer on the BuRR filter probe hot path; inlining lets LLVM fold the \

--- a/src/table/filter/ribbon/mod.rs
+++ b/src/table/filter/ribbon/mod.rs
@@ -84,8 +84,8 @@
 //! equations (smaller storage at the cost of slightly higher false-positive
 //! rate at small `r`).
 //!
-//! See [`Params::new`] for the entry point and [`RibbonBuilder::build`] for
-//! the construction call.
+//! See [`Params::new`] for the entry point; ribbons are constructed from
+//! pre-hashed keys via `RibbonBuilder::build_with_seed_verbatim_from_hashes`.
 
 pub mod builder;
 pub mod burr;
@@ -94,7 +94,7 @@ pub mod filter;
 pub mod hashing;
 pub mod params;
 
-pub use builder::{RibbonBuilder, Scratch};
+pub use builder::RibbonBuilder;
 pub use error::{BuildError, ConstructionFailure, FilterReprError, ParamError};
 pub use filter::RibbonFilter;
 #[cfg(feature = "ribbon-serde")]

--- a/src/table/filter/ribbon/params.rs
+++ b/src/table/filter/ribbon/params.rs
@@ -59,9 +59,9 @@ impl Params {
             // seed; the retry just iterates derived seeds within that
             // seed family).
             //
-            // BuRR's own build path bypasses retry entirely via
-            // `build_with_seed_verbatim`, so this default only affects
-            // direct `RibbonBuilder::build` consumers.
+            // BuRR's build path bypasses retry entirely via
+            // `build_with_seed_verbatim_from_hashes` (single verbatim-seed
+            // attempt), so retry/grow are inert for the in-crate caller.
             retry_limit: 8,
             grow_limit: 0,
         };

--- a/src/table/filter/ribbon/tests.rs
+++ b/src/table/filter/ribbon/tests.rs
@@ -1,10 +1,6 @@
 use super::{BuildError, Mode, ParamError, Params, RibbonBuilder};
-use core::hash::BuildHasherDefault;
-use std::collections::hash_map::DefaultHasher;
 
-use super::hashing::{standard_equation_w64, start_position_from_stream};
-
-type DefaultBuildHasher = BuildHasherDefault<DefaultHasher>;
+use super::hashing::{standard_equation_from_hash, start_position_from_stream};
 
 #[test]
 fn params_rejects_zero_m() {
@@ -80,379 +76,62 @@ fn params_from_expected_items_rejects_overhead_out_of_range() {
     assert!(matches!(err, ParamError::InvalidOverhead { .. }));
 }
 
+// The equation pipeline is exercised directly from pre-computed hashes
+// (the only path the crate uses now that keys arrive pre-hashed).
+
 #[test]
-fn hash_pipeline_start_in_range_and_pivot_forced() {
-    let hasher = DefaultBuildHasher::default();
+fn equation_start_in_range_and_pivot_forced() {
     let params = Params::new(128, 17, 13, Mode::Standard).expect("params must be valid");
     let mut fp = vec![0u64; params.fingerprint_words()];
 
-    let eq = standard_equation_w64(&hasher, &"hello-key", 42, &params, &mut fp);
+    let eq = standard_equation_from_hash(0x0123_4567_89AB_CDEF, 42, &params, &mut fp);
 
     assert!(eq.start < params.start_range());
     assert_eq!(eq.coeff_lo & 1, 1);
 }
 
 #[test]
-fn hash_pipeline_masks_fingerprint_to_r_bits() {
-    let hasher = DefaultBuildHasher::default();
+fn equation_masks_fingerprint_to_r_bits() {
     let params = Params::new(64, 8, 9, Mode::Standard).expect("params must be valid");
     let mut fp = vec![0u64; params.fingerprint_words()];
 
-    let _ = standard_equation_w64(&hasher, &12345u64, 7, &params, &mut fp);
+    let _ = standard_equation_from_hash(0xDEAD_BEEF_CAFE_F00D, 7, &params, &mut fp);
 
     assert_eq!(fp[0] & !params.fingerprint_last_word_mask(), 0);
 }
 
 #[test]
-fn hash_pipeline_is_deterministic_for_seed_and_key() {
-    let hasher = DefaultBuildHasher::default();
+fn equation_is_deterministic_for_seed_and_hash() {
     let params = Params::new(96, 16, 20, Mode::Standard).expect("params must be valid");
     let mut fp_a = vec![0u64; params.fingerprint_words()];
     let mut fp_b = vec![0u64; params.fingerprint_words()];
 
-    let eq_a = standard_equation_w64(&hasher, &"deterministic-key", 999, &params, &mut fp_a);
-    let eq_b = standard_equation_w64(&hasher, &"deterministic-key", 999, &params, &mut fp_b);
+    let h = 0x1122_3344_5566_7788;
+    let eq_a = standard_equation_from_hash(h, 999, &params, &mut fp_a);
+    let eq_b = standard_equation_from_hash(h, 999, &params, &mut fp_b);
 
     assert_eq!(eq_a, eq_b);
     assert_eq!(fp_a, fp_b);
 }
 
 #[test]
-fn standard_builder_has_no_false_negatives_1k() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 12, Mode::Standard).expect("params should be valid");
-    let builder = RibbonBuilder::new(params.with_seed(11), hasher).expect("builder should build");
-
-    let keys: Vec<u64> = (0..1000).collect();
-    let filter = builder.build(&keys).expect("construction should succeed");
-
-    for key in &keys {
-        assert!(filter.contains(key), "false negative for key {key}");
-    }
-}
-
-#[test]
-fn standard_builder_has_no_false_negatives_10k() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(30000, 16, 10, Mode::Standard).expect("params should be valid");
-    let builder = RibbonBuilder::new(params.with_seed(13), hasher).expect("builder should build");
-
-    let keys: Vec<u64> = (0..10000).collect();
-    let filter = builder.build(&keys).expect("construction should succeed");
-
-    for key in &keys {
-        assert!(filter.contains(key), "false negative for key {key}");
-    }
-}
-
-#[test]
-fn standard_builder_reports_inconsistent_equation_failure() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(5);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should build");
-
-    let keys: Vec<u64> = (0..200).collect();
-    let result = builder.build(&keys);
-
-    match result {
-        Err(BuildError::ConstructionFailed { last_failure, .. }) => {
-            assert!(matches!(
-                last_failure,
-                super::ConstructionFailure::InconsistentEquation { .. }
-            ));
-        }
-        Err(other) => panic!("expected construction failure, got {other}"),
-        Ok(_) => panic!("expected failure, got success"),
-    }
-}
-
-#[test]
-fn standard_builder_is_deterministic_for_same_input() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 9, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(99);
-
-    let builder_a = RibbonBuilder::new(params, hasher.clone()).expect("builder should build");
-    let builder_b = RibbonBuilder::new(params, hasher).expect("builder should build");
-
-    let keys: Vec<u64> = (1000..2000).collect();
-    let filter_a = builder_a.build(&keys).expect("first build should succeed");
-    let filter_b = builder_b.build(&keys).expect("second build should succeed");
-
-    for probe in 990..2010u64 {
-        assert_eq!(
-            filter_a.contains(&probe),
-            filter_b.contains(&probe),
-            "non-deterministic result for key {probe}"
-        );
-    }
-}
-
-#[derive(Default, Clone)]
-struct ConstantBuildHasher;
-
-impl std::hash::BuildHasher for ConstantBuildHasher {
-    type Hasher = ConstantHasher;
-
-    fn build_hasher(&self) -> Self::Hasher {
-        ConstantHasher
-    }
-}
-
-#[derive(Default, Clone)]
-struct ConstantHasher;
-
-impl std::hash::Hasher for ConstantHasher {
-    fn finish(&self) -> u64 {
-        0
-    }
-
-    fn write(&mut self, _bytes: &[u8]) {}
-}
-
-#[test]
-fn builder_supports_custom_buildhasher() {
-    let hasher = ConstantBuildHasher;
-    let params = Params::new(3000, 16, 9, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(88);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should build");
-
-    let keys: Vec<u64> = (0..200).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
-
-    let mut scratch = filter.new_scratch();
-    for key in &keys {
-        assert!(filter.contains_in(key, &mut scratch));
-    }
-}
-
-#[test]
-fn contains_and_contains_in_are_equivalent() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 9, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(77);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should build");
-    let keys: Vec<u64> = (1000..2000).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
-
-    let mut scratch = filter.new_scratch();
-    for probe in 900..2100u64 {
-        assert_eq!(
-            filter.contains(&probe),
-            filter.contains_in(&probe, &mut scratch),
-            "contains mismatch at key {probe}"
-        );
-    }
-}
-
-#[test]
-fn retry_path_is_exercised_and_eventually_succeeds() {
-    let hasher = DefaultBuildHasher::default();
-    let keys: Vec<u64> = (0..500).collect();
-    let params = Params::new(16, 16, 8, Mode::Standard)
-        .expect("params valid")
-        .with_seed(1)
-        .with_retry_policy(3, 0)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder valid");
-
-    match builder.build(&keys) {
-        Err(BuildError::ConstructionFailed {
-            final_m,
-            attempts,
-            last_failure,
-        }) => {
-            assert_eq!(final_m, 16);
-            assert_eq!(attempts, 3);
-            assert!(matches!(
-                last_failure,
-                super::ConstructionFailure::InconsistentEquation { .. }
-            ));
-        }
-        other => panic!("expected retry-exhausted failure, got {other:?}"),
-    }
-}
-
-#[test]
-fn growth_path_is_exercised_and_reports_grown_m() {
-    let hasher = DefaultBuildHasher::default();
-    let keys: Vec<u64> = (0..500).collect();
-    let params = Params::new(16, 16, 8, Mode::Standard)
-        .expect("params valid")
-        .with_seed(1)
-        .with_retry_policy(2, 2)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder valid");
-
-    match builder.build(&keys) {
-        Err(BuildError::ConstructionFailed {
-            final_m,
-            attempts,
-            last_failure,
-        }) => {
-            assert_eq!(attempts, 6);
-            assert_eq!(final_m, 19);
-            assert!(matches!(
-                last_failure,
-                super::ConstructionFailure::InconsistentEquation { .. }
-            ));
-        }
-        other => panic!("expected growth-exhausted failure, got {other:?}"),
-    }
-}
-
-#[test]
-fn terminal_failure_reports_attempts_and_final_m() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Standard)
-        .expect("params valid")
-        .with_seed(1)
-        .with_retry_policy(2, 2)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder valid");
-    let keys: Vec<u64> = (0..500).collect();
-
-    match builder.build(&keys) {
-        Err(BuildError::ConstructionFailed {
-            final_m,
-            attempts,
-            last_failure,
-        }) => {
-            assert_eq!(attempts, 6);
-            assert_eq!(final_m, 19);
-            assert!(matches!(
-                last_failure,
-                super::ConstructionFailure::InconsistentEquation { .. }
-            ));
-        }
-        other => panic!("expected terminal construction failure, got {other:?}"),
-    }
-}
-
-#[test]
-fn successful_build_persists_selected_attempt_seed() {
-    let hasher = DefaultBuildHasher::default();
-    let base_seed = 123u64;
-    let params = Params::new(3000, 16, 9, Mode::Standard)
-        .expect("params valid")
-        .with_seed(base_seed)
-        .with_retry_policy(1, 0)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder valid");
-    let keys: Vec<u64> = (0..1000).collect();
-
-    let filter = builder.build(&keys).expect("build should succeed");
-    assert_eq!(
-        filter.params().seed,
-        super::hashing::derive_attempt_seed(base_seed, 0)
-    );
-}
-
-#[test]
-fn homogeneous_build_succeeds_and_has_no_false_negatives() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(4000, 16, 8, Mode::Homogeneous)
-        .expect("params valid")
-        .with_seed(55);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder valid");
-    let keys: Vec<u64> = (0..1000).collect();
-
-    let filter = builder
-        .build(&keys)
-        .expect("homogeneous build should succeed");
-    let mut scratch = filter.new_scratch();
-    for key in &keys {
-        assert!(filter.contains_in(key, &mut scratch));
-    }
-}
-
-#[test]
-fn homogeneous_mode_false_positive_rate_is_sane_across_seeds_and_sizes() {
-    let hasher = DefaultBuildHasher::default();
-    let r = 8usize;
-    let seeds = [7u64, 77u64, 777u64];
-    let sizes = [2_000usize, 8_000usize];
-    let queries = 40_000usize;
-
-    for &seed in &seeds {
-        for &n in &sizes {
-            let params = Params::new(n * 4, 16, r, Mode::Homogeneous)
-                .expect("params valid")
-                .with_seed(seed)
-                .with_retry_policy(2, 0)
-                .expect("retry policy valid");
-            let builder = RibbonBuilder::new(params, hasher.clone()).expect("builder valid");
-            let keys: Vec<u64> = (0..n as u64).collect();
-            let filter = builder
-                .build(&keys)
-                .expect("homogeneous build should succeed");
-
-            let mut scratch = filter.new_scratch();
-            let mut fp = 0usize;
-            let query_start = 10_000_000u64 + (seed << 20) + n as u64;
-            for q in 0..queries {
-                if filter.contains_in(&(query_start + q as u64), &mut scratch) {
-                    fp += 1;
-                }
-            }
-
-            let observed = fp as f64 / queries as f64;
-            let expected = 2f64.powi(-(r as i32));
-
-            assert!(
-                observed > 0.0005,
-                "homogeneous fp unexpectedly near-zero seed={seed} n={n}: observed={observed}, expected~{expected}"
-            );
-            assert!(
-                observed < 0.05,
-                "homogeneous fp unexpectedly near-trivial-high seed={seed} n={n}: observed={observed}, expected~{expected}"
-            );
-            assert!(
-                observed >= expected / 8.0 && observed <= expected * 8.0,
-                "homogeneous fp far from expected envelope seed={seed} n={n}: observed={observed}, expected~{expected}"
-            );
-        }
-    }
-}
-
-#[test]
-fn construction_failure_out_of_bounds_display_contains_context() {
-    let err = super::ConstructionFailure::OutOfBounds {
-        key_index: Some(12),
-        row_index: 99,
-        m: 80,
-    };
-    let msg = err.to_string();
-    assert!(msg.contains("row index 99"));
-    assert!(msg.contains("m=80"));
-    assert!(msg.contains("key at index 12"));
-}
-
-#[test]
 fn homogeneous_pipeline_has_zero_fingerprint() {
-    let hasher = DefaultBuildHasher::default();
     let params = Params::new(128, 16, 9, Mode::Homogeneous).expect("params must be valid");
     let mut fp = vec![0u64; params.fingerprint_words()];
 
-    let _ = standard_equation_w64(&hasher, &"h-key", 11, &params, &mut fp);
+    let _ = standard_equation_from_hash(0xABCD_1234_5678_9ABC, 11, &params, &mut fp);
 
     assert!(fp.iter().all(|&w| w == 0));
 }
 
 #[test]
 fn width_128_pipeline_sets_bits_in_both_halves() {
-    let hasher = DefaultBuildHasher::default();
     let params = Params::new(400, 128, 8, Mode::Standard).expect("params valid");
 
     let mut saw_hi = false;
     for seed in 0..500u64 {
         let mut fp = vec![0u64; params.fingerprint_words()];
-        let eq = standard_equation_w64(&hasher, &"w128-key", seed, &params, &mut fp);
+        let eq = standard_equation_from_hash(0xF00D_BA11_0BAD_F00D, seed, &params, &mut fp);
 
         if eq.coeff_hi != 0 {
             saw_hi = true;
@@ -464,72 +143,6 @@ fn width_128_pipeline_sets_bits_in_both_halves() {
         saw_hi,
         "expected at least one seed with high-half coefficient bits"
     );
-}
-
-#[test]
-fn builder_supports_width_above_64() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(4000, 96, 10, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(303)
-        .with_retry_policy(4, 1)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should build");
-    let keys: Vec<u64> = (0..800).collect();
-    let filter = builder.build(&keys).expect("construction should succeed");
-    let mut scratch = filter.new_scratch();
-
-    for key in &keys {
-        assert!(filter.contains_in(key, &mut scratch));
-    }
-}
-
-#[test]
-fn bitpacked_storage_maintains_membership_behavior() {
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 12, Mode::Standard)
-        .expect("params should be valid")
-        .with_seed(1234);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should build");
-    let keys: Vec<u64> = (0..1000).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
-
-    let mut scratch = filter.new_scratch();
-    for key in &keys {
-        assert!(filter.contains_in(key, &mut scratch));
-    }
-}
-
-#[test]
-fn compatibility_matrix_modes_widths_and_fingerprints() {
-    let hasher = DefaultBuildHasher::default();
-    let modes = [Mode::Standard, Mode::Homogeneous];
-    let widths = [16usize, 80usize, 128usize];
-    let rs = [8usize, 12usize];
-
-    for mode in modes {
-        for w in widths {
-            for r in rs {
-                let params = Params::new(6000, w, r, mode)
-                    .expect("params should be valid")
-                    .with_seed(700 + w as u64 + r as u64)
-                    .with_retry_policy(5, 2)
-                    .expect("retry policy valid");
-                let builder =
-                    RibbonBuilder::new(params, hasher.clone()).expect("builder should build");
-                let keys: Vec<u64> = (0..1000).collect();
-                let filter = builder.build(&keys).expect("construction should succeed");
-                let mut scratch = filter.new_scratch();
-
-                for key in &keys {
-                    assert!(
-                        filter.contains_in(key, &mut scratch),
-                        "false negative for mode={mode}, w={w}, r={r}, key={key}"
-                    );
-                }
-            }
-        }
-    }
 }
 
 #[test]
@@ -545,239 +158,87 @@ fn start_position_hook_stays_in_bounds() {
 }
 
 #[test]
-fn statistical_false_positive_rates_are_within_confidence_bounds() {
-    let hasher = DefaultBuildHasher::default();
-    let seeds = [11u64, 42u64, 777u64];
-    let sizes = [1000usize, 5000usize];
-    let rs = [8usize, 12usize];
-
-    for &seed in &seeds {
-        for &n in &sizes {
-            for &r in &rs {
-                let params = Params::new(n * 4, 16, r, Mode::Standard)
-                    .expect("params should be valid")
-                    .with_seed(seed)
-                    .with_retry_policy(4, 1)
-                    .expect("retry policy should be valid");
-                let builder =
-                    RibbonBuilder::new(params, hasher.clone()).expect("builder should be valid");
-                let keys: Vec<u64> = (0..n as u64).collect();
-                let filter = builder.build(&keys).expect("construction should succeed");
-
-                let queries = 20_000usize;
-                let query_start = 10_000_000u64 + (seed << 20) + n as u64;
-                let mut scratch = filter.new_scratch();
-                let mut fp = 0usize;
-                for q in 0..queries {
-                    if filter.contains_in(&(query_start + q as u64), &mut scratch) {
-                        fp += 1;
-                    }
-                }
-
-                let p = 2f64.powi(-(r as i32));
-                let mean = (queries as f64) * p;
-                let var = (queries as f64) * p * (1.0 - p);
-                let sigma = var.sqrt();
-                let tolerance = (8.0 * sigma).max(8.0);
-                let lower = (mean - tolerance).max(0.0);
-                let upper = mean + tolerance;
-                let observed = fp as f64;
-
-                assert!(
-                    observed >= lower && observed <= upper,
-                    "fp out of bounds seed={seed} n={n} r={r}: observed={observed} expected~{mean} bounds=[{lower}, {upper}]"
-                );
-            }
-        }
-    }
-}
-
-fn lcg_next(state: &mut u64) -> u64 {
-    *state = state
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add(1442695040888963407);
-    *state
-}
-
-#[test]
-fn property_no_false_negatives_across_generated_cases() {
-    let hasher = DefaultBuildHasher::default();
-    let mut rng = 1u64;
-
-    for case in 0..20u64 {
-        let seed = lcg_next(&mut rng);
-        let n = 200 + (lcg_next(&mut rng) % 400) as usize;
-        let w_choices = [16usize, 32usize, 80usize, 128usize];
-        let w = w_choices[(lcg_next(&mut rng) as usize) % w_choices.len()];
-        let r_choices = [8usize, 10usize, 12usize];
-        let r = r_choices[(lcg_next(&mut rng) as usize) % r_choices.len()];
-        let mode = if (lcg_next(&mut rng) & 1) == 0 {
-            Mode::Standard
-        } else {
-            Mode::Homogeneous
-        };
-
-        let params = Params::new((n * 5).max(w), w, r, mode)
-            .expect("params should be valid")
-            .with_seed(seed)
-            .with_retry_policy(4, 2)
-            .expect("retry policy should be valid");
-        let builder = RibbonBuilder::new(params, hasher.clone()).expect("builder should be valid");
-        let keys: Vec<u64> = (0..n as u64)
-            .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(seed))
-            .collect();
-        let filter = builder
-            .build(&keys)
-            .expect("construction should succeed for generated case");
-        let mut scratch = filter.new_scratch();
-
-        for key in &keys {
-            assert!(
-                filter.contains_in(key, &mut scratch),
-                "false negative for case={case}, mode={mode}, w={w}, r={r}, seed={seed}, key={key}"
-            );
-        }
-    }
-}
-
-#[test]
-fn property_determinism_across_generated_cases() {
-    let hasher = DefaultBuildHasher::default();
-    let mut rng = 99u64;
-
-    for case in 0..16u64 {
-        let seed = lcg_next(&mut rng);
-        let n = 180 + (lcg_next(&mut rng) % 320) as usize;
-        let w_choices = [16usize, 64usize, 96usize];
-        let w = w_choices[(lcg_next(&mut rng) as usize) % w_choices.len()];
-        let r = if (lcg_next(&mut rng) & 1) == 0 { 8 } else { 12 };
-        let mode = if (lcg_next(&mut rng) & 1) == 0 {
-            Mode::Standard
-        } else {
-            Mode::Homogeneous
-        };
-
-        let params = Params::new((n * 5).max(w), w, r, mode)
-            .expect("params should be valid")
-            .with_seed(seed)
-            .with_retry_policy(4, 2)
-            .expect("retry policy should be valid");
-        let keys: Vec<u64> = (0..n as u64)
-            .map(|i| i.wrapping_mul(0xD6E8_FEB8_6659_FD93).wrapping_add(seed))
-            .collect();
-
-        let builder_a = RibbonBuilder::new(params, hasher.clone()).expect("builder a valid");
-        let builder_b = RibbonBuilder::new(params, hasher.clone()).expect("builder b valid");
-        let filter_a = builder_a.build(&keys).expect("build a should succeed");
-        let filter_b = builder_b.build(&keys).expect("build b should succeed");
-
-        let mut scratch_a = filter_a.new_scratch();
-        let mut scratch_b = filter_b.new_scratch();
-        for probe in 0..(n as u64 + 128) {
-            let q = probe.wrapping_mul(0x94D0_49BB_1331_11EB).wrapping_add(seed);
-            assert_eq!(
-                filter_a.contains_in(&q, &mut scratch_a),
-                filter_b.contains_in(&q, &mut scratch_b),
-                "determinism mismatch case={case}, mode={mode}, w={w}, r={r}, seed={seed}, q={q}"
-            );
-        }
-    }
-}
-
-fn adversarial_patterns(n: usize) -> Vec<(&'static str, Vec<u64>)> {
-    let ordered: Vec<u64> = (0..n as u64).collect();
-    let constant_low_bits: Vec<u64> = (0..n as u64).map(|i| (i << 16) | 0xFFFF).collect();
-    let stride_1024: Vec<u64> = (0..n as u64).map(|i| i * 1024).collect();
-    let gray_code: Vec<u64> = (0..n as u64).map(|i| i ^ (i >> 1)).collect();
-    let mul_mix_a: Vec<u64> = (0..n as u64)
-        .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+fn build_with_seed_verbatim_from_hashes_round_trips() {
+    // The entry point BuRR uses with xxh3-hashed LSM keys.
+    let params = Params::new(3000, 16, 9, Mode::Standard).expect("valid");
+    let builder = RibbonBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..500_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
         .collect();
-    let mul_mix_b: Vec<u64> = (0..n as u64)
-        .map(|i| i.wrapping_mul(0xD6E8_FEB8_6659_FD93))
-        .collect();
-
-    vec![
-        ("ordered_u64", ordered),
-        ("constant_low_bits", constant_low_bits),
-        ("stride_1024", stride_1024),
-        ("gray_code", gray_code),
-        ("mul_mix_a", mul_mix_a),
-        ("mul_mix_b", mul_mix_b),
-    ]
+    let filter = builder
+        .build_with_seed_verbatim_from_hashes(&hashes, 0x1234_5678_9ABC_DEF0, 3000)
+        .expect("verbatim-from-hashes build should land");
+    assert_eq!(filter.params().seed, 0x1234_5678_9ABC_DEF0);
 }
 
 #[test]
-fn adversarial_regression_corpus_has_no_false_negatives() {
-    let hasher = DefaultBuildHasher::default();
-    let n = 2000usize;
-
-    for (name, keys) in adversarial_patterns(n) {
-        let params = Params::new(8000, 16, 10, Mode::Standard)
-            .expect("params should be valid")
-            .with_seed(404)
-            .with_retry_policy(6, 2)
-            .expect("retry policy should be valid");
-        let builder = RibbonBuilder::new(params, hasher.clone()).expect("builder should be valid");
-        let filter = builder
-            .build(&keys)
-            .expect("construction should succeed for adversarial set");
-        let mut scratch = filter.new_scratch();
-
-        for key in &keys {
-            assert!(
-                filter.contains_in(key, &mut scratch),
-                "false negative in adversarial set '{name}' for key {key}"
-            );
+fn build_with_seed_verbatim_from_hashes_propagates_failure() {
+    // Hashes that overload a tight m must surface ConstructionFailed
+    // through the from-hashes wrapper — single-attempt contract.
+    let params = Params::new(16, 16, 8, Mode::Standard).expect("valid");
+    let builder = RibbonBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..200_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let result = builder.build_with_seed_verbatim_from_hashes(&hashes, 7, 16);
+    match result {
+        Err(BuildError::ConstructionFailed {
+            attempts, final_m, ..
+        }) => {
+            assert_eq!(attempts, 1);
+            assert_eq!(final_m, 16);
         }
+        Ok(_) => panic!("tight m=16 with 200 hashes must not build"),
+        Err(other) => panic!("expected ConstructionFailed, got {other:?}"),
     }
 }
 
 #[cfg(feature = "ribbon-serde")]
 #[test]
-fn serde_roundtrip_preserves_membership_behavior() {
-    let hasher = DefaultBuildHasher::default();
+fn serde_roundtrip_preserves_storage() {
     let params = Params::new(3000, 16, 10, Mode::Standard)
         .expect("params should be valid")
         .with_seed(4242);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should be valid");
-    let keys: Vec<u64> = (0..1000).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
+    let builder = RibbonBuilder::new(params).expect("builder should be valid");
+    let hashes: Vec<u64> = (0..1000_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder
+        .build_with_seed_verbatim_from_hashes(&hashes, params.seed, 3000)
+        .expect("build should succeed");
 
     let repr = filter.to_repr();
     let encoded = serde_json::to_string(&repr).expect("serialize should succeed");
     let decoded_repr: super::RibbonFilterRepr =
         serde_json::from_str(&encoded).expect("deserialize should succeed");
-    let decoded = super::RibbonFilter::from_repr(decoded_repr, DefaultBuildHasher::default())
-        .expect("reconstructing filter should succeed");
+    let decoded =
+        super::RibbonFilter::from_repr(decoded_repr).expect("reconstructing filter should succeed");
 
-    let mut scratch_original = filter.new_scratch();
-    let mut scratch_decoded = decoded.new_scratch();
-    for probe in 0..1200u64 {
-        assert_eq!(
-            filter.contains_in(&probe, &mut scratch_original),
-            decoded.contains_in(&probe, &mut scratch_decoded),
-            "membership mismatch for probe {probe}"
-        );
-    }
+    // No on-disk change: the solution matrix and seed survive the round trip.
+    assert_eq!(filter.z_raw_words(), decoded.z_raw_words());
+    assert_eq!(filter.params().seed, decoded.params().seed);
 }
 
 #[cfg(feature = "ribbon-serde")]
 #[test]
 fn serde_rejects_unknown_filter_version() {
-    let hasher = DefaultBuildHasher::default();
     let params = Params::new(512, 16, 8, Mode::Standard)
         .expect("params should be valid")
         .with_seed(9);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should be valid");
-    let keys: Vec<u64> = (0..100).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
+    let builder = RibbonBuilder::new(params).expect("builder should be valid");
+    let hashes: Vec<u64> = (0..100_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder
+        .build_with_seed_verbatim_from_hashes(&hashes, params.seed, 512)
+        .expect("build should succeed");
 
     let mut value = serde_json::to_value(filter.to_repr()).expect("serialize should succeed");
     value["version"] = serde_json::Value::from(99u64);
 
     let repr = serde_json::from_value::<super::RibbonFilterRepr>(value)
         .expect("deserializing repr should succeed");
-    let err = super::RibbonFilter::from_repr(repr, DefaultBuildHasher::default())
+    let err = super::RibbonFilter::from_repr(repr)
         .expect_err("reconstructing unknown version should fail");
     assert!(err.to_string().contains("unsupported RibbonFilter version"));
 }
@@ -785,25 +246,41 @@ fn serde_rejects_unknown_filter_version() {
 #[cfg(feature = "ribbon-serde")]
 #[test]
 fn serde_rejects_incorrect_storage_word_length() {
-    let hasher = DefaultBuildHasher::default();
     let params = Params::new(512, 16, 8, Mode::Standard)
         .expect("params should be valid")
         .with_seed(10);
-    let builder = RibbonBuilder::new(params, hasher).expect("builder should be valid");
-    let keys: Vec<u64> = (0..100).collect();
-    let filter = builder.build(&keys).expect("build should succeed");
+    let builder = RibbonBuilder::new(params).expect("builder should be valid");
+    let hashes: Vec<u64> = (0..100_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder
+        .build_with_seed_verbatim_from_hashes(&hashes, params.seed, 512)
+        .expect("build should succeed");
 
     let mut repr = filter.to_repr();
     let expected_words = repr.params.m * repr.params.fingerprint_words();
     let wrong_words = expected_words - 1;
     repr.z = vec![0_u64; wrong_words];
 
-    let err = super::RibbonFilter::from_repr(repr, DefaultBuildHasher::default())
+    let err = super::RibbonFilter::from_repr(repr)
         .expect_err("reconstructing invalid storage should fail");
     assert!(
         err.to_string()
             .contains("invalid RibbonFilter storage word length")
     );
+}
+
+#[test]
+fn construction_failure_out_of_bounds_display_contains_context() {
+    let err = super::ConstructionFailure::OutOfBounds {
+        key_index: Some(12),
+        row_index: 99,
+        m: 80,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("row index 99"));
+    assert!(msg.contains("m=80"));
+    assert!(msg.contains("key at index 12"));
 }
 
 #[test]
@@ -913,149 +390,4 @@ fn filter_repr_error_display_covers_variants() {
         }
     );
     assert!(s.contains('5') && s.contains("10"), "got: {s}");
-}
-
-#[test]
-fn build_with_seed_verbatim_succeeds_with_generous_m() {
-    // Direct exercise of `build_with_seed_verbatim` (the no-retry,
-    // verbatim-seed entry BuRR builds layers through). Generous m so a
-    // single attempt with the fixed seed lands.
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 9, Mode::Standard).expect("valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder");
-    let keys: Vec<u64> = (0..500).collect();
-    let filter = builder
-        .build_with_seed_verbatim(&keys, 0xABCD_1234, 3000)
-        .expect("verbatim build should land at m=3000");
-    for k in &keys {
-        assert!(filter.contains(k), "false negative for {k}");
-    }
-    // Persisted seed must be the one we passed, not derive_attempt_seed-mixed.
-    assert_eq!(filter.params().seed, 0xABCD_1234);
-}
-
-#[test]
-fn build_with_seed_verbatim_reports_single_attempt_on_failure() {
-    // Tight m forces a build failure even with a verbatim seed.
-    // The error must carry attempts=1 (no retry budget on verbatim).
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Standard).expect("valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder");
-    let keys: Vec<u64> = (0..200).collect();
-    let result = builder.build_with_seed_verbatim(&keys, 0xDEAD_BEEF, 16);
-    match result {
-        Err(BuildError::ConstructionFailed {
-            attempts, final_m, ..
-        }) => {
-            assert_eq!(attempts, 1, "verbatim must not retry");
-            assert_eq!(final_m, 16);
-        }
-        Ok(_) => panic!("tight m=16 with 200 keys should not build"),
-        Err(other) => panic!("expected ConstructionFailed, got {other:?}"),
-    }
-}
-
-#[test]
-fn build_with_seed_verbatim_from_hashes_round_trips() {
-    // Same as build_with_seed_verbatim but feeds raw u64 hashes — the
-    // entry point BuRR actually uses with xxh3-hashed LSM keys.
-    let bh = DefaultBuildHasher::default();
-    let params = Params::new(3000, 16, 9, Mode::Standard).expect("valid");
-    let builder = RibbonBuilder::new(params, bh).expect("builder");
-    let hashes: Vec<u64> = (0..500_u64)
-        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
-        .collect();
-    let filter = builder
-        .build_with_seed_verbatim_from_hashes(&hashes, 0x1234_5678_9ABC_DEF0, 3000)
-        .expect("verbatim-from-hashes build should land");
-    assert_eq!(filter.params().seed, 0x1234_5678_9ABC_DEF0);
-}
-
-#[test]
-fn build_with_seed_verbatim_from_hashes_propagates_failure() {
-    // Hashes that overload a tight m must surface ConstructionFailed
-    // through the from-hashes wrapper too — same single-attempt
-    // contract as the key-based variant.
-    let bh = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Standard).expect("valid");
-    let builder = RibbonBuilder::new(params, bh).expect("builder");
-    let hashes: Vec<u64> = (0..200_u64)
-        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
-        .collect();
-    let result = builder.build_with_seed_verbatim_from_hashes(&hashes, 7, 16);
-    match result {
-        Err(BuildError::ConstructionFailed {
-            attempts, final_m, ..
-        }) => {
-            assert_eq!(attempts, 1);
-            assert_eq!(final_m, 16);
-        }
-        Ok(_) => panic!("tight m=16 with 200 hashes must not build"),
-        Err(other) => panic!("expected ConstructionFailed, got {other:?}"),
-    }
-}
-
-#[test]
-fn build_homogeneous_does_not_iterate_retries() {
-    // In Homogeneous mode the inner retry loop must break after the
-    // first attempt (the algorithm has no notion of retrying with a
-    // different seed). With retry_limit=5 we should see attempts=1 on
-    // failure, not 5.
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Homogeneous)
-        .expect("valid")
-        .with_seed(1)
-        .with_retry_policy(5, 0)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder");
-    let keys: Vec<u64> = (0..200).collect();
-    let result = builder.build(&keys);
-    // Homogeneous "build" always succeeds on insertable input because
-    // unoccupied rows get random fingerprints. With m=16 << 200 keys
-    // the insertion loop should fail; if so, attempts must be 1.
-    if let Err(BuildError::ConstructionFailed { attempts, .. }) = result {
-        assert_eq!(attempts, 1, "Homogeneous must break after first attempt");
-    }
-    // If it succeeded, that's also fine — the break path was still
-    // exercised on the success arm via the loop's natural exit.
-}
-
-#[test]
-fn build_homogeneous_does_not_grow() {
-    // The outer grow loop must also short-circuit in Homogeneous mode:
-    // even with grow_limit=3 we should never grow m past the original.
-    let hasher = DefaultBuildHasher::default();
-    let params = Params::new(16, 16, 8, Mode::Homogeneous)
-        .expect("valid")
-        .with_seed(2)
-        .with_retry_policy(2, 3)
-        .expect("retry policy valid");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder");
-    let keys: Vec<u64> = (0..200).collect();
-    if let Err(BuildError::ConstructionFailed { final_m, .. }) = builder.build(&keys) {
-        assert_eq!(final_m, 16, "Homogeneous must not grow m");
-    }
-}
-
-#[test]
-fn builder_terminal_failure_after_grow_exhausted() {
-    let hasher = DefaultBuildHasher::default();
-    // Tight: m=16, w=16 — small chance of single-attempt success. With
-    // grow_limit=0 + retry_limit=1 it should fail.
-    let params = Params::new(16, 16, 8, Mode::Standard)
-        .expect("valid")
-        .with_seed(123)
-        .with_retry_limit(1)
-        .expect("retry");
-    let builder = RibbonBuilder::new(params, hasher).expect("builder");
-    let keys: Vec<u64> = (0..16).collect();
-    let result = builder.build(&keys);
-    if let Err(super::error::BuildError::ConstructionFailed {
-        attempts, final_m, ..
-    }) = result
-    {
-        assert_eq!(attempts, 1);
-        assert_eq!(final_m, 16);
-    }
-    // Either succeeds or fails — both are valid; we just exercised the path.
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2370,9 +2370,12 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     // via RS parity, and drop any cached fd so the re-read re-opens the tampered
     // file from disk (confirming the fault is persistent).
     let mut bytes = std::fs::read(&file)?;
-    #[expect(
+    // `as usize` is a target-conditional truncation (only narrows on 32-bit
+    // pointer widths); `allow`, not `expect`, so it stays clean on the 64-bit
+    // host where clippy frames it purely as a portability note.
+    #[allow(
         clippy::cast_possible_truncation,
-        reason = "an in-file block offset fits usize on the 64-bit test host"
+        reason = "in-file block offset fits usize; only narrows on 32-bit targets"
     )]
     let pos = handle.offset().0 as usize + Header::MIN_LEN + 3;
     bytes[pos] ^= 0x80;

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -2370,6 +2370,10 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     // via RS parity, and drop any cached fd so the re-read re-opens the tampered
     // file from disk (confirming the fault is persistent).
     let mut bytes = std::fs::read(&file)?;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "an in-file block offset fits usize on the 64-bit test host"
+    )]
     let pos = handle.offset().0 as usize + Header::MIN_LEN + 3;
     bytes[pos] ^= 0x80;
     std::fs::write(&file, &bytes)?;


### PR DESCRIPTION
## Summary

Strip the dead from-keys `BuildHasher` surface from the vendored ribbon filter (`src/table/filter/ribbon/`). The LSM filter path always pre-hashes keys with xxh3 (`crate::hash::hash64`) and builds via `build_from_hashes` / probes via `contains_hash`, so the generic `S: BuildHasher` slot and the key-hashing construction/query API were never exercised.

## Changes

- Drop the `S` generic from `RibbonBuilder`, `RibbonFilter`, `BurrBuilder`, `BurrFilter`, `BurrLayer`, and delete the phantom `FilterHasher = BuildHasherDefault<FxHasher>` in `filter/mod.rs`.
- Remove the from-keys surface: `RibbonBuilder::build` / `build_with_seed_verbatim`, `BurrBuilder::build`, `RibbonFilter::contains` / `contains_in`, `BurrFilter::contains` / `contains_in`, and `standard_equation_w64`.
- Remove the now-dead `Scratch` / `new_scratch` / `derive_attempt_seed` machinery that only the removed key-based probe used.
- Rebuild the ribbon and BuRR test suites against the `build_from_hashes` + `contains_hash` pair (membership coverage lives at the BuRR level, which is the only queryable surface).

## Outcome

- Simpler types: one fewer type parameter on every filter struct, no `BuildHasher` dependency.
- ~1500 lines of dead code removed.
- **No behavioural or on-disk change** — the hasher was never invoked on the build-from-hashes path the crate actually uses.

## Testing

- `cargo nextest run --lib --all-features` — 1412 pass (incl. 122 ribbon/BuRR filter tests)
- `cargo clippy --all-features -- -D warnings` clean; benches compile
- `cargo test --doc --features lz4` — 47 pass
- `no-std-check` (`thumbv7em-none-eabihf --no-default-features --features alloc`) — 0 errors

Closes #450

## Also: CI clippy now lints test + bench targets

Found in review: the strict clippy job ran `--all-features` **without** `--all-targets`, so test-harness and bench code was never clippy-checked under the full feature set (the only `--all-targets` job ran a narrow `--no-default-features --features zstd,lz4` subset that cfg'd the encryption / ECC tests out, and was since removed). This left 8 latent clippy violations in real tests that no CI job caught.

This PR adds `--all-targets` to the `lint` job and clears those violations (`significant_drop_tightening`, `indexing_slicing`, `cast_possible_truncation`, `expect_used`) in `compaction/heal.rs`, `encryption/block.rs`, and `table/tests.rs`. The tests are valid; only the wiring was incomplete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the internal filter builder API by removing generic hasher parameter requirements, streamlining filter construction from pre-computed hashes.

* **Chores**
  * Updated CI workflow to lint additional code paths and test targets.
  * Added clippy warning annotations throughout test code for improved code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->