### PR TITLE
feat(bench): RocksDbParity preset + Benchmark Symmetry Invariant

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -176,6 +176,14 @@ jobs:
           fi
 
       - name: Run compare-rocksdb head-to-head benches
+        # Pin the published dashboard to the RocksDbParity preset (the apples-to-
+        # apples comparison): every lsm-tree-only on-disk opt-in is OFF so the
+        # numbers are not paying for protection RocksDB has no equivalent for.
+        # Set explicitly rather than relying on the in-code default, so a future
+        # default change cannot silently alter the public comparison. See
+        # docs/BENCHMARKING.md.
+        env:
+          LSM_BENCH_PRESET: rocksdb-parity
         run: |
           cd tools/compare-rocksdb
           cargo bench --bench compare -- \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,15 @@ By contributing to this project, you agree that your contributions will be licen
 
 Thank you for your contribution!
 
+## Changing the on-disk format
+
+Any PR that adds or changes an on-disk format feature must satisfy the
+Benchmark Symmetry Invariant: a new feature is OFF by default, has a
+RocksDB-equivalent, or provides a wire-identical OFF mode, and new opt-ins are
+disabled in the `RocksDbParity` bench preset so head-to-head comparisons stay
+apples-to-apples. See [docs/BENCHMARKING.md](docs/BENCHMARKING.md) for the rule,
+the preset matrix, and the per-PR checklist.
+
 ## Looking for issues?
 
 https://github.com/structured-world/coordinode-lsm-tree/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,91 @@
+# Benchmarking
+
+How to run the head-to-head benchmarks and, more importantly, how to keep
+their results honest.
+
+## The Benchmark Symmetry Invariant
+
+`coordinode-lsm-tree` ships on-disk integrity features (manifest hardening,
+per-KV checksums, Page ECC, seqno-in-index) that RocksDB and most other LSM
+engines have no equivalent for. If those are active while a competitor's are
+not, every published comparison is unfair in one of two directions:
+
+- we pay for protection the competitor lacks, losing a comparison we should
+  win, or
+- we win unfairly on a workload where the competitor simply has no equivalent
+  feature enabled.
+
+To prevent both, every new on-disk format feature MUST satisfy at least one of:
+
+1. **OFF by default** (the user opts in explicitly), OR
+2. have a **baseline equivalent in RocksDB** with a matching durability
+   profile, OR
+3. provide an **explicit OFF mode** that produces wire-output identical to
+   "feature absent".
+
+The `compare-rocksdb` harness encodes this as a set of presets. Public
+comparisons use the `RocksDbParity` preset (or a documented equivalent).
+
+## Presets
+
+Only OUR engine's configuration moves across presets; RocksDB is the fixed
+baseline. Select a preset with the `LSM_BENCH_PRESET` environment variable
+(default: `rocksdb-parity`):
+
+| `LSM_BENCH_PRESET` | Preset | Purpose |
+|--------------------|--------|---------|
+| `rocksdb-parity` (default) | `RocksDbParity` | Every lsm-tree-only opt-in OFF, matching RocksDB's durability defaults. The honest apples-to-apples number, used by the dashboard CI run. |
+| `lsm-default` | `LsmTreeDefault` | Production defaults (manifest hardening + FS-aware optimizations ON). What a real deployment runs. |
+| `lsm-paranoid` | `LsmTreeParanoid` | Every opt-in ON. Worst-case protection-overhead measurement. |
+
+`RocksDbParity` disables, in one place (`apply_preset` in
+`tools/compare-rocksdb/benches/compare.rs`):
+
+| Feature | Parity setting | Rationale |
+|---------|----------------|-----------|
+| `manifest_footer_mirror` | off | lsm-tree-only manifest hardening |
+| `kv_checksums` | `Off` | RocksDB has no per-KV checksum |
+| `seqno_in_index` | off | lsm-tree-only index extension |
+| `page_ecc` | off | RocksDB has no Page ECC |
+| `disable_cow_on_sst_files` | off | RocksDB has no FS-aware CoW control |
+| `use_reflink_for_checkpoint` | off | RocksDB has no reflink path |
+| `manifest_kv_checksums` | **on** | parity: matches RocksDB's per-record MANIFEST CRC32 |
+| block-level XXH3 checksum | **on** | parity: matches RocksDB's per-block checksum |
+
+The preset disables each opt-in explicitly even when it is already off by
+default, so the comparison stays honest if a default ever flips and so the full
+parity surface is documented in one place.
+
+## Running
+
+The harness links RocksDB through `librocksdb-sys`, whose `bindgen` build step
+needs `libclang`.
+
+```sh
+# Linux: the distro libclang.so is found automatically.
+cd tools/compare-rocksdb && cargo bench
+
+# macOS (Homebrew LLVM):
+export LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib
+export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib
+cd tools/compare-rocksdb && cargo bench
+
+# Worst-case overhead run:
+LSM_BENCH_PRESET=lsm-paranoid cargo bench
+```
+
+The active preset is printed once to stderr at the start of the run, so it is
+recorded in the dashboard provenance.
+
+## Checklist for format-changing PRs
+
+A PR that adds or changes an on-disk format feature MUST:
+
+- [ ] Make the feature satisfy the invariant (off by default, RocksDB-equivalent,
+      or wire-identical OFF mode).
+- [ ] Document the feature's default in the `Config` / `RuntimeConfig` docstring
+      and the README "what works" surface.
+- [ ] If it adds a new opt-in field, disable it in the `RocksDbParity` preset
+      (`apply_preset`) so the parity comparison stays apples-to-apples.
+- [ ] Include bench data showing the ON-vs-OFF impact (`lsm-paranoid` vs
+      `rocksdb-parity`).

