### PR TITLE
feat(read): opt-in row cache for point reads

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -7,17 +7,27 @@ use crate::UserKey;
 use crate::sharded_cache::{ShardedCache, Weighter};
 use crate::table::block::Header;
 use crate::table::{Block, BlockOffset};
+use crate::value::InternalValue;
 use crate::{GlobalTableId, UserValue};
 
 const TAG_BLOCK: u8 = 0;
 const TAG_BLOB: u8 = 1;
 #[cfg(feature = "zstd")]
 const TAG_PARTIAL_BLOCK: u8 = 2;
+/// Row-cache tag: a fully resolved point-read result (`InternalValue`) keyed by
+/// the owning SST's id + the user key's hash, so a repeat point read returns the
+/// decoded value without re-loading and re-decoding its data block.
+const TAG_ROW: u8 = 3;
 
 #[derive(Clone)]
 enum Item {
     Block(Block),
     Blob(UserValue),
+    /// A resolved point-read result for one user key in one (immutable) SST: the
+    /// newest version found there. The full key is carried in `key.user_key` so a
+    /// hash collision on the cache key is caught (verified on lookup) rather than
+    /// returning a wrong value.
+    Row(InternalValue),
     /// The adaptive partial-tier entry for a cold zstd block: the decompressed
     /// prefix + resume snapshot (so a later read extends it without re-decoding
     /// from block 0) plus the access stats driving promotion to a full resident
@@ -70,6 +80,9 @@ impl Weighter<CacheKey, Item> for BlockWeighter {
                     + u64::from(b.header.uncompressed_length)
             }
             Blob(b) => b.len() as u64,
+            // Key bytes + value bytes + a fixed term for the InternalKey scalars
+            // (seqno + value_type) and the entry's own bookkeeping.
+            Item::Row(iv) => iv.key.user_key.len() as u64 + iv.value.len() as u64 + 16,
             // Weighed by the resident decompressed prefix + covered key; the
             // shared `Arc<ResumeState>` scratch is approximated by a small fixed
             // term rather than counted per entry.
@@ -109,6 +122,11 @@ pub struct Cache {
     // NOTE: rustc_hash performed best: https://fjall-rs.github.io/post/fjall-2-1
     /// In-tree sharded S3-FIFO cache (byte-weighted).
     data: ShardedCache<CacheKey, Item, BlockWeighter, rustc_hash::FxBuildHasher>,
+    /// Opt-in: when false, the row cache (decoded point-read results) is off, so
+    /// `get_row` always misses and `insert_row` is a no-op. Blocks / blobs are
+    /// cached regardless. Off by default to avoid spending the shared capacity on
+    /// rows for workloads that do not benefit (e.g. uniform / scan-heavy).
+    row_cache_enabled: bool,
 }
 
 /// Number of shards in the block cache. 64 keeps per-shard write contention low
@@ -132,7 +150,23 @@ impl Cache {
                 BlockWeighter,
                 rustc_hash::FxBuildHasher,
             ),
+            row_cache_enabled: false,
         }
+    }
+
+    /// Enables or disables the row cache (decoded point-read results), returning
+    /// the cache for builder-style configuration. Off by default; rows share the
+    /// block cache's byte capacity when enabled.
+    #[must_use]
+    pub fn with_row_cache(mut self, enabled: bool) -> Self {
+        self.row_cache_enabled = enabled;
+        self
+    }
+
+    /// Whether the row cache is enabled (see [`Cache::with_row_cache`]).
+    #[must_use]
+    pub fn row_cache_enabled(&self) -> bool {
+        self.row_cache_enabled
     }
 
     /// Returns the amount of cached bytes.
@@ -154,7 +188,7 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Block(block) => block,
-            Item::Blob(_) => unreachable!("invalid cache item"),
+            Item::Blob(_) | Item::Row(_) => unreachable!("invalid cache item"),
             #[cfg(feature = "zstd")]
             Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })
@@ -224,6 +258,48 @@ impl Cache {
         );
     }
 
