### PR TITLE
perf(memtable): devirtualize the default comparator in skiplist search

### DIFF
--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -88,6 +88,11 @@ pub struct SkipMap {
     values: ValueStore,
     /// User key comparator for ordering entries.
     comparator: SharedComparator,
+    /// Cached `comparator.is_lexicographic()`, read once at construction.
+    /// Lets the per-comparison hot path (`compare_key`) take a direct,
+    /// inlinable `slice::cmp` for the default byte-ordering comparator instead
+    /// of an indirect `dyn` vtable call on every node visited during a search.
+    is_lexicographic: bool,
     /// Offset of the sentinel head node in the arena.
     head: u32,
     /// Current maximum height of any inserted node.
@@ -146,10 +151,12 @@ impl SkipMap {
             if p == 0 { 0xDEAD_BEEF } else { p }
         };
 
+        let is_lexicographic = comparator.is_lexicographic();
         Self {
             arena,
             values: ValueStore::new(),
             comparator,
+            is_lexicographic,
             head,
             height: AtomicUsize::new(1),
             len: AtomicUsize::new(0),
@@ -503,7 +510,18 @@ impl SkipMap {
         let node_uk = self.node_user_key_bytes(node);
         let target_uk: &[u8] = &target.user_key;
 
-        match self.comparator.compare(node_uk, target_uk) {
+        // Hot path: for the default byte-ordering comparator, compare the user
+        // keys with a direct `slice::cmp` (inlines to `memcmp`) instead of the
+        // `dyn` vtable call. This search visits O(log n) nodes per insert/lookup
+        // and is the dominant memtable-write cost, so removing the indirect call
+        // per visit matters. Custom comparators still go through the trait.
+        let uk_ord = if self.is_lexicographic {
+            node_uk.cmp(target_uk)
+        } else {
+            self.comparator.compare(node_uk, target_uk)
+        };
+
+        match uk_ord {
             CmpOrdering::Equal => {
                 // Reverse seqno: higher seqno sorts first.
                 let node_seq = self.node_seqno(node);
@@ -521,7 +539,14 @@ impl SkipMap {
     fn compare_nodes(&self, a: u32, b: u32) -> CmpOrdering {
         let a_uk = self.node_user_key_bytes(a);
         let b_uk = self.node_user_key_bytes(b);
-        match self.comparator.compare(a_uk, b_uk) {
+        // Same direct-`slice::cmp` fast path as `compare_key` for the default
+        // comparator (avoids the `dyn` vtable call per comparison).
+        let uk_ord = if self.is_lexicographic {
+            a_uk.cmp(b_uk)
+        } else {
+            self.comparator.compare(a_uk, b_uk)
+        };
+        match uk_ord {
             CmpOrdering::Equal => {
                 let a_seq = self.node_seqno(a);
                 let b_seq = self.node_seqno(b);

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -1045,6 +1045,58 @@ mod tests {
     }
 
     #[test]
+    fn custom_comparator_orders_and_reverse_iterates() {
+        // A non-lexicographic comparator (orders user keys in REVERSE byte
+        // order) exercises the trait-dispatch (`else`) branch of compare_key
+        // (via insert / find_splice) and compare_nodes (via reverse iteration /
+        // find_predecessor) — the paths the default lexicographic fast path
+        // skips.
+        #[derive(Debug)]
+        struct ReverseComparator;
+        impl crate::comparator::UserComparator for ReverseComparator {
+            fn name(&self) -> &'static str {
+                "reverse-test"
+            }
+            fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
+                b.cmp(a)
+            }
+            fn is_lexicographic(&self) -> bool {
+                false
+            }
+        }
+
+        let map = SkipMap::new(alloc::sync::Arc::new(ReverseComparator));
+        assert!(
+            !map.is_lexicographic,
+            "a custom comparator must take the trait-dispatch path"
+        );
+
+        map.insert(&make_key(b"aaa", 1), &make_value(b"a"));
+        map.insert(&make_key(b"ccc", 1), &make_value(b"c"));
+        map.insert(&make_key(b"bbb", 1), &make_value(b"b"));
+
+        // Forward iteration follows the custom (reverse) order.
+        let fwd: Vec<Vec<u8>> = map.iter().map(|e| e.key().user_key.to_vec()).collect();
+        assert_eq!(
+            fwd,
+            vec![b"ccc".to_vec(), b"bbb".to_vec(), b"aaa".to_vec()],
+            "custom comparator orders entries in reverse byte order"
+        );
+
+        // Reverse iteration (drives compare_nodes via find_predecessor) mirrors it.
+        let rev: Vec<Vec<u8>> = map
+            .iter()
+            .rev()
+            .map(|e| e.key().user_key.to_vec())
+            .collect();
+        assert_eq!(
+            rev,
+            vec![b"aaa".to_vec(), b"bbb".to_vec(), b"ccc".to_vec()],
+            "reverse iteration mirrors the custom order"
+        );
+    }
+
+    #[test]
     fn ordering_user_key_asc_seqno_desc() {
         let map = new_map();
 


### PR DESCRIPTION
## Summary

The skiplist's `compare_key` / `compare_nodes` dispatched user-key comparison through the `SharedComparator` trait object — a `dyn` vtable indirect call — on **every node visited** during a search (O(log n) per insert/lookup, on the hottest memtable path). The indirect call also blocks LLVM from inlining the underlying `memcmp`.

Cache `comparator.is_lexicographic()` once at construction and, for the default byte-ordering comparator (the overwhelmingly common case), compare the user keys with a direct `slice::cmp` instead of the vtable call. Custom comparators still go through the trait. Ordering semantics are unchanged.

## Why land it

Removing a per-comparison vtable indirect call on the hottest memtable-write path is an architecturally clean, zero-risk reduction of work — the kind of small hot-path win that compounds (many such gains sum into P99).

## Honest measurement note

I could **not** decisively prove a wall-clock win on the available shared bench runner, and I'm not going to claim one inside the noise:

- `db_bench fillrandom` wall-clock: ~1.5-2% median improvement, but the run-to-run distributions overlap (~5% spread on the pinned single-core bench) — at the noise floor.
- `db_bench` instruction counts are non-deterministic here (random keys → varying skiplist depth; even small-N fillseq varied ~6%), so they don't give a clean delta.
- The `memtable get` criterion microbench uses a non-deterministic (random) setup, so its cross-run comparison is meaningless (swings of ±20-90% between configs, not from this change).

What **is** solid: the change is mechanically a strict reduction (one indirect call + an un-inlined `memcmp` per comparison removed for the default comparator), and correctness is unchanged — the full **1234-test** lib suite passes and clippy is clean.

## Verification

- `cargo check --all-features`: clean.
- 1234/1234 lib tests pass; 86/86 skiplist/memtable tests pass; clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized skip list key comparisons by leveraging a cached lexicographic check to speed up common ordering paths, while keeping custom comparator behavior consistent.

* **Tests**
  * Added coverage for non-lexicographic custom comparators to confirm both forward and reverse iteration follow the expected custom ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->