### PR TITLE
feat(fs): no_std io_uring driver core on raw Linux syscalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
+# Standalone workspace root. This crate publishes to crates.io and is also
+# checked out as a subdirectory of larger trees (and CI runners that host other
+# workspaces). Declaring an empty workspace here pins it as its own root so
+# Cargo never absorbs it into a surrounding workspace — which would otherwise
+# try to resolve that workspace's path dependencies (absent in a standalone
+# clone) and fail before the build even starts.
+[workspace]
+
 [package]
 name = "coordinode-lsm-tree"
 description = "Embedded LSM-tree storage engine: BuRR filters, zstd dictionary compression, MVCC, range tombstones, merge operators, K/V separation, AES-256-GCM at rest."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 # Standalone workspace root. This crate publishes to crates.io and is also
 # checked out as a subdirectory of larger trees (and CI runners that host other
-# workspaces). Declaring an empty workspace here pins it as its own root so
-# Cargo never absorbs it into a surrounding workspace — which would otherwise
-# try to resolve that workspace's path dependencies (absent in a standalone
-# clone) and fail before the build even starts.
+# workspaces). Declaring a workspace here pins it as its own root so Cargo never
+# absorbs it into a surrounding workspace — which would otherwise try to resolve
+# that workspace's path dependencies (absent in a standalone clone) and fail
+# before the build even starts.
+#
+# The `tools/*` crates are standalone binaries that build independently (they
+# pull in heavy, optional deps like librocksdb); they are NOT members of this
+# single-package workspace, so they are excluded — otherwise Cargo would treat
+# them as orphan members of this root and refuse to build.
 [workspace]
+exclude = ["tools/compare-rocksdb", "tools/db_bench", "tools/sst-dump"]
 
 [package]
 name = "coordinode-lsm-tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,14 @@ alloc = []
 # no-std + alloc (tracked in the migration epic), the `std`
 # transitive dep can be lifted on a per-feature basis.
 io-uring = ["dep:io-uring", "std"]
+# Pure-Rust `no_std` io_uring backend on raw Linux syscalls (#346). Unlike
+# `io-uring` (the std-bound `io-uring` crate wrapper), this needs NO `std`: it
+# drives the kernel ring through the `syscalls` crate's raw `syscall!` and its
+# own mmap'd ring management, so a Linux no-std consumer gets kernel async I/O.
+# Linux-only by nature (io_uring is a Linux kernel API); the backend module is
+# additionally `cfg(target_os = "linux")`, so enabling this on a non-Linux
+# target compiles to nothing.
+io-uring-raw = ["dep:syscalls"]
 lz4 = ["dep:lz4_flex", "std"]
 # The previous `zstd-pure = ["zstd"]` alias was removed. It was
 # documented as deprecated when there were two candidate zstd backends
