### PR TITLE
feat(bench): blob_tree (KV-separation) arm + read-gap attribution

### DIFF
--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -94,7 +94,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 // for method resolution (clippy `-D warnings` confirms it is live).
 use lsm_tree::{
     AbstractTree, CompressionType, Config, Guard, MAX_SEQNO, SequenceNumberCounter,
-    config::CompressionPolicy,
+    config::{CompressionPolicy, KvSeparationOptions},
     runtime_config::{KvChecksumPolicy, RuntimeConfig},
 };
 use surrealkv::{
@@ -196,6 +196,12 @@ enum Engine {
     /// (only None / Snappy), so it participates ONLY in the
     /// None-compression (codec-neutral) groups — see [`engines_for`].
     SurrealKv,
+    /// Our engine in its KV-separated (`blob_tree`) configuration: values at or
+    /// above [`BLOB_SEPARATION_THRESHOLD`] are stored out-of-line in blob files,
+    /// so the key-LSM the reads walk is smaller (like surrealkv's vlog). Drives
+    /// the same `AbstractTree` API as `Ours`; participates only in the
+    /// None-compression groups where surrealkv overlays (see [`engines_for`]).
+    BlobTree,
 }
 
 impl Engine {
@@ -204,9 +210,23 @@ impl Engine {
             Self::Ours => "ours",
             Self::RocksDb => "rocksdb",
             Self::SurrealKv => "surrealkv",
+            Self::BlobTree => "blob_tree",
         }
     }
+
+    /// Whether this engine opens our tree with KV-separation enabled.
+    fn kv_separated(self) -> bool {
+        matches!(self, Self::BlobTree)
+    }
 }
+
+/// KV-separation threshold for the `blob_tree` arm: values at or above this many
+/// bytes are stored out-of-line. The benchmark value is 256 bytes (see
+/// [`value_for`]), so 128 separates every value out-of-line, mirroring
+/// surrealkv's vlog and isolating the "smaller key-LSM" read effect the
+/// `blob_tree` arm exists to measure. Below the default 1 KiB threshold, which
+/// would leave the 256-byte values inlined (no separation, no measurement).
+const BLOB_SEPARATION_THRESHOLD: u32 = 128;
 
 /// Engines to overlay for a given compression variant.
 ///
@@ -217,7 +237,12 @@ impl Engine {
 /// engines run codec-neutral. The `_zstd22` groups stay ours-vs-rocksdb.
 fn engines_for(compression: Compression) -> &'static [Engine] {
     match compression {
-        Compression::None => &[Engine::Ours, Engine::RocksDb, Engine::SurrealKv],
+        Compression::None => &[
+            Engine::Ours,
+            Engine::RocksDb,
+            Engine::SurrealKv,
+            Engine::BlobTree,
+        ],
         Compression::Zstd22 => &[Engine::Ours, Engine::RocksDb],
     }
 }
