### PR TITLE
perf(table): move seqno bounds to a parallel section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,3 +353,9 @@ name = "partial_decode"
 harness = false
 path = "benches/partial_decode.rs"
 required-features = ["zstd"]
+
+[[bench]]
+name = "scan_since"
+harness = false
+path = "benches/scan_since.rs"
+required-features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ spin = { version = "0.12", default-features = false, features = ["mutex", "spin_
 hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }
 parking_lot = { version = "0.12", optional = true }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-structured-zstd = { version = "0.0.39", optional = true, default-features = false, features = ["std", "lsm"] }
+structured-zstd = { version = "0.0.40", optional = true, default-features = false, features = ["std", "lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is

--- a/benches/scan_since.rs
+++ b/benches/scan_since.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Benchmarks for the `seqno_in_index` block-skip optimization behind
+//! `Tree::scan_since_seqno` (the CDC / incremental-scan primitive).
+//!
+//! Three head-to-head comparisons of `seqno_in_index = true` vs `false`:
+//!   - `scan_since/sparse_1pct` — only the top 1% of seqnos are recent, so
+//!     block-skip should read a tiny fraction of the data blocks (target: a
+//!     large speedup vs the full per-entry filter).
+//!   - `write_throughput` — bulk insert + flush; the seqno-bounded index is
+//!     slightly larger, so this measures the write-side cost (target: small).
+//!   - `point_lookup` — random `get`; the index format must not affect the
+//!     point-read path (target: indistinguishable).
+
+#![expect(
+    clippy::expect_used,
+    reason = "benchmark setup favors concise panic messages"
+)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lsm_tree::runtime_config::RuntimeConfig;
+use lsm_tree::{AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, Tree};
+use tempfile::TempDir;
+
+/// Build a freshly-flushed single-run tree of `n` entries (seqno = key index),
+/// with the seqno-bounded index on or off. Small data blocks make the per-block
+/// seqno bounds meaningful.
+fn build_tree(seqno_in_index: bool, n: u64) -> (TempDir, Tree) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut rc = RuntimeConfig::default();
+    rc.seqno_in_index = seqno_in_index;
+    let any = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_runtime_config(rc)
+    .open()
+    .expect("open");
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), b"value", i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    (dir, tree)
+}
+
+/// Sparse-changes scan: target near the top of the seqno range so only ~1% of
+/// entries qualify. With `seqno_in_index = true` the scan skips data blocks
+/// whose `seqno_max < target`; with it off, every block is read and filtered.
+fn bench_scan_since_sparse(c: &mut Criterion) {
+    let n = 100_000u64;
+    let target: SeqNo = n - n / 100; // top 1% are "recent"
+
+    let mut group = c.benchmark_group("scan_since/sparse_1pct");
+    for &on in &[false, true] {
+        let (_dir, tree) = build_tree(on, n);
+        // Sanity: both formats must return the same number of recent entries.
+        let count = tree.scan_since_seqno(target).expect("scan").count();
+        assert_eq!(count as u64, n / 100, "1% of entries must qualify");
+
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let c = tree.scan_since_seqno(target).expect("scan").count();
+                std::hint::black_box(c);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Write-side cost of the seqno-bounded index: bulk insert + flush from an empty
+/// tree each iteration.
+fn bench_write_throughput(c: &mut Criterion) {
+    let n = 20_000u64;
+    let mut group = c.benchmark_group("scan_since/write_throughput");
+    for &on in &[false, true] {
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let (dir, _tree) = build_tree(on, n);
+                std::hint::black_box(&dir);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Point-lookup cost: the index format must not affect `get`. Random-ish key
+/// order via a multiplicative hash over the keyspace.
+fn bench_point_lookup(c: &mut Criterion) {
+    let n = 100_000u64;
+    // Precompute a shuffled key set ONCE so the timed loop measures only `get`,
+    // not per-iteration `format!` allocation (which would dwarf a ~1 us lookup
+    // and mask the index-format delta this bench is meant to isolate).
+    let keys: Vec<Vec<u8>> = (0..n)
+        .map(|i| {
+            let idx = i.wrapping_mul(2_654_435_761) % n;
+            format!("key{idx:08}").into_bytes()
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("scan_since/point_lookup");
+    for &on in &[false, true] {
+        let (_dir, tree) = build_tree(on, n);
+        let label = if on {
+            "seqno_index_on"
+        } else {
+            "seqno_index_off"
+        };
+        group.bench_function(label, |b| {
+            let mut i = 0usize;
+            b.iter(|| {
+                let key = &keys[i % keys.len()];
+                i = i.wrapping_add(1);
+                let v = tree.get(key, SeqNo::MAX).expect("get");
+                std::hint::black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_scan_since_sparse,
+    bench_write_throughput,
+    bench_point_lookup
+);
+criterion_main!(benches);

--- a/benches/scan_since.rs
+++ b/benches/scan_since.rs
@@ -49,6 +49,37 @@ fn build_tree(seqno_in_index: bool, n: u64) -> (TempDir, Tree) {
     (dir, tree)
 }
 
+/// Run `iters` timed invocations of `op` for Criterion's `iter_custom`, also
+/// recording each op's individual latency and printing P99/P999 to stderr.
+///
+/// Aggregate throughput still comes from Criterion's own statistics over the
+/// returned total; the per-op tail percentiles surface latency regressions that
+/// a central-tendency-only view would hide. stderr keeps the line out of
+/// Criterion's stdout report.
+fn timed_with_tail<F: FnMut()>(label: &str, iters: u64, mut op: F) -> std::time::Duration {
+    use std::time::Instant;
+    let mut samples = Vec::with_capacity(iters as usize);
+    let started = Instant::now();
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        op();
+        samples.push(t0.elapsed());
+    }
+    let total = started.elapsed();
+    if !samples.is_empty() {
+        samples.sort_unstable();
+        let pct =
+            |per_mille: usize| samples[(samples.len() * per_mille / 1000).min(samples.len() - 1)];
+        eprintln!(
+            "{label}: p50={:?} p99={:?} p999={:?}",
+            pct(500),
+            pct(990),
+            pct(999)
+        );
+    }
+    total
+}
+
 /// Sparse-changes scan: target near the top of the seqno range so only ~1% of
 /// entries qualify. With `seqno_in_index = true` the scan skips data blocks
 /// whose `seqno_max < target`; with it off, every block is read and filtered.
@@ -69,9 +100,11 @@ fn bench_scan_since_sparse(c: &mut Criterion) {
             "seqno_index_off"
         };
         group.bench_function(label, |b| {
-            b.iter(|| {
-                let c = tree.scan_since_seqno(target).expect("scan").count();
-                std::hint::black_box(c);
+            b.iter_custom(|iters| {
+                timed_with_tail(label, iters, || {
+                    let c = tree.scan_since_seqno(target).expect("scan").count();
+                    std::hint::black_box(c);
+                })
             });
         });
     }
@@ -90,9 +123,11 @@ fn bench_write_throughput(c: &mut Criterion) {
             "seqno_index_off"
         };
         group.bench_function(label, |b| {
-            b.iter(|| {
-                let (dir, _tree) = build_tree(on, n);
-                std::hint::black_box(&dir);
+            b.iter_custom(|iters| {
+                timed_with_tail(label, iters, || {
+                    let (dir, _tree) = build_tree(on, n);
+                    std::hint::black_box(&dir);
+                })
             });
         });
     }
@@ -123,11 +158,13 @@ fn bench_point_lookup(c: &mut Criterion) {
         };
         group.bench_function(label, |b| {
             let mut i = 0usize;
-            b.iter(|| {
-                let key = &keys[i % keys.len()];
-                i = i.wrapping_add(1);
-                let v = tree.get(key, SeqNo::MAX).expect("get");
-                std::hint::black_box(v);
+            b.iter_custom(|iters| {
+                timed_with_tail(label, iters, || {
+                    let key = &keys[i % keys.len()];
+                    i = i.wrapping_add(1);
+                    let v = tree.get(key, SeqNo::MAX).expect("get");
+                    std::hint::black_box(v);
+                })
             });
         });
     }

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -245,7 +245,7 @@ impl BlobTree {
         target_seqno: SeqNo,
     ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
         self.index
-            .scan_since_seqno_with(target_seqno, |version, entry| {
+            .scan_since_seqno_with(target_seqno, true, |version, entry| {
                 let seqno = entry.key.seqno;
                 let (key, value) = resolve_value_handle(
                     self.id(),

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -764,24 +764,23 @@ pub struct RuntimeConfig {
     /// compaction I/O. Toggling takes effect immediately for subsequent reads.
     pub auto_heal: bool,
 
-    /// Per-block seqno bounds in SST index entries (#224). When `true`,
-    /// SSTs written by the next flush / compaction record each data
-    /// block's `seqno_min` / `seqno_max` in its index entry
-    /// (`index_format = 1` in the table Properties), enabling fast
-    /// `scan_since_seqno` via block-skip: the scan skips any block whose
-    /// `seqno_max < target` without reading it.
+    /// Per-block seqno bounds for `scan_since_seqno` block-skip (#224). When
+    /// `true`, SSTs written by the next flush / compaction emit the optional
+    /// parallel `seqno_bounds` section, recording each data block's
+    /// `seqno_min` / `seqno_max` keyed by its file offset. A seqno-scoped scan
+    /// then skips any block whose bounds cannot overlap the target window
+    /// without reading it.
     ///
-    /// Default `false`: index blocks are byte-identical to the pre-#224
-    /// `index_format = 0` format, and `scan_since_seqno` falls back to a
-    /// per-entry filter. Decoding is marker-based: each index entry is
-    /// self-describing (legacy markers `0`/`1`, seqno-bounded `2`/`3`), so
-    /// mixed-format trees (some SSTs migrated, some not) read correctly
-    /// regardless of this setting; the stored `index_format` byte is a
-    /// metadata hint, not the decode switch.
+    /// Default `false`: no section is emitted (zero extra bytes) and
+    /// `scan_since_seqno` falls back to a per-entry filter. The index entries
+    /// are byte-identical regardless of this setting, so a point read pays
+    /// nothing either way, and a tree mixing SSTs with and without the section
+    /// reads correctly (a missing section simply means full-filter scan for
+    /// that SST).
     ///
-    /// Toggle takes effect on the next compaction / flush; existing SSTs
-    /// keep their original `index_format`. Compaction migrates source
-    /// SSTs to the current setting over time.
+    /// Toggle takes effect on the next compaction / flush; existing SSTs keep
+    /// whatever they were written with. Compaction migrates source SSTs to the
+    /// current setting over time.
     pub seqno_in_index: bool,
 
     /// Index-size threshold (bytes) at or below which an SST's block index
@@ -1272,10 +1271,9 @@ mod tests {
 
     #[test]
     fn runtime_config_default_seqno_in_index_off() {
-        // seqno_in_index is explicit opt-in (#224): default false keeps
-        // index blocks byte-identical to the pre-#224 index_format=0
-        // format. A regression flipping this default would change the
-        // on-disk index layout for every existing tree.
+        // seqno_in_index is explicit opt-in (#224): default false emits no
+        // seqno_bounds section, so SSTs carry zero extra bytes. A regression
+        // flipping this default would add the section to every new tree.
         assert!(!RuntimeConfig::default().seqno_in_index);
     }
 

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -49,6 +49,11 @@ pub enum BlockType {
     /// precision); absent when the level's locator policy is disabled or the
     /// per-SST ribbon could not be built.
     Locator,
+    /// Optional per-table seqno-bounds section: maps each data block's file
+    /// offset to its `[seqno_min, seqno_max]`, powering the `scan_since_seqno`
+    /// block-skip without bloating the index entries. Absent unless
+    /// `seqno_in_index` is on.
+    SeqnoBounds,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -71,6 +76,7 @@ impl From<BlockType> for u8 {
             BlockType::ManifestFooter => 6,
             BlockType::BlockLayout => 7,
             BlockType::Locator => 8,
+            BlockType::SeqnoBounds => 9,
         }
     }
 }
@@ -89,6 +95,7 @@ impl TryFrom<u8> for BlockType {
             6 => Ok(Self::ManifestFooter),
             7 => Ok(Self::BlockLayout),
             8 => Ok(Self::Locator),
+            9 => Ok(Self::SeqnoBounds),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -116,6 +123,7 @@ mod tests {
             (6, BlockType::ManifestFooter),
             (7, BlockType::BlockLayout),
             (8, BlockType::Locator),
+            (9, BlockType::SeqnoBounds),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -134,9 +142,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 9 is the first
+        // not a silent coercion to a known variant. 10 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(9).is_err());
+        assert!(BlockType::try_from(10).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -215,6 +215,17 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
     ) -> Option<IndexBlockParsedItem> {
         let marker = reader.read_u8().ok()?;
 
+        // Markers 2/3 were the pre-release inline seqno-bounds entries; this
+        // build never writes them and there is no on-disk compat obligation, so
+        // a 2/3 here means a stale-format SST or a reader/writer mismatch. Assert
+        // against them (debug-only, zero release cost) so that case surfaces
+        // instead of silently ending iteration like the trailer. Genuine
+        // corruption is still rejected gracefully as `None` below (and caught
+        // upstream by the index block's checksum).
+        debug_assert!(
+            marker != 2 && marker != 3,
+            "stale inline seqno-bounds marker {marker} in index full entry (pre-release format, unsupported)"
+        );
         if marker == TRAILER_START_MARKER {
             return None;
         }
@@ -272,6 +283,16 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
 
         let marker = *buf.get(pos)?;
         pos += 1;
+        // Markers 2/3 were the pre-release inline seqno-bounds entries (no
+        // on-disk compat); a 2/3 restart head means a stale-format SST or a
+        // reader/writer mismatch. Assert against them so that case surfaces
+        // instead of a silent miss. `debug_assert` is a no-op in release, so the
+        // point-read hot path pays nothing; genuine corruption is still rejected
+        // gracefully as `None` below (and caught upstream by the checksum).
+        debug_assert!(
+            marker != 2 && marker != 3,
+            "stale inline seqno-bounds marker {marker} in index restart head (pre-release format, unsupported)"
+        );
         if marker == TRAILER_START_MARKER {
             return None;
         }
@@ -323,6 +344,17 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
     ) -> Option<IndexBlockParsedItem> {
         let marker = reader.read_u8().ok()?;
 
+        // Markers 2/3 were the pre-release inline seqno-bounds entries; this
+        // build never writes them and there is no on-disk compat obligation, so
+        // a 2/3 here means a stale-format SST or a reader/writer mismatch. Assert
+        // against them (debug-only, zero release cost) so that case surfaces
+        // instead of silently ending iteration like the trailer. Genuine
+        // corruption is still rejected gracefully as `None` below (and caught
+        // upstream by the index block's checksum).
+        debug_assert!(
+            marker != 2 && marker != 3,
+            "stale inline seqno-bounds marker {marker} in index truncated entry (pre-release format, unsupported)"
+        );
         if marker == TRAILER_START_MARKER {
             return None;
         }
@@ -584,6 +616,27 @@ mod tests {
             bytes.len(),
         );
         assert!(parsed.is_none());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "stale inline seqno-bounds marker")]
+    fn parse_full_asserts_on_stale_inline_marker() {
+        // Marker 2 was the pre-release inline seqno-bounds full entry. This
+        // build never writes it and has no on-disk compat obligation, so a 2
+        // must fire the debug assertion rather than silently ending iteration
+        // like the trailer (the silent-stop a stale-format SST would otherwise
+        // cause). Release builds compile the assert out and reject it as `None`;
+        // genuine corruption is caught upstream by the index block checksum.
+        let mut bytes = make_full_entry();
+        *bytes.get_mut(0).unwrap() = 2;
+        let entries_end = bytes.len();
+        let mut cursor = Cursor::new(bytes.as_slice());
+        let _ = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
+            &mut cursor,
+            0,
+            entries_end,
+        );
     }
 
     #[test]

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -83,14 +83,6 @@ pub struct KeyedBlockHandle {
     /// Seqno of last item in block
     seqno: SeqNo,
 
-    /// Per-block seqno bounds `(min, max)` for the referenced data block.
-    /// `Some` ⇒ this index entry uses the seqno-bounded wire format (markers
-    /// 2 / 3), letting a seqno-scoped scan skip a data block whose `max` is
-    /// below the target without reading it; `None` ⇒ legacy entry (markers
-    /// 0 / 1, no bounds on disk). The writer sets this uniformly per SST from
-    /// the runtime config; the decoder populates it from the on-disk marker.
-    seqno_bounds: Option<(SeqNo, SeqNo)>,
-
     inner: BlockHandle,
 }
 
@@ -111,46 +103,13 @@ impl KeyedBlockHandle {
         Self {
             end_key,
             seqno,
-            seqno_bounds: None,
             inner: handle,
         }
-    }
-
-    /// Attaches per-block seqno bounds `(min, max)`, switching this handle to
-    /// the seqno-bounded wire format (markers 2 / 3) when encoded.
-    ///
-    /// # Panics
-    ///
-    /// In debug builds, panics if `seqno_min > seqno_max`. Inverted bounds are
-    /// a caller invariant violation (the writer derives them from a single
-    /// min/max fold over the block, so it cannot produce them); encoding an
-    /// inverted pair would let a seqno-scoped scan skip a block that still
-    /// holds visible entries. Corruption arriving from disk is rejected
-    /// separately on the decode path (`parse_full` / `parse_truncated`).
-    #[must_use]
-    pub fn with_seqno_bounds(mut self, seqno_min: SeqNo, seqno_max: SeqNo) -> Self {
-        debug_assert!(
-            seqno_min <= seqno_max,
-            "inverted seqno bounds: min {seqno_min} > max {seqno_max}",
-        );
-        self.seqno_bounds = Some((seqno_min, seqno_max));
-        self
     }
 
     #[must_use]
     pub fn seqno(&self) -> SeqNo {
         self.seqno
-    }
-
-    /// Per-block seqno bounds `(min, max)` if this entry uses the
-    /// seqno-bounded wire format (markers 2 / 3), else `None` (legacy entry).
-    ///
-    /// A seqno-scoped scan skips the referenced data block without reading it
-    /// when `max < target`; `None` means the bounds are unavailable on disk and
-    /// the caller must fall back to reading and filtering the block.
-    #[must_use]
-    pub fn seqno_bounds(&self) -> Option<(SeqNo, SeqNo)> {
-        self.seqno_bounds
     }
 
     pub fn shift(&mut self, delta: BlockOffset) {
@@ -186,28 +145,18 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         writer: &mut W,
         state: &mut BlockOffset,
     ) -> crate::Result<()> {
-        // Legacy full entry (marker 0):
+        // Full entry (marker 0):
         // [marker=0] [offset] [size] [seqno] [key len] [end key]
         // 1          2        3      4       5         6
         //
-        // Seqno-bounded full entry (marker 2): same, with per-block seqno
-        // bounds inserted right after [seqno]:
-        // [marker=2] [offset] [size] [seqno] [seqno min] [seqno max] [key len] [end key]
-        // 1          2        3      4       4a          4b          5         6
-
-        match self.seqno_bounds {
-            None => writer.write_u8(0)?, // 1
-            Some(_) => writer.write_u8(2)?,
-        }
+        // Per-block seqno bounds are NOT stored inline; they live in the
+        // optional parallel `seqno_bounds` section keyed by block offset, so a
+        // point read never pays for them. See `crate::table::seqno_bounds`.
+        writer.write_u8(0)?; // 1
 
         self.inner.encode_into(writer)?; // 2, 3
 
         writer.write_u64_varint(self.seqno)?; // 4
-
-        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
-            writer.write_u64_varint(seqno_min)?; // 4a
-            writer.write_u64_varint(seqno_max)?; // 4b
-        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(self.end_key.len() as u16)?; // 5
@@ -225,24 +174,16 @@ impl Encodable<BlockOffset> for KeyedBlockHandle {
         _state: &mut BlockOffset,
         shared_len: usize,
     ) -> crate::Result<()> {
-        // Legacy truncated entry (marker 1):
+        // Truncated entry (marker 1):
         // [marker=1] [offset] [size] [seqno] [shared prefix len] [rest key len] [rest key]
         // 1          2        3      4       5                   6              7
         //
-        // Seqno-bounded truncated entry (marker 3): same, with per-block seqno
-        // bounds inserted right after [seqno].
-        match self.seqno_bounds {
-            None => writer.write_u8(1)?,
-            Some(_) => writer.write_u8(3)?,
-        }
+        // Per-block seqno bounds live in the parallel `seqno_bounds` section,
+        // never inline (see `encode_full_into`).
+        writer.write_u8(1)?;
 
         self.inner.encode_into(writer)?;
         writer.write_u64_varint(self.seqno)?;
-
-        if let Some((seqno_min, seqno_max)) = self.seqno_bounds {
-            writer.write_u64_varint(seqno_min)?;
-            writer.write_u64_varint(seqno_max)?;
-        }
 
         #[expect(clippy::cast_possible_truncation, reason = "keys are u16 long max")]
         writer.write_u16_varint(shared_len as u16)?;
@@ -277,30 +218,14 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        // Full entries are marker 0 (legacy) or marker 2 (seqno-bounded).
-        let has_bounds = match marker {
-            0 => false,
-            2 => true,
-            _ => return None,
-        };
+        // Full entries are marker 0. (Seqno bounds are no longer inline; they
+        // live in the parallel `seqno_bounds` section.)
+        if marker != 0 {
+            return None;
+        }
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
-
-        let seqno_bounds = if has_bounds {
-            let seqno_min = reader.read_u64_varint().ok()?;
-            let seqno_max = reader.read_u64_varint().ok()?;
-            // Reject inverted bounds: a forged `seqno_max < seqno_min` would
-            // let a seqno-scoped scan skip a block that still holds visible
-            // entries, silently returning incomplete results. Surface it as a
-            // decode failure instead of propagating bogus bounds.
-            if seqno_min > seqno_max {
-                return None;
-            }
-            Some((seqno_min, seqno_max))
-        } else {
-            None
-        };
 
         let key_len: usize = reader.read_u16_varint().ok()?.into();
         #[expect(
@@ -329,7 +254,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
-            seqno_bounds,
         })
     }
 
@@ -351,12 +275,10 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         if marker == TRAILER_START_MARKER {
             return None;
         }
-        // Restart heads are full entries: marker 0 (legacy) or 2 (seqno-bounded).
-        let has_bounds = match marker {
-            0 => false,
-            2 => true,
-            _ => return None,
-        };
+        // Restart heads are full entries: marker 0.
+        if marker != 0 {
+            return None;
+        }
 
         // The binary-search probe only needs `(key, seqno)`, but the block
         // handle (file offset + size) is still decoded so a corrupt restart
@@ -371,19 +293,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         pos = np;
         let (seqno, np) = read_leb128(buf, pos)?;
         pos = np;
-
-        if has_bounds {
-            // The restart key only needs the key, but still reject inverted
-            // bounds (seqno_min > seqno_max) here as `parse_full` /
-            // `parse_truncated` do — a malformed marker-2 head must not feed a
-            // forged entry into restart-table navigation.
-            let (seqno_min, np) = read_leb128(buf, pos)?;
-            let (seqno_max, np2) = read_leb128(buf, np)?;
-            pos = np2;
-            if seqno_min > seqno_max {
-                return None;
-            }
-        }
 
         let (key_len_raw, np) = read_leb128(buf, pos)?;
         pos = np;
@@ -418,28 +327,14 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             return None;
         }
 
-        // Truncated entries are marker 1 (legacy) or marker 3 (seqno-bounded).
-        let has_bounds = match marker {
-            1 => false,
-            3 => true,
-            _ => return None,
-        };
+        // Truncated entries are marker 1. (Seqno bounds live in the parallel
+        // `seqno_bounds` section, never inline.)
+        if marker != 1 {
+            return None;
+        }
 
         let handle = BlockHandle::decode_from(reader).ok()?;
         let seqno = reader.read_u64_varint().ok()?;
-
-        let seqno_bounds = if has_bounds {
-            let seqno_min = reader.read_u64_varint().ok()?;
-            let seqno_max = reader.read_u64_varint().ok()?;
-            // Reject inverted bounds (see `parse_full`): a forged
-            // `seqno_max < seqno_min` could drive an incorrect block-skip.
-            if seqno_min > seqno_max {
-                return None;
-            }
-            Some((seqno_min, seqno_max))
-        } else {
-            None
-        };
 
         let shared_prefix_len: usize = reader.read_u16_varint().ok()?.into();
         let rest_key_len: usize = reader.read_u16_varint().ok()?.into();
@@ -486,7 +381,6 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
             offset: handle.offset(),
             size: handle.size(),
             seqno,
-            seqno_bounds,
         })
     }
 }
@@ -642,8 +536,8 @@ mod tests {
     #[test]
     fn parse_truncated_rejects_invalid_marker() {
         let mut bytes = make_truncated_entry(1);
-        // 99 is outside the valid marker set {0 full, 1 truncated, 2 full+bounds,
-        // 3 truncated+bounds, 255 trailer}, so parse_truncated must reject it.
+        // 99 is outside the valid marker set {0 full, 1 truncated, 255 trailer},
+        // so parse_truncated must reject it.
         let invalid_marker = 99u8;
         *bytes.get_mut(0).unwrap() = invalid_marker;
         let offset = 16;
@@ -693,9 +587,9 @@ mod tests {
     }
 
     #[test]
-    fn full_entry_without_bounds_keeps_legacy_marker() {
-        // A handle with no seqno bounds must encode with the legacy full
-        // marker (0) so off-mode SSTs stay byte-identical to the prior layout.
+    fn full_entry_encodes_with_legacy_marker() {
+        // A full index entry encodes with marker 0; seqno bounds are never
+        // inline (they live in the parallel `seqno_bounds` section).
         let bytes = make_full_entry();
         assert_eq!(bytes.first().copied(), Some(0));
 
@@ -706,207 +600,7 @@ mod tests {
             bytes.len(),
         )
         .unwrap();
-        assert_eq!(parsed.seqno_bounds, None);
-    }
-
-    #[test]
-    fn full_entry_with_seqno_bounds_round_trips() {
-        // marker 2: seqno bounds survive an encode -> parse_full round-trip,
-        // and the marker byte switches to the seqno-bounded variant.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        assert_eq!(bytes.first().copied(), Some(2));
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
-            &mut cursor,
-            0,
-            bytes.len(),
-        )
-        .unwrap();
-        assert_eq!(parsed.seqno, 7);
-        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
-        assert_eq!(
-            bytes.get(parsed.end_key.0..parsed.end_key.1).unwrap(),
-            b"abcdef"
-        );
-    }
-
-    #[test]
-    fn full_entry_with_inverted_seqno_bounds_is_rejected() {
-        // A forged entry whose seqno_min > seqno_max must fail to decode, not
-        // propagate bounds that could drive an incorrect seqno block-skip
-        // (skipping a block that still holds visible entries). Build a VALID
-        // (3, 9) entry — `with_seqno_bounds` debug-asserts min <= max — then
-        // swap the two single-byte bound varints on the wire to invert them.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        // Layout: [marker=2][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
-        // all single-byte varints, so the bounds sit at indices 4 and 5.
-        assert_eq!(bytes.first().copied(), Some(2));
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // → seqno_min=9, seqno_max=3 (inverted)
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_full(
-            &mut cursor,
-            0,
-            bytes.len(),
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds (min > max) must be rejected on decode",
-        );
-    }
-
-    #[test]
-    fn truncated_entry_with_inverted_seqno_bounds_is_rejected() {
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle
-            .encode_truncated_into(&mut bytes, &mut state, 2)
-            .unwrap();
-        // Layout: [marker=3][offset=0][size=1][seqno=7][seqno_min=3][seqno_max=9]…
-        assert_eq!(bytes.first().copied(), Some(3));
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // invert
-
-        let offset = 16;
-        let entries_end = offset + bytes.len();
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
-            &mut cursor,
-            offset,
-            12,
-            16,
-            entries_end,
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds (min > max) must be rejected on decode",
-        );
-    }
-
-    #[test]
-    fn truncated_entry_with_seqno_bounds_round_trips() {
-        // marker 3: seqno bounds survive an encode -> parse_truncated
-        // round-trip on a truncated (prefix-compressed) entry.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle
-            .encode_truncated_into(&mut bytes, &mut state, 2)
-            .unwrap();
-        assert_eq!(bytes.first().copied(), Some(3));
-
-        let offset = 16;
-        let entries_end = offset + bytes.len();
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_truncated(
-            &mut cursor,
-            offset,
-            12,
-            16,
-            entries_end,
-        )
-        .unwrap();
-        assert_eq!(parsed.seqno, 7);
-        assert_eq!(parsed.seqno_bounds, Some((3, 9)));
-    }
-
-    #[test]
-    fn parse_restart_key_skips_seqno_bounds_on_marker_2() {
-        // parse_restart_key must step over the two seqno-bounds varints so the
-        // returned restart key is correct for a marker-2 (seqno-bounded) head.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let (key, seqno) =
-            <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
-                &mut cursor,
-                0,
-                bytes.as_slice(),
-                bytes.len(),
-            )
-            .unwrap();
-        assert_eq!(key, b"abcdef");
-        assert_eq!(seqno, 7);
-    }
-
-    #[test]
-    fn parse_restart_key_rejects_inverted_seqno_bounds() {
-        // A marker-2 restart head with seqno_min > seqno_max must be rejected
-        // (like parse_full / parse_truncated), not feed a forged entry into
-        // restart-table navigation. Build valid (3, 9), then swap the two
-        // single-byte bound varints on the wire to invert them.
-        let handle = KeyedBlockHandle::new(
-            b"abcdef".to_vec().into(),
-            7,
-            BlockHandle::new(BlockOffset(0), 1),
-        )
-        .with_seqno_bounds(3, 9);
-        let mut bytes = Vec::new();
-        let mut state = BlockOffset(0);
-        handle.encode_full_into(&mut bytes, &mut state).unwrap();
-        assert_eq!(
-            (bytes.get(4).copied(), bytes.get(5).copied()),
-            (Some(3), Some(9)),
-            "bound varint layout changed",
-        );
-        bytes.swap(4, 5); // invert
-
-        let mut cursor = Cursor::new(bytes.as_slice());
-        let parsed = <KeyedBlockHandle as Decodable<IndexBlockParsedItem>>::parse_restart_key(
-            &mut cursor,
-            0,
-            bytes.as_slice(),
-            bytes.len(),
-        );
-        assert!(
-            parsed.is_none(),
-            "inverted seqno bounds must be rejected by parse_restart_key",
-        );
+        assert_eq!(parsed.seqno, 0);
     }
 
     #[test]

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -31,9 +31,6 @@ pub struct IndexBlockParsedItem {
     pub prefix: Option<SliceIndexes>,
     pub end_key: SliceIndexes,
     pub seqno: SeqNo,
-    /// Per-block seqno bounds `(min, max)`, present only for seqno-bounded
-    /// index entries (markers 2 / 3); `None` for legacy entries.
-    pub seqno_bounds: Option<(SeqNo, SeqNo)>,
 }
 
 impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
@@ -88,12 +85,7 @@ impl ParsedItem<KeyedBlockHandle> for IndexBlockParsedItem {
             bytes.slice(self.end_key.0..self.end_key.1)
         };
 
-        let handle =
-            KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size));
-        match self.seqno_bounds {
-            Some((seqno_min, seqno_max)) => handle.with_seqno_bounds(seqno_min, seqno_max),
-            None => handle,
-        }
+        KeyedBlockHandle::new(key, self.seqno, BlockHandle::new(self.offset, self.size))
     }
 }
 

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -109,6 +109,12 @@ pub struct Inner {
     )]
     pub(crate) block_layout: BlockLayoutMap,
 
+    /// Per-data-block seqno bounds, loaded on open from the optional
+    /// `seqno_bounds` section. Empty when the table has none (legacy or
+    /// `seqno_in_index` off), so `scan_since_seqno` falls back to a full
+    /// per-entry filter. Read only by the seqno-scoped scan path.
+    pub(crate) seqno_bounds: crate::table::seqno_bounds::SeqnoBoundsMap,
+
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy
     /// enabled; lets a point read resolve a key to its data block in O(1),

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -99,17 +99,6 @@ pub struct ParsedMeta {
     /// [`Self::ecc_params`].
     pub ecc_unrecognized: bool,
 
-    /// Index block format for this SST (#224). `0` = legacy: index
-    /// entries carry no per-block seqno bounds (byte-identical to the
-    /// pre-#224 format). `1` = each index entry includes
-    /// `seqno_min` / `seqno_max` for its data block, enabling
-    /// `scan_since_seqno` block-skip.
-    ///
-    /// Optional on disk: SSTs written before this field existed lack the
-    /// `index_format` property and parse as `0`, so legacy tables read
-    /// correctly and fall back to the per-entry filter scan path.
-    pub index_format: u8,
-
     /// Restart interval the data blocks were encoded with. Needed to rebuild a
     /// positional restart index when partial-decoding a block on the lazy read
     /// path (the restart heads sit every `data_block_restart_interval` entries).
@@ -413,28 +402,6 @@ impl ParsedMeta {
             }
         };
 
-        // Optional field introduced for scan_since_seqno block-skip (#224).
-        // SSTs written before this key existed parse as 0 (legacy index
-        // format, no per-block seqno bounds).
-        let index_format = match block.point_read(b"index_format", SeqNo::MAX, &cmp)? {
-            None => 0u8,
-            // The value must be EXACTLY one byte. Matching a single-element slice
-            // rejects trailing bytes, so a corrupt payload like `[1, 0xFF]` is an
-            // error rather than parsing as `1`. This byte is a metadata hint
-            // recording which index format the writer emitted; the per-entry
-            // decode itself dispatches on per-entry markers, not on this value.
-            Some(item) => match &item.value[..] {
-                [b] => *b,
-                _ => return Err(crate::Error::InvalidHeader("TableMeta")),
-            },
-        };
-        // Only `0` (legacy) and `1` (per-block seqno bounds) are defined in
-        // this format slice. Reject any other byte as corrupt / forward-
-        // incompatible metadata rather than trusting a bogus on-disk hint.
-        if index_format > 1 {
-            return Err(crate::Error::InvalidHeader("TableMeta"));
-        }
-
         Ok(Self {
             id,
             created_at,
@@ -454,7 +421,6 @@ impl ParsedMeta {
             page_ecc,
             ecc_params,
             ecc_unrecognized,
-            index_format,
             data_block_restart_interval,
         })
     }
@@ -630,62 +596,6 @@ mod tests {
         let items = valid_meta_items();
         let result = load_meta_from_items(&items);
         assert!(result.is_ok(), "valid meta must parse: {result:?}");
-    }
-
-    #[test]
-    fn index_format_absent_parses_as_legacy_zero() {
-        // valid_meta_items() carries no `index_format` key (legacy SST).
-        // It must parse as index_format = 0 so pre-#224 tables fall back
-        // to the per-entry scan path.
-        let meta = load_meta_from_items(&valid_meta_items()).unwrap();
-        assert_eq!(meta.index_format, 0);
-    }
-
-    #[test]
-    fn index_format_present_parses_its_value() {
-        // An SST carrying `index_format = 1` must parse as 1 so the read
-        // path knows the index entries hold per-block seqno bounds.
-        let mut items = valid_meta_items();
-        // Insert in sorted position (between filter_hash_type and
-        // index_keys_have_seqno) to keep the block ordered.
-        items.push(meta("index_format", &[1u8]));
-        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-        let meta = load_meta_from_items(&items).unwrap();
-        assert_eq!(meta.index_format, 1);
-    }
-
-    #[test]
-    fn index_format_unknown_byte_is_rejected() {
-        // Only 0 and 1 are defined in this format slice; a present-but-unknown
-        // byte (e.g. corrupt metadata, or a forward-incompatible writer) must
-        // fail fast as InvalidHeader rather than flowing downstream as a bogus
-        // on-disk index format.
-        for bad in [2u8, 255u8] {
-            let mut items = valid_meta_items();
-            items.push(meta("index_format", &[bad]));
-            items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-            let result = load_meta_from_items(&items);
-            assert!(
-                matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
-                "index_format = {bad} must be rejected, got {result:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn index_format_overlong_payload_is_rejected() {
-        // The index_format value must be exactly one byte. A payload with
-        // trailing bytes (e.g. [1, 0xFF]) would otherwise parse as 1 because
-        // read_u8 ignores the remainder — since this byte selects the index
-        // decoder, an overlong payload is corrupt metadata and must be rejected.
-        let mut items = valid_meta_items();
-        items.push(meta("index_format", &[1u8, 0xFF]));
-        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
-        let result = load_meta_from_items(&items);
-        assert!(
-            matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
-            "overlong index_format payload must be rejected, got {result:?}",
-        );
     }
 
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod meta;
 pub(crate) mod multi_writer;
 pub(crate) mod regions;
 mod scanner;
+pub(crate) mod seqno_bounds;
 pub mod util;
 pub mod writer;
 
@@ -1116,12 +1117,12 @@ impl Table {
     /// Collects every entry in this SST with `seqno >= target_seqno`,
     /// applying the per-block seqno-bounds skip when the SST carries it.
     ///
-    /// A data block whose index entry reports `seqno_max < target_seqno`
-    /// (seqno-bounded format, `Properties.index_format = 1`) cannot hold a
-    /// qualifying record, so it is skipped without being read. Blocks without
-    /// bounds on disk (legacy `index_format = 0`) are always read and filtered
-    /// per entry, so the result is correct regardless of the SST's index
-    /// format. Entries come back in the SST's stored order (key-ascending,
+    /// A data block whose `seqno_bounds` section entry reports
+    /// `seqno_max < target_seqno` cannot hold a qualifying record, so it is
+    /// skipped without being read. When the SST has no `seqno_bounds` section
+    /// (the feature was off), every block is read and filtered per entry, so
+    /// the result is correct regardless. Entries come back in the SST's stored
+    /// order (key-ascending,
     /// seqno-descending within a key); ordering across sources is the caller's
     /// job.
     ///
@@ -1130,13 +1131,20 @@ impl Table {
     /// Returns `Err` if reading the index or a data block fails.
     #[doc(hidden)]
     pub fn scan_since_seqno(&self, target_seqno: SeqNo) -> crate::Result<Vec<InternalValue>> {
-        self.scan_seqno_range(target_seqno, SeqNo::MAX)
+        self.scan_seqno_range(target_seqno, SeqNo::MAX, true)
     }
 
     /// Like [`Self::scan_since_seqno`] but also bounds the result above:
     /// collects entries whose global seqno is in `[target_seqno, end_seqno)`.
     /// The upper bound lets the tree-level scan pin a stable snapshot watermark
     /// so a concurrent write cannot leak in mid-scan.
+    ///
+    /// `block_skip` enables the per-block seqno-bounds optimization (skip data
+    /// blocks whose recorded `[seqno_min, seqno_max]` cannot overlap the
+    /// window). Pass `false` for a paranoid full scan that reads every block and
+    /// filters per entry, so even an undetected-corrupt seqno bound (one that
+    /// somehow slipped past the block XXH3 checksum) cannot cause a qualifying
+    /// record to be skipped.
     ///
     /// # Errors
     ///
@@ -1146,6 +1154,7 @@ impl Table {
         &self,
         target_seqno: SeqNo,
         end_seqno: SeqNo,
+        block_skip: bool,
     ) -> crate::Result<Vec<InternalValue>> {
         // Bulk-ingested tables store entries at LOCAL seqno coordinates with a
         // `global_seqno` offset; the on-disk seqno bounds and per-entry seqnos
@@ -1174,10 +1183,17 @@ impl Table {
         for handle in self.block_index.iter() {
             let handle = handle?;
 
-            // Block-skip: a seqno-bounded entry whose (local) min exceeds the
-            // upper bound, or whose (local) max is below the target, cannot
-            // reference any qualifying record — skip the data-block read.
-            if let Some((seqno_min, seqno_max)) = handle.seqno_bounds()
+            // Block-skip: look this block's seqno bounds up in the parallel
+            // `seqno_bounds` section (keyed by file offset). If its (local) min
+            // exceeds the upper bound, or its (local) max is below the target, it
+            // cannot reference a qualifying record — skip the data-block read.
+            // Bounds live in the section, NOT inline in the index entry, so a
+            // point read never pays for them. Disabled in paranoid full-scan
+            // mode (`block_skip == false`); absent for legacy/off tables → no
+            // skip, full filter (correct regardless).
+            if block_skip
+                && let Some((seqno_min, seqno_max)) =
+                    self.seqno_bounds.bounds_for(handle.as_ref().offset().0)
                 && (seqno_max < local_target || seqno_min >= local_end)
             {
                 continue;
@@ -1730,6 +1746,45 @@ impl Table {
             crate::table::block_layout::BlockLayoutMap::default()
         };
 
+        // Load the optional seqno-bounds section (parallel to the index; powers
+        // the scan_since_seqno block-skip). Absent unless seqno_in_index was on.
+        let seqno_bounds = if let Some(sb_handle) = regions.seqno_bounds {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                sb_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_type: BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::SeqnoBounds {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            let map = crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)?;
+            if !map.is_empty() {
+                log::trace!("Loaded {} seqno-bounds entries", map.len());
+            }
+            map
+        } else {
+            crate::table::seqno_bounds::SeqnoBoundsMap::default()
+        };
+
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
@@ -1829,6 +1884,7 @@ impl Table {
             cached_blob_bytes: AtomicU64::new(u64::MAX),
             range_tombstones,
             block_layout,
+            seqno_bounds,
             locator_index,
             encryption,
 

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -106,9 +106,9 @@ pub struct MultiWriter {
     )>,
 
     /// `seqno_in_index` runtime config — preserved here so the rotation
-    /// path stamps the same index format on every successor [`Writer`],
-    /// keeping all SSTs of one flush / compaction at a uniform
-    /// `index_format`.
+    /// path sets the same flag on every successor [`Writer`], so all SSTs
+    /// of one flush / compaction uniformly emit (or omit) the `seqno_bounds`
+    /// section.
     use_seqno_in_index: bool,
 
     /// When `true`, each output SST has per-file copy-on-write cleared at
@@ -539,7 +539,7 @@ impl MultiWriter {
 
     /// Wires the `seqno_in_index` runtime config through to the inner
     /// [`Writer`] and preserves it across rotations so every successor
-    /// writer stamps the same `index_format` on its index entries.
+    /// writer emits a matching `seqno_bounds` section.
     #[must_use]
     pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
         self.use_seqno_in_index = seqno_in_index;

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -88,6 +88,11 @@ pub struct ParsedRegions {
     /// widths fit; maps each key to its data block and slot for O(1) point
     /// reads. Absent on tables written without the locator feature.
     pub locator: Option<BlockHandle>,
+    /// Optional seqno-bounds section (the `seqno_bounds` section). Present only
+    /// when `seqno_in_index` was on; maps each data block's offset to its
+    /// `[seqno_min, seqno_max]` for the `scan_since_seqno` block-skip, kept
+    /// parallel to the index so point reads pay nothing for it.
+    pub seqno_bounds: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -137,6 +142,10 @@ impl ParsedRegions {
                 .transpose()?,
             locator: toc
                 .section(b"locator")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            seqno_bounds: toc
+                .section(b"seqno_bounds")
                 .map(toc_entry_to_handle)
                 .transpose()?,
             linked_blob_files: toc

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -36,18 +36,32 @@ use crate::SeqNo;
 /// Serialize the per-data-block seqno bounds into the `seqno_bounds` section.
 /// `bounds[i]` is `(block_offset, (seqno_min, seqno_max))` for one data block,
 /// in write (ascending-offset) order.
-pub fn encode_seqno_bounds(out: &mut Vec<u8>, bounds: &[(BlockOffset, (SeqNo, SeqNo))]) {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "data-block count is bounded well within u32"
-    )]
-    let count = bounds.len() as u32;
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidHeader`] if the block count does not fit the
+/// `u32` section-header width. Validating at encode time fails fast at the
+/// source rather than deferring detection to the decoder.
+pub fn encode_seqno_bounds(
+    out: &mut Vec<u8>,
+    bounds: &[(BlockOffset, (SeqNo, SeqNo))],
+) -> crate::Result<()> {
+    let count =
+        u32::try_from(bounds.len()).map_err(|_| crate::Error::InvalidHeader("SeqnoBounds"))?;
     out.extend_from_slice(&count.to_le_bytes());
     for (offset, (seqno_min, seqno_max)) in bounds {
+        // Write-side invariant: a block's bounds must be ordered. Asserted here
+        // (debug builds) so a writer bug surfaces at its source, in addition to
+        // the decoder's runtime check that catches it at open time.
+        debug_assert!(
+            seqno_min <= seqno_max,
+            "seqno bounds inverted: min {seqno_min} > max {seqno_max}"
+        );
         out.extend_from_slice(&offset.0.to_le_bytes());
         out.extend_from_slice(&seqno_min.to_le_bytes());
         out.extend_from_slice(&seqno_max.to_le_bytes());
     }
+    Ok(())
 }
 
 /// Decoded `seqno_bounds` section: a lookup from a data block's file offset to
@@ -165,7 +179,7 @@ mod tests {
             (BlockOffset(9000), (0, 1_000_000)),
         ];
         let mut buf = Vec::new();
-        encode_seqno_bounds(&mut buf, &bounds);
+        encode_seqno_bounds(&mut buf, &bounds).expect("encode");
         let map = SeqnoBoundsMap::decode(&buf).expect("decode");
         assert_eq!(map.len(), 3);
         assert_eq!(map.bounds_for(0), Some((10, 20)));
@@ -179,7 +193,7 @@ mod tests {
     #[test]
     fn decode_empty_section_is_empty_map() {
         let mut buf = Vec::new();
-        encode_seqno_bounds(&mut buf, &[]);
+        encode_seqno_bounds(&mut buf, &[]).expect("encode");
         let map = SeqnoBoundsMap::decode(&buf).expect("decode empty");
         assert!(map.is_empty());
         assert_eq!(map.bounds_for(0), None);
@@ -221,7 +235,7 @@ mod tests {
         // silently parsed with the wrong length: leftover data means a wrong
         // count or a corrupt / padded section, so it must surface as an error.
         let mut buf = Vec::new();
-        encode_seqno_bounds(&mut buf, &[(BlockOffset(0), (1u64, 2u64))]);
+        encode_seqno_bounds(&mut buf, &[(BlockOffset(0), (1u64, 2u64))]).expect("encode");
         buf.push(0xAB); // one stray trailing byte
         assert!(SeqnoBoundsMap::decode(&buf).is_err());
     }

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Per-SST seqno-bounds section: a parallel `(data-block offset -> [seqno_min,
+//! seqno_max])` map that powers the `scan_since_seqno` block-skip WITHOUT
+//! bloating the index entries.
+//!
+//! The bounds used to live inline in each index entry (markers 2/3), which made
+//! every point-read index probe step over two extra varints and enlarged the
+//! index block (measurable point-read cost). Moving them into this optional
+//! parallel section keeps the index entries at their legacy size: a point read
+//! never touches the bounds, while a seqno-scoped scan looks the bounds up by
+//! data-block file offset and skips blocks whose `[min, max]` cannot overlap the
+//! target window.
+//!
+//! Optional + format-gated (emitted only when `seqno_in_index` is on), so a
+//! table written without it carries zero extra bytes. Offset-keyed (not ordinal)
+//! so a lookup cannot silently mis-map if block iteration order ever shifts.
+//!
+//! # Wire layout
+//!
+//! ```text
+//! [count: u32 LE]
+//! count × [ block_offset: u64 LE | seqno_min: u64 LE | seqno_max: u64 LE ]
+//! ```
+//!
+//! Entries are strictly ascending by `block_offset` (write order == file order),
+//! enabling a binary-search lookup.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::BlockOffset;
+use crate::SeqNo;
+
+/// Serialize the per-data-block seqno bounds into the `seqno_bounds` section.
+/// `bounds[i]` is `(block_offset, (seqno_min, seqno_max))` for one data block,
+/// in write (ascending-offset) order.
+pub fn encode_seqno_bounds(out: &mut Vec<u8>, bounds: &[(BlockOffset, (SeqNo, SeqNo))]) {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "data-block count is bounded well within u32"
+    )]
+    let count = bounds.len() as u32;
+    out.extend_from_slice(&count.to_le_bytes());
+    for (offset, (seqno_min, seqno_max)) in bounds {
+        out.extend_from_slice(&offset.0.to_le_bytes());
+        out.extend_from_slice(&seqno_min.to_le_bytes());
+        out.extend_from_slice(&seqno_max.to_le_bytes());
+    }
+}
+
+/// Decoded `seqno_bounds` section: a lookup from a data block's file offset to
+/// its `[seqno_min, seqno_max]`. Empty when the table has no seqno bounds (the
+/// section was absent), in which case every lookup returns `None` and the scan
+/// falls back to a full per-entry filter.
+#[derive(Debug, Default, Clone)]
+pub struct SeqnoBoundsMap {
+    /// `(block_offset, (seqno_min, seqno_max))`, sorted ascending by offset for
+    /// binary-search lookup.
+    entries: Vec<(u64, (SeqNo, SeqNo))>,
+}
+
+impl SeqnoBoundsMap {
+    /// Decode a `seqno_bounds` section payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidHeader`] if the payload is truncated, the
+    /// entries are not strictly ascending by offset, or any entry has
+    /// `seqno_min > seqno_max` (a corrupt section must surface rather than
+    /// silently mis-skip a block).
+    pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
+        const ERR: crate::Error = crate::Error::InvalidHeader("SeqnoBounds");
+
+        fn take<'a>(r: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+            if r.len() < n {
+                return None;
+            }
+            let (head, tail) = r.split_at(n);
+            *r = tail;
+            Some(head)
+        }
+        fn read_u32(r: &mut &[u8]) -> Option<u32> {
+            let b: [u8; 4] = take(r, 4)?.try_into().ok()?;
+            Some(u32::from_le_bytes(b))
+        }
+        fn read_u64(r: &mut &[u8]) -> Option<u64> {
+            let b: [u8; 8] = take(r, 8)?.try_into().ok()?;
+            Some(u64::from_le_bytes(b))
+        }
+
+        // Each entry is exactly three u64s on the wire.
+        const ENTRY_SIZE: usize = 3 * core::mem::size_of::<u64>();
+
+        let mut r = bytes;
+        let count = read_u32(&mut r).ok_or(ERR)?;
+        // Reject a corrupt count BEFORE the speculative allocation below: a
+        // count claiming more entries than the remaining payload can hold is
+        // invalid, and validating it up front bounds `with_capacity` to the
+        // real payload size (so a corrupt count cannot trigger a multi-GB
+        // pre-allocation / OOM instead of a clean `InvalidHeader`).
+        match (count as usize).checked_mul(ENTRY_SIZE) {
+            Some(needed) if needed <= r.len() => {}
+            _ => return Err(ERR),
+        }
+        let mut entries = Vec::with_capacity(count as usize);
+        let mut prev: Option<u64> = None;
+        for _ in 0..count {
+            let offset = read_u64(&mut r).ok_or(ERR)?;
+            if prev.is_some_and(|p| offset <= p) {
+                return Err(ERR);
+            }
+            prev = Some(offset);
+            let seqno_min = read_u64(&mut r).ok_or(ERR)?;
+            let seqno_max = read_u64(&mut r).ok_or(ERR)?;
+            if seqno_min > seqno_max {
+                return Err(ERR);
+            }
+            entries.push((offset, (seqno_min, seqno_max)));
+        }
+        // The section must contain exactly `count` entries and nothing more:
+        // leftover bytes mean a wrong count or a corrupt / padded section, so
+        // reject them rather than silently accept a mis-sized parse.
+        if !r.is_empty() {
+            return Err(ERR);
+        }
+        Ok(Self { entries })
+    }
+
+    /// The `[seqno_min, seqno_max]` for the data block at `offset`, or `None` if
+    /// the block was not recorded (legacy table without seqno bounds).
+    #[must_use]
+    pub fn bounds_for(&self, offset: u64) -> Option<(SeqNo, SeqNo)> {
+        let idx = self
+            .entries
+            .binary_search_by_key(&offset, |(o, _)| *o)
+            .ok()?;
+        self.entries.get(idx).map(|(_, b)| *b)
+    }
+
+    /// Whether any per-block bounds are recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Number of recorded data blocks.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let bounds = [
+            (BlockOffset(0), (10u64, 20u64)),
+            (BlockOffset(4096), (5, 5)),
+            (BlockOffset(9000), (0, 1_000_000)),
+        ];
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &bounds);
+        let map = SeqnoBoundsMap::decode(&buf).expect("decode");
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.bounds_for(0), Some((10, 20)));
+        assert_eq!(map.bounds_for(4096), Some((5, 5)));
+        assert_eq!(map.bounds_for(9000), Some((0, 1_000_000)));
+        // An offset not present (e.g. between recorded blocks) returns None.
+        assert_eq!(map.bounds_for(1), None);
+        assert_eq!(map.bounds_for(5000), None);
+    }
+
+    #[test]
+    fn decode_empty_section_is_empty_map() {
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &[]);
+        let map = SeqnoBoundsMap::decode(&buf).expect("decode empty");
+        assert!(map.is_empty());
+        assert_eq!(map.bounds_for(0), None);
+    }
+
+    #[test]
+    fn decode_rejects_non_ascending_offsets() {
+        // count=2 with offsets 100 then 50 (descending) must be rejected.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&2u32.to_le_bytes());
+        for (off, lo, hi) in [(100u64, 1u64, 2u64), (50, 1, 2)] {
+            buf.extend_from_slice(&off.to_le_bytes());
+            buf.extend_from_slice(&lo.to_le_bytes());
+            buf.extend_from_slice(&hi.to_le_bytes());
+        }
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_inverted_bounds() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        buf.extend_from_slice(&9u64.to_le_bytes()); // min
+        buf.extend_from_slice(&3u64.to_le_bytes()); // max < min
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_truncated_payload() {
+        // count=1 but no entry bytes.
+        let buf = 1u32.to_le_bytes().to_vec();
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_trailing_bytes_after_last_entry() {
+        // A section with bytes past the declared entries must be rejected, not
+        // silently parsed with the wrong length: leftover data means a wrong
+        // count or a corrupt / padded section, so it must surface as an error.
+        let mut buf = Vec::new();
+        encode_seqno_bounds(&mut buf, &[(BlockOffset(0), (1u64, 2u64))]);
+        buf.push(0xAB); // one stray trailing byte
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_count_larger_than_payload() {
+        // A corrupt count must be rejected up front, before any speculative
+        // allocation sized by that count: each entry is exactly 24 bytes, so a
+        // count claiming far more entries than the payload can hold is invalid.
+        // (The pathological multi-GB count that would OOM the old `with_capacity`
+        // cannot itself be unit-tested without risking an allocator abort; this
+        // guards the same contract with a count the decoder must reject fast.)
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&100_000u32.to_le_bytes()); // claims 100k entries
+        buf.extend_from_slice(&0u64.to_le_bytes()); // ...but only 8 stray bytes
+        assert!(SeqnoBoundsMap::decode(&buf).is_err());
+    }
+}

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -112,7 +112,8 @@ pub fn load_block(
             BlockType::Manifest
             | BlockType::ManifestFooter
             | BlockType::BlockLayout
-            | BlockType::Locator => {}
+            | BlockType::Locator
+            | BlockType::SeqnoBounds => {}
         }
 
         return Ok(block);
@@ -205,7 +206,8 @@ pub fn load_block(
         BlockType::Manifest
         | BlockType::ManifestFooter
         | BlockType::BlockLayout
-        | BlockType::Locator => {}
+        | BlockType::Locator
+        | BlockType::SeqnoBounds => {}
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -140,6 +140,14 @@ pub struct Writer {
     /// partial decode.
     block_layouts: Vec<(BlockOffset, Vec<u32>)>,
 
+    /// Per-data-block `(offset, (seqno_min, seqno_max))`, accumulated in write
+    /// order when `use_seqno_in_index` is on and serialized into the optional
+    /// `seqno_bounds` SST section at finish. The bounds live here (a parallel
+    /// section) rather than inline in the index entries, so a point read's index
+    /// walk never pays for them; only a seqno-scoped scan loads the section.
+    /// Empty when `use_seqno_in_index` is off (section absent, zero extra bytes).
+    seqno_bounds_section: Vec<(BlockOffset, (u64, u64))>,
+
     /// Resolved retrieval-ribbon locator settings for this table, or `None`
     /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
     /// `Some` makes the writer accumulate a per-key locator and emit the
@@ -193,13 +201,14 @@ pub struct Writer {
     )>,
 
     /// Per-block seqno bounds opt-in (the `seqno_in_index` runtime config).
-    /// When `true`, every data-block index entry carries `(seqno_min,
-    /// seqno_max)` (wire markers 2 / 3) and the SST is tagged
-    /// `index_format = 1`, letting a seqno-scoped scan skip blocks below the
-    /// target without reading them. Default `false` (legacy `index_format =
-    /// 0`, byte-identical index entries). Caller wires the live runtime
-    /// config into this field via [`Self::use_seqno_in_index`] before the
-    /// first key is added.
+    /// When `true`, the writer accumulates each data block's `(seqno_min,
+    /// seqno_max)` and emits them in the optional parallel `seqno_bounds`
+    /// SST section, letting a seqno-scoped scan skip blocks that cannot
+    /// overlap the target window without reading them. The index entries
+    /// stay byte-identical to the off-mode layout, so a point read pays
+    /// nothing. Default `false` (no section emitted). Caller wires the live
+    /// runtime config into this field via [`Self::use_seqno_in_index`]
+    /// before the first key is added.
     use_seqno_in_index: bool,
 
     /// Pre-trained zstd dictionary for dictionary compression
@@ -288,6 +297,7 @@ impl Writer {
                 .use_table_id(table_id),
 
             block_layouts: Vec::new(),
+            seqno_bounds_section: Vec::new(),
 
             locator: None,
             locators: Vec::new(),
@@ -618,20 +628,19 @@ impl Writer {
         self
     }
 
-    /// Enables per-block seqno bounds in the data-block index (the
-    /// `seqno_in_index` runtime config). When `true`, each index entry
-    /// carries `(seqno_min, seqno_max)` and the SST is tagged
-    /// `index_format = 1`. Must be called BEFORE the first key is added so
-    /// every index entry in the table uses the same format; callers
-    /// (`Tree` flush + compaction worker) pass the live config once at
-    /// writer construction. Default `false` (legacy `index_format = 0`).
+    /// Enables the optional per-block seqno-bounds section (the
+    /// `seqno_in_index` runtime config). When `true`, the writer records each
+    /// data block's `(seqno_min, seqno_max)` and emits the parallel
+    /// `seqno_bounds` section at `finish()`, powering the `scan_since_seqno`
+    /// block-skip. Must be called BEFORE the first key is added so the section
+    /// covers every block; callers (`Tree` flush + compaction worker) pass the
+    /// live config once at writer construction. Default `false` (no section).
     #[must_use]
     pub fn use_seqno_in_index(mut self, seqno_in_index: bool) -> Self {
-        // Must be fixed before the first key: `finish()` stamps a single
-        // SST-wide `index_format` from the final flag, while `spill_block`
-        // snapshots it per block — a mid-write toggle would leave mixed
-        // index-entry encodings behind incorrect table metadata. Same
-        // contract as `use_page_ecc` / `use_kv_checksums`.
+        // Must be fixed before the first key: the section must cover every
+        // block, so the flag is snapshotted per block in `spill_block` and a
+        // mid-write toggle would leave some blocks unrecorded. Same contract
+        // as `use_page_ecc` / `use_kv_checksums`.
         self.assert_not_started("use_seqno_in_index");
         self.use_seqno_in_index = seqno_in_index;
         self
@@ -993,13 +1002,18 @@ impl Writer {
         // or the handle over-reads on a non-default scheme.
         let bytes_written = header.on_disk_size_with(self.ecc);
 
-        let mut handle = KeyedBlockHandle::new(
+        let handle = KeyedBlockHandle::new(
             last_key.clone(),
             last_seqno,
             BlockHandle::new(self.meta.file_pos, bytes_written),
         );
+        // Seqno bounds go into the parallel `seqno_bounds` section keyed by this
+        // block's file offset, NOT inline in the index entry: keeping them out of
+        // the index keeps point-read index probes at their legacy cost while the
+        // seqno-scoped scan loads the section.
         if let Some((seqno_min, seqno_max)) = seqno_bounds {
-            handle = handle.with_seqno_bounds(seqno_min, seqno_max);
+            self.seqno_bounds_section
+                .push((self.meta.file_pos, (seqno_min, seqno_max)));
         }
         self.index_writer.register_data_block(handle)?;
 
@@ -1216,6 +1230,39 @@ impl Writer {
             )?;
         }
 
+        // Write the optional seqno-bounds section (only when seqno_in_index is on
+        // and at least one block was written). Parallel to the index, keyed by
+        // data-block offset; absent otherwise, so the index stays legacy-sized.
+        if !self.seqno_bounds_section.is_empty() {
+            self.file_writer.start("seqno_bounds")?;
+            self.block_buffer.clear();
+            crate::table::seqno_bounds::encode_seqno_bounds(
+                &mut self.block_buffer,
+                &self.seqno_bounds_section,
+            );
+            Block::write_into(
+                &mut self.file_writer,
+                &self.block_buffer,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_type: crate::table::block::BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
+
         // Write the optional retrieval-ribbon locator section. Emitted only when
         // the level's locator policy is enabled AND the per-SST widths fit the
         // actual layout (`build_locator_section` returns `None` to skip
@@ -1368,11 +1415,6 @@ impl Writer {
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
-            // `1` when the writer was built with `use_seqno_in_index(true)`:
-            // every data-block index entry carries `(seqno_min, seqno_max)`
-            // (wire markers 2 / 3) for seqno-scoped block-skip. `0` is the
-            // legacy format, byte-identical to the pre-seqno-bounds layout.
-            index_format: u8::from(self.use_seqno_in_index),
             range_tombstone_count,
             created_at_nanos,
         };
@@ -1589,11 +1631,6 @@ struct MetaSectionParams<'a> {
     data_block_restart_interval: u8,
     index_block_restart_interval: u8,
     initial_level: u8,
-    /// Index block format byte written to the SST Properties (#224).
-    /// `0` = legacy (no per-block seqno bounds); `1` = each data-block
-    /// index entry carries `(seqno_min, seqno_max)`. Set from the writer's
-    /// `seqno_in_index` config (`u8::from(self.use_seqno_in_index)`).
-    index_format: u8,
     range_tombstone_count: u64,
     /// `created_at` snapshot taken once in `finish()`. Both MID and
     /// TAIL writes consume this same value; generating it inside
@@ -1746,12 +1783,6 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         meta("descriptor#page_ecc", &ecc_descriptor),
         meta("file_size", &p.file_size.to_le_bytes()),
         meta("filter_hash_type", &[u8::from(ChecksumType::Xxh3)]),
-        // Index block format: 0 = legacy (no per-block seqno bounds in
-        // index entries, byte-identical to the prior layout); 1 = each
-        // data-block index entry carries `(seqno_min, seqno_max)` for
-        // seqno-scoped block-skip. Set from the writer's `seqno_in_index`
-        // config at build time.
-        meta("index_format", &[p.index_format]),
         meta("index_keys_have_seqno", &[0x1]),
         meta("initial_level", &p.initial_level.to_le_bytes()),
         meta("item_count", &p.item_count.to_le_bytes()),

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1239,7 +1239,7 @@ impl Writer {
             crate::table::seqno_bounds::encode_seqno_bounds(
                 &mut self.block_buffer,
                 &self.seqno_bounds_section,
-            );
+            )?;
             Block::write_into(
                 &mut self.file_writer,
                 &self.block_buffer,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1083,6 +1083,7 @@ impl Tree {
     pub(crate) fn scan_since_seqno_with<F>(
         &self,
         target_seqno: SeqNo,
+        block_skip: bool,
         resolve_indirection: F,
     ) -> crate::Result<alloc::vec::IntoIter<ScanSinceEvent>>
     where
@@ -1133,7 +1134,9 @@ impl Tree {
         for table in version.iter_tables() {
             // `scan_seqno_range` upper bound is exclusive; `end_seqno` is the
             // inclusive max, so add one (saturating for the MAX edge).
-            for entry in table.scan_seqno_range(target_seqno, end_seqno.saturating_add(1))? {
+            for entry in
+                table.scan_seqno_range(target_seqno, end_seqno.saturating_add(1), block_skip)?
+            {
                 events.push(Self::map_event(entry, version, &resolve_indirection)?);
             }
         }
@@ -1179,10 +1182,10 @@ impl Tree {
     ///
     /// # Block-skip
     ///
-    /// On SSTs written in the seqno-bounded index format (`seqno_in_index`),
-    /// data blocks whose `seqno_max < target_seqno` are skipped without being
-    /// read; legacy SSTs are read and filtered per entry, so mixed-format trees
-    /// are handled transparently.
+    /// On SSTs written with the `seqno_bounds` section (`seqno_in_index`), data
+    /// blocks whose bounds cannot overlap the target window are skipped without
+    /// being read; SSTs without the section are read and filtered per entry, so
+    /// mixed trees are handled transparently.
     ///
     /// # KV-separation
     ///
@@ -1190,6 +1193,18 @@ impl Tree {
     /// a KV-separated (blob) tree this returns an `Err` for indirected entries:
     /// blob resolution into [`ScanSinceEvent::Insert`] is provided by the
     /// blob-tree scan path, which owns the blob files.
+    ///
+    /// # Corruption resilience
+    ///
+    /// The per-block seqno-bounds used for skipping live in the optional
+    /// `seqno_bounds` SST section, a Block covered by XXH3-128 (+ optional Page
+    /// ECC) and verified when it is loaded at open, plus a decode that rejects
+    /// non-ascending offsets and inverted bounds, so a corrupted bound is caught
+    /// rather than trusted. Even in the impossible case of a fault bypassing
+    /// those checks, a bad bound can only cause a *missed* record, never a wrong
+    /// one. Callers who want defense against that hypothetical can use
+    /// [`Self::scan_since_seqno_full_scan`], which reads every block (slower, no
+    /// skip).
     ///
     /// # Panics
     ///
@@ -1206,7 +1221,43 @@ impl Tree {
         // A standard tree never stores blob-indirected values; the resolver
         // errors so an indirected entry (only reachable via a blob tree's inner
         // index) surfaces as a clear error rather than a wrong event.
-        self.scan_since_seqno_with(target_seqno, |_version, _entry| {
+        self.scan_since_seqno_with(target_seqno, true, |_version, _entry| {
+            Err(crate::Error::FeatureUnsupported(
+                "scan_since_seqno on KV-separated values requires the blob-tree scan path",
+            ))
+        })
+    }
+
+    /// Paranoid variant of [`Self::scan_since_seqno`] that disables the
+    /// per-block seqno-bounds skip: every data block is read and filtered per
+    /// entry, even on seqno-indexed SSTs.
+    ///
+    /// # When to use
+    ///
+    /// The fast [`Self::scan_since_seqno`] trusts each block's recorded
+    /// `[seqno_min, seqno_max]` to skip blocks that cannot hold a qualifying
+    /// record. Those bounds live in the `seqno_bounds` SST section, a Block
+    /// covered by XXH3-128 (and optional Page ECC) and verified at open, so
+    /// on-disk corruption is caught, not silently trusted. This method exists
+    /// for callers who
+    /// want defense even against a fault that somehow bypassed those checks: a
+    /// corrupted `seqno_max` can only ever cause a *missed* record (never a
+    /// wrong one), and a full scan cannot miss. It is slower (no skip), so
+    /// prefer [`Self::scan_since_seqno`] unless you specifically need this
+    /// guarantee.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal version-history lock is poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::scan_since_seqno`].
+    pub fn scan_since_seqno_full_scan(
+        &self,
+        target_seqno: SeqNo,
+    ) -> crate::Result<impl Iterator<Item = ScanSinceEvent> + use<>> {
+        self.scan_since_seqno_with(target_seqno, false, |_version, _entry| {
             Err(crate::Error::FeatureUnsupported(
                 "scan_since_seqno on KV-separated values requires the blob-tree scan path",
             ))

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -180,12 +180,13 @@ fn tree_kv_checksums_all_levels_round_trips_through_disk() {
 
 #[test]
 fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> {
-    // With `seqno_in_index` enabled, every data-block index entry is written
-    // in the seqno-bounded format (markers 2 / 3) and the SST is tagged
-    // index_format=1. The whole point of the format is that the data must
-    // read back identically: flush, point-read, reopen, point-read again.
-    // Reopen is the load-bearing step — it re-parses the on-disk index from
-    // scratch, so a broken seqno-bounded decode surfaces as a read failure.
+    // With `seqno_in_index` enabled, the writer emits the parallel
+    // `seqno_bounds` SST section (one `(seqno_min, seqno_max)` per data block);
+    // the index entries themselves stay legacy. The whole point is that the
+    // data must read back identically: flush, point-read, reopen, point-read
+    // again. Reopen is the load-bearing step — it re-parses the on-disk index
+    // and the seqno-bounds section from scratch, so a broken decode surfaces as
+    // a read failure.
     let folder = get_tmp_folder();
 
     {
@@ -230,9 +231,9 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
         }
     }
 
-    // Reopen: the index blocks are decoded fresh from disk. Runtime config
-    // resets to default on reopen (not persisted), but the on-disk
-    // index_format=1 entries must still decode via per-marker dispatch.
+    // Reopen: the index blocks and the seqno-bounds section are decoded fresh
+    // from disk. Runtime config resets to default on reopen (not persisted),
+    // but the on-disk data must still read back correctly.
     let tree = open_tree(folder.path());
     for i in 0..500u64 {
         let key = format!("key{i:05}");
@@ -244,8 +245,7 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
         );
     }
 
-    // A key never inserted must still be absent (index seek lands correctly
-    // on the seqno-bounded entries).
+    // A key never inserted must still be absent (index seek lands correctly).
     assert!(tree.get(b"key99999", SeqNo::MAX)?.is_none());
 
     Ok(())

--- a/tests/scan_since_seqno.rs
+++ b/tests/scan_since_seqno.rs
@@ -4,9 +4,9 @@
 //! End-to-end coverage for `Tree::scan_since_seqno` (CDC event stream):
 //! target filtering, increasing-seqno replay order, event-type mapping
 //! (Insert / PointTombstone / RangeTombstone), coverage across memtable and
-//! SSTs, the seqno-bounded block-skip path, and mixed-format trees (a tree
-//! that holds both legacy `index_format=0` and seqno-bounded `index_format=1`
-//! SSTs must scan correctly).
+//! SSTs, the per-block seqno-bounds block-skip path, and mixed trees (a tree
+//! that holds both SSTs with a `seqno_bounds` section and SSTs without one
+//! must scan correctly).
 
 use lsm_tree::{
     AbstractTree, AnyTree, BlobTree, Config, ScanSinceEvent, SeqNo, SequenceNumberCounter, Tree,
@@ -205,13 +205,13 @@ fn scan_since_mixed_format_tree_scans_correctly() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path())?;
 
-    // First SST: legacy index_format=0 (seqno_in_index defaults off).
+    // First SST: no seqno_bounds section (seqno_in_index defaults off).
     for i in 0..250u64 {
         tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
     }
     tree.flush_active_memtable(0)?;
 
-    // Toggle on, second SST: seqno-bounded index_format=1.
+    // Toggle on, second SST: emits a seqno_bounds section.
     tree.update_runtime_config(|cfg| {
         cfg.seqno_in_index = true;
     })?;
@@ -343,5 +343,190 @@ fn scan_since_caught_up_target_returns_empty() -> lsm_tree::Result<()> {
         events(&tree, 100)?.is_empty(),
         "a far-future target must yield no events"
     );
+    Ok(())
+}
+
+// ---- Corruption matrix (#224) ---------------------------------------------
+
+/// The paranoid full-scan variant disables the per-block seqno-bounds skip but
+/// must return byte-identical results to the fast block-skip path. This proves
+/// the no-skip path is correct (and, by extension, that a hypothetical
+/// undetected-corrupt bound which made the fast path skip a block could only
+/// ever cause a missed record, which the full scan recovers).
+#[test]
+fn scan_since_full_scan_matches_block_skip() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path())?;
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+    for i in 0..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"v", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    for target in [0u64, 123, 450, 499, 500] {
+        let fast: Vec<SeqNo> = events(&tree, target)?
+            .iter()
+            .map(ScanSinceEvent::seqno)
+            .collect();
+        let full: Vec<SeqNo> = tree
+            .scan_since_seqno_full_scan(target)?
+            .map(|e| e.seqno())
+            .collect();
+        assert_eq!(
+            fast, full,
+            "paranoid full scan must equal block-skip scan at target {target}",
+        );
+    }
+    Ok(())
+}
+
+/// A bit-flip in a sub-index block must be caught by the index block's XXH3-128
+/// on the scan's index walk, not silently trusted: the seqno-scoped scan still
+/// reads the full index to enumerate data blocks, so a corrupt sub-index block
+/// must surface as an error. Forces a partitioned index so
+/// `read_top_level_index_entries` yields multiple sub-index blocks.
+#[test]
+fn scan_since_seqno_index_corruption_is_caught() -> lsm_tree::Result<()> {
+    use lsm_tree::config::{BlockSizePolicy, PinningPolicy};
+    use lsm_tree::inspect::read_top_level_index_entries;
+    use lsm_tree::runtime_config::RuntimeConfig;
+    use std::io::{Seek, Write};
+
+    // Runtime config at open: enable the seqno_bounds section + force the index
+    // to partition (zero spill threshold) so the index spills into multiple
+    // checksummed sub-index blocks.
+    let mut rc = RuntimeConfig::default();
+    rc.seqno_in_index = true;
+    rc.index_partition_spill_threshold = 0;
+
+    let folder = get_tmp_folder();
+    {
+        let any = Config::new(
+            folder.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .index_block_partitioning_policy(PinningPolicy::all(true))
+        .data_block_size_policy(BlockSizePolicy::all(256))
+        .with_runtime_config(rc)
+        .open()?;
+        let tree = match any {
+            AnyTree::Standard(t) => t,
+            AnyTree::Blob(_) => panic!("expected Standard tree"),
+        };
+        // Large corpus → many small data blocks → many index handles → multiple
+        // sub-index partitions (the partition budget is ~4 KiB).
+        for i in 0..30_000u64 {
+            tree.insert(format!("key{i:08}").as_bytes(), b"v", i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Locate the single SST and a sub-index block to corrupt.
+    let sst = std::fs::read_dir(folder.path().join("tables"))
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.is_file())
+        .expect("one SST file");
+    let tli = read_top_level_index_entries(&sst).expect("read top-level index");
+    assert!(
+        tli.len() > 1,
+        "test needs a partitioned index (>1 sub-index block), got {}",
+        tli.len(),
+    );
+    let victim = &tli[0];
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&sst)
+            .expect("open sst");
+        f.seek(std::io::SeekFrom::Start(victim.offset))
+            .expect("seek");
+        f.write_all(&vec![0xFF; victim.size as usize])
+            .expect("flip");
+        f.sync_all().expect("sync");
+    }
+
+    // Reopen and scan: the corrupted sub-index block fails its checksum.
+    let tree = open_tree(folder.path())?;
+    let res: lsm_tree::Result<Vec<ScanSinceEvent>> =
+        tree.scan_since_seqno(0).map(Iterator::collect);
+    assert!(
+        res.is_err(),
+        "a corrupted sub-index block must be caught by XXH3 on the scan, not trusted",
+    );
+    Ok(())
+}
+
+/// The retrieval-ribbon locator (point-read fast path) and the `seqno_bounds`
+/// section (scan_since_seqno block-skip) are independent optional SST sections.
+/// An SST that carries BOTH must serve both paths correctly: point reads via the
+/// locator and seqno-scoped scans via the block-skip, neither perturbing the
+/// other. Locks down that the two features compose.
+#[test]
+fn scan_since_with_locator_enabled_is_correct() -> lsm_tree::Result<()> {
+    use lsm_tree::config::{LocatorPolicy, LocatorPolicyEntry, LocatorPrecision};
+
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    // Many small data blocks so both the locator's block_id space and the
+    // seqno-bounds block-skip are non-trivial.
+    .data_block_size_policy(lsm_tree::config::BlockSizePolicy::all(4_096))
+    .locator_policy(LocatorPolicy::all(LocatorPolicyEntry::Enabled {
+        precision: LocatorPrecision::Block,
+        block_id_bits: None,
+        slot_bits: None,
+    }))
+    .open()?;
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    // Enable the seqno_bounds section too, so the flushed SST carries BOTH.
+    tree.update_runtime_config(|cfg| {
+        cfg.seqno_in_index = true;
+    })?;
+
+    // Fixed-width big-endian keys (the locator's proven corpus shape) so the
+    // ribbon is well-conditioned; rising seqnos so block-skip has work to do.
+    for i in 0..1_500u64 {
+        tree.insert(i.to_be_bytes(), format!("v{i:05}").as_bytes(), i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Point reads resolve through the locator and must be exact.
+    for i in 0..1_500u64 {
+        let got = tree.get(i.to_be_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("v{i:05}").as_bytes()),
+            "locator point read of key {i} must be exact",
+        );
+    }
+
+    // Seqno-scoped scans block-skip via the seqno_bounds section; the fast path
+    // must equal the paranoid full scan at every target despite the locator
+    // also being present in the same SST.
+    for target in [0u64, 500, 1_234, 1_499, 1_500] {
+        let fast: Vec<SeqNo> = events(&tree, target)?
+            .iter()
+            .map(ScanSinceEvent::seqno)
+            .collect();
+        let full: Vec<SeqNo> = tree
+            .scan_since_seqno_full_scan(target)?
+            .map(|e| e.seqno())
+            .collect();
+        assert_eq!(
+            fast, full,
+            "block-skip scan must equal full scan at target {target} with the locator enabled",
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Moves per-block seqno bounds (the data powering `scan_since_seqno` block-skip) out of the inline index entries and into an optional parallel `seqno_bounds` SST section (new `BlockType::SeqnoBounds`), keyed by data-block file offset with a binary-search lookup.

Inline bounds made every point-read index probe step over two extra varints and enlarged the index block: a measurable **~12% point-read penalty** on any SST with `seqno_in_index` on. With the parallel section, index entries return to their legacy size (a point read never touches the bounds), while a seqno-scoped scan looks the bounds up by offset and skips non-overlapping blocks. The section is emitted only when `seqno_in_index` is on, so a table written without it carries zero extra bytes (no format-version bump).

The decoder validates a corrupt section up front (entry count must fit the payload, bounding the allocation) and rejects trailing bytes, surfacing `InvalidHeader` instead of panicking or silently mis-skipping.

Also removes the now-dead inline machinery (inline markers, the `KeyedBlockHandle` seqno-bounds field, the vestigial `index_format` table property) and adds the `scan_since` paranoid full-scan mode + corruption matrix, the CDC event stream / synchronous `clear()` reclaim, and a `scan_since` benchmark.

## Why a fresh PR

Supersedes #470. That branch had accumulated a tangle of back-merge commits from its old `#464` base; #464 has since landed on main, leaving #470 conflicting. This branch is the same feature cleanly reconstructed on the current main (with the locator, SIMD key-compare, and io_uring work already merged), conflict-free.

## Verification

- Rebased cleanly onto current main; `cargo check --all-features` clean
- 1233/1233 lib unit tests + 79 seqno/scan integration tests pass, including `scan_since_with_locator_enabled_is_correct` (confirms correct interaction with the merged locator)
- Decoder hardening covered by `decode_rejects_trailing_bytes_after_last_entry` + `decode_rejects_count_larger_than_payload`

Part of #224.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional seqno bounds metadata section to improve scan performance when `seqno_in_index` configuration is enabled
  * Implemented block-skip optimization for seqno-scoped scans to skip non-overlapping data blocks

* **Tests**
  * Added benchmark for seqno-scoped scan performance
  * Added validation tests for corruption detection in seqno bounds

* **Documentation**
  * Updated configuration documentation for `seqno_in_index` behavior and seqno bounds section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->