@@ -211,6 +219,11 @@ rayon = { version = "1.10", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7", optional = true }
+# `#![no_std]` raw Linux syscall layer for the `io-uring-raw` backend (#346):
+# the `syscall!` macro + `Sysno` numbers for `io_uring_setup` / `io_uring_enter`
+# / `mmap` / `openat` / `close` etc. No libc, no std. Linux-target-gated since
+# io_uring is Linux-only.
+syscalls = { version = "0.8", optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 # Unix syscall surface that std does not expose:

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -244,6 +244,10 @@ unsafe fn io_uring_enter(
 ///
 /// # Safety
 /// Standard `mmap` contract. The caller owns the mapping and must `munmap` it.
+// Coverage: the `MAP_FAILED` / `Err` arms require an `mmap` failure (address
+// space exhaustion or a kernel fault), which cannot be provoked deterministically
+// in CI. The success arm IS covered by every ring setup.
+#[cfg_attr(coverage_nightly, coverage(off))]
 unsafe fn mmap(
     len: usize,
     prot: usize,
@@ -368,6 +372,11 @@ impl IoUringRaw {
     ///
     /// # Errors
     /// Returns an [`Error`] if `io_uring_setup` or any `mmap` fails.
+    // Coverage: the post-setup `mmap`-failure unwind arms and the pre-5.4
+    // separate-CQ-mmap layout require a kernel fault / an old kernel to exercise
+    // and cannot be reached in CI (the runner kernel always reports SINGLE_MMAP).
+    // The setup-success path and the zero-entry setup error ARE covered by tests.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     pub fn new(entries: u32) -> Result<Self, Error> {
         let mut params = IoUringParams::default();
 
@@ -558,6 +567,12 @@ impl IoUringRaw {
     /// Returns an [`Error`] if the SQ is full, `io_uring_enter` fails, no
     /// completion is visible after the wait, or the completion's `res` is a
     /// negative `-errno`.
+    // Coverage: the SQ-full and no-completion guards are defensive and
+    // unreachable through this one-submit-one-reap driver (it never lets the SQ
+    // fill or `io_uring_enter` return without a completion); they would need
+    // kernel fault injection. The submit/enter/reap success path and the
+    // negative-`res` error path ARE covered by tests.
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn submit_and_reap_one(&mut self, sqe: &IoUringSqe) -> Result<i32, Error> {
         // SAFETY: single-threaded driver. Read the kernel-advanced SQ head
         // (Acquire) to confirm the ring has a free slot, write the SQE into
@@ -651,6 +666,11 @@ impl FdGuard {
 }
 
 impl Drop for FdGuard {
+    // Coverage: this fires only when `mmap` fails AFTER `io_uring_setup`
+    // succeeds — an allocation fault that cannot be provoked in CI. On the
+    // covered paths the guard is either disarmed (setup + mmap succeed) or never
+    // built (setup itself fails).
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn drop(&mut self) {
         // SAFETY: `self.0` is the live ring fd; only reached on the setup-error
         // path where nothing else owns it yet.

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -96,8 +96,6 @@ const PROT_READ: usize = 0x1;
 const PROT_WRITE: usize = 0x2;
 const MAP_SHARED: usize = 0x01;
 const MAP_POPULATE: usize = 0x0_8000;
-/// `mmap` sentinel return for failure (`MAP_FAILED` is `(void *) -1`).
-const MAP_FAILED: usize = usize::MAX;
 
 // ---- ABI structs (repr(C), field order per linux/io_uring.h) ----
 
@@ -187,6 +185,7 @@ fn errno_to_kind(errno: i32) -> ErrorKind {
         2 => ErrorKind::NotFound,              // ENOENT
         4 => ErrorKind::Interrupted,           // EINTR
         9 | 22 => ErrorKind::InvalidInput,     // EBADF / EINVAL
+        11 => ErrorKind::WouldBlock,           // EAGAIN / EWOULDBLOCK
         17 => ErrorKind::AlreadyExists,        // EEXIST
         95 => ErrorKind::Unsupported,          // EOPNOTSUPP
         _ => ErrorKind::Other,
@@ -244,9 +243,9 @@ unsafe fn io_uring_enter(
 ///
 /// # Safety
 /// Standard `mmap` contract. The caller owns the mapping and must `munmap` it.
-// Coverage: the `MAP_FAILED` / `Err` arms require an `mmap` failure (address
-// space exhaustion or a kernel fault), which cannot be provoked deterministically
-// in CI. The success arm IS covered by every ring setup.
+// Coverage: the `Err` arm requires an `mmap` failure (address-space exhaustion
+// or a kernel fault), which cannot be provoked deterministically in CI. The
+// success arm IS covered by every ring setup.
 #[cfg_attr(coverage_nightly, coverage(off))]
 unsafe fn mmap(
     len: usize,
@@ -255,9 +254,10 @@ unsafe fn mmap(
     fd: i32,
     offset: u64,
 ) -> Result<*mut u8, Error> {
-    // SAFETY: forwarded to the kernel. `mmap` returns `MAP_FAILED` (`-1` as
-    // usize) on error rather than `-errno`, so check that sentinel explicitly;
-    // the syscalls Result form would otherwise treat the huge address as Ok.
+    // SAFETY: forwarded to the kernel. The raw `mmap` syscall returns `-errno`
+    // (in `[-4095, -1]`) on failure, which the `syscalls` Result form maps to
+    // `Err` for us; a success is the actual mapping address (page 0 included,
+    // though the kernel does not hand it out for a NULL hint).
     let ret = unsafe {
         syscall6(
             Sysno::mmap,
@@ -270,8 +270,7 @@ unsafe fn mmap(
         )
     };
     match ret {
-        Ok(addr) if addr != MAP_FAILED && addr != 0 => Ok(addr as *mut u8),
-        Ok(_) => Err(Error::new(ErrorKind::Other, "mmap returned MAP_FAILED")),
+        Ok(addr) => Ok(addr as *mut u8),
         Err(e) => Err(err("mmap", e)),
     }
 }
@@ -508,11 +507,17 @@ impl IoUringRaw {
     /// # Errors
     /// Returns an [`Error`] if the read completes with a negative `-errno`.
     pub fn read_at(&mut self, fd: i32, buf: &mut [u8], offset: u64) -> Result<usize, Error> {
+        let len = u32::try_from(buf.len()).map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "read length exceeds the 4 GiB io_uring single-op limit",
+            )
+        })?;
         let sqe = IoUringSqe {
             opcode: IORING_OP_READ,
             fd,
             addr: buf.as_mut_ptr() as u64,
-            len: buf.len() as u32,
+            len,
             off: offset,
             ..IoUringSqe::default()
         };
@@ -526,11 +531,17 @@ impl IoUringRaw {
     /// # Errors
     /// Returns an [`Error`] if the write completes with a negative `-errno`.
     pub fn write_at(&mut self, fd: i32, buf: &[u8], offset: u64) -> Result<usize, Error> {
+        let len = u32::try_from(buf.len()).map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "write length exceeds the 4 GiB io_uring single-op limit",
+            )
+        })?;
         let sqe = IoUringSqe {
             opcode: IORING_OP_WRITE,
             fd,
             addr: buf.as_ptr() as u64,
-            len: buf.len() as u32,
+            len,
             off: offset,
             ..IoUringSqe::default()
         };
@@ -595,9 +606,22 @@ impl IoUringRaw {
             core::ptr::write_volatile(self.sq_ktail, tail.wrapping_add(1));
         }
 
-        // Submit 1, wait for 1 completion.
-        // SAFETY: `self.ring_fd` is the live ring fd owned by this `IoUringRaw`.
-        let _ = unsafe { io_uring_enter(self.ring_fd, 1, 1, IORING_ENTER_GETEVENTS) }?;
+        // Submit 1, wait for 1 completion. Retry on EINTR: the SQE is already
+        // published to the SQ (the tail was advanced above), so a
+        // signal-interrupted `enter` must be re-entered to reap that in-flight
+        // submission rather than returning and leaking it (the next call would
+        // then reap this completion against the wrong `user_data`). The kernel
+        // submits `min(to_submit, pending)` SQEs, so a retry after the first
+        // `enter` already consumed the entry simply waits for the completion.
+        loop {
+            // SAFETY: `self.ring_fd` is the live ring fd owned by this `IoUringRaw`.
+            match unsafe { io_uring_enter(self.ring_fd, 1, 1, IORING_ENTER_GETEVENTS) } {
+                Ok(_) => break,
+                // EINTR: fall through to re-enter the ring on the next iteration.
+                Err(e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
 
         // SAFETY: read the kernel-advanced CQ tail (Acquire) before touching the
         // CQE so we never read a slot the kernel has not published. After a
@@ -772,6 +796,7 @@ mod tests {
         assert_eq!(errno_to_kind(2), ErrorKind::NotFound); // ENOENT
         assert_eq!(errno_to_kind(4), ErrorKind::Interrupted); // EINTR
         assert_eq!(errno_to_kind(9), ErrorKind::InvalidInput); // EBADF
+        assert_eq!(errno_to_kind(11), ErrorKind::WouldBlock); // EAGAIN
         assert_eq!(errno_to_kind(13), ErrorKind::PermissionDenied); // EACCES
         assert_eq!(errno_to_kind(17), ErrorKind::AlreadyExists); // EEXIST
         assert_eq!(errno_to_kind(22), ErrorKind::InvalidInput); // EINVAL

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -600,6 +600,12 @@ impl IoUringRaw {
                 ));
             }
             let cqe = core::ptr::read(self.cqes.add((head & self.cq_ring_mask) as usize));
+            // Release the CQE read before publishing the advanced head: the
+            // (non-volatile) read above must complete before the kernel can see
+            // the new head and reuse the slot, otherwise the read could be
+            // reordered after the head store and observe a torn / overwritten
+            // entry. Matters once a future reaper drains multiple CQEs.
+            fence(Ordering::Release);
             core::ptr::write_volatile(self.cq_khead, head.wrapping_add(1));
             cqe.res
         };

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Pure-Rust, `no_std` `io_uring` driver core on raw Linux syscalls.
+//!
+//! The std-bound [`IoUringFs`](super::io_uring_fs) backend wraps the `io-uring`
+//! crate, which pulls in `std` (it returns `std::io::Error` and consumes
+//! `std::os::unix::io::RawFd`). This module drives the kernel ring directly via
+//! the `syscalls` crate's raw `syscall!` and its own `mmap`'d ring management,
+//! so a Linux `no_std + alloc` consumer gets kernel async I/O with no `std`.
+//!
+//! This is the driver CORE: it sets up a ring, submits a single SQE, and reaps
+//! its CQE. The `IORING_OP_NOP` round-trip exercised by the tests proves the
+//! whole submission/completion machinery (ring `mmap`, SQE encode, tail/head
+//! handoff, `io_uring_enter`, CQE decode) end to end. File-operation opcodes
+//! (READ / WRITE / FSYNC) and the [`Fs`](crate::fs::Fs) / [`FsFile`] impls layer
+//! on top of this core in follow-up work.
+//!
+//! Linux-only by construction (`io_uring` is a Linux kernel API); the module is
+//! `cfg(all(target_os = "linux", feature = "io-uring-raw"))` at its declaration.
+
+// This module is a thin Linux syscall / mmap ABI surface. Descriptors (`i32`)
+// and ring offsets (`u64`) are cast to the register-width `usize` the syscall
+// layer takes, the ring fd from `io_uring_setup` is narrowed back to `i32`, and
+// the mmap'd ring fields are read through pointers cast from the page-aligned
+// mapping base. These casts are inherent to the ABI and individually sound
+// (non-negative fds, bounded `IORING_OFF_*` offsets, kernel-natural field
+// alignment within a page-aligned mapping), so the cast lints are expected here.
+#![expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_ptr_alignment,
+    reason = "Linux syscall/mmap ABI: register-width arg casts + page-aligned ring field reads"
+)]
+
+#[cfg(not(feature = "std"))]
+use alloc::format;
+
+use core::sync::atomic::{Ordering, fence};
+
+use syscalls::{Errno, Sysno, syscall1, syscall2, syscall6};
+
+use crate::io::{Error, ErrorKind};
+
+// ---- Linux io_uring ABI constants (stable kernel uapi, linux/io_uring.h) ----
+
+/// `mmap` offset for the submission-queue ring.
+const IORING_OFF_SQ_RING: u64 = 0;
+/// `mmap` offset for the completion-queue ring.
+const IORING_OFF_CQ_RING: u64 = 0x0800_0000;
+/// `mmap` offset for the SQE array.
+const IORING_OFF_SQES: u64 = 0x1000_0000;
+
+/// `io_uring_enter` flag: wait for at least `min_complete` completions.
+const IORING_ENTER_GETEVENTS: u32 = 1;
+
+/// `io_uring_params.features` bit: the SQ and CQ rings live in a single `mmap`
+/// (every kernel since 5.4). When set, we map the CQ ring as part of the SQ
+/// ring mapping instead of a second `mmap`.
+const IORING_FEAT_SINGLE_MMAP: u32 = 1;
+
+/// No-op opcode: completes immediately with `res == 0`. Used to smoke-test the
+/// ring without touching a file.
+const IORING_OP_NOP: u8 = 0;
+
+// `mmap` protection / flags.
+const PROT_READ: usize = 0x1;
+const PROT_WRITE: usize = 0x2;
+const MAP_SHARED: usize = 0x01;
+const MAP_POPULATE: usize = 0x0_8000;
+/// `mmap` sentinel return for failure (`MAP_FAILED` is `(void *) -1`).
+const MAP_FAILED: usize = usize::MAX;
+
+// ---- ABI structs (repr(C), field order per linux/io_uring.h) ----
+
+/// Submission-queue ring offsets, filled in by the kernel on `io_uring_setup`.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct SqRingOffsets {
+    head: u32,
+    tail: u32,
+    ring_mask: u32,
+    ring_entries: u32,
+    flags: u32,
+    dropped: u32,
+    array: u32,
+    resv1: u32,
+    resv2: u64,
+}
+
+/// Completion-queue ring offsets, filled in by the kernel on `io_uring_setup`.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct CqRingOffsets {
+    head: u32,
+    tail: u32,
+    ring_mask: u32,
+    ring_entries: u32,
+    overflow: u32,
+    cqes: u32,
+    flags: u32,
+    resv1: u32,
+    resv2: u64,
+}
+
+/// Parameters passed to (and filled in by) `io_uring_setup`.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct IoUringParams {
+    sq_entries: u32,
+    cq_entries: u32,
+    flags: u32,
+    sq_thread_cpu: u32,
+    sq_thread_idle: u32,
+    features: u32,
+    wq_fd: u32,
+    resv: [u32; 3],
+    sq_off: SqRingOffsets,
+    cq_off: CqRingOffsets,
+}
+
+/// Submission-queue entry (64 bytes). Only the fields the NOP / file opcodes
+/// need are named; the rest are kept as padding so the struct matches the
+/// kernel layout exactly.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct IoUringSqe {
+    opcode: u8,
+    flags: u8,
+    ioprio: u16,
+    fd: i32,
+    off: u64,
+    addr: u64,
+    len: u32,
+    op_flags: u32,
+    user_data: u64,
+    buf_index: u16,
+    personality: u16,
+    splice_fd_in: i32,
+    pad2: [u64; 2],
+}
+
+/// Completion-queue entry (16 bytes).
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct IoUringCqe {
+    user_data: u64,
+    res: i32,
+    flags: u32,
+}
+
+/// Maps a raw `errno` to the crate's `no_std` [`ErrorKind`].
+fn errno_to_kind(errno: i32) -> ErrorKind {
+    // libc errno numbers (Linux generic). Only the ones the I/O paths can
+    // realistically surface are mapped explicitly; the rest fold into `Other`,
+    // and the numeric errno is preserved in the message for diagnosis.
+    match errno {
+        1 | 13 => ErrorKind::PermissionDenied, // EPERM / EACCES
+        2 => ErrorKind::NotFound,              // ENOENT
+        4 => ErrorKind::Interrupted,           // EINTR
+        9 | 22 => ErrorKind::InvalidInput,     // EBADF / EINVAL
+        17 => ErrorKind::AlreadyExists,        // EEXIST
+        95 => ErrorKind::Unsupported,          // EOPNOTSUPP
+        _ => ErrorKind::Other,
+    }
+}
+
+/// Converts a `syscalls::Errno` into a crate [`Error`], preserving the numeric
+/// errno in the message.
+fn err(syscall: &str, e: Errno) -> Error {
+    let raw = e.into_raw();
+    Error::new(errno_to_kind(raw), format!("{syscall} failed: errno {raw}"))
+}
+
+/// `io_uring_setup(entries, params)` -> ring fd.
+///
+/// # Safety
+/// `params` must point to a valid, writable [`IoUringParams`] the kernel fills
+/// in. The caller owns the returned fd and must `close` it.
+unsafe fn io_uring_setup(entries: u32, params: *mut IoUringParams) -> Result<i32, Error> {
+    // SAFETY: forwarded to the kernel; `params` validity is the caller's
+    // contract (documented above). The Result form maps `-errno` to `Err`.
+    let fd = unsafe { syscall2(Sysno::io_uring_setup, entries as usize, params as usize) }
+        .map_err(|e| err("io_uring_setup", e))?;
+    Ok(fd as i32)
+}
+
+/// `io_uring_enter(fd, to_submit, min_complete, flags, NULL, 0)`.
+///
+/// # Safety
+/// `fd` must be a live ring fd from [`io_uring_setup`].
+unsafe fn io_uring_enter(
+    fd: i32,
+    to_submit: u32,
+    min_complete: u32,
+    flags: u32,
+) -> Result<u32, Error> {
+    // SAFETY: `fd` is a live ring fd (caller contract). `sig`/`sigsz` are
+    // NULL/0 — we never block on a signal mask.
+    let n = unsafe {
+        syscall6(
+            Sysno::io_uring_enter,
+            fd as usize,
+            to_submit as usize,
+            min_complete as usize,
+            flags as usize,
+            0,
+            0,
+        )
+    }
+    .map_err(|e| err("io_uring_enter", e))?;
+    Ok(n as u32)
+}
+
+/// `mmap` wrapper returning the mapped address or a typed error.
+///
+/// # Safety
+/// Standard `mmap` contract. The caller owns the mapping and must `munmap` it.
+unsafe fn mmap(
+    len: usize,
+    prot: usize,
+    flags: usize,
+    fd: i32,
+    offset: u64,
+) -> Result<*mut u8, Error> {
+    // SAFETY: forwarded to the kernel. `mmap` returns `MAP_FAILED` (`-1` as
+    // usize) on error rather than `-errno`, so check that sentinel explicitly;
+    // the syscalls Result form would otherwise treat the huge address as Ok.
+    let ret = unsafe {
+        syscall6(
+            Sysno::mmap,
+            0,
+            len,
+            prot,
+            flags,
+            fd as usize,
+            offset as usize,
+        )
+    };
+    match ret {
+        Ok(addr) if addr != MAP_FAILED && addr != 0 => Ok(addr as *mut u8),
+        Ok(_) => Err(Error::new(ErrorKind::Other, "mmap returned MAP_FAILED")),
+        Err(e) => Err(err("mmap", e)),
+    }
+}
+
+/// `munmap(addr, len)`. Errors are swallowed (best-effort teardown).
+///
+/// # Safety
+/// `addr`/`len` must come from a prior [`mmap`] of exactly this region.
+unsafe fn munmap(addr: *mut u8, len: usize) {
+    // SAFETY: caller passes a region from a prior `mmap`. Teardown is
+    // best-effort: a failed unmap cannot be meaningfully handled in `Drop`.
+    let _ = unsafe { syscall2(Sysno::munmap, addr as usize, len) };
+}
+
+/// `close(fd)`, best-effort.
+///
+/// # Safety
+/// `fd` must be a live descriptor this code owns.
+unsafe fn close(fd: i32) {
+    // SAFETY: `fd` is owned by the caller (the ring fd in `Drop`).
+    let _ = unsafe { syscall1(Sysno::close, fd as usize) };
+}
+
+/// A minimal, `no_std` `io_uring` instance: an `mmap`'d submission ring, an
+/// `mmap`'d completion ring, the SQE array, and the ring fd.
+///
+/// This owns its mappings and the ring fd; [`Drop`] unmaps and closes them.
+pub struct IoUringRaw {
+    ring_fd: i32,
+
+    /// Base of the SQ-ring mmap (also holds the CQ ring when the kernel reports
+    /// `IORING_FEAT_SINGLE_MMAP`).
+    sq_ptr: *mut u8,
+    sq_len: usize,
+    /// Base of the CQ-ring mmap when it is a SEPARATE mapping; `null` under
+    /// single-mmap (the CQ ring lives inside `sq_ptr`).
+    cq_ptr: *mut u8,
+    cq_len: usize,
+    /// Base of the SQE-array mmap.
+    sqes: *mut IoUringSqe,
+    sqes_len: usize,
+
+    sq_entries: u32,
+
+    // Cached pointers into the SQ ring (kernel-shared, accessed volatile).
+    sq_khead: *const u32,
+    sq_ktail: *mut u32,
+    sq_ring_mask: u32,
+    sq_array: *mut u32,
+
+    // Cached pointers into the CQ ring.
+    cq_khead: *mut u32,
+    cq_ktail: *const u32,
+    cq_ring_mask: u32,
+    cqes: *const IoUringCqe,
+}
+
+impl IoUringRaw {
+    /// Sets up a ring sized for `entries` (rounded up to a power of two by the
+    /// kernel) and maps its submission and completion rings.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if `io_uring_setup` or any `mmap` fails.
+    pub fn new(entries: u32) -> Result<Self, Error> {
+        let mut params = IoUringParams::default();
+
+        // SAFETY: `params` is a valid writable struct the kernel fills in.
+        let ring_fd = unsafe { io_uring_setup(entries, &raw mut params) }?;
+
+        // On any setup failure past this point, close the ring fd.
+        let guard = FdGuard(ring_fd);
+
+        let sq_entries = params.sq_entries;
+        let single_mmap = params.features & IORING_FEAT_SINGLE_MMAP != 0;
+
+        // SQ ring length covers the array of u32 indices past `sq_off.array`.
+        let sq_ring_sz = params.sq_off.array as usize + sq_entries as usize * size_of::<u32>();
+        // CQ ring length covers the CQE array past `cq_off.cqes`.
+        let cq_ring_sz =
+            params.cq_off.cqes as usize + params.cq_entries as usize * size_of::<IoUringCqe>();
+
+        // Under single-mmap the two rings share one mapping sized to the larger.
+        let sq_len = if single_mmap {
+            sq_ring_sz.max(cq_ring_sz)
+        } else {
+            sq_ring_sz
+        };
+
+        // SAFETY: standard ring mmap per the io_uring setup protocol.
+        let sq_ptr = unsafe {
+            mmap(
+                sq_len,
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_POPULATE,
+                ring_fd,
+                IORING_OFF_SQ_RING,
+            )
+        }?;
+
+        let (cq_ptr, cq_len, cq_base) = if single_mmap {
+            (core::ptr::null_mut(), 0usize, sq_ptr)
+        } else {
+            // SAFETY: separate CQ mapping for pre-5.4 kernels.
+            let p = match unsafe {
+                mmap(
+                    cq_ring_sz,
+                    PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_POPULATE,
+                    ring_fd,
+                    IORING_OFF_CQ_RING,
+                )
+            } {
+                Ok(p) => p,
+                Err(e) => {
+                    // SAFETY: unwind the SQ mapping before bailing.
+                    unsafe { munmap(sq_ptr, sq_len) };
+                    return Err(e);
+                }
+            };
+            (p, cq_ring_sz, p)
+        };
+
+        // SAFETY: SQE array mmap.
+        let sqes = match unsafe {
+            mmap(
+                sq_entries as usize * size_of::<IoUringSqe>(),
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED | MAP_POPULATE,
+                ring_fd,
+                IORING_OFF_SQES,
+            )
+        } {
+            Ok(p) => p.cast::<IoUringSqe>(),
+            Err(e) => {
+                // SAFETY: unwind prior mappings before bailing.
+                unsafe {
+                    munmap(sq_ptr, sq_len);
+                    if !cq_ptr.is_null() {
+                        munmap(cq_ptr, cq_len);
+                    }
+                }
+                return Err(e);
+            }
+        };
+
+        // Setup succeeded — disarm the fd guard; `Drop` owns teardown now.
+        guard.disarm();
+
+        // SAFETY: the offsets come from the kernel and address fields inside the
+        // mapped rings; the casts compute in-bounds pointers per the protocol.
+        let sqes_len = sq_entries as usize * size_of::<IoUringSqe>();
+        Ok(unsafe {
+            Self {
+                ring_fd,
+                sq_ptr,
+                sq_len,
+                cq_ptr,
+                cq_len,
+                sqes,
+                sqes_len,
+                sq_entries,
+                sq_khead: sq_ptr.add(params.sq_off.head as usize).cast(),
+                sq_ktail: sq_ptr.add(params.sq_off.tail as usize).cast(),
+                sq_ring_mask: *(sq_ptr.add(params.sq_off.ring_mask as usize).cast::<u32>()),
+                sq_array: sq_ptr.add(params.sq_off.array as usize).cast(),
+                cq_khead: cq_base.add(params.cq_off.head as usize).cast(),
+                cq_ktail: cq_base.add(params.cq_off.tail as usize).cast(),
+                cq_ring_mask: *(cq_base.add(params.cq_off.ring_mask as usize).cast::<u32>()),
+                cqes: cq_base.add(params.cq_off.cqes as usize).cast(),
+            }
+        })
+    }
+
+    /// Submits a single no-op and waits for its completion, returning the CQE
+    /// `res` (`0` on success). Exercises the full submit/complete cycle.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if `io_uring_enter` fails or the completion carries
+    /// a negative `res` (a `-errno`).
+    pub fn nop(&mut self, user_data: u64) -> Result<i32, Error> {
+        let sqe = IoUringSqe {
+            opcode: IORING_OP_NOP,
+            user_data,
+            ..IoUringSqe::default()
+        };
+        self.submit_and_reap_one(&sqe)
+    }
+
+    /// Submits one SQE and reaps exactly one completion, returning its `res`.
+    ///
+    /// This is the shared submit/complete path the opcode helpers build on. It
+    /// follows the full `io_uring` ring protocol: a submit-side overflow guard
+    /// against the kernel-advanced SQ head, an `io_uring_enter` that submits one
+    /// and blocks for one completion, and a reap that consults the
+    /// kernel-advanced CQ tail before reading the CQE.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if the SQ is full, `io_uring_enter` fails, no
+    /// completion is visible after the wait, or the completion's `res` is a
+    /// negative `-errno`.
+    fn submit_and_reap_one(&mut self, sqe: &IoUringSqe) -> Result<i32, Error> {
+        // SAFETY: single-threaded driver. Read the kernel-advanced SQ head
+        // (Acquire) to confirm the ring has a free slot, write the SQE into
+        // `tail & mask`, then publish the new tail (Release) so the kernel sees
+        // a fully-written SQE before the index it reads.
+        unsafe {
+            let tail = core::ptr::read_volatile(self.sq_ktail);
+            let head = core::ptr::read_volatile(self.sq_khead);
+            fence(Ordering::Acquire);
+            if tail.wrapping_sub(head) >= self.sq_entries {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "io_uring submission queue is full",
+                ));
+            }
+            let index = tail & self.sq_ring_mask;
+            core::ptr::write(self.sqes.add(index as usize), *sqe);
+            core::ptr::write(self.sq_array.add(index as usize), index);
+            fence(Ordering::Release);
+            core::ptr::write_volatile(self.sq_ktail, tail.wrapping_add(1));
+        }
+
+        // Submit 1, wait for 1 completion.
+        // SAFETY: `self.ring_fd` is the live ring fd owned by this `IoUringRaw`.
+        let _ = unsafe { io_uring_enter(self.ring_fd, 1, 1, IORING_ENTER_GETEVENTS) }?;
+
+        // SAFETY: read the kernel-advanced CQ tail (Acquire) before touching the
+        // CQE so we never read a slot the kernel has not published. After a
+        // successful `enter` with `min_complete == 1` a completion is present,
+        // but the explicit tail check keeps the reaper correct and ready to
+        // drain multiple completions in later opcode work.
+        let res = unsafe {
+            let head = core::ptr::read_volatile(self.cq_khead);
+            let ktail = core::ptr::read_volatile(self.cq_ktail);
+            fence(Ordering::Acquire);
+            if head == ktail {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "io_uring_enter returned with no completion",
+                ));
+            }
+            let cqe = core::ptr::read(self.cqes.add((head & self.cq_ring_mask) as usize));
+            core::ptr::write_volatile(self.cq_khead, head.wrapping_add(1));
+            cqe.res
+        };
+        if res < 0 {
+            return Err(Error::new(
+                errno_to_kind(-res),
+                format!("io_uring op completed with errno {}", -res),
+            ));
+        }
+        Ok(res)
+    }
+
+    /// The submission-queue depth the kernel allocated.
+    #[must_use]
+    pub fn sq_entries(&self) -> u32 {
+        self.sq_entries
+    }
+}
+
+impl Drop for IoUringRaw {
+    fn drop(&mut self) {
+        // SAFETY: every pointer/length here came from this struct's own `mmap` /
+        // `io_uring_setup` and is unmapped/closed exactly once.
+        unsafe {
+            munmap(self.sqes.cast(), self.sqes_len);
+            if !self.cq_ptr.is_null() {
+                munmap(self.cq_ptr, self.cq_len);
+            }
+            munmap(self.sq_ptr, self.sq_len);
+            close(self.ring_fd);
+        }
+    }
+}
+
+/// Closes a fd on drop unless disarmed. Used to release the ring fd if `mmap`
+/// fails between `io_uring_setup` and the `IoUringRaw` value taking ownership.
+struct FdGuard(i32);
+
+impl FdGuard {
+    fn disarm(self) {
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for FdGuard {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is the live ring fd; only reached on the setup-error
+        // path where nothing else owns it yet.
+        unsafe { close(self.0) };
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+
+    // These tests require a Linux kernel with io_uring; they are compiled only
+    // under `cfg(target_os = "linux")` (the module gate) and run on the Linux
+    // CI / bench runner, not on the macOS dev host.
+
+    #[test]
+    fn ring_setup_and_nop_round_trips() {
+        let mut ring = IoUringRaw::new(8).expect("io_uring_setup + mmap should succeed");
+        assert!(
+            ring.sq_entries() >= 8,
+            "kernel rounds entries up to >= request"
+        );
+        // A NOP completes immediately with res == 0 and echoes our user_data
+        // slot through the full submit -> enter -> complete cycle.
+        let res = ring
+            .nop(0xDEAD_BEEF)
+            .expect("NOP submit/complete should succeed");
+        assert_eq!(res, 0, "NOP res must be 0");
+    }
+
+    #[test]
+    fn multiple_nops_reuse_slots() {
+        let mut ring = IoUringRaw::new(4).expect("setup");
+        // Submit more NOPs than the ring depth to exercise tail/head wraparound
+        // and slot reuse across several enter calls.
+        for i in 0..16u64 {
+            let res = ring.nop(i).expect("nop");
+            assert_eq!(res, 0);
+        }
+    }
+}

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -39,7 +39,7 @@ use alloc::format;
 
 use core::sync::atomic::{Ordering, fence};
 
-use syscalls::{Errno, Sysno, syscall1, syscall2, syscall6};
+use syscalls::{Errno, Sysno, syscall1, syscall2, syscall4, syscall6};
 
 use crate::io::{Error, ErrorKind};
 
@@ -63,6 +63,33 @@ const IORING_FEAT_SINGLE_MMAP: u32 = 1;
 /// No-op opcode: completes immediately with `res == 0`. Used to smoke-test the
 /// ring without touching a file.
 const IORING_OP_NOP: u8 = 0;
+/// `fsync` opcode: flush the file's data + metadata (or just data, with the
+/// `IORING_FSYNC_DATASYNC` flag) to stable storage.
+const IORING_OP_FSYNC: u8 = 3;
+/// `read` opcode: read into a single buffer at an explicit offset (the `addr` /
+/// `len` form, not the iovec `readv`).
+const IORING_OP_READ: u8 = 22;
+/// `write` opcode: write a single buffer at an explicit offset.
+const IORING_OP_WRITE: u8 = 23;
+/// `op_flags` bit for [`IORING_OP_FSYNC`]: flush data only (skip non-essential
+/// metadata), matching `fdatasync(2)`.
+const IORING_FSYNC_DATASYNC: u32 = 1;
+
+/// `openat` dir-fd sentinel meaning "resolve relative paths against the cwd".
+const AT_FDCWD: i32 = -100;
+
+// `open(2)` access-mode / creation flags for [`open_raw`] callers (Linux
+// generic ABI values).
+/// Open read-only.
+pub const O_RDONLY: i32 = 0;
+/// Open write-only.
+pub const O_WRONLY: i32 = 1;
+/// Open read-write.
+pub const O_RDWR: i32 = 2;
+/// Create the file if it does not exist.
+pub const O_CREAT: i32 = 0o100;
+/// Truncate the file to zero length on open.
+pub const O_TRUNC: i32 = 0o1000;
 
 // `mmap` protection / flags.
 const PROT_READ: usize = 0x1;
@@ -264,6 +291,43 @@ unsafe fn close(fd: i32) {
     let _ = unsafe { syscall1(Sysno::close, fd as usize) };
 }
 
+/// Opens a file via the raw `openat(AT_FDCWD, path, flags, mode)` syscall,
+/// returning the new descriptor.
+///
+/// Path resolution is relative to the process cwd; `mode` only applies when
+/// `flags` requests creation (`O_CREAT`). File open is a one-shot control
+/// operation, so it goes through a plain blocking syscall rather than the
+/// ring; the ring is reserved for the hot read / write / fsync data path.
+///
+/// # Errors
+/// Returns an [`Error`] if the `openat` syscall fails.
+pub fn open_raw(path: &core::ffi::CStr, flags: i32, mode: u32) -> Result<i32, Error> {
+    // SAFETY: `path` is a valid, NUL-terminated C string for the call's
+    // duration (borrowed `&CStr`); the kernel only reads it.
+    let fd = unsafe {
+        syscall4(
+            Sysno::openat,
+            AT_FDCWD as usize,
+            path.as_ptr() as usize,
+            flags as usize,
+            mode as usize,
+        )
+    }
+    .map_err(|e| err("openat", e))?;
+    Ok(fd as i32)
+}
+
+/// Closes a descriptor returned by [`open_raw`].
+///
+/// # Errors
+/// Returns an [`Error`] if `close` fails (e.g. a write-back error flushed at
+/// close time on some filesystems).
+pub fn close_raw(fd: i32) -> Result<(), Error> {
+    // SAFETY: `fd` is a descriptor the caller owns.
+    unsafe { syscall1(Sysno::close, fd as usize) }.map_err(|e| err("close", e))?;
+    Ok(())
+}
+
 /// A minimal, `no_std` `io_uring` instance: an `mmap`'d submission ring, an
 /// `mmap`'d completion ring, the SQE array, and the ring fd.
 ///
@@ -429,6 +493,59 @@ impl IoUringRaw {
         self.submit_and_reap_one(&sqe)
     }
 
+    /// Reads up to `buf.len()` bytes from `fd` starting at `offset` through the
+    /// ring, returning the number of bytes read (`0` at end of file).
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if the read completes with a negative `-errno`.
+    pub fn read_at(&mut self, fd: i32, buf: &mut [u8], offset: u64) -> Result<usize, Error> {
+        let sqe = IoUringSqe {
+            opcode: IORING_OP_READ,
+            fd,
+            addr: buf.as_mut_ptr() as u64,
+            len: buf.len() as u32,
+            off: offset,
+            ..IoUringSqe::default()
+        };
+        let res = self.submit_and_reap_one(&sqe)?;
+        Ok(res as usize)
+    }
+
+    /// Writes up to `buf.len()` bytes to `fd` starting at `offset` through the
+    /// ring, returning the number of bytes written.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if the write completes with a negative `-errno`.
+    pub fn write_at(&mut self, fd: i32, buf: &[u8], offset: u64) -> Result<usize, Error> {
+        let sqe = IoUringSqe {
+            opcode: IORING_OP_WRITE,
+            fd,
+            addr: buf.as_ptr() as u64,
+            len: buf.len() as u32,
+            off: offset,
+            ..IoUringSqe::default()
+        };
+        let res = self.submit_and_reap_one(&sqe)?;
+        Ok(res as usize)
+    }
+
+    /// Flushes `fd` to stable storage through the ring. With `datasync`, only
+    /// the file data (and the metadata needed to read it back) is flushed,
+    /// matching `fdatasync(2)`; otherwise all metadata is flushed too.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if the fsync completes with a negative `-errno`.
+    pub fn fsync(&mut self, fd: i32, datasync: bool) -> Result<(), Error> {
+        let sqe = IoUringSqe {
+            opcode: IORING_OP_FSYNC,
+            fd,
+            op_flags: if datasync { IORING_FSYNC_DATASYNC } else { 0 },
+            ..IoUringSqe::default()
+        };
+        self.submit_and_reap_one(&sqe)?;
+        Ok(())
+    }
+
     /// Submits one SQE and reaps exactly one completion, returning its `res`.
     ///
     /// This is the shared submit/complete path the opcode helpers build on. It
@@ -568,5 +685,55 @@ mod tests {
             let res = ring.nop(i).expect("nop");
             assert_eq!(res, 0);
         }
+    }
+
+    #[test]
+    fn file_write_fsync_read_round_trips_through_the_ring() {
+        // Real data path: open a file (raw openat), write a payload at an
+        // offset through the ring, fsync it through the ring, read it back
+        // through the ring, and verify the bytes — then close (raw) + clean up.
+        let path = std::env::temp_dir().join(format!(
+            "iou_raw_rt_{}_{}.bin",
+            std::process::id(),
+            // a per-test suffix so parallel runs do not collide
+            line!()
+        ));
+        let cpath = std::ffi::CString::new(path.to_str().expect("utf8 path"))
+            .expect("path has no interior NUL");
+
+        let fd =
+            open_raw(&cpath, O_CREAT | O_RDWR | O_TRUNC, 0o600).expect("openat should succeed");
+
+        let mut ring = IoUringRaw::new(8).expect("ring setup");
+
+        let payload = b"io_uring raw round-trip payload";
+        let offset = 4096u64; // a non-zero offset to exercise positioned I/O
+
+        let written = ring
+            .write_at(fd, payload, offset)
+            .expect("write_at should succeed");
+        assert_eq!(written, payload.len(), "short write");
+
+        ring.fsync(fd, false).expect("fsync should succeed");
+
+        let mut readback = vec![0u8; payload.len()];
+        let read = ring
+            .read_at(fd, &mut readback, offset)
+            .expect("read_at should succeed");
+        assert_eq!(read, payload.len(), "short read");
+        assert_eq!(
+            &readback, payload,
+            "read-back bytes must match what we wrote"
+        );
+
+        // Reading past EOF returns 0 bytes (the file is exactly offset+len long).
+        let mut tail = [0u8; 8];
+        let eof = ring
+            .read_at(fd, &mut tail, offset + payload.len() as u64)
+            .expect("read at EOF should succeed");
+        assert_eq!(eof, 0, "read past EOF must return 0");
+
+        close_raw(fd).expect("close should succeed");
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -742,4 +742,54 @@ mod tests {
         close_raw(fd).expect("close should succeed");
         let _ = std::fs::remove_file(&path);
     }
+
+    #[test]
+    fn errno_maps_to_expected_error_kinds() {
+        // Every explicitly-mapped errno lands on its kind; anything else folds
+        // into `Other`. Covers the whole `errno_to_kind` table without needing
+        // to provoke each real failure.
+        assert_eq!(errno_to_kind(1), ErrorKind::PermissionDenied); // EPERM
+        assert_eq!(errno_to_kind(2), ErrorKind::NotFound); // ENOENT
+        assert_eq!(errno_to_kind(4), ErrorKind::Interrupted); // EINTR
+        assert_eq!(errno_to_kind(9), ErrorKind::InvalidInput); // EBADF
+        assert_eq!(errno_to_kind(13), ErrorKind::PermissionDenied); // EACCES
+        assert_eq!(errno_to_kind(17), ErrorKind::AlreadyExists); // EEXIST
+        assert_eq!(errno_to_kind(22), ErrorKind::InvalidInput); // EINVAL
+        assert_eq!(errno_to_kind(95), ErrorKind::Unsupported); // EOPNOTSUPP
+        assert_eq!(errno_to_kind(132), ErrorKind::Other); // unmapped
+    }
+
+    #[test]
+    fn ring_setup_with_zero_entries_is_rejected() {
+        // `io_uring_setup` rejects a zero-entry ring with EINVAL; this covers
+        // the setup error path (and the fd guard never arming). `IoUringRaw`
+        // is not `Debug`, so match rather than `expect_err`.
+        match IoUringRaw::new(0) {
+            Ok(_) => panic!("zero-entry ring must be rejected"),
+            Err(e) => assert_eq!(e.kind(), ErrorKind::InvalidInput),
+        }
+    }
+
+    #[test]
+    fn open_raw_missing_file_returns_not_found() {
+        // Opening a missing path read-only (no O_CREAT) fails with ENOENT,
+        // exercising `open_raw`'s error path and the `err` -> `ErrorKind`
+        // conversion.
+        let cpath = std::ffi::CString::new("/proc/does-not-exist/iou_raw_missing")
+            .expect("no interior NUL");
+        let err = open_raw(&cpath, O_RDONLY, 0).expect_err("missing file must fail to open");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn ring_op_on_bad_fd_surfaces_completion_error() {
+        // A write against a descriptor that is not open completes with -EBADF;
+        // the reaper must surface that negative `res` as an error (covering the
+        // `res < 0` branch of `submit_and_reap_one`).
+        let mut ring = IoUringRaw::new(4).expect("ring setup");
+        let err = ring
+            .write_at(1 << 30, b"x", 0)
+            .expect_err("write to a non-open fd must fail");
+        assert_eq!(err.kind(), ErrorKind::InvalidInput); // EBADF -> InvalidInput
+    }
 }

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -78,18 +78,53 @@ const IORING_FSYNC_DATASYNC: u32 = 1;
 /// `openat` dir-fd sentinel meaning "resolve relative paths against the cwd".
 const AT_FDCWD: i32 = -100;
 
-// `open(2)` access-mode / creation flags for [`open_raw`] callers (Linux
-// generic ABI values).
+// `open(2)` access-mode / creation flags for [`open_raw`] callers.
+//
+// The access modes (O_RDONLY/O_WRONLY/O_RDWR = 0/1/2) are universal across every
+// Linux architecture. O_CREAT and O_TRUNC, however, are among the handful of
+// open() flags whose bit values are arch-specific: x86/x86_64, ARM, AArch64,
+// RISC-V, PowerPC, etc. use the asm-generic values, while MIPS and SPARC define
+// their own (verified against each arch's kernel <asm/fcntl.h>). Hardcoding the
+// asm-generic values unconditionally would silently pass the wrong flag on a
+// MIPS or SPARC build, so they are selected per target_arch below.
+
 /// Open read-only.
 pub const O_RDONLY: i32 = 0;
 /// Open write-only.
 pub const O_WRONLY: i32 = 1;
 /// Open read-write.
 pub const O_RDWR: i32 = 2;
-/// Create the file if it does not exist.
+
+/// Create the file if it does not exist. Asm-generic value (`0o100`); MIPS and
+/// SPARC override below.
+#[cfg(not(any(
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6",
+    target_arch = "sparc",
+    target_arch = "sparc64"
+)))]
 pub const O_CREAT: i32 = 0o100;