@@ -437,9 +462,14 @@ fn rocksdb_options(compression: Compression) -> rocksdb::Options {
 /// "uncompressed baseline"); `Zstd22` applies level-22 zstd to every
 /// level. Keeping the `None` arm explicit holds the baseline apples-to-
 /// apples with RocksDB's `DBCompressionType::None`.
+///
+/// When `kv_separated` is set, values at or above [`BLOB_SEPARATION_THRESHOLD`]
+/// are stored out-of-line (the `blob_tree` arm); the blob files inherit the
+/// `None`-compression baseline so the separated path stays codec-neutral too.
 fn open_ours(
     dir: &std::path::Path,
     compression: Compression,
+    kv_separated: bool,
 ) -> Result<lsm_tree::AnyTree, Box<dyn std::error::Error>> {
     let config = Config::new(
         dir,
@@ -453,6 +483,18 @@ fn open_ours(
         Compression::Zstd22 => config.data_block_compression_policy(CompressionPolicy::all(
             CompressionType::Zstd(Compression::ZSTD_MAX_LEVEL),
         )),
+    };
+    let config = if kv_separated {
+        // Blobs stay `None`-compressed (the bench crate has no `lz4` feature, so
+        // `KvSeparationOptions::default().compression` is already `None`; set it
+        // explicitly so a future feature flip cannot silently compress blobs).
+        config.with_kv_separation(Some(
+            KvSeparationOptions::default()
+                .separation_threshold(BLOB_SEPARATION_THRESHOLD)
+                .compression(CompressionType::None),
+        ))
+    } else {
+        config
     };
     // Apply the symmetry preset (RocksDbParity by default) so our opt-ins match
     // RocksDB's feature set for the head-to-head.
@@ -505,8 +547,8 @@ fn run_write_throughput(
     let dir = tempfile::tempdir()?;
     let start = std::time::Instant::now();
     let elapsed = match engine {
-        Engine::Ours => {
-            let tree = open_ours(dir.path(), compression)?;
+        Engine::Ours | Engine::BlobTree => {
+            let tree = open_ours(dir.path(), compression, engine.kv_separated())?;
             // Zip the seqno counter as a native `u64` instead of
             // enumerate()+try_from(usize). lsm-tree's `insert` takes
             // SeqNo (= u64) directly; using `0u64..` avoids the
@@ -689,8 +731,9 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                 // pays for reads, never for open / write / flush.
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
-                    Engine::Ours => {
-                        let tree = open_ours(dir.path(), compression).expect("ours: open");
+                    Engine::Ours | Engine::BlobTree => {
+                        let tree = open_ours(dir.path(), compression, engine.kv_separated())
+                            .expect("ours: open");
                         for ((key, value), seqno) in
                             inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..)
                         {
@@ -810,13 +853,15 @@ fn populate_rocksdb(
 }
 
 /// Populates our engine at `dir` and flushes, returning the warm handle.
-/// Companion to [`populate_rocksdb`] for the warm read groups.
+/// Companion to [`populate_rocksdb`] for the warm read groups. `kv_separated`
+/// selects the `blob_tree` (KV-separated) configuration.
 fn populate_ours(
     dir: &std::path::Path,
     compression: Compression,
     inputs: &WorkloadInputs,
+    kv_separated: bool,
 ) -> lsm_tree::AnyTree {
-    let tree = open_ours(dir, compression).expect("ours: open");
+    let tree = open_ours(dir, compression, kv_separated).expect("ours: open");
     for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
         tree.insert(key, value, seqno);
     }
@@ -844,8 +889,9 @@ fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compress
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
-                    Engine::Ours => {
-                        let tree = populate_ours(dir.path(), compression, &inputs);
+                    Engine::Ours | Engine::BlobTree => {
+                        let tree =
+                            populate_ours(dir.path(), compression, &inputs, engine.kv_separated());
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
                             for _ in 0..iters {
@@ -917,8 +963,9 @@ fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compres
             group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
-                    Engine::Ours => {
-                        let tree = populate_ours(dir.path(), compression, &inputs);
+                    Engine::Ours | Engine::BlobTree => {
+                        let tree =
+                            populate_ours(dir.path(), compression, &inputs, engine.kv_separated());
                         b.iter_custom(|iters| {
                             let start = std::time::Instant::now();
                             for _ in 0..iters {
@@ -1008,10 +1055,15 @@ fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compressi
                     for _ in 0..iters {
                         let dir = tempfile::tempdir().expect("tempdir");
                         match engine {
-                            Engine::Ours => {
+                            Engine::Ours | Engine::BlobTree => {
                                 // First copy (untimed): populate + flush so the
                                 // timed pass overwrites existing keys.
-                                let tree = populate_ours(dir.path(), compression, &inputs);
+                                let tree = populate_ours(
+                                    dir.path(),
+                                    compression,
+                                    &inputs,
+                                    engine.kv_separated(),
+                                );
                                 let start = std::time::Instant::now();
                                 // Second seqno range so the overwrite produces a
                                 // newer version of every key.
@@ -1173,6 +1225,12 @@ fn run_compaction(
         // loop is fixed to ours+rocksdb). The arm exists only for exhaustiveness.
         Engine::SurrealKv => {
             unreachable!("surrealkv is excluded from zstd-level compaction benches")
+        }
+        // blob_tree overlays only the read/write groups (where surrealkv runs),
+        // not the zstd-level compaction benches whose loop is fixed to
+        // ours+rocksdb. The arm exists only for exhaustiveness.
+        Engine::BlobTree => {
+            unreachable!("blob_tree is excluded from the zstd-level compaction benches")
         }
     };
     drop(dir);
@@ -1395,6 +1453,12 @@ fn run_subcompaction_bench(
         // loop is fixed to ours+rocksdb). The arm exists only for exhaustiveness.
         Engine::SurrealKv => {
             unreachable!("surrealkv is excluded from zstd-level compaction benches")
+        }
+        // blob_tree overlays only the read/write groups (where surrealkv runs),
+        // not the zstd-level compaction benches whose loop is fixed to
+        // ours+rocksdb. The arm exists only for exhaustiveness.
+        Engine::BlobTree => {
+            unreachable!("blob_tree is excluded from the zstd-level compaction benches")
         }
     };
     drop(dir);


### PR DESCRIPTION
## Summary

Adds a `blob_tree` (KV-separated) engine arm to the `compare-rocksdb` harness, overlaid alongside `ours` / `rocksdb` / `surrealkv` on the None-compression read/write groups. This isolates the #426 question: is surrealkv's read advantage from **KV-separation** (it stores values out-of-line, exactly what our `blob_tree` does) or from **residual read-path overhead**?

Values at/above a documented 128-byte threshold are separated, so the 256-byte bench values all go out-of-line, mirroring surrealkv's vlog. The arm reuses the existing `AbstractTree` workload bodies and stays out of the zstd-level compaction benches (where surrealkv does not run).

## Analysis (local macOS run; indicative, canonical numbers come from the dashboard runner)

Median wall-time, None-compression:

| group | n | ours | rocksdb | surrealkv | blob_tree |
|-------|---|------|---------|-----------|-----------|
| point_read | 1k | 1.09 ms | 0.99 ms | **0.28 ms** | 1.11 ms |
| point_read | 10k | 12.4 ms | 10.6 ms | **4.0 ms** | 13.7 ms |
| range_scan | 1k | 145 µs | 195 µs | **92 µs** | 227 µs |
| range_scan | 10k | 1.45 ms | 1.90 ms | **1.06 ms** | ~2.6-3.5 ms |
| seek_random | 1k | ~1.8 ms | 1.82 ms | **1.00 ms** | 1.78 ms |
| write | 1k | **2.53 ms** | 4.16 ms | 39.7 ms | 3.42 ms |
| write | 10k | **12.8 ms** | 14.3 ms | 58.7 ms | 18.5 ms |

### How much of the surrealkv read advantage is KV-separation?

**Essentially none.** `blob_tree` (KV-separated) tracks `ours`, not surrealkv:

- **point_read:** blob_tree is within ~2-10% of `ours` (1.11 vs 1.09 ms; 13.7 vs 12.4 ms), while surrealkv is **3.1-3.9x faster** than both. Separating values out-of-line did not move the warm point-read needle at this scale.
- **range_scan:** blob_tree is **1.6-2.4x slower** than `ours` (227 µs vs 145 µs) because the blob indirection gathers each value from a separate blob file, breaking the sequential locality a scan relies on. surrealkv is faster than both.
- **write:** blob_tree costs ~1.35-1.45x more than `ours` (extra blob-file writes), as expected.

So at the 1k-10k / 256-byte working set, KV-separation does **not** close the surrealkv read gap (and hurts scans + writes). The surrealkv read advantage is **residual read-path overhead, not KV layout**.

### Recommendation

Do **not** build a new on-disk index on top of KV-separation expecting it to close the read gap: `blob_tree` already provides KV-separation and does not help. The residual ~3-4x point_read gap vs surrealkv lives in the LSM read path (block-index descent, within-block restart scan, block decode, bloom probe, cache behaviour), not in value placement.

## Remaining for #426 (needs the Linux perf runner)

The one acceptance bullet not delivered here is the **flamegraph component-bucketing** of `ours`' read path (`cargo flamegraph --bench compare -- point_read` / `range_scan`, attributing the residual to block-index search / restart scan / decompress / cache miss / filter probe). macOS `dtrace` needs elevated privileges unavailable in this environment, so the attribution should run on the self-hosted Linux bench runner (`perf`). The headline conclusion above (KV-separation does not close the gap; the gap is read-path) does not depend on it.

## Testing

- `cargo bench --no-run` compiles (libclang); `cargo clippy --benches` clean; `cargo fmt --check` clean
- all four engines smoke-run on point_read / range_scan / seek_random / write_throughput
- no `src/` changes, so the main test suite is unaffected

Part of #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for benchmarking key-value separated storage behavior
  * Introduced BlobTree engine variant to the benchmark suite for extended performance comparison across storage configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->