### PR TITLE
feat(time): injectable Clock trait + no-std-check as a required gate

### DIFF
--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -328,25 +328,21 @@ jobs:
         run: cargo nextest run
 
   no-std-check:
-    # Tracks no-std + alloc migration progress. The crate is incrementally
-    # being ported to support `#![no_std]` builds: modules with std-only
-    # dependencies stay gated behind `#[cfg(feature = "std")]` until they
-    # are migrated. This job runs `cargo check --no-default-features
+    # Gates the `#![no_std]` + alloc engine path. The engine modules compile
+    # unconditionally; only the std default trait implementations (the system
+    # filesystem, the io_uring backend, the system clock) stay behind
+    # `#[cfg(feature = "std")]`. This job runs `cargo check --no-default-features
     # --features alloc` on a true no-std-only target (the `thumbv7em-none-eabihf`
     # cross-compile target has no std at all, so any leaked `std::*` import
     # surfaces here even if the host toolchain has std available).
     #
-    # The job is currently EXPECTED TO FAIL — that's the whole point. It is
-    # the canonical progress meter for the migration: the number of compile
-    # errors must monotonically decrease across PRs until it reaches zero,
-    # at which point the `continue-on-error: true` flag below is removed and
-    # this becomes a gating check. New code added to this crate MUST be
-    # no-std-friendly (prefer `core::*` / `alloc::*`, gate std-only behind
-    # `#[cfg(feature = "std")]`); reviewers should request the error count
-    # from this job and compare against main.
+    # This is a HARD GATE: the alloc build must stay clean. New code added to
+    # this crate MUST be no-std-friendly (prefer `core::*` / `alloc::*`, gate
+    # std-only behind `#[cfg(feature = "std")]`). A failure here means a
+    # `std::*` leak crept onto an engine path: fix the leak, do not relax the
+    # gate.
     needs: [changes, lint]
     if: ${{ always() && !cancelled() && needs.lint.result == 'success' && needs.changes.outputs.code != 'false' }}
-    continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,12 @@ mod format_version;
 mod time;
 mod tree;
 
+pub use time::Clock;
+#[cfg(feature = "std")]
+pub use time::SystemClock;
+#[cfg(not(feature = "std"))]
+pub use time::set_clock;
+
 /// Utility functions
 pub mod util;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,13 +2,71 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+use core::time::Duration;
+
+/// A source of wall-clock time.
+///
+/// The engine reads wall-clock time (for the `created_at` stamp on tables and
+/// blob files, and for FIFO TTL expiry) through this trait. Under `std` the
+/// built-in [`SystemClock`] is used automatically. Under `no_std` there is no
+/// ambient system clock, so a consumer (e.g. a WASM host exposing `Date.now()`)
+/// injects one once via [`set_clock`] before opening a tree.
+///
+/// # Examples
+///
+/// ```
+/// # use lsm_tree::Clock;
+/// # use core::time::Duration;
+/// struct FixedClock(Duration);
+/// impl Clock for FixedClock {
+///     fn unix_time(&self) -> Duration {
+///         self.0
+///     }
+/// }
+/// let clock = FixedClock(Duration::from_secs(1_700_000_000));
+/// assert_eq!(clock.unix_time().as_secs(), 1_700_000_000);
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a wall-clock source",
+    label = "this type does not implement `Clock`",
+    note = "implement `Clock` to inject a wall-clock under `no_std`, or enable the `std` feature to use the built-in `SystemClock`"
+)]
+pub trait Clock: Send + Sync {
+    /// Wall-clock time elapsed since the Unix epoch.
+    ///
+    /// A clock with no real time source should return [`Duration::ZERO`] (the
+    /// epoch), which disables TTL expiry rather than expiring everything.
+    fn unix_time(&self) -> Duration;
+}
+
+/// The system wall-clock, backed by [`std::time::SystemTime`].
+///
+/// The default [`Clock`] under `feature = "std"`; consumers never need to
+/// register it explicitly.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+#[cfg(feature = "std")]
+impl Clock for SystemClock {
+    fn unix_time(&self) -> Duration {
+        #[expect(
+            clippy::expect_used,
+            reason = "the system clock predates the Unix epoch only on a grossly misconfigured host"
+        )]
+        std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("system time is before the Unix epoch")
+    }
+}
+
 /// Gets the unix timestamp as a duration (wall-clock time since the epoch).
 ///
