### PR TITLE
feat(recovery): cross-process directory lock for exclusive tree access

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -520,6 +520,19 @@ pub struct Config {
     /// `fsync`. Set via [`Config::sync_mode`].
     pub(crate) sync_mode: SyncMode,
 
+    /// When `true` (the default), [`Config::open`] and [`Config::repair`]
+    /// acquire an exclusive cross-process lock on a `LOCK` file in the tree
+    /// directory (an advisory OS file lock) and hold it for the lifetime of the
+    /// [`Tree`](crate::Tree) (open) or the duration of the call (repair). A
+    /// second process attempting to open / repair the same directory fails fast
+    /// with [`Error::Locked`](crate::Error::Locked) instead of racing on the
+    /// manifest. Set `false` via [`Config::with_directory_lock`] only when the
+    /// embedder already enforces exclusive directory ownership at a higher layer
+    /// (e.g. a keyspace / journal manager). Best-effort per `Fs` backend: real
+    /// on-disk backends enforce it, in-memory backends are single-process and
+    /// satisfy it vacuously.
+    pub(crate) directory_lock: bool,
+
     /// Edit-log size (bytes) past which the next manifest persist rotates: it
     /// writes a fresh full snapshot and starts an empty log instead of appending
     /// another [`VersionEdit`](crate::version::edit::VersionEdit). Bounds both
@@ -692,6 +705,7 @@ impl Default for Config {
             encryption: None,
             manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
             sync_mode: SyncMode::Normal,
+            directory_lock: true,
             manifest_log_rotate_bytes: 1024 * 1024,
             compaction_rate_limit: 0,
 
@@ -705,6 +719,44 @@ impl Default for Config {
             #[cfg(all(test, feature = "std"))]
             fail_one_subcompaction: Arc::new(core::sync::atomic::AtomicBool::new(false)),
         }
+    }
+}
+
+/// Name of the lock file created in a tree directory for the cross-process
+/// exclusive directory lock.
+pub(crate) const DIRECTORY_LOCK_FILE: &str = "LOCK";
+
+/// Acquires the cross-process exclusive directory lock when `enabled`.
+///
+/// Opens (creating if absent) a `LOCK` file under `dir` and takes a
+/// non-blocking exclusive advisory lock on it through the `Fs` backend. Returns
+/// the locked handle to hold for as long as exclusivity is required; dropping it
+/// releases the lock (the OS frees an advisory lock when the fd / handle
+/// closes). `Ok(None)` when `enabled` is false. Fails with
+/// [`Error::Locked`](crate::Error::Locked) when another live instance holds the
+/// lock. The directory must already exist (the caller creates it for a fresh
+/// tree before acquiring).
+#[cfg(feature = "std")]
+pub(crate) fn acquire_directory_lock(
+    fs: &dyn Fs,
+    dir: &Path,
+    enabled: bool,
+) -> crate::Result<Option<Box<dyn crate::fs::FsFile>>> {
+    if !enabled {
+        return Ok(None);
+    }
+    let lock_path = dir.join(DIRECTORY_LOCK_FILE);
+    let file = fs.open(
+        &lock_path,
+        &crate::fs::FsOpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true),
+    )?;
+    if file.try_lock_exclusive()? {
+        Ok(Some(file))
+    } else {
+        Err(crate::Error::Locked(dir.display().to_string()))
     }
 }
 
