### PR TITLE
feat(metrics): unified ECC-recovery counters, wire SEC-DED reads

### DIFF
--- a/src/compaction/heal.rs
+++ b/src/compaction/heal.rs
@@ -230,11 +230,30 @@ mod tests {
             "a persistent ECC correction must record a heal hint",
         );
         #[cfg(feature = "metrics")]
-        assert_eq!(
-            tree.metrics().ecc_auto_heal_scheduled_count(),
-            1,
-            "the scheduled SST is counted once",
-        );
+        {
+            assert_eq!(
+                tree.metrics().ecc_auto_heal_scheduled_count(),
+                1,
+                "the scheduled SST is counted once",
+            );
+            // The recovery is attributed to the RS shard path (this SST uses an
+            // RS scheme), not SEC-DED, and counted once on the primary read.
+            assert_eq!(
+                tree.metrics().ecc_shard_recovered_count(),
+                1,
+                "the RS recovery is counted once",
+            );
+            assert_eq!(
+                tree.metrics().ecc_secded_corrected_count(),
+                0,
+                "an RS recovery must not increment the SEC-DED counter",
+            );
+            assert_eq!(
+                tree.metrics().ecc_recovered_count(),
+                1,
+                "one total recovery"
+            );
+        }
 
         // Run the heal strategy: it claims the SST and rewrites it clean.
         let result = tree.compact(
@@ -257,6 +276,98 @@ mod tests {
             "the rewritten SST must read clean (no further correction)",
         );
 
+        Ok(())
+    }
+
+    /// End-to-end SEC-DED recovery through a tree read: a single-bit flip in a
+    /// SEC-DED-protected SST is healed on read by the SEC-DED fast path and
+    /// attributed to the SEC-DED counter (NOT the RS shard counter), proving the
+    /// unified recovery metric distinguishes the two heal mechanisms. Gated on
+    /// `metrics`: the counter is the whole point.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn read_healing_single_bit_increments_secded_counter() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        // Write one SST whose data blocks carry SEC-DED parity, capture the
+        // first data block's on-disk offset.
+        let (sst_path, corrupt_pos) = {
+            let crate::AnyTree::Standard(tree) = Config::new(
+                dir.path(),
+                SequenceNumberCounter::default(),
+                SequenceNumberCounter::default(),
+            )
+            .page_ecc(true)
+            .ecc_scheme(EccScheme::Secded)
+            .open()?
+            else {
+                unreachable!("standard tree configured (no kv separation)");
+            };
+            for i in 0u64..2_000 {
+                tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+            }
+            tree.flush_active_memtable(2_000)?;
+
+            let binding = tree.version_history.read().latest_version();
+            #[expect(clippy::expect_used, reason = "flush produced exactly one table")]
+            let table = binding.version.iter_tables().next().expect("one table");
+            #[expect(clippy::expect_used, reason = "table has at least one data block")]
+            let keyed = table.block_index.iter().next().expect("a data block")?;
+            // Target-conditional truncation: `as usize` only narrows on 32-bit
+            // pointer widths, so `allow` (not `expect`) keeps it clean on the
+            // 64-bit host.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "in-file block offset fits usize; only narrows on 32-bit targets"
+            )]
+            let off = keyed.offset().0 as usize;
+            ((*table.path).clone(), off + Header::MIN_LEN + 3)
+        };
+
+        // Flip a SINGLE bit: the SEC-DED fast path corrects one bit per word.
+        let mut bytes = std::fs::read(&sst_path)?;
+        {
+            #[expect(
+                clippy::expect_used,
+                reason = "corrupt_pos is an in-file block offset, in range for the SST bytes"
+            )]
+            let slot = bytes.get_mut(corrupt_pos).expect("corrupt_pos in range");
+            *slot ^= 0x01;
+        }
+        std::fs::write(&sst_path, &bytes)?;
+
+        // Reopen (fresh caches + fds) so the read hits the tampered bytes.
+        let crate::AnyTree::Standard(tree) = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .page_ecc(true)
+        .ecc_scheme(EccScheme::Secded)
+        .open()?
+        else {
+            unreachable!("standard tree configured (no kv separation)");
+        };
+
+        #[expect(clippy::expect_used, reason = "key was inserted before flush")]
+        let got = tree.get(b"key-000000", MAX_SEQNO)?.expect("key present");
+        assert_eq!(&*got, b"v000000", "SEC-DED must heal the single-bit flip");
+
+        assert_eq!(
+            tree.metrics().ecc_secded_corrected_count(),
+            1,
+            "the SEC-DED heal is counted once",
+        );
+        assert_eq!(
+            tree.metrics().ecc_shard_recovered_count(),
+            0,
+            "a SEC-DED heal must not increment the RS shard counter",
+        );
+        assert_eq!(
+            tree.metrics().ecc_recovered_count(),
+            1,
+            "one total recovery"
+        );
         Ok(())
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -71,6 +71,19 @@ pub struct Metrics {
     /// only when `auto_heal` is enabled). Each SST is counted once per pending
     /// schedule.
     pub(crate) ecc_auto_heal_scheduled: AtomicUsize,
+
+    /// On-read blocks healed by the SEC-DED single-bit fast path (one corrected
+    /// bit flip). Counted on every primary read that observes the recovery
+    /// (point/range loads, partial-decode, patrol scrub); the persistence
+    /// confirming re-read does NOT re-count. A non-zero, growing value is a
+    /// scrapeable latent-bit-rot signal.
+    pub(crate) ecc_secded_corrected: AtomicUsize,
+
+    /// On-read blocks recovered from Reed-Solomon shard parity (the general
+    /// multi-byte path). Same counting discipline as
+    /// [`Self::ecc_secded_corrected`]; the two are disjoint by recovery
+    /// mechanism and sum to the total on-read ECC recoveries.
+    pub(crate) ecc_shard_recovered: AtomicUsize,
 }
 
 #[expect(