-/// Under `std` this reads the system clock. Under `no_std` there is no ambient
-/// clock, so the value comes from a caller-registered hook (see
-/// [`set_clock`]); until one is registered it is [`core::time::Duration::ZERO`]
+/// Reads through the active [`Clock`]: the built-in [`SystemClock`] under
+/// `std`, or the caller-registered clock under `no_std` (see [`set_clock`]).
+/// Until a `no_std` clock is registered the value is [`Duration::ZERO`]
 /// (epoch), which disables TTL expiry rather than expiring everything.
-pub fn unix_timestamp() -> core::time::Duration {
+pub fn unix_timestamp() -> Duration {
     #[cfg(test)]
     #[allow(clippy::significant_drop_in_scrutinee, clippy::expect_used)]
     {
@@ -21,10 +79,7 @@ pub fn unix_timestamp() -> core::time::Duration {
 
     #[cfg(feature = "std")]
     {
-        let now = std::time::SystemTime::now();
-        #[expect(clippy::expect_used, reason = "trivial")]
-        now.duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .expect("time went backwards")
+        SystemClock.unix_time()
     }
 
     #[cfg(not(feature = "std"))]
@@ -65,30 +120,33 @@ impl Instant {
     }
 }
 
-/// Registers the wall-clock source used by [`unix_timestamp`] under `no_std`
-/// (e.g. a WASM host's `Date.now()`). Idempotent — the first registration
-/// wins; later calls are ignored. A no-op under `std`, where the system clock
-/// is always available.
+/// Registers the [`Clock`] used by [`unix_timestamp`] under `no_std` (e.g. a
+/// WASM host's `Date.now()`). Idempotent: the first registration wins, later
+/// calls are ignored. Only present under `no_std`: under `std` the built-in
+/// [`SystemClock`] is always available, so no registration is needed.
 #[cfg(not(feature = "std"))]
-pub fn set_clock(clock: fn() -> core::time::Duration) {
+pub fn set_clock(clock: alloc::boxed::Box<dyn Clock>) {
     nostd_clock::set(clock);
 }
 
 #[cfg(not(feature = "std"))]
 mod nostd_clock {
+    use super::Clock;
     use alloc::boxed::Box;
     use core::time::Duration;
     use once_cell::race::OnceBox;
 
     // Caller-injected wall-clock. Lock-free (atomic pointer), set once.
-    static CLOCK: OnceBox<fn() -> Duration> = OnceBox::new();
+    static CLOCK: OnceBox<Box<dyn Clock>> = OnceBox::new();
 
-    pub fn set(clock: fn() -> Duration) {
+    pub fn set(clock: Box<dyn Clock>) {
         let _ = CLOCK.set(Box::new(clock));
     }
 
     pub fn now() -> Duration {
-        CLOCK.get().map_or(Duration::ZERO, |clock| clock())
+        CLOCK
+            .get()
+            .map_or(Duration::ZERO, |clock| clock.unix_time())
     }
 }
 
@@ -103,4 +161,39 @@ static NOW_OVERRIDE: OnceLock<Mutex<Option<std::time::Duration>>> = OnceLock::ne
 pub fn set_unix_timestamp_for_test(value: Option<std::time::Duration>) {
     let cell = NOW_OVERRIDE.get_or_init(|| Mutex::new(None));
     *cell.lock().expect("lock is poisoned") = value;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    #[test]
+    fn system_clock_unix_time_is_after_a_known_recent_epoch() {
+        // Any wall-clock reading taken after this fixed past instant (2023-11-14)
+        // proves SystemClock consults the real system clock rather than a stub.
+        let known_past = Duration::from_secs(1_700_000_000);
+        assert!(
+            SystemClock.unix_time() > known_past,
+            "SystemClock must read the real system clock"
+        );
+    }
+
+    #[test]
+    fn unix_timestamp_matches_system_clock_when_no_test_override_is_set() {
+        // With no override registered, the free `unix_timestamp` helper must read
+        // through the same SystemClock the rest of the engine uses.
+        set_unix_timestamp_for_test(None);
+        let known_past = Duration::from_secs(1_700_000_000);
+        assert!(unix_timestamp() > known_past);
+    }
+
+    #[test]
+    fn unix_timestamp_honours_the_test_override() {
+        let fixed = Duration::from_secs(42);
+        set_unix_timestamp_for_test(Some(fixed));
+        assert_eq!(unix_timestamp(), fixed);
+        // Restore so later tests in this binary see the real clock again.
+        set_unix_timestamp_for_test(None);
+    }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -168,6 +168,12 @@ mod tests {
     use super::*;
     use test_log::test;
 
+    // These tests assert std wall-clock behaviour, so they are gated behind
+    // `feature = "std"`: under `--no-default-features` the `std` feature is off,
+    // `SystemClock` is absent, and `unix_timestamp()` takes the no_std (epoch)
+    // branch where these assertions would not hold.
+
+    #[cfg(feature = "std")]
     #[test]
     fn system_clock_unix_time_is_after_a_known_recent_epoch() {
         // Any wall-clock reading taken after this fixed past instant (2023-11-14)
@@ -179,20 +185,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn unix_timestamp_matches_system_clock_when_no_test_override_is_set() {
-        // With no override registered, the free `unix_timestamp` helper must read
-        // through the same SystemClock the rest of the engine uses.
-        set_unix_timestamp_for_test(None);
-        let known_past = Duration::from_secs(1_700_000_000);
-        assert!(unix_timestamp() > known_past);
-    }
-
+    // The no-override and override cases share one test so they cannot observe
+    // each other's mutation of the process-global test override. (The suite runs
+    // under nextest, which isolates each test in its own process, but keeping the
+    // override roundtrip self-contained holds under any runner.)
+    #[cfg(feature = "std")]
     #[test]
     fn unix_timestamp_honours_the_test_override() {
+        // With no override registered, the free `unix_timestamp` helper reads
+        // through the same SystemClock the rest of the engine uses.
+        set_unix_timestamp_for_test(None);
+        assert!(
+            unix_timestamp() > Duration::from_secs(1_700_000_000),
+            "without an override, unix_timestamp must read the real system clock"
+        );
+
+        // An override pins the value regardless of the wall-clock.
         let fixed = Duration::from_secs(42);
         set_unix_timestamp_for_test(Some(fixed));
         assert_eq!(unix_timestamp(), fixed);
+
         // Restore so later tests in this binary see the real clock again.
         set_unix_timestamp_for_test(None);
     }


### PR DESCRIPTION
## Summary

Completes the last two unmet acceptance criteria of #449 (no-std full alloc engine), which turned out far closer to done than its body suggested: the core engine (`tree` mod is unconditional) already compiles on the no-std-only `thumbv7em-none-eabihf` target (`--no-default-features --features alloc`) with **0 errors**, so criteria 1/3/4/5 were already met. Only the `Clock` trait and the CI gate remained.

### Clock trait (criterion 2)

A no_std consumer (e.g. a WASM host exposing `Date.now()`) needs to supply wall-clock time, which the engine reads for the `created_at` stamp on tables/blob files and for FIFO TTL expiry.

- `Clock` trait with `unix_time()` + `#[diagnostic::on_unimplemented]`; the std `SystemClock` default is gated behind `feature = "std"` and used automatically.
- The no_std injection point `set_clock` now takes `Box<dyn Clock>` (was a bare `fn() -> Duration`), stored in the same set-once lock-free `OnceBox` (the idiomatic no_std hook, like `log::set_logger`).
- `unix_timestamp()` reads through the active clock, encapsulating the only direct `std::time::SystemTime` use behind the gated `SystemClock` impl.
- `Clock` / `SystemClock` / `set_clock` are re-exported from the crate root (the `time` module was private, so the injection point was previously unreachable).

A process-wide wall-clock is injected as a trait object behind the global set-once hook rather than threaded per-tree through writers: per-tree wall-clocks have no meaning and would add an `Arc` clone + vtable call to the hot writer-construction path for zero functional gain.

### no-std-check as a required gate (criterion 6)

The alloc build is clean on the no-std-only target, so the `no-std-check` job no longer needs `continue-on-error`. The flag is removed and the stale "expected to fail" comment rewritten: a non-zero count now means a `std::*` leak crept onto an engine path and must be fixed, not tolerated.

## Testing

- `cargo check --all-features` clean
- `cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc` → **0 errors**
- `cargo clippy --all-features --all-targets` clean
- `cargo test --doc` (new `Clock` doctest) passes
- full `cargo nextest run --all-features` → **2070 passed**, 2 skipped (+3 new `time::tests`)
- fmt clean; `tools/sst-dump` (separate crate) compiles

Part of #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pluggable wall-clock abstraction so `unix_timestamp()` can use an active clock implementation.
  * Provided a `SystemClock` for standard-library builds.
* **Breaking Changes**
  * In no-std builds, `set_clock()` now takes a boxed clock trait object instead of a function pointer.
* **Chores**
  * Tightened CI behavior for the no-std check to fail the workflow on failures (removed “allow failure” behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->