--- a/tools/compare-rocksdb/Cargo.toml
+++ b/tools/compare-rocksdb/Cargo.toml
@@ -23,7 +23,9 @@ publish = false
 # (`CompressionType::Zstd(22)`); the `None`-compression baseline
 # groups still run on the same build. Future `*_lz4` variants add the
 # `lz4` feature alongside their workload.
-lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["zstd"] }
+# `page_ecc` is compiled in so the `lsm-paranoid` bench preset can measure
+# Page-ECC write overhead; the default `rocksdb-parity` preset keeps it OFF.
+lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["zstd", "page_ecc"] }
 # RocksDB binding — the whole reason this crate exists outside the
 # main `--all-features` graph. `default-features = false` strips
 # the upstream default compression codecs (snappy, lz4, bz2, zlib);

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -95,6 +95,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use lsm_tree::{
     AbstractTree, CompressionType, Config, Guard, MAX_SEQNO, SequenceNumberCounter,
     config::CompressionPolicy,
+    runtime_config::{KvChecksumPolicy, RuntimeConfig},
 };
 use surrealkv::{
     Durability as SkvDurability, LSMIterator as _, Options as SkvOptions, Tree as SkvTree,
@@ -240,6 +241,101 @@ impl Compression {
     const ZSTD_MAX_LEVEL: i32 = 22;
 }
 
+/// Which lsm-tree-only on-disk opt-ins are active for the `ours` engine, per
+/// the Benchmark Symmetry Invariant: any feature RocksDB has no equivalent for
+/// must be OFF when we publish a head-to-head, or we either pay for protection
+/// the competitor lacks (losing a comparison we should win) or win unfairly on
+/// a benchmark where the competitor lacks a feature we enable by default.
+///
+/// Only OUR config moves across presets; RocksDB is the fixed baseline. The
+/// default is [`Preset::RocksDbParity`], so the public dashboard is honest
+/// out of the box.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Preset {
+    /// Every lsm-tree-only opt-in OFF, matching RocksDB's durability defaults.
+    /// The single source of truth for "disable features RocksDB has no
+    /// equivalent for": when a new opt-in lands it must be turned off here too.
+    RocksDbParity,
+    /// Production defaults (manifest hardening + FS-aware optimizations on):
+    /// what a real lsm-tree deployment runs.
+    LsmTreeDefault,
+    /// Every opt-in ON: the worst-case protection-overhead measurement.
+    LsmTreeParanoid,
+}
+
+impl Preset {
+    /// Selects the preset from the `LSM_BENCH_PRESET` env var
+    /// (`rocksdb-parity` | `lsm-default` | `lsm-paranoid`), defaulting to
+    /// [`Preset::RocksDbParity`] (also used for any unrecognized value).
+    fn from_env() -> Self {
+        match std::env::var("LSM_BENCH_PRESET").as_deref() {
+            Ok("lsm-default") => Self::LsmTreeDefault,
+            Ok("lsm-paranoid") => Self::LsmTreeParanoid,
+            _ => Self::RocksDbParity,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::RocksDbParity => "rocksdb-parity",
+            Self::LsmTreeDefault => "lsm-default",
+            Self::LsmTreeParanoid => "lsm-paranoid",
+        }
+    }
+}
+
+/// The preset for this whole bench process, resolved once from the environment.
+/// Cached so every engine open in the run sees the same preset (and the choice
+/// is logged exactly once, to stderr, for the dashboard provenance).
+fn active_preset() -> Preset {
+    static PRESET: std::sync::OnceLock<Preset> = std::sync::OnceLock::new();
+    *PRESET.get_or_init(|| {
+        let p = Preset::from_env();
+        eprintln!(
+            "compare-rocksdb: lsm-tree preset = {} (set LSM_BENCH_PRESET to override)",
+            p.label()
+        );
+        p
+    })
+}
+
+/// Applies the active [`Preset`]'s on-disk feature toggles to our engine config.
+/// `RocksDbParity` explicitly disables every lsm-tree-only opt-in (even those
+/// already off by default) so the preset stays correct if a default ever flips,
+/// and documents the full parity surface in one place.
+fn apply_preset(config: Config, preset: Preset) -> Config {
+    let mut rc = RuntimeConfig::default();
+    match preset {
+        Preset::RocksDbParity => {
+            // Disable every feature RocksDB has no equivalent for.
+            rc.manifest_footer_mirror = false;
+            rc.kv_checksums = KvChecksumPolicy::Off;
+            rc.seqno_in_index = false;
+            rc.page_ecc = false;
+            rc.disable_cow_on_sst_files = false;
+            rc.use_reflink_for_checkpoint = false;
+            // Keep manifest per-record checksums ON: this matches RocksDB's
+            // per-record MANIFEST CRC32 granularity (same durability profile),
+            // so it is parity, not an extra opt-in.
+            rc.manifest_kv_checksums = true;
+            // `Config::page_ecc` is the separate tree-open gate for DATA-block
+            // ECC (the runtime `page_ecc` above covers manifest blocks).
+            config.with_runtime_config(rc).page_ecc(false)
+        }
+        // Production defaults are exactly `RuntimeConfig::default()` + the
+        // `Config` defaults, so leave the config untouched.
+        Preset::LsmTreeDefault => config,
+        Preset::LsmTreeParanoid => {
+            rc.manifest_footer_mirror = true;
+            rc.manifest_kv_checksums = true;
+            rc.kv_checksums = KvChecksumPolicy::AllLevels;
+            rc.seqno_in_index = true;
+            rc.page_ecc = true;
+            config.with_runtime_config(rc).page_ecc(true)
+        }
+    }
+}
+
 /// Deterministic but pseudo-random key derivation. Each key is the
 /// big-endian encoding of `(i * GOLDEN_RATIO_64) wrapping_mul()` —
 /// avoids hot-path RNG cost inside the timing loop while still