@@ -143,6 +156,36 @@ impl Metrics {
     /// ECC correction on read (`auto_heal` enabled).
     pub fn ecc_auto_heal_scheduled_count(&self) -> usize {
         self.ecc_auto_heal_scheduled.load(Relaxed)
+    }
+
+    /// On-read blocks healed by the SEC-DED single-bit fast path.
+    pub fn ecc_secded_corrected_count(&self) -> usize {
+        self.ecc_secded_corrected.load(Relaxed)
+    }
+
+    /// On-read blocks recovered from Reed-Solomon shard parity.
+    pub fn ecc_shard_recovered_count(&self) -> usize {
+        self.ecc_shard_recovered.load(Relaxed)
+    }
+
+    /// Total on-read ECC recoveries across both mechanisms (SEC-DED + RS shard).
+    /// A scrapeable latent-bit-rot signal: growth here means the medium is
+    /// returning faulty bytes that parity is silently repairing.
+    pub fn ecc_recovered_count(&self) -> usize {
+        self.ecc_secded_corrected_count() + self.ecc_shard_recovered_count()
+    }
+
+    /// Records one on-read ECC recovery, attributing it to the mechanism that
+    /// did the repair. Called from the primary read paths (`load_block`, the
+    /// partial-decode path, patrol scrub); the persistence-confirming re-read
+    /// must NOT call this, to avoid double-counting a single fault.
+    pub(crate) fn record_ecc_recovery(&self, kind: crate::table::block::EccRecoveryKind) {
+        use crate::table::block::EccRecoveryKind;
+        match kind {
+            EccRecoveryKind::Secded => &self.ecc_secded_corrected,
+            EccRecoveryKind::Shard => &self.ecc_shard_recovered,
+        }
+        .fetch_add(1, Relaxed);
     }
 
     /// Number of blocks that were loaded from disk or OS page cache.
@@ -270,6 +313,22 @@ mod tests {
         assert_eq!(0, m.range_tombstone_block_load_count());
         assert_eq!(0, m.range_tombstone_block_load_cached_count());
         assert_eq!(0, m.range_tombstone_block_io());
+    }
+
+    #[test]
+    fn record_ecc_recovery_attributes_each_kind_to_its_own_counter() {
+        use crate::table::block::EccRecoveryKind;
+        let m = Metrics::default();
+        assert_eq!(0, m.ecc_recovered_count(), "counters start at zero");
+
+        m.record_ecc_recovery(EccRecoveryKind::Secded);
+        m.record_ecc_recovery(EccRecoveryKind::Secded);
+        m.record_ecc_recovery(EccRecoveryKind::Shard);
+
+        assert_eq!(2, m.ecc_secded_corrected_count(), "two SEC-DED heals");
+        assert_eq!(1, m.ecc_shard_recovered_count(), "one RS shard recovery");
+        // The two mechanisms are disjoint and sum to the total.
+        assert_eq!(3, m.ecc_recovered_count(), "total across both mechanisms");
     }
 
     #[test]

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -349,13 +349,14 @@ impl PreparedBlock<'_> {
 /// - [`Self::Corrected`] — ECC repaired the on-disk payload (the caller saw
 ///   correct bytes, but the on-disk copy still holds a latent fault). Treat as
 ///   a signal to confirm persistence and potentially schedule an auto-heal
-///   recompaction.
+///   recompaction. Which mechanism did the repair (SEC-DED vs RS shard) is
+///   surfaced separately to internal read paths via [`EccRecoveryKind`] for
+///   metrics attribution.
 /// - [`Self::Unrecognized`] — the block carries an ECC trailer this build
-///   cannot interpret (an unimplemented or non-canonical scheme: Secded,
-///   page granularity, unknown kind, …). The payload was returned (its
-///   checksum passed), but ECC recovery is unavailable for this block;
-///   recompaction re-stamps it with a supported scheme. A "typing" warning,
-///   not a read failure.
+///   cannot interpret (a non-canonical scheme, page granularity, unknown kind,
+///   …). The payload was returned (its checksum passed), but ECC recovery is
+///   unavailable for this block; recompaction re-stamps it with a supported
+///   scheme. A "typing" warning, not a read failure.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
 pub enum EccStatus {
     /// ECC absent or a recognized scheme verified normally.
@@ -372,6 +373,21 @@ pub enum EccStatus {
     /// persistent (not a transient read-path fault) and, if so, schedule a
     /// recompaction so the corrected bytes are persisted to a fresh SST.
     Corrected,
+}
+
+/// Which ECC mechanism recovered a block whose checksum failed on read.
+///
+/// Returned alongside [`EccStatus`] by the internal recovery-aware read paths
+/// (kept out of the public `EccStatus` to keep that enum stable) so an operator
+/// metric can attribute each on-read recovery to the right heal path: the cheap
+/// single-bit fast path versus full shard reconstruction.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum EccRecoveryKind {
+    /// A single-bit flip healed by the SEC-DED fast path (one XOR-and-recheck
+    /// per word, no shard arithmetic).
+    Secded,
+    /// Recovered from Reed-Solomon shard parity (the general multi-byte path).
+    Shard,
 }
 
 #[derive(Clone)]
@@ -408,7 +424,7 @@ impl Block {
             expect(unused_variables, reason = "recovery scheme only used under page_ecc")
         )]
         ecc_params: EccParams,