-/// Truncate the file to zero length on open.
+/// Create the file if it does not exist (MIPS: `0x100`).
+#[cfg(any(
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6"
+))]
+pub const O_CREAT: i32 = 0x100;
+/// Create the file if it does not exist (SPARC: `0x200`).
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+pub const O_CREAT: i32 = 0x200;
+
+/// Truncate the file to zero length on open. Asm-generic and MIPS share `0o1000`
+/// (`0x200`); only SPARC overrides below.
+#[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
 pub const O_TRUNC: i32 = 0o1000;
+/// Truncate the file to zero length on open (SPARC: `0x400`).
+#[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+pub const O_TRUNC: i32 = 0x400;
 
 // `mmap` protection / flags.
 const PROT_READ: usize = 0x1;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -67,7 +67,9 @@ pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 // driver is exposed now so feature-gated `no_std` consumers can drive the ring
 // directly.
 #[cfg(all(target_os = "linux", feature = "io-uring-raw"))]
-pub use io_uring_raw::IoUringRaw;
+pub use io_uring_raw::{
+    IoUringRaw, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, close_raw, open_raw,
+};
 
 // `Read` / `Write` / `Seek` come from `crate::io`, the local mirror
 // of `std::io` that compiles under `no_std + alloc`. Under `feature =

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -49,6 +49,10 @@ pub use aligned_buf::AlignedBuf;
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 mod io_uring_fs;
 