@@ -1156,6 +1208,21 @@ impl Config {
     #[must_use]
     pub fn page_ecc(mut self, enabled: bool) -> Self {
         self.page_ecc = enabled;
+        self
+    }
+
+    /// Enables or disables the cross-process directory lock (default: enabled).
+    ///
+    /// When enabled, [`Config::open`] and [`Config::repair`] acquire an
+    /// exclusive advisory lock on a `LOCK` file in the tree directory, so a
+    /// second process opening / repairing the same directory fails fast with
+    /// [`Error::Locked`](crate::Error::Locked) rather than corrupting the shared
+    /// manifest. Disable ONLY when exclusive directory ownership is already
+    /// guaranteed at a higher layer (e.g. an embedding keyspace / journal
+    /// manager that opens each directory at most once per host).
+    #[must_use]
+    pub fn with_directory_lock(mut self, enabled: bool) -> Self {
+        self.directory_lock = enabled;
         self
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -202,6 +202,19 @@ pub enum Error {
     /// strings.
     FeatureUnsupported(&'static str),
 
+    /// The tree directory is already locked by another live instance.
+    ///
+    /// Returned by [`Config::open`](crate::Config::open) and
+    /// [`Config::repair`](crate::Config::repair) when the cross-process
+    /// directory lock (a `LOCK` file under the tree directory, held via an
+    /// advisory OS file lock) could not be acquired because another process
+    /// owns it. Holds the directory path as a display string for diagnostics.
+    /// Two processes mutating the same manifest would corrupt it, so the second
+    /// acquirer fails fast here. Disable the lock with
+    /// [`Config::with_directory_lock`](crate::Config::with_directory_lock) only
+    /// when exclusivity is enforced at a higher layer.
+    Locked(String),
+
     /// Manifest footer / TOC / file-level discovery failure.
     ///
     /// Scoped to errors detected at or before the TOC is parsed —

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -334,6 +334,12 @@ impl FsFile for IoUringFile {
         // Delegate to the platform-specific FsFile impl for std::fs::File.
         FsFile::lock_exclusive(&self.file)
     }
+
+    fn try_lock_exclusive(&self) -> crate::io::Result<bool> {
+        // io_uring wraps a real on-disk file, so it needs the genuine
+        // non-blocking OS lock, not the trivial-acquire default.
+        FsFile::try_lock_exclusive(&self.file)
+    }
 }
 
 impl Read for IoUringFile {

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -319,6 +319,14 @@ impl FsFile for MemFile {
     fn lock_exclusive(&self) -> io::Result<()> {
         Ok(())
     }
+
+    fn try_lock_exclusive(&self) -> io::Result<bool> {
+        // `MemFs` is a single-process in-memory backend: there is no other
+        // process to contend with, so the directory lock is vacuously held.
+        // Opt in explicitly (the trait default fails closed for backends that
+        // have not implemented non-blocking locking).
+        Ok(true)
+    }
 }
 
 /// Rejects empty paths before they can create entries in the `/`-rooted namespace.

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -451,6 +451,28 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
     /// Returns an I/O error if locking fails or is unsupported.
     fn lock_exclusive(&self) -> io::Result<()>;
 
+    /// Tries to acquire an exclusive (write) lock on this file WITHOUT blocking.
+    ///
+    /// Returns `Ok(true)` if the lock was acquired, `Ok(false)` if another holder
+    /// (typically another process) currently owns it. Used for the cross-process
+    /// directory lock acquired at [`Config::open`](crate::Config::open) /
+    /// [`Config::repair`](crate::Config::repair): a second opener must fail fast
+    /// (`Ok(false)` → `Error::Locked`), not hang on a blocking acquire.
+    ///
+    /// The default implementation returns `Ok(true)` (a trivial acquire): an
+    /// in-memory or single-process backend has no cross-process contention to
+    /// guard against, so exclusivity is satisfied vacuously. Real on-disk
+    /// backends override this with a non-blocking OS lock (`flock` `LOCK_NB` /
+    /// `LockFileEx` `LOCKFILE_FAIL_IMMEDIATELY`).
+    ///
+    /// # Errors
+    ///
+    /// An I/O error if the lock operation itself fails (a held lock is reported
+    /// as `Ok(false)`, not an error).
+    fn try_lock_exclusive(&self) -> io::Result<bool> {
+        Ok(true)
+    }
+
     /// Advise the kernel about the expected access pattern for this file.
     ///
     /// Implementations translate the [`FileHint`] to the platform's

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -459,18 +459,28 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
     /// [`Config::repair`](crate::Config::repair): a second opener must fail fast
     /// (`Ok(false)` → `Error::Locked`), not hang on a blocking acquire.
     ///
-    /// The default implementation returns `Ok(true)` (a trivial acquire): an
-    /// in-memory or single-process backend has no cross-process contention to
-    /// guard against, so exclusivity is satisfied vacuously. Real on-disk
-    /// backends override this with a non-blocking OS lock (`flock` `LOCK_NB` /
-    /// `LockFileEx` `LOCKFILE_FAIL_IMMEDIATELY`).
+    /// The default implementation **fails closed**: it returns an
+    /// [`io::ErrorKind::Unsupported`] error so a backend that has not opted in
+    /// cannot silently bypass the cross-process directory lock. A disk-backed
+    /// backend that forgot to override this would otherwise let two processes
+    /// race on the same tree's manifest. Real on-disk backends override this
+    /// with a non-blocking OS lock (`flock` `LOCK_NB` / `LockFileEx`
+    /// `LOCKFILE_FAIL_IMMEDIATELY`); intentionally single-process backends
+    /// (e.g. in-memory) override it to return `Ok(true)` (exclusivity is
+    /// vacuous when there is only one process).
     ///
     /// # Errors
     ///
-    /// An I/O error if the lock operation itself fails (a held lock is reported
-    /// as `Ok(false)`, not an error).
+    /// [`io::ErrorKind::Unsupported`] from the default (un-opted-in) impl, or an
+    /// I/O error if a real lock operation fails (a held lock is reported as
+    /// `Ok(false)`, not an error).
     fn try_lock_exclusive(&self) -> io::Result<bool> {
-        Ok(true)
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "FsFile::try_lock_exclusive is not implemented for this backend; \
+             override it (real lock, or Ok(true) for single-process backends) \
+             or disable the directory lock via Config::with_directory_lock(false)",
+        ))
     }
 
     /// Advise the kernel about the expected access pattern for this file.

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -142,6 +142,10 @@ impl FsFile for File {
         sys::lock_exclusive(self).map_err(io::Error::from)
     }
 
+    fn try_lock_exclusive(&self) -> io::Result<bool> {
+        sys::try_lock_exclusive(self).map_err(io::Error::from)
+    }
+
     fn hint(&self, hint: FileHint) -> io::Result<()> {
         sys::fadvise(self, hint).map_err(io::Error::from)
     }
@@ -476,6 +480,9 @@ mod sys {
 
     // Declare flock directly to avoid requiring libc as a direct dependency.
     const LOCK_EX: c_int = 2;
+    // Non-blocking modifier: flock returns EWOULDBLOCK instead of waiting when
+    // the lock is already held.
+    const LOCK_NB: c_int = 4;
 
     // SAFETY: declaration matches the POSIX `flock` ABI on Unix targets.
     unsafe extern "C" {
@@ -497,6 +504,32 @@ mod sys {
             let err = std::io::Error::last_os_error();
             if err.kind() == std::io::ErrorKind::Interrupted {
                 continue;
+            }
+            return Err(err);
+        }
+    }
+
+    pub(super) fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+        let fd = file.as_raw_fd();
+
+        loop {
+            // SAFETY: fd is a valid file descriptor owned by `file`.
+            #[expect(unsafe_code, reason = "flock FFI call with valid fd")]
+            let ret = unsafe { flock(fd, LOCK_EX | LOCK_NB) };
+
+            if ret == 0 {
+                return Ok(true);
+            }
+
+            // EINTR can interrupt even the non-blocking call; retry. EWOULDBLOCK
+            // (the lock is held elsewhere) is the expected contention signal and
+            // maps to `Ok(false)`, not an error.
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            if err.kind() == std::io::ErrorKind::WouldBlock {
+                return Ok(false);
             }
             return Err(err);
         }
@@ -707,6 +740,72 @@ mod sys {
         }
         Ok(())
     }
+
+    pub(super) fn try_lock_exclusive(file: &File) -> io::Result<bool> {
+        use core::ptr;
+
+        const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x0000_0002;
+        // Non-blocking: fail immediately with ERROR_LOCK_VIOLATION instead of
+        // waiting when the region is already locked.
+        const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x0000_0001;
+        // Windows system error code returned when the lock is already held.
+        const ERROR_LOCK_VIOLATION: i32 = 33;
+
+        // SAFETY: declaration matches the Windows `LockFileEx` ABI and `Overlapped` layout.
+        #[allow(non_snake_case, reason = "FFI name matches Windows API")]
+        unsafe extern "system" {
+            fn LockFileEx(
+                h_file: *mut std::ffi::c_void,
+                dw_flags: u32,
+                dw_reserved: u32,
+                n_number_of_bytes_to_lock_low: u32,
+                n_number_of_bytes_to_lock_high: u32,
+                lp_overlapped: *mut Overlapped,
+            ) -> i32;
+        }
+
+        #[repr(C)]
+        struct Overlapped {
+            internal: usize,
+            internal_high: usize,
+            offset: u32,
+            offset_high: u32,
+            h_event: *mut std::ffi::c_void,
+        }
+
+        let handle = file.as_raw_handle();
+        let mut overlapped = Overlapped {
+            internal: 0,
+            internal_high: 0,
+            offset: 0,
+            offset_high: 0,
+            h_event: ptr::null_mut(),
+        };
+
+        // SAFETY: handle is a valid file handle owned by `file`.
+        #[expect(unsafe_code, reason = "LockFileEx FFI call with valid handle")]
+        let ret = unsafe {
+            LockFileEx(
+                handle as *mut std::ffi::c_void,
+                LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                0,
+                u32::MAX,
+                u32::MAX,
+                &mut overlapped,
+            )
+        };
+
+        if ret == 0 {
+            let err = std::io::Error::last_os_error();
+            // The "already locked" case is the expected contention signal and
+            // maps to `Ok(false)`, mirroring the unix EWOULDBLOCK path.
+            if err.raw_os_error() == Some(ERROR_LOCK_VIOLATION) {
+                return Ok(false);
+            }
+            return Err(err);
+        }
+        Ok(true)
+    }
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -716,6 +815,13 @@ mod sys {
     use std::io;
 
     pub(super) fn lock_exclusive(_file: &File) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "file locking is not supported on this platform",
+        ))
+    }
+
+    pub(super) fn try_lock_exclusive(_file: &File) -> io::Result<bool> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "file locking is not supported on this platform",

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -146,14 +146,17 @@ impl Config {
     /// compaction restructures it into proper levels (expect elevated I/O for a
     /// period proportional to the data size).
     ///
-    /// # Exclusive access (required)
+    /// # Exclusive access
     ///
-    /// The caller MUST guarantee no other instance has this tree directory open.
     /// Repair rewrites `CURRENT`, writes a fresh snapshot, and removes the stale
-    /// `edits-*` logs in place — `lsm-tree` takes no cross-process directory lock
-    /// here (nor does [`Config::open`]; exclusive directory ownership is the
-    /// embedder's responsibility). Running repair against a live tree corrupts
-    /// that instance's manifest state.
+    /// `edits-*` logs in place, so it requires exclusive access to the tree
+    /// directory. It acquires the same cross-process directory lock as
+    /// [`Config::open`] for the duration of the call: if another live instance
+    /// holds the directory (open or repairing), this fails fast with
+    /// [`crate::Error::Locked`] instead of corrupting that instance's manifest
+    /// state. The lock can be disabled via
+    /// [`Config::with_directory_lock`](crate::Config::with_directory_lock) for
+    /// embedders enforcing exclusivity at a higher layer.
     ///
     /// # Errors
     ///
@@ -196,6 +199,16 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
             "repair of KV-separated (blob) trees",
         ));
     }