-    ) -> crate::Result<(Vec<u8>, bool)> {
+    ) -> crate::Result<(Vec<u8>, Option<EccRecoveryKind>)> {
         let mut data = vec![0u8; data_length as usize];
         reader.read_exact(&mut data)?;
 
@@ -420,7 +436,7 @@ impl Block {
                     "Checksum mismatch for block payload, got={computed}, expected={expected}",
                 );
             })?;
-            return Ok((data, false));
+            return Ok((data, None));
         }
 
         // ECC trailer present — always consume the parity bytes so
@@ -430,7 +446,7 @@ impl Block {
         reader.read_exact(&mut parity)?;
 
         if computed == expected {
-            return Ok((data, false));
+            return Ok((data, None));
         }
 
         // Mismatch — try ECC recovery before failing.
@@ -455,7 +471,7 @@ impl Block {
                          checksum mismatch (data_len={}, ecc_len={ecc_length})",
                         data.len(),
                     );
-                    return Ok((healed, true));
+                    return Ok((healed, Some(EccRecoveryKind::Secded)));
                 }
                 log::error!(
                     "Checksum mismatch on SEC-DED block, heal failed, \
@@ -481,7 +497,7 @@ impl Block {
                      (data_len={}, ecc_len={ecc_length})",
                     data.len(),
                 );
