### PR TITLE
fix(build): pin standalone tool crates as their own workspace roots

### DIFF
--- a/tools/compare-rocksdb/Cargo.toml
+++ b/tools/compare-rocksdb/Cargo.toml
@@ -11,6 +11,15 @@
 # and through RocksDB side-by-side; results land in
 # `tools/compare-rocksdb/target/criterion/`. The gh-pages
 # dashboard pipeline consumes those JSON outputs (per #244).
+#
+# An empty `[workspace]` pins this crate as its own workspace root. The main
+# crate already lists it under `workspace.exclude`, but exclusion alone does not
+# stop Cargo from absorbing it into a DIFFERENT workspace manifest higher up the
+# directory tree (e.g. a stray one in a CI runner's temp dir, or a surrounding
+# monorepo). Declaring our own root makes a standalone `cargo bench` here immune
+# to whatever lives above this directory.
+[workspace]
+
 [package]
 name = "compare-rocksdb-bench"
 version = "0.1.0"

--- a/tools/db_bench/Cargo.toml
+++ b/tools/db_bench/Cargo.toml
@@ -1,5 +1,12 @@
 # Standalone benchmark tool — not part of the main coordinode-lsm-tree crate.
 # Build with: cd tools/db_bench && cargo build --release
+#
+# The empty `[workspace]` pins this crate as its own root so a standalone build
+# is never absorbed into a workspace manifest higher up the tree (the main crate
+# excludes it, but exclusion alone does not stop a DIFFERENT parent workspace,
+# e.g. a stray one in a CI runner's temp dir, from claiming it).
+[workspace]
+
 [package]
 name = "db-bench"
 version = "0.1.0"

--- a/tools/sst-dump/Cargo.toml
+++ b/tools/sst-dump/Cargo.toml
@@ -8,6 +8,13 @@
 #
 # Modeled after RocksDB's sst_dump utility; follows the tools/db_bench
 # layout convention (separate Cargo crate, path dep on the main lib).
+#
+# The empty `[workspace]` pins this crate as its own root so a standalone build
+# is never absorbed into a workspace manifest higher up the tree (the main crate
+# excludes it, but exclusion alone does not stop a DIFFERENT parent workspace,
+# e.g. a stray one in a CI runner's temp dir, from claiming it).
+[workspace]
+
 [package]
 name = "sst-dump"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

The three `tools/` crates (`compare-rocksdb`, `db_bench`, `sst-dump`) build standalone and are listed under the main crate's `workspace.exclude`. Exclusion stops them joining the main crate's workspace, but it does **not** stop Cargo absorbing them into a *different* workspace manifest higher up the tree: an excluded package keeps searching upward and joins the next workspace that doesn't exclude it.

On a bench runner this bit us: a stray root-owned `/tmp/Cargo.toml` left by another job claimed `tools/compare-rocksdb` when building from a temp-dir clone, so `cargo bench` failed at resolve time trying to read a phantom member crate.

## Fix

Give each tool crate an empty `[workspace]` table so it is its own root. Cargo never walks past the crate directory, making standalone builds immune to whatever workspace lives above.

## Verification

`cargo metadata --no-deps` on each tool now reports its own directory as `workspace_root` (previously could resolve to a parent). Surfaced while setting up the #426 read-path profiling on the bench runner.