+
+    // Hold the cross-process directory lock for the whole repair: it rewrites
+    // CURRENT, writes a fresh snapshot, and sweeps `edits-*` in place, so a
+    // concurrent open / repair of the same directory would corrupt the manifest.
+    // A second acquirer fails fast with `Error::Locked`. Dropped at function
+    // return, releasing the lock. The directory is expected to exist (repair
+    // operates on an existing tree).
+    #[cfg(feature = "std")]
+    let _directory_lock =
+        crate::config::acquire_directory_lock(&*config.fs, &config.path, config.directory_lock)?;
 
     let mut recovered_tables: Vec<Table> = Vec::new();
     let mut unreadable_files: Vec<(PathBuf, String)> = Vec::new();

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -176,17 +176,12 @@ pub struct TreeInner {
 }
 
 impl TreeInner {
-    pub(crate) fn create_new(config: Config) -> crate::Result<Self> {
-        // Acquire the cross-process directory lock before the first manifest
-        // write below. The caller (`Tree::create_new`) has already created the
-        // tree directory, so the `LOCK` file can be opened here.
-        #[cfg(feature = "std")]
-        let directory_lock = crate::config::acquire_directory_lock(
-            &*config.fs,
-            &config.path,
-            config.directory_lock,
-        )?;
-
+    pub(crate) fn create_new(
+        config: Config,
+        // The cross-process directory lock acquired by `Tree::open` before the
+        // manifest probe; held for the tree's lifetime.
+        #[cfg(feature = "std")] directory_lock: Option<Box<dyn crate::fs::FsFile>>,
+    ) -> crate::Result<Self> {
         let version = Version::new(
             0,
             if config.kv_separation_opts.is_some() {

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -111,6 +111,19 @@ pub struct TreeInner {
     /// Serializes flush operations.
     pub(crate) flush_lock: Mutex<()>,
 
+    /// Holds the cross-process exclusive directory lock for this tree's
+    /// lifetime: the locked `LOCK` file handle acquired by `Config::open` (via
+    /// `acquire_directory_lock`). Dropping it on tree close releases the OS
+    /// advisory lock so another process can open the directory. `None` when the
+    /// lock is disabled via
+    /// [`Config::with_directory_lock`](crate::Config::with_directory_lock). The
+    /// field is never read directly (the `_` prefix marks it as a lifetime
+    /// guard); its sole job is to keep the lock held.
+    // std-only: cross-process file locking needs real OS files; a no_std build
+    // is single-context and has nothing to guard against.
+    #[cfg(feature = "std")]
+    pub(crate) _directory_lock: Option<Box<dyn crate::fs::FsFile>>,
+
     /// Tree-wide gate that defers SST / blob-file deletions while a
     /// [`Tree::create_checkpoint`](crate::Tree::create_checkpoint) is in
     /// flight. Acquired by checkpoint code via
@@ -164,6 +177,16 @@ pub struct TreeInner {
 
 impl TreeInner {
     pub(crate) fn create_new(config: Config) -> crate::Result<Self> {
+        // Acquire the cross-process directory lock before the first manifest
+        // write below. The caller (`Tree::create_new`) has already created the
+        // tree directory, so the `LOCK` file can be opened here.
+        #[cfg(feature = "std")]
+        let directory_lock = crate::config::acquire_directory_lock(
+            &*config.fs,
+            &config.path,
+            config.directory_lock,
+        )?;
+
         let version = Version::new(
             0,
             if config.kv_separation_opts.is_some() {
@@ -217,6 +240,8 @@ impl TreeInner {
             stop_signal: StopSignal::default(),
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
+            #[cfg(feature = "std")]
+            _directory_lock: directory_lock,
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: DeletionPause::new_shared(),
             #[cfg(feature = "std")]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2015,6 +2015,22 @@ impl Tree {
             return Err(crate::Error::PageEccUnsupported);
         }
 
+        // Acquire the cross-process directory lock BEFORE any manifest access
+        // (the `CURRENT` probe + `has_existing_version_state` check below, and
+        // the recover / create paths). Acquiring it here makes `open()`
+        // exclusive end-to-end: a concurrent opener fails fast with
+        // `Error::Locked` instead of racing through the probe and observing a
+        // peer's half-created directory (which would surface as the InvalidData
+        // "half-written checkpoint" path rather than `Locked`). The `LOCK` file
+        // needs its directory to exist, so create the root directory first
+        // (idempotent; `create_new` re-creates the `tables/` subtree). The lock
+        // is threaded into the constructor so it lives for the tree's lifetime.
+        #[cfg(feature = "std")]
+        let directory_lock = {
+            config.fs.create_dir_all(&config.path)?;
+            crate::config::acquire_directory_lock(&*config.fs, &config.path, config.directory_lock)?
+        };
+
         // Check for old version
         if config.fs.exists(&config.path.join("version"))? {
             log::error!(
@@ -2031,7 +2047,11 @@ impl Tree {
             &*config.fs,
             config.encryption.clone(),
         ) {
-            Ok(_) => Self::recover(config),
+            Ok(_) => Self::recover(
+                config,
+                #[cfg(feature = "std")]
+                directory_lock,
+            ),
             Err(crate::Error::Io(e)) if e.kind() == crate::io::ErrorKind::NotFound => {
                 // Missing CURRENT MUST coincide with a directory that
                 // has no version artifacts; otherwise we are looking at
@@ -2063,7 +2083,11 @@ impl Tree {
                         msg,
                     )));
                 }
-                Self::create_new(config)
+                Self::create_new(
+                    config,
+                    #[cfg(feature = "std")]
+                    directory_lock,
+                )
             }
             Err(e) => Err(e),
         }?;
@@ -2208,22 +2232,17 @@ impl Tree {
                   TreeInner assembly) — splitting it would create helper functions whose \
                   only caller is this one site"
     )]
-    fn recover(mut config: Config) -> crate::Result<Self> {
+    fn recover(
+        mut config: Config,
+        // The cross-process directory lock acquired by `Tree::open` before the
+        // manifest probe; held for the tree's lifetime via
+        // `TreeInner::_directory_lock`.
+        #[cfg(feature = "std")] directory_lock: Option<Box<dyn crate::fs::FsFile>>,
+    ) -> crate::Result<Self> {
         use crate::stop_signal::StopSignal;
         use inner::get_next_tree_id;
 
         log::info!("Recovering LSM-tree at {}", config.path.display());
-
-        // Acquire the cross-process directory lock before any recovery work
-        // mutates the on-disk manifest (CURRENT / snapshots / edit logs). The
-        // directory already exists on the recover path. Held for the tree's
-        // lifetime via `TreeInner::_directory_lock`.
-        #[cfg(feature = "std")]
-        let directory_lock = crate::config::acquire_directory_lock(
-            &*config.fs,
-            &config.path,
-            config.directory_lock,
-        )?;
 
         // Validate manifest metadata (format version, comparator name)
         // BEFORE recover_levels, so a rejected open is side-effect free
@@ -2390,7 +2409,12 @@ impl Tree {
     }
 
     /// Creates a new LSM-tree in a directory.
-    fn create_new(config: Config) -> crate::Result<Self> {
+    fn create_new(
+        config: Config,
+        // The cross-process directory lock acquired by `Tree::open`, held for
+        // the tree's lifetime.
+        #[cfg(feature = "std")] directory_lock: Option<Box<dyn crate::fs::FsFile>>,
+    ) -> crate::Result<Self> {
         use crate::file::fsync_directory;
 
         let path = config.path.clone();
@@ -2418,7 +2442,11 @@ impl Tree {
         // IMPORTANT: fsync primary folder on Unix
         fsync_directory(&path, &*config.fs, sync_mode)?;
 
-        let inner = TreeInner::create_new(config)?;
+        let inner = TreeInner::create_new(
+            config,
+            #[cfg(feature = "std")]
+            directory_lock,
+        )?;
         Ok(Self(Arc::new(inner)))
     }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2214,6 +2214,17 @@ impl Tree {
 
         log::info!("Recovering LSM-tree at {}", config.path.display());
 
+        // Acquire the cross-process directory lock before any recovery work
+        // mutates the on-disk manifest (CURRENT / snapshots / edit logs). The
+        // directory already exists on the recover path. Held for the tree's
+        // lifetime via `TreeInner::_directory_lock`.
+        #[cfg(feature = "std")]
+        let directory_lock = crate::config::acquire_directory_lock(
+            &*config.fs,
+            &config.path,
+            config.directory_lock,
+        )?;
+
         // Validate manifest metadata (format version, comparator name)
         // BEFORE recover_levels, so a rejected open is side-effect free
         // — recover_levels loads tables and cleans up orphans.
@@ -2338,6 +2349,8 @@ impl Tree {
             config: Arc::new(config),
             major_compaction_lock: RwLock::default(),
             flush_lock: Mutex::default(),
+            #[cfg(feature = "std")]
+            _directory_lock: directory_lock,
             compaction_state: Arc::new(Mutex::new(CompactionState::default())),
             deletion_pause: Arc::clone(&deletion_pause),
             #[cfg(feature = "std")]

--- a/tests/directory_lock.rs
+++ b/tests/directory_lock.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Cross-process exclusive directory lock (#422).
+//!
+//! `Config::open` / `Config::repair` take an advisory `flock` on a `LOCK` file
+//! in the tree directory. Because `flock` conflicts across distinct open file
+//! descriptions even within one process, these single-process tests exercise the
+//! real contention path: a second `open()` of the same directory while the first
+//! `Tree` is alive must fail fast with [`Error::Locked`], and the lock must be
+//! released when the holding `Tree` is dropped.
+
+use lsm_tree::{Config, Error, SequenceNumberCounter};
+
+fn config(path: &std::path::Path) -> Config {
+    Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+}
+
+#[test]
+fn second_open_of_locked_directory_fails_with_locked() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // First open acquires and holds the directory lock for its lifetime.
+    let _tree = config(dir.path()).open().expect("first open succeeds");
+
+    // A second open of the same directory must fail fast, not block.
+    // (`AnyTree` is not `Debug`, so match rather than `expect_err`.)
+    let Err(err) = config(dir.path()).open() else {
+        panic!("second open of a locked directory must fail");
+    };
+    assert!(
+        matches!(err, Error::Locked(_)),
+        "expected Error::Locked, got {err:?}",
+    );
+}
+
+#[test]
+fn dropping_the_tree_releases_the_directory_lock() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    {
+        let _tree = config(dir.path()).open().expect("first open succeeds");
+        // Lock is held here; dropping `_tree` at the end of this scope releases it.
+    }
+
+    // A second open of the same directory must succeed only because the lock was
+    // released when the first tree dropped (otherwise it would be Error::Locked).
+    let _tree = config(dir.path())
+        .open()
+        .expect("open after the holder dropped must succeed (lock released)");
+}
+
+#[test]
+fn repair_of_open_directory_fails_with_locked() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Create the tree so there is a manifest to repair, and keep it open so it
+    // holds the lock.
+    let _tree = config(dir.path()).open().expect("first open succeeds");
+
+    let err = config(dir.path())
+        .repair()
+        .expect_err("repair of a live (open) directory must fail");
+    assert!(
+        matches!(err, Error::Locked(_)),
+        "expected Error::Locked, got {err:?}",
+    );
+}
+
+#[test]
+fn directory_lock_opt_out_allows_concurrent_open() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // With the lock disabled, a second concurrent open of the same directory is
+    // permitted (the embedder is responsible for exclusivity).
+    let _tree1 = config(dir.path())
+        .with_directory_lock(false)
+        .open()
+        .expect("first open succeeds");
+    let _tree2 = config(dir.path())
+        .with_directory_lock(false)
+        .open()
+        .expect("second open succeeds when the directory lock is disabled");
+}
+
+#[test]
+fn reopen_after_lock_disabled_open_still_works() {
+    // Sanity: a tree opened with the lock disabled can be reopened (with the
+    // lock back on) once dropped — the disabled run leaves no stuck lock.
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let _tree = config(dir.path())
+            .with_directory_lock(false)
+            .open()
+            .expect("open with lock disabled");
+    }
+    let _tree = config(dir.path())
+        .open()
+        .expect("reopen with lock enabled succeeds");
+}

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -161,6 +161,11 @@ fn tree_kv_checksums_all_levels_round_trips_through_disk() {
         );
     }
 
+    // Drop the first tree to release the cross-process directory lock before
+    // reopening the same directory (a second concurrent open would be rejected
+    // with `Error::Locked`).
+    drop(tree);
+
     // Reopen (fresh block cache) and re-read to exercise the cold disk
     // read path, not just the post-flush cache.
     let reopened = open_tree(folder.path());

--- a/tests/tree_write_read.rs
+++ b/tests/tree_write_read.rs
@@ -33,6 +33,11 @@ fn tree_write_and_read() -> lsm_tree::Result<()> {
 
     tree.flush_active_memtable(0)?;
 
+    // Drop the first tree to release the cross-process directory lock before
+    // reopening the same directory (a second concurrent open would fail with
+    // `Error::Locked`).
+    drop(tree);
+
     let tree = Config::new(
         &folder,
         SequenceNumberCounter::default(),


### PR DESCRIPTION
## Summary

`Config::open` and `Config::repair` now acquire an exclusive advisory lock on a `LOCK` file in the tree directory and hold it for the lifetime of the `Tree` (open) or the duration of the call (repair). A second process opening or repairing the same directory **fails fast with `Error::Locked`** instead of racing on the manifest, where two writers of `CURRENT` / snapshots / `edits-*` logs would corrupt it. This matches the `LOCK`-file model of RocksDB and friends, and closes a hole raised in the #421 (incremental manifest) review where `repair()` against a live instance destroys its manifest state.

## Design

- **`FsFile::try_lock_exclusive(&self) -> io::Result<bool>`** — non-blocking exclusive lock (`flock` `LOCK_NB` on unix, `LockFileEx` `LOCKFILE_FAIL_IMMEDIATELY` on windows), returning `Ok(false)` on contention so a second opener fails fast rather than blocking. The default trivially acquires (`Ok(true)`), so in-memory / single-process backends are unaffected; `StdFs` and the io_uring backend perform the real OS lock.
- **`Config::with_directory_lock(false)`** — opt-out for embedders that already enforce exclusive directory ownership at a higher layer (keyspace / journal manager).
- The locked handle lives in `TreeInner` and releases on `Tree` drop (the OS frees an advisory lock when the fd / handle closes).
- Acquired in `recover()`, `TreeInner::create_new()`, and `repair_tree()` before any manifest mutation; `BlobTree::open` delegates to `Tree::open` and is covered.
- std-gated; **no on-disk format change**.

## Non-breaking

`Error::Locked` is an additive variant on the `#[non_exhaustive]` error enum; the new trait method has a default impl; `with_directory_lock` is additive. The behavioural change is that an in-process double-open of the same directory (always unsafe — manifest corruption) now fails loudly with `Error::Locked`; the opt-out is the escape hatch. Two existing tests reopened a directory while still holding the first handle (a fresh-cache cold-read shortcut) and were fixed to drop the first tree before reopening.

## Testing

- 5 new integration tests (`tests/directory_lock.rs`): second open of a locked dir fails with `Error::Locked`; lock released on `Tree` drop (reopen succeeds); `repair()` of an open dir fails; opt-out allows concurrent open; reopen after a lock-disabled run still works.
- Full suite `--all-features`: 2064 passed.
- `clippy --all-features --all-targets -D warnings` clean on **both** macOS and the `x86_64-unknown-linux-gnu` cross target (the io_uring backend is Linux-only and is verified there). no-std `alloc` build: 0 errors. Doctests pass.

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-process directory locking to prevent concurrent access; lock held for the lifetime of an open tree.
  * New configuration option to enable/disable the directory lock (enabled by default).
  * Attempts to open an already-locked directory fail fast with an explicit Locked error.

* **Documentation**
  * Repair operation docs updated to describe exclusive-access locking behavior.

* **Tests**
  * New and adjusted tests cover locking, lock release on drop, disablement, and interaction with repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->