-                return Ok((recovered, true));
+                return Ok((recovered, Some(EccRecoveryKind::Shard)));
             }
             log::error!(
                 "Checksum mismatch on ECC-protected block, recovery failed, \
@@ -917,7 +933,7 @@ impl Block {
             // `from_reader` returns no EccStatus, so a heal here is logged but
             // not surfaced; the status-returning `from_file_with_status` path is
             // what auto-heal observes.
-            let (raw_vec, _corrected) = Self::read_payload_and_verify(
+            let (raw_vec, _recovery) = Self::read_payload_and_verify(
                 reader,
                 header.data_length,
                 ecc_length,
@@ -1017,7 +1033,7 @@ impl Block {
                 s
             } else {
                 // from_reader has no EccStatus return; a heal is logged only.
-                let (payload, _corrected) = Self::read_payload_and_verify(
+                let (payload, _recovery) = Self::read_payload_and_verify(
                     reader,
                     header.data_length,
                     ecc_length,
@@ -1129,17 +1145,34 @@ impl Block {
     ///
     /// Pipeline: read → verify checksum → decrypt → decompress. When
     /// `encryption` is `None`, the decrypt step is skipped.
-    // Same duplication rationale as from_reader — see comment there.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "encrypt/no-encrypt branches duplicate compression match — see from_reader"
-    )]
     pub fn from_file_with_status(
         file: &dyn FsFile,
         handle: BlockHandle,
         identity: BlockIdentity,
         transform: &BlockTransform<'_>,
     ) -> crate::Result<(Self, EccStatus)> {
+        let (block, status, _recovery) =
+            Self::from_file_with_recovery(file, handle, identity, transform)?;
+        Ok((block, status))
+    }
+
+    /// Like [`Self::from_file_with_status`] but additionally reports which ECC
+    /// mechanism repaired the block (`Some(kind)` iff the status is
+    /// [`EccStatus::Corrected`]). Internal to the read path: the primary read
+    /// call sites (`load_block`, the partial-decode path, patrol scrub) use it
+    /// to attribute the on-read recovery to the right metric counter, keeping
+    /// the public [`EccStatus`] free of the kind.
+    // Same duplication rationale as from_reader — see comment there.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "encrypt/no-encrypt branches duplicate compression match — see from_reader"
+    )]
+    pub(crate) fn from_file_with_recovery(
+        file: &dyn FsFile,
+        handle: BlockHandle,
+        identity: BlockIdentity,
+        transform: &BlockTransform<'_>,
+    ) -> crate::Result<(Self, EccStatus, Option<EccRecoveryKind>)> {
         let compression = transform.compression();
         let encryption = transform.encryption();
         #[cfg(zstd_any)]
@@ -1193,7 +1226,7 @@ impl Block {
         // No intermediate Slice, no overlap of encrypted + decrypted buffers.
         // When no encryption, read into a Slice (zero-copy on the
         // None-compression path).
-        let (header, data, ecc_status) = if let Some(enc) = encryption {
+        let (header, data, ecc_status, recovery) = if let Some(enc) = encryption {
             let block_size = handle.size() as usize;
 
             // Pre-decode lower bound: every header is at least MIN_LEN; the
@@ -1296,7 +1329,7 @@ impl Block {
                 // Strip header prefix + any opaque trailer so buf is the payload.
                 buf.copy_within(header_len..header_len + actual_data_len, 0);
                 buf.truncate(actual_data_len);
-                (buf, false)
+                (buf, None)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
                 let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
@@ -1309,9 +1342,10 @@ impl Block {
                 )?
             };
 
-            // Fold a successful ECC repair into the reported status (an
-            // unrecognized scheme never heals, so the two are exclusive).
-            let ecc_status = if payload_corrected {
+            // Fold a successful ECC repair into the reported status; an
+            // unrecognized scheme never heals, so the two are exclusive. The
+            // recovery mechanism is carried out separately as `payload_corrected`.
+            let ecc_status = if payload_corrected.is_some() {
                 EccStatus::Corrected
             } else {
                 ecc_status
@@ -1391,7 +1425,7 @@ impl Block {
                 }
             };
 
-            (parsed_header, data, ecc_status)
+            (parsed_header, data, ecc_status, payload_corrected)
         } else {
             // Single I/O read — header + payload in one Slice.
             let buf = crate::file::read_exact(file, *handle.offset(), handle.size() as usize)?;
@@ -1433,36 +1467,38 @@ impl Block {
             // opaque trailer); recognized-ECC blocks go through the
             // recovery-capable helper. The checksum covers exactly the
             // `data_length` payload bytes, so an opaque trailer is excluded.
-            let (payload_slice, payload_corrected): (Slice, bool) = if ecc_length == 0 {
-                #[expect(
-                    clippy::indexing_slicing,
-                    reason = "actual_data_len <= post-header len"
-                )]
-                let checksum = Checksum::from_raw(crate::hash::hash128(
-                    &buf[header_len..header_len + actual_data_len],
-                ));
-                checksum.check(parsed_header.checksum).inspect_err(|_| {
-                    log::error!(
-                        "Checksum mismatch for block {handle:?}, got={}, expected={}",
-                        checksum,
+            let (payload_slice, payload_corrected): (Slice, Option<EccRecoveryKind>) =
+                if ecc_length == 0 {
+                    #[expect(
+                        clippy::indexing_slicing,
+                        reason = "actual_data_len <= post-header len"
+                    )]
+                    let checksum = Checksum::from_raw(crate::hash::hash128(
+                        &buf[header_len..header_len + actual_data_len],
+                    ));
+                    checksum.check(parsed_header.checksum).inspect_err(|_| {
+                        log::error!(
+                            "Checksum mismatch for block {handle:?}, got={}, expected={}",
+                            checksum,
+                            parsed_header.checksum,
+                        );
+                    })?;
+                    (buf.slice(header_len..header_len + actual_data_len), None)
+                } else {
+                    #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
+                    let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
+                    let (payload, recovery) = Self::read_payload_and_verify(
+                        &mut cursor,
+                        parsed_header.data_length,
+                        ecc_length,
                         parsed_header.checksum,
-                    );
-                })?;
-                (buf.slice(header_len..header_len + actual_data_len), false)
-            } else {
-                #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
-                let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
-                let (payload, corrected) = Self::read_payload_and_verify(
-                    &mut cursor,
-                    parsed_header.data_length,
-                    ecc_length,
-                    parsed_header.checksum,
-                    block_ecc_params(&parsed_header, transform),
-                )?;
-                (Slice::from(payload), corrected)
-            };
-            // Fold a successful ECC repair into the reported status.
-            let ecc_status = if payload_corrected {
+                        block_ecc_params(&parsed_header, transform),
+                    )?;
+                    (Slice::from(payload), recovery)
+                };
+            // Fold a successful ECC repair into the status; the recovery
+            // mechanism is carried out separately as `payload_corrected`.
+            let ecc_status = if payload_corrected.is_some() {
                 EccStatus::Corrected
             } else {
                 ecc_status
@@ -1547,16 +1583,17 @@ impl Block {
                 }
             };
 
-            (parsed_header, data, ecc_status)
+            (parsed_header, data, ecc_status, payload_corrected)
         };
 
-        Ok((Self { header, data }, ecc_status))
+        Ok((Self { header, data }, ecc_status, recovery))
     }
 
     /// Reads a data block's verified COMPRESSED payload (the zstd frame) WITHOUT
-    /// decompressing it, for partial / lazy decode. Returns the header and the
+    /// decompressing it, for partial / lazy decode. Returns the header, the
     /// compressed-frame bytes (checksum-verified; ECC-recovered if a recognized
-    /// parity trailer is present).
+    /// parity trailer is present), and `Some(kind)` when a recovery occurred so
+    /// the caller can schedule auto-heal and count the recovery.
     ///
     /// Non-encrypted blocks only — the caller must ensure
     /// `transform.encryption().is_none()` (an encrypted block's plaintext frame
@@ -1573,7 +1610,7 @@ impl Block {
         file: &dyn FsFile,
         handle: BlockHandle,
         transform: &BlockTransform<'_>,
-    ) -> crate::Result<(Header, Slice, bool)> {
+    ) -> crate::Result<(Header, Slice, Option<EccRecoveryKind>)> {
         if transform.encryption().is_some() {
             return Err(crate::Error::Io(crate::io::Error::other(
                 "read_data_frame: encrypted blocks are not supported on the lazy path",
@@ -1631,7 +1668,7 @@ impl Block {
             &handle,
         )?;
 
-        let (payload, corrected): (Slice, bool) = if ecc_length == 0 {
+        let (payload, recovery): (Slice, Option<EccRecoveryKind>) = if ecc_length == 0 {
             #[expect(
                 clippy::indexing_slicing,
                 reason = "actual_data_len <= post-header len, checked via classify_block_trailer"
@@ -1640,24 +1677,25 @@ impl Block {
                 &buf[header_len..header_len + actual_data_len],
             ));
             checksum.check(parsed_header.checksum)?;
-            (buf.slice(header_len..header_len + actual_data_len), false)
+            (buf.slice(header_len..header_len + actual_data_len), None)
         } else {
             #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
             let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
-            // `corrected` is surfaced so the partial-decode caller can schedule
+            // `recovery` is surfaced so the partial-decode caller can schedule
             // auto-heal (the recovered bytes are correct but the on-disk copy is
-            // still faulty); a heal is also logged inside read_payload_and_verify.
-            let (frame, corrected) = Self::read_payload_and_verify(
+            // still faulty) and count the recovery; a heal is also logged inside
+            // read_payload_and_verify.
+            let (frame, recovery) = Self::read_payload_and_verify(
                 &mut cursor,
                 parsed_header.data_length,
                 ecc_length,
                 parsed_header.checksum,
                 block_ecc_params(&parsed_header, transform),
             )?;
-            (Slice::from(frame), corrected)
+            (Slice::from(frame), recovery)
         };
 
-        Ok((parsed_header, payload, corrected))
+        Ok((parsed_header, payload, recovery))
     }
 }
 
@@ -3604,7 +3642,7 @@ mod tests {
             std::fs::write(&path, &bytes)?;
 
             let file = std::fs::File::open(&path)?;
-            let (block, status) = Block::from_file_with_status(
+            let (block, status, recovery) = Block::from_file_with_recovery(
                 &file,
                 tmp.handle,
                 BlockIdentity::for_test(0, BlockType::Data),
@@ -3614,7 +3652,56 @@ mod tests {
             assert_eq!(
                 status,
                 EccStatus::Corrected,
-                "a read that repaired the block must report Corrected",
+                "a repaired read reports Corrected"
+            );
+            assert_eq!(
+                recovery,
+                Some(EccRecoveryKind::Shard),
+                "an RS repair is attributed to the shard mechanism",
+            );
+            Ok(())
+        }
+
+        /// A single-bit flip in a SEC-DED-protected block is healed by the
+        /// SEC-DED fast path and reported as `Corrected(Secded)`, distinct from
+        /// the RS shard path. This is the kind-attribution the unified recovery
+        /// metric relies on (the per-kind counter is bumped from this status at
+        /// the `load_block` / scrub / partial-decode call sites).
+        #[test]
+        fn from_file_with_status_reports_secded_kind_after_single_bit_heal() -> crate::Result<()> {
+            let transform = BlockTransform::PlainEcc(EccParams::SECDED);
+            let tmp = super::write_block_to_tempfile(
+                PAYLOAD,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &transform,
+            )?;
+            let path = tmp.dir.path().join("block");
+
+            // Flip a SINGLE bit so the SEC-DED per-word code heals it.
+            let mut bytes = std::fs::read(&path)?;
+            bytes[Header::MIN_LEN + 3] ^= 0x01;
+            std::fs::write(&path, &bytes)?;
+
+            let file = std::fs::File::open(&path)?;
+            let (block, status, recovery) = Block::from_file_with_recovery(
+                &file,
+                tmp.handle,
+                BlockIdentity::for_test(0, BlockType::Data),
+                &transform,
+            )?;
+            assert_eq!(
+                &*block.data, PAYLOAD,
+                "SEC-DED must heal the single-bit flip"
+            );
+            assert_eq!(
+                status,
+                EccStatus::Corrected,
+                "a repaired read reports Corrected"
+            );
+            assert_eq!(
+                recovery,
+                Some(EccRecoveryKind::Secded),
+                "a SEC-DED single-bit heal is attributed to the SEC-DED mechanism",
             );
             Ok(())
         }

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -385,12 +385,17 @@ impl Iter {
             None => transform,
         };
         let block_handle = BlockHandle::new(handle.offset(), handle.size());
-        let (_header, frame, corrected) =
+        let (_header, frame, recovery) =
             crate::table::block::Block::read_data_frame(fd.as_ref(), block_handle, &transform)?;
         // The partial path bypasses `load_block`, so schedule auto-heal here too:
         // an ECC-corrected frame read flags the SST for a healing rewrite (the
-        // partial path is non-encrypted by the guard above).
-        if corrected {
+        // partial path is non-encrypted by the guard above). This is a primary
+        // read, so count the recovery by mechanism as well.
+        if let Some(kind) = recovery {
+            #[cfg(feature = "metrics")]
+            self.metrics.record_ecc_recovery(kind);
+            #[cfg(not(feature = "metrics"))]
+            let _ = kind;
             crate::table::util::maybe_record_persistent_heal(
                 self.table_id,
                 &self.path,

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -88,8 +88,9 @@ pub struct ParsedMeta {
     pub ecc_params: Option<crate::table::block::EccParams>,
 
     /// `true` when the `descriptor#page_ecc` value decoded to an ECC scheme
-    /// this build cannot apply: an unimplemented scheme (`Secded`), page
-    /// granularity, an unknown kind, or a non-canonical descriptor. The
+    /// this build cannot apply: page granularity, an unknown kind, or a
+    /// non-canonical descriptor (recognized block-granularity `Secded` /
+    /// `Xor` / `ReedSolomon` are applicable, not flagged here). The
     /// per-block read still returns the payload (framed by `data_length`,
     /// checksum-verified) with `EccStatus::Unrecognized`, but the trailer
     /// length is not derivable from a scheme — so the sequential scrub walk
@@ -373,17 +374,25 @@ impl ParsedMeta {
                 .ok_or(crate::Error::InvalidHeader("TableMeta"))?;
             use crate::runtime_config::{EccDescriptor, EccGranularity};
             // Three-state ECC contract: a recognized + applicable scheme
-            // (`Xor`/`ReedSolomon`, block granularity, valid shards) yields the
-            // recovery params (`ecc_unrecognized = false`). Anything else that
-            // still decodes — an unimplemented scheme (`Secded`), page
-            // granularity, an unknown kind, or a non-canonical descriptor — is
-            // NOT a hard error: it resolves to "no recovery scheme" (`None`)
-            // with `ecc_unrecognized = true`. The per-block read then frames
-            // the payload by `data_length`, verifies it by checksum, and
-            // reports `EccStatus::Unrecognized` (a WARN + recompaction hint)
-            // instead of failing; the scrub skips ECC-walk of such tables.
+            // (`Secded`, `Xor`/`ReedSolomon`, block granularity, valid shards)
+            // yields the recovery params (`ecc_unrecognized = false`). Anything
+            // else that still decodes (page granularity, an unknown kind, or a
+            // non-canonical descriptor) is NOT a hard error: it resolves to "no
+            // recovery scheme" (`None`) with `ecc_unrecognized = true`. The
+            // per-block read then frames the payload by `data_length`, verifies
+            // it by checksum, and reports `EccStatus::Unrecognized` (a WARN +
+            // recompaction hint) instead of failing; the scrub skips ECC-walk of
+            // such tables.
+            use crate::runtime_config::EccScheme;
             match crate::runtime_config::ecc_descriptor_from_bytes(&v.value)? {
                 EccDescriptor::Off => (false, None, false),
+                // SEC-DED has no shard layout (`shard_params() == None`); it
+                // sizes its parity from `block_parity_len` instead, so it is
+                // mapped to its dedicated `EccParams::SECDED` rather than going
+                // through the shard path. Mirrors the writer's `resolve_ecc`.
+                EccDescriptor::Recognized(EccScheme::Secded, EccGranularity::Block) => {
+                    (true, Some(crate::table::block::EccParams::SECDED), false)
+                }
                 EccDescriptor::Recognized(scheme, EccGranularity::Block) => {
                     let params = scheme
                         .shard_params()
@@ -395,8 +404,7 @@ impl ParsedMeta {
                             crate::table::block::EccParams::try_new(d as u8, p as u8)
                         })
                         .transpose()?;
-                    // `Secded` is recognized but has no shard layout
-                    // (`shard_params() == None`) → unimplemented → unrecognized.
+                    // A non-SECDED scheme with no shard layout is unimplemented.
                     let unrecognized = params.is_none();
                     (params.is_some(), params, unrecognized)
                 }
@@ -859,17 +867,16 @@ mod tests {
         );
     }
 
-    /// An unsupported-but-decodable ECC descriptor (page granularity, the
-    /// unimplemented `Secded` scheme) does NOT fail meta load: it resolves to
-    /// "no recovery scheme" (`ecc_params == None`). The per-block read then
-    /// frames the payload by `data_length` and reports `EccStatus::Unrecognized`
-    /// (a WARN) rather than failing the read. This is the three-state contract:
+    /// An unsupported-but-decodable ECC descriptor (page granularity, an unknown
+    /// kind, a non-canonical "off") does NOT fail meta load: it resolves to "no
+    /// recovery scheme" (`ecc_params == None`). The per-block read then frames
+    /// the payload by `data_length` and reports `EccStatus::Unrecognized` (a
+    /// WARN) rather than failing the read. This is the three-state contract:
     /// unrecognized ECC is a typing warning, not corruption.
     #[test]
     fn load_with_handle_unsupported_ecc_descriptor_parses_without_recovery_scheme() {
         for descriptor in [
             [3u8, 8, 2, 1], // ReedSolomon(8,2) with page granularity
-            [1u8, 0, 0, 0], // Secded, block granularity (unimplemented)
             [9u8, 0, 0, 0], // unknown kind
             [0u8, 8, 2, 1], // non-canonical "off" with junk reserved bytes
         ] {
@@ -913,6 +920,28 @@ mod tests {
         assert!(
             parsed.page_ecc && !parsed.ecc_unrecognized && parsed.ecc_params.is_some(),
             "recognized RS(8,2) is applicable, not unrecognized",
+        );
+
+        // SEC-DED (block granularity, no shard layout) is a recognized,
+        // applicable scheme: it resolves to its dedicated `EccParams::SECDED`,
+        // is NOT flagged unrecognized, and turns Page ECC on.
+        let mut items = valid_meta_items();
+        if let Some(item) = items
+            .iter_mut()
+            .find(|iv| &*iv.key.user_key == b"descriptor#page_ecc")
+        {
+            *item = meta("descriptor#page_ecc", &[1u8, 0, 0, 0]); // Secded, block
+        }
+        let parsed = load_meta_from_items(&items).unwrap();
+        assert!(parsed.page_ecc, "SEC-DED turns Page ECC on");
+        assert!(
+            !parsed.ecc_unrecognized,
+            "SEC-DED is recognized, not a warning"
+        );
+        assert_eq!(
+            parsed.ecc_params,
+            Some(crate::table::block::EccParams::SECDED),
+            "SEC-DED resolves to its dedicated parity params",
         );
     }
 

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -137,7 +137,7 @@ pub fn load_block(
         #[cfg(zstd_any)]
         zstd_dict,
     )?;
-    let (block, ecc_status) = Block::from_file_with_status(
+    let (block, ecc_status, recovery) = Block::from_file_with_recovery(
         fd.as_ref(),
         *handle,
         crate::table::block::BlockIdentity {
@@ -148,6 +148,15 @@ pub fn load_block(
         },
         &transform,
     )?;
+    // Count the on-read ECC recovery (by mechanism) at this primary read site.
+    // The persistence-confirming re-read below goes through a path that does
+    // NOT count, so a single fault is counted exactly once.
+    #[cfg(feature = "metrics")]
+    if let Some(kind) = recovery {
+        metrics.record_ecc_recovery(kind);
+    }
+    #[cfg(not(feature = "metrics"))]
+    let _ = recovery;
     let corrected = matches!(ecc_status, crate::table::block::EccStatus::Corrected);
 
     if block.header.block_type != block_type {
@@ -362,7 +371,7 @@ pub(crate) fn scrub_block(
         #[cfg(zstd_any)]
         zstd_dict,
     )?;
-    let (_block, ecc_status) = Block::from_file_with_status(
+    let (_block, ecc_status, recovery) = Block::from_file_with_recovery(
         fd.as_ref(),
         *handle,
         crate::table::block::BlockIdentity {
@@ -376,6 +385,15 @@ pub(crate) fn scrub_block(
 
     Ok(match ecc_status {
         crate::table::block::EccStatus::Corrected => {
+            // Primary read for the scrub: count the recovery by mechanism here
+            // (the confirming re-read inside maybe_record_persistent_heal does
+            // not count).
+            #[cfg(feature = "metrics")]
+            if let Some(kind) = recovery {
+                metrics.record_ecc_recovery(kind);
+            }
+            #[cfg(not(feature = "metrics"))]
+            let _ = recovery;
             let scheduled = maybe_record_persistent_heal(
                 table_id,
                 path,


### PR DESCRIPTION
## Summary

Adds a scrapeable on-read **ECC-recovery counter**, split by heal mechanism, and wires tree-level SEC-DED reads so SEC-DED actually protects data.

### Counters

- `ecc_secded_corrected` — single-bit SEC-DED fast-path heals
- `ecc_shard_recovered` — Reed-Solomon shard reconstructions
- `ecc_recovered` — the total (the two are disjoint and sum to it)

The block read path now reports which mechanism repaired a block via a new `EccRecoveryKind`, returned alongside `EccStatus`. The three **primary** read sites (`load_block`, the partial-decode path, patrol scrub) bump the matching counter; the persistence-confirming re-read does **not** re-count, so a single fault is counted exactly once. A growing value is an operator's latent-bit-rot signal.

### Non-breaking

`EccStatus` is publicly reachable (`lsm_tree::table::block::EccStatus`), so embedding the kind in `EccStatus::Corrected` would be a breaking change. Instead the kind is threaded through a new pub(crate) `Block::from_file_with_recovery`, with the existing public `from_file_with_status` kept as a thin wrapper. Public enum + signature are unchanged; `EccRecoveryKind` is purely additive. No format / version bump.

### Wire SEC-DED reads

Discovered SEC-DED was inert at the tree level: the writer already emits SEC-DED parity (`resolve_ecc` → `EccParams::SECDED`), but the meta reader mapped the `Secded` descriptor to *unrecognized* (`ecc_params = None`), so reads never recovered — a SEC-DED-configured tree carried parity it never used and got **zero** bit-rot protection. This maps `Secded` to its dedicated `EccParams::SECDED` on read (mirroring the writer), so SEC-DED SSTs self-heal single-bit flips and the SEC-DED counter is live. On-disk descriptor encoding is unchanged.

## Testing

- RS recovery counter asserted end-to-end through a tree read.
- SEC-DED recovery counter asserted end-to-end through a tree read (now that SEC-DED reads recover).
- Per-kind attribution verified at the block level (RS + SEC-DED) and via a `Metrics` unit test.
- Updated meta tests for the now-recognized SEC-DED descriptor.
- Full suite `--all-features`: 2059 passed. `clippy --all-features --all-targets -D warnings` clean (also clean without the metrics feature). no-std `alloc` build: 0 errors. Doctests pass.

Closes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error correction recovery metrics to distinguish between SEC-DED and Reed-Solomon shard correction mechanisms, improving observability into recovery operations.

* **Tests**
  * Extended test coverage for SEC-DED single-bit correction and Reed-Solomon shard recovery scenarios.

* **Documentation**
  * Clarified error correction scheme handling and recovery attribution semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->