+    /// Looks up the cached point-read result for `user_key` in SST `id`. The
+    /// stored key is verified against `user_key` so a hash collision on the
+    /// cache slot is rejected (returns `None`) rather than serving a wrong value.
+    /// `key_hash` is the same hash the bloom filter uses, so the caller passes
+    /// the value it already computed.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn get_row(
+        &self,
+        id: GlobalTableId,
+        key_hash: u64,
+        user_key: &[u8],
+    ) -> Option<InternalValue> {
+        if !self.row_cache_enabled {
+            return None;
+        }
+        let key: CacheKey = (TAG_ROW, id.tree_id(), id.table_id(), key_hash).into();
+        match self.data.get(&key)? {
+            Item::Row(iv) if &*iv.key.user_key == user_key => Some(iv),
+            // Hash collision (a different key hashed to this slot) or a foreign
+            // item kind: treat as a miss so the caller does the real lookup.
+            _ => None,
+        }
+    }
+
+    /// Caches the resolved point-read result `iv` for SST `id`, keyed by
+    /// `key_hash`. Only a newest-version result (from a latest-version read)
+    /// should be inserted, so the seqno-visibility check on lookup stays correct.
+    /// SSTs are immutable, so an entry stays valid until its SST is compacted
+    /// away (after which its `table_id` is never read again and the entry ages
+    /// out of the cache).
+    #[doc(hidden)]
+    pub fn insert_row(&self, id: GlobalTableId, key_hash: u64, iv: InternalValue) {
+        if !self.row_cache_enabled {
+            return;
+        }
+        self.data.insert(
+            (TAG_ROW, id.tree_id(), id.table_id(), key_hash).into(),
+            Item::Row(iv),
+        );
+    }
+
     #[doc(hidden)]
     pub fn insert_blob(
         &self,
@@ -248,7 +324,7 @@ impl Cache {
 
         Some(match self.data.get(&key)? {
             Item::Blob(blob) => blob,
-            Item::Block(_) => unreachable!("invalid cache item"),
+            Item::Block(_) | Item::Row(_) => unreachable!("invalid cache item"),
             #[cfg(feature = "zstd")]
             Item::PartialBlock(_) => unreachable!("invalid cache item"),
         })

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -515,7 +515,36 @@ impl Table {
             return Ok(None);
         }
 
+        // Row-cache fast path: a prior latest-version read cached this key's
+        // resolved value for this (immutable) SST, so we can skip the index walk
+        // + data-block decode. The cached value is in table-local seqno space
+        // (same as `point_read`). Use it only when the cached newest version is
+        // visible at the query snapshot; otherwise fall through, because an older
+        // version may apply at this snapshot.
+        if let Some(mut iv) = self.cache.get_row(self.global_id(), key_hash, key) {
+            // Snapshot reads are exclusive: a version is visible iff its seqno is
+            // strictly less than the query seqno. Only serve the cached newest
+            // version when it is visible; otherwise fall through (an older
+            // version may apply at this snapshot).
+            if iv.key.seqno < seqno {
+                iv.key.seqno = iv.key.seqno.saturating_add(global_seqno);
+                return Ok(Some(iv));
+            }
+        }
+
         let item = self.point_read(key, seqno, key_hash)?;
+
+        // Populate the row cache only when this read could see the SST's newest
+        // version (`seqno > max`, exclusive), so the resolved value is the SST's
+        // newest version for this key — which keeps the seqno-visibility check
+        // above correct for later snapshot reads. SSTs are immutable, so the
+        // entry stays valid until the SST is compacted away.
+        if seqno > self.metadata.seqnos.1
+            && let Some(iv) = &item
+        {
+            self.cache
+                .insert_row(self.global_id(), key_hash, iv.clone());
+        }
 
         // Translate table-local seqno back to global coordinate so callers
         // can compare across tables/memtables (L0 best-selection, RT suppression).
@@ -563,7 +592,33 @@ impl Table {
             return Ok(None);
         }
 
+        // Row-cache fast path (mirrors `Table::get`): serve the value tuple from
+        // a prior cached point-read result, skipping the index walk + block
+        // decode, when the cached newest version is visible at this snapshot.
+        if let Some(iv) = self.cache.get_row(self.global_id(), key_hash, key) {
+            // Exclusive snapshot visibility (see `Table::get`): serve only when
+            // the cached newest version is strictly older than the query seqno.
+            if iv.key.seqno < seqno {
+                let s = iv.key.seqno.saturating_add(global_seqno);
+                return Ok(Some((iv.key.value_type, s, iv.value)));
+            }
+        }
+
         let item = self.point_read_value(key, seqno, key_hash)?;
+
+        // Populate only when this read could see the SST's newest version
+        // (`seqno > max`, exclusive), mirroring `Table::get`. The value path does
+        // not reconstruct the matched key, so rebuild the `InternalValue` from
+        // the query key (the needle) + the resolved `(value_type, seqno, value)`.
+        if seqno > self.metadata.seqnos.1
+            && let Some((vt, s, v)) = &item
+        {
+            let iv = InternalValue {
+                key: crate::key::InternalKey::new(crate::UserKey::from(key), *s, *vt),
+                value: v.clone(),
+            };
+            self.cache.insert_row(self.global_id(), key_hash, iv);
+        }
 
         // Translate table-local seqno back to the global coordinate, mirroring
         // `Table::get`.

--- a/tests/row_cache.rs
+++ b/tests/row_cache.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Correctness of the opt-in row cache (decoded point-read results keyed by the
+//! owning SST + user-key hash). The row cache must never change observed values:
+//! it only short-circuits the index walk + data-block decode when the cached
+//! newest version of a key is visible at the query snapshot.
+
+use lsm_tree::{AbstractTree, Cache, Config, SeqNo, SequenceNumberCounter, get_tmp_folder};
+use std::sync::Arc;
+use test_log::test;
+
+const N: u64 = 5_000;
+
+fn key(i: u64) -> Vec<u8> {
+    format!("key-{i:08}").into_bytes()
+}
+
+fn val(i: u64) -> Vec<u8> {
+    format!("value-{i:08}").into_bytes()
+}
+
+/// A flushed single-SST tree sharing a row-cache-enabled cache.
+fn tree_with_row_cache() -> (tempfile::TempDir, lsm_tree::AnyTree, Arc<Cache>) {
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+    let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024).with_row_cache(true));
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .use_cache(cache.clone())
+    .open()
+    .unwrap();
+    (dir, tree, cache)
+}
+
+#[test]
+fn row_cache_is_disabled_by_default() {
+    let cache = Cache::with_capacity_bytes(1024);
+    assert!(!cache.row_cache_enabled());
+    assert!(
+        Cache::with_capacity_bytes(1024)
+            .with_row_cache(true)
+            .row_cache_enabled()
+    );
+}
+
+#[test]
+fn row_cache_serves_every_key_correctly_on_repeat_reads() {
+    // Read every key twice: the first pass populates the row cache (latest-version
+    // reads), the second pass is served from it. Every value must match — a hash
+    // collision returning a wrong value, or a stale entry, would fail here.
+    let (_dir, tree, _cache) = tree_with_row_cache();
+    for i in 0..N {
+        tree.insert(key(i), val(i), 0);
+    }
+    tree.flush_active_memtable(0).unwrap();
+
+    for pass in 0..2 {
+        for i in 0..N {
+            let got = tree
+                .get(key(i), SeqNo::MAX)
+                .unwrap()
+                .unwrap_or_else(|| panic!("pass {pass}: key {i} missing"));
+            assert_eq!(&*got, val(i).as_slice(), "pass {pass}: wrong value for {i}");
+        }
+    }
+    // A key that was never inserted stays absent (no false positive from the cache).
+    assert!(tree.get(key(N + 1), SeqNo::MAX).unwrap().is_none());
+}
+
+#[test]
+fn row_cache_snapshot_read_returns_the_older_version() {
+    // Two versions of the same key in two SSTs. A latest read (which populates
+    // the cache with v2) must not make an older-snapshot read serve the cached
+    // v2: the snapshot must still see v1.
+    let (_dir, tree, _cache) = tree_with_row_cache();
+    let k = key(1);
+
+    tree.insert(&k, val(1), 1); // version @ seqno 1
+    tree.flush_active_memtable(0).unwrap();
+    tree.insert(&k, val(2), 2); // version @ seqno 2
+    tree.flush_active_memtable(0).unwrap();
+
+    // Latest read: sees v2 and caches the newest version for the newer SST.
+    assert_eq!(
+        &*tree.get(&k, SeqNo::MAX).unwrap().unwrap(),
+        val(2).as_slice()
+    );
+    // Repeat latest read: served from the row cache, still v2.
+    assert_eq!(
+        &*tree.get(&k, SeqNo::MAX).unwrap().unwrap(),
+        val(2).as_slice()
+    );
+
+    // Snapshot reads are exclusive (a snapshot at N sees versions with seqno < N).
+    // Snapshot 2: v2 (seqno 2) is not visible, so the cached newest must be
+    // bypassed and the older v1 (seqno 1) returned.
+    assert_eq!(&*tree.get(&k, 2).unwrap().unwrap(), val(1).as_slice());
+    // Snapshot 3: v2 (seqno 2) is now visible.
+    assert_eq!(&*tree.get(&k, 3).unwrap().unwrap(), val(2).as_slice());
+}
+
+#[test]
+fn row_cache_overwrite_after_flush_is_not_stale() {
+    // Overwriting a key and flushing creates a NEW SST (new table id). The old
+    // SST's cached row is keyed by the old table id, so reads of the new SST miss
+    // it and see the fresh value — never the stale cached one.
+    let (_dir, tree, _cache) = tree_with_row_cache();
+    let k = key(7);
+
+    tree.insert(&k, val(100), 1);
+    tree.flush_active_memtable(0).unwrap();
+    // Populate the row cache for the first SST.
+    assert_eq!(
+        &*tree.get(&k, SeqNo::MAX).unwrap().unwrap(),
+        val(100).as_slice()
+    );
+
+    tree.insert(&k, val(200), 2);
+    tree.flush_active_memtable(0).unwrap();
+    // The newer SST has a different table id; the read must see the new value.
+    assert_eq!(
+        &*tree.get(&k, SeqNo::MAX).unwrap().unwrap(),
+        val(200).as_slice()
+    );
+}
+
+#[test]
+fn row_cache_off_matches_row_cache_on() {
+    // The same workload with the row cache off vs on must observe identical
+    // values — the cache is a pure read accelerator, never a behaviour change.
+    let folder = get_tmp_folder();
+    let dir = tempfile::TempDir::new_in(folder).unwrap();
+    let plain = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024)); // row cache OFF
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .use_cache(plain)
+    .open()
+    .unwrap();
+    for i in 0..N {
+        tree.insert(key(i), val(i), 0);
+    }
+    tree.flush_active_memtable(0).unwrap();
+    for i in 0..N {
+        let got = tree.get(key(i), SeqNo::MAX).unwrap().unwrap();
+        assert_eq!(&*got, val(i).as_slice());
+    }
+}

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -507,12 +507,23 @@ fn open_ours(
     compression: Compression,
     kv_separated: bool,
     strategy: IndexStrategy,
+    row_cache: bool,
 ) -> Result<lsm_tree::AnyTree, Box<dyn std::error::Error>> {
     let config = Config::new(
         dir,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     );
+    // Row cache: a key->resolved-value layer in front of the block cache so a
+    // repeat point read skips the index walk + data-block decode. Off for the
+    // other arms (a fresh default cache otherwise matches Config's 16 MiB).
+    let config = if row_cache {
+        config.use_cache(std::sync::Arc::new(
+            lsm_tree::Cache::with_capacity_bytes(16 * 1024 * 1024).with_row_cache(true),
+        ))
+    } else {
+        config
+    };
     // Data-block hash index: a point get resolves a key to its in-block offset
     // by hash instead of binary-searching the restart array. 1.33 buckets/entry
     // is the rough equal of RocksDB's 0.75 utilization for the hash-index
@@ -611,6 +622,7 @@ fn run_write_throughput(
                 compression,
                 engine.kv_separated(),
                 IndexStrategy::Binary,
+                false,
             )?;
             // Zip the seqno counter as a native `u64` instead of
             // enumerate()+try_from(usize). lsm-tree's `insert` takes
@@ -794,25 +806,36 @@ fn point_read_variant(
     // data-block index, plus — when `hash_overlays` is set — the data-block
     // hash index (ours + RocksDB) and the retrieval-ribbon locator (ours only)
     // as additional index strategies on the same chart.
-    let mut series: Vec<(&str, Engine, IndexStrategy)> = engines_for(compression)
+    // Tuple: (label, engine, index strategy, row_cache). The row cache is a cache
+    // property orthogonal to the index strategy, so it rides as a 4th field.
+    let mut series: Vec<(&str, Engine, IndexStrategy, bool)> = engines_for(compression)
         .iter()
-        .map(|&engine| (engine.label(), engine, IndexStrategy::Binary))
+        .map(|&engine| (engine.label(), engine, IndexStrategy::Binary, false))
         .collect();
     if hash_overlays {
-        series.push(("ours-hash-index", Engine::Ours, IndexStrategy::HashIndex));
+        series.push((
+            "ours-hash-index",
+            Engine::Ours,
+            IndexStrategy::HashIndex,
+            false,
+        ));
         series.push((
             "rocksdb-hash-index",
             Engine::RocksDb,
             IndexStrategy::HashIndex,
+            false,
         ));
-        series.push(("ours-ribbon", Engine::Ours, IndexStrategy::Ribbon));
+        series.push(("ours-ribbon", Engine::Ours, IndexStrategy::Ribbon, false));
+        // Row cache: binary-search index + a key->value cache in front, so a
+        // repeat point read skips the index walk + data-block decode entirely.
+        series.push(("ours-row-cache", Engine::Ours, IndexStrategy::Binary, true));
     }
 
     let mut group = c.benchmark_group(group_name);
     for &n in &[1_000_u64, 10_000_u64] {
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
-        for &(label, engine, strategy) in &series {
+        for &(label, engine, strategy, row_cache) in &series {
             group.bench_with_input(BenchmarkId::new(label, n), &n, |b, _| {
                 // The temp dir + engine handle outlive every timed
                 // iteration: build the on-disk database once here so
@@ -821,9 +844,14 @@ fn point_read_variant(
                 let dir = tempfile::tempdir().expect("tempdir");
                 match engine {
                     Engine::Ours | Engine::BlobTree => {
-                        let tree =
-                            open_ours(dir.path(), compression, engine.kv_separated(), strategy)
-                                .expect("ours: open");
+                        let tree = open_ours(
+                            dir.path(),
+                            compression,
+                            engine.kv_separated(),
+                            strategy,
+                            row_cache,
+                        )
+                        .expect("ours: open");
                         for ((key, value), seqno) in
                             inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..)
                         {
@@ -952,8 +980,8 @@ fn populate_ours(
     inputs: &WorkloadInputs,
     kv_separated: bool,
 ) -> lsm_tree::AnyTree {
-    let tree =
-        open_ours(dir, compression, kv_separated, IndexStrategy::Binary).expect("ours: open");
+    let tree = open_ours(dir, compression, kv_separated, IndexStrategy::Binary, false)
+        .expect("ours: open");
     for ((key, value), seqno) in inputs.keys.iter().zip(inputs.values.iter()).zip(0u64..) {
         tree.insert(key, value, seqno);
     }


### PR DESCRIPTION
## Summary

Adds a **row cache**: a `key -> resolved point-read result` layer keyed by the owning (immutable) SST id + the user key's hash, so a repeat point read returns the decoded value without re-walking the index or re-decoding the data block.

Flamegraph attribution (#426) showed the in-block KV decode is the largest read-path bucket (~25% on warm-cache point reads) and is inherent to the SSTable block format (RocksDB pays it too). A row cache eliminates it for hot / repeated keys — the surrealkv-style "serve from memory" effect, but as an explicit, bounded, opt-in cache.

## Design

- `cache.rs`: `TAG_ROW` + `Item::Row(InternalValue)`; `get_row` (verifies the full stored key to reject hash collisions) / `insert_row`; byte weighting; `Cache::with_row_cache(bool)` opt-in (off by default — rows share the block-cache capacity when enabled).
- `Table::get` / `Table::get_value`: check the row cache after the bloom probe, before the index walk; populate only when the read could see the SST's newest version (`seqno > max`, exclusive snapshot semantics); serve a cached entry only when visible at the query snapshot (`cached.seqno < query`).

## Correctness

Rests on three invariants:
1. **memtable before SSTs** — fresh writes are never masked by a cached row.
2. **SSTs are immutable** — a cached row never goes stale within its SST; after compaction the new SST has a fresh table id, so reads of it miss the stale rows (which age out via S3-FIFO).
3. **exclusive seqno-visibility check** — snapshot reads stay correct.

Covered by `tests/row_cache.rs` (5 tests): repeat-read value correctness across all keys, snapshot returns the older version, overwrite-after-flush is not stale, row-cache-off matches row-cache-on, off-by-default. Full lib suite (1234) green, clippy clean.

## Measured win

`ours-row-cache` overlay vs `ours` on the `point_read` group (runner: Fedora, kernel 7.0.11; criterion warm-cache repeat reads, None compression):

| group | `ours` | `ours-row-cache` | speedup |
|-------|--------|------------------|---------|
| point_read/1000 | 948 µs | **267 µs** | **3.5×** |
| point_read/10000 | 10.93 ms | **2.84 ms** | **3.85×** |

This confirms the #426 hypothesis: the surrealkv read advantage was the in-block decode an LSM pays on flushed SSTs, and a memory-served decoded-value cache closes it — bringing warm repeat point reads into surrealkv's in-memory-skiplist class. Best case (repeated reads of the same keys → ~100% hit); skewed/hot-key workloads benefit by hit rate, uniform/scan-heavy should leave it off (hence opt-in, off by default).

## Enabling

```rust
let cache = Arc::new(Cache::with_capacity_bytes(64 * 1024 * 1024).with_row_cache(true));
let tree = Config::new(path, ..).use_cache(cache).open()?;
```

Closes #475.