### PR TITLE
perf(table): expand leb128 decode as a macro at call sites

### DIFF
--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -17,45 +17,71 @@ use core::marker::PhantomData;
 
 use crate::io::Cursor;
 
-/// Decodes one LEB128 varint directly from `buf` at `pos`, returning the value
-/// and the position just past it.
+/// Decodes one LEB128 varint from `$buf` at byte offset `$pos`, evaluating to
+/// `(u64, usize)`: the value and the position just past it.
 ///
-/// Reads through a plain slice index instead of `std::io::Cursor::read_u8` (a
-/// `read_exact` of one byte each), which is the hottest cost on the point-read
-/// path's block-entry parse. Rejects an overlong (> 64-bit) encoding, matching
-/// `VarintReader::read_u64_varint`.
-#[inline]
-pub fn read_leb128(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
-    // Fast path: a single-byte varint (value < 128) is by far the most common
-    // on the read path (small keys, seqnos, shared/rest lengths). One
-    // bounds-checked load, a compare, and a return — no loop setup.
-    let first = *buf.get(pos)?;
-    if first < 0x80 {
-        return Some((u64::from(first), pos + 1));
-    }
-    // Multi-byte continuation: fold in the low 7 bits already read, then loop.
-    let mut result = u64::from(first & 0x7f);
-    let mut shift = 7u32;
-    let mut p = pos + 1;
-    loop {
-        let byte = *buf.get(p)?;
-        p += 1;
-        // The 10th byte (shift == 63) can only carry bit 63; any higher payload
-        // bit (mask 0x7e) would overflow u64. Reject before folding it in so a
-        // corrupt overlong encoding fails the decode instead of silently
-        // truncating to a wrapped value.
-        if shift == 63 && (byte & 0x7e) != 0 {
-            return None;
+/// A macro, not a function, so the whole decode (single-byte fast path **and**
+/// the multi-byte continuation) expands inline at the call site. This is the
+/// hottest cost on the point-read path's block-entry parse, where several
+/// varints are decoded per entry; as a `#[inline]` function it still showed up
+/// as a standalone hot symbol (LLVM declined to inline the body once the loop
+/// made it large enough), so each varint paid a call. The macro removes that
+/// call for every case and lets the decode fuse with the caller's bounds checks
+/// and constants. Reads through a plain slice index (no `Cursor::read_u8`
+/// `read_exact`-per-byte) and rejects an overlong (> 64-bit) encoding, matching
+/// [`VarintReader::read_u64_varint`].
+///
+/// On a truncated buffer (`?` on the bounds-checked load) or an overlong
+/// encoding it returns `None` from the **enclosing** function, so every call
+/// site must sit in a function returning `Option`.
+macro_rules! read_leb128 {
+    ($buf:expr, $pos:expr) => {{
+        let buf: &[u8] = $buf;
+        let start: usize = $pos;
+        let first = *buf.get(start)?;
+        if first < 0x80 {
+            // Single-byte fast path (the common case: small keys, seqnos,
+            // shared/rest lengths). One bounds-checked load, a compare, done.
+            (u64::from(first), start + 1)
+        } else {
+            // Multi-byte continuation: fold in the low 7 bits already read,
+            // then loop. Block offsets / sizes routinely land here, so this
+            // path is inlined too rather than outlined.
+            let mut result = u64::from(first & 0x7f);
+            let mut shift = 7u32;
+            let mut p = start + 1;
+            loop {
+                let byte = *buf.get(p)?;
+                p += 1;
+                // The 10th byte (shift == 63) can only carry bit 63; any higher
+                // payload bit (mask 0x7e) would overflow u64. Reject before
+                // folding it in so a corrupt overlong encoding fails the decode
+                // instead of silently truncating to a wrapped value.
+                if shift == 63 && (byte & 0x7e) != 0 {
+                    return None;
+                }
+                result |= u64::from(byte & 0x7f) << shift;
+                if byte & 0x80 == 0 {
+                    break (result, p);
+                }
+                shift += 7;
+                if shift >= 64 {
+                    return None;
+                }
+            }
         }
-        result |= u64::from(byte & 0x7f) << shift;
-        if byte & 0x80 == 0 {
-            return Some((result, p));
-        }
-        shift += 7;
-        if shift >= 64 {
-            return None;
-        }
-    }
+    }};
+}
+pub(crate) use read_leb128;
+
+/// Function form of [`read_leb128!`] for the unit tests, which assert on the
+/// `Option` return directly. Returns the decoded `(value, position)` or `None`
+/// on a truncated or overlong encoding. Production call sites use the macro so
+/// the decode inlines; a non-test caller that prefers the function form can lift
+/// this out of the `cfg(test)` gate.
+#[cfg(test)]
+fn read_leb128_fn(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
+    Some(read_leb128!(buf, pos))
 }
 
 /// Validates that `restart_interval` and `binary_index_step_size` read from a
@@ -1264,22 +1290,23 @@ mod tests {
 
     #[test]
     fn read_leb128_rejects_overlong_10th_byte() {
-        use super::read_leb128;
+        use super::read_leb128_fn;
         // A 10-byte varint whose final payload byte exceeds 1 encodes a value
         // wider than u64. It must be rejected (None), not silently truncated
         // into a Some(_), or corruption in on-disk seqnos/lengths that every
         // slice-based parse path now decodes through read_leb128 goes
         // undetected. Nine continuation bytes (payload 0) + a terminating 10th
-        // byte with payload 2.
+        // byte with payload 2. `read_leb128_fn` is the function form of the
+        // `read_leb128!` macro (same body), exercised here.
         let overlong = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
         assert!(
-            read_leb128(&overlong, 0).is_none(),
+            read_leb128_fn(&overlong, 0).is_none(),
             "10-byte varint with 10th-byte payload > 1 overflows u64 and must be rejected",
         );
         // The boundary-valid case (10th-byte payload 1 → sets bit 63) is still
         // accepted and round-trips to 1 << 63, so the reject is not over-broad.
         let max_bit = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01];
-        assert_eq!(read_leb128(&max_bit, 0), Some((1u64 << 63, 10)));
+        assert_eq!(read_leb128_fn(&max_bit, 0), Some((1u64 << 63, 10)));
     }
 
     fn make_handles(count: usize) -> Vec<KeyedBlockHandle> {

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -44,10 +44,10 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
             return None;
         }
 
-        let (seqno, np) = read_leb128(buf, pos)?;
+        let (seqno, np) = read_leb128!(buf, pos);
         pos = np;
 
-        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        let (key_len_raw, np) = read_leb128!(buf, pos);
         pos = np;
         let key_len = usize::try_from(key_len_raw)
             .ok()
@@ -83,10 +83,10 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
 
         let value_type = ValueType::try_from(value_type).ok()?;
 
-        let (seqno, np) = read_leb128(buf, pos)?;
+        let (seqno, np) = read_leb128!(buf, pos);
         pos = np;
 
-        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        let (key_len_raw, np) = read_leb128!(buf, pos);
         pos = np;
         // key_len is encoded as a u16 varint on the wire.
         let key_len = usize::try_from(key_len_raw)
@@ -105,7 +105,7 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         let is_value = !value_type.is_tombstone();
 
         let val_len: usize = if is_value {
-            let (val_len_raw, np) = read_leb128(buf, pos)?;
+            let (val_len_raw, np) = read_leb128!(buf, pos);
             pos = np;
             // val_len is encoded as a u32 varint on the wire.
             usize::try_from(val_len_raw)
@@ -162,15 +162,15 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         }
         let value_type = ValueType::try_from(value_type).ok()?;
 
-        let (seqno, np) = read_leb128(buf, pos)?;
+        let (seqno, np) = read_leb128!(buf, pos);
         pos = np;
 
-        let (shared_raw, np) = read_leb128(buf, pos)?;
+        let (shared_raw, np) = read_leb128!(buf, pos);
         pos = np;
         let shared_prefix_len = usize::try_from(shared_raw)
             .ok()
             .filter(|&k| u16::try_from(k).is_ok())?;
-        let (rest_raw, np) = read_leb128(buf, pos)?;
+        let (rest_raw, np) = read_leb128!(buf, pos);
         pos = np;
         let rest_key_len = usize::try_from(rest_raw)
             .ok()
@@ -200,7 +200,7 @@ impl Decodable<DataBlockParsedItem> for InternalValue {
         let is_value = !value_type.is_tombstone();
 
         let val_len: usize = if is_value {
-            let (val_len_raw, np) = read_leb128(buf, pos)?;
+            let (val_len_raw, np) = read_leb128!(buf, pos);
             pos = np;
             usize::try_from(val_len_raw)
                 .ok()

--- a/src/table/index_block/block_handle.rs
+++ b/src/table/index_block/block_handle.rs
@@ -307,15 +307,15 @@ impl Decodable<IndexBlockParsedItem> for KeyedBlockHandle {
         // restart-table navigation: read_leb128 rejects an overlong offset,
         // and the size must fit u32 exactly as `parse_full` / `parse_truncated`
         // require.
-        let (_file_offset, np) = read_leb128(buf, pos)?;
+        let (_file_offset, np) = read_leb128!(buf, pos);
         pos = np;
-        let (size, np) = read_leb128(buf, pos)?;
+        let (size, np) = read_leb128!(buf, pos);
         u32::try_from(size).ok()?;
         pos = np;
-        let (seqno, np) = read_leb128(buf, pos)?;
+        let (seqno, np) = read_leb128!(buf, pos);
         pos = np;
 
-        let (key_len_raw, np) = read_leb128(buf, pos)?;
+        let (key_len_raw, np) = read_leb128!(buf, pos);
         pos = np;
         // key_len is encoded as a u16 varint on the wire; reject an overlong
         // value exactly as `read_u16_varint` did.


### PR DESCRIPTION
## Summary

`read_leb128` carried `#[inline]`, but the multi-byte continuation loop made the body large enough that LLVM declined to inline it — so on the point-read flamegraph it showed up as a **standalone hot self-time symbol (~5%)**: every block-entry parse decodes several varints, and each paid a real function call.

Replace the function with a `read_leb128!` macro that expands the whole decode (single-byte fast path **and** the multi-byte continuation) inline at every call site. This removes the call for all cases and lets the decode fuse with each caller's bounds checks and constants. The block-entry parsers in `data_block` (×9) and `index_block::parse_restart_key` (×4) now invoke the macro; decode behaviour (including the overlong-encoding reject) is unchanged.

## Why a macro and not `#[inline(always)]`

`#[inline]` is a hint LLVM can (and did) decline once the body grew past its threshold; a macro is textual expansion, so inlining is guaranteed. A naive hot/cold split (`#[inline(always)]` fast path + `#[cold] #[inline(never)]` multi-byte helper) is the wrong fix here: block **sizes** (e.g. 4096 → a 2-byte varint) and **offsets** are routinely multi-byte on the read path, so outlining the multi-byte path would add a call to the common case. The macro inlines every case, so there is no such penalty.

## Mechanics

The macro is a block expression evaluating to `(u64, usize)`; `?` on the bounds-checked load and the overlong-encoding `return None` propagate to the **enclosing** function, so every call site sits in a function returning `Option` (all 13 do). A `#[cfg(test)] read_leb128_fn` keeps the function form the overlong-reject unit test asserts on.

## Proof

Measured on a Linux bench runner, **pinned to dedicated cores** (`taskset`) so a concurrent CI benchmark on other cores could not contaminate it; criterion `--save-baseline`/`--baseline` back-to-back, 10 s measurement:

| group | baseline | macro | change |
|-------|----------|-------|--------|
| point_read/ours/1000 | 956.85 µs | **879.84 µs** | **−8.97%** (p < 0.05) |
| point_read/ours/10000 | 10.96 ms | **9.52 ms** | **−13.14%** (p < 0.05, CI ±0.2%) |

Both report "Performance has improved". 1234/1234 lib tests + the 136 decode/point-read tests pass; clippy clean.