### PR TITLE
perf(table): move seqno bounds to a parallel section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,3 +316,9 @@ name = "partial_decode"
 harness = false
 path = "benches/partial_decode.rs"
 required-features = ["zstd"]
+
+[[bench]]
+name = "scan_since"
+harness = false
+path = "benches/scan_since.rs"
+required-features = []

--- a/benches/scan_since.rs
+++ b/benches/scan_since.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Benchmarks for the `seqno_in_index` block-skip optimization behind
+//! `Tree::scan_since_seqno` (the CDC / incremental-scan primitive).
+//!
+//! Three head-to-head comparisons of `seqno_in_index = true` vs `false`:
+//!   - `scan_since/sparse_1pct` — only the top 1% of seqnos are recent, so
+//!     block-skip should read a tiny fraction of the data blocks (target: a
+//!     large speedup vs the full per-entry filter).
+//!   - `write_throughput` — bulk insert + flush; the seqno-bounded index is
+//!     slightly larger, so this measures the write-side cost (target: small).
+//!   - `point_lookup` — random `get`; the index format must not affect the
+//!     point-read path (target: indistinguishable).
+
+#![expect(
+    clippy::expect_used,
+    reason = "benchmark setup favors concise panic messages"
+)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lsm_tree::runtime_config::RuntimeConfig;
+use lsm_tree::{AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, Tree};
+use tempfile::TempDir;
+
+/// Build a freshly-flushed single-run tree of `n` entries (seqno = key index),
+/// with the seqno-bounded index on or off. Small data blocks make the per-block
+/// seqno bounds meaningful.
+fn build_tree(seqno_in_index: bool, n: u64) -> (TempDir, Tree) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut rc = RuntimeConfig::default();
+    rc.seqno_in_index = seqno_in_index;
+    let any = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_runtime_config(rc)
+    .open()
+    .expect("open");
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), b"value", i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    (dir, tree)
+}
+
+/// Sparse-changes scan: target near the top of the seqno range so only ~1% of
+/// entries qualify. With `seqno_in_index = true` the scan skips data blocks
+/// whose `seqno_max < target`; with it off, every block is read and filtered.
+fn bench_scan_since_sparse(c: &mut Criterion) {
+    let n = 100_000u64;
+    let target: SeqNo = n - n / 100; // top 1% are "recent"
+
+    let mut group = c.benchmark_group("scan_since/sparse_1pct");
+    for &on in &[false, true] {
+        let (_dir, tree) = build_tree(on, n);
+        // Sanity: both formats must return the same number of recent entries.
+        let count = tree.scan_since_seqno(target).expect("scan").count();
+        assert_eq!(count as u64, n / 100, "1% of entries must qualify");
+
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let c = tree.scan_since_seqno(target).expect("scan").count();
+                std::hint::black_box(c);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Write-side cost of the seqno-bounded index: bulk insert + flush from an empty
+/// tree each iteration.
+fn bench_write_throughput(c: &mut Criterion) {
+    let n = 20_000u64;
+    let mut group = c.benchmark_group("scan_since/write_throughput");
+    for &on in &[false, true] {
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let (dir, _tree) = build_tree(on, n);
+                std::hint::black_box(&dir);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Point-lookup cost: the index format must not affect `get`. Random-ish key
+/// order via a multiplicative hash over the keyspace.
+fn bench_point_lookup(c: &mut Criterion) {
+    let n = 100_000u64;
+    // Precompute a shuffled key set ONCE so the timed loop measures only `get`,
+    // not per-iteration `format!` allocation (which would dwarf a ~1 us lookup
+    // and mask the index-format delta this bench is meant to isolate).
+    let keys: Vec<Vec<u8>> = (0..n)
+        .map(|i| {
+            let idx = i.wrapping_mul(2_654_435_761) % n;
+            format!("key{idx:08}").into_bytes()
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("scan_since/point_lookup");
+    for &on in &[false, true] {
+        let (_dir, tree) = build_tree(on, n);
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            let mut i = 0usize;
+            b.iter(|| {
+                let key = &keys[i % keys.len()];
+                i = i.wrapping_add(1);
+                let v = tree.get(key, SeqNo::MAX).expect("get");
+                std::hint::black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_scan_since_sparse,
+    bench_write_throughput,
+    bench_point_lookup
+);
+criterion_main!(benches);

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -245,7 +245,7 @@ impl BlobTree {
         target_seqno: SeqNo,
     ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
         self.index
-            .scan_since_seqno_with(target_seqno, |version, entry| {
+            .scan_since_seqno_with(target_seqno, true, |version, entry| {
                 let seqno = entry.key.seqno;
                 let (key, value) = resolve_value_handle(
                     self.id(),

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -160,6 +160,13 @@ pub(super) fn prepare_table_writer(
     // data-block payload encoding is unchanged; the V5 header/meta layout
     // still differs from pre-V5 regardless).
     let table_writer = table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
+    // Resolve the locator policy for the output level (compaction is the
+    // migration mechanism: a toggle takes effect as data is rewritten down).
+    let table_writer = table_writer.use_locator(
+        opts.config
+            .locator_policy
+            .get(usize::from(payload.dest_level)),
+    );
 
     #[cfg(zstd_any)]
     let table_writer = table_writer.use_zstd_dictionary(opts.config.zstd_dictionary.clone());

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024-present, fjall-rs
+// Copyright (c) 2026-present, Structured World Foundation
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// In-block addressing precision for the retrieval-ribbon locator.
+///
+/// A locator is `(block_id, slot)`; this selects what `slot` indexes, trading
+/// ribbon width against in-block read work. Data blocks are delta-coded within
+/// restart intervals, so only a restart head has a directly-addressable byte
+/// offset; both modes land there and differ in how the exact entry is reached.
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+pub enum LocatorPrecision {
+    /// `slot` is the restart index. The read jumps to the restart head and
+    /// scans up to `restart_interval` entries. Most compact; the in-block
+    /// granularity matches a data-block hash index.
+    Restart,
+    /// `slot` is the exact entry index. The read jumps to the restart head and
+    /// decodes forward to the entry with no key comparisons. Costs roughly
+    /// `log2(restart_interval)` more bits per key than [`Restart`].
+    ///
+    /// [`Restart`]: LocatorPrecision::Restart
+    Entry,
+}
+
+/// Per-level retrieval-ribbon locator policy entry.
+///
+/// Each level can independently disable the locator or enable it with its own
+/// precision and width budget.
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+pub enum LocatorPolicyEntry {
+    /// No locator section is built for this level. The point read uses the
+    /// sorted index, exactly as without the feature. This is the default and
+    /// produces byte-identical SSTs (no section, no padding).
+    None,
+
+    /// Build a per-SST retrieval-ribbon locator section for this level.
+    Enabled {
+        /// What `slot` addresses within a data block.
+        precision: LocatorPrecision,
+        /// Bits reserved for the data-block id. `None` = auto, sized per SST as
+        /// `ceil(log2(num_data_blocks))`. An explicit value too small for an
+        /// SST's real layout makes that SST skip the section (graceful: it
+        /// falls back to the index), never a build error.
+        block_id_bits: Option<u8>,
+        /// Bits reserved for `slot`. `None` = auto, sized per SST as
+        /// `ceil(log2(max restarts per block))` (or entries per block for
+        /// [`LocatorPrecision::Entry`]). Same overflow handling as
+        /// `block_id_bits`.
+        slot_bits: Option<u8>,
+    },
+}
+
+/// Retrieval-ribbon locator policy.
+///
+/// One [`LocatorPolicyEntry`] per LSM level (the last entry covers any deeper
+/// level). Off by default ([`Self::disabled`]); enabling it adds an optional,
+/// format-gated `locator` section to written SSTs so point reads can resolve a
+/// key to its data block and slot in O(1) via the retrieval ribbon, skipping
+/// both the index-block and in-block binary searches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocatorPolicy(Vec<LocatorPolicyEntry>);
+
+impl core::ops::Deref for LocatorPolicy {
+    type Target = [LocatorPolicyEntry];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl LocatorPolicy {
+    /// The locator entry for `level`, falling back to the last entry for levels
+    /// beyond the configured length.
+    #[must_use]
+    pub(crate) fn get(&self, level: usize) -> LocatorPolicyEntry {
+        #[expect(clippy::expect_used, reason = "policy is expected not to be empty")]
+        self.0
+            .get(level)
+            .copied()
+            .unwrap_or_else(|| self.last().copied().expect("policy should not be empty"))
+    }
+
+    /// Disables the locator on every level (the default).
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::all(LocatorPolicyEntry::None)
+    }
+
+    /// Uses the same locator entry on every level.
+    #[must_use]
+    pub fn all(entry: LocatorPolicyEntry) -> Self {
+        Self(vec![entry])
+    }
+
+    /// Constructs a custom per-level locator policy.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is empty or contains more than 255 elements.
+    #[must_use]
+    pub fn new(policy: impl Into<Vec<LocatorPolicyEntry>>) -> Self {
+        let policy = policy.into();
+        assert!(!policy.is_empty(), "locator policy may not be empty");
+        assert!(policy.len() <= 255, "locator policy is too large");
+        Self(policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_enabled(entry: LocatorPolicyEntry) -> bool {
+        matches!(entry, LocatorPolicyEntry::Enabled { .. })
+    }
+
+    #[test]
+    fn disabled_policy_reports_no_level_enabled() {
+        let policy = LocatorPolicy::disabled();
+        assert!(!is_enabled(policy.get(0)));
+        assert!(!is_enabled(policy.get(7)));
+    }
+
+    #[test]
+    fn get_beyond_length_falls_back_to_last_entry() {
+        let policy = LocatorPolicy::new(vec![
+            LocatorPolicyEntry::Enabled {
+                precision: LocatorPrecision::Restart,
+                block_id_bits: None,
+                slot_bits: None,
+            },
+            LocatorPolicyEntry::None,
+        ]);
+        assert!(is_enabled(policy.get(0)));
+        assert!(!is_enabled(policy.get(1)));
+        // Level 5 has no explicit entry → falls back to the last (None).
+        assert!(!is_enabled(policy.get(5)));
+    }
+
+    #[test]
+    fn all_applies_one_entry_to_every_level() {
+        let policy = LocatorPolicy::all(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Entry,
+            block_id_bits: Some(20),
+            slot_bits: Some(10),
+        });
+        for level in 0..4 {
+            assert_eq!(
+                policy.get(level),
+                LocatorPolicyEntry::Enabled {
+                    precision: LocatorPrecision::Entry,
+                    block_id_bits: Some(20),
+                    slot_bits: Some(10),
+                },
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "locator policy may not be empty")]
+    fn new_rejects_empty_policy() {
+        let _ = LocatorPolicy::new(Vec::new());
+    }
+}

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -39,8 +39,8 @@ pub enum LocatorPrecision {
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum LocatorPolicyEntry {
     /// No locator section is built for this level. The point read uses the
-    /// sorted index, exactly as without the feature. This is the default and
-    /// produces byte-identical SSTs (no section, no padding).
+    /// sorted index, exactly as without the feature, producing byte-identical
+    /// SSTs (no section, no padding).
     None,
 
     /// Build a per-SST retrieval-ribbon locator section for this level.
@@ -63,10 +63,12 @@ pub enum LocatorPolicyEntry {
 /// Retrieval-ribbon locator policy.
 ///
 /// One [`LocatorPolicyEntry`] per LSM level (the last entry covers any deeper
-/// level). Off by default ([`Self::disabled`]); enabling it adds an optional,
-/// format-gated `locator` section to written SSTs so point reads can resolve a
-/// key to its data block and slot in O(1) via the retrieval ribbon, skipping
-/// both the index-block and in-block binary searches.
+/// level). Defaults to [`Self::block_level`]; the optional, format-gated
+/// `locator` section it adds to written SSTs lets a point read resolve a key to
+/// its data block in O(1) via the retrieval ribbon, skipping the index-block
+/// binary search. Finer precisions ([`LocatorPrecision::Restart`] /
+/// [`LocatorPrecision::Entry`]) also skip the in-block search; [`Self::disabled`]
+/// turns the section off entirely.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocatorPolicy(Vec<LocatorPolicyEntry>);
 
@@ -90,10 +92,29 @@ impl LocatorPolicy {
             .unwrap_or_else(|| self.last().copied().expect("policy should not be empty"))
     }
 
-    /// Disables the locator on every level (the default).
+    /// Disables the locator on every level.
     #[must_use]
     pub fn disabled() -> Self {
         Self::all(LocatorPolicyEntry::None)
+    }
+
+    /// Enables the locator at [`LocatorPrecision::Block`] on every level with
+    /// auto-sized widths (the default).
+    ///
+    /// Block precision is the cheapest tier: the ribbon stores only `block_id`
+    /// (no `slot`), so it is the narrowest ribbon to build and store while still
+    /// delivering the structural win — a point read resolves the data block in
+    /// O(1) and skips the index-block binary search (the costly part on
+    /// partitioned indexes), then does the existing in-block lookup. An SST
+    /// whose ribbon cannot be built simply omits the section and falls back to
+    /// the sorted index, so enabling this by default never risks a write.
+    #[must_use]
+    pub fn block_level() -> Self {
+        Self::all(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Block,
+            block_id_bits: None,
+            slot_bits: None,
+        })
     }
 
     /// Uses the same locator entry on every level.

--- a/src/config/locator.rs
+++ b/src/config/locator.rs
@@ -7,19 +7,26 @@ use alloc::vec::Vec;
 
 /// In-block addressing precision for the retrieval-ribbon locator.
 ///
-/// A locator is `(block_id, slot)`; this selects what `slot` indexes, trading
-/// ribbon width against in-block read work. Data blocks are delta-coded within
-/// restart intervals, so only a restart head has a directly-addressable byte
-/// offset; both modes land there and differ in how the exact entry is reached.
+/// Selects the locator granularity, trading ribbon width against in-block read
+/// work. The three modes correspond to **per-block**, **per-sub-block**, and
+/// **per-key** addressing. Data blocks are delta-coded within restart intervals,
+/// so only a restart head has a directly-addressable byte offset; the finer
+/// modes land there and differ in how the exact entry is reached.
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum LocatorPrecision {
-    /// `slot` is the restart index. The read jumps to the restart head and
-    /// scans up to `restart_interval` entries. Most compact; the in-block
+    /// **Per-block**: the locator is `block_id` only (no `slot`). The read
+    /// resolves the data block in O(1) and does the existing in-block binary
+    /// search. Most compact; eliminates the index-block search (the structural
+    /// win over a data-block hash index) while leaving the in-block lookup.
+    Block,
+    /// **Per-sub-block**: `slot` is the restart index. The read jumps to the
+    /// restart head and scans up to `restart_interval` entries. In-block
     /// granularity matches a data-block hash index.
     Restart,
-    /// `slot` is the exact entry index. The read jumps to the restart head and
-    /// decodes forward to the entry with no key comparisons. Costs roughly
-    /// `log2(restart_interval)` more bits per key than [`Restart`].
+    /// **Per-key**: `slot` is the exact entry index. The read jumps to the
+    /// restart head and decodes forward to the entry with no key comparisons.
+    /// Costs roughly `log2(restart_interval)` more bits per key than
+    /// [`Restart`].
     ///
     /// [`Restart`]: LocatorPrecision::Restart
     Entry,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -469,10 +469,11 @@ pub struct Config {
     /// Filter construction policy
     pub filter_policy: FilterPolicy,
 
-    /// Retrieval-ribbon locator policy (per level). Off by default; when
-    /// enabled, written SSTs carry an optional `locator` section that maps each
-    /// key to its data block and slot for O(1) point reads. Disabled levels
-    /// produce byte-identical SSTs (no section).
+    /// Retrieval-ribbon locator policy (per level). Defaults to
+    /// [`LocatorPolicy::block_level`]: written SSTs carry an optional `locator`
+    /// section mapping each key to its data block for O(1) point reads (skipping
+    /// the index-block binary search). Set [`LocatorPolicy::disabled`] to opt
+    /// out — disabled levels produce byte-identical SSTs (no section).
     pub locator_policy: LocatorPolicy,
 
     /// Compaction filter factory
@@ -689,7 +690,7 @@ impl Default for Config {
 
             data_block_hash_ratio_policy: HashRatioPolicy::all(0.0),
 
-            locator_policy: LocatorPolicy::disabled(),
+            locator_policy: LocatorPolicy::block_level(),
             filter_policy: FilterPolicy::all(FilterPolicyEntry::Bloom(
                 BloomConstructionPolicy::BitsPerKey(10.0),
             )),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1393,10 +1393,12 @@ impl Config {
 
     /// Sets the retrieval-ribbon locator policy.
     ///
-    /// Off by default. When enabled for a level, written SSTs on that level
-    /// carry an optional `locator` section mapping each key to its data block
-    /// and slot, letting point reads skip the index-block and in-block binary
-    /// searches. Disabled levels are unaffected and emit byte-identical SSTs.
+    /// On by default at [`LocatorPrecision::Block`] (see
+    /// [`LocatorPolicy::block_level`]). When enabled for a level, written SSTs on
+    /// that level carry an optional `locator` section mapping each key to its
+    /// data block (and, at finer precisions, its slot), letting point reads skip
+    /// the index-block binary search. Set [`LocatorPolicy::disabled`] to opt out;
+    /// disabled levels emit byte-identical SSTs.
     #[must_use]
     pub fn locator_policy(mut self, policy: LocatorPolicy) -> Self {
         self.locator_policy = policy;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ mod block_size;
 mod compression;
 mod filter;
 mod hash_ratio;
+mod locator;
 mod pinning;
 mod restart_interval;
 
@@ -13,6 +14,7 @@ pub use block_size::BlockSizePolicy;
 pub use compression::CompressionPolicy;
 pub use filter::{BloomConstructionPolicy, FilterPolicy, FilterPolicyEntry};
 pub use hash_ratio::HashRatioPolicy;
+pub use locator::{LocatorPolicy, LocatorPolicyEntry, LocatorPrecision};
 pub use pinning::PinningPolicy;
 pub use restart_interval::RestartIntervalPolicy;
 
@@ -467,6 +469,12 @@ pub struct Config {
     /// Filter construction policy
     pub filter_policy: FilterPolicy,
 
+    /// Retrieval-ribbon locator policy (per level). Off by default; when
+    /// enabled, written SSTs carry an optional `locator` section that maps each
+    /// key to its data block and slot for O(1) point reads. Disabled levels
+    /// produce byte-identical SSTs (no section).
+    pub locator_policy: LocatorPolicy,
+
     /// Compaction filter factory
     pub compaction_filter_factory: Option<Arc<dyn Factory>>,
 
@@ -681,6 +689,7 @@ impl Default for Config {
 
             data_block_hash_ratio_policy: HashRatioPolicy::all(0.0),
 
+            locator_policy: LocatorPolicy::disabled(),
             filter_policy: FilterPolicy::all(FilterPolicyEntry::Bloom(
                 BloomConstructionPolicy::BitsPerKey(10.0),
             )),
@@ -1378,6 +1387,18 @@ impl Config {
     #[must_use]
     pub fn filter_policy(mut self, policy: FilterPolicy) -> Self {
         self.filter_policy = policy;
+        self
+    }
+
+    /// Sets the retrieval-ribbon locator policy.
+    ///
+    /// Off by default. When enabled for a level, written SSTs on that level
+    /// carry an optional `locator` section mapping each key to its data block
+    /// and slot, letting point reads skip the index-block and in-block binary
+    /// searches. Disabled levels are unaffected and emit byte-identical SSTs.
+    #[must_use]
+    pub fn locator_policy(mut self, policy: LocatorPolicy) -> Self {
+        self.locator_policy = policy;
         self
     }
 

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -764,24 +764,23 @@ pub struct RuntimeConfig {
     /// compaction I/O. Toggling takes effect immediately for subsequent reads.
     pub auto_heal: bool,
 
-    /// Per-block seqno bounds in SST index entries (#224). When `true`,
-    /// SSTs written by the next flush / compaction record each data
-    /// block's `seqno_min` / `seqno_max` in its index entry
-    /// (`index_format = 1` in the table Properties), enabling fast
-    /// `scan_since_seqno` via block-skip: the scan skips any block whose
-    /// `seqno_max < target` without reading it.
+    /// Per-block seqno bounds for `scan_since_seqno` block-skip (#224). When
+    /// `true`, SSTs written by the next flush / compaction emit the optional
+    /// parallel `seqno_bounds` section, recording each data block's
+    /// `seqno_min` / `seqno_max` keyed by its file offset. A seqno-scoped scan
+    /// then skips any block whose bounds cannot overlap the target window
+    /// without reading it.
     ///
-    /// Default `false`: index blocks are byte-identical to the pre-#224
-    /// `index_format = 0` format, and `scan_since_seqno` falls back to a
-    /// per-entry filter. Decoding is marker-based: each index entry is
-    /// self-describing (legacy markers `0`/`1`, seqno-bounded `2`/`3`), so
-    /// mixed-format trees (some SSTs migrated, some not) read correctly
-    /// regardless of this setting; the stored `index_format` byte is a
-    /// metadata hint, not the decode switch.
+    /// Default `false`: no section is emitted (zero extra bytes) and
+    /// `scan_since_seqno` falls back to a per-entry filter. The index entries
+    /// are byte-identical regardless of this setting, so a point read pays
+    /// nothing either way, and a tree mixing SSTs with and without the section
+    /// reads correctly (a missing section simply means full-filter scan for
+    /// that SST).
     ///
-    /// Toggle takes effect on the next compaction / flush; existing SSTs
-    /// keep their original `index_format`. Compaction migrates source
-    /// SSTs to the current setting over time.
+    /// Toggle takes effect on the next compaction / flush; existing SSTs keep
+    /// whatever they were written with. Compaction migrates source SSTs to the
+    /// current setting over time.
     pub seqno_in_index: bool,
 
     /// Index-size threshold (bytes) at or below which an SST's block index
@@ -1272,10 +1271,9 @@ mod tests {
 
     #[test]
     fn runtime_config_default_seqno_in_index_off() {
-        // seqno_in_index is explicit opt-in (#224): default false keeps
-        // index blocks byte-identical to the pre-#224 index_format=0
-        // format. A regression flipping this default would change the
-        // on-disk index layout for every existing tree.
+        // seqno_in_index is explicit opt-in (#224): default false emits no
+        // seqno_bounds section, so SSTs carry zero extra bytes. A regression
+        // flipping this default would add the section to every new tree.
         assert!(!RuntimeConfig::default().seqno_in_index);
     }
 

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -45,8 +45,9 @@ pub enum BlockType {
     /// Absent unless the table has at least one such multi-inner-block block.
     BlockLayout,
     /// Optional per-table retrieval-ribbon locator section: maps each key to a
-    /// packed `(block_id, slot)` for O(1) point reads. Absent unless the level's
-    /// locator policy is enabled, so a default table gains no bytes.
+    /// packed `(block_id, slot)` for O(1) point reads. Present by default (block
+    /// precision); absent when the level's locator policy is disabled or the
+    /// per-SST ribbon could not be built.
     Locator,
 }
 

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -44,6 +44,10 @@ pub enum BlockType {
     /// range query partial-decode only the inner blocks covering a key range.
     /// Absent unless the table has at least one such multi-inner-block block.
     BlockLayout,
+    /// Optional per-table retrieval-ribbon locator section: maps each key to a
+    /// packed `(block_id, slot)` for O(1) point reads. Absent unless the level's
+    /// locator policy is enabled, so a default table gains no bytes.
+    Locator,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -65,6 +69,7 @@ impl From<BlockType> for u8 {
             BlockType::Manifest => 5,
             BlockType::ManifestFooter => 6,
             BlockType::BlockLayout => 7,
+            BlockType::Locator => 8,
         }
     }
 }
@@ -82,6 +87,7 @@ impl TryFrom<u8> for BlockType {
             5 => Ok(Self::Manifest),
             6 => Ok(Self::ManifestFooter),
             7 => Ok(Self::BlockLayout),
+            8 => Ok(Self::Locator),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -108,6 +114,7 @@ mod tests {
             (5, BlockType::Manifest),
             (6, BlockType::ManifestFooter),
             (7, BlockType::BlockLayout),
+            (8, BlockType::Locator),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -126,9 +133,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 8 is the first
+        // not a silent coercion to a known variant. 9 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(8).is_err());
+        assert!(BlockType::try_from(9).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -48,6 +48,11 @@ pub enum BlockType {
     /// packed `(block_id, slot)` for O(1) point reads. Absent unless the level's
     /// locator policy is enabled, so a default table gains no bytes.
     Locator,
+    /// Optional per-table seqno-bounds section: maps each data block's file
+    /// offset to its `[seqno_min, seqno_max]`, powering the `scan_since_seqno`
+    /// block-skip without bloating the index entries. Absent unless
+    /// `seqno_in_index` is on.
+    SeqnoBounds,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -70,6 +75,7 @@ impl From<BlockType> for u8 {
             BlockType::ManifestFooter => 6,
             BlockType::BlockLayout => 7,
             BlockType::Locator => 8,
+            BlockType::SeqnoBounds => 9,
         }
     }
 }
@@ -88,6 +94,7 @@ impl TryFrom<u8> for BlockType {
             6 => Ok(Self::ManifestFooter),
             7 => Ok(Self::BlockLayout),
             8 => Ok(Self::Locator),
+            9 => Ok(Self::SeqnoBounds),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -115,6 +122,7 @@ mod tests {
             (6, BlockType::ManifestFooter),
             (7, BlockType::BlockLayout),
             (8, BlockType::Locator),
+            (9, BlockType::SeqnoBounds),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -133,9 +141,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 9 is the first
+        // not a silent coercion to a known variant. 10 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(9).is_err());
+        assert!(BlockType::try_from(10).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -559,9 +559,40 @@ impl DataBlock {
         seqno: SeqNo,
         comparator: &crate::comparator::SharedComparator,
     ) -> crate::Result<Option<InternalValue>> {
-        self.point_read_with(needle, seqno, comparator, |item, bytes| {
+        self.point_read_with(needle, seqno, comparator, None, |item, bytes| {
             item.materialize(bytes)
         })
+    }
+
+    /// Like [`Self::point_read`], but positioned by a retrieval-ribbon locator
+    /// `slot` instead of the in-block binary search.
+    ///
+    /// `slot` is the restart index (`is_entry == false`) or the exact entry
+    /// index (`is_entry == true`, mapped to its restart via the block's
+    /// `restart_interval`). The scan jumps straight to that restart head and
+    /// proceeds forward, skipping the binary search. If the block has no binary
+    /// index or the restart is out of range, it falls back to the seqno-aware
+    /// seek, so a stale hint never returns a wrong answer.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a trailer/decoder error (same conditions as
+    /// [`Self::point_read`]).
+    pub fn point_read_at_slot(
+        &self,
+        slot: u64,
+        is_entry: bool,
+        needle: &[u8],
+        seqno: SeqNo,
+        comparator: &crate::comparator::SharedComparator,
+    ) -> crate::Result<Option<InternalValue>> {
+        self.point_read_with(
+            needle,
+            seqno,
+            comparator,
+            Some((slot, is_entry)),
+            DataBlockParsedItem::materialize,
+        )
     }
 
     /// Value-only point read: returns `(value_type, seqno, value)` without
@@ -577,7 +608,7 @@ impl DataBlock {
         seqno: SeqNo,
         comparator: &crate::comparator::SharedComparator,
     ) -> crate::Result<Option<(ValueType, SeqNo, Slice)>> {
-        self.point_read_with(needle, seqno, comparator, |item, bytes| {
+        self.point_read_with(needle, seqno, comparator, None, |item, bytes| {
             let value = item
                 .value
                 .as_ref()
@@ -586,9 +617,43 @@ impl DataBlock {
         })
     }
 
+    /// Value-only counterpart of [`Self::point_read_at_slot`]: positioned by a
+    /// retrieval-ribbon locator `slot`, returns `(value_type, seqno, value)`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a trailer/decoder error (same conditions as
+    /// [`Self::point_read_value`]).
+    pub fn point_read_value_at_slot(
+        &self,
+        slot: u64,
+        is_entry: bool,
+        needle: &[u8],
+        seqno: SeqNo,
+        comparator: &crate::comparator::SharedComparator,
+    ) -> crate::Result<Option<(ValueType, SeqNo, Slice)>> {
+        self.point_read_with(
+            needle,
+            seqno,
+            comparator,
+            Some((slot, is_entry)),
+            |item, bytes| {
+                let value = item
+                    .value
+                    .as_ref()
+                    .map_or_else(Slice::empty, |v| bytes.slice(v.0..v.1));
+                (item.value_type, item.seqno, value)
+            },
+        )
+    }
+
     /// Shared point-read seek + scan, parameterized over how the matched entry
     /// is turned into a result. `point_read` materializes a full
     /// [`InternalValue`]; `point_read_value` extracts only the value.
+    ///
+    /// `slot_hint` (`Some((slot, is_entry))`) positions the scan directly at a
+    /// retrieval-ribbon locator's restart head instead of binary-searching;
+    /// `None` keeps the default hash-index / seqno-seek positioning.
     ///
     /// Drives the [`Decoder`] directly rather than through [`Iter`]: point reads
     /// are forward-only seek + scan, so the double-ended peeking wrapper is pure
@@ -603,6 +668,7 @@ impl DataBlock {
         needle: &[u8],
         seqno: SeqNo,
         comparator: &crate::comparator::SharedComparator,
+        slot_hint: Option<(u64, bool)>,
         extract: impl FnOnce(&DataBlockParsedItem, &Slice) -> R,
     ) -> crate::Result<Option<R>> {
         use crate::table::block::BlockType;
@@ -621,7 +687,30 @@ impl DataBlock {
         // try_new validates + caches all trailer fields once.
         let mut decoder = Decoder::<InternalValue, DataBlockParsedItem>::try_new(&self.inner)?;
 
-        let positioned = if let Some(hash_index_reader) = decoder.cached_hash_index_reader() {
+        let positioned = if let Some((slot, is_entry)) = slot_hint {
+            // Retrieval-ribbon positioning: jump straight to the restart head the
+            // key's newest version lives in, skipping the binary search. For
+            // Entry precision the slot is an exact entry index, mapped to its
+            // restart via the block's restart_interval.
+            let restart_idx = if is_entry {
+                let ri = u64::from(decoder.restart_interval());
+                if ri == 0 { slot } else { slot / ri }
+            } else {
+                slot
+            };
+            let restart_idx = usize::try_from(restart_idx).unwrap_or(usize::MAX);
+            match decoder.cached_binary_index_reader() {
+                Some(binary_index_reader) if restart_idx < binary_index_reader.len() => {
+                    let offset: usize = binary_index_reader.get(restart_idx);
+                    decoder.set_lo_offset(offset);
+                    true
+                }
+                // No binary index, or a stale/out-of-range restart (corruption /
+                // format drift): fall back to the seqno-aware seek so the hint
+                // can never produce a wrong answer.
+                _ => seek_data_block(&mut decoder, needle, seqno, comparator),
+            }
+        } else if let Some(hash_index_reader) = decoder.cached_hash_index_reader() {
             match hash_index_reader.get(needle) {
                 MARKER_FREE => return Ok(None),
                 // NOTE: Fallback to seqno-aware binary search on a hash conflict.
@@ -1304,6 +1393,63 @@ mod tests {
             assert_eq!(got.key.seqno, want.key.seqno);
             assert_eq!(got.key.value_type, want.key.value_type);
             assert_eq!(got.value, want.value);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn point_read_at_slot_positions_by_restart_and_matches_point_read() -> crate::Result<()> {
+        // restart_interval = 4 → 25 restart intervals over 100 sorted keys, so
+        // the locator slot positioning is meaningfully exercised.
+        let ri: u8 = 4;
+        let items: Vec<InternalValue> = (0..100u32)
+            .map(|i| {
+                InternalValue::from_components(
+                    format!("key{i:04}").into_bytes(),
+                    format!("val{i}").into_bytes(),
+                    0,
+                    Value,
+                )
+            })
+            .collect();
+        let bytes = DataBlock::encode_into_vec(&items, ri, 0.0)?;
+        let block = DataBlock::new(Block {
+            data: bytes.into(),
+            header: Header::test_dummy(BlockType::Data),
+        });
+        let cmp = default_comparator();
+
+        for (idx, it) in items.iter().enumerate() {
+            let key = &it.key.user_key;
+            let expected = block.point_read(key, crate::SeqNo::MAX, &cmp)?;
+            assert!(expected.is_some(), "key {idx} must be present");
+
+            let restart_idx = (idx / usize::from(ri)) as u64;
+            // Restart precision: slot IS the key's restart index → exact hit.
+            assert_eq!(
+                block.point_read_at_slot(restart_idx, false, key, crate::SeqNo::MAX, &cmp)?,
+                expected,
+                "restart-slot read mismatch at key {idx}",
+            );
+            // Entry precision: slot is the exact entry index, mapped to its
+            // restart via restart_interval internally.
+            assert_eq!(
+                block.point_read_at_slot(idx as u64, true, key, crate::SeqNo::MAX, &cmp)?,
+                expected,
+                "entry-slot read mismatch at key {idx}",
+            );
+            // Restart 0 scans the whole block → still finds every key.
+            assert_eq!(
+                block.point_read_at_slot(0, false, key, crate::SeqNo::MAX, &cmp)?,
+                expected,
+                "restart-0 read mismatch at key {idx}",
+            );
+            // An out-of-range restart falls back to the seqno seek → same answer.
+            assert_eq!(
+                block.point_read_at_slot(9_999, false, key, crate::SeqNo::MAX, &cmp)?,
+                expected,
+                "out-of-range-slot read mismatch at key {idx}",
+            );
         }
         Ok(())
     }

--- a/src/table/filter/ribbon/builder.rs
+++ b/src/table/filter/ribbon/builder.rs
@@ -37,7 +37,33 @@ impl RibbonBuilder {
         m: usize,
     ) -> Result<RibbonFilter, BuildError> {
         self.params.validate().map_err(BuildError::InvalidParams)?;
-        self.build_once_from_hashes(hashes, m, seed)
+        self.build_once_core(hashes, None, m, seed)
+            .map_err(|failure| BuildError::ConstructionFailed {
+                final_m: m,
+                attempts: 1,
+                last_failure: failure,
+            })
+    }
+
+    /// Build a Ribbon mapping each hashed key to a caller-supplied r-bit
+    /// value (a *retrieval* ribbon) instead of a hash-derived membership
+    /// fingerprint. Verbatim seed, no retry.
+    ///
+    /// `values[i]` is the value stored for `hashes[i]`; both slices must be
+    /// the same length and each value must already fit in `r` bits. The band
+    /// placement (`coeff`, `start`) is still derived from the key hash, so
+    /// the solve is identical to the membership path apart from the RHS — a
+    /// later dot-product query recovers `values[i]` exactly for a key in the
+    /// set (garbage for an absent key, which the caller verifies separately).
+    pub(crate) fn build_with_seed_verbatim_from_values(
+        &self,
+        hashes: &[u64],
+        values: &[u64],
+        seed: u64,
+        m: usize,
+    ) -> Result<RibbonFilter, BuildError> {
+        self.params.validate().map_err(BuildError::InvalidParams)?;
+        self.build_once_core(hashes, Some(values), m, seed)
             .map_err(|failure| BuildError::ConstructionFailed {
                 final_m: m,
                 attempts: 1,
@@ -47,16 +73,32 @@ impl RibbonBuilder {
 
     /// Build a single ribbon over pre-computed key hashes.
     ///
-    /// Used by BuRR through `build_with_seed_verbatim_from_hashes` so the
-    /// LSM-side stable u64 hash (xxh3 / `crate::hash::hash64`) flows
-    /// straight into the banded solver.
-    fn build_once_from_hashes(
+    /// Used by BuRR through `build_with_seed_verbatim_from_hashes` (RHS =
+    /// hash-derived fingerprint, `values = None`) and
+    /// `build_with_seed_verbatim_from_values` (RHS = caller locator,
+    /// `values = Some`). The band placement and Gaussian-elimination solve
+    /// are shared verbatim between the two paths — only the per-key RHS
+    /// differs — so the membership and retrieval ribbons cannot drift.
+    fn build_once_core(
         &self,
         hashes: &[u64],
+        values: Option<&[u64]>,
         m: usize,
         seed: u64,
     ) -> Result<RibbonFilter, ConstructionFailure> {
         debug_assert!(m >= self.params.w);
+        if let Some(values) = values {
+            debug_assert_eq!(
+                values.len(),
+                hashes.len(),
+                "retrieval RHS values must be parallel to hashes",
+            );
+            debug_assert_eq!(
+                self.params.fingerprint_words(),
+                1,
+                "retrieval ribbon stores a single-word (r<=64) value",
+            );
+        }
 
         let stride_words = self.params.fingerprint_words();
         let total_words = m
@@ -80,6 +122,16 @@ impl RibbonBuilder {
             let mut c_lo = equation.coeff_lo;
             let mut c_hi = equation.coeff_hi;
             let mut b = key_fp.clone();
+            if let Some(values) = values {
+                // Retrieval ribbon: replace the hash-derived fingerprint
+                // RHS with the caller's r-bit value. The band (coeff/start)
+                // above is still hash-derived, so the solve is unchanged;
+                // only what it solves *for* differs. stride is 1 for r<=64
+                // (asserted above), so the value lives in word 0, masked to
+                // r bits (identity for an already-fitting value).
+                b.fill(0);
+                b[0] = values[key_index] & fp_last_mask;
+            }
 
             if i >= m {
                 return Err(ConstructionFailure::OutOfBounds {

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -5,7 +5,7 @@ use super::super::builder::RibbonBuilder;
 use super::super::hashing::StandardEquation;
 use super::super::params::{Mode, Params};
 use super::error::BurrBuildError;
-use super::filter::{BurrFilter, BurrLayer};
+use super::filter::{BurrFilter, BurrFilterKind, BurrLayer};
 use super::params::BurrParams;
 use super::threshold::{compute_thresholds, partition_keys_by_threshold};
 
@@ -166,6 +166,14 @@ impl BurrBuilder {
         if hashes.is_empty() {
             return Err(BurrBuildError::InvalidParams("key set must be non-empty"));
         }
+        // Capture the flavour before the loop drains `values`: presence of
+        // a value slice means a retrieval (key → locator) build, absence a
+        // membership build. The wire encoder maps it to the filter_type tag.
+        let kind = if values.is_some() {
+            BurrFilterKind::Retrieval
+        } else {
+            BurrFilterKind::Membership
+        };
         let mut remaining: Vec<u64> = hashes;
         let mut remaining_values: Option<Vec<u64>> = values;
         let mut layers: Vec<BurrLayer> = Vec::with_capacity(usize::from(self.params.max_layers));
@@ -289,7 +297,7 @@ impl BurrBuilder {
             });
         }
 
-        Ok(BurrFilter::from_layers(self.params, layers))
+        Ok(BurrFilter::from_layers(self.params, kind, layers))
     }
 }
 

--- a/src/table/filter/ribbon/burr/builder.rs
+++ b/src/table/filter/ribbon/burr/builder.rs
@@ -103,6 +103,60 @@ impl BurrBuilder {
     /// so per-partition construction doesn't pay the copy cost twice
     /// (once here, once during the per-layer recursion).
     pub fn build_from_hashes_owned(&self, hashes: Vec<u64>) -> Result<BurrFilter, BurrBuildError> {
+        self.build_layers(hashes, None)
+    }
+
+    /// Build a *retrieval* BuRR from pre-computed key hashes plus a parallel
+    /// slice of r-bit locators. Where [`Self::build_from_hashes`] stores a
+    /// hash-derived membership fingerprint per key, this stores `locators[i]`
+    /// as the value recovered for `hashes[i]`.
+    ///
+    /// A later [`BurrFilter::recover_value`] query returns the exact locator
+    /// for a key in the set; for an absent key it returns an unspecified
+    /// r-bit value, which the caller distinguishes by verifying the key at
+    /// the located slot (the locate step subsumes the membership check).
+    ///
+    /// # Errors
+    /// - `InvalidParams` if `hashes` is empty, `hashes.len() != locators.len()`,
+    ///   or any locator does not fit in `r` bits.
+    /// - `RibbonLayerFailed` / `LayerExhaustion` on a construction failure
+    ///   (same conditions as [`Self::build_from_hashes`]).
+    pub fn build_from_hashes_with_values(
+        &self,
+        hashes: &[u64],
+        locators: &[u64],
+    ) -> Result<BurrFilter, BurrBuildError> {
+        if hashes.len() != locators.len() {
+            return Err(BurrBuildError::InvalidParams(
+                "hashes and locators must have equal length",
+            ));
+        }
+        // A locator wider than r bits would be silently truncated by the
+        // ribbon and resolve to the wrong block/slot. Reject loudly at build
+        // time rather than mis-locating at read time.
+        let value_mask = if self.params.r == 64 {
+            u64::MAX
+        } else {
+            (1u64 << self.params.r) - 1
+        };
+        if locators.iter().any(|&loc| loc & !value_mask != 0) {
+            return Err(BurrBuildError::InvalidParams(
+                "locator does not fit in r bits",
+            ));
+        }
+        self.build_layers(hashes.to_vec(), Some(locators.to_vec()))
+    }
+
+    /// Shared layer-recursion driver for both the membership build
+    /// (`values = None`, RHS = hash fingerprint) and the retrieval build
+    /// (`values = Some`, RHS = caller locator). Keeping one loop means the
+    /// threshold / partition / per-layer sizing logic cannot diverge between
+    /// the two filter flavours.
+    fn build_layers(
+        &self,
+        hashes: Vec<u64>,
+        values: Option<Vec<u64>>,
+    ) -> Result<BurrFilter, BurrBuildError> {
         // Empty input would produce a zero-layer filter that
         // `to_wire_bytes` correctly serialises as an empty Vec, but
         // `BurrFilterReader::new` rejects num_layers == 0 — so the
@@ -113,6 +167,7 @@ impl BurrBuilder {
             return Err(BurrBuildError::InvalidParams("key set must be non-empty"));
         }
         let mut remaining: Vec<u64> = hashes;
+        let mut remaining_values: Option<Vec<u64>> = values;
         let mut layers: Vec<BurrLayer> = Vec::with_capacity(usize::from(self.params.max_layers));
 
         for layer_idx in 0..self.params.max_layers {
@@ -160,9 +215,6 @@ impl BurrBuilder {
                 compute_thresholds(&equations, m, self.params.b)
             };
 
-            let (kept, bumped) =
-                partition_keys_by_threshold(&remaining, &equations, &thresholds, self.params.b);
-
             let ribbon_builder = RibbonBuilder::new(equation_params).map_err(|e| {
                 BurrBuildError::RibbonLayerFailed {
                     layer_index: usize::from(layer_idx),
@@ -170,21 +222,64 @@ impl BurrBuilder {
                 }
             })?;
 
-            let ribbon = ribbon_builder
-                .build_with_seed_verbatim_from_hashes(&kept, layer_seed, m)
-                .map_err(|e| BurrBuildError::RibbonLayerFailed {
-                    layer_index: usize::from(layer_idx),
-                    ribbon_error: e,
-                })?;
+            // Partition the layer input into kept (built here) and bumped
+            // (forwarded to the next layer). For the retrieval build each
+            // locator travels with its key through the partition so the
+            // bumped set carries the right values; build the ribbon over the
+            // kept locators. For the membership build the RHS is the hash
+            // fingerprint, so no values ride along.
+            let (kept_ribbon, bumped_values) = match &remaining_values {
+                None => {
+                    let (kept, bumped) = partition_keys_by_threshold(
+                        &remaining,
+                        &equations,
+                        &thresholds,
+                        self.params.b,
+                    );
+                    let ribbon = ribbon_builder
+                        .build_with_seed_verbatim_from_hashes(&kept, layer_seed, m)
+                        .map_err(|e| BurrBuildError::RibbonLayerFailed {
+                            layer_index: usize::from(layer_idx),
+                            ribbon_error: e,
+                        })?;
+                    remaining = bumped;
+                    (ribbon, None)
+                }
+                Some(vals) => {
+                    let pairs: Vec<(u64, u64)> = remaining
+                        .iter()
+                        .copied()
+                        .zip(vals.iter().copied())
+                        .collect();
+                    let (kept, bumped) =
+                        partition_keys_by_threshold(&pairs, &equations, &thresholds, self.params.b);
+                    let (kept_hashes, kept_values): (Vec<u64>, Vec<u64>) = kept.into_iter().unzip();
+                    let (bumped_hashes, bumped_vals): (Vec<u64>, Vec<u64>) =
+                        bumped.into_iter().unzip();
+                    let ribbon = ribbon_builder
+                        .build_with_seed_verbatim_from_values(
+                            &kept_hashes,
+                            &kept_values,
+                            layer_seed,
+                            m,
+                        )
+                        .map_err(|e| BurrBuildError::RibbonLayerFailed {
+                            layer_index: usize::from(layer_idx),
+                            ribbon_error: e,
+                        })?;
+                    remaining = bumped_hashes;
+                    (ribbon, Some(bumped_vals))
+                }
+            };
 
             layers.push(BurrLayer {
                 m,
                 seed: layer_seed,
                 thresholds,
-                ribbon,
+                ribbon: kept_ribbon,
             });
 
-            remaining = bumped;
+            remaining_values = bumped_values;
         }
 
         if !remaining.is_empty() {

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -35,20 +35,55 @@ impl core::fmt::Debug for BurrLayer {
     }
 }
 
+/// Whether a built BuRR stores membership fingerprints (probe → bool) or
+/// caller-supplied locators (recover → value).
+///
+/// Recorded in the wire header as the `filter_type` byte so a retrieval
+/// filter can never be mis-queried as a membership filter (or vice versa):
+/// the membership decoders accept only [`Membership`], the retrieval
+/// recover path only [`Retrieval`]. This is a new tag within the existing
+/// wire `FORMAT_VERSION`, not a version bump.
+///
+/// [`Membership`]: BurrFilterKind::Membership
+/// [`Retrieval`]: BurrFilterKind::Retrieval
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BurrFilterKind {
+    /// RHS = hash-derived fingerprint; query compares and yields presence.
+    Membership,
+    /// RHS = caller locator; query recovers and yields the stored value.
+    Retrieval,
+}
+
 /// A built, queryable BuRR filter.
 ///
 /// Layers are tried in order on each probe: layer 0 first, then layer 1
-/// (the bumped-from-layer-0 set), etc. A key is "present" if any layer's
-/// Ribbon body reports a match. False positives carry the FPR ≈ 2⁻ʳ of
-/// the underlying Ribbon layers.
+/// (the bumped-from-layer-0 set), etc. A membership filter reports a key
+/// "present" if any layer's Ribbon body matches (FPR ≈ 2⁻ʳ); a retrieval
+/// filter recovers the stored locator at the first non-bumped layer.
 pub struct BurrFilter {
     params: BurrParams,
+    kind: BurrFilterKind,
     layers: Vec<BurrLayer>,
 }
 
 impl BurrFilter {
-    pub(crate) fn from_layers(params: BurrParams, layers: Vec<BurrLayer>) -> Self {
-        Self { params, layers }
+    pub(crate) fn from_layers(
+        params: BurrParams,
+        kind: BurrFilterKind,
+        layers: Vec<BurrLayer>,
+    ) -> Self {
+        Self {
+            params,
+            kind,
+            layers,
+        }
+    }
+
+    /// Whether this filter stores membership fingerprints or retrieval
+    /// locators. The wire encoder maps it to the `filter_type` byte.
+    #[must_use]
+    pub(crate) fn kind(&self) -> BurrFilterKind {
+        self.kind
     }
 
     /// Returns the layer count after construction. Useful for diagnostics
@@ -270,6 +305,28 @@ pub struct BurrFilterReader<'a> {
 #[inline]
 pub fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result<bool> {
     super::wire::contains_hash_from_bytes(bytes, hash)
+}
+
+/// Single-pass parse + locator recovery over a wire-format *retrieval* BuRR
+/// (one serialized from a filter built via
+/// [`BurrBuilder::build_from_hashes_with_values`]).
+///
+/// The retrieval counterpart of [`contains_hash_from_bytes`]: accepts only a
+/// retrieval payload and returns the r-bit locator stored for `hash`.
+/// `Ok(Some(locator))` is the value at the first non-bumped layer (exact for
+/// a key in the set, unspecified for an absent key — the caller verifies the
+/// key at the located slot); `Ok(None)` means the ribbon cannot answer (all
+/// layers bumped, or a truncated payload) and the caller should fall back to
+/// the sorted index.
+///
+/// # Errors
+/// Returns `InvalidHeader` / `InvalidTag` if the wire prefix is unparseable
+/// or is not a retrieval payload (e.g. a membership filter).
+///
+/// [`BurrBuilder::build_from_hashes_with_values`]: super::builder::BurrBuilder::build_from_hashes_with_values
+#[inline]
+pub fn recover_value_from_bytes(bytes: &[u8], hash: u64) -> crate::Result<Option<u64>> {
+    super::wire::recover_value_from_bytes(bytes, hash)
 }
 
 impl<'a> BurrFilterReader<'a> {

--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -160,6 +160,75 @@ impl BurrFilter {
         }
         false
     }
+
+    /// Recover the r-bit value stored for `hash` in a *retrieval* BuRR
+    /// (one built via [`BurrBuilder::build_from_hashes_with_values`]).
+    ///
+    /// For a key in the built set this returns its exact stored value
+    /// (`Some(locator)`); for an absent key it returns an unspecified r-bit
+    /// value, so the caller must verify the key at the located slot to reject
+    /// absent keys — the locate step subsumes the membership probe. Returns
+    /// `None` only if no layer can answer (every layer bumps the key), which
+    /// a well-formed build never produces since the final layer accepts all.
+    ///
+    /// [`BurrBuilder::build_from_hashes_with_values`]: super::builder::BurrBuilder::build_from_hashes_with_values
+    #[inline]
+    #[must_use]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "Same bounds invariant as `contains_hash`: start ∈ [0, m-w] and every set-bit \
+                  offset ∈ [0, w-1], so `z_words[start + offset]` is `< m = z_words.len()`. A \
+                  per-row `.get()` would add a branch on the locate hot path."
+    )]
+    pub fn recover_value(&self, hash: u64) -> Option<u64> {
+        debug_assert!(self.params.r <= 64, "BuRR params pin r <= 64");
+        let value_mask = if self.params.r == 64 {
+            u64::MAX
+        } else {
+            (1u64 << self.params.r) - 1
+        };
+        let mut fingerprint_buf = [0_u64; 1];
+        for layer in &self.layers {
+            let layer_params = match Params::new(
+                layer.m,
+                usize::from(self.params.w),
+                usize::from(self.params.r),
+                Mode::Standard,
+            ) {
+                Ok(p) => p.with_seed(layer.seed),
+                // Layer params were valid at build time → unreachable.
+                Err(_) => return None,
+            };
+
+            fingerprint_buf[0] = 0;
+            let equation =
+                standard_equation_from_hash(hash, layer.seed, &layer_params, &mut fingerprint_buf);
+
+            // The first layer that does NOT bump this key is the layer that
+            // holds it (the builder kept it at exactly that layer). Same
+            // routing as `contains_hash`.
+            if is_bumped(&equation, &layer.thresholds, self.params.b) {
+                continue;
+            }
+
+            // GF(2) XOR-reduce recovers the stored RHS = the locator.
+            let z_words = layer.ribbon.z_raw_words();
+            let mut acc: u64 = 0;
+            let mut lo = equation.coeff_lo;
+            while lo != 0 {
+                let offset = lo.trailing_zeros() as usize;
+                acc ^= z_words[equation.start + offset];
+                lo &= lo - 1;
+            }
+            debug_assert_eq!(
+                equation.coeff_hi, 0,
+                "BuRR builds with w <= 64; coeff_hi must be 0",
+            );
+
+            return Some(acc & value_mask);
+        }
+        None
+    }
 }
 
 impl core::fmt::Debug for BurrFilter {

--- a/src/table/filter/ribbon/burr/mod.rs
+++ b/src/table/filter/ribbon/burr/mod.rs
@@ -81,7 +81,9 @@ pub(crate) mod wire;
 
 pub use builder::BurrBuilder;
 pub use error::{BurrBuildError, BurrConstructionFailure};
-pub use filter::{BurrFilter, BurrFilterReader, contains_hash_from_bytes};
+pub use filter::{
+    BurrFilter, BurrFilterReader, contains_hash_from_bytes, recover_value_from_bytes,
+};
 pub use params::BurrParams;
 
 #[cfg(test)]

--- a/src/table/filter/ribbon/burr/tests.rs
+++ b/src/table/filter/ribbon/burr/tests.rs
@@ -1096,3 +1096,127 @@ fn retrieval_ribbon_full_width_locator_round_trips() {
         );
     }
 }
+
+#[test]
+fn retrieval_ribbon_wire_round_trips_recover_value() {
+    // Serialize a retrieval ribbon and recover locators straight from the
+    // wire bytes — the on-disk read path. Must match the in-memory query.
+    use super::filter::recover_value_from_bytes;
+
+    let n = 1_000_usize;
+    let params = retrieval_params(n, 24.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = (0..n as u64).collect();
+
+    let filter = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build");
+    let bytes = filter.to_wire_bytes();
+
+    for (i, h) in hashes.iter().enumerate() {
+        assert_eq!(
+            recover_value_from_bytes(&bytes, *h).expect("recover"),
+            Some(locators[i]),
+            "wire recover for key {i} disagrees with stored locator",
+        );
+        // Wire and in-memory recovery must agree exactly.
+        assert_eq!(
+            recover_value_from_bytes(&bytes, *h).expect("recover"),
+            filter.recover_value(*h),
+            "wire vs in-memory recovery diverged for key {i}",
+        );
+    }
+}
+
+#[test]
+fn recover_value_from_bytes_rejects_membership_filter() {
+    // A membership filter (tag 2) must not be recoverable as a retrieval
+    // ribbon — the locate path would otherwise return fingerprint garbage as
+    // a locator. The tag guard rejects it instead.
+    use super::filter::recover_value_from_bytes;
+
+    let params = BurrParams::with_fp_rate(64, 0.01).expect("params");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..64_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let filter = builder.build_from_hashes(&hashes).expect("build");
+    let bytes = filter.to_wire_bytes();
+
+    let err = recover_value_from_bytes(&bytes, hashes[0]).expect_err("membership tag must reject");
+    assert!(
+        matches!(err, crate::Error::InvalidTag(("FilterType", 2))),
+        "expected InvalidTag(FilterType, 2), got: {err:?}",
+    );
+}
+
+#[test]
+fn contains_hash_from_bytes_rejects_retrieval_filter() {
+    // Symmetric guard: a retrieval ribbon (tag 3) must not be probed for
+    // membership — the stored locators are not fingerprints.
+    use super::filter::contains_hash_from_bytes;
+
+    let n = 64_usize;
+    let params = retrieval_params(n, 16.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = (0..n as u64).collect();
+    let filter = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build");
+    let bytes = filter.to_wire_bytes();
+
+    let err = contains_hash_from_bytes(&bytes, hashes[0]).expect_err("retrieval tag must reject");
+    assert!(
+        matches!(err, crate::Error::InvalidTag(("FilterType", 3))),
+        "expected InvalidTag(FilterType, 3), got: {err:?}",
+    );
+}
+
+#[test]
+fn membership_wire_bytes_keep_filter_type_two() {
+    // The membership wire payload is unchanged by the retrieval-tag work:
+    // the filter_type byte at the MAGIC offset stays 2, so existing on-disk
+    // filter blocks remain byte-identical (no format-version bump).
+    let params = BurrParams::with_fp_rate(64, 0.01).expect("params");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..64_u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let bytes = builder
+        .build_from_hashes(&hashes)
+        .expect("build")
+        .to_wire_bytes();
+    assert_eq!(
+        bytes[crate::file::MAGIC_BYTES.len()],
+        2,
+        "membership filter_type tag must stay 2",
+    );
+}
+
+#[test]
+fn retrieval_wire_bytes_use_filter_type_three() {
+    // The retrieval payload is tagged 3 (a new tag in the same wire version),
+    // so it is distinguishable from membership without a version bump.
+    let n = 64_usize;
+    let params = retrieval_params(n, 16.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = (0..n as u64).collect();
+    let bytes = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build")
+        .to_wire_bytes();
+    assert_eq!(
+        bytes[crate::file::MAGIC_BYTES.len()],
+        3,
+        "retrieval filter_type tag must be 3",
+    );
+}

--- a/src/table/filter/ribbon/burr/tests.rs
+++ b/src/table/filter/ribbon/burr/tests.rs
@@ -940,3 +940,159 @@ fn burr_filter_debug_includes_layer_count() {
     assert!(debug.contains("BurrFilter"), "got: {debug}");
     assert!(debug.contains("layer_count"), "got: {debug}");
 }
+
+// ---- Retrieval ribbon (key -> r-bit locator) ----------------------------
+//
+// The retrieval ribbon reuses the membership BuRR solve but stores a
+// caller-supplied locator as the RHS instead of a hash fingerprint, so a
+// query recovers the exact locator for a key in the set. These tests pin
+// the core viability claim of the O(1) point-read design: `coeff . solution
+// = locator` round-trips for every inserted key, across single and multiple
+// layers, with build-time rejection of malformed input.
+
+/// Helper: r-bit params with an explicit fingerprint width (= locator
+/// width). `with_bpk` maps the bits-per-key target directly to `r`.
+fn retrieval_params(n: usize, r_bits: f32) -> BurrParams {
+    BurrParams::with_bpk(n, r_bits).expect("valid retrieval params")
+}
+
+#[test]
+fn retrieval_ribbon_recovers_exact_locator_for_present_keys() {
+    // Each key i stores a distinct locator i (the realistic block_id|slot
+    // case). Every inserted key must recover its exact locator.
+    let n = 1_000_usize;
+    let params = retrieval_params(n, 24.0); // 24-bit locator space (16M)
+    assert_eq!(params.r, 24, "with_bpk(_, 24.0) must pin r = 24");
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = (0..n as u64).collect();
+
+    let filter = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build");
+
+    for (i, h) in hashes.iter().enumerate() {
+        assert_eq!(
+            filter.recover_value(*h),
+            Some(locators[i]),
+            "key {i} recovered the wrong locator",
+        );
+    }
+}
+
+#[test]
+fn retrieval_ribbon_multi_layer_recovers_all_locators() {
+    // A large key set forces keys to bump across multiple BuRR layers. The
+    // locator must travel with its key through every bump, so recovery stays
+    // exact regardless of which layer ends up holding the key.
+    let n = 20_000_usize;
+    let params = retrieval_params(n, 32.0); // 32-bit locator space
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    // Spread locators across the 32-bit space so a layer-mix-up would
+    // surface as a wrong value, not an accidental match.
+    let locators: Vec<u64> = (0..n as u64)
+        .map(|i| i.wrapping_mul(2_654_435_761) & 0xFFFF_FFFF)
+        .collect();
+
+    let filter = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build");
+    assert!(
+        filter.layer_count() >= 2,
+        "n={n} should bump across >=2 layers; got {}",
+        filter.layer_count(),
+    );
+
+    for (i, h) in hashes.iter().enumerate() {
+        assert_eq!(
+            filter.recover_value(*h),
+            Some(locators[i]),
+            "key {i} recovered the wrong locator across layers",
+        );
+    }
+}
+
+#[test]
+fn build_from_hashes_with_values_rejects_oversized_locator() {
+    // r = 16 bits → max locator 2^16 - 1. A locator of 2^16 overflows and
+    // would be silently truncated to 0; the build must reject it instead.
+    let n = 8_usize;
+    let params = retrieval_params(n, 16.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let mut locators: Vec<u64> = vec![1; n];
+    locators[3] = 1 << 16; // one bit past the 16-bit ceiling
+
+    let err = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect_err("oversized locator must reject");
+    assert!(
+        format!("{err}").contains("locator does not fit in r bits"),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn build_from_hashes_with_values_rejects_length_mismatch() {
+    let n = 8_usize;
+    let params = retrieval_params(n, 16.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = vec![1; n - 1]; // one short
+
+    let err = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect_err("length mismatch must reject");
+    assert!(format!("{err}").contains("equal length"), "got: {err}",);
+}
+
+#[test]
+fn build_from_hashes_with_values_rejects_empty_input() {
+    let params = retrieval_params(8, 16.0);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let err = builder
+        .build_from_hashes_with_values(&[], &[])
+        .expect_err("empty input must reject");
+    assert!(
+        format!("{err}").contains("key set must be non-empty"),
+        "got: {err}",
+    );
+}
+
+#[test]
+fn retrieval_ribbon_full_width_locator_round_trips() {
+    // r = 64: the locator occupies the whole word, so the value mask is
+    // u64::MAX. Exercises the `r == 64` branch of both the build-time bounds
+    // check and the recovery mask.
+    let n = 256_usize;
+    let params = retrieval_params(n, 64.0);
+    assert_eq!(params.r, 64);
+    let builder = BurrBuilder::new(params).expect("builder");
+    let hashes: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_le_bytes()))
+        .collect();
+    let locators: Vec<u64> = (0..n as u64)
+        .map(|i| crate::hash::hash64(&i.to_be_bytes())) // full 64-bit values
+        .collect();
+
+    let filter = builder
+        .build_from_hashes_with_values(&hashes, &locators)
+        .expect("retrieval build");
+
+    for (i, h) in hashes.iter().enumerate() {
+        assert_eq!(
+            filter.recover_value(*h),
+            Some(locators[i]),
+            "full-width key {i} recovered the wrong locator",
+        );
+    }
+}

--- a/src/table/filter/ribbon/burr/wire.rs
+++ b/src/table/filter/ribbon/burr/wire.rs
@@ -53,10 +53,18 @@ use super::filter::BurrFilter;
 use super::threshold::is_bumped;
 use crate::file::MAGIC_BYTES;
 
-/// Wire-format identifier for the BuRR filter. Distinct from the legacy
-/// bloom values (0 = StandardBloom, 1 = BlockedBloom — both retired
-/// alongside this rollout in task #17/#18); 2 is the new BuRR slot.
+/// Wire-format identifier for the membership BuRR filter. Distinct from
+/// the legacy bloom values (0 = StandardBloom, 1 = BlockedBloom, both
+/// retired); 2 is the BuRR membership slot.
 pub(crate) const BURR_FILTER_TYPE_BYTE: u8 = 2;
+
+/// Wire-format identifier for a retrieval BuRR (key → locator). Structurally
+/// identical to the membership payload — same header, same per-layer z words
+/// — but the stored RHS is a caller locator, so it answers
+/// [`recover_value_from_bytes`] rather than `contains_hash_from_bytes`. A new
+/// tag within the same `FORMAT_VERSION`, NOT a version bump: membership
+/// readers reject it as a wrong-type tag, retrieval readers reject tag 2.
+pub(crate) const BURR_RETRIEVAL_TYPE_BYTE: u8 = 3;
 
 /// Format version. Bumped if/when the wire layout changes
 /// incompatibly. Readers reject mismatched versions explicitly.
@@ -83,11 +91,18 @@ pub(crate) fn encode(filter: &BurrFilter) -> Vec<u8> {
             .sum::<usize>();
     let mut buf = Vec::with_capacity(estimated_size);
 
-    // Header.
+    // Header. The filter_type tag distinguishes a membership payload
+    // (probe → bool) from a retrieval payload (recover → locator); both
+    // share the rest of the layout. A membership filter writes tag 2
+    // verbatim, so existing on-disk output is byte-identical.
+    let filter_type_byte = match filter.kind() {
+        super::filter::BurrFilterKind::Membership => BURR_FILTER_TYPE_BYTE,
+        super::filter::BurrFilterKind::Retrieval => BURR_RETRIEVAL_TYPE_BYTE,
+    };
     buf.extend_from_slice(&MAGIC_BYTES);
     #[expect(clippy::expect_used, reason = "writing to a Vec<u8> cannot fail")]
     {
-        buf.write_u8(BURR_FILTER_TYPE_BYTE).expect("vec write");
+        buf.write_u8(filter_type_byte).expect("vec write");
         buf.write_u8(FORMAT_VERSION).expect("vec write");
         buf.write_u8(params.r).expect("vec write");
         buf.write_u8(params.w).expect("vec write");
@@ -334,24 +349,38 @@ pub(crate) fn decode(bytes: &[u8]) -> crate::Result<DecodedFilter<'_>> {
     })
 }
 
-/// Single-pass parse + probe over raw wire bytes.
+/// Outcome of walking a wire-format BuRR to the layer that holds `hash`
+/// (the first layer whose per-block threshold does not bump it).
 ///
-/// Equivalent to `decode(bytes).map(|d| contains_hash(&d, hash))` but
-/// without allocating the intermediate `DecodedFilter` (and its
-/// `Vec<LayerView>`). Used on the LSM table read hot path
-/// (`FilterBlock::maybe_contains_hash`) where the wire buffer is
-/// already in the block cache — re-parsing the header and walking
-/// per-layer payloads in place avoids the per-probe heap allocation.
-///
-/// Returns:
-/// - `Ok(true)`  — hash may be present (or wire is corrupted in a way
-///   we cannot validate → fail-closed: caller falls through to a real
-///   index lookup rather than reporting a false negative);
-/// - `Ok(false)` — hash is definitely not in the inserted set;
-/// - `Err(InvalidHeader)` — wire prefix is unparseable (bad magic,
-///   wrong filter_type/version, truncated). Differs from the
-///   fail-closed `true` path: a structurally invalid header is a real
-///   error returned upstream so the table read path can surface it.
+/// The header + per-layer bounds parsing is byte-for-byte identical for the
+/// membership probe and the retrieval recover, and it is security-sensitive
+/// (every slice is gated by a checked length / `checked_add` endpoint).
+/// Sharing it in [`walk_first_layer`] keeps that parsing in ONE place so the
+/// two query paths cannot drift on the bounds checks; each caller only
+/// interprets the terminal `acc`.
+enum FirstLayerWalk {
+    /// `hash` is kept at some layer: `acc` is the GF(2) dot-product over
+    /// that layer's z rows (the recovered r-bit RHS — already masked to r
+    /// bits because the builder masks every stored z row); `fingerprint` is
+    /// the hash-derived fingerprint recomputed for the membership compare.
+    Found { acc: u64, fingerprint: u64 },
+    /// Every layer bumped `hash`. For a membership filter that is
+    /// definitely-absent; normally unreachable since the last layer accepts
+    /// all keys.
+    AllBumped,
+    /// A layer's z payload was truncated mid-row past the header-validated
+    /// lengths (structure parsed, but a row slice is short). The caller
+    /// fail-closes (membership → possibly-present; retrieval → fall back to
+    /// the sorted index).
+    Truncated,
+}
+
+/// Parse a wire-format BuRR header (rejecting a wrong `expected_type`) and
+/// walk per-layer payloads in place to the first non-bumped layer, returning
+/// its dot-product `acc` and recomputed fingerprint. No allocation — used on
+/// the LSM table read hot path where the wire buffer is already in the block
+/// cache, so re-parsing in place avoids the per-probe heap allocation an
+/// intermediate `DecodedFilter` would cost.
 #[inline]
 #[expect(
     clippy::many_single_char_names,
@@ -363,13 +392,12 @@ pub(crate) fn decode(bytes: &[u8]) -> crate::Result<DecodedFilter<'_>> {
               length check: bytes[..MAGIC_BYTES.len()] and the per-byte \
               MAGIC_BYTES.len() + N reads are gated by `bytes.len() < HEADER_LEN` \
               on the line above (HEADER_LEN >= MAGIC_BYTES.len() + 6 + 8); \
-              the bytes[seed_off..seed_off+8] window is bounded by HEADER_LEN. \
-              Replacing with .get(..).ok_or(...) would multiply the function's \
-              error-return paths without improving safety — and this function \
-              is on the read-path hot loop, so the explicit pre-check + raw \
-              indexing avoids per-field Option unwrapping."
+              the bytes[seed_off..seed_off+8] window is bounded by HEADER_LEN; \
+              per-layer windows are gated by checked_add endpoints + \
+              `bytes.len() < ...`. Raw indexing avoids per-field Option \
+              unwrapping on the read hot loop."
 )]
-pub(crate) fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result<bool> {
+fn walk_first_layer(bytes: &[u8], hash: u64, expected_type: u8) -> crate::Result<FirstLayerWalk> {
     if bytes.len() < HEADER_LEN {
         return Err(crate::Error::InvalidHeader("BurrFilter"));
     }
@@ -378,7 +406,7 @@ pub(crate) fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result
         return Err(crate::Error::InvalidHeader("BurrFilter"));
     }
     let filter_type = bytes[MAGIC_BYTES.len()];
-    if filter_type != BURR_FILTER_TYPE_BYTE {
+    if filter_type != expected_type {
         return Err(crate::Error::InvalidTag(("FilterType", filter_type)));
     }
     let version = bytes[MAGIC_BYTES.len() + 1];
@@ -480,20 +508,71 @@ pub(crate) fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result
             let row_byte = (equation.start + offset) * 8;
             let Some(slice) = z.get(row_byte..row_byte + 8) else {
                 // row_byte+8 > z len: payload truncated mid-row.
-                // Fail closed.
-                return Ok(true);
+                return Ok(FirstLayerWalk::Truncated);
             };
             let Ok(arr) = <[u8; 8]>::try_from(slice) else {
-                return Ok(true);
+                return Ok(FirstLayerWalk::Truncated);
             };
             acc ^= u64::from_le_bytes(arr);
             lo &= lo - 1;
         }
         debug_assert_eq!(equation.coeff_hi, 0, "w <= 64 keeps coeff_hi == 0");
-        return Ok(acc == fingerprint);
+        return Ok(FirstLayerWalk::Found { acc, fingerprint });
     }
 
-    Ok(false)
+    Ok(FirstLayerWalk::AllBumped)
+}
+
+/// Single-pass parse + membership probe over raw wire bytes.
+///
+/// Used on the LSM table read hot path (`FilterBlock::maybe_contains_hash`)
+/// where the wire buffer is already in the block cache.
+///
+/// Returns:
+/// - `Ok(true)`  — hash may be present (or wire is corrupted in a way we
+///   cannot validate → fail-closed: caller falls through to a real index
+///   lookup rather than reporting a false negative);
+/// - `Ok(false)` — hash is definitely not in the inserted set;
+/// - `Err(InvalidHeader)` / `Err(InvalidTag)` — wire prefix is unparseable
+///   (bad magic, wrong filter_type/version, truncated). Differs from the
+///   fail-closed `true` path: a structurally invalid header is a real error
+///   returned upstream so the table read path can surface it.
+#[inline]
+pub(crate) fn contains_hash_from_bytes(bytes: &[u8], hash: u64) -> crate::Result<bool> {
+    match walk_first_layer(bytes, hash, BURR_FILTER_TYPE_BYTE)? {
+        FirstLayerWalk::Found { acc, fingerprint } => Ok(acc == fingerprint),
+        FirstLayerWalk::AllBumped => Ok(false),
+        // Truncated payload → fail closed: report possibly-present so the
+        // table read path falls through to a real index lookup rather than
+        // a false negative on substituted zeros.
+        FirstLayerWalk::Truncated => Ok(true),
+    }
+}
+
+/// Single-pass parse + locator recovery over raw retrieval-BuRR wire bytes.
+///
+/// The retrieval counterpart of [`contains_hash_from_bytes`]: it accepts only
+/// a retrieval payload (filter_type tag [`BURR_RETRIEVAL_TYPE_BYTE`]) and
+/// recovers the r-bit locator stored for `hash`.
+///
+/// Returns:
+/// - `Ok(Some(locator))` — the value recovered at the first non-bumped layer.
+///   For a key in the built set this is its exact stored locator; for an
+///   absent key it is an unspecified r-bit value, so the caller MUST verify
+///   the key at the located slot (the locate step subsumes membership).
+/// - `Ok(None)` — the ribbon cannot answer (every layer bumped the key, or a
+///   payload was truncated mid-row): the caller falls back to the sorted
+///   index.
+/// - `Err(InvalidHeader)` / `Err(InvalidTag)` — the wire prefix is
+///   unparseable or is not a retrieval payload (e.g. a membership tag 2).
+#[inline]
+pub(crate) fn recover_value_from_bytes(bytes: &[u8], hash: u64) -> crate::Result<Option<u64>> {
+    // `acc` is already masked to r bits (the builder masks every stored z
+    // row to the fingerprint width), so no extra masking is needed here.
+    match walk_first_layer(bytes, hash, BURR_RETRIEVAL_TYPE_BYTE)? {
+        FirstLayerWalk::Found { acc, .. } => Ok(Some(acc)),
+        FirstLayerWalk::AllBumped | FirstLayerWalk::Truncated => Ok(None),
+    }
 }
 
 /// Probe a decoded BuRR filter with a pre-computed hash. Returns

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -83,14 +83,6 @@ pub struct KeyedBlockHandle {
     /// Seqno of last item in block
     seqno: SeqNo,
 
-    /// Per-block seqno bounds `(min, max)` for the referenced data block.
-    /// `Some` ⇒ this index entry uses the seqno-bounded wire format (markers
-    /// 2 / 3), letting a seqno-scoped scan skip a data block whose `max` is
-    /// below the target without reading it; `None` ⇒ legacy entry (markers
-    /// 0 / 1, no bounds on disk). The writer sets this uniformly per SST from
-    /// the runtime config; the decoder populates it from the on-disk marker.
-    seqno_bounds: Option<(SeqNo, SeqNo)>,
-
     inner: BlockHandle,
 }
 
@@ -111,46 +103,13 @@ impl KeyedBlockHandle {
         Self {
             end_key,
             seqno,
-            seqno_bounds: None,
             inner: handle,
         }
-    }
-
-    /// Attaches per-block seqno bounds `(min, max)`, switching this handle to
-    /// the seqno-bounded wire format (markers 2 / 3) when encoded.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `seqno_min > seqno_max`. Inverted bounds are
-    /// a caller invariant violation (the writer derives them from a single
-    /// min/max fold over the block, so it cannot produce them); encoding an
-    /// inverted pair would let a seqno-scoped scan skip a block that still
-    /// holds visible entries. Corruption arriving from disk is rejected
-    /// separately on the decode path (`parse_full` / `parse_truncated`).
-    #[must_use]
-    pub fn with_seqno_bounds(mut self, seqno_min: SeqNo, seqno_max: SeqNo) -> Self {
-        debug_assert!(
-            seqno_min <= seqno_max,
-            "inverted seqno bounds: min {seqno_min} > max {seqno_max}",
-        );
-        self.seqno_bounds = Some((seqno_min, seqno_max));
-        self
     }
 
     #[must_use]
     pub fn seqno(&self) -> SeqNo {
         self.seqno
-    }
-
-    /// Per-block seqno bounds `(min, max)` if this entry uses the
-    /// seqno-bounded wire format (markers 2 / 3), else `None` (legacy entry).
-    ///
-    /// A seqno-scoped scan skips the referenced data block without reading it
-    /// when `max < target`; `None` means the bounds are unavailable on disk and
-    /// the caller must fall back to reading and filtering the block.
-    #[must_use]
-    pub fn seqno_bounds(&self) -> Option<(SeqNo, SeqNo)> {
-        self.seqno_bounds
     }
 
     pub fn shift(&mut self, delta: BlockOffset) {
@@ -186,28 +145,18 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         writer: &mut W,
         state: &mut BlockOffset,
     ) -> crate::Result<()> {
-        // Legacy full entry (marker 0):
+        // Full entry (marker 0):
         // [marker=0] [offset] [size] [seqno] [key len] [end key]
         // 1          2        3      4       5         6
         //
-        // Seqno-bounded full entry (marker 2): same, with per-block seqno
-        // bounds inserted right after [seqno]:
-        // [marker=2] [offset] [size] [seqno] [seqno min] [seqno max] [key len] [end key]
-        // 1          2        3      4       4a          4b          5         6
-
-        match self.seqno_bounds {
-            None => writer.write_u8(0)?, // 1
-            Some(_) => writer.write_u8(2)?,
-        }
+        // Per-block seqno bounds are NOT stored inline; they live in the
+        // optional parallel `seqno_bounds` section keyed by block offset, so a
+        // point read never pays for them. See `crate::table::seqno_bounds`.
+        writer.write_u8(0)?; // 1
 
         self.inner.encode_into(writer)?; // 2, 3
 
         writer.write_u64_varint(self.seqno)?; // 4
-
-        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
-            writer.write_u64_varint(seqno_min)?; // 4a
-            writer.write_u64_varint(seqno_max)?; // 4b
-        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(self.end_key.len() as u16)?; // 5
@@ -225,24 +174,16 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         _state: &mut BlockOffset,
         shared_len: usize,
     ) -> crate::Result<()> {
-        // Legacy truncated entry (marker 1):
+        // Truncated entry (marker 1):
         // [marker=1] [offset] [size] [seqno] [shared prefix len] [rest key len] [rest key]
         // 1          2        3      4       5                   6              7
         //
-        // Seqno-bounded truncated entry (marker 3): same, with per-block seqno
-        // bounds inserted right after [seqno].
-        match self.seqno_bounds {
-            None => writer.write_u8(1)?,
-            Some(_) => writer.write_u8(3)?,
-        }
+        // Per-block seqno bounds live in the parallel `seqno_bounds` section,
+        // never inline (see `encode_full_into`).
+        writer.write_u8(1)?;
 
         self.inner.encode_into(writer)?;
         writer.write_u64_varint(self.seqno)?;
-
-        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
-            writer.write_u64_varint(seqno_min)?;
-            writer.write_u64_varint(seqno_max)?;
-        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(shared_len as u16)?;
@@ -277,30 +218,14 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        // Full entries are marker 0 (legacy) or marker 2 (seqno-bounded).
-        let has_bounds = match marker {
-            0 => false,
-            2 => true,
-            _ => return None,
-        };
+        // Full entries are marker 0. (Seqno bounds are no longer inline; they
+        // live in the parallel `seqno_bounds` section.)
+        if marker != 0 {
+            return None;
+        }
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
-
-        let seqno_bounds = if has_bounds {
-            let seqno_min = reader.read_u64_varint().ok()?;
-            let seqno_max = reader.read_u64_varint().ok()?;
-            // Reject inverted bounds: a forged `seqno_max < seqno_min` would
-            // let a seqno-scoped scan skip a block that still holds visible
-            // entries, silently returning incomplete results. Surface it as a
-            // decode failure instead of propagating bogus bounds.
-            if seqno_min > seqno_max {
-                return None;
-            }
-            Some((seqno_min, seqno_max))
-        } else {
-            None
-        };
 
         let key_len: usize = reader.read_u16_varint().ok()?.into();
         #[expect(
@@ -329,7 +254,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
-            seqno_bounds,
         })
     }
 
@@ -351,12 +275,10 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        // Restart heads are full entries: marker 0 (legacy) or 2 (seqno-bounded).
-        let has_bounds = match marker {
-            0 => false,
-            2 => true,
-            _ => return None,
-        };
+        // Restart heads are full entries: marker 0.
+        if marker != 0 {
+            return None;
+        }
 
         // The binary-search probe only needs `(key, seqno)`, but the block
         // handle (file offset + size) is still decoded so a corrupt restart
@@ -371,19 +293,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         pos = np;
         let (seqno, np) = read_leb128(buf, pos)?;
         pos = np;
-
-        if has_bounds {
-            // The restart key only needs the key, but still reject inverted
-            // bounds (seqno_min > seqno_max) here as `parse_full` /
-            // `parse_truncated` do — a malformed marker-2 head must not feed a
-            // forged entry into restart-table navigation.
-            let (seqno_min, np) = read_leb128(buf, pos)?;
-            let (seqno_max, np2) = read_leb128(buf, np)?;
-            pos = np2;
-            if seqno_min > seqno_max {
-                return None;
-            }
-        }
 
         let (key_len_raw, np) = read_leb128(buf, pos)?;
         pos = np;
@@ -418,28 +327,14 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             return None;
         }
 
-        // Truncated entries are marker 1 (legacy) or marker 3 (seqno-bounded).
-        let has_bounds = match marker {
-            1 => false,
-            3 => true,
-            _ => return None,
-        };
+        // Truncated entries are marker 1. (Seqno bounds live in the parallel
+        // `seqno_bounds` section, never inline.)
+        if marker != 1 {
+            return None;
+        }
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
-
-        let seqno_bounds = if has_bounds {
-            let seqno_min = reader.read_u64_varint().ok()?;
-            let seqno_max = reader.read_u64_varint().ok()?;
-            // Reject inverted bounds (see `parse_full`): a forged
-            // `seqno_max < seqno_min` could drive an incorrect block-skip.
-            if seqno_min > seqno_max {
-                return None;
-            }
-            Some((seqno_min, seqno_max))
-        } else {
-            None
-        };
 
         let shared_prefix_len: usize = reader.read_u16_varint().ok()?.into();
         let rest_key_len: usize = reader.read_u16_varint().ok()?.into();
@@ -486,7 +381,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
-            seqno_bounds,
         })
     }
 }
@@ -642,8 +536,8 @@ mod tests {
     #[test]
     fn parse_truncated_rejects_invalid_marker() {
         let mut bytes = make_truncated_entry(1);
-        // 99 is outside the valid marker set {0 full, 1 truncated, 2 full+bounds,
-        // 3 truncated+bounds, 255 trailer}, so parse_truncated must reject it.
+        // 99 is outside the valid marker set {0 full, 1 truncated, 255 trailer},
+        // so parse_truncated must reject it.
         let invalid_marker = 99u8;
         *bytes.get_mut(0).unwrap() = invalid_marker;
         let offset = 16;
@@ -693,9 +587,9 @@ mod tests {
     }
 
     #[test]
-    fn full_entry_without_bounds_keeps_legacy_marker() {
-        // A handle with no seqno bounds must encode with the legacy full
-        // marker (0) so off-mode SSTs stay byte-identical to the prior layout.
+    fn full_entry_encodes_with_legacy_marker() {
+        // A full index entry encodes with marker 0; seqno bounds are never
+        // inline (they live in the parallel `seqno_bounds` section).
         let bytes = make_full_entry();
         assert_eq!(bytes.first().copied(), Some(0));
 
@@ -706,207 +600,7 @@ mod tests {
             bytes.len(),
         )
         .unwrap();
-        assert_eq!(parsed.seqno_bounds, None);
-    }
-
-    #[test]
-    fn full_entry_with_seqno_bounds_round_trips() {
-        // marker 2: seqno bounds survive an encode -> parse_full round-trip,
-        // and the marker byte switches to the seqno-bounded variant.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        assert_eq!(bytes.first().copied(), Some(2));
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
-            &mut cursor,
-            0,
-            bytes.len(),
-        )
-        .unwrap();
-        assert_eq!(parsed.seqno, 7);
-        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
-        assert_eq!(
-            bytes.get(parsed.end_key.0..parsed.end_key.1).unwrap(),
-            b"abcdef"
-        );
-    }
-
-    #[test]
-    fn full_entry_with_inverted_seqno_bounds_is_rejected() {
-        // A forged entry whose seqno_min > seqno_max must fail to decode, not
-        // propagate bounds that could drive an incorrect seqno block-skip
-        // (skipping a block that still holds visible entries). Build a VALID
-        // (3, 9) entry — `with_seqno_bounds` debug-asserts min <= max — then
-        // swap the two single-byte bound varints on the wire to invert them.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        // Layout: [marker=2][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
-        // all single-byte varints, so the bounds sit at indices 4 and 5.
-        assert_eq!(bytes.first().copied(), Some(2));
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // → seqno_min=9, seqno_max=3 (inverted)
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
-            &mut cursor,
-            0,
-            bytes.len(),
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds (min > max) must be rejected on decode",
-        );
-    }
-
-    #[test]
-    fn truncated_entry_with_inverted_seqno_bounds_is_rejected() {
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle
-            .encode_truncated_into(&mut bytes, &mut state, 2)
-            .unwrap();
-        // Layout: [marker=3][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
-        assert_eq!(bytes.first().copied(), Some(3));
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // invert
-
-        let offset = 16;
-        let entries_end = offset + bytes.len();
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
-            &mut cursor,
-            offset,
-            12,
-            16,
-            entries_end,
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds (min > max) must be rejected on decode",
-        );
-    }
-
-    #[test]
-    fn truncated_entry_with_seqno_bounds_round_trips() {
-        // marker 3: seqno bounds survive an encode -> parse_truncated
-        // round-trip on a truncated (prefix-compressed) entry.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle
-            .encode_truncated_into(&mut bytes, &mut state, 2)
-            .unwrap();
-        assert_eq!(bytes.first().copied(), Some(3));
-
-        let offset = 16;
-        let entries_end = offset + bytes.len();
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
-            &mut cursor,
-            offset,
-            12,
-            16,
-            entries_end,
-        )
-        .unwrap();
-        assert_eq!(parsed.seqno, 7);
-        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
-    }
-
-    #[test]
-    fn parse_restart_key_skips_seqno_bounds_on_marker_2() {
-        // parse_restart_key must step over the two seqno-bounds varints so the
-        // returned restart key is correct for a marker-2 (seqno-bounded) head.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let (key, seqno) =
-            <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
-                &mut cursor,
-                0,
-                bytes.as_slice(),
-                bytes.len(),
-            )
-            .unwrap();
-        assert_eq!(key, b"abcdef");
-        assert_eq!(seqno, 7);
-    }
-
-    #[test]
-    fn parse_restart_key_rejects_inverted_seqno_bounds() {
-        // A marker-2 restart head with seqno_min > seqno_max must be rejected
-        // (like parse_full / parse_truncated), not feed a forged entry into
-        // restart-table navigation. Build valid (3, 9), then swap the two
-        // single-byte bound varints on the wire to invert them.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // invert
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
-            &mut cursor,
-            0,
-            bytes.as_slice(),
-            bytes.len(),
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds must be rejected by parse_restart_key",
-        );
+        assert_eq!(parsed.seqno, 0);
     }
 
     #[test]

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -31,9 +31,6 @@ pub struct IndexBlockParsedItem {
     pub prefix: Option<SliceIndexes>,
     pub end_key: SliceIndexes,
     pub seqno: SeqNo,
-    /// Per-block seqno bounds `(min, max)`, present only for seqno-bounded
-    /// index entries (markers 2 / 3); `None` for legacy entries.
-    pub seqno_bounds: Option<(SeqNo, SeqNo)>,
 }
 
 impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
@@ -88,12 +85,7 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
             bytes.slice(self.end_key.0..self.end_key.1)
         };
 
-        let handle =
-            KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size));
-        match self.seqno_bounds {
-            Some((seqno_min, seqno_max)) => handle.with_seqno_bounds(seqno_min, seqno_max),
-            None => handle,
-        }
+        KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size))
     }
 }
 

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -109,6 +109,12 @@ pub struct Inner {
     )]
     pub(crate) block_layout: BlockLayoutMap,
 
+    /// Per-data-block seqno bounds, loaded on open from the optional
+    /// `seqno_bounds` section. Empty when the table has none (legacy or
+    /// `seqno_in_index` off), so `scan_since_seqno` falls back to a full
+    /// per-entry filter. Read only by the seqno-scoped scan path.
+    pub(crate) seqno_bounds: crate::table::seqno_bounds::SeqnoBoundsMap,
+
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy
     /// enabled; lets a point read resolve a key to its data block in O(1),

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -109,6 +109,13 @@ pub struct Inner {
     )]
     pub(crate) block_layout: BlockLayoutMap,
 
+    /// Retrieval-ribbon locator, loaded on open from the optional `locator`
+    /// section. `Some` only when the table was written with a locator policy
+    /// enabled; lets a point read resolve a key to its data block in O(1),
+    /// skipping the index-block binary search. `None` (default) leaves the
+    /// point read on the sorted-index path.
+    pub(crate) locator_index: Option<crate::table::locator::LoadedLocator>,
+
     /// Block encryption provider for encryption at rest.
     pub(crate) encryption: Option<Arc<dyn EncryptionProvider>>,
 

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -226,7 +226,16 @@ pub fn locate(section: &[u8], hash: u64) -> crate::Result<Option<(u64, u64)>> {
     } else {
         (1u64 << slot_bits) - 1
     };
-    Ok(Some((packed >> slot_bits, packed & slot_mask)))
+    // Guard the block-id shift the same way the mask is guarded: `packed >> 64`
+    // panics in debug and wraps to `>> 0` in release. A valid section always has
+    // `slot_bits <= 63`, so this only matters for a checksum-surviving corruption
+    // — but it keeps both extractions consistent and panic-free.
+    let block_id = if slot_bits >= 64 {
+        0
+    } else {
+        packed >> slot_bits
+    };
+    Ok(Some((block_id, packed & slot_mask)))
 }
 
 /// A loaded `locator` section ready for point-read resolution: the framed

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -75,6 +75,7 @@ fn precision_byte(p: LocatorPrecision) -> u8 {
     match p {
         LocatorPrecision::Restart => 0,
         LocatorPrecision::Entry => 1,
+        LocatorPrecision::Block => 2,
     }
 }
 
@@ -101,12 +102,20 @@ pub fn build_locator_section(entries: &[(u64, u64, u64)], spec: LocatorSpec) -> 
     let max_block = entries.iter().map(|e| e.1).max().unwrap_or(0);
     let max_slot = entries.iter().map(|e| e.2).max().unwrap_or(0);
 
+    // Per-block precision drops `slot` entirely (locator = block_id), so its
+    // width is 0 regardless of the recorded slot values and there is no slot
+    // fit to check.
+    let block_only = spec.precision == LocatorPrecision::Block;
     let block_id_bits = spec.block_id_bits.unwrap_or_else(|| bits_for(max_block));
-    let slot_bits = spec.slot_bits.unwrap_or_else(|| bits_for(max_slot));
+    let slot_bits = if block_only {
+        0
+    } else {
+        spec.slot_bits.unwrap_or_else(|| bits_for(max_slot))
+    };
 
     // Explicit widths that cannot hold the real layout → graceful skip.
     let block_fits = block_id_bits >= bits_for(max_block);
-    let slot_fits = slot_bits >= bits_for(max_slot);
+    let slot_fits = block_only || slot_bits >= bits_for(max_slot);
     let r = u16::from(block_id_bits) + u16::from(slot_bits);
     if !block_fits || !slot_fits || r == 0 || r > 64 {
         log::debug!(
@@ -115,6 +124,13 @@ pub fn build_locator_section(entries: &[(u64, u64, u64)], spec: LocatorSpec) -> 
         );
         return None;
     }
+    let slot_mask: u64 = if slot_bits == 0 {
+        0
+    } else if slot_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << slot_bits) - 1
+    };
     #[expect(
         clippy::cast_possible_truncation,
         reason = "r is validated to 1..=64 above, fits u8"
@@ -125,9 +141,10 @@ pub fn build_locator_section(entries: &[(u64, u64, u64)], spec: LocatorSpec) -> 
     let mut locators = Vec::with_capacity(entries.len());
     for &(hash, block_id, slot) in entries {
         hashes.push(hash);
-        // Pack (block_id, slot) into the low r bits. Both are proven to fit
-        // their widths by the checks above.
-        locators.push((block_id << slot_bits) | slot);
+        // Pack (block_id, slot) into the low r bits. block_id is proven to fit;
+        // slot is masked to its width (0 for per-block precision → block_id
+        // only).
+        locators.push((block_id << slot_bits) | (slot & slot_mask));
     }
 
     let params = match BurrParams::with_bpk(entries.len(), f32::from(r_u8)) {
@@ -165,23 +182,36 @@ pub fn build_locator_section(entries: &[(u64, u64, u64)], spec: LocatorSpec) -> 
     Some(section)
 }
 
-/// Test-only reader: parse a framed section and recover `(block_id, slot)` for
-/// `hash`. The production reader lands with the point-read path; this mirrors its
-/// unpack so the write-side build can be round-trip-tested here and from the
-/// table-writer integration test. `None` = the ribbon could not answer.
-#[cfg(test)]
+/// Recover the `(block_id, slot)` locator stored for `hash` in a framed
+/// `locator` section.
+///
+/// For a key in the table this is exact; for an absent key it is an unspecified
+/// pair (the caller verifies the key at the located block, so a stray locator
+/// only costs a wasted block read, never a wrong answer). `Ok(None)` means the
+/// ribbon could not answer and the caller should fall back to the sorted index.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidHeader`] if the section is shorter than its
+/// fixed header or carries an unrecognised section version, or propagates a
+/// wire-parse error from the retrieval ribbon.
 #[expect(
     clippy::indexing_slicing,
-    clippy::unwrap_used,
-    reason = "test helper over a freshly-built section; out-of-range or parse \
-              failure is a bug to surface via panic"
+    reason = "header bytes [0..4) are gated by the `section.len() < SECTION_HEADER_LEN` \
+              check on the line above; the wire slice starts at the validated header end"
 )]
-pub fn locate_in_section(section: &[u8], hash: u64) -> Option<(u64, u64)> {
+pub fn locate(section: &[u8], hash: u64) -> crate::Result<Option<(u64, u64)>> {
     use crate::table::filter::ribbon::burr::recover_value_from_bytes;
-    assert!(section.len() >= SECTION_HEADER_LEN);
-    assert_eq!(section[0], SECTION_VERSION);
+    if section.len() < SECTION_HEADER_LEN {
+        return Err(crate::Error::InvalidHeader("LocatorSection"));
+    }
+    if section[0] != SECTION_VERSION {
+        return Err(crate::Error::InvalidHeader("LocatorSection version"));
+    }
     let slot_bits = section[3];
-    let packed = recover_value_from_bytes(&section[SECTION_HEADER_LEN..], hash).unwrap()?;
+    let Some(packed) = recover_value_from_bytes(&section[SECTION_HEADER_LEN..], hash)? else {
+        return Ok(None);
+    };
     let slot_mask = if slot_bits == 0 {
         0
     } else if slot_bits >= 64 {
@@ -189,13 +219,58 @@ pub fn locate_in_section(section: &[u8], hash: u64) -> Option<(u64, u64)> {
     } else {
         (1u64 << slot_bits) - 1
     };
-    Some((packed >> slot_bits, packed & slot_mask))
+    Ok(Some((packed >> slot_bits, packed & slot_mask)))
+}
+
+/// A loaded `locator` section ready for point-read resolution: the framed
+/// section bytes plus an ordinal → data-block-handle map.
+///
+/// `block_id` is the data block's 0-based ordinal in key (write) order, which
+/// the SST index yields in iteration order, so `blocks[block_id]` is the handle
+/// of the block the writer addressed. Built once at table open.
+#[derive(Debug)]
+pub struct LoadedLocator {
+    section: crate::Slice,
+    blocks: Vec<crate::table::BlockHandle>,
+}
+
+impl LoadedLocator {
+    /// Wrap the framed section bytes and the ordinal → handle map.
+    #[must_use]
+    pub fn new(section: crate::Slice, blocks: Vec<crate::table::BlockHandle>) -> Self {
+        Self { section, blocks }
+    }
+
+    /// Resolve `key_hash` to the data block holding the key's newest version.
+    ///
+    /// `Ok(None)` means the ribbon could not answer or the recovered `block_id`
+    /// is out of range; the caller falls back to the sorted index. The caller
+    /// MUST still verify the key inside the returned block: an absent key yields
+    /// a stray locator (a wasted block read), never a wrong answer.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a parse error from [`locate`].
+    pub fn locate_block(&self, key_hash: u64) -> crate::Result<Option<crate::table::BlockHandle>> {
+        let Some((block_id, _slot)) = locate(&self.section, key_hash)? else {
+            return Ok(None);
+        };
+        // Block-id is bounds-validated against the ordinal map; the in-block
+        // `slot` is recovered but not yet used (the located block's own
+        // point_read does the in-block lookup), so block-id alone already
+        // eliminates the index-block binary search.
+        Ok(usize::try_from(block_id)
+            .ok()
+            .and_then(|i| self.blocks.get(i))
+            .copied())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     #![expect(
         clippy::expect_used,
+        clippy::unwrap_used,
         clippy::indexing_slicing,
         reason = "test assertions over known-good fixtures; failure surfaces via panic"
     )]
@@ -232,7 +307,7 @@ mod tests {
         assert_eq!(bytes[3], 5);
         for i in 0..300u64 {
             assert_eq!(
-                locate_in_section(&bytes, key_hash(i)),
+                locate(&bytes, key_hash(i)).unwrap(),
                 Some((i % 12, i % 25)),
                 "key {i} locator mismatch",
             );
@@ -267,7 +342,7 @@ mod tests {
         assert_eq!(bytes[3], 12);
         for i in 0..500u64 {
             assert_eq!(
-                locate_in_section(&bytes, key_hash(i)),
+                locate(&bytes, key_hash(i)).unwrap(),
                 Some((i % 1000, i % 4000))
             );
         }

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -431,6 +431,28 @@ mod tests {
     }
 
     #[test]
+    fn locate_does_not_panic_on_forged_slot_bits_64() {
+        // The writer never emits slot_bits == 64 (it enforces block_id_bits >= 1
+        // and r <= 64), but a checksum-surviving corruption could. The block-id
+        // extraction `packed >> slot_bits` must be guarded the same way the slot
+        // mask is: `>> 64` panics in debug and wraps to `>> 0` in release. locate
+        // must return without panicking for every key.
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        };
+        let entries: Vec<(u64, u64, u64)> =
+            (0..100u64).map(|i| (key_hash(i), i % 8, i % 4)).collect();
+        let mut bytes = build_locator_section(&entries, spec).expect("section built");
+        bytes[3] = 64; // forge slot_bits = 64
+        for i in 0..100u64 {
+            // Decoded values may be garbage, but the shift must not panic.
+            let _ = locate(&bytes, key_hash(i)).expect("locate must not error");
+        }
+    }
+
+    #[test]
     fn locate_rejects_unknown_version() {
         // A header whose version byte is not the one this build writes is a
         // forward-incompatibility / corruption signal, surfaced as an error.

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -70,12 +70,19 @@ fn bits_for(max: u64) -> u8 {
     bits.max(1)
 }
 
+/// On-disk precision byte: `slot` is a restart index.
+const PRECISION_RESTART: u8 = 0;
+/// On-disk precision byte: `slot` is an exact entry index.
+const PRECISION_ENTRY: u8 = 1;
+/// On-disk precision byte: per-block (no `slot`; `slot_bits == 0`).
+const PRECISION_BLOCK: u8 = 2;
+
 /// Maps the precision enum to its on-disk byte.
 fn precision_byte(p: LocatorPrecision) -> u8 {
     match p {
-        LocatorPrecision::Restart => 0,
-        LocatorPrecision::Entry => 1,
-        LocatorPrecision::Block => 2,
+        LocatorPrecision::Restart => PRECISION_RESTART,
+        LocatorPrecision::Entry => PRECISION_ENTRY,
+        LocatorPrecision::Block => PRECISION_BLOCK,
     }
 }
 
@@ -232,16 +239,33 @@ pub fn locate(section: &[u8], hash: u64) -> crate::Result<Option<(u64, u64)>> {
 pub struct LoadedLocator {
     section: crate::Slice,
     blocks: Vec<crate::table::BlockHandle>,
+    /// The on-disk precision byte (`PRECISION_*`), governing how a recovered
+    /// `slot` is interpreted on the read path.
+    precision: u8,
 }
 
+/// A resolved locator: the data block holding the key's newest version, plus an
+/// optional in-block slot hint. `Some((slot, is_entry))` lets the read jump
+/// straight to the restart head (`is_entry` selects entry-index vs restart-index
+/// semantics); `None` (per-block precision) leaves the in-block binary search.
+pub type Located = (crate::table::BlockHandle, Option<(u64, bool)>);
+
 impl LoadedLocator {
-    /// Wrap the framed section bytes and the ordinal → handle map.
+    /// Wrap the framed section bytes and the ordinal → handle map. The precision
+    /// is read from the section header (defaulting to per-block, the safe
+    /// no-slot-hint mode, if the header is somehow short).
     #[must_use]
     pub fn new(section: crate::Slice, blocks: Vec<crate::table::BlockHandle>) -> Self {
-        Self { section, blocks }
+        let precision = section.get(1).copied().unwrap_or(PRECISION_BLOCK);
+        Self {
+            section,
+            blocks,
+            precision,
+        }
     }
 
-    /// Resolve `key_hash` to the data block holding the key's newest version.
+    /// Resolve `key_hash` to the data block holding the key's newest version and
+    /// an optional in-block slot hint.
     ///
     /// `Ok(None)` means the ribbon could not answer or the recovered `block_id`
     /// is out of range; the caller falls back to the sorted index. The caller
@@ -251,18 +275,25 @@ impl LoadedLocator {
     /// # Errors
     ///
     /// Propagates a parse error from [`locate`].
-    pub fn locate_block(&self, key_hash: u64) -> crate::Result<Option<crate::table::BlockHandle>> {
-        let Some((block_id, _slot)) = locate(&self.section, key_hash)? else {
+    pub fn locate_block(&self, key_hash: u64) -> crate::Result<Option<Located>> {
+        let Some((block_id, slot)) = locate(&self.section, key_hash)? else {
             return Ok(None);
         };
-        // Block-id is bounds-validated against the ordinal map; the in-block
-        // `slot` is recovered but not yet used (the located block's own
-        // point_read does the in-block lookup), so block-id alone already
-        // eliminates the index-block binary search.
-        Ok(usize::try_from(block_id)
+        let Some(handle) = usize::try_from(block_id)
             .ok()
             .and_then(|i| self.blocks.get(i))
-            .copied())
+            .copied()
+        else {
+            return Ok(None);
+        };
+        let hint = match self.precision {
+            PRECISION_RESTART => Some((slot, false)),
+            PRECISION_ENTRY => Some((slot, true)),
+            // Per-block (or an unrecognised precision): no slot hint, the block's
+            // own point_read does the in-block lookup.
+            _ => None,
+        };
+        Ok(Some((handle, hint)))
     }
 }
 

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -410,6 +410,27 @@ mod tests {
     }
 
     #[test]
+    fn build_skips_when_ribbon_cannot_satisfy_conflicting_values() {
+        // Two entries share a key hash but map to different locators, so the
+        // retrieval ribbon has no consistent solution. The build must fail
+        // gracefully and skip the section (the point read falls back to the
+        // index) rather than abort the SST.
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        };
+        let mut entries: Vec<(u64, u64, u64)> =
+            (0..200u64).map(|i| (key_hash(i), i % 8, i % 4)).collect();
+        // Re-use entry 0's hash with a different (block_id, slot) → conflict.
+        entries.push((key_hash(0), 7, 3));
+        assert!(
+            build_locator_section(&entries, spec).is_none(),
+            "a conflicting hash collision must skip the section, not panic or abort",
+        );
+    }
+
+    #[test]
     fn locate_rejects_unknown_version() {
         // A header whose version byte is not the one this build writes is a
         // forward-incompatibility / corruption signal, surfaced as an error.

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Per-SST retrieval-ribbon locator section (write side).
+//!
+//! Optional, format-gated section that maps every key in a table to a packed
+//! `(block_id, slot)` locator via a retrieval `BuRR` ribbon (see
+//! [`crate::table::filter::ribbon::burr`]). A point read recovers the locator
+//! in O(1), fetches the addressed data block, and verifies the key at the slot,
+//! skipping both the index-block and in-block binary searches.
+//!
+//! This module builds and frames the section at table-write time. The point-read
+//! consumer (recovering `(block_id, slot)` from the section and resolving it to a
+//! value) lives on the read path.
+//!
+//! The section is written only when the [`crate::config::LocatorPolicy`] enables
+//! it for the table's level; an unenabled table emits nothing (the section is
+//! absent from the TOC, so on-disk output is byte-identical). The section is a
+//! new TOC entry, not a format-version bump.
+//!
+//! # Section layout
+//!
+//! ```text
+//! offset  size  field
+//! ──────  ────  ──────────────────────────────────────────
+//! 0       1     section_version (= SECTION_VERSION)
+//! 1       1     precision (0 = Restart, 1 = Entry)
+//! 2       1     block_id_bits
+//! 3       1     slot_bits
+//! 4       —     retrieval BuRR wire bytes (its own magic/header follows)
+//! ```
+//!
+//! `r = block_id_bits + slot_bits` is the ribbon width; the locator value is
+//! `(block_id << slot_bits) | slot`.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::config::LocatorPrecision;
+use crate::table::filter::ribbon::burr::{BurrBuilder, BurrParams};
+
+/// Section format version. Bumped only if this section's framing changes
+/// incompatibly; independent of the SST format version.
+pub const SECTION_VERSION: u8 = 1;
+
+/// Fixed section header length: version + precision + `block_id_bits` +
+/// `slot_bits`.
+pub const SECTION_HEADER_LEN: usize = 4;
+
+/// Resolved locator settings for a single table writer (one level's policy
+/// entry, already selected from the per-level [`crate::config::LocatorPolicy`]).
+#[derive(Copy, Clone, Debug)]
+pub struct LocatorSpec {
+    /// What `slot` addresses (restart index vs exact entry index).
+    pub precision: LocatorPrecision,
+    /// Explicit data-block-id width, or `None` for auto (minimal per SST).
+    pub block_id_bits: Option<u8>,
+    /// Explicit slot width, or `None` for auto (minimal per SST).
+    pub slot_bits: Option<u8>,
+}
+
+/// Bits needed to represent every value in `0..=max` (at least 1, so the ribbon
+/// width is always valid).
+fn bits_for(max: u64) -> u8 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "64 - leading_zeros() is in 0..=64, fits u8"
+    )]
+    let bits = (64 - max.leading_zeros()) as u8;
+    bits.max(1)
+}
+
+/// Maps the precision enum to its on-disk byte.
+fn precision_byte(p: LocatorPrecision) -> u8 {
+    match p {
+        LocatorPrecision::Restart => 0,
+        LocatorPrecision::Entry => 1,
+    }
+}
+
+/// Build the `locator` section bytes from accumulated `(hash, block_id, slot)`
+/// triples (one per unique key, the newest version's position).
+///
+/// Returns `None` to **gracefully skip** the section (no bytes written, the
+/// point read falls back to the index) when:
+/// - there are no entries, or
+/// - explicit widths cannot represent this SST's actual `block_id` / `slot`
+///   range, or the combined width exceeds 64 bits, or
+/// - the ribbon build fails (e.g. a u64 hash collision between two distinct
+///   keys yields an inconsistent equation).
+///
+/// `Some(bytes)` is the framed section ready to write. The build never returns
+/// an error: every failure degrades to a graceful skip rather than aborting the
+/// SST write.
+#[must_use]
+pub fn build_locator_section(entries: &[(u64, u64, u64)], spec: LocatorSpec) -> Option<Vec<u8>> {
+    if entries.is_empty() {
+        return None;
+    }
+
+    let max_block = entries.iter().map(|e| e.1).max().unwrap_or(0);
+    let max_slot = entries.iter().map(|e| e.2).max().unwrap_or(0);
+
+    let block_id_bits = spec.block_id_bits.unwrap_or_else(|| bits_for(max_block));
+    let slot_bits = spec.slot_bits.unwrap_or_else(|| bits_for(max_slot));
+
+    // Explicit widths that cannot hold the real layout → graceful skip.
+    let block_fits = block_id_bits >= bits_for(max_block);
+    let slot_fits = slot_bits >= bits_for(max_slot);
+    let r = u16::from(block_id_bits) + u16::from(slot_bits);
+    if !block_fits || !slot_fits || r == 0 || r > 64 {
+        log::debug!(
+            "locator section skipped: widths block_id_bits={block_id_bits} slot_bits={slot_bits} \
+             cannot represent max_block={max_block} max_slot={max_slot} (r={r})"
+        );
+        return None;
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "r is validated to 1..=64 above, fits u8"
+    )]
+    let r_u8 = r as u8;
+
+    let mut hashes = Vec::with_capacity(entries.len());
+    let mut locators = Vec::with_capacity(entries.len());
+    for &(hash, block_id, slot) in entries {
+        hashes.push(hash);
+        // Pack (block_id, slot) into the low r bits. Both are proven to fit
+        // their widths by the checks above.
+        locators.push((block_id << slot_bits) | slot);
+    }
+
+    let params = match BurrParams::with_bpk(entries.len(), f32::from(r_u8)) {
+        Ok(p) => p,
+        Err(e) => {
+            log::debug!("locator section skipped: BurrParams::with_bpk failed: {e}");
+            return None;
+        }
+    };
+    let builder = match BurrBuilder::new(params) {
+        Ok(b) => b,
+        Err(e) => {
+            log::debug!("locator section skipped: BurrBuilder::new failed: {e}");
+            return None;
+        }
+    };
+    let filter = match builder.build_from_hashes_with_values(&hashes, &locators) {
+        Ok(f) => f,
+        Err(e) => {
+            // A u64 hash collision between two distinct keys yields an
+            // inconsistent equation; rather than abort the SST, skip the
+            // section and let the point read use the index.
+            log::debug!("locator section skipped: retrieval ribbon build failed: {e}");
+            return None;
+        }
+    };
+
+    let wire = filter.to_wire_bytes();
+    let mut section = Vec::with_capacity(SECTION_HEADER_LEN + wire.len());
+    section.push(SECTION_VERSION);
+    section.push(precision_byte(spec.precision));
+    section.push(block_id_bits);
+    section.push(slot_bits);
+    section.extend_from_slice(&wire);
+    Some(section)
+}
+
+/// Test-only reader: parse a framed section and recover `(block_id, slot)` for
+/// `hash`. The production reader lands with the point-read path; this mirrors its
+/// unpack so the write-side build can be round-trip-tested here and from the
+/// table-writer integration test. `None` = the ribbon could not answer.
+#[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "test helper over a freshly-built section; out-of-range or parse \
+              failure is a bug to surface via panic"
+)]
+pub fn locate_in_section(section: &[u8], hash: u64) -> Option<(u64, u64)> {
+    use crate::table::filter::ribbon::burr::recover_value_from_bytes;
+    assert!(section.len() >= SECTION_HEADER_LEN);
+    assert_eq!(section[0], SECTION_VERSION);
+    let slot_bits = section[3];
+    let packed = recover_value_from_bytes(&section[SECTION_HEADER_LEN..], hash).unwrap()?;
+    let slot_mask = if slot_bits == 0 {
+        0
+    } else if slot_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << slot_bits) - 1
+    };
+    Some((packed >> slot_bits, packed & slot_mask))
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test assertions over known-good fixtures; failure surfaces via panic"
+    )]
+
+    use super::*;
+
+    fn key_hash(i: u64) -> u64 {
+        crate::hash::hash64(&i.to_le_bytes())
+    }
+
+    #[test]
+    fn build_returns_none_for_empty_input() {
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        };
+        assert!(build_locator_section(&[], spec).is_none());
+    }
+
+    #[test]
+    fn auto_width_section_round_trips_block_id_and_slot() {
+        // 300 keys across 12 blocks, up to 25 restarts per block.
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        };
+        let entries: Vec<(u64, u64, u64)> =
+            (0..300u64).map(|i| (key_hash(i), i % 12, i % 25)).collect();
+        let bytes = build_locator_section(&entries, spec).expect("section built");
+        // Auto widths: 12 blocks → 4 bits, 25 slots → 5 bits.
+        assert_eq!(bytes[2], 4);
+        assert_eq!(bytes[3], 5);
+        for i in 0..300u64 {
+            assert_eq!(
+                locate_in_section(&bytes, key_hash(i)),
+                Some((i % 12, i % 25)),
+                "key {i} locator mismatch",
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_widths_too_small_skips_gracefully() {
+        // max block_id = 100 needs 7 bits; configure only 4 → skip.
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: Some(4),
+            slot_bits: Some(4),
+        };
+        let entries: Vec<(u64, u64, u64)> =
+            (0..200u64).map(|i| (key_hash(i), i % 101, i % 8)).collect();
+        assert!(build_locator_section(&entries, spec).is_none());
+    }
+
+    #[test]
+    fn explicit_widths_that_fit_round_trip() {
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Entry,
+            block_id_bits: Some(10),
+            slot_bits: Some(12),
+        };
+        let entries: Vec<(u64, u64, u64)> = (0..500u64)
+            .map(|i| (key_hash(i), i % 1000, i % 4000))
+            .collect();
+        let bytes = build_locator_section(&entries, spec).expect("section built");
+        assert_eq!(bytes[2], 10);
+        assert_eq!(bytes[3], 12);
+        for i in 0..500u64 {
+            assert_eq!(
+                locate_in_section(&bytes, key_hash(i)),
+                Some((i % 1000, i % 4000))
+            );
+        }
+    }
+}

--- a/src/table/locator.rs
+++ b/src/table/locator.rs
@@ -378,4 +378,47 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn block_precision_section_round_trips_block_id_only() {
+        // Block precision is the default: `slot` is dropped (locator = block_id),
+        // so every key resolves to (block_id, 0). Covers the `block_only` build
+        // path and a zero-width slot decode.
+        let spec = LocatorSpec {
+            precision: LocatorPrecision::Block,
+            block_id_bits: None,
+            slot_bits: None,
+        };
+        let entries: Vec<(u64, u64, u64)> =
+            (0..300u64).map(|i| (key_hash(i), i % 12, i % 25)).collect();
+        let bytes = build_locator_section(&entries, spec).expect("section built");
+        assert_eq!(bytes[3], 0, "block precision must record slot_bits = 0");
+        for i in 0..300u64 {
+            assert_eq!(
+                locate(&bytes, key_hash(i)).unwrap(),
+                Some((i % 12, 0)),
+                "key {i} must resolve to its block with slot 0",
+            );
+        }
+    }
+
+    #[test]
+    fn locate_rejects_truncated_section() {
+        // A section shorter than the fixed header cannot be parsed.
+        let err = locate(&[0u8; SECTION_HEADER_LEN - 1], 123).unwrap_err();
+        assert!(matches!(err, crate::Error::InvalidHeader("LocatorSection")));
+    }
+
+    #[test]
+    fn locate_rejects_unknown_version() {
+        // A header whose version byte is not the one this build writes is a
+        // forward-incompatibility / corruption signal, surfaced as an error.
+        let mut section = [0u8; SECTION_HEADER_LEN];
+        section[0] = SECTION_VERSION.wrapping_add(1);
+        let err = locate(&section, 123).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::Error::InvalidHeader("LocatorSection version")
+        ));
+    }
 }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -99,17 +99,6 @@ pub struct ParsedMeta {
     /// [`Self::ecc_params`].
     pub ecc_unrecognized: bool,
 
-    /// Index block format for this SST (#224). `0` = legacy: index
-    /// entries carry no per-block seqno bounds (byte-identical to the
-    /// pre-#224 format). `1` = each index entry includes
-    /// `seqno_min` / `seqno_max` for its data block, enabling
-    /// `scan_since_seqno` block-skip.
-    ///
-    /// Optional on disk: SSTs written before this field existed lack the
-    /// `index_format` property and parse as `0`, so legacy tables read
-    /// correctly and fall back to the per-entry filter scan path.
-    pub index_format: u8,
-
     /// Restart interval the data blocks were encoded with. Needed to rebuild a
     /// positional restart index when partial-decoding a block on the lazy read
     /// path (the restart heads sit every `data_block_restart_interval` entries).
@@ -413,28 +402,6 @@ impl ParsedMeta {
             }
         };
 
-        // Optional field introduced for scan_since_seqno block-skip (#224).
-        // SSTs written before this key existed parse as 0 (legacy index
-        // format, no per-block seqno bounds).
-        let index_format = match block.point_read(b"index_format", SeqNo::MAX, &cmp)? {
-            None => 0u8,
-            // The value must be EXACTLY one byte. Matching a single-element slice
-            // rejects trailing bytes, so a corrupt payload like `[1, 0xFF]` is an
-            // error rather than parsing as `1`. This byte is a metadata hint
-            // recording which index format the writer emitted; the per-entry
-            // decode itself dispatches on per-entry markers, not on this value.
-            Some(item) => match &item.value[..] {
-                [b] => *b,
-                _ => return Err(crate::Error::InvalidHeader("TableMeta")),
-            },
-        };
-        // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
-        // this format slice. Reject any other byte as corrupt / forward-
-        // incompatible metadata rather than trusting a bogus on-disk hint.
-        if index_format > 1 {
-            return Err(crate::Error::InvalidHeader("TableMeta"));
-        }
-
         Ok(Self {
             id,
             created_at,
@@ -454,7 +421,6 @@ impl ParsedMeta {
             page_ecc,
             ecc_params,
             ecc_unrecognized,
-            index_format,
             data_block_restart_interval,
         })
     }
@@ -630,62 +596,6 @@ mod tests {
         let items = valid_meta_items();
         let result = load_meta_from_items(&items);
         assert!(result.is_ok(), "valid meta must parse: {result:?}");
-    }
-
-    #[test]
-    fn index_format_absent_parses_as_legacy_zero() {
-        // valid_meta_items() carries no `index_format` key (legacy SST).
-        // It must parse as index_format = 0 so pre-#224 tables fall back
-        // to the per-entry scan path.
-        let meta = load_meta_from_items(&valid_meta_items()).unwrap();
-        assert_eq!(meta.index_format, 0);
-    }
-
-    #[test]
-    fn index_format_present_parses_its_value() {
-        // An SST carrying `index_format = 1` must parse as 1 so the read
-        // path knows the index entries hold per-block seqno bounds.
-        let mut items = valid_meta_items();
-        // Insert in sorted position (between filter_hash_type and
-        // index_keys_have_seqno) to keep the block ordered.
-        items.push(meta("index_format", &[1u8]));
-        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-        let meta = load_meta_from_items(&items).unwrap();
-        assert_eq!(meta.index_format, 1);
-    }
-
-    #[test]
-    fn index_format_unknown_byte_is_rejected() {
-        // Only 0 and 1 are defined in this format slice; a present-but-unknown
-        // byte (e.g. corrupt metadata, or a forward-incompatible writer) must
-        // fail fast as InvalidHeader rather than flowing downstream as a bogus
-        // on-disk index format.
-        for bad in [2u8, 255u8] {
-            let mut items = valid_meta_items();
-            items.push(meta("index_format", &[bad]));
-            items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-            let result = load_meta_from_items(&items);
-            assert!(
-                matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
-                "index_format = {bad} must be rejected, got {result:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn index_format_overlong_payload_is_rejected() {
-        // The index_format value must be exactly one byte. A payload with
-        // trailing bytes (e.g. [1, 0xFF]) would otherwise parse as 1 because
-        // read_u8 ignores the remainder — since this byte selects the index
-        // decoder, an overlong payload is corrupt metadata and must be rejected.
-        let mut items = valid_meta_items();
-        items.push(meta("index_format", &[1u8, 0xFF]));
-        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-        let result = load_meta_from_items(&items);
-        assert!(
-            matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
-            "overlong index_format payload must be rejected, got {result:?}",
-        );
     }
 
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -13,6 +13,7 @@ mod inner;
 pub(crate) mod iter;
 #[cfg(feature = "zstd")]
 pub(crate) mod lazy_block;
+pub(crate) mod locator;
 pub(crate) mod meta;
 pub(crate) mod multi_writer;
 pub(crate) mod regions;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -591,9 +591,19 @@ impl Table {
         // Fast path: retrieval-ribbon locator (see `point_read_inner` for the
         // MVCC-correctness argument). A located-block miss falls through to the
         // index walk below.
-        if let Some(handle) = self.locator_block(key_hash)? {
+        if let Some((handle, hint)) = self.locator_block(key_hash)? {
             let data_block = self.load_data_block(&handle)?;
-            if let Some(found) = data_block.point_read_value(key, seqno, &self.comparator)? {
+            let found = match hint {
+                Some((slot, is_entry)) => data_block.point_read_value_at_slot(
+                    slot,
+                    is_entry,
+                    key,
+                    seqno,
+                    &self.comparator,
+                )?,
+                None => data_block.point_read_value(key, seqno, &self.comparator)?,
+            };
+            if let Some(found) = found {
                 return Ok(Some(found));
             }
         }
@@ -664,10 +674,14 @@ impl Table {
     /// Shared block-index walk for point reads. Returns the matching entry
     /// together with the [`DataBlock`] it was found in, so callers that need
     /// the block (e.g. for [`PinnableSlice`]) can keep it alive.
-    /// Resolve the data block holding `key_hash`'s newest version via the
-    /// retrieval-ribbon locator, if one is loaded. `Ok(None)` means no locator
-    /// or the ribbon could not answer → the caller uses the sorted-index walk.
-    fn locator_block(&self, key_hash: u64) -> crate::Result<Option<BlockHandle>> {
+    /// Resolve the data block holding `key_hash`'s newest version (plus an
+    /// optional in-block slot hint) via the retrieval-ribbon locator, if one is
+    /// loaded. `Ok(None)` means no locator or the ribbon could not answer → the
+    /// caller uses the sorted-index walk.
+    fn locator_block(
+        &self,
+        key_hash: u64,
+    ) -> crate::Result<Option<crate::table::locator::Located>> {
         match &self.locator_index {
             Some(loc) => loc.locate_block(key_hash),
             None => Ok(None),
@@ -686,9 +700,15 @@ impl Table {
         // hit returns the correct MVCC answer and a miss (absent key, or the
         // visible version lives in a later block) safely falls through to the
         // index walk below.
-        if let Some(handle) = self.locator_block(key_hash)? {
+        if let Some((handle, hint)) = self.locator_block(key_hash)? {
             let data_block = self.load_data_block(&handle)?;
-            if let Some(item) = data_block.point_read(key, seqno, &self.comparator)? {
+            let found = match hint {
+                Some((slot, is_entry)) => {
+                    data_block.point_read_at_slot(slot, is_entry, key, seqno, &self.comparator)?
+                }
+                None => data_block.point_read(key, seqno, &self.comparator)?,
+            };
+            if let Some(item) = found {
                 return Ok(Some((item, data_block)));
             }
         }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -514,7 +514,7 @@ impl Table {
             return Ok(None);
         }
 
-        let item = self.point_read(key, seqno)?;
+        let item = self.point_read(key, seqno, key_hash)?;
 
         // Translate table-local seqno back to global coordinate so callers
         // can compare across tables/memtables (L0 best-selection, RT suppression).
@@ -562,7 +562,7 @@ impl Table {
             return Ok(None);
         }
 
-        let item = self.point_read_value(key, seqno)?;
+        let item = self.point_read_value(key, seqno, key_hash)?;
 
         // Translate table-local seqno back to the global coordinate, mirroring
         // `Table::get`.
@@ -586,7 +586,18 @@ impl Table {
         &self,
         key: &[u8],
         seqno: SeqNo,
+        key_hash: u64,
     ) -> crate::Result<Option<(crate::ValueType, SeqNo, crate::Slice)>> {
+        // Fast path: retrieval-ribbon locator (see `point_read_inner` for the
+        // MVCC-correctness argument). A located-block miss falls through to the
+        // index walk below.
+        if let Some(handle) = self.locator_block(key_hash)? {
+            let data_block = self.load_data_block(&handle)?;
+            if let Some(found) = data_block.point_read_value(key, seqno, &self.comparator)? {
+                return Ok(Some(found));
+            }
+        }
+
         let Some(iter) = self.block_index.point_read_reader(key, seqno) else {
             return Ok(None);
         };
@@ -631,7 +642,7 @@ impl Table {
             return Ok(None);
         }
 
-        let result = self.point_read_with_block(key, seqno)?;
+        let result = self.point_read_with_block(key, seqno, key_hash)?;
 
         // Translate table-local seqno back to global coordinate (see Table::get).
         let result = result.map(|(mut iv, block)| {
@@ -653,11 +664,35 @@ impl Table {
     /// Shared block-index walk for point reads. Returns the matching entry
     /// together with the [`DataBlock`] it was found in, so callers that need
     /// the block (e.g. for [`PinnableSlice`]) can keep it alive.
+    /// Resolve the data block holding `key_hash`'s newest version via the
+    /// retrieval-ribbon locator, if one is loaded. `Ok(None)` means no locator
+    /// or the ribbon could not answer → the caller uses the sorted-index walk.
+    fn locator_block(&self, key_hash: u64) -> crate::Result<Option<BlockHandle>> {
+        match &self.locator_index {
+            Some(loc) => loc.locate_block(key_hash),
+            None => Ok(None),
+        }
+    }
+
     fn point_read_inner(
         &self,
         key: &[u8],
         seqno: SeqNo,
+        key_hash: u64,
     ) -> crate::Result<Option<(InternalValue, DataBlock)>> {
+        // Fast path: a retrieval-ribbon locator resolves the key to its data
+        // block in O(1), skipping the index-block binary search. The located
+        // block holds the newest version (the run's highest-seqno prefix), so a
+        // hit returns the correct MVCC answer and a miss (absent key, or the
+        // visible version lives in a later block) safely falls through to the
+        // index walk below.
+        if let Some(handle) = self.locator_block(key_hash)? {
+            let data_block = self.load_data_block(&handle)?;
+            if let Some(item) = data_block.point_read(key, seqno, &self.comparator)? {
+                return Ok(Some((item, data_block)));
+            }
+        }
+
         // Borrowing point-read seek: avoids cloning the index block + reuses
         // the trailer metadata parsed at table open (see
         // `BlockIndexImpl::point_read_reader`).
@@ -685,8 +720,13 @@ impl Table {
         Ok(None)
     }
 
-    fn point_read(&self, key: &[u8], seqno: SeqNo) -> crate::Result<Option<InternalValue>> {
-        self.point_read_inner(key, seqno)
+    fn point_read(
+        &self,
+        key: &[u8],
+        seqno: SeqNo,
+        key_hash: u64,
+    ) -> crate::Result<Option<InternalValue>> {
+        self.point_read_inner(key, seqno, key_hash)
             .map(|opt| opt.map(|(iv, _)| iv))
     }
 
@@ -699,8 +739,9 @@ impl Table {
         &self,
         key: &[u8],
         seqno: SeqNo,
+        key_hash: u64,
     ) -> crate::Result<Option<(InternalValue, Block)>> {
-        self.point_read_inner(key, seqno)
+        self.point_read_inner(key, seqno, key_hash)
             .map(|opt| opt.map(|(iv, db)| (iv, db.inner)))
     }
 
@@ -1669,6 +1710,53 @@ impl Table {
             crate::table::block_layout::BlockLayoutMap::default()
         };
 
+        // Load the optional retrieval-ribbon locator section and pair it with an
+        // ordinal → data-block-handle map (the index yields handles in key/write
+        // order, which is the writer's block_id ordering). Only when the section
+        // exists, so non-locator tables pay nothing.
+        let locator_index = if let Some(loc_handle) = regions.locator {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                loc_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_type: BlockType::Locator,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::Locator {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            let blocks: Vec<BlockHandle> = block_index
+                .iter()
+                .map(|r| r.map(|kbh| *kbh.as_ref()))
+                .collect::<crate::Result<Vec<_>>>()?;
+            log::trace!(
+                "Loaded retrieval-ribbon locator over {} blocks",
+                blocks.len()
+            );
+            Some(crate::table::locator::LoadedLocator::new(
+                block.data, blocks,
+            ))
+        } else {
+            None
+        };
+
         log::debug!(
             "Recovered table #{} from {}",
             metadata.id,
@@ -1706,6 +1794,7 @@ impl Table {
             cached_blob_bytes: AtomicU64::new(u64::MAX),
             range_tombstones,
             block_layout,
+            locator_index,
             encryption,
 
             #[cfg(zstd_any)]

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod meta;
 pub(crate) mod multi_writer;
 pub(crate) mod regions;
 mod scanner;
+pub(crate) mod seqno_bounds;
 pub mod util;
 pub mod writer;
 
@@ -1116,12 +1117,12 @@ impl Table {
     /// Collects every entry in this SST with `seqno >= target_seqno`,
     /// applying the per-block seqno-bounds skip when the SST carries it.
     ///
-    /// A data block whose index entry reports `seqno_max < target_seqno`
-    /// (seqno-bounded format, `Properties.index_format = 1`) cannot hold a
-    /// qualifying record, so it is skipped without being read. Blocks without
-    /// bounds on disk (legacy `index_format = 0`) are always read and filtered
-    /// per entry, so the result is correct regardless of the SST's index
-    /// format. Entries come back in the SST's stored order (key-ascending,
+    /// A data block whose `seqno_bounds` section entry reports
+    /// `seqno_max < target_seqno` cannot hold a qualifying record, so it is
+    /// skipped without being read. When the SST has no `seqno_bounds` section
+    /// (the feature was off), every block is read and filtered per entry, so
+    /// the result is correct regardless. Entries come back in the SST's stored
+    /// order (key-ascending,
     /// seqno-descending within a key); ordering across sources is the caller's
     /// job.
     ///
@@ -1182,12 +1183,17 @@ impl Table {
         for handle in self.block_index.iter() {
             let handle = handle?;
 
-            // Block-skip: a seqno-bounded entry whose (local) min exceeds the
-            // upper bound, or whose (local) max is below the target, cannot
-            // reference any qualifying record — skip the data-block read.
-            // Disabled in paranoid full-scan mode (`block_skip == false`).
+            // Block-skip: look this block's seqno bounds up in the parallel
+            // `seqno_bounds` section (keyed by file offset). If its (local) min
+            // exceeds the upper bound, or its (local) max is below the target, it
+            // cannot reference a qualifying record — skip the data-block read.
+            // Bounds live in the section, NOT inline in the index entry, so a
+            // point read never pays for them. Disabled in paranoid full-scan
+            // mode (`block_skip == false`); absent for legacy/off tables → no
+            // skip, full filter (correct regardless).
             if block_skip
-                && let Some((seqno_min, seqno_max)) = handle.seqno_bounds()
+                && let Some((seqno_min, seqno_max)) =
+                    self.seqno_bounds.bounds_for(handle.as_ref().offset().0)
                 && (seqno_max < local_target || seqno_min >= local_end)
             {
                 continue;
@@ -1740,6 +1746,45 @@ impl Table {
             crate::table::block_layout::BlockLayoutMap::default()
         };
 
+        // Load the optional seqno-bounds section (parallel to the index; powers
+        // the scan_since_seqno block-skip). Absent unless seqno_in_index was on.
+        let seqno_bounds = if let Some(sb_handle) = regions.seqno_bounds {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                sb_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_type: BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::SeqnoBounds {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            let map = crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)?;
+            if !map.is_empty() {
+                log::trace!("Loaded {} seqno-bounds entries", map.len());
+            }
+            map
+        } else {
+            crate::table::seqno_bounds::SeqnoBoundsMap::default()
+        };
+
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
@@ -1824,6 +1869,7 @@ impl Table {
             cached_blob_bytes: AtomicU64::new(u64::MAX),
             range_tombstones,
             block_layout,
+            seqno_bounds,
             locator_index,
             encryption,
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1130,13 +1130,20 @@ impl Table {
     /// Returns `Err` if reading the index or a data block fails.
     #[doc(hidden)]
     pub fn scan_since_seqno(&self, target_seqno: SeqNo) -> crate::Result<Vec<InternalValue>> {
-        self.scan_seqno_range(target_seqno, SeqNo::MAX)
+        self.scan_seqno_range(target_seqno, SeqNo::MAX, true)
     }
 
     /// Like [`Self::scan_since_seqno`] but also bounds the result above:
     /// collects entries whose global seqno is in `[target_seqno, end_seqno)`.
     /// The upper bound lets the tree-level scan pin a stable snapshot watermark
     /// so a concurrent write cannot leak in mid-scan.
+    ///
+    /// `block_skip` enables the per-block seqno-bounds optimization (skip data
+    /// blocks whose recorded `[seqno_min, seqno_max]` cannot overlap the
+    /// window). Pass `false` for a paranoid full scan that reads every block and
+    /// filters per entry, so even an undetected-corrupt seqno bound (one that
+    /// somehow slipped past the block XXH3 checksum) cannot cause a qualifying
+    /// record to be skipped.
     ///
     /// # Errors
     ///
@@ -1146,6 +1153,7 @@ impl Table {
         &self,
         target_seqno: SeqNo,
         end_seqno: SeqNo,
+        block_skip: bool,
     ) -> crate::Result<Vec<InternalValue>> {
         // Bulk-ingested tables store entries at LOCAL seqno coordinates with a
         // `global_seqno` offset; the on-disk seqno bounds and per-entry seqnos
@@ -1177,7 +1185,9 @@ impl Table {
             // Block-skip: a seqno-bounded entry whose (local) min exceeds the
             // upper bound, or whose (local) max is below the target, cannot
             // reference any qualifying record — skip the data-block read.
-            if let Some((seqno_min, seqno_max)) = handle.seqno_bounds()
+            // Disabled in paranoid full-scan mode (`block_skip == false`).
+            if block_skip
+                && let Some((seqno_min, seqno_max)) = handle.seqno_bounds()
                 && (seqno_max < local_target || seqno_min >= local_end)
             {
                 continue;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1734,7 +1734,15 @@ impl Table {
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
         // exists, so non-locator tables pay nothing.
-        let locator_index = if let Some(loc_handle) = regions.locator {
+        // Load the optional retrieval-ribbon locator as a BEST-EFFORT point-read
+        // accelerator: any failure (corrupt locator section, unexpected block
+        // type, or a corrupt sub-index block hit while walking the index to pair
+        // locators with their data-block handles) degrades to `None` rather than
+        // failing the table open. Point reads then use the sorted-index path,
+        // which isolates a corrupt sub-index partition to its own keys — so
+        // enabling the locator by default does NOT widen the blast radius of a
+        // partitioned-index corruption from "one partition" back to "whole SST".
+        let locator_index = regions.locator.and_then(|loc_handle| {
             let block = Block::from_file(
                 file_handle.as_ref(),
                 loc_handle,
@@ -1755,17 +1763,26 @@ impl Table {
                         t
                     }
                 },
-            )?;
+            )
+            .inspect_err(|e| {
+                log::warn!("retrieval-ribbon locator disabled: section load failed: {e:?}");
+            })
+            .ok()?;
             if block.header.block_type != BlockType::Locator {
-                return Err(crate::Error::InvalidTag((
-                    "BlockType",
-                    block.header.block_type.into(),
-                )));
+                log::warn!(
+                    "retrieval-ribbon locator disabled: unexpected block type {:?}",
+                    block.header.block_type
+                );
+                return None;
             }
             let blocks: Vec<BlockHandle> = block_index
                 .iter()
                 .map(|r| r.map(|kbh| *kbh.as_ref()))
-                .collect::<crate::Result<Vec<_>>>()?;
+                .collect::<crate::Result<Vec<_>>>()
+                .inspect_err(|e| {
+                    log::warn!("retrieval-ribbon locator disabled: index walk failed: {e:?}");
+                })
+                .ok()?;
             log::trace!(
                 "Loaded retrieval-ribbon locator over {} blocks",
                 blocks.len()
@@ -1773,9 +1790,7 @@ impl Table {
             Some(crate::table::locator::LoadedLocator::new(
                 block.data, blocks,
             ))
-        } else {
-            None
-        };
+        });
 
         log::debug!(
             "Recovered table #{} from {}",

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -106,9 +106,9 @@ pub struct MultiWriter {
     )>,
 
     /// `seqno_in_index` runtime config — preserved here so the rotation
-    /// path stamps the same index format on every successor [`Writer`],
-    /// keeping all SSTs of one flush / compaction at a uniform
-    /// `index_format`.
+    /// path sets the same flag on every successor [`Writer`], so all SSTs
+    /// of one flush / compaction uniformly emit (or omit) the `seqno_bounds`
+    /// section.
     use_seqno_in_index: bool,
 
     /// When `true`, each output SST has per-file copy-on-write cleared at
@@ -539,7 +539,7 @@ impl MultiWriter {
 
     /// Wires the `seqno_in_index` runtime config through to the inner
     /// [`Writer`] and preserves it across rotations so every successor
-    /// writer stamps the same `index_format` on its index entries.
+    /// writer emits a matching `seqno_bounds` section.
     #[must_use]
     pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
         self.use_seqno_in_index = seqno_in_index;

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -117,6 +117,12 @@ pub struct MultiWriter {
     /// table in the run is flagged the same way. No-op on non-CoW filesystems.
     disable_cow_on_sst: bool,
 
+    /// Resolved retrieval-ribbon locator policy entry for this run's level,
+    /// preserved here so the rotation path stamps the same setting on every
+    /// successor [`Writer`]. Each table gets its own per-SST locator section
+    /// (block ordinals reset per table). Defaults to `None` (disabled).
+    locator_entry: crate::config::LocatorPolicyEntry,
+
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
 
@@ -185,6 +191,7 @@ impl MultiWriter {
             kv_checksum: None,
             use_seqno_in_index: false,
             disable_cow_on_sst: false,
+            locator_entry: crate::config::LocatorPolicyEntry::None,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -540,6 +547,17 @@ impl MultiWriter {
         self
     }
 
+    /// Wires the resolved retrieval-ribbon locator policy entry through to the
+    /// inner [`Writer`] and preserves it across rotations, so every successor
+    /// table in the run emits its own per-SST locator section (or none, when
+    /// disabled). Block ordinals reset per table.
+    #[must_use]
+    pub fn use_locator(mut self, entry: crate::config::LocatorPolicyEntry) -> Self {
+        self.locator_entry = entry;
+        self.writer = self.writer.use_locator(entry);
+        self
+    }
+
     /// Wires the `disable_cow_on_sst_files` runtime config through to the inner
     /// [`Writer`] (clearing per-file copy-on-write on the current output file) and
     /// preserves it across rotations so every successor SST is flagged the same
@@ -594,6 +612,7 @@ impl MultiWriter {
         }
         new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
         new_writer = new_writer.use_disable_cow(self.disable_cow_on_sst);
+        new_writer = new_writer.use_locator(self.locator_entry);
 
         #[cfg(zstd_any)]
         {
@@ -967,6 +986,118 @@ mod tests {
         tree.major_compact(1_024, 0)?;
         assert_eq!(3, tree.table_count());
         assert_eq!(3, tree.len(SeqNo::MAX, None)?);
+
+        Ok(())
+    }
+
+    // D5b round-trip: the retrieval-ribbon locator section must survive the real
+    // table writer + reader path. With the policy enabled every inserted key
+    // recovers a `(block_id, slot)` from the on-disk section (validating the
+    // writer's per-key block_id/slot accumulation, not just synthetic inputs);
+    // with the policy disabled the section is absent entirely (zero bytes, the
+    // byte-identical guarantee).
+    #[test]
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts a freshly-written section is present + recovers"
+    )]
+    fn locator_section_round_trips_through_writer() -> crate::Result<()> {
+        use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+        use crate::table::block::BlockType;
+        use crate::table::locator::locate_in_section;
+        use crate::{CompressionType, InternalValue, UserKey, fs::StdFs};
+        use std::sync::Arc;
+
+        let folder = tempfile::tempdir()?;
+        let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+        // Small data blocks + many small KVs → many data blocks, so block_id is
+        // non-trivial and the accumulation across block boundaries is exercised.
+        let n = 2_000u64;
+
+        let write_and_recover =
+            |base: &std::path::Path, entry: LocatorPolicyEntry| -> crate::Result<crate::Table> {
+                std::fs::create_dir_all(base)?;
+                let mut mw = super::MultiWriter::new(
+                    base.to_path_buf(),
+                    SequenceNumberCounter::default(),
+                    64 * 1_024 * 1_024,
+                    1,
+                    fs.clone(),
+                )?
+                .use_data_block_size(4_096)
+                .use_locator(entry);
+                for i in 0..n {
+                    mw.write(InternalValue::from_components(
+                        UserKey::from(i.to_be_bytes().as_slice()),
+                        vec![0u8; 64],
+                        1,
+                        crate::ValueType::Value,
+                    ))?;
+                }
+                let results = mw.finish()?;
+                assert_eq!(results.len(), 1, "single output table expected");
+                let (table_id, checksum) = results[0];
+                crate::Table::recover(
+                    base.join(table_id.to_string()),
+                    checksum,
+                    0,
+                    0,
+                    table_id,
+                    Arc::new(crate::Cache::with_capacity_bytes(1 << 20)),
+                    None,
+                    Arc::new(StdFs),
+                    false,
+                    false,
+                    None,
+                    #[cfg(zstd_any)]
+                    None,
+                    Arc::new(crate::DefaultUserComparator),
+                    #[cfg(feature = "metrics")]
+                    Arc::new(crate::Metrics::default()),
+                )
+            };
+
+        // 1) Enabled (auto widths): section present, every key recovers.
+        let base_on = folder.path().join("on");
+        let table = write_and_recover(
+            &base_on,
+            LocatorPolicyEntry::Enabled {
+                precision: LocatorPrecision::Restart,
+                block_id_bits: None,
+                slot_bits: None,
+            },
+        )?;
+        let handle = table
+            .regions
+            .locator
+            .expect("locator section must be present when enabled");
+        let block = table.load_block(
+            &handle,
+            BlockType::Locator,
+            CompressionType::None,
+            #[cfg(zstd_any)]
+            None,
+        )?;
+        let section_bytes: &[u8] = &block.data;
+        let num_blocks = table.metadata.data_block_count;
+        assert!(num_blocks > 1, "test should produce multiple data blocks");
+        for i in 0..n {
+            let h = crate::hash::hash64(&i.to_be_bytes());
+            let (block_id, _slot) = locate_in_section(section_bytes, h)
+                .unwrap_or_else(|| panic!("inserted key {i} must locate"));
+            assert!(
+                block_id < num_blocks,
+                "key {i}: block_id {block_id} >= data_block_count {num_blocks}",
+            );
+        }
+
+        // 2) Disabled (default): no section (zero bytes, byte-identical).
+        let base_off = folder.path().join("off");
+        let table_off = write_and_recover(&base_off, LocatorPolicyEntry::None)?;
+        assert!(
+            table_off.regions.locator.is_none(),
+            "disabled policy must emit no locator section",
+        );
 
         Ok(())
     }

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -1004,7 +1004,7 @@ mod tests {
     fn locator_section_round_trips_through_writer() -> crate::Result<()> {
         use crate::config::{LocatorPolicyEntry, LocatorPrecision};
         use crate::table::block::BlockType;
-        use crate::table::locator::locate_in_section;
+        use crate::table::locator::locate;
         use crate::{CompressionType, InternalValue, UserKey, fs::StdFs};
         use std::sync::Arc;
 
@@ -1083,8 +1083,8 @@ mod tests {
         assert!(num_blocks > 1, "test should produce multiple data blocks");
         for i in 0..n {
             let h = crate::hash::hash64(&i.to_be_bytes());
-            let (block_id, _slot) = locate_in_section(section_bytes, h)
-                .unwrap_or_else(|| panic!("inserted key {i} must locate"));
+            let (block_id, _slot) =
+                locate(section_bytes, h)?.unwrap_or_else(|| panic!("inserted key {i} must locate"));
             assert!(
                 block_id < num_blocks,
                 "key {i}: block_id {block_id} >= data_block_count {num_blocks}",

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -88,6 +88,11 @@ pub struct ParsedRegions {
     /// widths fit; maps each key to its data block and slot for O(1) point
     /// reads. Absent on tables written without the locator feature.
     pub locator: Option<BlockHandle>,
+    /// Optional seqno-bounds section (the `seqno_bounds` section). Present only
+    /// when `seqno_in_index` was on; maps each data block's offset to its
+    /// `[seqno_min, seqno_max]` for the `scan_since_seqno` block-skip, kept
+    /// parallel to the index so point reads pay nothing for it.
+    pub seqno_bounds: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -137,6 +142,10 @@ impl ParsedRegions {
                 .transpose()?,
             locator: toc
                 .section(b"locator")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            seqno_bounds: toc
+                .section(b"seqno_bounds")
                 .map(toc_entry_to_handle)
                 .transpose()?,
             linked_blob_files: toc

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -83,6 +83,11 @@ pub struct ParsedRegions {
     /// Present only when the table has at least one data block that compressed
     /// into >= 2 inner zstd blocks; powers range-query partial decode.
     pub block_layout: Option<BlockHandle>,
+    /// Optional retrieval-ribbon locator section (the `locator` section).
+    /// Present only when the level's locator policy is enabled and the per-SST
+    /// widths fit; maps each key to its data block and slot for O(1) point
+    /// reads. Absent on tables written without the locator feature.
+    pub locator: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -128,6 +133,10 @@ impl ParsedRegions {
                 .transpose()?,
             block_layout: toc
                 .section(b"block_layout")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            locator: toc
+                .section(b"locator")
                 .map(toc_entry_to_handle)
                 .transpose()?,
             linked_blob_files: toc

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -196,4 +196,29 @@ mod tests {
         let buf = 1u32.to_le_bytes().to_vec();
         assert!(SeqnoBoundsMap::decode(&buf).is_err());
     }
+
+    #[test]
+    fn decode_rejects_trailing_bytes_after_last_entry() {
+        // A section with bytes past the declared entries must be rejected, not
+        // silently parsed with the wrong length: leftover data means a wrong
+        // count or a corrupt / padded section, so it must surface as an error.
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &[(BlockOffset(0), (1u64, 2u64))]);
+        buf.push(0xAB); // one stray trailing byte
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_count_larger_than_payload() {
+        // A corrupt count must be rejected up front, before any speculative
+        // allocation sized by that count: each entry is exactly 24 bytes, so a
+        // count claiming far more entries than the payload can hold is invalid.
+        // (The pathological multi-GB count that would OOM the old `with_capacity`
+        // cannot itself be unit-tested without risking an allocator abort; this
+        // guards the same contract with a count the decoder must reject fast.)
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&100_000u32.to_le_bytes()); // claims 100k entries
+        buf.extend_from_slice(&0u64.to_le_bytes()); // ...but only 8 stray bytes
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
 }

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Per-SST seqno-bounds section: a parallel `(data-block offset -> [seqno_min,
+//! seqno_max])` map that powers the `scan_since_seqno` block-skip WITHOUT
+//! bloating the index entries.
+//!
+//! The bounds used to live inline in each index entry (markers 2/3), which made
+//! every point-read index probe step over two extra varints and enlarged the
+//! index block (measurable point-read cost). Moving them into this optional
+//! parallel section keeps the index entries at their legacy size: a point read
+//! never touches the bounds, while a seqno-scoped scan looks the bounds up by
+//! data-block file offset and skips blocks whose `[min, max]` cannot overlap the
+//! target window.
+//!
+//! Optional + format-gated (emitted only when `seqno_in_index` is on), so a
+//! table written without it carries zero extra bytes. Offset-keyed (not ordinal)
+//! so a lookup cannot silently mis-map if block iteration order ever shifts.
+//!
+//! # Wire layout
+//!
+//! ```text
+//! [count: u32 LE]
+//! count × [ block_offset: u64 LE | seqno_min: u64 LE | seqno_max: u64 LE ]
+//! ```
+//!
+//! Entries are strictly ascending by `block_offset` (write order == file order),
+//! enabling a binary-search lookup.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::BlockOffset;
+use crate::SeqNo;
+
+/// Serialize the per-data-block seqno bounds into the `seqno_bounds` section.
+/// `bounds[i]` is `(block_offset, (seqno_min, seqno_max))` for one data block,
+/// in write (ascending-offset) order.
+pub fn encode_seqno_bounds(out: &mut Vec<u8>, bounds: &[(BlockOffset, (SeqNo, SeqNo))]) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "data-block count is bounded well within u32"
+    )]
+    let count = bounds.len() as u32;
+    out.extend_from_slice(&count.to_le_bytes());
+    for (offset, (seqno_min, seqno_max)) in bounds {
+        out.extend_from_slice(&offset.0.to_le_bytes());
+        out.extend_from_slice(&seqno_min.to_le_bytes());
+        out.extend_from_slice(&seqno_max.to_le_bytes());
+    }
+}
+
+/// Decoded `seqno_bounds` section: a lookup from a data block's file offset to
+/// its `[seqno_min, seqno_max]`. Empty when the table has no seqno bounds (the
+/// section was absent), in which case every lookup returns `None` and the scan
+/// falls back to a full per-entry filter.
+#[derive(Debug, Default, Clone)]
+pub struct SeqnoBoundsMap {
+    /// `(block_offset, (seqno_min, seqno_max))`, sorted ascending by offset for
+    /// binary-search lookup.
+    entries: Vec<(u64, (SeqNo, SeqNo))>,
+}
+
+impl SeqnoBoundsMap {
+    /// Decode a `seqno_bounds` section payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidHeader`] if the payload is truncated, the
+    /// entries are not strictly ascending by offset, or any entry has
+    /// `seqno_min > seqno_max` (a corrupt section must surface rather than
+    /// silently mis-skip a block).
+    pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
+        const ERR: crate::Error = crate::Error::InvalidHeader("SeqnoBounds");
+
+        fn take<'a>(r: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+            if r.len() < n {
+                return None;
+            }
+            let (head, tail) = r.split_at(n);
+            *r = tail;
+            Some(head)
+        }
+        fn read_u32(r: &mut &[u8]) -> Option<u32> {
+            let b: [u8; 4] = take(r, 4)?.try_into().ok()?;
+            Some(u32::from_le_bytes(b))
+        }
+        fn read_u64(r: &mut &[u8]) -> Option<u64> {
+            let b: [u8; 8] = take(r, 8)?.try_into().ok()?;
+            Some(u64::from_le_bytes(b))
+        }
+
+        let mut r = bytes;
+        let count = read_u32(&mut r).ok_or(ERR)?;
+        let mut entries = Vec::with_capacity(count as usize);
+        let mut prev: Option<u64> = None;
+        for _ in 0..count {
+            let offset = read_u64(&mut r).ok_or(ERR)?;
+            if prev.is_some_and(|p| offset <= p) {
+                return Err(ERR);
+            }
+            prev = Some(offset);
+            let seqno_min = read_u64(&mut r).ok_or(ERR)?;
+            let seqno_max = read_u64(&mut r).ok_or(ERR)?;
+            if seqno_min > seqno_max {
+                return Err(ERR);
+            }
+            entries.push((offset, (seqno_min, seqno_max)));
+        }
+        Ok(Self { entries })
+    }
+
+    /// The `[seqno_min, seqno_max]` for the data block at `offset`, or `None` if
+    /// the block was not recorded (legacy table without seqno bounds).
+    #[must_use]
+    pub fn bounds_for(&self, offset: u64) -> Option<(SeqNo, SeqNo)> {
+        let idx = self
+            .entries
+            .binary_search_by_key(&offset, |(o, _)| *o)
+            .ok()?;
+        self.entries.get(idx).map(|(_, b)| *b)
+    }
+
+    /// Whether any per-block bounds are recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Number of recorded data blocks.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let bounds = [
+            (BlockOffset(0), (10u64, 20u64)),
+            (BlockOffset(4096), (5, 5)),
+            (BlockOffset(9000), (0, 1_000_000)),
+        ];
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &bounds);
+        let map = SeqnoBoundsMap::decode(&buf).expect("decode");
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.bounds_for(0), Some((10, 20)));
+        assert_eq!(map.bounds_for(4096), Some((5, 5)));
+        assert_eq!(map.bounds_for(9000), Some((0, 1_000_000)));
+        // An offset not present (e.g. between recorded blocks) returns None.
+        assert_eq!(map.bounds_for(1), None);
+        assert_eq!(map.bounds_for(5000), None);
+    }
+
+    #[test]
+    fn decode_empty_section_is_empty_map() {
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &[]);
+        let map = SeqnoBoundsMap::decode(&buf).expect("decode empty");
+        assert!(map.is_empty());
+        assert_eq!(map.bounds_for(0), None);
+    }
+
+    #[test]
+    fn decode_rejects_non_ascending_offsets() {
+        // count=2 with offsets 100 then 50 (descending) must be rejected.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&2u32.to_le_bytes());
+        for (off, lo, hi) in [(100u64, 1u64, 2u64), (50, 1, 2)] {
+            buf.extend_from_slice(&off.to_le_bytes());
+            buf.extend_from_slice(&lo.to_le_bytes());
+            buf.extend_from_slice(&hi.to_le_bytes());
+        }
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_inverted_bounds() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        buf.extend_from_slice(&9u64.to_le_bytes()); // min
+        buf.extend_from_slice(&3u64.to_le_bytes()); // max < min
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_truncated_payload() {
+        // count=1 but no entry bytes.
+        let buf = 1u32.to_le_bytes().to_vec();
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+}

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -90,8 +90,20 @@ impl SeqnoBoundsMap {
             Some(u64::from_le_bytes(b))
         }
 
+        // Each entry is exactly three u64s on the wire.
+        const ENTRY_SIZE: usize = 3 * core::mem::size_of::<u64>();
+
         let mut r = bytes;
         let count = read_u32(&mut r).ok_or(ERR)?;
+        // Reject a corrupt count BEFORE the speculative allocation below: a
+        // count claiming more entries than the remaining payload can hold is
+        // invalid, and validating it up front bounds `with_capacity` to the
+        // real payload size (so a corrupt count cannot trigger a multi-GB
+        // pre-allocation / OOM instead of a clean `InvalidHeader`).
+        match (count as usize).checked_mul(ENTRY_SIZE) {
+            Some(needed) if needed <= r.len() => {}
+            _ => return Err(ERR),
+        }
         let mut entries = Vec::with_capacity(count as usize);
         let mut prev: Option<u64> = None;
         for _ in 0..count {
@@ -106,6 +118,12 @@ impl SeqnoBoundsMap {
                 return Err(ERR);
             }
             entries.push((offset, (seqno_min, seqno_max)));
+        }
+        // The section must contain exactly `count` entries and nothing more:
+        // leftover bytes mean a wrong count or a corrupt / padded section, so
+        // reject them rather than silently accept a mis-sized parse.
+        if !r.is_empty() {
+            return Err(ERR);
         }
         Ok(Self { entries })
     }

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -112,7 +112,8 @@ pub fn load_block(
             BlockType::Manifest
             | BlockType::ManifestFooter
             | BlockType::BlockLayout
-            | BlockType::Locator => {}
+            | BlockType::Locator
+            | BlockType::SeqnoBounds => {}
         }
 
         return Ok(block);
@@ -205,7 +206,8 @@ pub fn load_block(
         BlockType::Manifest
         | BlockType::ManifestFooter
         | BlockType::BlockLayout
-        | BlockType::Locator => {}
+        | BlockType::Locator
+        | BlockType::SeqnoBounds => {}
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -109,7 +109,10 @@ pub fn load_block(
             // Manifest variants are rejected by the function-level guard
             // above; the block-layout section is loaded once on open via
             // `Block::from_file`, never through this cached data-block path.
-            BlockType::Manifest | BlockType::ManifestFooter | BlockType::BlockLayout => {}
+            BlockType::Manifest
+            | BlockType::ManifestFooter
+            | BlockType::BlockLayout
+            | BlockType::Locator => {}
         }
 
         return Ok(block);
@@ -199,7 +202,10 @@ pub fn load_block(
         // Manifest variants are rejected by the function-level guard above;
         // the block-layout section is loaded once on open via
         // `Block::from_file`, never through this cached data-block path.
-        BlockType::Manifest | BlockType::ManifestFooter | BlockType::BlockLayout => {}
+        BlockType::Manifest
+        | BlockType::ManifestFooter
+        | BlockType::BlockLayout
+        | BlockType::Locator => {}
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -140,6 +140,26 @@ pub struct Writer {
     /// partial decode.
     block_layouts: Vec<(BlockOffset, Vec<u32>)>,
 
+    /// Resolved retrieval-ribbon locator settings for this table, or `None`
+    /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
+    /// `Some` makes the writer accumulate a per-key locator and emit the
+    /// optional `locator` section at finish. Wired via [`Self::use_locator`].
+    locator: Option<crate::table::locator::LocatorSpec>,
+
+    /// Accumulated `(key_hash, block_id, slot)` triples, one per unique user key
+    /// (the newest version's position), captured at the global new-key boundary
+    /// in [`Self::write`]. `block_id` is the data block's ordinal; `slot` is the
+    /// restart index (or exact entry index for `Entry` precision) of the key's
+    /// newest version within that block. Empty unless `locator` is `Some`;
+    /// packed and built into the `locator` section at finish.
+    locators: Vec<(u64, u64, u64)>,
+
+    /// Ordinal of the data block currently being filled (0-based, in write
+    /// order). Incremented once per spilled block, so it matches the block's
+    /// eventual registration ordinal in both the serial and parallel paths.
+    /// Stamped into each accumulated locator's `block_id`.
+    locator_block_id: u64,
+
     initial_level: u8,
 
     /// Block encryption provider (if encryption at rest is enabled)
@@ -268,6 +288,10 @@ impl Writer {
                 .use_table_id(table_id),
 
             block_layouts: Vec::new(),
+
+            locator: None,
+            locators: Vec::new(),
+            locator_block_id: 0,
 
             block_buffer: Vec::new(),
             file_writer: writer,
@@ -613,6 +637,31 @@ impl Writer {
         self
     }
 
+    /// Wires the resolved per-level retrieval-ribbon locator policy entry.
+    ///
+    /// `Enabled` makes the writer accumulate a per-key `(block_id, slot)`
+    /// locator and emit the optional `locator` section at finish; `None` leaves
+    /// the writer producing byte-identical SSTs (no section, no padding). Must
+    /// be set before the first key, like the other format-affecting `use_*`
+    /// toggles, since it changes which sections the table emits.
+    #[must_use]
+    pub fn use_locator(mut self, entry: crate::config::LocatorPolicyEntry) -> Self {
+        self.assert_not_started("use_locator");
+        self.locator = match entry {
+            crate::config::LocatorPolicyEntry::None => None,
+            crate::config::LocatorPolicyEntry::Enabled {
+                precision,
+                block_id_bits,
+                slot_bits,
+            } => Some(crate::table::locator::LocatorSpec {
+                precision,
+                block_id_bits,
+                slot_bits,
+            }),
+        };
+        self
+    }
+
     /// When `enabled`, clears per-file copy-on-write on this table's (still
     /// empty) file via [`crate::fs::Fs::try_disable_cow`], so a write-once SST
     /// on a copy-on-write filesystem (Btrfs) avoids the fragmentation penalty.
@@ -695,6 +744,25 @@ impl Writer {
             if self.bloom_policy.is_active() {
                 self.filter_writer.register_key(&user_key)?;
             }
+
+            // Retrieval-ribbon locator: record this key's newest version (its
+            // first occurrence in scan order) at its position in the forming
+            // data block. `chunk.len()` is the item index this key will take
+            // (it is pushed below at the same index); `locator_block_id` is the
+            // current block's ordinal. `slot` is the restart index the encoder
+            // will assign (`item_index / restart_interval`) for `Restart`, or
+            // the exact item index for `Entry`.
+            if let Some(spec) = self.locator {
+                let pos = self.chunk.len() as u64;
+                let slot = match spec.precision {
+                    crate::config::LocatorPrecision::Restart => {
+                        pos / u64::from(self.data_block_restart_interval)
+                    }
+                    crate::config::LocatorPrecision::Entry => pos,
+                };
+                self.locators
+                    .push((crate::hash::hash64(&user_key), self.locator_block_id, slot));
+            }
         }
 
         if self.meta.first_key.is_none() {
@@ -731,6 +799,15 @@ impl Writer {
         let Some(last) = self.chunk.last() else {
             return Ok(());
         };
+
+        // Advance the locator block ordinal: this spill flushes the block whose
+        // keys were recorded with the current `locator_block_id`, so the next
+        // block's keys belong to the next ordinal. Done here (not per write
+        // path) so it stays correct for both the serial and parallel spills.
+        // Gated on the feature so an unenabled writer pays nothing.
+        if self.locator.is_some() {
+            self.locator_block_id += 1;
+        }
 
         // Order-independent index-handle data, captured before the chunk is
         // consumed. The parallel path needs it owned because the chunk is
@@ -1122,6 +1199,40 @@ impl Writer {
                 // Layout metadata is small and read on the cold-block path;
                 // store it uncompressed. Encryption / page_ecc still apply via
                 // the configured providers, matching the other meta sections.
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
+
+        // Write the optional retrieval-ribbon locator section. Emitted only when
+        // the level's locator policy is enabled AND the per-SST widths fit the
+        // actual layout (`build_locator_section` returns `None` to skip
+        // gracefully otherwise). Absent for a default table, so no bytes added.
+        if let Some(spec) = self.locator
+            && let Some(section) =
+                crate::table::locator::build_locator_section(&self.locators, spec)
+        {
+            self.file_writer.start("locator")?;
+            Block::write_into(
+                &mut self.file_writer,
+                &section,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_type: crate::table::block::BlockType::Locator,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                // Same protection envelope as the other meta sections: optional
+                // encryption + page ECC via the configured providers.
                 &{
                     let t = match self.encryption.as_deref() {
                         Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -755,6 +755,9 @@ impl Writer {
             if let Some(spec) = self.locator {
                 let pos = self.chunk.len() as u64;
                 let slot = match spec.precision {
+                    // Per-block precision drops slot (the section build masks it
+                    // to 0-width); record 0 to keep max_slot minimal.
+                    crate::config::LocatorPrecision::Block => 0,
                     crate::config::LocatorPrecision::Restart => {
                         pos / u64::from(self.data_block_restart_interval)
                     }

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -140,6 +140,14 @@ pub struct Writer {
     /// partial decode.
     block_layouts: Vec<(BlockOffset, Vec<u32>)>,
 
+    /// Per-data-block `(offset, (seqno_min, seqno_max))`, accumulated in write
+    /// order when `use_seqno_in_index` is on and serialized into the optional
+    /// `seqno_bounds` SST section at finish. The bounds live here (a parallel
+    /// section) rather than inline in the index entries, so a point read's index
+    /// walk never pays for them; only a seqno-scoped scan loads the section.
+    /// Empty when `use_seqno_in_index` is off (section absent, zero extra bytes).
+    seqno_bounds_section: Vec<(BlockOffset, (u64, u64))>,
+
     /// Resolved retrieval-ribbon locator settings for this table, or `None`
     /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
     /// `Some` makes the writer accumulate a per-key locator and emit the
@@ -193,13 +201,14 @@ pub struct Writer {
     )>,
 
     /// Per-block seqno bounds opt-in (the `seqno_in_index` runtime config).
-    /// When `true`, every data-block index entry carries `(seqno_min,
-    /// seqno_max)` (wire markers 2 / 3) and the SST is tagged
-    /// `index_format = 1`, letting a seqno-scoped scan skip blocks below the
-    /// target without reading them. Default `false` (legacy `index_format =
-    /// 0`, byte-identical index entries). Caller wires the live runtime
-    /// config into this field via [`Self::use_seqno_in_index`] before the
-    /// first key is added.
+    /// When `true`, the writer accumulates each data block's `(seqno_min,
+    /// seqno_max)` and emits them in the optional parallel `seqno_bounds`
+    /// SST section, letting a seqno-scoped scan skip blocks that cannot
+    /// overlap the target window without reading them. The index entries
+    /// stay byte-identical to the off-mode layout, so a point read pays
+    /// nothing. Default `false` (no section emitted). Caller wires the live
+    /// runtime config into this field via [`Self::use_seqno_in_index`]
+    /// before the first key is added.
     use_seqno_in_index: bool,
 
     /// Pre-trained zstd dictionary for dictionary compression
@@ -288,6 +297,7 @@ impl Writer {
                 .use_table_id(table_id),
 
             block_layouts: Vec::new(),
+            seqno_bounds_section: Vec::new(),
 
             locator: None,
             locators: Vec::new(),
@@ -618,20 +628,19 @@ impl Writer {
         self
     }
 
-    /// Enables per-block seqno bounds in the data-block index (the
-    /// `seqno_in_index` runtime config). When `true`, each index entry
-    /// carries `(seqno_min, seqno_max)` and the SST is tagged
-    /// `index_format = 1`. Must be called BEFORE the first key is added so
-    /// every index entry in the table uses the same format; callers
-    /// (`Tree` flush + compaction worker) pass the live config once at
-    /// writer construction. Default `false` (legacy `index_format = 0`).
+    /// Enables the optional per-block seqno-bounds section (the
+    /// `seqno_in_index` runtime config). When `true`, the writer records each
+    /// data block's `(seqno_min, seqno_max)` and emits the parallel
+    /// `seqno_bounds` section at `finish()`, powering the `scan_since_seqno`
+    /// block-skip. Must be called BEFORE the first key is added so the section
+    /// covers every block; callers (`Tree` flush + compaction worker) pass the
+    /// live config once at writer construction. Default `false` (no section).
     #[must_use]
     pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
-        // Must be fixed before the first key: `finish()` stamps a single
-        // SST-wide `index_format` from the final flag, while `spill_block`
-        // snapshots it per block — a mid-write toggle would leave mixed
-        // index-entry encodings behind incorrect table metadata. Same
-        // contract as `use_page_ecc` / `use_kv_checksums`.
+        // Must be fixed before the first key: the section must cover every
+        // block, so the flag is snapshotted per block in `spill_block` and a
+        // mid-write toggle would leave some blocks unrecorded. Same contract
+        // as `use_page_ecc` / `use_kv_checksums`.
         self.assert_not_started("use_seqno_in_index");
         self.use_seqno_in_index = seqno_in_index;
         self
@@ -993,13 +1002,18 @@ impl Writer {
         // or the handle over-reads on a non-default scheme.
         let bytes_written = header.on_disk_size_with(self.ecc);
 
-        let mut handle = KeyedBlockHandle::new(
+        let handle = KeyedBlockHandle::new(
             last_key.clone(),
             last_seqno,
             BlockHandle::new(self.meta.file_pos, bytes_written),
         );
+        // Seqno bounds go into the parallel `seqno_bounds` section keyed by this
+        // block's file offset, NOT inline in the index entry: keeping them out of
+        // the index keeps point-read index probes at their legacy cost while the
+        // seqno-scoped scan loads the section.
         if let Some((seqno_min, seqno_max)) = seqno_bounds {
-            handle = handle.with_seqno_bounds(seqno_min, seqno_max);
+            self.seqno_bounds_section
+                .push((self.meta.file_pos, (seqno_min, seqno_max)));
         }
         self.index_writer.register_data_block(handle)?;
 
@@ -1216,6 +1230,39 @@ impl Writer {
             )?;
         }
 
+        // Write the optional seqno-bounds section (only when seqno_in_index is on
+        // and at least one block was written). Parallel to the index, keyed by
+        // data-block offset; absent otherwise, so the index stays legacy-sized.
+        if !self.seqno_bounds_section.is_empty() {
+            self.file_writer.start("seqno_bounds")?;
+            self.block_buffer.clear();
+            crate::table::seqno_bounds::encode_seqno_bounds(
+                &mut self.block_buffer,
+                &self.seqno_bounds_section,
+            );
+            Block::write_into(
+                &mut self.file_writer,
+                &self.block_buffer,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_type: crate::table::block::BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
+
         // Write the optional retrieval-ribbon locator section. Emitted only when
         // the level's locator policy is enabled AND the per-SST widths fit the
         // actual layout (`build_locator_section` returns `None` to skip
@@ -1368,11 +1415,6 @@ impl Writer {
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
-            // `1` when the writer was built with `use_seqno_in_index(true)`:
-            // every data-block index entry carries `(seqno_min, seqno_max)`
-            // (wire markers 2 / 3) for seqno-scoped block-skip. `0` is the
-            // legacy format, byte-identical to the pre-seqno-bounds layout.
-            index_format: u8::from(self.use_seqno_in_index),
             range_tombstone_count,
             created_at_nanos,
         };
@@ -1589,11 +1631,6 @@ struct MetaSectionParams<'a> {
     data_block_restart_interval: u8,
     index_block_restart_interval: u8,
     initial_level: u8,
-    /// Index block format byte written to the SST Properties (#224).
-    /// `0` = legacy (no per-block seqno bounds); `1` = each data-block
-    /// index entry carries `(seqno_min, seqno_max)`. Set from the writer's
-    /// `seqno_in_index` config (`u8::from(self.use_seqno_in_index)`).
-    index_format: u8,
     range_tombstone_count: u64,
     /// `created_at` snapshot taken once in `finish()`. Both MID and
     /// TAIL writes consume this same value; generating it inside
@@ -1746,12 +1783,6 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         meta("descriptor#page_ecc", &ecc_descriptor),
         meta("file_size", &p.file_size.to_le_bytes()),
         meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
-        // Index block format: 0 = legacy (no per-block seqno bounds in
-        // index entries, byte-identical to the prior layout); 1 = each
-        // data-block index entry carries `(seqno_min, seqno_max)` for
-        // seqno-scoped block-skip. Set from the writer's `seqno_in_index`
-        // config at build time.
-        meta("index_format", &[p.index_format]),
         meta("index_keys_have_seqno", &[0x1]),
         meta("initial_level", &p.initial_level.to_le_bytes()),
         meta("item_count", &p.item_count.to_le_bytes()),

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -146,6 +146,7 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_seqno_in_index(rc.seqno_in_index);
         writer = writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
+        writer = writer.use_locator(tree.config.locator_policy.get(INITIAL_CANONICAL_LEVEL));
 
         #[cfg(zstd_any)]
         {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1182,10 +1182,10 @@ impl Tree {
     ///
     /// # Block-skip
     ///
-    /// On SSTs written in the seqno-bounded index format (`seqno_in_index`),
-    /// data blocks whose `seqno_max < target_seqno` are skipped without being
-    /// read; legacy SSTs are read and filtered per entry, so mixed-format trees
-    /// are handled transparently.
+    /// On SSTs written with the `seqno_bounds` section (`seqno_in_index`), data
+    /// blocks whose bounds cannot overlap the target window are skipped without
+    /// being read; SSTs without the section are read and filtered per entry, so
+    /// mixed trees are handled transparently.
     ///
     /// # KV-separation
     ///
@@ -1196,13 +1196,15 @@ impl Tree {
     ///
     /// # Corruption resilience
     ///
-    /// The per-block seqno-bounds used for skipping live in the index block and
-    /// are covered by its XXH3-128 checksum (+ optional Page ECC), so a
-    /// corrupted bound is caught on read, not trusted. Even in the impossible
-    /// case of a fault bypassing those checks, a bad bound can only cause a
-    /// *missed* record, never a wrong one. Callers who want defense against that
-    /// hypothetical can use [`Self::scan_since_seqno_full_scan`], which reads
-    /// every block (slower, no skip).
+    /// The per-block seqno-bounds used for skipping live in the optional
+    /// `seqno_bounds` SST section, a Block covered by XXH3-128 (+ optional Page
+    /// ECC) and verified when it is loaded at open, plus a decode that rejects
+    /// non-ascending offsets and inverted bounds, so a corrupted bound is caught
+    /// rather than trusted. Even in the impossible case of a fault bypassing
+    /// those checks, a bad bound can only cause a *missed* record, never a wrong
+    /// one. Callers who want defense against that hypothetical can use
+    /// [`Self::scan_since_seqno_full_scan`], which reads every block (slower, no
+    /// skip).
     ///
     /// # Panics
     ///
@@ -1234,9 +1236,10 @@ impl Tree {
     ///
     /// The fast [`Self::scan_since_seqno`] trusts each block's recorded
     /// `[seqno_min, seqno_max]` to skip blocks that cannot hold a qualifying
-    /// record. Those bounds live inside the index block and are covered by its
-    /// XXH3-128 checksum (and optional Page ECC), so on-disk corruption is
-    /// caught on read, not silently trusted. This method exists for callers who
+    /// record. Those bounds live in the `seqno_bounds` SST section, a Block
+    /// covered by XXH3-128 (and optional Page ECC) and verified at open, so
+    /// on-disk corruption is caught, not silently trusted. This method exists
+    /// for callers who
     /// want defense even against a fault that somehow bypassed those checks: a
     /// corrupted `seqno_max` can only ever cause a *missed* record (never a
     /// wrong one), and a full scan cannot miss. It is slower (no skip), so

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1083,6 +1083,7 @@ impl Tree {
     pub(crate) fn scan_since_seqno_with<F>(
         &self,
         target_seqno: SeqNo,
+        block_skip: bool,
         resolve_indirection: F,
     ) -> crate::Result<alloc::vec::IntoIter<ScanSinceEvent>>
     where
@@ -1133,7 +1134,9 @@ impl Tree {
         for table in version.iter_tables() {
             // `scan_seqno_range` upper bound is exclusive; `end_seqno` is the
             // inclusive max, so add one (saturating for the MAX edge).
-            for entry in table.scan_seqno_range(target_seqno, end_seqno.saturating_add(1))? {
+            for entry in
+                table.scan_seqno_range(target_seqno, end_seqno.saturating_add(1), block_skip)?
+            {
                 events.push(Self::map_event(entry, version, &resolve_indirection)?);
             }
         }
@@ -1191,6 +1194,16 @@ impl Tree {
     /// blob resolution into [`ScanSinceEvent::Insert`] is provided by the
     /// blob-tree scan path, which owns the blob files.
     ///
+    /// # Corruption resilience
+    ///
+    /// The per-block seqno-bounds used for skipping live in the index block and
+    /// are covered by its XXH3-128 checksum (+ optional Page ECC), so a
+    /// corrupted bound is caught on read, not trusted. Even in the impossible
+    /// case of a fault bypassing those checks, a bad bound can only cause a
+    /// *missed* record, never a wrong one. Callers who want defense against that
+    /// hypothetical can use [`Self::scan_since_seqno_full_scan`], which reads
+    /// every block (slower, no skip).
+    ///
     /// # Panics
     ///
     /// Panics if the internal version-history lock is poisoned.
@@ -1206,7 +1219,42 @@ impl Tree {
         // A standard tree never stores blob-indirected values; the resolver
         // errors so an indirected entry (only reachable via a blob tree's inner
         // index) surfaces as a clear error rather than a wrong event.
-        self.scan_since_seqno_with(target_seqno, |_version, _entry| {
+        self.scan_since_seqno_with(target_seqno, true, |_version, _entry| {
+            Err(crate::Error::FeatureUnsupported(
+                "scan_since_seqno on KV-separated values requires the blob-tree scan path",
+            ))
+        })
+    }
+
+    /// Paranoid variant of [`Self::scan_since_seqno`] that disables the
+    /// per-block seqno-bounds skip: every data block is read and filtered per
+    /// entry, even on seqno-indexed SSTs.
+    ///
+    /// # When to use
+    ///
+    /// The fast [`Self::scan_since_seqno`] trusts each block's recorded
+    /// `[seqno_min, seqno_max]` to skip blocks that cannot hold a qualifying
+    /// record. Those bounds live inside the index block and are covered by its
+    /// XXH3-128 checksum (and optional Page ECC), so on-disk corruption is
+    /// caught on read, not silently trusted. This method exists for callers who
+    /// want defense even against a fault that somehow bypassed those checks: a
+    /// corrupted `seqno_max` can only ever cause a *missed* record (never a
+    /// wrong one), and a full scan cannot miss. It is slower (no skip), so
+    /// prefer [`Self::scan_since_seqno`] unless you specifically need this
+    /// guarantee.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal version-history lock is poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::scan_since_seqno`].
+    pub fn scan_since_seqno_full_scan(
+        &self,
+        target_seqno: SeqNo,
+    ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
+        self.scan_since_seqno_with(target_seqno, false, |_version, _entry| {
             Err(crate::Error::FeatureUnsupported(
                 "scan_since_seqno on KV-separated values requires the blob-tree scan path",
             ))

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -582,6 +582,8 @@ impl AbstractTree for Tree {
         // and the meta block a descriptor key regardless, so the on-disk bytes
         // are not identical to a pre-V5 table).
         table_writer = table_writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
+        // Flush writes level 0; resolve that level's locator policy entry.
+        table_writer = table_writer.use_locator(self.config.locator_policy.get(0));
 
         #[cfg(zstd_any)]
         {

--- a/tests/locator_read_path.rs
+++ b/tests/locator_read_path.rs
@@ -119,3 +119,58 @@ fn locator_precisions_match_index_path() {
     // Absent key → None.
     assert_eq!(on.get(key_of(N + 50), SeqNo::MAX).expect("get"), None);
 }
+
+/// A corrupt on-disk locator section must NOT fail table open: the loader is
+/// best-effort, so it degrades the section to `None` and every point read still
+/// returns the right answer via the sorted-index fallback. Exercises the
+/// section-load failure branch of the locator open path.
+#[test]
+fn corrupt_locator_section_degrades_to_index_fallback() {
+    use std::io::{Seek, SeekFrom, Write};
+
+    let (folder, tree) = build(Some(LocatorPrecision::Block));
+    let baseline = answers(&tree);
+
+    let lsm_tree::AnyTree::Standard(std_tree) = &tree else {
+        panic!("expected a standard tree");
+    };
+    let (sst_path, offset, size) = {
+        let version = std_tree.current_version();
+        let table = version
+            .iter_tables()
+            .next()
+            .expect("corpus compacts to a single SST");
+        let loc = table
+            .regions
+            .locator
+            .expect("a default Block-precision SST carries a locator section");
+        (table.path.as_ref().clone(), *loc.offset(), loc.size())
+    };
+    drop(tree);
+
+    // Overwrite the locator section so its block checksum no longer matches.
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&sst_path)
+        .expect("open SST for corruption");
+    f.seek(SeekFrom::Start(offset)).expect("seek");
+    f.write_all(&vec![0xFF; size as usize]).expect("corrupt");
+    f.sync_all().expect("sync");
+    drop(f);
+
+    // Reopen: the table must still open (no hard failure on the corrupt
+    // section), and answers must match the pre-corruption baseline.
+    let reopened = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(lsm_tree::config::BlockSizePolicy::all(4_096))
+    .open()
+    .expect("reopen must succeed despite a corrupt locator section");
+    assert_eq!(
+        answers(&reopened),
+        baseline,
+        "index fallback must return identical answers after locator degrades",
+    );
+}

--- a/tests/locator_read_path.rs
+++ b/tests/locator_read_path.rs
@@ -1,0 +1,121 @@
+//! End-to-end correctness of the retrieval-ribbon locator on the point-read
+//! path: a tree written with the locator enabled must return byte-identical
+//! results to one written without it, across multiple versions per key,
+//! tombstones, and snapshot reads. The locator only changes *how* a point read
+//! finds the block (O(1) ribbon resolve vs index binary search); the answer
+//! must be unchanged, with a safe fall-through to the index on any miss.
+
+use lsm_tree::config::{LocatorPolicy, LocatorPolicyEntry, LocatorPrecision};
+use lsm_tree::{AbstractTree, Config, SeqNo, SequenceNumberCounter, get_tmp_folder};
+use test_log::test;
+
+const N: u64 = 1_500;
+
+fn key_of(i: u64) -> [u8; 8] {
+    i.to_be_bytes()
+}
+
+/// Build a tree (locator on/off), write a fixed multi-version + tombstone
+/// corpus, flush, and compact to a single run so point reads exercise the
+/// locator's block resolution over many data blocks.
+fn build(precision: Option<LocatorPrecision>) -> (tempfile::TempDir, lsm_tree::AnyTree) {
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let mut cfg = Config::new(folder.path(), seqno, SequenceNumberCounter::default())
+        // Force many small data blocks so block_id is non-trivial.
+        .data_block_size_policy(lsm_tree::config::BlockSizePolicy::all(4_096));
+    if let Some(precision) = precision {
+        cfg = cfg.locator_policy(LocatorPolicy::all(LocatorPolicyEntry::Enabled {
+            precision,
+            block_id_bits: None,
+            slot_bits: None,
+        }));
+    }
+    let tree = cfg.open().expect("open");
+
+    for i in 0..N {
+        // v1 at seqno 10 for every key.
+        tree.insert(key_of(i), format!("v1-{i}").as_bytes(), 10);
+        // v2 at seqno 20 for even keys.
+        if i % 2 == 0 {
+            tree.insert(key_of(i), format!("v2-{i}").as_bytes(), 20);
+        }
+        // tombstone at seqno 30 for every 5th key.
+        if i % 5 == 0 {
+            tree.remove(key_of(i), 30);
+        }
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(u64::MAX, 0).expect("compact");
+
+    (folder, tree)
+}
+
+/// Run the full query matrix and return the answers as bytes (None encoded as
+/// an empty marker) so two trees can be compared exactly.
+fn answers(tree: &lsm_tree::AnyTree) -> Vec<Option<Vec<u8>>> {
+    let mut out = Vec::new();
+    // Probe at three snapshots + present and absent keys.
+    for snap in [15u64, 25, SeqNo::MAX] {
+        for i in 0..(N + 200) {
+            let v = tree
+                .get(key_of(i), snap)
+                .expect("get")
+                .map(|slice| slice.to_vec());
+            out.push(v);
+        }
+    }
+    out
+}
+
+#[test]
+fn locator_precisions_match_index_path() {
+    let (_off_dir, off) = build(None);
+    let off_answers = answers(&off);
+
+    // Every precision (per-block / per-sub-block / per-key) resolves the data
+    // block the same way on the read path; all must match the index baseline.
+    for precision in [
+        LocatorPrecision::Block,
+        LocatorPrecision::Restart,
+        LocatorPrecision::Entry,
+    ] {
+        let (_on_dir, on) = build(Some(precision));
+        let on_answers = answers(&on);
+
+        assert_eq!(
+            on_answers.len(),
+            off_answers.len(),
+            "answer matrices must be the same shape",
+        );
+        for (idx, (a, b)) in on_answers.iter().zip(off_answers.iter()).enumerate() {
+            assert_eq!(
+                a, b,
+                "locator {precision:?} vs locator-off disagree at query #{idx}",
+            );
+        }
+    }
+
+    // Spot-check known expectations against an enabled tree so a both-wrong
+    // bug (fast path and index path corrupted identically) cannot pass.
+    let (_on_dir, on) = build(Some(LocatorPrecision::Restart));
+    // Spot-check a couple of known expectations so a both-wrong bug can't pass.
+    // Key 0: v1@10, v2@20 (even), tombstone@30 (i%5==0) → None at MAX.
+    assert_eq!(on.get(key_of(0), SeqNo::MAX).expect("get"), None);
+    // Key 2: even, not i%5 → v2 at MAX.
+    assert_eq!(
+        on.get(key_of(2), SeqNo::MAX)
+            .expect("get")
+            .map(|s| s.to_vec()),
+        Some(b"v2-2".to_vec()),
+    );
+    // Key 3: odd, not i%5 → v1 at MAX.
+    assert_eq!(
+        on.get(key_of(3), SeqNo::MAX)
+            .expect("get")
+            .map(|s| s.to_vec()),
+        Some(b"v1-3".to_vec()),
+    );
+    // Absent key → None.
+    assert_eq!(on.get(key_of(N + 50), SeqNo::MAX).expect("get"), None);
+}

--- a/tests/partitioned_index_blast_radius.rs
+++ b/tests/partitioned_index_blast_radius.rs
@@ -12,6 +12,12 @@
 //! justifies flipping the partitioned-index default ON for every
 //! level: blast radius shrinks from "whole SST unreadable" to "one
 //! partition unreadable".
+//!
+//! These tests run with the default config, which enables the retrieval-ribbon
+//! locator (block precision). The locator must NOT widen this blast radius: a
+//! corrupt sub-index block must still degrade the locator to a graceful skip at
+//! open (falling back to the sorted index) rather than failing the whole table
+//! open — so this suite also guards that interaction.
 
 use lsm_tree::{
     AbstractTree, Config, SequenceNumberCounter,

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -180,12 +180,13 @@ fn tree_kv_checksums_all_levels_round_trips_through_disk() {
 
 #[test]
 fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> {
-    // With `seqno_in_index` enabled, every data-block index entry is written
-    // in the seqno-bounded format (markers 2 / 3) and the SST is tagged
-    // index_format=1. The whole point of the format is that the data must
-    // read back identically: flush, point-read, reopen, point-read again.
-    // Reopen is the load-bearing step — it re-parses the on-disk index from
-    // scratch, so a broken seqno-bounded decode surfaces as a read failure.
+    // With `seqno_in_index` enabled, the writer emits the parallel
+    // `seqno_bounds` SST section (one `(seqno_min, seqno_max)` per data block);
+    // the index entries themselves stay legacy. The whole point is that the
+    // data must read back identically: flush, point-read, reopen, point-read
+    // again. Reopen is the load-bearing step — it re-parses the on-disk index
+    // and the seqno-bounds section from scratch, so a broken decode surfaces as
+    // a read failure.
     let folder = get_tmp_folder();
 
     {
@@ -230,9 +231,9 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
         }
     }
 
-    // Reopen: the index blocks are decoded fresh from disk. Runtime config
-    // resets to default on reopen (not persisted), but the on-disk
-    // index_format=1 entries must still decode via per-marker dispatch.
+    // Reopen: the index blocks and the seqno-bounds section are decoded fresh
+    // from disk. Runtime config resets to default on reopen (not persisted),
+    // but the on-disk data must still read back correctly.
     let tree = open_tree(folder.path());
     for i in 0..500u64 {
         let key = format!("key{i:05}");
@@ -244,8 +245,7 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
         );
     }
 
-    // A key never inserted must still be absent (index seek lands correctly
-    // on the seqno-bounded entries).
+    // A key never inserted must still be absent (index seek lands correctly).
     assert!(tree.get(b"key99999", SeqNo::MAX)?.is_none());
 
     Ok(())

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -345,3 +345,118 @@ fn scan_since_caught_up_target_returns_empty() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+// ---- Corruption matrix (#224) ---------------------------------------------
+
+/// The paranoid full-scan variant disables the per-block seqno-bounds skip but
+/// must return byte-identical results to the fast block-skip path. This proves
+/// the no-skip path is correct (and, by extension, that a hypothetical
+/// undetected-corrupt bound which made the fast path skip a block could only
+/// ever cause a missed record, which the full scan recovers).
+#[test]
+fn scan_since_full_scan_matches_block_skip() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path())?;
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+    for i in 0..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    for target in [0u64, 123, 450, 499, 500] {
+        let fast: Vec<SeqNo> = events(&tree, target)?
+            .iter()
+            .map(ScanSinceEvent::seqno)
+            .collect();
+        let full: Vec<SeqNo> = tree
+            .scan_since_seqno_full_scan(target)?
+            .map(|e| e.seqno())
+            .collect();
+        assert_eq!(
+            fast, full,
+            "paranoid full scan must equal block-skip scan at target {target}",
+        );
+    }
+    Ok(())
+}
+
+/// A bit-flip in a seqno-bounded sub-index block (which stores the per-block
+/// `[seqno_min, seqno_max]`) must be caught by the index block's XXH3-128 on the
+/// scan's index walk, not silently trusted. Forces a partitioned index so
+/// `read_top_level_index_entries` yields the sub-index blocks that carry the
+/// bounds.
+#[test]
+fn scan_since_seqno_index_corruption_is_caught() -> lsm_tree::Result<()> {
+    use lsm_tree::config::{BlockSizePolicy, PinningPolicy};
+    use lsm_tree::inspect::read_top_level_index_entries;
+    use lsm_tree::runtime_config::RuntimeConfig;
+    use std::io::{Seek, Write};
+
+    // Runtime config at open: seqno bounds in the index + force the index to
+    // partition (zero spill threshold) so the bounds land in checksummed
+    // sub-index blocks.
+    let mut rc = RuntimeConfig::default();
+    rc.seqno_in_index = true;
+    rc.index_partition_spill_threshold = 0;
+
+    let folder = get_tmp_folder();
+    {
+        let any = Config::new(
+            folder.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .index_block_partitioning_policy(PinningPolicy::all(true))
+        .data_block_size_policy(BlockSizePolicy::all(256))
+        .with_runtime_config(rc)
+        .open()?;
+        let tree = match any {
+            AnyTree::Standard(t) => t,
+            AnyTree::Blob(_) => panic!("expected Standard tree"),
+        };
+        // Large corpus → many small data blocks → many index handles → multiple
+        // sub-index partitions (the partition budget is ~4 KiB).
+        for i in 0..30_000u64 {
+            tree.insert(format!("key{i:08}").as_bytes(), b"v", i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Locate the single SST and a sub-index block to corrupt.
+    let sst = std::fs::read_dir(folder.path().join("tables"))
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.is_file())
+        .expect("one SST file");
+    let tli = read_top_level_index_entries(&sst).expect("read top-level index");
+    assert!(
+        tli.len() > 1,
+        "test needs a partitioned index (>1 sub-index block), got {}",
+        tli.len(),
+    );
+    let victim = &tli[0];
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&sst)
+            .expect("open sst");
+        f.seek(std::io::SeekFrom::Start(victim.offset))
+            .expect("seek");
+        f.write_all(&vec![0xFF; victim.size as usize])
+            .expect("flip");
+        f.sync_all().expect("sync");
+    }
+
+    // Reopen and scan: the corrupted sub-index block fails its checksum.
+    let tree = open_tree(folder.path())?;
+    let res: lsm_tree::Result<Vec<ScanSinceEvent>> =
+        tree.scan_since_seqno(0).map(Iterator::collect);
+    assert!(
+        res.is_err(),
+        "a corrupted seqno-bounded sub-index block must be caught by XXH3, not trusted",
+    );
+    Ok(())
+}

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -4,9 +4,9 @@
 //! End-to-end coverage for `Tree::scan_since_seqno` (CDC event stream):
 //! target filtering, increasing-seqno replay order, event-type mapping
 //! (Insert / PointTombstone / RangeTombstone), coverage across memtable and
-//! SSTs, the seqno-bounded block-skip path, and mixed-format trees (a tree
-//! that holds both legacy `index_format=0` and seqno-bounded `index_format=1`
-//! SSTs must scan correctly).
+//! SSTs, the per-block seqno-bounds block-skip path, and mixed trees (a tree
+//! that holds both SSTs with a `seqno_bounds` section and SSTs without one
+//! must scan correctly).
 
 use lsm_tree::{
     AbstractTree, AnyTree, BlobTree, Config, ScanSinceEvent, SeqNo, SequenceNumberCounter, Tree,
@@ -205,13 +205,13 @@ fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path())?;
 
-    // First SST: legacy index_format=0 (seqno_in_index defaults off).
+    // First SST: no seqno_bounds section (seqno_in_index defaults off).
     for i in 0..250u64 {
         tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
     }
     tree.flush_active_memtable(0)?;
 
-    // Toggle on, second SST: seqno-bounded index_format=1.
+    // Toggle on, second SST: emits a seqno_bounds section.
     tree.update_runtime_config(|cfg| {
         cfg.seqno_in_index = true;
     })?;
@@ -382,11 +382,11 @@ fn scan_since_full_scan_matches_block_skip() -> lsm_tree::Result<()> {
     Ok(())
 }
 
-/// A bit-flip in a seqno-bounded sub-index block (which stores the per-block
-/// `[seqno_min, seqno_max]`) must be caught by the index block's XXH3-128 on the
-/// scan's index walk, not silently trusted. Forces a partitioned index so
-/// `read_top_level_index_entries` yields the sub-index blocks that carry the
-/// bounds.
+/// A bit-flip in a sub-index block must be caught by the index block's XXH3-128
+/// on the scan's index walk, not silently trusted: the seqno-scoped scan still
+/// reads the full index to enumerate data blocks, so a corrupt sub-index block
+/// must surface as an error. Forces a partitioned index so
+/// `read_top_level_index_entries` yields multiple sub-index blocks.
 #[test]
 fn scan_since_seqno_index_corruption_is_caught() -> lsm_tree::Result<()> {
     use lsm_tree::config::{BlockSizePolicy, PinningPolicy};
@@ -394,9 +394,9 @@ fn scan_since_seqno_index_corruption_is_caught() -> lsm_tree::Result<()> {
     use lsm_tree::runtime_config::RuntimeConfig;
     use std::io::{Seek, Write};
 
-    // Runtime config at open: seqno bounds in the index + force the index to
-    // partition (zero spill threshold) so the bounds land in checksummed
-    // sub-index blocks.
+    // Runtime config at open: enable the seqno_bounds section + force the index
+    // to partition (zero spill threshold) so the index spills into multiple
+    // checksummed sub-index blocks.
     let mut rc = RuntimeConfig::default();
     rc.seqno_in_index = true;
     rc.index_partition_spill_threshold = 0;
@@ -456,7 +456,77 @@ fn scan_since_seqno_index_corruption_is_caught() -> lsm_tree::Result<()> {
         tree.scan_since_seqno(0).map(Iterator::collect);
     assert!(
         res.is_err(),
-        "a corrupted seqno-bounded sub-index block must be caught by XXH3, not trusted",
+        "a corrupted sub-index block must be caught by XXH3 on the scan, not trusted",
     );
+    Ok(())
+}
+
+/// The retrieval-ribbon locator (point-read fast path) and the `seqno_bounds`
+/// section (scan_since_seqno block-skip) are independent optional SST sections.
+/// An SST that carries BOTH must serve both paths correctly: point reads via the
+/// locator and seqno-scoped scans via the block-skip, neither perturbing the
+/// other. Locks down that the two features compose.
+#[test]
+fn scan_since_with_locator_enabled_is_correct() -> lsm_tree::Result<()> {
+    use lsm_tree::config::{LocatorPolicy, LocatorPolicyEntry, LocatorPrecision};
+
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    // Many small data blocks so both the locator's block_id space and the
+    // seqno-bounds block-skip are non-trivial.
+    .data_block_size_policy(lsm_tree::config::BlockSizePolicy::all(4_096))
+    .locator_policy(LocatorPolicy::all(LocatorPolicyEntry::Enabled {
+        precision: LocatorPrecision::Block,
+        block_id_bits: None,
+        slot_bits: None,
+    }))
+    .open()?;
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    // Enable the seqno_bounds section too, so the flushed SST carries BOTH.
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+
+    // Fixed-width big-endian keys (the locator's proven corpus shape) so the
+    // ribbon is well-conditioned; rising seqnos so block-skip has work to do.
+    for i in 0..1_500u64 {
+        tree.insert(i.to_be_bytes(), format!("v{i:05}").as_bytes(), i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Point reads resolve through the locator and must be exact.
+    for i in 0..1_500u64 {
+        let got = tree.get(i.to_be_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("v{i:05}").as_bytes()),
+            "locator point read of key {i} must be exact",
+        );
+    }
+
+    // Seqno-scoped scans block-skip via the seqno_bounds section; the fast path
+    // must equal the paranoid full scan at every target despite the locator
+    // also being present in the same SST.
+    for target in [0u64, 500, 1_234, 1_499, 1_500] {
+        let fast: Vec<SeqNo> = events(&tree, target)?
+            .iter()
+            .map(ScanSinceEvent::seqno)
+            .collect();
+        let full: Vec<SeqNo> = tree
+            .scan_since_seqno_full_scan(target)?
+            .map(|e| e.seqno())
+            .collect();
+        assert_eq!(
+            fast, full,
+            "block-skip scan must equal full scan at target {target} with the locator enabled",
+        );
+    }
     Ok(())
 }

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -72,7 +72,9 @@
 //!   `rocksdb` series use a binary-search data-block index; the same chart
 //!   overlays `ours-hash-index` / `rocksdb-hash-index` series (data-block
 //!   hash index ON — ours: 1.33 buckets/entry; RocksDB: `BinaryAndHash` @
-//!   0.75) so both index strategies are compared head-to-head on one plot.
+//!   0.75) and an `ours-ribbon` series (retrieval-ribbon locator: key ->
+//!   block + restart in O(1), skipping both the index-block and in-block
+//!   searches) so every index strategy is compared head-to-head on one plot.
 //! - `range_scan/{1k,10k}` — full forward scan reading every value
 //!   from a warm, pre-populated engine. Steady-state sequential-scan
 //!   throughput (block decode + iterator advance).
@@ -98,9 +100,25 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 // for method resolution (clippy `-D warnings` confirms it is live).
 use lsm_tree::{
     AbstractTree, CompressionType, Config, Guard, MAX_SEQNO, SequenceNumberCounter,
-    config::{CompressionPolicy, HashRatioPolicy, KvSeparationOptions},
+    config::{
+        CompressionPolicy, HashRatioPolicy, KvSeparationOptions, LocatorPolicy, LocatorPolicyEntry,
+        LocatorPrecision,
+    },
     runtime_config::{KvChecksumPolicy, RuntimeConfig},
 };
+
+/// In-block index strategy overlaid as a separate `point_read` series.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IndexStrategy {
+    /// Binary search over the restart array (the engine default).
+    Binary,
+    /// Data-block hash index (key -> restart by hash). Supported by both ours
+    /// and RocksDB.
+    HashIndex,
+    /// Retrieval-ribbon locator (ours only): key -> (block_id, slot) in O(1),
+    /// skipping both the index-block and in-block searches.
+    Ribbon,
+}
 use surrealkv::{
     Durability as SkvDurability, LSMIterator as _, Options as SkvOptions, Tree as SkvTree,
     TreeBuilder as SkvTreeBuilder,
@@ -483,7 +501,7 @@ fn open_ours(
     dir: &std::path::Path,
     compression: Compression,
     kv_separated: bool,
-    hash_index: bool,
+    strategy: IndexStrategy,
 ) -> Result<lsm_tree::AnyTree, Box<dyn std::error::Error>> {
     let config = Config::new(
         dir,
@@ -494,8 +512,20 @@ fn open_ours(
     // by hash instead of binary-searching the restart array. 1.33 buckets/entry
     // is the rough equal of RocksDB's 0.75 utilization for the hash-index
     // overlay. Default policy (0.0) leaves it off for the binary-search arms.
-    let config = if hash_index {
+    let config = if strategy == IndexStrategy::HashIndex {
         config.data_block_hash_ratio_policy(HashRatioPolicy::all(1.33))
+    } else {
+        config
+    };
+    // Retrieval-ribbon locator: a point get resolves the key to its data block
+    // and restart in O(1), skipping both the index-block and in-block searches.
+    // Restart precision (per-sub-block) is the recommended default.
+    let config = if strategy == IndexStrategy::Ribbon {
+        config.locator_policy(LocatorPolicy::all(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        }))
     } else {
         config
     };
@@ -571,7 +601,12 @@ fn run_write_throughput(
     let start = std::time::Instant::now();
     let elapsed = match engine {
         Engine::Ours | Engine::BlobTree => {
-            let tree = open_ours(dir.path(), compression, engine.kv_separated(), false)?;
+            let tree = open_ours(
+                dir.path(),
+                compression,
+                engine.kv_separated(),
+                IndexStrategy::Binary,
+            )?;
             // Zip the seqno counter as a native `u64` instead of
             // enumerate()+try_from(usize). lsm-tree's `insert` takes
             // SeqNo (= u64) directly; using `0u64..` avoids the
@@ -750,25 +785,29 @@ fn point_read_variant(
     compression: Compression,
     hash_overlays: bool,
 ) {
-    // Series overlaid on this ONE chart: every base engine with the data-block
-    // hash index OFF (binary search), plus — when `hash_overlays` is set — the
-    // two engines that support a data-block hash index again with it ON. Extend
-    // this list to add more index strategies (e.g. a future `ours-burr` ribbon
-    // series) as additional overlays on the same chart.
-    let mut series: Vec<(&str, Engine, bool)> = engines_for(compression)
+    // Series overlaid on this ONE chart: every base engine with binary-search
+    // data-block index, plus — when `hash_overlays` is set — the data-block
+    // hash index (ours + RocksDB) and the retrieval-ribbon locator (ours only)
+    // as additional index strategies on the same chart.
+    let mut series: Vec<(&str, Engine, IndexStrategy)> = engines_for(compression)
         .iter()
-        .map(|&engine| (engine.label(), engine, false))
+        .map(|&engine| (engine.label(), engine, IndexStrategy::Binary))
         .collect();
     if hash_overlays {
-        series.push(("ours-hash-index", Engine::Ours, true));
-        series.push(("rocksdb-hash-index", Engine::RocksDb, true));
+        series.push(("ours-hash-index", Engine::Ours, IndexStrategy::HashIndex));
+        series.push((
+            "rocksdb-hash-index",
+            Engine::RocksDb,
+            IndexStrategy::HashIndex,
+        ));
+        series.push(("ours-ribbon", Engine::Ours, IndexStrategy::Ribbon));
     }
 
     let mut group = c.benchmark_group(group_name);
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for &(label, engine, hash_index) in &series {
+        for &(label, engine, strategy) in &series {
             group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
                 // The temp dir + engine handle outlive every timed
                 // iteration: build the on-disk database once here so
@@ -778,7 +817,7 @@ fn point_read_variant(
                 match engine {
                     Engine::Ours | Engine::BlobTree => {
                         let tree =
-                            open_ours(dir.path(), compression, engine.kv_separated(), hash_index)
+                            open_ours(dir.path(), compression, engine.kv_separated(), strategy)
                                 .expect("ours: open");
                         for ((key, value), seqno) in
                             inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..)
@@ -814,7 +853,8 @@ fn point_read_variant(
                         // matching our engine's defaults so the per-`get`
                         // overhead is attributable, not a config artefact —
                         // see `rocksdb_options`.
-                        let opts = rocksdb_options(compression, hash_index);
+                        let opts =
+                            rocksdb_options(compression, strategy == IndexStrategy::HashIndex);
                         let db = rocksdb::DB::open(&opts, dir.path()).expect("rocksdb: open");
                         let mut write_opts = rocksdb::WriteOptions::default();
                         write_opts.disable_wal(true);
@@ -907,7 +947,8 @@ fn populate_ours(
     inputs: &WorkloadInputs,
     kv_separated: bool,
 ) -> lsm_tree::AnyTree {
-    let tree = open_ours(dir, compression, kv_separated, false).expect("ours: open");
+    let tree =
+        open_ours(dir, compression, kv_separated, IndexStrategy::Binary).expect("ours: open");
     for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
         tree.insert(key, value, seqno);
     }

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -367,7 +367,12 @@ fn apply_preset(config: Config, preset: Preset) -> Config {
             rc.manifest_kv_checksums = true;
             // `Config::page_ecc` is the separate tree-open gate for DATA-block
             // ECC (the runtime `page_ecc` above covers manifest blocks).
-            config.with_runtime_config(rc).page_ecc(false)
+            // The retrieval-ribbon locator is on by default (block precision);
+            // RocksDB has no equivalent, so parity disables it.
+            config
+                .with_runtime_config(rc)
+                .page_ecc(false)
+                .locator_policy(LocatorPolicy::disabled())
         }
         // Production defaults are exactly `RuntimeConfig::default()` + the
         // `Config` defaults, so leave the config untouched.


### PR DESCRIPTION
> **Stacked PR** — base is `feat/#464-retrieval-ribbon-build` (#468), not `main`. Do **not** merge before #468; retarget to `main` (or rebase) once #468 lands. Opened for visibility/review of the #224 changes in isolation.

## Summary

Per-block seqno bounds for the `scan_since_seqno` block-skip used to live inline in each index entry (markers 2/3, two extra varints per entry). Every point-read binary-search probe then stepped over those varints in `parse_restart_key` and paid a larger index block — ~12% on point reads for any SST written with `seqno_in_index` on.

This moves the bounds out of the index entries into an optional parallel `seqno_bounds` SST section, keyed by data-block file offset:

- New `seqno_bounds` module: offset-keyed `(offset, seqno_min, seqno_max)` codec with strictly-ascending offsets and binary-search lookup; decode rejects truncation, non-ascending offsets, and inverted bounds.
- Writer accumulates per-block bounds and emits the section only when `seqno_in_index` is on, so a default table carries zero extra bytes.
- Recover loads the section (via the TOC); the scan looks bounds up by block offset instead of reading them from the index entry.
- Index entries are now always legacy (markers 0/1), byte-identical whether or not `seqno_in_index` is set, so point reads pay nothing.
- Removes the now-dead inline machinery: the seqno-bounded index markers, the `KeyedBlockHandle` bounds field/builder/getter, the `parse_restart_key` bounds skip, and the vestigial `index_format` table property.

## Result

- Point-lookup penalty eliminated: `on` now matches `off` (−16.8% vs the inline baseline).
- Sparse seqno scan still block-skips (~35x over full scan).
- Composes with the locator: an SST may carry both the `locator` and `seqno_bounds` sections; point reads use the locator, seqno-scoped scans use the block-skip (regression test included).

## Testing

- Full suite: 2091 nextest + 51 doctests pass
- `cargo clippy --all-features --all-targets`: clean
- no-std-check (`thumbv7em-none-eabihf`): 0 errors