+// Pure-Rust `no_std` io_uring driver core on raw Linux syscalls (#346).
+#[cfg(all(target_os = "linux", feature = "io-uring-raw"))]
+mod io_uring_raw;
+
 pub use mem_fs::MemFs;
 #[cfg(feature = "std")]
 pub use std_fs::StdFs;
@@ -57,6 +61,13 @@ pub(crate) use std_fs::is_cross_device;
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring_fs::{IoUringFs, is_io_uring_available};
+
+// Raw-syscall `no_std` io_uring driver core (#346). The `IoUringRawFs`
+// [`Fs`](crate::fs::Fs) backend built on top of it lands in follow-up work; the
+// driver is exposed now so feature-gated `no_std` consumers can drive the ring
+// directly.
+#[cfg(all(target_os = "linux", feature = "io-uring-raw"))]
+pub use io_uring_raw::IoUringRaw;
 
 // `Read` / `Write` / `Seek` come from `crate::io`, the local mirror
 // of `std::io` that compiles under `no_std + alloc`. Under `feature =

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -56,6 +56,9 @@ pub enum ErrorKind {
     UnexpectedEof,
     /// Operation is not supported on this platform / backend / build.
     Unsupported,
+    /// Operation would block (`EAGAIN` / `EWOULDBLOCK`-equivalent); the caller
+    /// can retry. Mirrors [`std::io::ErrorKind::WouldBlock`].
+    WouldBlock,
     /// `write` returned `Ok(0)` while bytes still needed to be
     /// written. Mirrors [`std::io::ErrorKind::WriteZero`] so callers
     /// can distinguish a stuck-writer short write from a generic
@@ -77,6 +80,7 @@ impl ErrorKind {
             Self::PermissionDenied => "permission denied",
             Self::UnexpectedEof => "unexpected end of file",
             Self::Unsupported => "unsupported",
+            Self::WouldBlock => "operation would block",
             Self::WriteZero => "write returned 0 bytes",
         }
     }