@@ -358,6 +454,9 @@ fn open_ours(
             CompressionType::Zstd(Compression::ZSTD_MAX_LEVEL),
         )),
     };
+    // Apply the symmetry preset (RocksDbParity by default) so our opt-ins match
+    // RocksDB's feature set for the head-to-head.
+    let config = apply_preset(config, active_preset());
     Ok(config.open()?)
 }
 
@@ -1006,7 +1105,7 @@ fn run_compaction(
 
     let elapsed = match engine {
         Engine::Ours => {
-            let tree = Config::new(
+            let config = Config::new(
                 dir.path(),
                 SequenceNumberCounter::default(),
                 SequenceNumberCounter::default(),
@@ -1015,8 +1114,8 @@ fn run_compaction(
             .compaction_threads(COMPACTION_THREADS)
             // Disable range-split sub-compaction so this bench isolates parallel
             // block compression only, matching RocksDB's max_subcompactions(1).
-            .subcompaction_min_bytes(u64::MAX)
-            .open()?;
+            .subcompaction_min_bytes(u64::MAX);
+            let tree = apply_preset(config, active_preset()).open()?;
 
             let mut written = 0u64;
             for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
@@ -1208,15 +1307,15 @@ fn run_subcompaction_bench(
 
     let elapsed = match engine {
         Engine::Ours => {
-            let tree = Config::new(
+            let config = Config::new(
                 dir.path(),
                 SequenceNumberCounter::default(),
                 SequenceNumberCounter::default(),
             )
             .data_block_compression_policy(CompressionPolicy::all(CompressionType::Zstd(level)))
             .compaction_threads(SUBCOMPACTION_THREADS)
-            .subcompaction_min_bytes(0)
-            .open()?;
+            .subcompaction_min_bytes(0);
+            let tree = apply_preset(config, active_preset()).open()?;
 
             // Step 1: populate the bottom level with several tables.
             for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {


### PR DESCRIPTION
## Summary

Implements the Benchmark Symmetry Invariant (#353) end-to-end: public head-to-head benchmarks must not run our engine with on-disk opt-ins that RocksDB has no equivalent for. The `compare-rocksdb` harness previously ran `ours` with its production defaults (manifest footer mirror, FS-aware CoW/reflink) active while RocksDB had none, so the comparison silently was not apples-to-apples.

### Preset selector

A `Preset` enum, selected via the `LSM_BENCH_PRESET` env var (default `rocksdb-parity`):

| Value | Preset | Purpose |
|-------|--------|---------|
| `rocksdb-parity` (default) | `RocksDbParity` | Every lsm-tree-only opt-in OFF, matching RocksDB's durability defaults. The honest dashboard number. |
| `lsm-default` | `LsmTreeDefault` | Production defaults. |
| `lsm-paranoid` | `LsmTreeParanoid` | Every opt-in ON. Worst-case overhead. |

`apply_preset` is the single source of truth for the parity surface: `RocksDbParity` explicitly disables `manifest_footer_mirror`, `kv_checksums`, `seqno_in_index`, `page_ecc`, `disable_cow_on_sst_files`, `use_reflink_for_checkpoint` (even those already off by default), and keeps `manifest_kv_checksums` ON (parity with RocksDB's per-record MANIFEST CRC). Only our config moves across presets; RocksDB stays the fixed baseline. The active preset is logged once to stderr for dashboard provenance.

The bench crate now compiles in the `page_ecc` feature so `lsm-paranoid` can measure Page-ECC write overhead; `rocksdb-parity` keeps it off.

### Used in the default CI dashboard run

The `benchmark.yml` head-to-head step now sets `LSM_BENCH_PRESET=rocksdb-parity` explicitly, pinning the published gh-pages comparison to the parity preset rather than relying on the in-code default that a future change could silently alter.

### Docs

- `docs/BENCHMARKING.md`: the invariant, the preset matrix, how to run, and the per-PR checklist for format-changing PRs.
- `CONTRIBUTING.md`: cross-link for format-changing PRs.

## Acceptance criteria (#353)

- [x] preset selector in `compare-rocksdb`
- [x] `RocksDbParity` implemented and used in the default benchmark CI run
- [x] `docs/BENCHMARKING.md` documents the invariant + preset matrix
- [x] CONTRIBUTING cross-link for format-changing PRs
- [x] per-PR discipline documented (BENCHMARKING.md checklist)

## Testing

- `cargo bench --no-run` compiles (libclang)
- `cargo clippy --benches` clean; `cargo fmt --check` clean
- all three presets smoke-run: `rocksdb-parity` (default), `lsm-paranoid` (ECC + kv_checksums on), `lsm-default`
- no `src/` changes, so the main test suite is unaffected

Closes #353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the benchmarking guide with an on-disk format “symmetry invariant” for fair comparisons, including a preset parity approach and a run/checklist workflow.
  * Expanded contributor guidance with requirements for any on-disk format changes (including OFF-by-default and parity/opt-in constraints).

* **Benchmarks / Tooling**
  * Added a configurable benchmark preset mechanism controlled by `LSM_BENCH_PRESET` (rocksdb-parity, lsm-default, lsm-paranoid) and applied consistently across benchmark scenarios.
  * Enabled Page-ECC coverage in the benchmark tooling and pinned the workflow to `rocksdb-parity`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->