### PR TITLE
feat(tooling): repair KV-separated (blob) trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ old
 **/proptest-regressions/
 **/*.proptest-regressions
 benchmark-results.json
+
+# Per-tree exclusive directory lock file: a runtime artifact created when a tree
+# directory is opened. Never committed (e.g. when tests open a fixture tree).
+LOCK

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -45,6 +45,10 @@ use crate::{
 };
 use std::{path::PathBuf, sync::Arc};
 
+/// Per-file repair failures: `(path, human-readable reason)`. Mirrors
+/// [`RepairReport::unreadable_files`].
+type UnreadableFiles = Vec<(PathBuf, String)>;
+
 /// Outcome of a [`Config::repair`] run.
 ///
 /// `recovered` plus `unreadable` accounts for every SST-named file the scan
@@ -136,6 +140,83 @@ fn quarantine_file(
     Ok(dest)
 }
 
+/// Discovers the blob files of a KV-separated tree for `repair` by scanning the
+/// single `blobs/` folder, with no manifest id list to filter against.
+///
+/// Mirrors the table scan in [`repair_tree`]: a non-numeric name is quarantined
+/// out of `blobs/` (the reopened tree's blob recovery parses every name and
+/// would abort on a bad one); a blob file that cannot be checksummed or whose
+/// metadata is unreadable is reported and left in place (it reads back as a
+/// harmless orphan on the next open). The recovered checksum is the whole-file
+/// XXH3-128 digest, identical to the one the blob writer accumulated via
+/// `ChecksummedWriter`, since blob files are written strictly sequentially.
+///
+/// Returns the recovered blob files and the per-file failure reasons (merged
+/// into the repair report's `unreadable_files`).
+fn recover_blob_files(
+    config: &Config,
+) -> crate::Result<(Vec<crate::vlog::BlobFile>, UnreadableFiles)> {
+    let blobs_folder = config.path.join(crate::file::BLOBS_FOLDER);
+    let mut blob_files: Vec<crate::vlog::BlobFile> = Vec::new();
+    let mut unreadable: UnreadableFiles = Vec::new();
+
+    // No `blobs/` folder = no blob files (a blob tree that never spilled a value
+    // to the value log). Nothing to recover; the manifest records an empty list.
+    if !config.fs.exists(&blobs_folder)? {
+        return Ok((blob_files, unreadable));
+    }
+
+    // Guard against the same id surfacing twice (symlinked / aliased entries).
+    let mut seen_ids: crate::HashSet<crate::vlog::BlobFileId> = crate::HashSet::default();
+
+    for dirent in config.fs.read_dir(&blobs_folder)? {
+        let crate::fs::FsDirEntry {
+            path: blob_path,
+            file_name,
+            is_dir,
+        } = dirent;
+
+        if is_dir || file_name == ".DS_Store" || file_name.starts_with("._") {
+            continue;
+        }
+
+        let Ok(blob_id) = file_name.parse::<crate::vlog::BlobFileId>() else {
+            let reason = match quarantine_file(&*config.fs, &blobs_folder, &blob_path, &file_name) {
+                Ok(dest) => format!(
+                    "file name is not a blob id; quarantined to {}",
+                    dest.display()
+                ),
+                Err(e) => format!("file name is not a blob id; quarantine failed: {e}"),
+            };
+            unreadable.push((blob_path, reason));
+            continue;
+        };
+
+        if !seen_ids.insert(blob_id) {
+            continue;
+        }
+
+        let checksum = match compute_table_checksum(&*config.fs, &blob_path) {
+            Ok(c) => crate::Checksum::from_raw(c),
+            Err(e) => {
+                seen_ids.remove(&blob_id);
+                unreadable.push((blob_path, e.to_string()));
+                continue;
+            }
+        };
+
+        match crate::vlog::recover_blob_file(&blob_path, blob_id, checksum, 0, &config.fs) {
+            Ok(bf) => blob_files.push(bf),
+            Err(e) => {
+                seen_ids.remove(&blob_id);
+                unreadable.push((blob_path, e.to_string()));
+            }
+        }
+    }
+
+    Ok((blob_files, unreadable))
+}
+
 impl Config {
     /// Rebuilds the `MANIFEST` for the tree at this config's path from the SST
     /// files present on disk, then returns a [`RepairReport`].
@@ -190,16 +271,6 @@ impl Config {
 /// Core repair routine. Separated from the [`Config::repair`] entry point so the
 /// logic is testable against a borrowed config.
 fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
-    if config.kv_separation_opts.is_some() {
-        // The blob manifest also records per-blob-file fragmentation stats that
-        // a directory scan cannot reconstruct; supporting it needs its own
-        // design (tracked in #408). Fail loudly rather than write a manifest
-        // that drops blobs.
-        return Err(crate::Error::FeatureUnsupported(
-            "repair of KV-separated (blob) trees",
-        ));
-    }
-
     // Hold the cross-process directory lock for the whole repair: it rewrites
     // CURRENT, writes a fresh snapshot, and sweeps `edits-*` in place, so a
     // concurrent open / repair of the same directory would corrupt the manifest.
@@ -332,11 +403,32 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
     let version_id = highest_existing_version_id(&*config.fs, &config.path)?
         .map_or(0, |max| max.saturating_add(1));
 
+    // KV-separated (blob) trees additionally carry a blob-file list. Discover the
+    // blob files from the `blobs/` folder (no manifest to filter against) and
+    // record them in the rebuilt manifest with the matching `TreeType::Blob` so
+    // the tree reopens (the reopened tree's type must match its config's
+    // `kv_separation_opts`). Fragmentation stats are NOT reconstructable from a
+    // directory scan (they are derived from compaction history), so they start
+    // empty: blob GC is advisory and re-learns them over time. The empty start
+    // never drops live data; it only resets GC's view of reclaimable space.
+    let (tree_type, blob_file_list) = if config.kv_separation_opts.is_some() {
+        let (blob_files, blob_unreadable) = recover_blob_files(config)?;
+        unreadable_files.extend(blob_unreadable);
+        let map: crate::HashMap<crate::vlog::BlobFileId, crate::vlog::BlobFile> =
+            blob_files.into_iter().map(|bf| (bf.id(), bf)).collect();
+        (TreeType::Blob, BlobFileList::new(map))
+    } else {
+        (
+            TreeType::Standard,
+            BlobFileList::new(crate::HashMap::default()),
+        )
+    };
+
     let version = Version::from_levels(
         version_id,
-        TreeType::Standard,
+        tree_type,
         levels,
-        BlobFileList::new(crate::HashMap::default()),
+        blob_file_list,
         crate::blob_tree::FragmentationMap::default(),
     );
 
@@ -372,15 +464,22 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
         }
     }
 
+    let mut warnings = vec![
+        "All recovered tables placed at L0; background compaction will redistribute them",
+        "Recent unlogged version edits (in-flight compactions, recent deletions) are lost",
+    ];
+    if config.kv_separation_opts.is_some() {
+        warnings.push(
+            "Blob fragmentation stats reset to empty; blob GC will re-learn reclaimable space over time",
+        );
+    }
+
     Ok(RepairReport {
         recovered,
         unreadable: unreadable_files.len(),
         unreadable_files,
         method: "all-to-L0 with sequence-number ordering",
-        warnings: vec![
-            "All recovered tables placed at L0; background compaction will redistribute them",
-            "Recent unlogged version edits (in-flight compactions, recent deletions) are lost",
-        ],
+        warnings,
     })
 }
 

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -34,9 +34,11 @@
 //!
 //! ## Scope
 //!
-//! KV-separated (blob) trees are not yet supported: their manifest also tracks
-//! blob-file fragmentation statistics that cannot be reconstructed from a
-//! directory scan alone. Repairing one returns [`crate::Error::FeatureUnsupported`].
+//! KV-separated (blob) trees are supported: the `blobs/` folder is scanned to
+//! rediscover the blob files and record them in the rebuilt manifest. Blob-file
+//! fragmentation statistics cannot be reconstructed from a directory scan
+//! (they are derived from compaction history), so they start empty; blob GC is
+//! advisory and re-learns reclaimable space over time without dropping data.
 
 use crate::{
     Table, TableId,

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -181,14 +181,19 @@ fn recover_blob_files(
         }
 
         let Ok(blob_id) = file_name.parse::<crate::vlog::BlobFileId>() else {
-            let reason = match quarantine_file(&*config.fs, &blobs_folder, &blob_path, &file_name) {
-                Ok(dest) => format!(
+            // A non-numeric name aborts the reopen's blob recovery (it parses
+            // every name in blobs/), so it MUST be moved out of the way. If the
+            // quarantine itself fails the bad name stays in place and the tree
+            // would not reopen, so fail the repair rather than report a false
+            // success.
+            let dest = quarantine_file(&*config.fs, &blobs_folder, &blob_path, &file_name)?;
+            unreadable.push((
+                blob_path,
+                format!(
                     "file name is not a blob id; quarantined to {}",
                     dest.display()
                 ),
-                Err(e) => format!("file name is not a blob id; quarantine failed: {e}"),
-            };
-            unreadable.push((blob_path, reason));
+            ));
             continue;
         };
 
@@ -310,18 +315,17 @@ fn repair_tree(config: &Config) -> crate::Result<RepairReport> {
                 // `tables/`). Leaving it in place would let repair report
                 // success while the tree still cannot reopen, so move it out of
                 // `tables/` into a sibling quarantine dir; report where it went.
-                let reason =
-                    match quarantine_file(&*folder_fs, &table_base_folder, &table_path, &file_name)
-                    {
-                        Ok(dest) => {
-                            format!(
-                                "file name is not a table id; quarantined to {}",
-                                dest.display()
-                            )
-                        }
-                        Err(e) => format!("file name is not a table id; quarantine failed: {e}"),
-                    };
-                unreadable_files.push((table_path, reason));
+                // If the quarantine itself fails the bad name stays in place, so
+                // fail the repair rather than report a false success.
+                let dest =
+                    quarantine_file(&*folder_fs, &table_base_folder, &table_path, &file_name)?;
+                unreadable_files.push((
+                    table_path,
+                    format!(
+                        "file name is not a table id; quarantined to {}",
+                        dest.display()
+                    ),
+                ));
                 continue;
             };
 

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -165,6 +165,64 @@ pub fn recover_blob_files(
     Ok((blob_files, orphaned_blob_files))
 }
 
+/// Recovers a SINGLE blob file from its path, for the manifest-rebuild
+/// (`Config::repair`) path where there is no manifest id list to filter against.
+///
+/// Reads the file's `meta` SFA section and constructs a [`BlobFile`] bound to
+/// the caller-computed `checksum`. Unlike [`recover_blob_files`] (which filters
+/// a known id list and fails fast on any miss), the caller discovers ids from a
+/// directory scan and handles per-file errors itself: a corrupt blob is reported
+/// and left in place (it reads back as a harmless orphan on the next open)
+/// rather than aborting the whole repair.
+///
+/// `tree_id` is `0` and there is no descriptor table, mirroring the table
+/// recovery in `repair`: the repaired tree is reopened fresh afterwards, so a
+/// transient handle must not pollute any shared cache.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or its `meta` section is
+/// missing / undecodable.
+pub fn recover_blob_file(
+    path: &Path,
+    id: BlobFileId,
+    checksum: Checksum,
+    tree_id: TreeId,
+    fs: &Arc<dyn Fs>,
+) -> crate::Result<BlobFile> {
+    let mut file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
+
+    // Same meta-section read as `recover_blob_files`' per-id branch above.
+    let meta = {
+        let reader = crate::sfa::Reader::from_reader(&mut file)?;
+        let toc = reader.toc();
+        let metadata_section = toc.section(b"meta").ok_or_else(|| {
+            log::error!("meta section in blob file #{id} is missing (file may be corrupted)");
+            crate::Error::Unrecoverable
+        })?;
+        let metadata_len =
+            usize::try_from(metadata_section.len()).map_err(|_| crate::Error::Unrecoverable)?;
+        let metadata_slice = crate::file::read_exact(&*file, metadata_section.pos(), metadata_len)?;
+        Metadata::from_slice(&metadata_slice)?
+    };
+
+    let file: Arc<dyn crate::fs::FsFile> = Arc::from(file);
+    Ok(BlobFile(Arc::new(BlobFileInner {
+        id,
+        path: path.to_path_buf(),
+        meta,
+        is_deleted: AtomicBool::new(false),
+        checksum,
+        file_accessor: FileAccessor::File(file),
+        tree_id,
+        fs: fs.clone(),
+        deletion_pause: once_cell::race::OnceBox::new(),
+
+        #[cfg(feature = "std")]
+        background_deleter: once_cell::race::OnceBox::new(),
+    })))
+}
+
 /// The unique identifier for a value log blob file.
 pub type BlobFileId = u64;
 
@@ -217,5 +275,21 @@ mod tests {
             &(Arc::new(crate::fs::StdFs) as Arc<dyn crate::fs::Fs>),
         );
         assert!(matches!(result, Err(crate::Error::Unrecoverable)));
+    }
+
+    #[test]
+    fn recover_blob_file_on_non_blob_file_errors() {
+        // A file that is not a valid blob (no SFA trailer / `meta` section) must
+        // surface an error instead of producing a bogus BlobFile, so the repair
+        // caller can report it and skip it rather than wiring corruption into the
+        // rebuilt manifest.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("000042");
+        std::fs::write(&path, b"this is not a blob file").unwrap();
+
+        let fs: Arc<dyn crate::fs::Fs> = Arc::new(crate::fs::StdFs);
+        let result = recover_blob_file(path.as_path(), 42, Checksum::from_raw(0), 0, &fs);
+        // `BlobFile` is not `Debug`, so assert on the boolean rather than the value.
+        assert!(result.is_err(), "recovering a non-blob file must fail");
     }
 }

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -430,6 +430,53 @@ fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
     Ok(())
 }
 
+#[test]
+fn repair_fails_when_a_bad_filename_cannot_be_quarantined() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let big = |i: u64| format!("{i:08}").repeat(512);
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(KvSeparationOptions::default()))
+        .open()?;
+        for i in 0..10 {
+            tree.insert(key(i), big(i).as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+    assert!(count_blob_files(dir.path())? >= 1);
+
+    nuke_manifest(dir.path())?;
+
+    // A non-numeric name in blobs/ would make the reopened tree's blob recovery
+    // (which parses every name) abort, so repair must quarantine it.
+    std::fs::write(dir.path().join("blobs").join("not-a-blob-id"), b"junk")?;
+    // Block the quarantine: occupy the `repair-quarantine` directory path with a
+    // regular file so the rename's `create_dir_all` fails. Repair must then abort
+    // rather than report success while leaving the un-quarantined name in place
+    // (which would make the tree unopenable).
+    std::fs::write(dir.path().join("repair-quarantine"), b"blocker")?;
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default()))
+    .repair();
+
+    assert!(
+        result.is_err(),
+        "repair must fail when it cannot quarantine a bad filename, got {result:?}",
+    );
+
+    Ok(())
+}
+
 /// Counts numerically-named blob files in a tree's `blobs/` folder.
 fn count_blob_files(dir: &std::path::Path) -> std::io::Result<usize> {
     let blobs = dir.join("blobs");

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -477,6 +477,52 @@ fn repair_fails_when_a_bad_filename_cannot_be_quarantined() -> lsm_tree::Result<
     Ok(())
 }
 
+#[test]
+fn repair_fails_when_a_bad_table_filename_cannot_be_quarantined() -> lsm_tree::Result<()> {
+    // Sibling of the blob-side test above, covering the standard `tables/`
+    // quarantine path so the false-success regression cannot slip back for
+    // standard trees.
+    let dir = tempfile::tempdir()?;
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..10 {
+            tree.insert(key(i), format!("v-{i}").as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+    assert!(count_sst_files(dir.path())? >= 1);
+
+    nuke_manifest(dir.path())?;
+
+    // A non-numeric name in tables/ would make the reopened tree's recovery
+    // (which parses every name) abort, so repair must quarantine it.
+    std::fs::write(dir.path().join("tables").join("not-a-table-id"), b"junk")?;
+    // Block the quarantine by occupying the `repair-quarantine` directory path
+    // with a regular file. Repair must abort rather than report success while
+    // leaving the un-quarantined name in place.
+    std::fs::write(dir.path().join("repair-quarantine"), b"blocker")?;
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair();
+
+    assert!(
+        result.is_err(),
+        "repair must fail when it cannot quarantine a bad table filename, got {result:?}",
+    );
+
+    Ok(())
+}
+
 /// Counts numerically-named blob files in a tree's `blobs/` folder.
 fn count_blob_files(dir: &std::path::Path) -> std::io::Result<usize> {
     let blobs = dir.join("blobs");

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -430,9 +430,26 @@ fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
     Ok(())
 }
 
+/// Counts numerically-named blob files in a tree's `blobs/` folder.
+fn count_blob_files(dir: &std::path::Path) -> std::io::Result<usize> {
+    let blobs = dir.join("blobs");
+    if !blobs.exists() {
+        return Ok(0);
+    }
+    Ok(std::fs::read_dir(blobs)?
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().parse::<u64>().is_ok())
+        .count())
+}
+
 #[test]
-fn repair_rejects_kv_separated_trees() -> lsm_tree::Result<()> {
+fn repair_rebuilds_blob_tree_manifest_and_preserves_values() -> lsm_tree::Result<()> {
     let dir = tempfile::tempdir()?;
+
+    // ~4 KiB values, above the 1 KiB KV-separation threshold, so they spill into
+    // the value log as blob files: the artifact a blob-tree repair must
+    // rediscover (a plain SST scan would otherwise lose them).
+    let big = |i: u64| format!("{i:08}").repeat(512);
 
     {
         let tree = Config::new(
@@ -442,24 +459,59 @@ fn repair_rejects_kv_separated_trees() -> lsm_tree::Result<()> {
         )
         .with_kv_separation(Some(KvSeparationOptions::default()))
         .open()?;
-        tree.insert("k", "v", 0);
+
+        for i in 0..50 {
+            tree.insert(key(i), big(i).as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        for i in 50..100 {
+            tree.insert(key(i), big(i).as_bytes(), i);
+        }
         tree.flush_active_memtable(0)?;
     }
 
+    let blob_count = count_blob_files(dir.path())?;
+    assert!(
+        blob_count >= 1,
+        "expected at least one blob file to exist, got {blob_count}",
+    );
+    let sst_count = count_sst_files(dir.path())?;
+
     nuke_manifest(dir.path())?;
 
-    let result = Config::new(
+    let report = Config::new(
         dir.path(),
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
     .with_kv_separation(Some(KvSeparationOptions::default()))
-    .repair();
+    .repair()?;
 
-    assert!(
-        matches!(result, Err(lsm_tree::Error::FeatureUnsupported(_))),
-        "blob trees are not yet repairable, got {result:?}",
+    assert_eq!(
+        report.recovered, sst_count,
+        "every SST on disk must be recovered",
     );
+    assert_eq!(report.unreadable, 0, "no file should be unreadable");
+
+    // Reopen and verify every blob-backed value reads back, proving the blob
+    // files were rediscovered and wired into the rebuilt manifest.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default()))
+    .open()?;
+
+    for i in 0..100 {
+        assert_eq!(
+            tree.get(key(i), MAX_SEQNO)?.as_deref(),
+            Some(big(i).as_bytes()),
+            "blob-backed value for key {} must survive repair",
+            key(i),
+        );
+    }
 
     Ok(())
 }

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -172,7 +172,8 @@ enum Command {
     /// Uses the default comparator and no encryption: a tree created
     /// with a custom comparator or with encryption must be repaired via
     /// the library `Config::repair` API with the matching config.
-    /// KV-separated (blob) trees are not supported by repair.
+    /// A KV-separated (blob) tree is detected by its `blobs/` folder and
+    /// repaired with KV separation enabled so its blob files are recovered.
     Repair,
 
     /// Print sizing stats for the SST's BuRR filter: on-disk filter
@@ -266,13 +267,22 @@ fn main() -> ExitCode {
 }
 
 fn run_repair(db_dir: &std::path::Path) -> ExitCode {
-    use lsm_tree::{Config, SequenceNumberCounter};
+    use lsm_tree::{Config, KvSeparationOptions, SequenceNumberCounter};
 
-    let config = Config::new(
+    let mut config = Config::new(
         db_dir,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     );
+
+    // A `blobs/` folder marks a KV-separated (blob) tree. Enable KV separation so
+    // repair rediscovers the blob files and records the matching tree type;
+    // without it, repair would rebuild a standard-tree manifest and drop the
+    // blobs. The separation options only affect future writes, so defaults are
+    // fine for recovery.
+    if db_dir.join("blobs").is_dir() {
+        config = config.with_kv_separation(Some(KvSeparationOptions::default()));
+    }
 
     let report = match config.repair() {
         Ok(report) => report,


### PR DESCRIPTION
## Summary

`Config::repair` now rebuilds the manifest of a KV-separated (blob) tree instead of returning `Error::FeatureUnsupported`. It discovers blob files by scanning the `blobs/` folder (there is no manifest to filter against), computes each file's whole-file XXH3-128 checksum, recovers its metadata, and records them in the rebuilt manifest with `TreeType::Blob` so the tree reopens correctly.

Blob fragmentation statistics start **empty**: they are derived from compaction history and cannot be reconstructed from a directory scan. Blob GC is advisory, so it re-learns reclaimable space over time without ever dropping live data. This is surfaced as a warning in the `RepairReport`.

## Changes

- **`vlog::recover_blob_file`** (new): single-file blob recovery for the manifest-rebuild path. Unlike `recover_blob_files` (which filters a known id list and fails fast on any miss), this is used by a directory scan with per-file error handling: a corrupt blob is reported and left in place (it reads back as a harmless orphan on the next open) rather than aborting the whole repair.
- **`repair.rs`**: lifts the `FeatureUnsupported` guard; scans `blobs/`, quarantines non-numeric names (the reopen's blob recovery parses every name and would abort otherwise), reports unreadable blobs, and wires the recovered list into the rebuilt `Version` with `TreeType::Blob`.
- **`sst-dump repair`**: detects a blob tree by its `blobs/` folder and enables KV separation, so the CLI recovers blobs too (a default config would rebuild a standard-tree manifest and silently drop them).
- **`.gitignore`**: ignore the per-tree `LOCK` file (a runtime artifact of the directory lock; tests that open a fixture tree would otherwise leave it untracked).

## Non-breaking

The new `vlog::recover_blob_file` is additive, and repair only removes an error path (enabling a previously-rejected operation). No public API was changed or removed.

## Testing

- `repair_rebuilds_blob_tree_manifest_and_preserves_values`: writes ~4 KiB (blob-backed) values, drops the manifest, repairs, reopens, and reads every value back (replaces the former `repair_rejects_kv_separated_trees`).
- `recover_blob_file_on_non_blob_file_errors`: error-path unit test.
- Full library suite `--all-features`: 2065 passed. `clippy --all-features --all-targets -D warnings` clean. sst-dump (separate crate): clippy clean + 31 tests pass. no-std `alloc` build: 0 errors. Doctests pass.

Closes #408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repair can now recover KV-separated (“blob”) trees, restoring blob-backed data after manifest rebuild scenarios.
* **Improvements**
  * Repair tooling auto-detects existing `blobs/` storage and enables KV separation; `sst-dump` help and behavior updated accordingly.
  * Blob fragmentation stats are reset during blob-tree repair, with a new warning.
* **Bug Fixes**
  * Invalid/non-blob entries in blob storage are quarantined and reported as unreadable, preventing bogus recovery.
* **Tests**
  * Expanded blob-tree repair success and failure/quarantine coverage.
* **Chores**
  * Updated `.gitignore` to ignore transient `LOCK` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->