@@ -230,6 +234,7 @@ impl From<std::io::Error> for Error {
             std::io::ErrorKind::PermissionDenied => (ErrorKind::PermissionDenied, true),
             std::io::ErrorKind::UnexpectedEof => (ErrorKind::UnexpectedEof, true),
             std::io::ErrorKind::Unsupported => (ErrorKind::Unsupported, true),
+            std::io::ErrorKind::WouldBlock => (ErrorKind::WouldBlock, true),
             std::io::ErrorKind::WriteZero => (ErrorKind::WriteZero, true),
             // `Other` is a mapped kind: a kind-only `Other` std error
             // would otherwise fall through to the unmapped branch and
@@ -291,6 +296,7 @@ impl From<Error> for std::io::Error {
             ErrorKind::PermissionDenied => std::io::ErrorKind::PermissionDenied,
             ErrorKind::UnexpectedEof => std::io::ErrorKind::UnexpectedEof,
             ErrorKind::Unsupported => std::io::ErrorKind::Unsupported,
+            ErrorKind::WouldBlock => std::io::ErrorKind::WouldBlock,
             ErrorKind::WriteZero => std::io::ErrorKind::WriteZero,
         };
         match err.message {
@@ -1424,6 +1430,7 @@ mod tests {
             ErrorKind::PermissionDenied,
             ErrorKind::UnexpectedEof,
             ErrorKind::Unsupported,
+            ErrorKind::WouldBlock,
             ErrorKind::WriteZero,
         ];
         for (i, a) in all.iter().enumerate() {
@@ -1565,7 +1572,7 @@ mod tests {
     /// to the enum without a row here fails the per-arm assertions
     /// (the std round trip would not preserve it).
     #[cfg(feature = "std")]
-    const ALL_KINDS: [ErrorKind; 12] = [
+    const ALL_KINDS: [ErrorKind; 13] = [
         ErrorKind::AlreadyExists,
         ErrorKind::BrokenPipe,
         ErrorKind::CrossesDevices,
@@ -1577,6 +1584,7 @@ mod tests {
         ErrorKind::PermissionDenied,
         ErrorKind::UnexpectedEof,
         ErrorKind::Unsupported,
+        ErrorKind::WouldBlock,
         ErrorKind::WriteZero,
     ];
 
@@ -1625,6 +1633,7 @@ mod tests {
             ),
             (std::io::ErrorKind::UnexpectedEof, ErrorKind::UnexpectedEof),
             (std::io::ErrorKind::Unsupported, ErrorKind::Unsupported),
+            (std::io::ErrorKind::WouldBlock, ErrorKind::WouldBlock),
             (std::io::ErrorKind::WriteZero, ErrorKind::WriteZero),
         ];
         for (std_kind, want) in mapped {
@@ -1697,6 +1706,7 @@ mod tests {
             ErrorKind::PermissionDenied,
             ErrorKind::UnexpectedEof,
             ErrorKind::Unsupported,
+            ErrorKind::WouldBlock,
             ErrorKind::WriteZero,
         ];
         for kind in all {


### PR DESCRIPTION
First slices of #346 — a pure-Rust, `no_std` io_uring backend (the std-bound `IoUringFs` wraps the `io-uring` crate, which pulls in `std`).

## What this adds

**Driver core** (`IoUringRaw`):
- **`io-uring-raw` Cargo feature** (no `std` dep) + a Linux-target-gated optional `syscalls` dependency. The backend module is `cfg(all(target_os = "linux", feature = "io-uring-raw"))`, so enabling the feature on a non-Linux target compiles to nothing.
- `io_uring_setup` + `mmap` of the SQ/CQ rings and SQE array (both the single-mmap and separate-mmap kernel layouts), with RAII teardown (`munmap` + `close`) and a setup-time fd guard.
- ABI structs (`io_uring_params`, SQ/CQ ring offsets, SQE, CQE) transcribed from the stable kernel uapi; raw `errno` → the crate's `no_std` `ErrorKind`.
- `submit_and_reap_one`: the full ring protocol — SQ-overflow guard against the kernel head, `io_uring_enter`, CQ-tail-checked reap with the correct Acquire/Release fences. Smoke-tested by an `IORING_OP_NOP` round-trip.

**File I/O opcodes** on `IoUringRaw`:
- `read_at` / `write_at` (`IORING_OP_READ` / `IORING_OP_WRITE`, positioned single-buffer I/O) and `fsync` (`IORING_OP_FSYNC` + optional `IORING_FSYNC_DATASYNC`).
- `open_raw` / `close_raw` (`openat(AT_FDCWD, …)` / `close`) for the one-shot control path, plus `O_*` flag constants.

Also pins this crate as a **standalone workspace root** (empty `[workspace]`): a bare clone inside another tree (e.g. a CI runner hosting a different workspace) was otherwise absorbed into the surrounding workspace and failed `cargo metadata` before building.

## Verification

- Compiles on `x86_64-unknown-linux-gnu` under both `std` and `--no-default-features --features alloc,io-uring-raw`.
- `thumbv7em-none-eabihf` no-std baseline unchanged (the feature is Linux-gated): 0 errors.
- `cargo clippy` clean for the new module on x86_64-linux.
- **All ring tests pass on a real Linux io_uring host** (kernel 7.0.11), from a pristine standalone clone: NOP round-trip + slot reuse, and a write → fsync → read round-trip at a non-zero offset (with an at-EOF read returning 0).

## Follow-up slices (this epic)

- `IoUringRawFs` / `IoUringRawFile` implementing `Fs` / `FsFile`.
- The raw-syscall path operations the `Fs` trait needs beyond the ring (openat variants, statx, getdents64, unlinkat, renameat2, ftruncate, flock).
- A CI job that builds + runs the `io-uring-raw` tests on the Linux runner.

Part of #346.