### PR TITLE
perf(table): cut point-read per-get overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,9 @@ libc = "0.2"
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"
+# Used by the concurrent fd-heavy stress tests to raise their own open-file
+# soft limit (setrlimit) so a low default soft limit does not surface as EMFILE.
+libc = "0.2"
 nanoid = "0.5.0"
 proptest = "1"
 rand = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"
 # Used by the concurrent fd-heavy stress tests to raise their own open-file
 # soft limit so a low default soft limit does not surface as EMFILE.
-rlimit = "0.10"
+rlimit = "0.11"
 nanoid = "0.5.0"
 proptest = "1"
 rand = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,8 +231,8 @@ byteorder = { package = "byteorder-lite", version = "0.1.0" }
 criterion = { version = "0.8.0", features = ["html_reports"] }
 fs_extra = "1.3.0"
 # Used by the concurrent fd-heavy stress tests to raise their own open-file
-# soft limit (setrlimit) so a low default soft limit does not surface as EMFILE.
-libc = "0.2"
+# soft limit so a low default soft limit does not surface as EMFILE.
+rlimit = "0.10"
 nanoid = "0.5.0"
 proptest = "1"
 rand = "0.10.1"

--- a/src/sharded_cache.rs
+++ b/src/sharded_cache.rs
@@ -88,7 +88,14 @@ struct Padded<T>(T);
 /// via lazy tombstoning — a removed key stays in its FIFO queue and is skipped
 /// (as "stale") when popped during eviction.
 struct ShardCore<K, V, S> {
-    map: hashbrown::HashMap<K, Slot<V>, S>,
+    /// Keyed by the entry's precomputed hash. The sharded wrapper already hashes
+    /// the key once (to pick the shard), so it passes that hash straight in and
+    /// the table never re-hashes on the read path. `(K, Slot)` tuples carry the
+    /// key for equality checks and rehashing during resize/eviction.
+    map: hashbrown::HashTable<(K, Slot<V>)>,
+    /// Kept so the cold paths (insert-resize, eviction lookups) can rehash a key
+    /// the wrapper did not pre-hash.
+    hasher: S,
     small: VecDeque<K>,
     main: VecDeque<K>,
     ghost: VecDeque<K>,
@@ -112,7 +119,8 @@ where
 {
     fn new(capacity: u64, ghost_capacity: usize, hasher: S) -> Self {
         Self {
-            map: hashbrown::HashMap::with_hasher(hasher.clone()),
+            map: hashbrown::HashTable::new(),
+            hasher: hasher.clone(),
             small: VecDeque::new(),
             main: VecDeque::new(),
             ghost: VecDeque::new(),
@@ -130,8 +138,8 @@ where
     /// Lock-free-path read: returns the value (cloned) and bumps the frequency
     /// counter. Runs under a shared lock — the only mutation is the atomic
     /// `freq` bump, which is safe to race (the counter is a hint).
-    fn get(&self, key: &K) -> Option<V> {
-        let slot = self.map.get(key)?;
+    fn get(&self, hash: u64, key: &K) -> Option<V> {
+        let (_, slot) = self.map.find(hash, |(k, _)| k == key)?;
         // Saturating bump. A racing pair of `get`s may drop one increment; that
         // only mildly under-counts frequency, never corrupts state.
         let f = slot.freq.load(Ordering::Relaxed);
@@ -144,8 +152,11 @@ where
     /// Read without promotion: returns the value (cloned) without touching the
     /// frequency counter. Used by the partial-decode tier, which inspects an
     /// entry without counting it as a hit.
-    fn peek(&self, key: &K) -> Option<V> {
-        self.map.get(key).map(|slot| slot.value.clone())
+    #[cfg(any(feature = "zstd", test))]
+    fn peek(&self, hash: u64, key: &K) -> Option<V> {
+        self.map
+            .find(hash, |(k, _)| k == key)
+            .map(|(_, slot)| slot.value.clone())
     }
 
     fn len(&self) -> usize {
@@ -155,8 +166,8 @@ where
     /// Inserts or replaces `key`, evicting to stay within capacity. The shard's
     /// running `small_bytes` / `main_bytes` tallies are kept current throughout
     /// (the sharded wrapper reads them under a shared lock for `weight()`).
-    fn insert(&mut self, key: K, value: V, weight: u64) {
-        if let Some(slot) = self.map.get_mut(&key) {
+    fn insert(&mut self, hash: u64, key: K, value: V, weight: u64) {
+        if let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) {
             // Replace in place: adjust the owning queue's byte tally by the
             // weight delta, keep the queue position and frequency.
             let old = slot.weight;
@@ -175,14 +186,19 @@ where
             } else {
                 Location::Small
             };
-            self.map.insert(
-                key.clone(),
-                Slot {
-                    value,
-                    weight,
-                    freq: AtomicU8::new(0),
-                    loc,
-                },
+            let hasher = &self.hasher;
+            self.map.insert_unique(
+                hash,
+                (
+                    key.clone(),
+                    Slot {
+                        value,
+                        weight,
+                        freq: AtomicU8::new(0),
+                        loc,
+                    },
+                ),
+                |(k, _)| hasher.hash_one(k),
             );
             match loc {
                 Location::Small => {
@@ -201,10 +217,11 @@ where
 
     /// Removes `key` if present (lazy tombstone — the stale queue entry is
     /// skipped on its next pop).
-    fn remove(&mut self, key: &K) {
-        let Some(slot) = self.map.remove(key) else {
+    fn remove(&mut self, hash: u64, key: &K) {
+        let Ok(entry) = self.map.find_entry(hash, |(k, _)| k == key) else {
             return;
         };
+        let (_, slot) = entry.remove().0;
         match slot.loc {
             Location::Small => self.small_bytes -= slot.weight,
             Location::Main => self.main_bytes -= slot.weight,
@@ -247,7 +264,8 @@ where
     /// no live entry.
     fn evict_from_small(&mut self) -> bool {
         while let Some(key) = self.small.pop_front() {
-            let Some(slot) = self.map.get_mut(&key) else {
+            let hash = self.hasher.hash_one(&key);
+            let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) else {
                 continue; // stale tombstone — already removed
             };
             let w = slot.weight;
@@ -260,7 +278,9 @@ where
                 self.main.push_back(key);
             } else {
                 // Cold: evict, remember the fingerprint in the ghost queue.
-                self.map.remove(&key);
+                if let Ok(entry) = self.map.find_entry(hash, |(k, _)| *k == key) {
+                    entry.remove();
+                }
                 self.small_bytes -= w;
                 self.push_ghost(key);
             }
@@ -275,7 +295,8 @@ where
     /// entry.
     fn evict_from_main(&mut self) -> bool {
         while let Some(key) = self.main.pop_front() {
-            let Some(slot) = self.map.get_mut(&key) else {
+            let hash = self.hasher.hash_one(&key);
+            let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) else {
                 continue; // stale tombstone
             };
             let f = slot.freq.load(Ordering::Relaxed);
@@ -284,7 +305,9 @@ where
                 self.main.push_back(key);
             } else {
                 let w = slot.weight;
-                self.map.remove(&key);
+                if let Ok(entry) = self.map.find_entry(hash, |(k, _)| *k == key) {
+                    entry.remove();
+                }
                 self.main_bytes -= w;
             }
             return true;
@@ -369,8 +392,11 @@ where
         }
     }
 
+    /// Hashes `key` once and resolves both the owning shard and the hash that
+    /// the shard's table reuses for its own lookup. Hashing here (instead of
+    /// once for the shard and again inside the table) is the per-access win.
     #[inline]
-    fn shard(&self, key: &K) -> &RwLock<ShardCore<K, V, S>> {
+    fn locate(&self, key: &K) -> (u64, &RwLock<ShardCore<K, V, S>>) {
         let h = self.hasher.hash_one(key);
         // High bits are the best-mixed for most hashers; fold them down to the
         // shard index. `shards.len()` is a power of two, so `& mask` is exact.
@@ -387,28 +413,33 @@ where
             clippy::indexing_slicing,
             reason = "idx = hash & (len - 1) with len a power of two, so idx < len"
         )]
-        &self.shards[idx].0
+        (h, &self.shards[idx].0)
     }
 
     /// Returns the value for `key`, counting the access as a hit (promotes).
     pub fn get(&self, key: &K) -> Option<V> {
-        self.shard(key).read().get(key)
+        let (h, shard) = self.locate(key);
+        shard.read().get(h, key)
     }
 
     /// Returns the value for `key` WITHOUT counting it as a hit (no promotion).
+    #[cfg(any(feature = "zstd", test))]
     pub fn peek(&self, key: &K) -> Option<V> {
-        self.shard(key).read().peek(key)
+        let (h, shard) = self.locate(key);
+        shard.read().peek(h, key)
     }
 
     /// Inserts or replaces `key`, evicting as needed to stay within capacity.
     pub fn insert(&self, key: K, value: V) {
         let weight = self.weighter.weight(&key, &value);
-        self.shard(&key).write().insert(key, value, weight);
+        let (h, shard) = self.locate(&key);
+        shard.write().insert(h, key, value, weight);
     }
 
     /// Removes `key` if present.
     pub fn remove(&self, key: &K) {
-        self.shard(key).write().remove(key);
+        let (h, shard) = self.locate(key);
+        shard.write().remove(h, key);
     }
 
     /// Total resident weight across all shards. Sums each shard's tally under a

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -1267,6 +1267,26 @@ mod tests {
         },
     };
 
+    #[test]
+    fn read_leb128_rejects_overlong_10th_byte() {
+        use super::read_leb128;
+        // A 10-byte varint whose final payload byte exceeds 1 encodes a value
+        // wider than u64. It must be rejected (None), not silently truncated
+        // into a Some(_), or corruption in on-disk seqnos/lengths that every
+        // slice-based parse path now decodes through read_leb128 goes
+        // undetected. Nine continuation bytes (payload 0) + a terminating 10th
+        // byte with payload 2.
+        let overlong = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        assert!(
+            read_leb128(&overlong, 0).is_none(),
+            "10-byte varint with 10th-byte payload > 1 overflows u64 and must be rejected",
+        );
+        // The boundary-valid case (10th-byte payload 1 → sets bit 63) is still
+        // accepted and round-trips to 1 << 63, so the reject is not over-broad.
+        let max_bit = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01];
+        assert_eq!(read_leb128(&max_bit, 0), Some((1u64 << 63, 10)));
+    }
+
     fn make_handles(count: usize) -> Vec<KeyedBlockHandle> {
         (0..count)
             .map(|i| {

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -2,7 +2,10 @@
 // Copyright (c) 2025-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-use super::{TRAILER_START_MARKER, binary_index::Reader as BinaryIndexReader};
+use super::{
+    TRAILER_START_MARKER, binary_index::Reader as BinaryIndexReader,
+    hash_index::Reader as HashIndexReader,
+};
 use crate::io::{LittleEndian, ReadBytesExt};
 use crate::{
     SeqNo, Slice,
@@ -13,6 +16,52 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use crate::io::Cursor;
+
+/// Decodes one LEB128 varint directly from `buf` at `pos`, returning the value
+/// and the position just past it.
+///
+/// Reads through a plain slice index instead of `std::io::Cursor::read_u8` (a
+/// `read_exact` of one byte each), which is the hottest cost on the point-read
+/// path's block-entry parse. Rejects an overlong (> 64-bit) encoding, matching
+/// `VarintReader::read_u64_varint`.
+#[inline]
+pub fn read_leb128(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
+    // Fast path: a single-byte varint (value < 128) is by far the most common
+    // on the read path (small keys, seqnos, shared/rest lengths). One
+    // bounds-checked load, a compare, and a return — no loop setup.
+    let first = *buf.get(pos)?;
+    if first < 0x80 {
+        return Some((u64::from(first), pos + 1));
+    }
+    // Multi-byte continuation: fold in the low 7 bits already read, then loop.
+    let mut result = u64::from(first & 0x7f);
+    let mut shift = 7u32;
+    let mut p = pos + 1;
+    loop {
+        let byte = *buf.get(p)?;
+        p += 1;
+        result |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Some((result, p));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+}
+
+/// Advances past one LEB128 varint in `buf` without materializing its value.
+#[inline]
+pub fn skip_leb128(buf: &[u8], mut pos: usize) -> Option<usize> {
+    loop {
+        let byte = *buf.get(pos)?;
+        pos += 1;
+        if byte & 0x80 == 0 {
+            return Some(pos);
+        }
+    }
+}
 
 /// Validates that `restart_interval` and `binary_index_step_size` read from a
 /// block trailer are within their allowed ranges.
@@ -155,7 +204,9 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
 
     /// Byte length of the entry region (offset where the trailer begins).
     /// Test-only: lets headerless-decode tests slice the exact entry region.
-    #[cfg(test)]
+    /// Only the zstd partial-decode / lazy-block tests use it, so it is gated
+    /// to that feature to stay dead-code-clean in the default test build.
+    #[cfg(all(test, feature = "zstd"))]
     #[must_use]
     pub(crate) fn entries_end_for_test(&self) -> Option<usize> {
         self.cached_entries_end
@@ -469,6 +520,28 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
             self.binary_index_offset,
             self.binary_index_len,
             self.binary_index_step_size,
+        ))
+    }
+
+    /// Binary index reader built from the trailer metadata cached at
+    /// construction, with no re-parse of the block trailer. Returns `None`
+    /// if the cached layout is inconsistent (mirrors the validation in
+    /// [`Self::get_binary_index_reader`]).
+    pub(crate) fn cached_binary_index_reader(&self) -> Option<BinaryIndexReader<'_>> {
+        self.get_binary_index_reader()
+    }
+
+    /// Hash index reader built from the trailer metadata cached at
+    /// construction, with no re-parse of the block trailer. Returns `None`
+    /// when the block carries no hash index (`hash_index_len == 0`).
+    pub(crate) fn cached_hash_index_reader(&self) -> Option<HashIndexReader<'_>> {
+        if self.hash_index_len == 0 {
+            return None;
+        }
+        Some(HashIndexReader::new(
+            &self.block.data,
+            self.hash_index_offset,
+            self.hash_index_len,
         ))
     }
 

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -40,6 +40,13 @@ pub fn read_leb128(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
     loop {
         let byte = *buf.get(p)?;
         p += 1;
+        // The 10th byte (shift == 63) can only carry bit 63; any higher payload
+        // bit (mask 0x7e) would overflow u64. Reject before folding it in so a
+        // corrupt overlong encoding fails the decode instead of silently
+        // truncating to a wrapped value.
+        if shift == 63 && (byte & 0x7e) != 0 {
+            return None;
+        }
         result |= u64::from(byte & 0x7f) << shift;
         if byte & 0x80 == 0 {
             return Some((result, p));
@@ -47,18 +54,6 @@ pub fn read_leb128(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
         shift += 7;
         if shift >= 64 {
             return None;
-        }
-    }
-}
-
-/// Advances past one LEB128 varint in `buf` without materializing its value.
-#[inline]
-pub fn skip_leb128(buf: &[u8], mut pos: usize) -> Option<usize> {
-    loop {
-        let byte = *buf.get(pos)?;
-        pos += 1;
-        if byte & 0x80 == 0 {
-            return Some(pos);
         }
     }
 }

--- a/src/table/block_index/full.rs
+++ b/src/table/block_index/full.rs
@@ -5,9 +5,60 @@
 use crate::comparator::SharedComparator;
 use crate::table::block::{BlockType, Decoder, DecoderMeta, ParsedItem};
 use crate::table::block_index::{BlockIndexIter, iter::OwnedIndexBlockIter};
-use crate::table::index_block::{IndexBlockParsedItem, Iter as BorrowedIndexIter};
+use crate::table::index_block::IndexBlockParsedItem;
 use crate::table::{IndexBlock, KeyedBlockHandle};
 use crate::{SeqNo, Slice};
+
+/// Seqno-aware binary search positioning a freshly-built index decoder at the
+/// first block handle whose `end_key >= needle` (or equal with a head seqno at
+/// least the snapshot boundary). Borrows the comparator (lex fast path is
+/// statically dispatched). Mirrors `index_block::Iter::seek_with_cache_resets`
+/// but drives the decoder directly: a fresh decoder has no peek/back-cursor
+/// state to reset, so those resets (and the double-ended peeking wrapper) are
+/// pure overhead on the point-read path.
+fn seek_index_block(
+    decoder: &mut Decoder<'_, KeyedBlockHandle, IndexBlockParsedItem>,
+    needle: &[u8],
+    seqno: SeqNo,
+    comparator: &SharedComparator,
+) -> bool {
+    let landed = if comparator.is_lexicographic() {
+        decoder.seek(
+            |end_key, s| match end_key.cmp(needle) {
+                core::cmp::Ordering::Greater => false,
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => s >= seqno,
+            },
+            true,
+        )
+    } else {
+        decoder.seek(
+            |end_key, s| match comparator.compare(end_key, needle) {
+                core::cmp::Ordering::Greater => false,
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => s >= seqno,
+            },
+            true,
+        )
+    };
+    if !landed {
+        return false;
+    }
+
+    // Restart heads only carry every Nth handle's key; scan within the landed
+    // interval to the first handle that actually covers the needle.
+    if decoder.restart_interval() > 1 {
+        decoder.advance_while(|item, bytes| {
+            match item.compare_key(needle, bytes, comparator.as_ref()) {
+                core::cmp::Ordering::Greater => false,
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => item.seqno() >= seqno,
+            }
+        });
+    }
+
+    true
+}
 
 /// Index that translates item keys to data block handles
 ///
@@ -62,12 +113,16 @@ impl FullBlockIndex {
     /// refcount bump nor a trailer re-parse. Used by the table point-read
     /// path; range scans keep the owned [`Self::forward_reader`].
     pub fn point_read_reader(&self, needle: &[u8], seqno: SeqNo) -> Option<PointReadIter<'_>> {
-        let mut it = self
-            .block
-            .iter_with_meta(self.comparator.clone(), self.meta);
-        if it.seek(needle, seqno) {
+        // from_meta reuses the trailer parsed at construction; the seek closure
+        // borrows the comparator (no Arc bump). Driving the decoder directly
+        // skips the double-ended peeking wrapper and its no-op cache resets.
+        let mut decoder = Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::from_meta(
+            &self.block.inner,
+            self.meta,
+        );
+        if seek_index_block(&mut decoder, needle, seqno, &self.comparator) {
             Some(PointReadIter {
-                iter: it,
+                decoder,
                 data: &self.block.inner.data,
             })
         } else {
@@ -95,12 +150,12 @@ impl FullBlockIndex {
 /// Borrowing point-read iterator returned by
 /// [`FullBlockIndex::point_read_reader`].
 ///
-/// Wraps the borrowing index-block [`BorrowedIndexIter`] (which yields raw
-/// parsed items) and materializes each into a [`KeyedBlockHandle`] against
-/// the borrowed block data. Both fields share an immutable borrow of the
-/// index block, so no `Arc`/`Bytes` clone happens per lookup.
+/// Drives the index-block [`Decoder`] directly (forward-only) and materializes
+/// each parsed item into a [`KeyedBlockHandle`] against the borrowed block
+/// data. Both fields share an immutable borrow of the index block, so no
+/// `Arc`/`Bytes` clone happens per lookup.
 pub struct PointReadIter<'a> {
-    iter: BorrowedIndexIter<'a>,
+    decoder: Decoder<'a, KeyedBlockHandle, IndexBlockParsedItem>,
     data: &'a Slice,
 }
 
@@ -110,7 +165,9 @@ impl Iterator for PointReadIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         // materialize is infallible; wrap in Ok to match the owned
         // `forward_reader` iterator's item type so the caller's `?` works.
-        self.iter.next().map(|item| Ok(item.materialize(self.data)))
+        self.decoder
+            .next()
+            .map(|item| Ok(item.materialize(self.data)))
     }
 }
 

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -141,7 +141,9 @@ impl BlockLayoutMap {
     }
 
     /// Recorded block offsets, ascending. Test-only enumeration helper.
-    #[cfg(test)]
+    /// Its sole caller is the zstd large-block roundtrip test, so it is gated
+    /// to that feature to stay dead-code-clean in every other test build.
+    #[cfg(all(test, feature = "zstd"))]
     pub(crate) fn offsets(&self) -> Vec<u64> {
         self.entries.iter().map(|(o, _)| *o).collect()
     }

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -11,9 +11,11 @@ pub use iter::Iter;
 
 use super::block::{
     Block, Decodable, Decoder, Encodable, Encoder, ParsedItem, TRAILER_START_MARKER, Trailer,
-    binary_index::Reader as BinaryIndexReader, hash_index::Reader as HashIndexReader,
+    decoder::read_leb128, hash_index::Reader as HashIndexReader,
 };
 use crate::io::Cursor;
+#[cfg(not(feature = "std"))]
+use crate::io::VarintWriter;
 use crate::io::WriteBytesExt;
 use crate::io::{LittleEndian, ReadBytesExt};
 use crate::key::InternalKey;
@@ -22,17 +24,8 @@ use crate::table::util::{SliceIndexes, compare_prefixed_slice};
 use crate::{InternalValue, SeqNo, Slice, ValueType};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-// `Seek` resolves to std under `std` (so `seek_relative` on `Cursor` comes
-// from `std::io::Seek`) and to the native trait under `no_std`; written bare
-// so the `seek_relative` calls below track whichever is imported.
-#[cfg(not(feature = "std"))]
-use crate::io::Seek;
-#[cfg(not(feature = "std"))]
-use crate::io::{VarintReader, VarintWriter};
 #[cfg(feature = "std")]
-use std::io::Seek;
-#[cfg(feature = "std")]
-use varint_rs::{VarintReader, VarintWriter};
+use varint_rs::VarintWriter;
 
 impl Decodable<DataBlockParsedItem> for InternalValue {
     fn parse_restart_key<'a>(
@@ -41,35 +34,34 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         data: &'a [u8],
         entries_end: usize,
     ) -> Option<(&'a [u8], SeqNo)> {
-        let value_type = reader.read_u8().ok()?;
+        // Slice-based decode (see `parse_full` / `read_leb128`).
+        let buf: &[u8] = reader.get_ref();
+        let mut pos = usize::try_from(reader.position()).ok()?;
 
+        let value_type = *buf.get(pos)?;
+        pos += 1;
         if value_type == TRAILER_START_MARKER {
             return None;
         }
 
-        let seqno = reader.read_u64_varint().ok()?;
+        let (seqno, np) = read_leb128(buf, pos)?;
+        pos = np;
 
-        let key_len: usize = reader.read_u16_varint().ok()?.into();
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "blocks tend to be some megabytes in size at most, so position should fit into usize"
-        )]
-        let key_start = offset.checked_add(reader.position() as usize)?;
+        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        pos = np;
+        let key_len = usize::try_from(key_len_raw)
+            .ok()
+            .filter(|&k| u16::try_from(k).is_ok())?;
+        let key_start = offset.checked_add(pos)?;
         let key_end = key_start.checked_add(key_len)?;
         if key_end > entries_end {
             return None;
         }
+        pos = pos.checked_add(key_len)?;
 
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "key_len is bounded by u16::MAX, no wrap expected"
-        )]
-        let key_len_i64 = key_len as i64;
-        reader.seek_relative(key_len_i64).ok()?;
-
-        let key = data.get(key_start..key_end);
-
-        key.map(|k| (k, seqno))
+        let key = data.get(key_start..key_end)?;
+        reader.set_position(pos as u64);
+        Some((key, seqno))
     }
 
     fn parse_full(
@@ -77,26 +69,30 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         offset: usize,
         entries_end: usize,
     ) -> Option<DataBlockParsedItem> {
-        let value_type = reader.read_u8().ok()?;
+        // Slice-based decode: read from the cursor's buffer through a local
+        // index instead of `Cursor::read_u8` per byte; advance the cursor once
+        // at the end. See `read_leb128`.
+        let buf: &[u8] = reader.get_ref();
+        let mut pos = usize::try_from(reader.position()).ok()?;
+
+        let value_type = *buf.get(pos)?;
+        pos += 1;
         if value_type == TRAILER_START_MARKER {
             return None;
         }
 
         let value_type = ValueType::try_from(value_type).ok()?;
 
-        let seqno = reader.read_u64_varint().ok()?;
+        let (seqno, np) = read_leb128(buf, pos)?;
+        pos = np;
 
-        let key_len: usize = reader.read_u16_varint().ok()?.into();
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "blocks tend to be some megabytes in size at most, so position should fit into usize"
-        )]
-        let key_start = offset.checked_add(reader.position() as usize)?;
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "key_len is bounded by u16::MAX, no wrap expected"
-        )]
-        let key_len_i64 = key_len as i64;
+        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        pos = np;
+        // key_len is encoded as a u16 varint on the wire.
+        let key_len = usize::try_from(key_len_raw)
+            .ok()
+            .filter(|&k| u16::try_from(k).is_ok())?;
+        let key_start = offset.checked_add(pos)?;
         if key_start > entries_end {
             return None;
         }
@@ -104,25 +100,21 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         if key_end > entries_end {
             return None;
         }
-        reader.seek_relative(key_len_i64).ok()?;
+        pos = pos.checked_add(key_len)?;
 
         let is_value = !value_type.is_tombstone();
 
         let val_len: usize = if is_value {
-            reader.read_u32_varint().ok()? as usize
+            let (val_len_raw, np) = read_leb128(buf, pos)?;
+            pos = np;
+            // val_len is encoded as a u32 varint on the wire.
+            usize::try_from(val_len_raw)
+                .ok()
+                .filter(|&v| u32::try_from(v).is_ok())?
         } else {
             0
         };
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "blocks tend to be some megabytes in size at most, so position should fit into usize"
-        )]
-        let val_offset = offset.checked_add(reader.position() as usize)?;
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "val_len is bounded by u32::MAX, no wrap expected"
-        )]
-        let val_len_i64 = val_len as i64;
+        let val_offset = offset.checked_add(pos)?;
         if val_offset > entries_end {
             return None;
         }
@@ -130,7 +122,8 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         if val_end > entries_end {
             return None;
         }
-        reader.seek_relative(val_len_i64).ok()?;
+        pos = pos.checked_add(val_len)?;
+        reader.set_position(pos as u64);
 
         Some(if is_value {
             DataBlockParsedItem {
@@ -158,16 +151,31 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         base_key_end: usize,
         entries_end: usize,
     ) -> Option<DataBlockParsedItem> {
-        let value_type = reader.read_u8().ok()?;
+        // Slice-based decode (see `parse_full` / `read_leb128`).
+        let buf: &[u8] = reader.get_ref();
+        let mut pos = usize::try_from(reader.position()).ok()?;
+
+        let value_type = *buf.get(pos)?;
+        pos += 1;
         if value_type == TRAILER_START_MARKER {
             return None;
         }
         let value_type = ValueType::try_from(value_type).ok()?;
 
-        let seqno = reader.read_u64_varint().ok()?;
+        let (seqno, np) = read_leb128(buf, pos)?;
+        pos = np;
 
-        let shared_prefix_len: usize = reader.read_u16_varint().ok()?.into();
-        let rest_key_len: usize = reader.read_u16_varint().ok()?.into();
+        let (shared_raw, np) = read_leb128(buf, pos)?;
+        pos = np;
+        let shared_prefix_len = usize::try_from(shared_raw)
+            .ok()
+            .filter(|&k| u16::try_from(k).is_ok())?;
+        let (rest_raw, np) = read_leb128(buf, pos)?;
+        pos = np;
+        let rest_key_len = usize::try_from(rest_raw)
+            .ok()
+            .filter(|&k| u16::try_from(k).is_ok())?;
+
         if base_key_end < base_key_offset || base_key_end > offset {
             return None;
         }
@@ -179,11 +187,7 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
             return None;
         }
 
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "truncation is not expected to happen"
-        )]
-        let key_offset = offset.checked_add(reader.position() as usize)?;
+        let key_offset = offset.checked_add(pos)?;
         if key_offset > entries_end {
             return None;
         }
@@ -191,26 +195,20 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         if key_end > entries_end {
             return None;
         }
-
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "rest_key_len is bounded by u16::MAX, no wrap expected"
-        )]
-        let rest_key_len_i64 = rest_key_len as i64;
-        reader.seek_relative(rest_key_len_i64).ok()?;
+        pos = pos.checked_add(rest_key_len)?;
 
         let is_value = !value_type.is_tombstone();
 
         let val_len: usize = if is_value {
-            reader.read_u32_varint().ok()? as usize
+            let (val_len_raw, np) = read_leb128(buf, pos)?;
+            pos = np;
+            usize::try_from(val_len_raw)
+                .ok()
+                .filter(|&v| u32::try_from(v).is_ok())?
         } else {
             0
         };
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "truncation is not expected to happen"
-        )]
-        let val_offset = offset.checked_add(reader.position() as usize)?;
+        let val_offset = offset.checked_add(pos)?;
         if val_offset > entries_end {
             return None;
         }
@@ -218,12 +216,8 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         if val_end > entries_end {
             return None;
         }
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "val_len is bounded by u32::MAX, fits in i64 without wrap"
-        )]
-        let val_len_i64 = val_len as i64;
-        reader.seek_relative(val_len_i64).ok()?;
+        pos = pos.checked_add(val_len)?;
+        reader.set_position(pos as u64);
 
         Some(if is_value {
             DataBlockParsedItem {
@@ -407,6 +401,39 @@ pub struct DataBlock {
     pub inner: Block,
 }
 
+/// Seqno-aware binary search positioning the decoder's forward cursor at the
+/// last restart interval whose head key is below `needle` (or equal with a
+/// seqno at least the snapshot boundary). Borrows the comparator: the lex fast
+/// path is statically dispatched and inlinable, the custom-comparator branch
+/// keeps the `dyn UserComparator::compare` call. Mirrors
+/// [`Iter::seek_to_key_seqno`] but drives the decoder directly.
+fn seek_data_block(
+    decoder: &mut Decoder<'_, InternalValue, DataBlockParsedItem>,
+    needle: &[u8],
+    seqno: SeqNo,
+    comparator: &crate::comparator::SharedComparator,
+) -> bool {
+    if comparator.is_lexicographic() {
+        decoder.seek(
+            |head_key, head_seqno| match head_key.cmp(needle) {
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => head_seqno >= seqno,
+                core::cmp::Ordering::Greater => false,
+            },
+            false,
+        )
+    } else {
+        decoder.seek(
+            |head_key, head_seqno| match comparator.compare(head_key, needle) {
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => head_seqno >= seqno,
+                core::cmp::Ordering::Greater => false,
+            },
+            false,
+        )
+    }
+}
+
 impl DataBlock {
     /// Interprets a block as a data block.
     ///
@@ -476,34 +503,6 @@ impl DataBlock {
         &self.inner.data
     }
 
-    pub(crate) fn get_binary_index_reader(&self) -> BinaryIndexReader<'_> {
-        use core::mem::size_of;
-
-        let trailer = Trailer::new(&self.inner);
-
-        // NOTE: Skip restart interval (u8)
-        let offset = size_of::<u8>();
-
-        let mut reader = unwrap!(trailer.as_slice().get(offset..));
-
-        let binary_index_step_size = unwrap!(reader.read_u8());
-
-        debug_assert!(
-            binary_index_step_size == 2 || binary_index_step_size == 4,
-            "invalid binary index step size",
-        );
-
-        let binary_index_len = unwrap!(reader.read_u32::<LittleEndian>());
-        let binary_index_offset = unwrap!(reader.read_u32::<LittleEndian>());
-
-        BinaryIndexReader::new(
-            &self.inner.data,
-            binary_index_offset,
-            binary_index_len,
-            binary_index_step_size,
-        )
-    }
-
     #[must_use]
     pub fn get_hash_index_reader(&self) -> Option<HashIndexReader<'_>> {
         use core::mem::size_of;
@@ -560,44 +559,94 @@ impl DataBlock {
         seqno: SeqNo,
         comparator: &crate::comparator::SharedComparator,
     ) -> crate::Result<Option<InternalValue>> {
-        // Validate trailer once via try_iter (which calls Decoder::try_new
-        // internally). This must happen before get_hash_index_reader /
-        // get_binary_index_reader which read trailer fields without their own
-        // validation.
-        let mut iter = self.try_iter(comparator.clone())?;
+        self.point_read_with(needle, seqno, comparator, |item, bytes| {
+            item.materialize(bytes)
+        })
+    }
 
-        let iter = if let Some(hash_index_reader) = self.get_hash_index_reader() {
+    /// Value-only point read: returns `(value_type, seqno, value)` without
+    /// reconstructing the entry key.
+    ///
+    /// On the value-returning `get` path the caller has the needle and never
+    /// reads the matched entry's key bytes, so fusing the delta-encoded key (an
+    /// allocation + copy per hit) is pure waste. The value is a zero-copy
+    /// sub-slice of the cached block, mirroring the `RocksDB` `PinnableSlice`.
+    pub fn point_read_value(
+        &self,
+        needle: &[u8],
+        seqno: SeqNo,
+        comparator: &crate::comparator::SharedComparator,
+    ) -> crate::Result<Option<(ValueType, SeqNo, Slice)>> {
+        self.point_read_with(needle, seqno, comparator, |item, bytes| {
+            let value = item
+                .value
+                .as_ref()
+                .map_or_else(Slice::empty, |v| bytes.slice(v.0..v.1));
+            (item.value_type, item.seqno, value)
+        })
+    }
+
+    /// Shared point-read seek + scan, parameterized over how the matched entry
+    /// is turned into a result. `point_read` materializes a full
+    /// [`InternalValue`]; `point_read_value` extracts only the value.
+    ///
+    /// Drives the [`Decoder`] directly rather than through [`Iter`]: point reads
+    /// are forward-only seek + scan, so the double-ended peeking wrapper is pure
+    /// overhead here. The hash / binary index readers are built from the
+    /// decoder's trailer metadata (parsed once in `try_new`), avoiding the
+    /// per-lookup trailer re-parse a fresh reader off the block would incur.
+    /// The seqno-aware seek closure borrows the comparator, so no `Arc`
+    /// refcount bump happens per lookup.
+    #[inline]
+    fn point_read_with<R>(
+        &self,
+        needle: &[u8],
+        seqno: SeqNo,
+        comparator: &crate::comparator::SharedComparator,
+        extract: impl FnOnce(&DataBlockParsedItem, &Slice) -> R,
+    ) -> crate::Result<Option<R>> {
+        use crate::table::block::BlockType;
+
+        // DataBlock is used for both Data and Meta blocks (same encoding).
+        if !matches!(
+            self.inner.header.block_type,
+            BlockType::Data | BlockType::Meta
+        ) {
+            return Err(crate::Error::InvalidTag((
+                "BlockType",
+                self.inner.header.block_type.into(),
+            )));
+        }
+
+        // try_new validates + caches all trailer fields once.
+        let mut decoder = Decoder::<InternalValue, DataBlockParsedItem>::try_new(&self.inner)?;
+
+        let positioned = if let Some(hash_index_reader) = decoder.cached_hash_index_reader() {
             match hash_index_reader.get(needle) {
-                MARKER_FREE => {
-                    return Ok(None);
-                }
-                MARKER_CONFLICT => {
-                    // NOTE: Fallback to seqno-aware binary search
-                    if !iter.seek_to_key_seqno(needle, seqno) {
-                        return Ok(None);
+                MARKER_FREE => return Ok(None),
+                // NOTE: Fallback to seqno-aware binary search on a hash conflict.
+                MARKER_CONFLICT => seek_data_block(&mut decoder, needle, seqno, comparator),
+                idx => match decoder.cached_binary_index_reader() {
+                    Some(binary_index_reader) => {
+                        let offset: usize = binary_index_reader.get(usize::from(idx));
+                        decoder.set_lo_offset(offset);
+                        true
                     }
-
-                    iter
-                }
-                idx => {
-                    let offset: usize = self.get_binary_index_reader().get(usize::from(idx));
-                    iter.seek_to_offset(offset);
-
-                    iter
-                }
+                    None => seek_data_block(&mut decoder, needle, seqno, comparator),
+                },
             }
         } else {
             // NOTE: Seqno-aware binary search reduces linear scanning by skipping most
             // restart intervals that contain only versions newer than the target seqno
-            if !iter.seek_to_key_seqno(needle, seqno) {
-                return Ok(None);
-            }
-
-            iter
+            seek_data_block(&mut decoder, needle, seqno, comparator)
         };
 
-        // Linear scan
-        for item in iter {
+        if !positioned {
+            return Ok(None);
+        }
+
+        // Linear scan (forward-only; the decoder is its own Iterator).
+        for item in decoder.by_ref() {
             match item.compare_key(needle, &self.inner.data, comparator.as_ref()) {
                 core::cmp::Ordering::Greater => {
                     // We are past our searched key
@@ -616,7 +665,7 @@ impl DataBlock {
                 continue;
             }
 
-            return Ok(Some(item.materialize(&self.inner.data)));
+            return Ok(Some(extract(&item, &self.inner.data)));
         }
 
         Ok(None)

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -8,10 +8,7 @@ use crate::{SeqNo, UserKey};
 use crate::{
     coding::{Decode, Encode},
     table::{
-        block::{
-            BlockOffset, Decodable, Encodable, TRAILER_START_MARKER,
-            decoder::{read_leb128, skip_leb128},
-        },
+        block::{BlockOffset, Decodable, Encodable, TRAILER_START_MARKER, decoder::read_leb128},
         index_block::IndexBlockParsedItem,
         util::SliceIndexes,
     },
@@ -361,11 +358,17 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             _ => return None,
         };
 
-        // The binary-search probe only needs `(key, seqno)`: the block handle
-        // (file offset + size) is never read on a probe, so skip both varints
-        // without materializing their values.
-        pos = skip_leb128(buf, pos)?; // file offset
-        pos = skip_leb128(buf, pos)?; // size
+        // The binary-search probe only needs `(key, seqno)`, but the block
+        // handle (file offset + size) is still decoded so a corrupt restart
+        // head fails the probe instead of feeding forged metadata into
+        // restart-table navigation: read_leb128 rejects an overlong offset,
+        // and the size must fit u32 exactly as `parse_full` / `parse_truncated`
+        // require.
+        let (_file_offset, np) = read_leb128(buf, pos)?;
+        pos = np;
+        let (size, np) = read_leb128(buf, pos)?;
+        u32::try_from(size).ok()?;
+        pos = np;
         let (seqno, np) = read_leb128(buf, pos)?;
         pos = np;
 

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -905,4 +905,34 @@ mod tests {
             "inverted seqno bounds must be rejected by parse_restart_key",
         );
     }
+
+    #[test]
+    fn parse_restart_key_rejects_oversized_block_handle_size() {
+        // A restart head whose block-handle size varint encodes a value beyond
+        // u32::MAX is corrupt: BlockHandle::size is u32. parse_restart_key must
+        // reject it (like parse_full / parse_truncated validate their handle
+        // fields) instead of skipping the field and feeding a forged entry into
+        // restart-table navigation. Built by hand because the encoder cannot
+        // emit an out-of-range size.
+        let mut bytes = Vec::new();
+        bytes.push(0u8); // marker 0 (legacy full restart head)
+        bytes.push(0u8); // file offset varint = 0
+        // size varint = u32::MAX + 1 = 4_294_967_296 (5-byte LEB128).
+        bytes.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x10]);
+        bytes.push(7u8); // seqno varint = 7
+        bytes.push(6u8); // key_len u16 varint = 6
+        bytes.extend_from_slice(b"abcdef"); // key
+
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
+            &mut cursor,
+            0,
+            bytes.as_slice(),
+            bytes.len(),
+        );
+        assert!(
+            parsed.is_none(),
+            "block-handle size beyond u32::MAX must be rejected by parse_restart_key",
+        );
+    }
 }

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -8,7 +8,10 @@ use crate::{SeqNo, UserKey};
 use crate::{
     coding::{Decode, Encode},
     table::{
-        block::{BlockOffset, Decodable, Encodable, TRAILER_START_MARKER},
+        block::{
+            BlockOffset, Decodable, Encodable, TRAILER_START_MARKER,
+            decoder::{read_leb128, skip_leb128},
+        },
         index_block::IndexBlockParsedItem,
         util::SliceIndexes,
     },
@@ -339,8 +342,15 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         data: &'a [u8],
         entries_end: usize,
     ) -> Option<(&'a [u8], SeqNo)> {
-        let marker = reader.read_u8().ok()?;
+        // Slice-based decode: read directly from the cursor's buffer through a
+        // local index instead of `Cursor::read_u8` (a `read_exact` of one byte
+        // each), then advance the cursor once at the end. This is the hottest
+        // function on the point-read path (index restart-key probe).
+        let buf: &[u8] = reader.get_ref();
+        let mut pos = usize::try_from(reader.position()).ok()?;
 
+        let marker = *buf.get(pos)?;
+        pos += 1;
         if marker == TRAILER_START_MARKER {
             return None;
         }
@@ -351,43 +361,45 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             _ => return None,
         };
 
-        let _file_offset = reader.read_u64_varint().ok()?;
-        let _size = reader.read_u32_varint().ok()?;
-        let seqno = reader.read_u64_varint().ok()?;
+        // The binary-search probe only needs `(key, seqno)`: the block handle
+        // (file offset + size) is never read on a probe, so skip both varints
+        // without materializing their values.
+        pos = skip_leb128(buf, pos)?; // file offset
+        pos = skip_leb128(buf, pos)?; // size
+        let (seqno, np) = read_leb128(buf, pos)?;
+        pos = np;
 
         if has_bounds {
             // The restart key only needs the key, but still reject inverted
             // bounds (seqno_min > seqno_max) here as `parse_full` /
             // `parse_truncated` do — a malformed marker-2 head must not feed a
             // forged entry into restart-table navigation.
-            let seqno_min = reader.read_u64_varint().ok()?;
-            let seqno_max = reader.read_u64_varint().ok()?;
+            let (seqno_min, np) = read_leb128(buf, pos)?;
+            let (seqno_max, np2) = read_leb128(buf, np)?;
+            pos = np2;
             if seqno_min > seqno_max {
                 return None;
             }
         }
 
-        let key_len: usize = reader.read_u16_varint().ok()?.into();
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "blocks tend to be some megabytes in size at most, so position should fit into usize"
-        )]
-        let key_start = offset.checked_add(reader.position() as usize)?;
+        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        pos = np;
+        // key_len is encoded as a u16 varint on the wire; reject an overlong
+        // value exactly as `read_u16_varint` did.
+        let key_len = usize::try_from(key_len_raw)
+            .ok()
+            .filter(|&k| u16::try_from(k).is_ok())?;
+
+        let key_start = offset.checked_add(pos)?;
         let key_end = key_start.checked_add(key_len)?;
         if key_end > entries_end {
             return None;
         }
+        pos = pos.checked_add(key_len)?;
 
-        #[expect(
-            clippy::cast_possible_wrap,
-            reason = "key_len is bounded by u16::MAX, no wrap expected"
-        )]
-        let key_len_i64 = key_len as i64;
-        reader.seek_relative(key_len_i64).ok()?;
-
-        let key = data.get(key_start..key_end);
-
-        key.map(|k| (k, seqno))
+        let key = data.get(key_start..key_end)?;
+        reader.set_position(pos as u64);
+        Some((key, seqno))
     }
 
     fn parse_truncated(

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -538,6 +538,76 @@ impl Table {
         Ok(item)
     }
 
+    /// Value-only point read: `(value_type, seqno, value)` without
+    /// reconstructing the entry key. Used by the value-returning `get` path,
+    /// which never reads the matched key (the caller has the needle), so the
+    /// delta-key fusion in [`DataBlock::point_read`] is skipped. The value is a
+    /// zero-copy slice of the cached block.
+    pub(crate) fn get_value(
+        &self,
+        key: &[u8],
+        seqno: SeqNo,
+        key_hash: u64,
+    ) -> crate::Result<Option<(crate::ValueType, SeqNo, crate::Slice)>> {
+        let global_seqno = self.global_seqno();
+        let seqno = seqno.saturating_sub(global_seqno);
+
+        if self.metadata.seqnos.0 >= seqno {
+            return Ok(None);
+        }
+
+        let bloom = self.check_bloom(key, key_hash)?;
+        if bloom.should_skip() {
+            return Ok(None);
+        }
+
+        let item = self.point_read_value(key, seqno)?;
+
+        // Translate table-local seqno back to the global coordinate, mirroring
+        // `Table::get`.
+        let item = item.map(|(vt, s, v)| (vt, s.saturating_add(global_seqno), v));
+
+        #[cfg(feature = "metrics")]
+        {
+            use core::sync::atomic::Ordering::Relaxed;
+            if item.is_none() && bloom.has_filter() {
+                self.metrics.filter_queries.fetch_add(1, Relaxed);
+            }
+        }
+
+        Ok(item)
+    }
+
+    /// Value-only block-index walk: companion to [`Table::point_read_inner`]
+    /// that reads each candidate data block with
+    /// [`DataBlock::point_read_value`] (no key fusion, no retained block).
+    fn point_read_value(
+        &self,
+        key: &[u8],
+        seqno: SeqNo,
+    ) -> crate::Result<Option<(crate::ValueType, SeqNo, crate::Slice)>> {
+        let Some(iter) = self.block_index.point_read_reader(key, seqno) else {
+            return Ok(None);
+        };
+
+        for block_handle in iter {
+            let block_handle = block_handle?;
+
+            let data_block = self.load_data_block(block_handle.as_ref())?;
+
+            if let Some(found) = data_block.point_read_value(key, seqno, &self.comparator)? {
+                return Ok(Some(found));
+            }
+
+            if self.comparator.compare(block_handle.end_key(), key) == core::cmp::Ordering::Greater
+            {
+                return Ok(None);
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Like [`Table::get`], but also returns the [`Block`] containing the value.
     ///
     /// Used by `get_pinned()` to construct `PinnableSlice::Pinned`.

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -132,6 +132,33 @@ impl TablePointLookup for TableEntryWithBlock {
     }
 }
 
+/// Lookup result for the value-returning `get()` path: `(value_type, seqno,
+/// value)`, no key reconstruction (the caller has the needle).
+type TableValue = (ValueType, SeqNo, crate::Slice);
+
+impl TablePointLookup for TableValue {
+    fn lookup(
+        table: &Table,
+        key: &[u8],
+        seqno: SeqNo,
+        key_hash: u64,
+    ) -> crate::Result<Option<Self>> {
+        table.get_value(key, seqno, key_hash)
+    }
+
+    fn entry_seqno(&self) -> SeqNo {
+        self.1
+    }
+
+    fn filter_tombstone(self) -> Option<Self> {
+        if self.0.is_tombstone() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
+
 fn ignore_tombstone_value(item: InternalValue) -> Option<InternalValue> {
     if item.is_tombstone() {
         None
@@ -1315,10 +1342,10 @@ impl Tree {
         merge_operator: Option<&Arc<dyn crate::merge_operator::MergeOperator>>,
         comparator: &dyn crate::comparator::UserComparator,
     ) -> crate::Result<Option<UserValue>> {
-        let entry = Self::get_internal_entry_from_version(super_version, key, seqno, comparator)?;
+        let entry = Self::get_value(super_version, key, seqno, comparator)?;
 
         match entry {
-            Some(entry) if entry.key.value_type == ValueType::MergeOperand => {
+            Some((ValueType::MergeOperand, entry_seqno, value)) => {
                 if let Some(merge_op) = merge_operator {
                     // Build a bloom-filtered single-key iterator pipeline that
                     // reuses MvccStream for merge/RT/Indirection resolution,
@@ -1332,16 +1359,16 @@ impl Tree {
                 } else if Self::is_suppressed_by_range_tombstones(
                     super_version,
                     key,
-                    entry.key.seqno,
+                    entry_seqno,
                     seqno,
                     comparator,
                 ) {
                     Ok(None)
                 } else {
-                    Ok(Some(entry.value))
+                    Ok(Some(value))
                 }
             }
-            Some(entry) => Ok(Some(entry.value)),
+            Some((_, _, value)) => Ok(Some(value)),
             None => Ok(None),
         }
     }
@@ -1640,6 +1667,78 @@ impl Tree {
                 return Ok(None);
             }
             return Ok(Some(entry));
+        }
+
+        Ok(None)
+    }
+
+    /// Value-only mirror of [`Self::get_internal_entry_from_version`].
+    ///
+    /// Returns `(value_type, seqno, value)` for the newest visible entry without
+    /// reconstructing the entry key. Same search order (active -> sealed -> SST,
+    /// newest first), tombstone filtering, and range-tombstone suppression; only
+    /// the SST path differs, using the value-only [`TableValue`] lookup that
+    /// skips the delta-key fusion of the full `InternalValue` path. Used by the
+    /// value-returning `get` path, which never reads the matched key.
+    pub(crate) fn get_value(
+        super_version: &SuperVersion,
+        key: &[u8],
+        seqno: SeqNo,
+        comparator: &dyn crate::comparator::UserComparator,
+    ) -> crate::Result<Option<(ValueType, SeqNo, crate::Slice)>> {
+        if let Some(entry) = super_version.active_memtable.get(key, seqno) {
+            let Some(entry) = ignore_tombstone_value(entry) else {
+                return Ok(None);
+            };
+            if Self::is_suppressed_by_range_tombstones(
+                super_version,
+                key,
+                entry.key.seqno,
+                seqno,
+                comparator,
+            ) {
+                return Ok(None);
+            }
+            return Ok(Some((entry.key.value_type, entry.key.seqno, entry.value)));
+        }
+
+        if let Some(entry) =
+            Self::get_internal_entry_from_sealed_memtables(super_version, key, seqno)
+        {
+            let Some(entry) = ignore_tombstone_value(entry) else {
+                return Ok(None);
+            };
+            if Self::is_suppressed_by_range_tombstones(
+                super_version,
+                key,
+                entry.key.seqno,
+                seqno,
+                comparator,
+            ) {
+                return Ok(None);
+            }
+            return Ok(Some((entry.key.value_type, entry.key.seqno, entry.value)));
+        }
+
+        let key_hash = crate::hash::hash64(key);
+        let entry = Self::find_in_tables::<TableValue>(
+            &super_version.version,
+            key,
+            seqno,
+            key_hash,
+            comparator,
+        )?;
+        if let Some((value_type, entry_seqno, value)) = entry {
+            if Self::is_suppressed_by_range_tombstones(
+                super_version,
+                key,
+                entry_seqno,
+                seqno,
+                comparator,
+            ) {
+                return Ok(None);
+            }
+            return Ok(Some((value_type, entry_seqno, value)));
         }
 
         Ok(None)

--- a/tests/encryption_stress.rs
+++ b/tests/encryption_stress.rs
@@ -43,57 +43,16 @@ fn test_key() -> [u8; 32] {
 
 /// Raise this process's open-file soft limit toward its hard limit.
 ///
-/// `setrlimit(RLIMIT_NOFILE)` raising the soft limit up to the hard limit is
-/// unprivileged. On macOS the hard limit is reported as an unbounded sentinel
-/// but the kernel rejects a soft limit above `kern.maxfilesperproc`, so the
-/// target is capped to that value there. Best-effort: any failure leaves the
-/// limit unchanged and the test simply runs closer to the original budget.
-#[cfg(unix)]
+/// The concurrent stress test flushes many SSTs while readers hold descriptors
+/// open via the engine's descriptor cache, so its live fd count can exceed a
+/// low default soft limit (macOS defaults to 256) and surface as EMFILE — a
+/// resource limit, not an encryption fault. `increase_nofile_limit` raises the
+/// soft limit toward the hard limit (capping to the per-process maximum on
+/// macOS). Best-effort: any failure leaves the limit unchanged and the test
+/// simply runs closer to the original budget.
 fn raise_fd_limit() {
-    // SAFETY: get/setrlimit operate on an `rlimit` we own; the macOS sysctl
-    // reads one `c_int` into a stack buffer whose byte length we pass and read
-    // back, so the kernel never writes past it.
-    unsafe {
-        let mut rlim: libc::rlimit = std::mem::zeroed();
-        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
-            return;
-        }
-
-        // On macOS an unbounded hard limit must be capped to the kernel's
-        // per-process file cap, else setrlimit is rejected. Elsewhere the hard
-        // limit is a usable finite value.
-        #[cfg(target_os = "macos")]
-        let target = if rlim.rlim_max == libc::RLIM_INFINITY {
-            let mut per_proc: libc::c_int = 0;
-            let mut len = std::mem::size_of::<libc::c_int>();
-            let queried = libc::sysctlbyname(
-                c"kern.maxfilesperproc".as_ptr(),
-                std::ptr::addr_of_mut!(per_proc).cast(),
-                &mut len,
-                std::ptr::null_mut(),
-                0,
-            ) == 0
-                && per_proc > 0;
-            if queried {
-                libc::rlim_t::try_from(per_proc).unwrap_or(8192)
-            } else {
-                8192
-            }
-        } else {
-            rlim.rlim_max
-        };
-        #[cfg(not(target_os = "macos"))]
-        let target = rlim.rlim_max;
-
-        if target > rlim.rlim_cur {
-            rlim.rlim_cur = target;
-            let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &rlim);
-        }
-    }
+    let _ = rlimit::increase_nofile_limit(u64::MAX);
 }
-
-#[cfg(not(unix))]
-fn raise_fd_limit() {}
 
 /// Default config + per-cell compression + optional encryption + optional
 /// Page ECC. When `ecc` is set the SST blocks carry a Reed-Solomon parity

--- a/tests/encryption_stress.rs
+++ b/tests/encryption_stress.rs
@@ -41,6 +41,60 @@ fn test_key() -> [u8; 32] {
     [0x42; 32]
 }
 
+/// Raise this process's open-file soft limit toward its hard limit.
+///
+/// `setrlimit(RLIMIT_NOFILE)` raising the soft limit up to the hard limit is
+/// unprivileged. On macOS the hard limit is reported as an unbounded sentinel
+/// but the kernel rejects a soft limit above `kern.maxfilesperproc`, so the
+/// target is capped to that value there. Best-effort: any failure leaves the
+/// limit unchanged and the test simply runs closer to the original budget.
+#[cfg(unix)]
+fn raise_fd_limit() {
+    // SAFETY: get/setrlimit operate on an `rlimit` we own; the macOS sysctl
+    // reads one `c_int` into a stack buffer whose byte length we pass and read
+    // back, so the kernel never writes past it.
+    unsafe {
+        let mut rlim: libc::rlimit = std::mem::zeroed();
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            return;
+        }
+
+        // On macOS an unbounded hard limit must be capped to the kernel's
+        // per-process file cap, else setrlimit is rejected. Elsewhere the hard
+        // limit is a usable finite value.
+        #[cfg(target_os = "macos")]
+        let target = if rlim.rlim_max == libc::RLIM_INFINITY {
+            let mut per_proc: libc::c_int = 0;
+            let mut len = std::mem::size_of::<libc::c_int>();
+            let queried = libc::sysctlbyname(
+                c"kern.maxfilesperproc".as_ptr(),
+                std::ptr::addr_of_mut!(per_proc).cast(),
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            ) == 0
+                && per_proc > 0;
+            if queried {
+                libc::rlim_t::try_from(per_proc).unwrap_or(8192)
+            } else {
+                8192
+            }
+        } else {
+            rlim.rlim_max
+        };
+        #[cfg(not(target_os = "macos"))]
+        let target = rlim.rlim_max;
+
+        if target > rlim.rlim_cur {
+            rlim.rlim_cur = target;
+            let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &rlim);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn raise_fd_limit() {}
+
 /// Default config + per-cell compression + optional encryption + optional
 /// Page ECC. When `ecc` is set the SST blocks carry a Reed-Solomon parity
 /// trailer OUTSIDE the encryption envelope, so this exercises the
@@ -498,6 +552,13 @@ fn major_compaction_encrypted_round_trips() -> lsm_tree::Result<()> {
 
 #[test]
 fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
+    // This test flushes many SSTs while readers hold descriptors open via the
+    // engine's descriptor cache, so its live fd count can exceed a low default
+    // soft limit (e.g. macOS's 256) and surface as EMFILE — a resource limit,
+    // not an encryption fault. Raise this process's soft limit to its hard
+    // limit so the assertion measures encryption correctness, not fd budget.
+    raise_fd_limit();
+
     let dir = tempfile::tempdir()?;
     let tree = Arc::new(open_tree(dir.path(), CompressionType::None, true, false)?);
 

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -68,7 +68,11 @@
 //!   pre-populated with N keys and flushed to disk. Warm: the engine
 //!   is opened + populated + flushed ONCE outside the timed window,
 //!   so the measurement is steady-state read latency (block cache +
-//!   bloom filter + on-disk block fetch), not setup cost.
+//!   bloom filter + on-disk block fetch), not setup cost. The `ours` /
+//!   `rocksdb` series use a binary-search data-block index; the same chart
+//!   overlays `ours-hash-index` / `rocksdb-hash-index` series (data-block
+//!   hash index ON — ours: 1.33 buckets/entry; RocksDB: `BinaryAndHash` @
+//!   0.75) so both index strategies are compared head-to-head on one plot.
 //! - `range_scan/{1k,10k}` — full forward scan reading every value
 //!   from a warm, pre-populated engine. Steady-state sequential-scan
 //!   throughput (block decode + iterator advance).
@@ -94,7 +98,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 // for method resolution (clippy `-D warnings` confirms it is live).
 use lsm_tree::{
     AbstractTree, CompressionType, Config, Guard, MAX_SEQNO, SequenceNumberCounter,
-    config::{CompressionPolicy, KvSeparationOptions},
+    config::{CompressionPolicy, HashRatioPolicy, KvSeparationOptions},
     runtime_config::{KvChecksumPolicy, RuntimeConfig},
 };
 use surrealkv::{
@@ -430,13 +434,22 @@ impl WorkloadInputs {
 /// per-variant setting: `None` leaves RocksDB uncompressed; `Zstd22`
 /// sets `DBCompressionType::Zstd` and pins the level to 22 via
 /// `set_compression_options`.
-fn rocksdb_options(compression: Compression) -> rocksdb::Options {
+fn rocksdb_options(compression: Compression, hash_index: bool) -> rocksdb::Options {
     let mut block_opts = rocksdb::BlockBasedOptions::default();
     let cache = rocksdb::Cache::new_lru_cache(16 * 1024 * 1024);
     block_opts.set_block_cache(&cache);
     // bits_per_key = 10.0, block_based = false → modern full-block filter,
     // the closest match to our `BitsPerKey(10.0)` policy.
     block_opts.set_bloom_filter(10.0, false);
+    if hash_index {
+        // Data-block hash index: a point get resolves a key to its in-block
+        // offset by hash instead of binary-searching the restart array. The
+        // 0.75 utilization is RocksDB's recommended default and is the rough
+        // equal of our 1.33 buckets/entry (1 / 1.33 ≈ 0.75) for an
+        // apples-to-apples hash-index overlay.
+        block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash);
+        block_opts.set_data_block_hash_ratio(0.75);
+    }
     let mut opts = rocksdb::Options::default();
     opts.create_if_missing(true);
     match compression {
@@ -470,12 +483,22 @@ fn open_ours(
     dir: &std::path::Path,
     compression: Compression,
     kv_separated: bool,
+    hash_index: bool,
 ) -> Result<lsm_tree::AnyTree, Box<dyn std::error::Error>> {
     let config = Config::new(
         dir,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     );
+    // Data-block hash index: a point get resolves a key to its in-block offset
+    // by hash instead of binary-searching the restart array. 1.33 buckets/entry
+    // is the rough equal of RocksDB's 0.75 utilization for the hash-index
+    // overlay. Default policy (0.0) leaves it off for the binary-search arms.
+    let config = if hash_index {
+        config.data_block_hash_ratio_policy(HashRatioPolicy::all(1.33))
+    } else {
+        config
+    };
     let config = match compression {
         Compression::None => {
             config.data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
@@ -548,7 +571,7 @@ fn run_write_throughput(
     let start = std::time::Instant::now();
     let elapsed = match engine {
         Engine::Ours | Engine::BlobTree => {
-            let tree = open_ours(dir.path(), compression, engine.kv_separated())?;
+            let tree = open_ours(dir.path(), compression, engine.kv_separated(), false)?;
             // Zip the seqno counter as a native `u64` instead of
             // enumerate()+try_from(usize). lsm-tree's `insert` takes
             // SeqNo (= u64) directly; using `0u64..` avoids the
@@ -570,7 +593,7 @@ fn run_write_throughput(
             // our engine's defaults — see `rocksdb_options`. Our engine
             // builds a bloom filter at flush, so giving RocksDB the same
             // keeps the write comparison apples-to-apples.
-            let opts = rocksdb_options(compression);
+            let opts = rocksdb_options(compression, false);
             // Match our engine's durability shape: lsm-tree has no
             // WAL — durability is the caller's responsibility, and
             // `flush_active_memtable` is the equivalent of an
@@ -713,18 +736,40 @@ fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Co
 /// bare `get` + `black_box` with no per-read branch.
 fn bench_point_read(c: &mut Criterion) {
     // `None` baseline + `Zstd22` high-ratio variant in sibling groups,
-    // mirroring `bench_write_throughput`.
-    point_read_variant(c, "point_read", Compression::None);
-    point_read_variant(c, "point_read_zstd22", Compression::Zstd22);
+    // mirroring `bench_write_throughput`. The `point_read` group ADDS the
+    // hash-index series (`ours-hash-index`, `rocksdb-hash-index`) as extra
+    // overlays ON THE SAME chart alongside the binary-search `ours` / `rocksdb`
+    // lines, so one chart shows both index strategies head-to-head.
+    point_read_variant(c, "point_read", Compression::None, true);
+    point_read_variant(c, "point_read_zstd22", Compression::Zstd22, false);
 }
 
-fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
+fn point_read_variant(
+    c: &mut Criterion,
+    group_name: &str,
+    compression: Compression,
+    hash_overlays: bool,
+) {
+    // Series overlaid on this ONE chart: every base engine with the data-block
+    // hash index OFF (binary search), plus — when `hash_overlays` is set — the
+    // two engines that support a data-block hash index again with it ON. Extend
+    // this list to add more index strategies (e.g. a future `ours-burr` ribbon
+    // series) as additional overlays on the same chart.
+    let mut series: Vec<(&str, Engine, bool)> = engines_for(compression)
+        .iter()
+        .map(|&engine| (engine.label(), engine, false))
+        .collect();
+    if hash_overlays {
+        series.push(("ours-hash-index", Engine::Ours, true));
+        series.push(("rocksdb-hash-index", Engine::RocksDb, true));
+    }
+
     let mut group = c.benchmark_group(group_name);
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for &engine in engines_for(compression) {
-            group.bench_with_input(BenchmarkId::new(engine.label(), n), &n, |b, _| {
+        for &(label, engine, hash_index) in &series {
+            group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
                 // The temp dir + engine handle outlive every timed
                 // iteration: build the on-disk database once here so
                 // the criterion warmup / measurement loop only ever
@@ -732,8 +777,9 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
                     Engine::Ours | Engine::BlobTree => {
-                        let tree = open_ours(dir.path(), compression, engine.kv_separated())
-                            .expect("ours: open");
+                        let tree =
+                            open_ours(dir.path(), compression, engine.kv_separated(), hash_index)
+                                .expect("ours: open");
                         for ((key, value), seqno) in
                             inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..)
                         {
@@ -768,7 +814,7 @@ fn point_read_variant(c: &mut Criterion, group_name: &str, compression: Compress
                         // matching our engine's defaults so the per-`get`
                         // overhead is attributable, not a config artefact —
                         // see `rocksdb_options`.
-                        let opts = rocksdb_options(compression);
+                        let opts = rocksdb_options(compression, hash_index);
                         let db = rocksdb::DB::open(&opts, dir.path()).expect("rocksdb: open");
                         let mut write_opts = rocksdb::WriteOptions::default();
                         write_opts.disable_wal(true);
@@ -841,7 +887,7 @@ fn populate_rocksdb(
     compression: Compression,
     inputs: &WorkloadInputs,
 ) -> rocksdb::DB {
-    let opts = rocksdb_options(compression);
+    let opts = rocksdb_options(compression, false);
     let db = rocksdb::DB::open(&opts, dir).expect("rocksdb: open");
     let mut write_opts = rocksdb::WriteOptions::default();
     write_opts.disable_wal(true);
@@ -861,7 +907,7 @@ fn populate_ours(
     inputs: &WorkloadInputs,
     kv_separated: bool,
 ) -> lsm_tree::AnyTree {
-    let tree = open_ours(dir, compression, kv_separated).expect("ours: open");
+    let tree = open_ours(dir, compression, kv_separated, false).expect("ours: open");
     for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
         tree.insert(key, value, seqno);
     }


### PR DESCRIPTION
## Summary

Squeezes the per-get cost on the point-read path toward RocksDB parity. No format or public-behaviour change; point reads return identical results.

- **Slice-based LEB128 decode** for the index restart-key probe and the data-block entry parse, replacing per-byte `Cursor::read_u8`. Single-byte varint fast path.
- **Value-only point-read path**: the value-returning `get` no longer fuses the matched entry's key; the value is a zero-copy sub-slice of the cached block.
- **Drive the decoders directly** on point reads (data + index block) instead of the double-ended peeking iterator: parse the block trailer once, build index readers from the decoder's cached metadata, seqno-aware seek with a comparator-borrowing closure (no `Arc` bump), skip the no-op cache resets.
- **Cache: hash the key once per access** (`hashbrown::HashTable` keyed by the precomputed hash) instead of hashing for the shard and again in the map.

## Performance

`point_read/10000`: ~12.8ms → ~10.3ms; gap to RocksDB closes from ~21% to ~parity. The `point_read` bench chart now overlays `ours-hash-index` / `rocksdb-hash-index` series (data-block hash index ON) alongside the binary-search `ours` / `rocksdb` lines, so both index strategies are compared head-to-head on one plot.

## Corruption-validation fixes (from review)

The slice-decode had dropped two on-disk validations; both restored, each with a regression test committed first (fails on the pre-fix code):

- `read_leb128` now rejects a 10-byte varint whose final payload byte overflows u64, instead of returning a wrapped `Some(_)`.
- `parse_restart_key` decodes the block-handle offset/size (rejecting an overlong offset and a size beyond `u32::MAX`) instead of skipping them unchecked.

## Test robustness

The concurrent encryption stress test raises its own open-file soft limit (`rlimit::increase_nofile_limit`) so a low default does not surface as EMFILE under the fd-heavy `--all-features` suite.

## Testing

- `cargo nextest run --all-features`: 2071 passed, 2 skipped.
- `cargo clippy --all-features --all-targets`: clean.
- `cargo fmt --check`: clean.

Closes #463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added value-only point read paths for tables and trees to retrieve values without reconstructing full keys.

* **Performance Improvements**
  * Optimized sharded cache lookups to reduce hashing and streamline entry access/removal.
  * Improved block decoding with a faster, stricter LEB128/varint decoder and better reuse of validated index-reader metadata.

* **Bug Fixes**
  * Strengthened restart/data-block parsing validation, including rejection of malformed varint/LEB128 encodings and invalid bounds.

* **Tests / Reliability**
  * Increased soft file-descriptor limits for the encryption stress test; added targeted decoder coverage.

* **Benchmarks**
  * Extended point-read benchmarks to include hash-index overlay comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->