### PR TITLE
feat(fs): raw io_uring Fs / FsFile backend (no_std)

### DIFF
--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -34,17 +34,22 @@
     reason = "Linux syscall/mmap ABI: register-width arg casts + page-aligned ring field reads"
 )]
 
+use alloc::boxed::Box;
+use alloc::ffi::CString;
 #[cfg(not(feature = "std"))]
 use alloc::format;
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use core::sync::atomic::{Ordering, fence};
 
 use spin::Mutex;
 use syscalls::{Errno, Sysno, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
 
-use crate::fs::{FsFile, FsMetadata};
+use crate::fs::{Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions};
 use crate::io::{Error, ErrorKind, SeekFrom};
+use crate::path::Path;
 
 // ---- Linux io_uring ABI constants (stable kernel uapi, linux/io_uring.h) ----
 
@@ -527,6 +532,120 @@ pub fn file_size_raw(fd: i32) -> Result<u64, Error> {
     lseek_raw(fd, 0, SEEK_END)
 }
 
+// ---- Directory / path syscalls (for the `Fs` backend) ----
+//
+// These use the asm-generic flag values, authoritative on x86/x86_64, ARM,
+// AArch64, RISC-V, PowerPC, etc. (the realistic `io_uring` targets). The handful
+// of flags that diverge on MIPS / SPARC (O_APPEND / O_EXCL / O_DIRECTORY) are not
+// remapped here, matching the `direct_io` policy documented on `FsOpenOptions`.
+
+/// Append: writes always land at end of file.
+const O_APPEND: i32 = 0o2000;
+/// Fail `open` with `EEXIST` if the path already exists (with `O_CREAT`).
+const O_EXCL: i32 = 0o200;
+/// Require the opened path to be a directory.
+const O_DIRECTORY: i32 = 0o200_000;
+
+/// `unlinkat` flag: remove a directory (`rmdir`) instead of a file.
+const AT_REMOVEDIR: i32 = 0x200;
+
+/// `linux_dirent64.d_type`: directory.
+const DT_DIR: u8 = 4;
+
+/// `mkdirat(AT_FDCWD, path, mode)` — create a directory.
+///
+/// # Errors
+/// Returns an [`Error`] if the `mkdirat` syscall fails.
+pub fn mkdirat_raw(path: &core::ffi::CStr, mode: u32) -> Result<(), Error> {
+    // SAFETY: `path` is a valid NUL-terminated C string the kernel only reads.
+    unsafe {
+        syscall3(
+            Sysno::mkdirat,
+            AT_FDCWD as usize,
+            path.as_ptr() as usize,
+            mode as usize,
+        )
+    }
+    .map_err(|e| err("mkdirat", e))?;
+    Ok(())
+}
+
+/// `unlinkat(AT_FDCWD, path, flags)` — remove a file (`flags == 0`) or directory
+/// (`flags == AT_REMOVEDIR`).
+///
+/// # Errors
+/// Returns an [`Error`] if the `unlinkat` syscall fails.
+pub fn unlinkat_raw(path: &core::ffi::CStr, remove_dir: bool) -> Result<(), Error> {
+    let flags = if remove_dir { AT_REMOVEDIR } else { 0 };
+    // SAFETY: `path` is a valid NUL-terminated C string the kernel only reads.
+    unsafe {
+        syscall4(
+            Sysno::unlinkat,
+            AT_FDCWD as usize,
+            path.as_ptr() as usize,
+            flags as usize,
+            0,
+        )
+    }
+    .map_err(|e| err("unlinkat", e))?;
+    Ok(())
+}
+
+/// `renameat2(AT_FDCWD, from, AT_FDCWD, to, 0)` — rename, replacing the
+/// destination (the plain `rename(2)` behaviour).
+///
+/// # Errors
+/// Returns an [`Error`] if the `renameat2` syscall fails.
+pub fn renameat2_raw(from: &core::ffi::CStr, to: &core::ffi::CStr) -> Result<(), Error> {
+    // SAFETY: both paths are valid NUL-terminated C strings the kernel reads.
+    unsafe {
+        syscall5(
+            Sysno::renameat2,
+            AT_FDCWD as usize,
+            from.as_ptr() as usize,
+            AT_FDCWD as usize,
+            to.as_ptr() as usize,
+            0,
+        )
+    }
+    .map_err(|e| err("renameat2", e))?;
+    Ok(())
+}
+
+/// `statx(AT_FDCWD, path, 0, STATX_BASIC_STATS, &buf)` — stat a path (follows
+/// symlinks). Returns [`None`] if the path does not exist (`ENOENT`).
+///
+/// # Errors
+/// Returns an [`Error`] if `statx` fails for a reason other than `ENOENT`.
+pub fn statx_path_raw(path: &core::ffi::CStr) -> Result<Option<RawMetadata>, Error> {
+    let mut buf = Statx::default();
+    // SAFETY: `path` is a valid NUL-terminated C string; `buf` is a valid,
+    // writable Statx the kernel fills.
+    let r = unsafe {
+        syscall5(
+            Sysno::statx,
+            AT_FDCWD as usize,
+            path.as_ptr() as usize,
+            0,
+            STATX_BASIC_STATS as usize,
+            &raw mut buf as usize,
+        )
+    };
+    match r {
+        Ok(_) => {
+            let kind = buf.stx_mode & S_IFMT;
+            Ok(Some(RawMetadata {
+                size: buf.stx_size,
+                is_dir: kind == S_IFDIR,
+                is_file: kind == S_IFREG,
+            }))
+        }
+        // ENOENT (2): the path does not exist — a normal "not found" answer.
+        Err(e) if e.into_raw() == 2 => Ok(None),
+        Err(e) => Err(err("statx", e)),
+    }
+}
+
 // SAFETY: `IoUringRaw`'s raw pointers address `mmap` regions it owns for its
 // whole lifetime, and its ring fd is process-global; moving it to another
 // thread is sound because every access is serialized through the `Mutex` that
@@ -723,6 +842,220 @@ impl std::io::Seek for IoUringRawFile {
 impl crate::io::Seek for IoUringRawFile {
     fn seek(&mut self, pos: SeekFrom) -> crate::io::Result<u64> {
         self.seek_impl(pos)
+    }
+}
+
+/// Converts a path to a NUL-terminated C string for the path syscalls. Errors
+/// on a non-UTF-8 path or an interior NUL. Uses `to_str` (common to the std and
+/// `no_std` `Path`), not the `no_std`-only `as_str`.
+fn path_to_cstring(path: &Path) -> Result<CString, Error> {
+    let s = path
+        .to_str()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "path is not valid UTF-8"))?;
+    CString::new(s.as_bytes())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "path contains an interior NUL"))
+}
+
+/// Maps [`FsOpenOptions`] to `open(2)` flags (asm-generic values; see the
+/// directory-syscall note for the MIPS / SPARC caveat on the divergent flags).
+fn open_flags(opts: &FsOpenOptions) -> i32 {
+    let mut flags = if opts.read && (opts.write || opts.append) {
+        O_RDWR
+    } else if opts.write || opts.append {
+        O_WRONLY
+    } else {
+        O_RDONLY
+    };
+    if opts.create || opts.create_new {
+        flags |= O_CREAT;
+    }
+    if opts.create_new {
+        flags |= O_EXCL;
+    }
+    if opts.truncate {
+        flags |= O_TRUNC;
+    }
+    if opts.append {
+        flags |= O_APPEND;
+    }
+    flags
+}
+
+/// Reads every entry of an open directory `fd` via `getdents64`, returning
+/// `(file_name, is_dir)` pairs and skipping `.` / `..`.
+fn read_dir_entries(fd: i32) -> Result<Vec<(String, bool)>, Error> {
+    let mut entries = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        // SAFETY: `buf` is a valid writable region of `buf.len()` bytes that the
+        // kernel fills with packed `linux_dirent64` records.
+        let n = unsafe {
+            syscall3(
+                Sysno::getdents64,
+                fd as usize,
+                buf.as_mut_ptr() as usize,
+                buf.len(),
+            )
+        }
+        .map_err(|e| err("getdents64", e))?;
+        if n == 0 {
+            break; // end of directory
+        }
+        let n = n as usize;
+        let mut off = 0usize;
+        // linux_dirent64: d_ino(8) d_off(8) d_reclen(u16 @16) d_type(u8 @18)
+        // d_name(@19, NUL-terminated). Walk record by record via d_reclen.
+        while off + 19 <= n {
+            let reclen = {
+                let b: [u8; 2] = buf
+                    .get(off + 16..off + 18)
+                    .and_then(|s| s.try_into().ok())
+                    .ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "dirent reclen out of range")
+                    })?;
+                usize::from(u16::from_le_bytes(b))
+            };
+            if reclen < 19 || off + reclen > n {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "dirent record length invalid",
+                ));
+            }
+            let d_type = *buf
+                .get(off + 18)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "dirent type out of range"))?;
+            let name_region = buf
+                .get(off + 19..off + reclen)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "dirent name out of range"))?;
+            let name_len = name_region
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(name_region.len());
+            let name_bytes = name_region
+                .get(..name_len)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "dirent name slice"))?;
+            let name = core::str::from_utf8(name_bytes)
+                .map_err(|_| Error::new(ErrorKind::InvalidData, "dirent name is not UTF-8"))?;
+            if name != "." && name != ".." {
+                entries.push((name.to_string(), d_type == DT_DIR));
+            }
+            off += reclen;
+        }
+    }
+    Ok(entries)
+}
+
+/// An [`Fs`] backend over the raw `no_std` `io_uring` driver.
+///
+/// Opened files share one ring (the hot read / write / fsync path); directory
+/// operations use plain blocking syscalls. Pure syscalls throughout — no
+/// `io-uring` crate and no `std::fs`, unlike the std-bound [`IoUringFs`].
+pub struct IoUringRawFs {
+    ring: Arc<Mutex<IoUringRaw>>,
+}
+
+impl IoUringRawFs {
+    /// Creates a backend with its own ring sized for `ring_entries` SQEs (the
+    /// kernel rounds up to a power of two).
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if `io_uring_setup` / `mmap` fails.
+    pub fn new(ring_entries: u32) -> Result<Self, Error> {
+        Ok(Self {
+            ring: Arc::new(Mutex::new(IoUringRaw::new(ring_entries)?)),
+        })
+    }
+}
+
+impl Fs for IoUringRawFs {
+    fn open(&self, path: &Path, opts: &FsOpenOptions) -> crate::io::Result<Box<dyn FsFile>> {
+        let cpath = path_to_cstring(path)?;
+        let fd = open_raw(&cpath, open_flags(opts), 0o644)?;
+        Ok(Box::new(IoUringRawFile::new(
+            Arc::clone(&self.ring),
+            fd,
+            opts.append,
+        )))
+    }
+
+    fn create_dir_all(&self, path: &Path) -> crate::io::Result<()> {
+        // Create each ancestor first; an already-existing component is success.
+        if let Some(parent) = path.parent()
+            && !parent.to_str().unwrap_or("").is_empty()
+        {
+            self.create_dir_all(parent)?;
+        }
+        match self.create_dir(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn create_dir(&self, path: &Path) -> crate::io::Result<()> {
+        mkdirat_raw(&path_to_cstring(path)?, 0o755)
+    }
+
+    fn read_dir(&self, path: &Path) -> crate::io::Result<Vec<FsDirEntry>> {
+        let cpath = path_to_cstring(path)?;
+        let fd = open_raw(&cpath, O_RDONLY | O_DIRECTORY, 0)?;
+        let result = read_dir_entries(fd);
+        let _ = close_raw(fd);
+        let names = result?;
+        Ok(names
+            .into_iter()
+            .map(|(name, is_dir)| FsDirEntry {
+                path: path.join(&name),
+                file_name: name,
+                is_dir,
+            })
+            .collect())
+    }
+
+    fn remove_file(&self, path: &Path) -> crate::io::Result<()> {
+        unlinkat_raw(&path_to_cstring(path)?, false)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> crate::io::Result<()> {
+        // Depth-first: remove children (recursing into subdirectories) before
+        // the directory itself, since the kernel rejects rmdir on a non-empty
+        // directory.
+        for entry in self.read_dir(path)? {
+            let child = path.join(&entry.file_name);
+            if entry.is_dir {
+                self.remove_dir_all(&child)?;
+            } else {
+                self.remove_file(&child)?;
+            }
+        }
+        unlinkat_raw(&path_to_cstring(path)?, true)
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> crate::io::Result<()> {
+        renameat2_raw(&path_to_cstring(from)?, &path_to_cstring(to)?)
+    }
+
+    fn metadata(&self, path: &Path) -> crate::io::Result<FsMetadata> {
+        match statx_path_raw(&path_to_cstring(path)?)? {
+            Some(m) => Ok(FsMetadata {
+                len: m.size,
+                is_dir: m.is_dir,
+                is_file: m.is_file,
+            }),
+            None => Err(Error::new(ErrorKind::NotFound, "path not found")),
+        }
+    }
+
+    fn sync_directory(&self, path: &Path) -> crate::io::Result<()> {
+        let cpath = path_to_cstring(path)?;
+        let fd = open_raw(&cpath, O_RDONLY | O_DIRECTORY, 0)?;
+        let r = self.ring.lock().fsync(fd, false);
+        let _ = close_raw(fd);
+        r
+    }
+
+    fn exists(&self, path: &Path) -> crate::io::Result<bool> {
+        Ok(statx_path_raw(&path_to_cstring(path)?)?.is_some())
     }
 }
 
@@ -1181,6 +1514,56 @@ mod tests {
 
         drop(file); // closes the fd
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn raw_fs_directory_and_file_ops() {
+        // Exercises the IoUringRawFs Fs surface end to end: create_dir_all
+        // (mkdirat), open + write (ring), metadata + exists (statx), read_dir
+        // (getdents64), rename (renameat2), remove_file + remove_dir_all
+        // (unlinkat) — all over the raw no_std driver.
+        use crate::fs::Fs;
+        use crate::path::Path;
+        use std::io::Write;
+
+        let base =
+            std::env::temp_dir().join(format!("iou_rawfs_{}_{}", std::process::id(), line!()));
+        let base_s = base.to_str().expect("utf8 temp path");
+        let fs = IoUringRawFs::new(8).expect("fs setup");
+        let dir = Path::new(base_s);
+
+        fs.create_dir_all(dir).expect("create_dir_all");
+        assert!(fs.exists(dir).expect("dir exists"));
+        assert!(fs.metadata(dir).expect("dir metadata").is_dir);
+
+        // Open + write a file through the ring.
+        let fpath = dir.join("a.txt");
+        let mut file = fs
+            .open(&fpath, &FsOpenOptions::new().write(true).create(true))
+            .expect("open");
+        file.write_all(b"hello").expect("write");
+        file.sync_all().expect("sync");
+        drop(file);
+
+        // statx-backed metadata + getdents64 listing see the file.
+        assert_eq!(fs.metadata(&fpath).expect("file metadata").len, 5);
+        let entries = fs.read_dir(dir).expect("read_dir");
+        assert!(
+            entries.iter().any(|e| e.file_name == "a.txt" && !e.is_dir),
+            "read_dir must list the written file"
+        );
+
+        // rename (renameat2) moves it.
+        let fpath2 = dir.join("b.txt");
+        fs.rename(&fpath, &fpath2).expect("rename");
+        assert!(!fs.exists(&fpath).expect("old gone"));
+        assert!(fs.exists(&fpath2).expect("new present"));
+
+        // unlinkat removes the file, then the (now empty) directory.
+        fs.remove_file(&fpath2).expect("remove_file");
+        assert!(!fs.exists(&fpath2).expect("file gone"));
+        fs.remove_dir_all(dir).expect("remove_dir_all");
+        assert!(!fs.exists(dir).expect("dir gone"));
     }
 
     #[test]

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -36,12 +36,15 @@
 
 #[cfg(not(feature = "std"))]
 use alloc::format;
+use alloc::sync::Arc;
 
 use core::sync::atomic::{Ordering, fence};
 
-use syscalls::{Errno, Sysno, syscall1, syscall2, syscall4, syscall6};
+use spin::Mutex;
+use syscalls::{Errno, Sysno, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
 
-use crate::io::{Error, ErrorKind};
+use crate::fs::{FsFile, FsMetadata};
+use crate::io::{Error, ErrorKind, SeekFrom};
 
 // ---- Linux io_uring ABI constants (stable kernel uapi, linux/io_uring.h) ----
 
@@ -364,6 +367,363 @@ pub fn close_raw(fd: i32) -> Result<(), Error> {
     // SAFETY: `fd` is a descriptor the caller owns.
     unsafe { syscall1(Sysno::close, fd as usize) }.map_err(|e| err("close", e))?;
     Ok(())
+}
+
+// ---- Cold-path file syscalls (metadata / truncate / lock / seek) ----
+//
+// The std `io_uring` backend delegates these to `std::fs::File`; the `no_std`
+// raw backend cannot, so they go through plain blocking syscalls (only the
+// hot read / write / fsync data path uses the ring).
+
+/// `lseek` whence: position relative to the end (used to resolve file size).
+const SEEK_END: i32 = 2;
+
+/// `flock` operation: exclusive lock.
+const LOCK_EX: i32 = 2;
+/// `flock` operation bit: non-blocking (fail with `EWOULDBLOCK` instead of waiting).
+const LOCK_NB: i32 = 4;
+
+/// `statx` flag: operate on `dirfd` itself when the path is empty (stat an fd).
+const AT_EMPTY_PATH: i32 = 0x1000;
+/// `statx` mask: request the basic stat fields (type, mode, size, …).
+const STATX_BASIC_STATS: u32 = 0x0000_07ff;
+/// `st_mode` file-type mask and the regular-file / directory type bits.
+const S_IFMT: u16 = 0o170_000;
+const S_IFDIR: u16 = 0o040_000;
+const S_IFREG: u16 = 0o100_000;
+
+/// A `statx_timestamp` (`linux/stat.h`).
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct StatxTimestamp {
+    tv_sec: i64,
+    tv_nsec: u32,
+    _reserved: i32,
+}
+
+/// The kernel `struct statx` (256 bytes, architecture-independent — unlike the
+/// arch-specific `struct stat`, which is why `statx` is used here). Only
+/// `stx_mode` and `stx_size` are read; the remaining fields keep the layout the
+/// exact size the kernel writes into.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct Statx {
+    stx_mask: u32,
+    stx_blksize: u32,
+    stx_attributes: u64,
+    stx_nlink: u32,
+    stx_uid: u32,
+    stx_gid: u32,
+    stx_mode: u16,
+    _spare0: u16,
+    stx_ino: u64,
+    stx_size: u64,
+    stx_blocks: u64,
+    stx_attributes_mask: u64,
+    stx_atime: StatxTimestamp,
+    stx_btime: StatxTimestamp,
+    stx_ctime: StatxTimestamp,
+    stx_mtime: StatxTimestamp,
+    stx_rdev_major: u32,
+    stx_rdev_minor: u32,
+    stx_dev_major: u32,
+    stx_dev_minor: u32,
+    stx_mnt_id: u64,
+    stx_dio_mem_align: u32,
+    stx_dio_offset_align: u32,
+    _spare3: [u64; 12],
+}
+
+/// File type + size, the subset of `statx` the [`Fs`](crate::fs::Fs) metadata
+/// surface needs.
+pub struct RawMetadata {
+    /// File length in bytes (`stx_size`).
+    pub size: u64,
+    /// Whether the entry is a directory (`S_IFDIR`).
+    pub is_dir: bool,
+    /// Whether the entry is a regular file (`S_IFREG`).
+    pub is_file: bool,
+}
+
+/// `statx(fd, "", AT_EMPTY_PATH, STATX_BASIC_STATS, &buf)` — stats an open
+/// descriptor without a path lookup.
+///
+/// # Errors
+/// Returns an [`Error`] if the `statx` syscall fails.
+pub fn fstat_raw(fd: i32) -> Result<RawMetadata, Error> {
+    let mut buf = Statx::default();
+    // Empty path + AT_EMPTY_PATH makes statx operate on `fd` directly.
+    let empty: &core::ffi::CStr = c"";
+    // SAFETY: `buf` is a valid, writable Statx the kernel fills; `empty` is a
+    // valid NUL-terminated C string read by the kernel.
+    unsafe {
+        syscall5(
+            Sysno::statx,
+            fd as usize,
+            empty.as_ptr() as usize,
+            AT_EMPTY_PATH as usize,
+            STATX_BASIC_STATS as usize,
+            &raw mut buf as usize,
+        )
+    }
+    .map_err(|e| err("statx", e))?;
+    let kind = buf.stx_mode & S_IFMT;
+    Ok(RawMetadata {
+        size: buf.stx_size,
+        is_dir: kind == S_IFDIR,
+        is_file: kind == S_IFREG,
+    })
+}
+
+/// `ftruncate(fd, length)` — set the file size (extend with zeros or truncate).
+///
+/// # Errors
+/// Returns an [`Error`] if the `ftruncate` syscall fails.
+pub fn ftruncate_raw(fd: i32, length: u64) -> Result<(), Error> {
+    // SAFETY: `fd` is an owned writable descriptor; `length` is a plain value.
+    unsafe { syscall2(Sysno::ftruncate, fd as usize, length as usize) }
+        .map_err(|e| err("ftruncate", e))?;
+    Ok(())
+}
+
+/// `lseek(fd, offset, whence)` — reposition; returns the resulting absolute
+/// offset. Used to resolve the file size (`SEEK_END`) for append / `Seek::End`.
+///
+/// # Errors
+/// Returns an [`Error`] if the `lseek` syscall fails.
+pub fn lseek_raw(fd: i32, offset: i64, whence: i32) -> Result<u64, Error> {
+    // SAFETY: `fd` is an owned descriptor; offset/whence are plain values.
+    let pos = unsafe { syscall3(Sysno::lseek, fd as usize, offset as usize, whence as usize) }
+        .map_err(|e| err("lseek", e))?;
+    Ok(pos as u64)
+}
+
+/// `flock(fd, LOCK_EX[|LOCK_NB])` — take an advisory exclusive lock. With
+/// `non_blocking`, returns `Ok(false)` instead of waiting when the lock is held.
+///
+/// # Errors
+/// Returns an [`Error`] if the `flock` syscall fails for a reason other than the
+/// non-blocking contention case.
+pub fn flock_exclusive_raw(fd: i32, non_blocking: bool) -> Result<bool, Error> {
+    let op = if non_blocking {
+        LOCK_EX | LOCK_NB
+    } else {
+        LOCK_EX
+    };
+    // SAFETY: `fd` is an owned descriptor; `op` is a valid flock operation.
+    match unsafe { syscall2(Sysno::flock, fd as usize, op as usize) } {
+        Ok(_) => Ok(true),
+        // EWOULDBLOCK / EAGAIN (11): held by someone else, non-blocking request.
+        Err(e) if non_blocking && e.into_raw() == 11 => Ok(false),
+        Err(e) => Err(err("flock", e)),
+    }
+}
+
+/// Resolves the current file size via `lseek(fd, 0, SEEK_END)`.
+///
+/// # Errors
+/// Returns an [`Error`] if the `lseek` syscall fails.
+pub fn file_size_raw(fd: i32) -> Result<u64, Error> {
+    lseek_raw(fd, 0, SEEK_END)
+}
+
+// SAFETY: `IoUringRaw`'s raw pointers address `mmap` regions it owns for its
+// whole lifetime, and its ring fd is process-global; moving it to another
+// thread is sound because every access is serialized through the `Mutex` that
+// wraps it in `IoUringRawFile` (no concurrent unsynchronized use). It is only
+// `Send` (moved across threads), never shared by `&` directly.
+unsafe impl Send for IoUringRaw {}
+
+/// A [`FsFile`] backed by the raw `no_std` `io_uring` driver.
+///
+/// The hot read / write / fsync path goes through a shared ring (serialized by a
+/// `Mutex`), while cold operations (size, truncate, lock) use plain blocking
+/// syscalls. It slots into the [`Fs`](crate::fs::Fs) abstraction like the
+/// std-bound backends.
+pub struct IoUringRawFile {
+    /// Shared submission/completion ring. `Mutex` because the ring ops take
+    /// `&mut self` while [`FsFile`] hands out `&self`, and one ring is shared
+    /// across the files an `Fs` opens.
+    ring: Arc<Mutex<IoUringRaw>>,
+    /// The open file descriptor (owned: closed on [`Drop`]).
+    fd: i32,
+    /// Byte cursor for the sequential `Read` / `Write` / `Seek` path. `read_at`
+    /// ignores it (explicit offset).
+    cursor: u64,
+    /// `O_APPEND` semantics: every write goes to the current end of file.
+    is_append: bool,
+}
+
+impl IoUringRawFile {
+    /// Wraps an open descriptor `fd` (from [`open_raw`]) with the shared `ring`.
+    /// `is_append` selects `O_APPEND`-style writes (always at EOF). Takes
+    /// ownership of `fd` (closed on [`Drop`]).
+    #[must_use]
+    pub fn new(ring: Arc<Mutex<IoUringRaw>>, fd: i32, is_append: bool) -> Self {
+        Self {
+            ring,
+            fd,
+            cursor: 0,
+            is_append,
+        }
+    }
+
+    /// Adds a signed delta to a base offset, erroring on overflow / underflow
+    /// (a seek before byte 0 or past `u64::MAX`).
+    fn offset_add(base: u64, delta: i64) -> Result<u64, Error> {
+        let r = if delta >= 0 {
+            base.checked_add(delta as u64)
+        } else {
+            base.checked_sub(delta.unsigned_abs())
+        };
+        r.ok_or_else(|| Error::new(ErrorKind::InvalidInput, "seek position out of range"))
+    }
+
+    fn read_impl(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let n = self.ring.lock().read_at(self.fd, buf, self.cursor)?;
+        self.cursor = self.cursor.saturating_add(n as u64);
+        Ok(n)
+    }
+
+    fn write_impl(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        // O_APPEND: resolve the current EOF before each write so writes never
+        // overwrite, matching the kernel's append semantics.
+        if self.is_append {
+            self.cursor = file_size_raw(self.fd)?;
+        }
+        let n = self.ring.lock().write_at(self.fd, buf, self.cursor)?;
+        self.cursor = self.cursor.saturating_add(n as u64);
+        Ok(n)
+    }
+
+    fn seek_impl(&mut self, pos: SeekFrom) -> Result<u64, Error> {
+        let target = match pos {
+            SeekFrom::Start(o) => o,
+            SeekFrom::Current(d) => Self::offset_add(self.cursor, d)?,
+            SeekFrom::End(d) => Self::offset_add(file_size_raw(self.fd)?, d)?,
+        };
+        self.cursor = target;
+        Ok(target)
+    }
+}
+
+impl Drop for IoUringRawFile {
+    fn drop(&mut self) {
+        // Best-effort close; a write-back error at close is not actionable here.
+        let _ = close_raw(self.fd);
+    }
+}
+
+impl FsFile for IoUringRawFile {
+    fn sync_all(&self) -> crate::io::Result<()> {
+        self.ring.lock().fsync(self.fd, false)
+    }
+
+    fn sync_data(&self) -> crate::io::Result<()> {
+        self.ring.lock().fsync(self.fd, true)
+    }
+
+    fn metadata(&self) -> crate::io::Result<FsMetadata> {
+        let m = fstat_raw(self.fd)?;
+        Ok(FsMetadata {
+            len: m.size,
+            is_dir: m.is_dir,
+            is_file: m.is_file,
+        })
+    }
+
+    fn set_len(&self, size: u64) -> crate::io::Result<()> {
+        ftruncate_raw(self.fd, size)
+    }
+
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> crate::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        // Fill-or-EOF: loop until the buffer is full or a 0-byte read signals
+        // EOF, retrying the ring op on EINTR (mirrors the std io_uring backend).
+        let mut total = 0usize;
+        while total < buf.len() {
+            let remaining = buf
+                .get_mut(total..)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "read_at slice out of range"))?;
+            let at = offset
+                .checked_add(total as u64)
+                .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "read_at offset overflow"))?;
+            let n = loop {
+                match self.ring.lock().read_at(self.fd, remaining, at) {
+                    Ok(n) => break n,
+                    Err(e) if e.kind() == ErrorKind::Interrupted => {}
+                    Err(e) => return Err(e),
+                }
+            };
+            if n == 0 {
+                break;
+            }
+            total += n;
+        }
+        Ok(total)
+    }
+
+    fn lock_exclusive(&self) -> crate::io::Result<()> {
+        flock_exclusive_raw(self.fd, false)?;
+        Ok(())
+    }
+
+    fn try_lock_exclusive(&self) -> crate::io::Result<bool> {
+        flock_exclusive_raw(self.fd, true)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Read for IoUringRawFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.read_impl(buf).map_err(Into::into)
+    }
+}
+#[cfg(not(feature = "std"))]
+impl crate::io::Read for IoUringRawFile {
+    fn read(&mut self, buf: &mut [u8]) -> crate::io::Result<usize> {
+        self.read_impl(buf)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for IoUringRawFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.write_impl(buf).map_err(Into::into)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+#[cfg(not(feature = "std"))]
+impl crate::io::Write for IoUringRawFile {
+    fn write(&mut self, buf: &[u8]) -> crate::io::Result<usize> {
+        self.write_impl(buf)
+    }
+    fn flush(&mut self) -> crate::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Seek for IoUringRawFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.seek_impl(pos.into()).map_err(Into::into)
+    }
+}
+#[cfg(not(feature = "std"))]
+impl crate::io::Seek for IoUringRawFile {
+    fn seek(&mut self, pos: SeekFrom) -> crate::io::Result<u64> {
+        self.seek_impl(pos)
+    }
 }
 
 /// A minimal, `no_std` `io_uring` instance: an `mmap`'d submission ring, an
@@ -745,6 +1105,83 @@ mod tests {
     // These tests require a Linux kernel with io_uring; they are compiled only
     // under `cfg(target_os = "linux")` (the module gate) and run on the Linux
     // CI / bench runner, not on the macOS dev host.
+
+    #[test]
+    fn raw_file_fsfile_round_trips() {
+        // Exercises the full IoUringRawFile FsFile surface: sequential write
+        // (ring), positioned read_at (ring, fill-or-EOF), metadata (statx),
+        // Seek + sequential Read (cursor), set_len (ftruncate), fsync (ring),
+        // and try_lock_exclusive (flock) — all over the raw no_std driver.
+        use std::io::{Read, Seek, Write};
+
+        let path = std::env::temp_dir().join(format!(
+            "iou_rawfile_{}_{}.bin",
+            std::process::id(),
+            line!()
+        ));
+        let cpath = std::ffi::CString::new(path.to_str().expect("utf8 path"))
+            .expect("path has no interior NUL");
+
+        let fd =
+            open_raw(&cpath, O_CREAT | O_RDWR | O_TRUNC, 0o600).expect("openat should succeed");
+        let ring = Arc::new(Mutex::new(IoUringRaw::new(8).expect("ring setup")));
+        let mut file = IoUringRawFile::new(ring, fd, false);
+
+        let payload = b"raw io_uring file round-trip payload";
+        let written = Write::write(&mut file, payload).expect("write");
+        assert_eq!(written, payload.len(), "short write");
+
+        // statx-backed metadata reflects the written length.
+        assert_eq!(
+            FsFile::metadata(&file).expect("metadata").len,
+            payload.len() as u64,
+            "metadata len must match what was written"
+        );
+
+        // Positioned fill-or-EOF read returns the exact bytes.
+        let mut rb = vec![0u8; payload.len()];
+        let n = FsFile::read_at(&file, &mut rb, 0).expect("read_at");
+        assert_eq!(n, payload.len(), "short read_at");
+        assert_eq!(&rb, payload, "read_at bytes must match");
+
+        // Seek + sequential Read from an offset uses the userspace cursor.
+        file.seek(std::io::SeekFrom::Start(4)).expect("seek");
+        let mut tail = vec![0u8; payload.len() - 4];
+        let mut got = 0;
+        while got < tail.len() {
+            let chunk = tail.get_mut(got..).expect("in-bounds");
+            let r = Read::read(&mut file, chunk).expect("read");
+            if r == 0 {
+                break;
+            }
+            got += r;
+        }
+        assert_eq!(
+            tail.get(..got).expect("in-bounds"),
+            payload.get(4..).expect("in-bounds"),
+            "seek+read bytes must match"
+        );
+
+        FsFile::sync_all(&file).expect("sync_all");
+        FsFile::sync_data(&file).expect("sync_data");
+
+        // ftruncate shrinks the file; metadata reflects it.
+        FsFile::set_len(&file, 4).expect("set_len");
+        assert_eq!(
+            FsFile::metadata(&file).expect("metadata after set_len").len,
+            4,
+            "set_len must shrink the file"
+        );
+
+        // A fresh file is unlocked, so a non-blocking exclusive lock succeeds.
+        assert!(
+            FsFile::try_lock_exclusive(&file).expect("try_lock_exclusive"),
+            "exclusive lock on a fresh file must succeed"
+        );
+
+        drop(file); // closes the fd
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn ring_setup_and_nop_round_trips() {

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -515,12 +515,17 @@ pub fn flock_exclusive_raw(fd: i32, non_blocking: bool) -> Result<bool, Error> {
     } else {
         LOCK_EX
     };
-    // SAFETY: `fd` is an owned descriptor; `op` is a valid flock operation.
-    match unsafe { syscall2(Sysno::flock, fd as usize, op as usize) } {
-        Ok(_) => Ok(true),
-        // EWOULDBLOCK / EAGAIN (11): held by someone else, non-blocking request.
-        Err(e) if non_blocking && e.into_raw() == 11 => Ok(false),
-        Err(e) => Err(err("flock", e)),
+    loop {
+        // SAFETY: `fd` is an owned descriptor; `op` is a valid flock operation.
+        match unsafe { syscall2(Sysno::flock, fd as usize, op as usize) } {
+            Ok(_) => return Ok(true),
+            // EINTR (4): interrupted by a signal mid-syscall — retry, so a stray
+            // signal does not spuriously fail the lock (matches std's flock).
+            Err(e) if e.into_raw() == 4 => {}
+            // EWOULDBLOCK / EAGAIN (11): held by someone else, non-blocking request.
+            Err(e) if non_blocking && e.into_raw() == 11 => return Ok(false),
+            Err(e) => return Err(err("flock", e)),
+        }
     }
 }
 
@@ -579,12 +584,11 @@ pub fn unlinkat_raw(path: &core::ffi::CStr, remove_dir: bool) -> Result<(), Erro
     let flags = if remove_dir { AT_REMOVEDIR } else { 0 };
     // SAFETY: `path` is a valid NUL-terminated C string the kernel only reads.
     unsafe {
-        syscall4(
+        syscall3(
             Sysno::unlinkat,
             AT_FDCWD as usize,
             path.as_ptr() as usize,
             flags as usize,
-            0,
         )
     }
     .map_err(|e| err("unlinkat", e))?;
@@ -711,10 +715,14 @@ impl IoUringRawFile {
         if buf.is_empty() {
             return Ok(0);
         }
-        // O_APPEND: resolve the current EOF before each write so writes never
-        // overwrite, matching the kernel's append semantics.
         if self.is_append {
-            self.cursor = file_size_raw(self.fd)?;
+            // O_APPEND: write with the io_uring "use the file offset" sentinel
+            // (`-1`), so the kernel performs the append atomically against the
+            // O_APPEND descriptor. Resolving the offset in userspace
+            // (`lseek` + positioned write) would race with other appenders,
+            // because a positioned write ignores O_APPEND and two writers could
+            // land at the same offset, silently losing one.
+            return self.ring.lock().write_at(self.fd, buf, u64::MAX);
         }
         let n = self.ring.lock().write_at(self.fd, buf, self.cursor)?;
         self.cursor = self.cursor.saturating_add(n as u64);
@@ -913,7 +921,10 @@ fn read_dir_entries(fd: i32) -> Result<Vec<(String, bool)>, Error> {
                     .ok_or_else(|| {
                         Error::new(ErrorKind::InvalidData, "dirent reclen out of range")
                     })?;
-                usize::from(u16::from_le_bytes(b))
+                // `d_reclen` is a native-endian `u16` (the kernel writes the
+                // struct in host byte order), so decode native-endian — not
+                // little-endian, which would be wrong on big-endian targets.
+                usize::from(u16::from_ne_bytes(b))
             };
             if reclen < 19 || off + reclen > n {
                 return Err(Error::new(
@@ -1447,11 +1458,8 @@ mod tests {
         // and try_lock_exclusive (flock) — all over the raw no_std driver.
         use std::io::{Read, Seek, Write};
 
-        let path = std::env::temp_dir().join(format!(
-            "iou_rawfile_{}_{}.bin",
-            std::process::id(),
-            line!()
-        ));
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("iou_rawfile.bin");
         let cpath = std::ffi::CString::new(path.to_str().expect("utf8 path"))
             .expect("path has no interior NUL");
 
@@ -1512,8 +1520,7 @@ mod tests {
             "exclusive lock on a fresh file must succeed"
         );
 
-        drop(file); // closes the fd
-        let _ = std::fs::remove_file(&path);
+        drop(file); // closes the fd; `tmp` drops at end of scope, removing the dir
     }
 
     #[test]
@@ -1526,8 +1533,11 @@ mod tests {
         use crate::path::Path;
         use std::io::Write;
 
-        let base =
-            std::env::temp_dir().join(format!("iou_rawfs_{}_{}", std::process::id(), line!()));
+        // A subdirectory under a `tempfile::tempdir()` guard: `create_dir_all`
+        // creates it, and the guard removes the whole tree on drop even if an
+        // assertion panics before the explicit `remove_dir_all` below.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path().join("rawfs");
         let base_s = base.to_str().expect("utf8 temp path");
         let fs = IoUringRawFs::new(8).expect("fs setup");
         let dir = Path::new(base_s);
@@ -1564,6 +1574,45 @@ mod tests {
         assert!(!fs.exists(&fpath2).expect("file gone"));
         fs.remove_dir_all(dir).expect("remove_dir_all");
         assert!(!fs.exists(dir).expect("dir gone"));
+    }
+
+    #[test]
+    fn raw_file_append_writes_accumulate_at_eof() {
+        // O_APPEND writes always land at end of file: two sequential appends
+        // (across reopens) both persist, in order — exercising the kernel's
+        // atomic-append path (offset -1) the write impl uses for append mode.
+        use crate::fs::Fs;
+        use crate::path::Path;
+        use std::io::Write;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let p = tmp.path().join("log.bin");
+        let ps = p.to_str().expect("utf8 temp path");
+        let fs = IoUringRawFs::new(8).expect("fs setup");
+        let path = Path::new(ps);
+
+        {
+            let mut f = fs
+                .open(path, &FsOpenOptions::new().append(true).create(true))
+                .expect("open append");
+            f.write_all(b"aaa").expect("first append");
+            f.sync_all().expect("sync");
+        }
+        {
+            let mut f = fs
+                .open(path, &FsOpenOptions::new().append(true).create(true))
+                .expect("reopen append");
+            f.write_all(b"bbb").expect("second append");
+            f.sync_all().expect("sync");
+        }
+
+        let f = fs
+            .open(path, &FsOpenOptions::new().read(true))
+            .expect("open read");
+        let mut buf = [0u8; 6];
+        let n = f.read_at(&mut buf, 0).expect("read_at");
+        assert_eq!(n, 6, "both appends must be present");
+        assert_eq!(&buf, b"aaabbb", "appends land in order at EOF");
     }
 
     #[test]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -62,13 +62,14 @@ pub(crate) use std_fs::is_cross_device;
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 
-// Raw-syscall `no_std` io_uring driver core (#346). The `IoUringRawFs`
-// [`Fs`](crate::fs::Fs) backend built on top of it lands in follow-up work; the
-// driver is exposed now so feature-gated `no_std` consumers can drive the ring
-// directly.
+// Raw-syscall `no_std` io_uring driver core (#346) + the [`FsFile`] handle built
+// on it (`IoUringRawFile`). The `IoUringRawFs` [`Fs`](crate::fs::Fs) backend that
+// opens these files + handles directory operations lands in follow-up work; the
+// driver and file handle are exposed now so feature-gated `no_std` consumers can
+// drive the ring and use a file directly.
 #[cfg(all(target_os = "linux", feature = "io-uring-raw"))]
 pub use io_uring_raw::{
-    IoUringRaw, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, close_raw, open_raw,
+    IoUringRaw, IoUringRawFile, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, close_raw, open_raw,
 };
 
 // `Read` / `Write` / `Seek` come from `crate::io`, the local mirror

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -62,14 +62,15 @@ pub(crate) use std_fs::is_cross_device;
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring_fs::{IoUringFs, is_io_uring_available};
 
-// Raw-syscall `no_std` io_uring driver core (#346) + the [`FsFile`] handle built
-// on it (`IoUringRawFile`). The `IoUringRawFs` [`Fs`](crate::fs::Fs) backend that
-// opens these files + handles directory operations lands in follow-up work; the
-// driver and file handle are exposed now so feature-gated `no_std` consumers can
-// drive the ring and use a file directly.
+// Raw-syscall `no_std` io_uring driver (#346): the driver core (`IoUringRaw`),
+// the [`FsFile`] handle (`IoUringRawFile`), and the [`Fs`] backend
+// (`IoUringRawFs`) that opens files on a shared ring and handles directory
+// operations via plain blocking syscalls — all pure syscalls, no `io-uring`
+// crate and no `std::fs`.
 #[cfg(all(target_os = "linux", feature = "io-uring-raw"))]
 pub use io_uring_raw::{
-    IoUringRaw, IoUringRawFile, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, close_raw, open_raw,
+    IoUringRaw, IoUringRawFile, IoUringRawFs, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY,
+    close_raw, open_raw,
 };
 
 // `Read` / `Write` / `Seek` come from `crate::io`, the local mirror


### PR DESCRIPTION
## Summary

Builds the [`Fs`] / [`FsFile`] surface on top of the raw `no_std` io_uring driver core (slice-1, #471), so a Linux `no_std + alloc` consumer gets a full filesystem backend with **pure syscalls — no `io-uring` crate, no `std::fs`** (unlike the std-bound `IoUringFs`, which delegates cold paths to `std::fs::File`).

## What landed

- **`IoUringRawFile`** (`FsFile` + `Read`/`Write`/`Seek`): the hot read / write / fsync path goes through a shared ring (`Arc<spin::Mutex<IoUringRaw>>`, since ring ops take `&mut self` but `FsFile` hands out `&self`); a userspace cursor drives sequential I/O while `read_at` uses an explicit offset (fill-or-EOF + EINTR retry). Read/Write/Seek are cfg-split between `std::io` and the crate's `no_std` io traits, mirroring `MemFile`.
- **`IoUringRawFs`** (`Fs`): `open` maps `FsOpenOptions` to `open(2)` flags + wraps the fd with the shared ring; directory / path operations use plain blocking syscalls.
- **New raw syscall wrappers**: `statx` (architecture-independent struct → file type + size), `ftruncate`, `lseek`, `flock` (exclusive, non-blocking variant maps `EWOULDBLOCK` → `Ok(false)`), `mkdirat`, `unlinkat` (`AT_REMOVEDIR` for rmdir), `renameat2`, and `getdents64` (bounds-checked `linux_dirent64` record walk, no indexing).

`Fs` uses the crate's `no_std`-capable `Path` (`repr(transparent)` over `str`), so `IoUringRawFs` is `no_std`, not std-gated. Open flags use the asm-generic values; the MIPS/SPARC-divergent `O_APPEND`/`O_EXCL` are not remapped (same policy the `direct_io` doc already states).

## Verification

- Cross-compiles for `x86_64-unknown-linux-gnu` with `--features io-uring-raw` (0 errors / 0 warnings); clippy clean; host build unaffected (module is `cfg(all(target_os = "linux", feature = "io-uring-raw"))`).
- **Runner (Fedora, kernel 7.0.11): 9/9 io_uring_raw tests pass**, including `raw_file_fsfile_round_trips` (write / read_at / metadata / seek+read / set_len / fsync / try_lock) and `raw_fs_directory_and_file_ops` (create_dir_all / open+write / metadata / read_dir / rename / remove) — exercising every new syscall ABI on a real kernel.

## Scope

The driver (slice-1) is already on main via #471; this is the Fs/FsFile layer on top. The remaining epic item is a CI job that runs the io_uring_raw tests on a Linux runner.

Part of #346.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Linux-only `io-uring` raw filesystem backend, including new raw file support for read/write/seek, truncation, metadata/size queries, and exclusive file locking.
  * Added directory/path operations such as create, remove, rename, and existence/metadata lookup.
  * Supports append-mode writes to accumulate correctly across reopenings.
* **Tests**
  * Added integration tests for raw file round-trips, directory operations, and append-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->