### PR TITLE
feat(integrity): per-KV residence checksum at memtable insert

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,3 +359,9 @@ name = "scan_since"
 harness = false
 path = "benches/scan_since.rs"
 required-features = []
+
+[[bench]]
+name = "at_insert"
+harness = false
+path = "benches/at_insert.rs"
+required-features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ ribbon-serde = ["dep:serde"]
 #     cd tools/compare-rocksdb && cargo bench
 
 [dependencies]
-bytes = { version = "1", optional = true }
+bytes = { version = "1.11.1", optional = true }
 # Lockless atomic snapshot for RuntimeConfig (see src/runtime_config/).
 # Lock-free atomic Arc swap. `arc-swap` 1.x is NOT `#![no_std]` (it requires
 # `std`), so it stays an optional dependency enabled only by the `std`
@@ -152,7 +152,7 @@ spin = { version = "0.12", default-features = false, features = ["mutex", "spin_
 # backing each shard (alloc-only, no std dependency), replacing quick_cache's
 # std-bound map. `parking_lot::RwLock` is the per-shard lock under `std` (small,
 # userspace fast-path, concurrent readers); `spin::RwLock` is the no_std lock.
-hashbrown = { version = "0.16", default-features = false, features = ["default-hasher"] }
+hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }
 parking_lot = { version = "0.12", optional = true }
 lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 structured-zstd = { version = "0.0.40", optional = true, default-features = false, features = ["std", "lsm"] }

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 [![dependency status](https://deps.rs/repo/github/structured-world/coordinode-lsm-tree/status.svg)](https://deps.rs/repo/github/structured-world/coordinode-lsm-tree)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](#license)
 
-LSM-tree storage engine in Rust. Embedded library; provides keyed point reads, prefix and range scans, MVCC snapshots, compaction, and a block cache. No write-ahead log — durability is the caller's responsibility. Built for [CoordiNode](https://github.com/structured-world/coordinode); usable standalone.
+LSM-tree storage engine in Rust. Embedded library; provides keyed point reads, prefix and range scans, MVCC snapshots, compaction, and a block cache. No write-ahead log: durability is the caller's responsibility. Built for [CoordiNode](https://github.com/structured-world/coordinode); usable standalone.
 
 ## Status
 
-On-disk format version **V5**. V5 introduces a wire-format break for filter blocks (BuRR replaces Bloom); V3 and V4 databases are not readable by this version and vice versa. Versioning is single-monotonic — every breaking format change bumps to the next version with explicit migration notes.
+On-disk format version **V5**. V5 introduces a wire-format break for filter blocks (BuRR replaces Bloom); V3 and V4 databases are not readable by this version and vice versa. Versioning is single-monotonic: every breaking format change bumps to the next version with explicit migration notes.
 
 ## Features
 
@@ -21,14 +21,14 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 
 - Point reads via `get` / `multi_get` (batch-optimized).
 - `PinnableSlice` for zero-copy reads.
-- `BurrFilter` AMQ filter (Bumped Ribbon Retrieval, Walzer & Dillinger 2022): ~1% memory overhead vs the information-theoretic minimum — ~30% smaller filter blocks than a same-FPR Bloom filter, or ~10× tighter FPR at the same memory budget. Used for both per-key and per-prefix membership checks.
+- `BurrFilter` AMQ filter (Bumped Ribbon Retrieval, Walzer & Dillinger 2022): ~1% memory overhead vs the information-theoretic minimum: ~30% smaller filter blocks than a same-FPR Bloom filter, or ~10× tighter FPR at the same memory budget. Used for both per-key and per-prefix membership checks.
 - Forward and reverse range / prefix iteration.
 - Block cache with size cap.
 - File-descriptor cache to bound `fopen` syscalls.
 
 ### Write path
 
-- `WriteBatch` with seqno-grouped batch writes — caller-controlled atomic visibility.
+- `WriteBatch` with seqno-grouped batch writes: caller-controlled atomic visibility.
 - Single deletion tombstones (`remove_weak`).
 - Range tombstones (`delete_range` / `delete_prefix`).
 - Merge operators for commutative LSM operations.
@@ -46,8 +46,8 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 
 - Block-based tables with optional compression (none / LZ4 / Zstd) and prefix truncation.
 - Per-table data block size policy and per-table compression policy.
-- Optional **zstd dictionary compression** — trained per-table or per-column for small (4-64 KiB) blocks and blob files.
-- Optional **block-level encryption at rest** — AES-256-GCM, key supplied by caller.
+- Optional **zstd dictionary compression**, trained per-table or per-column for small (4-64 KiB) blocks and blob files.
+- Optional **block-level encryption at rest**: AES-256-GCM, key supplied by caller.
 - Optional per-table block hash indexes for faster point lookups [[3]](#footnotes).
 - Optional partitioned block index & filters for better cache efficiency [[1]](#footnotes).
 - Per-level filter/index block pinning configuration.
@@ -55,10 +55,10 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 ### Concurrency & API
 
 - Thread-safe `BTreeMap`-like API.
-- `SequenceNumberGenerator` trait — pluggable seqno source.
+- `SequenceNumberGenerator` trait: pluggable seqno source.
 - Custom `UserComparator` for non-lexicographic ordering.
 - MVCC: snapshot reads at a chosen `SeqNo`.
-- Point-in-time recovery snapshots via `Tree::create_checkpoint` — hard-link
+- Point-in-time recovery snapshots via `Tree::create_checkpoint`: hard-link
   every live SST + blob file into a fresh directory in O(1) per file, zero
   extra disk until the source files compact away. Compaction continues
   during the checkpoint (deletions are deferred), and the resulting
@@ -68,7 +68,7 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 
 - 100% stable Rust, MSRV 1.92.
 - No FFI: zstd via [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust), LZ4 via `lz4_flex`, AES via `aes-gcm`.
-- Pluggable `Fs` trait — back the engine on the standard filesystem, on `io_uring`, on an in-memory `MemFs`, or on a custom implementation.
+- Pluggable `Fs` trait: back the engine on the standard filesystem, on `io_uring`, on an in-memory `MemFs`, or on a custom implementation.
 - Pluggable `CompressionProvider` for third-party codecs.
 
 ## Incremental scan / CDC
@@ -88,7 +88,7 @@ sparse-change workload (e.g. 1% of data changed since the last poll) this turns
 an O(data) scan into O(changed blocks). Trees with a mix of seqno-bounded and
 legacy SSTs are scanned transparently (legacy blocks fall back to a per-entry
 filter), so the policy can be enabled on a live tree and takes effect as
-compaction rewrites SSTs — no migration step, no format-version bump.
+compaction rewrites SSTs: no migration step, no format-version bump.
 
 | Engine | CDC granularity | Survives compaction | Embeddable | Block-skip |
 |--------|-----------------|---------------------|------------|------------|
@@ -117,9 +117,9 @@ All optional, all off by default. The default build is the minimal core (no comp
 | `lz4` | [`lz4_flex`](https://github.com/PSeitz/lz4_flex) | Block compression wanted, decompression latency matters more than ratio. |
 | `zstd` | [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust, no FFI) | Block compression wanted, ratio matters more than absolute decompression speed. Supports `CompressionType::Zstd` and dictionary-mode `CompressionType::ZstdDict`. Decompression is ~2-3.5× slower than C reference. |
 | `encryption` | `aes-gcm`, `rand_chacha` | AES-256-GCM block encryption at rest. Keys are caller-managed. |
-| `io-uring` (linux only) | [`io-uring`](https://github.com/tokio-rs/io-uring) | I/O-bound workload on a modern Linux kernel — adds an `io_uring` `Fs` backend. |
+| `io-uring` (linux only) | [`io-uring`](https://github.com/tokio-rs/io-uring) | I/O-bound workload on a modern Linux kernel: adds an `io_uring` `Fs` backend. |
 | `bytes_1` | [`bytes`](https://github.com/tokio-rs/bytes) | Consumer already speaks `bytes::Bytes` (tokio/hyper/tonic stack) and wants zero-copy interop with engine slices. |
-| `metrics` | — | Production observability or profiling. Compiles in atomic counters around block I/O, filter probes, compaction, and cache hit rates (`tree.metrics()`). Small but non-zero hot-path cost. |
+| `metrics` | (none) | Production observability or profiling. Compiles in atomic counters around block I/O, filter probes, compaction, and cache hit rates (`tree.metrics()`). Small but non-zero hot-path cost. |
 | `ribbon-serde` | `serde` | Snapshotting the internal `RibbonFilterRepr` for debugging or out-of-band transport. Not used by the on-disk format. |
 
 ## Benchmarks
@@ -151,60 +151,22 @@ cargo run --release --features flamegraph -- \
 | [`tools/db_bench`](tools/db_bench) | RocksDB-compatible benchmark suite, also drives the CI perf dashboard. |
 | [`tools/sst-dump`](tools/sst-dump) | Inspect / verify a single SST file out-of-band. Subcommands: `verify` (walk every block, check per-block XXH3, exit non-zero on corruption), `properties` (print the SST's stored metadata: id, key range, KV / tombstone counts, block counts, compression, timestamp), `hex <offset>` (raw hex dump of a region with optional `Header` decode; useful for inspecting a specific offset flagged by `verify --verbose`), `index-dump` (print TLI entries: end_key + offset + size + seqno per pointed-at block; useful for diagnosing range-read fan-out), `dump` (stream every KV entry to stdout with optional `--from` / `--to` / `--max=N` / `--keys-only` filters; full-index SSTs only), `filter-stats` (print BuRR filter sizing: section bytes, layer count, item count, approximate bits-per-key; single-block filters only, partitioned filters not yet supported). |
 
-## Manifest hardening
+## Data integrity & durability
 
-The per-version manifest file (`v{N}`) is stored as a sequence of standard lsm-tree `Block`s — one `BlockType::Manifest` Block per section, plus a `BlockType::ManifestFooter` Block at the tail carrying the table of contents and the manifest layout version. Every Block goes through the same XXH3-128 / optional ECC / optional AEAD pipeline data Blocks use, so every protection that applies to a data Block automatically applies to the manifest.
+Every record is checksummed end to end, from the in-memory memtable, through
+each on-disk block, to the manifest, with optional Reed-Solomon ECC,
+self-healing scrub, and AAD-bound encryption at rest. Off by default,
+byte-identical when disabled; turned on, detection becomes recovery.
 
-Five layers compose the manifest's integrity surface. L1 and L4 are always on as part of the on-disk format; L2, L3, and L5 are independently configurable (compile-time feature, encryption provider, or runtime config):
+This is the tamper-evident, silent-corruption protection that clinical and
+regulated systems require: the integrity controls behind HIPAA §164.312(c),
+FDA 21 CFR Part 11, and ALCOA+.
 
-| Layer | Defends against | Config knob | Default |
-|-------|-----------------|-------------|---------|
-| L1 — Block XXH3-128 | Bit-rot detection per section / footer Block | Always on (`Block` invariant) | always on |
-| L2 — Page ECC (Reed-Solomon (4, 2)) | Bit-rot recovery per Block | `RuntimeConfig::page_ecc` for **manifest Blocks** (current release) + `Config::page_ecc` for **SST data Blocks** (compile-time `page_ecc` feature gates both) | off (opt-in) |
-| L3 — AEAD encryption | Tampering detection + confidentiality | `Config::with_encryption(provider)` | off |
-| L4 — Footer Block tail hint | Reader locates footer without scanning | Always on (trailing `u32` size hint) | always on |
-| L5 — Head footer mirror | Partial-write / tail-bit-rot recovery via mirrored copy at offset 0 | `RuntimeConfig::manifest_footer_mirror` | on |
-
-Manifest-side ECC and the head mirror are reachable through `Tree::update_runtime_config` (for L2 *on manifest Blocks* and L5); SST data-block ECC is tree-static via `Config::page_ecc` at open time and not affected by runtime updates. AEAD is supplied at open via `Config::with_encryption` (L3). Runtime toggles take effect on the next manifest write, and existing on-disk manifests stay readable in their original format because each Block self-describes via its header.
-
-Failure-mode coverage with the defaults (mirror on, ECC off, AEAD off):
-
-- **Bit-flip inside one section Block** → XXH3 surfaces it, other sections + the footer Block still read correctly (per-section isolation; see [`manifest_blocks::reader::tests::reader_isolates_corruption_to_one_section_other_sections_readable`](src/manifest_blocks/reader.rs)).
-- **Tail footer Block corruption** → reader falls back to the head mirror at offset 0 and continues.
-- **Partial write mid-update on a fresh `v{N+1}`** → the prior version's manifest stays intact in its own `v{N}` file, and the atomic `CURRENT` rewrite either lands fully (pointing at `v{N+1}`) or stays at `v{N}`. A torn or truncated `v{N+1}` file is detected at open time: the reader's tail-footer + head-mirror probes both fail and `Tree::open` surfaces `ManifestFooterInvalid`. The head mirror inside each `v{N}` is a copy of THAT file's own tail footer Block (for tail-bit-rot recovery within one version), not a snapshot of a prior version's TOC.
-- **Accidental file substitution / mislinking** → the `CURRENT` pointer carries an XXH3-128 of the referenced `v{N}` manifest's canonical footer content (version_id + TOC entries + per-section XXH3-128 each section Block already carries in its own header); `Tree::open` recomputes this from the parsed footer on read and refuses to follow a mismatched pointer. The digest binds logical content, not raw bytes — a section bit-flip that per-Block Page ECC heals on read does NOT trip this check (the section's TOC checksum is unchanged), preserving recovery. XXH3-128 is **not** a cryptographic MAC: an adversary with write access can craft matching content. Enable `Config::with_encryption(...)` (AEAD per Block) for adversarial tamper resistance.
-
-Turning ECC on (`page_ecc = true`) upgrades the first three rows from "detect and refuse" to "detect and recover" without any change to call sites — the Block layer transparently emits / consumes the parity trailer per Block.
-
-## Manifest recovery modes
-
-`Config::manifest_recovery_mode` controls how the engine reacts to a malformed MANIFEST record at `Tree::open` time. Each mode trades a different point on the **strictness ↔ availability** axis; pick the one whose contract matches the deployment.
-
-| Mode | Behaviour on corruption | When to use |
-|------|-------------------------|-------------|
-| `AbsoluteConsistency` (default) | Any per-record decode mismatch (bad XXH3, invalid tag, truncated TOC entry, declared-count overrun) aborts the open with the original error. No data is silently dropped. | **Production default.** Surfaces every byte of corruption before the tree comes back online; matches what most workloads actually want. |
-| `TolerateCorruptedTailRecords` | If the iteration over `tables` / `blob_files` runs out of bytes before the declared count is reached (truncated tail), keep everything that decoded cleanly before the cut and emit a `warn!` listing the dropped count. Any mid-record error that is NOT a clean tail truncation (bad checksum, etc.) still aborts. | **Power-loss-at-write-tail salvage.** Use when a crash mid-fsync left the MANIFEST tail incomplete and you'd rather come up with the last consistent prefix than refuse to open. Not a general bit-rot tolerance, only "the writer never finished". |
-| `PointInTimeRecovery` | On the first record-decode mismatch inside the `tables` section, keeps the consistent prefix collected so far (records that decoded cleanly BEFORE the corrupt one in the current run, plus complete earlier runs in the same level, plus complete earlier levels) and drops everything after. "Record-decode mismatch" covers all three failure shapes the per-record loop produces: (a) framing-layer XXH3 mismatch, (b) framing-header structural failure (`len > MAX_FRAME_PAYLOAD`), and (c) payload-decode failure inside an otherwise-framed-OK record (e.g. `InvalidTag` from a corrupt `checksum_type` byte — the framing XXH3 happens to cover the corrupt byte, so the bytes pass the framing layer; the corruption only surfaces at per-entry decode). Analogous treatment on `blob_files`. Tail-truncation is still tolerated like `TolerateCorruptedTailRecords`. | **Post-corruption salvage with LSM invariants intact.** Use when a manifest has acquired real bit-rot (not just a truncated write) and you want the largest internally-consistent prefix the engine can still vouch for; matches RocksDB's `kPointInTimeRecovery` accept-the-prefix rule adapted to the level/run/table nesting. |
-| `SkipAnyCorruptedRecords` | On any per-record decode mismatch (framing-layer XXH3 mismatch, payload-decode failure inside an otherwise-framed-OK record, or framing-header `BadHeader`), logs the skip and advances past the bad record using the framing-supplied length field. If the framing header itself is corrupt (length field outside the legal range, so the next-record boundary cannot be located), the rest of that section is dropped — there's no safe way to find the next record boundary in that case. Symmetric on `tables` and `blob_files`. | **Maximum-availability forensic mode.** Use when you'd rather open the tree with whatever survives than refuse to open at all; pairs with the `repair_db` tooling tracked in [#303](https://github.com/structured-world/coordinode-lsm-tree/issues/303) for the cases where even the surviving records aren't enough. |
-
-When a non-default mode drops records, the recovery path logs `warn!` lines describing what was tolerated. Individual table-IDs / blob-file-IDs are NOT enumerated because they were never decoded. Warnings fall into two categories:
-
-**Per-condition warns** (one warn for each malformed shape encountered, at the point of detection):
-
-- `tables` section truncated before the `level_count` byte → tail-tolerant mode produces 0 levels.
-- `tables` declared `table_count` exceeds remaining section payload (count header forged or entries truncated) → loop walks bytes-actually-present and stops at the first EOF.
-- `blob_files` section truncated before its count header → 0 blob files.
-- `blob_files` declared count exceeds remaining section capacity → same forged-or-truncated shape, same walk-and-stop fallback.
-- `blob_gc_stats` payload truncated (power-loss between the `blob_files` commit and the `blob_gc_stats` payload landing) → tail-tolerant mode produces an empty `FragmentationMap`. GC stats are advisory (fragmentation re-accrues on the next compaction pass), so this is a "rebuild on next pass" outcome, not data loss. This is a single in-place warn with no later summary.
-
-**Per-section summary warns** (at end of section processing, only if the section actually lost records):
-
-- `tables` section, emitted only when `tables_dropped_to_tail > 0` OR `tables_truncated_headers > 0`. Reports two counters in one line: declared-but-missing table records (count header said N, only K < N records read before EOF → N-K dropped) and the separate counter for level / run / `table_count` headers cut mid-byte (no records were supposed to be present yet for those levels / runs, so the headers contribute zero to record loss but the levels / runs themselves are absent).
-- `blob_files` section, emitted only when `blob_dropped_to_tail > 0`. Reports the declared-but-missing blob-file records count, analogous to the tables-section record-drop counter. A `blob_files` section whose only damage was a missing count header surfaces the per-condition warn above but does NOT add a summary line.
-
-Operators wanting a per-record audit trail should pair a tail-tolerant open with an out-of-band integrity scan (see `verify::verify_integrity` / `tools/sst-dump verify`).
-
-For workflows where the MANIFEST is unrecoverable even under the lossy modes, the planned `repair_db` tool ([#303](https://github.com/structured-world/coordinode-lsm-tree/issues/303)) will rebuild the MANIFEST from the SST files themselves.
+See **[docs/data-integrity.md](docs/data-integrity.md)** for the full integrity
+stack: block + per-KV checksums (including memtable-residence RAM bit-flip
+detection), the Page ECC spectrum, self-healing scrub, tamper-evident
+encryption, the five-layer manifest hardening surface, and the manifest
+recovery modes.
 
 ## Support the project
 
@@ -218,13 +180,13 @@ USDT (TRC-20): `TFDsezHa1cBkoeZT5q2T49Wp66K8t2DmdA`
 
 ## Credits
 
-Originally created by Marvin Blum as part of [fjall-rs/lsm-tree](https://github.com/fjall-rs/lsm-tree); this codebase carries the original copyright (`Copyright (c) 2024-present, fjall-rs`). The vendored Ribbon filter (`src/table/filter/ribbon/`) is by [William Rågstad](https://github.com/WilliamRagstad) — see [`src/table/filter/ribbon/_vendored/`](src/table/filter/ribbon/_vendored/) for the upstream license texts.
+Originally created by Marvin Blum as part of [fjall-rs/lsm-tree](https://github.com/fjall-rs/lsm-tree); this codebase carries the original copyright (`Copyright (c) 2024-present, fjall-rs`). The vendored Ribbon filter (`src/table/filter/ribbon/`) is by [William Rågstad](https://github.com/WilliamRagstad); see [`src/table/filter/ribbon/_vendored/`](src/table/filter/ribbon/_vendored/) for the upstream license texts.
 
 ## License
 
 All source code is licensed under [Apache-2.0](LICENSE-APACHE). Each first-party `.rs` file carries an `SPDX-License-Identifier: Apache-2.0` header alongside the original-author copyright and the maintainer copyright (Structured World Foundation). Contributions are accepted under the same license.
 
-The vendored Ribbon filter (`src/table/filter/ribbon/`) keeps its upstream layout — it carries William Rågstad's per-module licensing commentary rather than per-file SPDX headers, plus the original `LICENSE-APACHE` and `LICENSE-MIT` preserved verbatim in `src/table/filter/ribbon/_vendored/`. The upstream crate is dual-licensed (`MIT OR Apache-2.0`); we redistribute the vendored copy only under the Apache-2.0 arm per Apache-2.0 §4.
+The vendored Ribbon filter (`src/table/filter/ribbon/`) keeps its upstream layout: it carries William Rågstad's per-module licensing commentary rather than per-file SPDX headers, plus the original `LICENSE-APACHE` and `LICENSE-MIT` preserved verbatim in `src/table/filter/ribbon/_vendored/`. The upstream crate is dual-licensed (`MIT OR Apache-2.0`); we redistribute the vendored copy only under the Apache-2.0 arm per Apache-2.0 §4.
 
 Maintained by [Structured World Foundation](https://sw.foundation).
 

--- a/benches/at_insert.rs
+++ b/benches/at_insert.rs
@@ -101,14 +101,30 @@ fn bench_at_insert_write(c: &mut Criterion) {
     for &(label, policy, algo, cp) in arms {
         group.bench_function(label, |b| {
             b.iter_custom(|iters| {
-                use std::time::Instant;
-                let started = Instant::now();
+                use std::time::{Duration, Instant};
+                // Time each insert+flush separately so the per-operation tail
+                // (P99/P999) is observable, not only Criterion's aggregate
+                // throughput. The sum of the per-op durations is returned as
+                // the total Criterion needs.
+                let mut samples = Vec::with_capacity(iters as usize);
                 for _ in 0..iters {
+                    let op_start = Instant::now();
                     let (dir, tree) = open_tree(policy, algo, cp);
                     insert_and_flush(&tree, n);
                     std::hint::black_box(&dir);
+                    samples.push(op_start.elapsed());
                 }
-                started.elapsed()
+                samples.sort_unstable();
+                let pct = |per_mille: usize| {
+                    samples[(samples.len() * per_mille / 1000).min(samples.len() - 1)]
+                };
+                eprintln!(
+                    "{label}: p50={:?} p99={:?} p999={:?}",
+                    pct(500),
+                    pct(990),
+                    pct(999),
+                );
+                samples.into_iter().fold(Duration::ZERO, |acc, d| acc + d)
             });
         });
     }

--- a/benches/at_insert.rs
+++ b/benches/at_insert.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Write-throughput cost of the per-KV insert-time digest
+//! (`KvChecksumComputePoint::AtInsert`).
+//!
+//! Three head-to-head insert + flush arms over the same workload:
+//!   - `off`: no per-KV checksums (the default, zero-overhead path). This is
+//!     also the pre-feature baseline: with the digest path disabled the insert
+//!     does only a cheap runtime-config load and two enum checks.
+//!   - `at_block_compile`: `kv_checksums = AllLevels` with the default
+//!     `AtBlockCompile`: per-KV footer on disk, no memtable-insert cost.
+//!   - `at_insert`: `AllLevels` + `AtInsert` + a 4-byte algorithm: the digest
+//!     is computed at insert and verified at flush (the residence check).
+//!
+//! The residence check is a deliberate extra hash pass over the memtable at
+//! flush: it verifies the AS-INSERTED entries (pre-merge), which is a distinct
+//! scope from the on-disk footer digest (computed over post-merge / post-filter
+//! bytes by the writer). The two cannot be fused without breaking correctness
+//! under a merge operator, where the flushed value differs from any single
+//! inserted value. So `at_insert` carries the per-insert digest cost plus this
+//! one verify pass; `off` is indistinguishable from a no-per-KV baseline (the
+//! digest path never runs).
+
+#![expect(
+    clippy::expect_used,
+    reason = "benchmark setup favors concise panic messages"
+)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lsm_tree::runtime_config::{
+    ChecksumAlgorithm, KvChecksumComputePoint, KvChecksumPolicy, RuntimeConfig,
+};
+use lsm_tree::{AbstractTree, AnyTree, Config, SequenceNumberCounter, Tree};
+use tempfile::TempDir;
+
+/// Opens a fresh tree configured with the given per-KV checksum knobs.
+fn open_tree(
+    policy: KvChecksumPolicy,
+    algo: ChecksumAlgorithm,
+    compute_point: KvChecksumComputePoint,
+) -> (TempDir, Tree) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut rc = RuntimeConfig::default();
+    rc.kv_checksums = policy;
+    rc.kv_checksum_algo = algo;
+    rc.kv_checksum_compute_point = compute_point;
+    let any = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_runtime_config(rc)
+    .open()
+    .expect("open");
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    (dir, tree)
+}
+
+/// Insert `n` entries and flush once (the flush runs the AtInsert residence
+/// verify when that arm is active).
+fn insert_and_flush(tree: &Tree, n: u64) {
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), b"value-payload", i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+}
+
+fn bench_at_insert_write(c: &mut Criterion) {
+    let n = 20_000u64;
+    let arms: &[(
+        &str,
+        KvChecksumPolicy,
+        ChecksumAlgorithm,
+        KvChecksumComputePoint,
+    )] = &[
+        (
+            "off",
+            KvChecksumPolicy::Off,
+            ChecksumAlgorithm::Xxh3_64,
+            KvChecksumComputePoint::AtBlockCompile,
+        ),
+        (
+            "at_block_compile",
+            KvChecksumPolicy::AllLevels,
+            ChecksumAlgorithm::Xxh3Low32,
+            KvChecksumComputePoint::AtBlockCompile,
+        ),
+        (
+            "at_insert",
+            KvChecksumPolicy::AllLevels,
+            ChecksumAlgorithm::Xxh3Low32,
+            KvChecksumComputePoint::AtInsert,
+        ),
+    ];
+
+    let mut group = c.benchmark_group("at_insert/write_throughput");
+    for &(label, policy, algo, cp) in arms {
+        group.bench_function(label, |b| {
+            b.iter_custom(|iters| {
+                use std::time::Instant;
+                let started = Instant::now();
+                for _ in 0..iters {
+                    let (dir, tree) = open_tree(policy, algo, cp);
+                    insert_and_flush(&tree, n);
+                    std::hint::black_box(&dir);
+                }
+                started.elapsed()
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_at_insert_write);
+criterion_main!(benches);

--- a/docs/data-integrity.md
+++ b/docs/data-integrity.md
@@ -1,0 +1,279 @@
+# Data integrity & durability
+
+Every record this engine stores is checksummed end to end: from the in-memory
+memtable, through each on-disk data block, to the manifest that ties a version
+together. On top of that detection layer the engine offers optional Reed-Solomon
+error correction, a self-healing scrub, and AAD-bound encryption at rest. The
+default configuration detects silent corruption everywhere and refuses to serve
+or commit data it cannot vouch for; opt-in layers turn detection into recovery.
+
+This document is the full map of that surface: what each layer protects against,
+how to configure it, and how the engine behaves when it meets corruption it can
+and cannot recover from.
+
+## End-to-end integrity at a glance
+
+| Stage | Mechanism | Detects | Corrects | Default |
+|-------|-----------|---------|----------|---------|
+| Memtable (RAM) | Per-KV digest at insert (`AtInsert`) | RAM bit-flip during a record's memtable residence | n/a | off (opt-in) |
+| Data block (disk) | Block XXH3-128 | Bit-rot of the block as written | n/a | always on |
+| Data block (disk) | Per-KV digest footer (`AtBlockCompile`) | Which record in a block diverged | n/a | off (opt-in) |
+| Data block (disk) | Page ECC parity trailer | Bit-rot of the block | yes (SEC-DED / XOR / Reed-Solomon) | off (opt-in) |
+| Data block (disk) | AAD-bound AEAD | Tampering, block-swap, codec/epoch relabel + confidentiality | n/a | off (opt-in) |
+| Manifest | 5-layer hardening (XXH3-128 + ECC + AEAD + footer mirror) | Bit-rot, partial write, file substitution | partial (ECC / mirror) | mirror on, rest opt-in |
+| On open | Manifest recovery modes | Malformed manifest records | salvage prefix (mode-dependent) | `AbsoluteConsistency` |
+| Out of band | `verify_integrity`, `patrol_scrub`, `sst-dump verify`, `Config::repair` | Latent corruption anywhere | scrub heals; repair rebuilds manifest | n/a |
+
+The rest of this document details each layer.
+
+## Block checksums (always on)
+
+Every on-disk `Block` (data, index, filter, manifest section, footer) carries an
+XXH3-128 over its on-disk bytes in its header. The read path verifies it before
+decoding, so a single flipped bit on disk surfaces as a typed
+`Error::ChecksumMismatch` rather than a silently wrong value. This baseline is
+part of the on-disk format and cannot be turned off: it is the floor every other
+layer builds on.
+
+## Per-KV checksums
+
+Block-level XXH3 covers the bytes as written to disk, but only as one digest over
+the whole block. A per-KV checksum gives finer protection: it pinpoints the
+corrupt **entry** rather than just the block, and (at insert) also covers the
+record's lifecycle in RAM.
+
+Configured through `RuntimeConfig` (live-toggleable via
+`Tree::update_runtime_config`; a change takes effect on the next flush /
+compaction, so compaction migrates the choice without downtime):
+
+- **`kv_checksums: KvChecksumPolicy`** selects which data blocks get a per-entry
+  checksum footer:
+  - `Off` (default): no per-KV footer, zero overhead.
+  - `AllLevels`: every data block on every level.
+  - `PerLevel(LevelMask)`: only the selected LSM levels (e.g. the hot tier), so
+    cold archival levels skip the per-entry cost.
+  - `PerTable(TableIdRange)`: only an inclusive table-id span (e.g. a
+    compliance-sensitive table) opts in.
+- **`kv_checksum_algo: ChecksumAlgorithm`** selects the digest: `Xxh3_64` (8-byte,
+  fastest on SIMD hardware, default), `Xxh3Low32` (the same digest truncated to 4
+  bytes), or `Crc32c` (4-byte, `crc32c` cargo feature).
+- **`kv_checksum_compute_point: KvChecksumComputePoint`** selects *when* the
+  digest is computed:
+  - `AtBlockCompile` (default): at flush / compaction. No memtable overhead;
+    covers the on-disk lifecycle but not the memtable-residence window.
+  - `AtInsert`: at `tree.insert` / `WriteBatch` insert, then re-checked at flush.
+    Closes the memtable-residence window, so a RAM bit-flip that corrupts a
+    record while it sits in the memtable (the seconds-to-minutes before flush) is
+    caught and surfaced as `Error::MemtableKvChecksumMismatch`. Requires a 4-byte
+    algorithm so the digest fits the skiplist node's reserved slot with zero size
+    growth; the algorithm is stored per node, so a mid-memtable algorithm change
+    cannot misverify earlier records.
+
+### Footer-wrapped layout
+
+A per-KV-checked data block is a standard `Data` block payload, byte-for-byte
+identical to a plain block, followed by a trailing footer:
+
+```text
+[ standard Data-block payload ]
+[ kv_checksums_array: count × digest_size ]   little-endian digests
+[ kv_checksum_algorithm: u8 ]                 ChecksumAlgorithm wire tag
+[ kv_count: u32 ]                             entry count, little-endian
+```
+
+Wrapping rather than prefixing keeps the inner payload identical to a plain data
+block, so the standard decoder / point-read / seek paths run on the inner slice
+unchanged. The reader splits the footer off the end and verifies per-entry
+digests only on the scrub / paranoid path; the block-level XXH3 already covers
+the on-disk bytes on the hot read path. Footer presence is learned out of band
+from the per-SST meta descriptor, so the hot paths never test a per-block flag.
+
+### Digest domain
+
+Each digest covers the entry's **logical content**, not its on-disk encoding:
+`value_type ‖ seqno (LE u64) ‖ len(user_key) (LE u32) ‖ user_key ‖ value`. The
+explicit `len(user_key)` frame keeps the domain injective across the key/value
+boundary. Because the domain is logical, it is invariant to restart-interval
+re-encoding, so a record's digest is reproduced every time a compaction re-packs
+it: recompute and carry always agree, which is what lets `AtInsert` verify a
+record at flush against the digest fixed at insert.
+
+## Page ECC (correction at rest)
+
+Where per-KV checksums and block XXH3 *detect* corruption, Page ECC *corrects*
+it. It adds a parity trailer outside the block payload (so the inner block stays
+decodable as-is) and is verified by the block's own XXH3 before decompress. ECC
+is off by default; enable it with the `page_ecc` cargo feature plus
+`Config::page_ecc` (SST data blocks, tree-static at open) and/or
+`RuntimeConfig::page_ecc` (manifest blocks, live). `RuntimeConfig::ecc_scheme`
+selects the algorithm, ordered cheapest-first:
+
+- **`Secded`**: Hsiao SEC-DED per word: single-bit correct + double-bit detect.
+  The cheap fast path that heals the overwhelmingly common single-bit flip before
+  any heavier scheme runs.
+- **`Xor`**: one XOR parity shard over `data_shards` data shards. Recovers a
+  single lost or garbled shard.
+- **`ReedSolomon { data_shards, parity_shards }`**: `parity_shards` Reed-Solomon
+  parity shards (needs `>= 2`; single parity is expressed as `Xor`). Recovers up
+  to `parity_shards` simultaneously corrupt shards.
+
+Turning ECC on upgrades the detection layers from "detect and refuse" to "detect
+and recover" with no change to call sites: the block layer transparently emits
+and consumes the parity trailer.
+
+## Self-healing
+
+ECC corrects on read, but a corrected-on-read block is still corrupt on disk
+until it is rewritten. Two mechanisms close that loop:
+
+- **Auto-heal** (`RuntimeConfig::auto_heal`): after a read repairs a block via
+  ECC, schedule a compaction rewrite so the healed bytes land on disk.
+  Correction-on-read happens whether or not auto-heal is on; auto-heal only adds
+  the durable rewrite.
+- **Patrol scrub** (`scrub::patrol_scrub(tree, &options) -> PatrolScrubReport`):
+  a proactive sweep that reads every block to surface latent errors before a
+  reader hits them, healing along the way when auto-heal is enabled. Run it on a
+  schedule (leader-only in a clustered deployment) to keep cold data from
+  accumulating undetected bit-rot.
+
+## Tamper-evident encryption at rest
+
+Block encryption is AAD-bound: the AEAD additional-authenticated-data binds each
+block's identity and transform context, so confidentiality comes with tamper
+evidence. Beyond plain content tampering (any AEAD catches that), the AAD binding
+detects block-swap (intra/inter-table), dictionary substitution, key-epoch
+downgrade, cipher-suite downgrade, and compression-type relabel; each surfaces as
+a typed decrypt error instead of a silently wrong plaintext. Enable it with
+`Config::with_encryption(provider)` (AES-256-GCM or ChaCha20-Poly1305); off by
+default, byte-identical to the non-encrypted format when disabled.
+
+The exact wire format, AAD field layout, and the full threat-model matrix are
+documented in **[aad-block-format.md](aad-block-format.md)**.
+
+## Manifest hardening
+
+The per-version manifest file (`v{N}`) is stored as a sequence of standard
+lsm-tree `Block`s: one `BlockType::Manifest` Block per section, plus a
+`BlockType::ManifestFooter` Block at the tail carrying the table of contents and
+the manifest layout version. Every Block goes through the same XXH3-128 /
+optional ECC / optional AEAD pipeline data Blocks use, so every protection that
+applies to a data Block automatically applies to the manifest.
+
+Five layers compose the manifest's integrity surface. L1 and L4 are always on as
+part of the on-disk format; L2, L3, and L5 are independently configurable
+(compile-time feature, encryption provider, or runtime config):
+
+| Layer | Defends against | Config knob | Default |
+|-------|-----------------|-------------|---------|
+| L1, Block XXH3-128 | Bit-rot detection per section / footer Block | Always on (`Block` invariant) | always on |
+| L2, Page ECC (Reed-Solomon (4, 2)) | Bit-rot recovery per Block | `RuntimeConfig::page_ecc` for **manifest Blocks** (current release) + `Config::page_ecc` for **SST data Blocks** (compile-time `page_ecc` feature gates both) | off (opt-in) |
+| L3, AEAD encryption | Tampering detection + confidentiality | `Config::with_encryption(provider)` | off |
+| L4, Footer Block tail hint | Reader locates footer without scanning | Always on (trailing `u32` size hint) | always on |
+| L5, Head footer mirror | Partial-write / tail-bit-rot recovery via mirrored copy at offset 0 | `RuntimeConfig::manifest_footer_mirror` | on |
+
+Manifest-side ECC and the head mirror are reachable through
+`Tree::update_runtime_config` (for L2 *on manifest Blocks* and L5); SST data-block
+ECC is tree-static via `Config::page_ecc` at open time and not affected by runtime
+updates. AEAD is supplied at open via `Config::with_encryption` (L3). Runtime
+toggles take effect on the next manifest write, and existing on-disk manifests
+stay readable in their original format because each Block self-describes via its
+header.
+
+Failure-mode coverage with the defaults (mirror on, ECC off, AEAD off):
+
+- **Bit-flip inside one section Block**: XXH3 surfaces it, other sections + the footer Block still read correctly (per-section isolation; see [`manifest_blocks::reader::tests::reader_isolates_corruption_to_one_section_other_sections_readable`](../src/manifest_blocks/reader.rs)).
+- **Tail footer Block corruption**: reader falls back to the head mirror at offset 0 and continues.
+- **Partial write mid-update on a fresh `v{N+1}`**: the prior version's manifest stays intact in its own `v{N}` file, and the atomic `CURRENT` rewrite either lands fully (pointing at `v{N+1}`) or stays at `v{N}`. A torn or truncated `v{N+1}` file is detected at open time: the reader's tail-footer + head-mirror probes both fail and `Tree::open` surfaces `ManifestFooterInvalid`. The head mirror inside each `v{N}` is a copy of THAT file's own tail footer Block (for tail-bit-rot recovery within one version), not a snapshot of a prior version's TOC.
+- **Accidental file substitution / mislinking**: the `CURRENT` pointer carries an XXH3-128 of the referenced `v{N}` manifest's canonical footer content (version_id + TOC entries + per-section XXH3-128 each section Block already carries in its own header); `Tree::open` recomputes this from the parsed footer on read and refuses to follow a mismatched pointer. The digest binds logical content, not raw bytes: a section bit-flip that per-Block Page ECC heals on read does NOT trip this check (the section's TOC checksum is unchanged), preserving recovery. XXH3-128 is **not** a cryptographic MAC: an adversary with write access can craft matching content. Enable `Config::with_encryption(...)` (AEAD per Block) for adversarial tamper resistance.
+
+Turning ECC on (`page_ecc = true`) upgrades the first three rows from "detect and
+refuse" to "detect and recover" without any change to call sites: the Block layer
+transparently emits / consumes the parity trailer per Block.
+
+## Manifest recovery modes
+
+`Config::manifest_recovery_mode` controls how the engine reacts to a malformed
+MANIFEST record at `Tree::open` time. Each mode trades a different point on the
+**strictness vs availability** axis; pick the one whose contract matches the
+deployment.
+
+| Mode | Behaviour on corruption | When to use |
+|------|-------------------------|-------------|
+| `AbsoluteConsistency` (default) | Any per-record decode mismatch (bad XXH3, invalid tag, truncated TOC entry, declared-count overrun) aborts the open with the original error. No data is silently dropped. | **Production default.** Surfaces every byte of corruption before the tree comes back online; matches what most workloads actually want. |
+| `TolerateCorruptedTailRecords` | If the iteration over `tables` / `blob_files` runs out of bytes before the declared count is reached (truncated tail), keep everything that decoded cleanly before the cut and emit a `warn!` listing the dropped count. Any mid-record error that is NOT a clean tail truncation (bad checksum, etc.) still aborts. | **Power-loss-at-write-tail salvage.** Use when a crash mid-fsync left the MANIFEST tail incomplete and you'd rather come up with the last consistent prefix than refuse to open. Not a general bit-rot tolerance, only "the writer never finished". |
+| `PointInTimeRecovery` | On the first record-decode mismatch inside the `tables` section, keeps the consistent prefix collected so far (records that decoded cleanly BEFORE the corrupt one in the current run, plus complete earlier runs in the same level, plus complete earlier levels) and drops everything after. "Record-decode mismatch" covers all three failure shapes the per-record loop produces: (a) framing-layer XXH3 mismatch, (b) framing-header structural failure (`len > MAX_FRAME_PAYLOAD`), and (c) payload-decode failure inside an otherwise-framed-OK record (e.g. `InvalidTag` from a corrupt `checksum_type` byte: the framing XXH3 happens to cover the corrupt byte, so the bytes pass the framing layer; the corruption only surfaces at per-entry decode). Analogous treatment on `blob_files`. Tail-truncation is still tolerated like `TolerateCorruptedTailRecords`. | **Post-corruption salvage with LSM invariants intact.** Use when a manifest has acquired real bit-rot (not just a truncated write) and you want the largest internally-consistent prefix the engine can still vouch for; matches RocksDB's `kPointInTimeRecovery` accept-the-prefix rule adapted to the level/run/table nesting. |
+| `SkipAnyCorruptedRecords` | On any per-record decode mismatch (framing-layer XXH3 mismatch, payload-decode failure inside an otherwise-framed-OK record, or framing-header `BadHeader`), logs the skip and advances past the bad record using the framing-supplied length field. If the framing header itself is corrupt (length field outside the legal range, so the next-record boundary cannot be located), the rest of that section is dropped: there's no safe way to find the next record boundary in that case. Symmetric on `tables` and `blob_files`. | **Maximum-availability forensic mode.** Use when you'd rather open the tree with whatever survives than refuse to open at all; pairs with the `repair_db` tooling tracked in [#303](https://github.com/structured-world/coordinode-lsm-tree/issues/303) for the cases where even the surviving records aren't enough. |
+
+When a non-default mode drops records, the recovery path logs `warn!` lines
+describing what was tolerated. Individual table-IDs / blob-file-IDs are NOT
+enumerated because they were never decoded. Warnings fall into two categories:
+
+**Per-condition warns** (one warn for each malformed shape encountered, at the point of detection):
+
+- `tables` section truncated before the `level_count` byte: tail-tolerant mode produces 0 levels.
+- `tables` declared `table_count` exceeds remaining section payload (count header forged or entries truncated): loop walks bytes-actually-present and stops at the first EOF.
+- `blob_files` section truncated before its count header: 0 blob files.
+- `blob_files` declared count exceeds remaining section capacity: same forged-or-truncated shape, same walk-and-stop fallback.
+- `blob_gc_stats` payload truncated (power-loss between the `blob_files` commit and the `blob_gc_stats` payload landing): tail-tolerant mode produces an empty `FragmentationMap`. GC stats are advisory (fragmentation re-accrues on the next compaction pass), so this is a "rebuild on next pass" outcome, not data loss. This is a single in-place warn with no later summary.
+
+**Per-section summary warns** (at end of section processing, only if the section actually lost records):
+
+- `tables` section, emitted only when `tables_dropped_to_tail > 0` OR `tables_truncated_headers > 0`. Reports two counters in one line: declared-but-missing table records (count header said N, only K < N records read before EOF, so N-K dropped) and the separate counter for level / run / `table_count` headers cut mid-byte (no records were supposed to be present yet for those levels / runs, so the headers contribute zero to record loss but the levels / runs themselves are absent).
+- `blob_files` section, emitted only when `blob_dropped_to_tail > 0`. Reports the declared-but-missing blob-file records count, analogous to the tables-section record-drop counter. A `blob_files` section whose only damage was a missing count header surfaces the per-condition warn above but does NOT add a summary line.
+
+Operators wanting a per-record audit trail should pair a tail-tolerant open with
+an out-of-band integrity scan (see `verify::verify_integrity` /
+`tools/sst-dump verify`).
+
+For workflows where the MANIFEST is unrecoverable even under the lossy modes, the
+`repair_db` tool ([#303](https://github.com/structured-world/coordinode-lsm-tree/issues/303))
+rebuilds the MANIFEST from the SST files themselves.
+
+## Point-in-time recovery
+
+`Tree::create_checkpoint(target_path) -> CheckpointInfo` captures a consistent
+snapshot by hard-linking every live SST + blob file into a fresh directory in
+O(1) per file, with zero extra disk until the source files compact away.
+Compaction continues during the checkpoint (deletions are deferred), and the
+resulting directory opens as an independent tree, usable for backup, forensic
+inspection, or rollback to a known-good point.
+
+## Out-of-band verification & repair
+
+- **`verify::verify_integrity(tree) -> IntegrityReport`**: walk the whole tree and
+  verify every block's checksum (and ECC where present), returning a report
+  rather than failing a read. Use it as a periodic health check.
+- **`tools/sst-dump verify <file>`**: verify a single SST out of band: walk every
+  block, check per-block XXH3, exit non-zero on corruption. Pair with
+  `tools/sst-dump hex <offset>` to inspect a flagged region.
+- **`Config::repair() -> RepairReport`**: rebuild a missing or corrupt manifest
+  (standard and KV-separated / blob trees) from the on-disk SST files when even
+  the lossy recovery modes cannot open the tree.
+
+## Regulated-data integrity
+
+The detection-and-correction layers above are precisely the **integrity
+controls** that medical, clinical, and other regulated environments are required
+to implement: the assurance that stored records have not been silently altered or
+destroyed.
+
+- **HIPAA Security Rule, §164.312(c)**, "Integrity": implement mechanisms to
+  protect ePHI from improper alteration or destruction, and electronic mechanisms
+  to corroborate that ePHI has not been altered or destroyed. The end-to-end
+  checksums (RAM through disk) and ECC are exactly such mechanisms.
+- **FDA 21 CFR Part 11, §11.10**: electronic records must be "accurate, reliable"
+  and protected throughout the retention period; tamper-evident. Block XXH3,
+  per-KV checksums, and AAD-bound encryption provide the accuracy-and-tamper-
+  evidence half of that requirement.
+- **ALCOA+ (Accurate / Original / Enduring)**: the data-integrity principles used
+  across GxP and clinical data: a record must remain an accurate, unaltered
+  representation of the original for its full lifetime. End-to-end checksums plus
+  self-healing ECC keep records bit-for-bit enduring.
+
+This engine supplies the storage-layer **integrity controls** those frameworks
+require; it is not, by itself, a certification. Full compliance is a property of
+the whole system: it also needs the controls this engine does not provide (audit
+trail of *who* changed a record, electronic signatures, access control, and a
+Business Associate Agreement where applicable). What this engine guarantees is the
+part it owns: a record you wrote is the record you read back, end to end, or you
+get a typed error instead of silent corruption.

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -218,7 +218,12 @@ pub trait AbstractTree: sealed::Sealed {
     ///
     /// # Errors
     ///
-    /// Will return `Err` if an IO error occurs.
+    /// Returns `Err` on an I/O error, or on a memtable residence-verification
+    /// failure under [`KvChecksumComputePoint::AtInsert`](crate::runtime_config::KvChecksumComputePoint::AtInsert):
+    /// a sealed memtable whose insert-time per-KV digests do not verify before
+    /// flush surfaces [`crate::Error::MemtableKvChecksumMismatch`],
+    /// [`crate::Error::MemtableKvChecksumCorruptAlgorithm`], or
+    /// [`crate::Error::InvalidTag`] (corrupt `value_type`).
     fn flush(&self, _lock: &FlushGuard<'_>, seqno_threshold: SeqNo) -> crate::Result<Option<u64>> {
         use crate::{
             compaction::stream::CompactionStream, merge::Merger, range_tombstone::RangeTombstone,

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -239,6 +239,25 @@ pub trait AbstractTree: sealed::Sealed {
 
         let flushed_size = latest.sealed_memtables.iter().map(|mt| mt.size()).sum();
 
+        // AtInsert residence check: verify each sealed memtable's insert-time
+        // per-KV digests against a recompute over the entries' current bytes
+        // before writing them out. A divergence means an entry was corrupted
+        // (a RAM bit-flip) while it sat in the memtable. Memtables with no
+        // insert digests (the default) return immediately without walking.
+        //
+        // This is a SEPARATE pass over the as-inserted memtable entries, not
+        // fused into the writer's per-KV footer encode, and deliberately so:
+        // the footer digest is computed over POST-merge / post-seqno-filter
+        // bytes (the CompactionStream below applies the merge operator), so a
+        // merge operator's combined value differs from any single inserted
+        // value. Comparing the carried insert digest against the footer digest
+        // would false-positive on every legitimate merge. Residence corruption
+        // is a property of what was inserted (pre-merge); it must be checked
+        // here, against the raw memtable entries.
+        for mt in latest.sealed_memtables.iter() {
+            mt.verify_kv_residence()?;
+        }
+
         // Collect range tombstones from sealed memtables
         let mut range_tombstones: Vec<RangeTombstone> = Vec::new();
         for mt in latest.sealed_memtables.iter() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,26 @@ pub enum Error {
         expected: Checksum,
     },
 
+    /// A memtable entry's per-KV digest, computed at insert under
+    /// [`KvChecksumComputePoint::AtInsert`](crate::runtime_config::KvChecksumComputePoint::AtInsert),
+    /// did not match a recompute over the entry's current bytes at flush.
+    ///
+    /// This is the memtable-residence RAM-corruption signal: the entry's
+    /// logical content (`value_type`, `seqno`, key, or value) changed while it
+    /// sat in the memtable, between insert and flush. Distinct from
+    /// [`Self::ChecksumMismatch`] (on-disk block bytes) — this catches a flip
+    /// that happens entirely in RAM, before any block is written.
+    MemtableKvChecksumMismatch {
+        /// Sequence number of the entry whose digest diverged (locates it).
+        seqno: u64,
+
+        /// Digest recomputed over the entry's current memtable bytes at flush.
+        got: u64,
+
+        /// Digest computed and stored when the entry was inserted.
+        expected: u64,
+    },
+
     /// Blob frame header CRC mismatch (V4 format).
     /// Distinct from `ChecksumMismatch` which covers data payload checksums.
     HeaderCrcMismatch {

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,26 @@ pub enum Error {
         expected: u64,
     },
 
+    /// A memtable entry carried an insert-time per-KV digest
+    /// ([`KvChecksumComputePoint::AtInsert`](crate::runtime_config::KvChecksumComputePoint::AtInsert))
+    /// tagged with an algorithm `AtInsert` never stores: a non-4-byte or
+    /// unknown algorithm wire tag.
+    ///
+    /// `AtInsert` only ever writes a 4-byte algorithm tag (`Xxh3Low32` /
+    /// `Crc32c`), so a digest-bearing node tagged otherwise means the node's
+    /// algorithm metadata was corrupted in RAM during memtable residence.
+    /// Distinct from [`Self::MemtableKvChecksumMismatch`] (the digest value
+    /// diverged): here the algorithm itself is unusable, so the engine refuses
+    /// to "verify" the entry under the wrong algorithm rather than risk a
+    /// flipped tag passing the residence check.
+    MemtableKvChecksumCorruptAlgorithm {
+        /// Sequence number of the entry whose algorithm tag is invalid.
+        seqno: u64,
+
+        /// The invalid algorithm wire tag read from the node.
+        tag: u8,
+    },
+
     /// Blob frame header CRC mismatch (V4 format).
     /// Distinct from `ChecksumMismatch` which covers data payload checksums.
     HeaderCrcMismatch {

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::ops::RangeBounds;
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic::{AtomicBool, AtomicU8};
 use portable_atomic::AtomicU64;
 // `parking_lot::RwLock` (std: small, userspace fast-path, no poisoning) /
 // `spin::RwLock` (no_std). Neither poisons on a panicked holder, so the read/
@@ -72,6 +72,14 @@ pub struct Memtable {
     pub(crate) highest_seqno: AtomicU64,
 
     pub(crate) requested_rotation: AtomicBool,
+
+    /// Algorithm of the insert-time per-KV digests stored in this memtable's
+    /// nodes (`KvChecksumComputePoint::AtInsert`), as `1 + wire_tag`, or `0`
+    /// when no `AtInsert` digest has been inserted. Set (idempotently) on the
+    /// first digest-bearing insert and read once at flush by
+    /// [`Self::verify_kv_residence`]. `0` means there is nothing to verify, so
+    /// the default (`Off` / `AtBlockCompile`) path never walks the nodes.
+    kv_insert_algo: AtomicU8,
 }
 
 impl Memtable {
@@ -113,6 +121,7 @@ impl Memtable {
             approximate_size: AtomicU64::default(),
             highest_seqno: AtomicU64::default(),
             requested_rotation: AtomicBool::default(),
+            kv_insert_algo: AtomicU8::new(0),
         }
     }
 
@@ -203,6 +212,22 @@ impl Memtable {
     /// Returns `(total_bytes_added, new_memtable_size)`.
     #[doc(hidden)]
     pub fn insert_batch(&self, items: Vec<InternalValue>) -> (u64, u64) {
+        self.insert_batch_with_kv_algo(items, None)
+    }
+
+    /// Bulk insert, optionally computing an insert-time per-KV digest per item
+    /// under `kv_algo` (`KvChecksumComputePoint::AtInsert`).
+    ///
+    /// `kv_algo` is `Some(algo)` (a 4-byte algorithm) to fix each entry's
+    /// digest at insert for the flush-time residence check, or `None` for the
+    /// plain bulk path. Same single-`fetch_add` / single-`fetch_max` accounting
+    /// as [`Self::insert_batch`].
+    #[doc(hidden)]
+    pub fn insert_batch_with_kv_algo(
+        &self,
+        items: Vec<InternalValue>,
+        kv_algo: Option<crate::runtime_config::ChecksumAlgorithm>,
+    ) -> (u64, u64) {
         if items.is_empty() {
             let size = self
                 .approximate_size
@@ -236,9 +261,25 @@ impl Memtable {
             .approximate_size
             .fetch_add(total_size, core::sync::atomic::Ordering::AcqRel);
 
+        if let Some(algo) = kv_algo {
+            // Record the algorithm once (idempotent) for the flush-time verify.
+            self.kv_insert_algo
+                .store(1 + algo.wire_tag(), core::sync::atomic::Ordering::Relaxed);
+        }
+
         for item in items {
+            let digest = kv_algo.and_then(|algo| {
+                crate::table::block::kv_checksum::kv_digest(&item, algo).map(|d| {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "AtInsert is config-validated to a 4-byte algorithm; the digest fits u32"
+                    )]
+                    let lo = d as u32;
+                    lo
+                })
+            });
             let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
-            self.items.insert(&key, &item.value);
+            self.items.insert_with_kv_digest(&key, &item.value, digest);
         }
 
         self.highest_seqno
@@ -275,6 +316,81 @@ impl Memtable {
             .fetch_max(item.key.seqno, core::sync::atomic::Ordering::AcqRel);
 
         (item_size, size_before + item_size)
+    }
+
+    /// Inserts an item, optionally carrying a precomputed insert-time per-KV
+    /// digest (`KvChecksumComputePoint::AtInsert`).
+    ///
+    /// `kv_digest` is `Some((digest, algo))` when the caller computed the
+    /// entry's 4-byte logical-content digest at insert (under `AtInsert` with a
+    /// 4-byte algorithm), or `None` for the plain path. When present, the
+    /// digest is stored in the skiplist node and the memtable records `algo`
+    /// so [`Self::verify_kv_residence`] can re-check every digest-bearing node
+    /// at flush. Mixed inserts (some with, some without a digest) are supported
+    /// for the `Off` -> `AtInsert` live toggle.
+    #[doc(hidden)]
+    pub fn insert_with_kv_digest(
+        &self,
+        item: InternalValue,
+        kv_digest: Option<(u32, crate::runtime_config::ChecksumAlgorithm)>,
+    ) -> (u64, u64) {
+        #[expect(
+            clippy::expect_used,
+            reason = "keys are limited to 16-bit length + values are limited to 32-bit length"
+        )]
+        let item_size = (item.key.user_key.len()
+            + item.value.len()
+            + core::mem::size_of::<InternalValue>()
+            + core::mem::size_of::<SharedComparator>())
+        .try_into()
+        .expect("should fit into u64");
+
+        let size_before = self
+            .approximate_size
+            .fetch_add(item_size, core::sync::atomic::Ordering::AcqRel);
+
+        if let Some((_, algo)) = kv_digest {
+            // Record the algorithm (idempotent) so the flush-time verify knows
+            // how to recompute. `1 + wire_tag` keeps `0` meaning "no AtInsert
+            // digest written" (so the default path never walks nodes).
+            self.kv_insert_algo
+                .store(1 + algo.wire_tag(), core::sync::atomic::Ordering::Relaxed);
+        }
+
+        let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
+        self.items
+            .insert_with_kv_digest(&key, &item.value, kv_digest.map(|(d, _)| d));
+
+        self.highest_seqno
+            .fetch_max(item.key.seqno, core::sync::atomic::Ordering::AcqRel);
+
+        (item_size, size_before + item_size)
+    }
+
+    /// Verifies every insert-time per-KV digest in this memtable against a
+    /// recompute over the entry's current bytes (the
+    /// [`KvChecksumComputePoint::AtInsert`](crate::runtime_config::KvChecksumComputePoint::AtInsert)
+    /// residence check), called once at flush.
+    ///
+    /// Returns `Ok` immediately when no `AtInsert` digest was ever inserted (the
+    /// recorded algorithm is `0`), so the default path pays nothing.
+    ///
+    /// # Errors
+    ///
+    /// - [`crate::Error::MemtableKvChecksumMismatch`] when an entry's stored
+    ///   digest diverges from the recompute (a RAM bit-flip during residence).
+    /// - [`crate::Error::FeatureUnsupported`] when the recorded algorithm is
+    ///   not compiled into this build.
+    pub fn verify_kv_residence(&self) -> crate::Result<()> {
+        let tag = self
+            .kv_insert_algo
+            .load(core::sync::atomic::Ordering::Relaxed);
+        if tag == 0 {
+            return Ok(());
+        }
+        let algo = crate::runtime_config::ChecksumAlgorithm::from_wire_tag(tag - 1)
+            .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
+        self.items.verify_kv_digests(algo)
     }
 
     /// Inserts a range tombstone covering `[start, end)` at the given seqno.
@@ -380,6 +496,79 @@ mod tests {
 
     fn new_memtable(id: MemtableId) -> Memtable {
         Memtable::new(id, default_comparator())
+    }
+
+    /// Low-32 logical digest of an entry under `algo`.
+    fn at_insert_digest(
+        item: &InternalValue,
+        algo: crate::runtime_config::ChecksumAlgorithm,
+    ) -> u32 {
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::expect_used,
+            reason = "4-byte algo fits u32; test helper"
+        )]
+        let d = crate::table::block::kv_checksum::kv_digest(item, algo)
+            .expect("xxh3 always available") as u32;
+        d
+    }
+
+    #[test]
+    fn verify_kv_residence_ok_when_intact() {
+        // AtInsert path: every entry carries the digest of its own bytes, so
+        // the flush-time residence check passes.
+        let algo = crate::runtime_config::ChecksumAlgorithm::Xxh3Low32;
+        let mt = new_memtable(0);
+        for i in 0..5u8 {
+            let item = InternalValue::from_components(
+                [b'k', i],
+                [b'v', i],
+                u64::from(i) + 1,
+                ValueType::Value,
+            );
+            let d = at_insert_digest(&item, algo);
+            mt.insert_with_kv_digest(item, Some((d, algo)));
+        }
+        assert!(mt.verify_kv_residence().is_ok());
+    }
+
+    #[test]
+    fn verify_kv_residence_ok_without_any_digest() {
+        // Default path (no AtInsert digest recorded): nothing to verify, so the
+        // residence check returns immediately even with data present.
+        let mt = new_memtable(0);
+        for i in 0..5u8 {
+            mt.insert(InternalValue::from_components(
+                [b'k', i],
+                [b'v', i],
+                u64::from(i) + 1,
+                ValueType::Value,
+            ));
+        }
+        assert!(mt.verify_kv_residence().is_ok());
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test asserts the error via expect_err")]
+    fn verify_kv_residence_detects_corruption_end_to_end() {
+        // Insert under AtInsert, then simulate a RAM bit-flip on the resident
+        // entry's key. The flush-time residence check recomputes and reports
+        // a MemtableKvChecksumMismatch.
+        let algo = crate::runtime_config::ChecksumAlgorithm::Xxh3Low32;
+        let mt = new_memtable(0);
+        let item = InternalValue::from_components(b"victim", b"payload", 7, ValueType::Value);
+        let d = at_insert_digest(&item, algo);
+        mt.insert_with_kv_digest(item, Some((d, algo)));
+
+        mt.items.test_flip_first_key_byte();
+
+        let err = mt
+            .verify_kv_residence()
+            .expect_err("residence corruption must be detected at flush");
+        assert!(
+            matches!(err, crate::Error::MemtableKvChecksumMismatch { .. }),
+            "expected MemtableKvChecksumMismatch, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::ops::RangeBounds;
-use core::sync::atomic::{AtomicBool, AtomicU8};
+use core::sync::atomic::AtomicBool;
 use portable_atomic::AtomicU64;
 // `parking_lot::RwLock` (std: small, userspace fast-path, no poisoning) /
 // `spin::RwLock` (no_std). Neither poisons on a panicked holder, so the read/
@@ -73,13 +73,13 @@ pub struct Memtable {
 
     pub(crate) requested_rotation: AtomicBool,
 
-    /// Algorithm of the insert-time per-KV digests stored in this memtable's
-    /// nodes (`KvChecksumComputePoint::AtInsert`), as `1 + wire_tag`, or `0`
-    /// when no `AtInsert` digest has been inserted. Set (idempotently) on the
-    /// first digest-bearing insert and read once at flush by
-    /// [`Self::verify_kv_residence`]. `0` means there is nothing to verify, so
-    /// the default (`Off` / `AtBlockCompile`) path never walks the nodes.
-    kv_insert_algo: AtomicU8,
+    /// Whether any insert-time per-KV digest (`KvChecksumComputePoint::AtInsert`)
+    /// has been stored in this memtable. Set on the first digest-bearing insert
+    /// and read once at flush by [`Self::verify_kv_residence`] to skip walking
+    /// the nodes entirely when there is nothing to verify (the default `Off` /
+    /// `AtBlockCompile` path). The per-node digest carries its own algorithm, so
+    /// no memtable-wide algorithm is tracked here.
+    has_at_insert_digests: AtomicBool,
 }
 
 impl Memtable {
@@ -121,7 +121,7 @@ impl Memtable {
             approximate_size: AtomicU64::default(),
             highest_seqno: AtomicU64::default(),
             requested_rotation: AtomicBool::default(),
-            kv_insert_algo: AtomicU8::new(0),
+            has_at_insert_digests: AtomicBool::default(),
         }
     }
 
@@ -261,10 +261,11 @@ impl Memtable {
             .approximate_size
             .fetch_add(total_size, core::sync::atomic::Ordering::AcqRel);
 
-        if let Some(algo) = kv_algo {
-            // Record the algorithm once (idempotent) for the flush-time verify.
-            self.kv_insert_algo
-                .store(1 + algo.wire_tag(), core::sync::atomic::Ordering::Relaxed);
+        if kv_algo.is_some() {
+            // Flag that this memtable carries residence digests for the
+            // flush-time verify. The algorithm lives per node.
+            self.has_at_insert_digests
+                .store(true, core::sync::atomic::Ordering::Relaxed);
         }
 
         for item in items {
@@ -275,7 +276,7 @@ impl Memtable {
                         reason = "AtInsert is config-validated to a 4-byte algorithm; the digest fits u32"
                     )]
                     let lo = d as u32;
-                    lo
+                    (lo, algo)
                 })
             });
             let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
@@ -323,11 +324,12 @@ impl Memtable {
     ///
     /// `kv_digest` is `Some((digest, algo))` when the caller computed the
     /// entry's 4-byte logical-content digest at insert (under `AtInsert` with a
-    /// 4-byte algorithm), or `None` for the plain path. When present, the
-    /// digest is stored in the skiplist node and the memtable records `algo`
-    /// so [`Self::verify_kv_residence`] can re-check every digest-bearing node
-    /// at flush. Mixed inserts (some with, some without a digest) are supported
-    /// for the `Off` -> `AtInsert` live toggle.
+    /// 4-byte algorithm), or `None` for the plain path. When present, the digest
+    /// and its algorithm are stored in the skiplist node (per node, so a later
+    /// config change cannot misverify it) and the memtable flags that it carries
+    /// at least one digest so [`Self::verify_kv_residence`] knows to walk at
+    /// flush. Mixed inserts (some with, some without a digest) are supported for
+    /// the `Off` -> `AtInsert` live toggle.
     #[doc(hidden)]
     pub fn insert_with_kv_digest(
         &self,
@@ -349,17 +351,17 @@ impl Memtable {
             .approximate_size
             .fetch_add(item_size, core::sync::atomic::Ordering::AcqRel);
 
-        if let Some((_, algo)) = kv_digest {
-            // Record the algorithm (idempotent) so the flush-time verify knows
-            // how to recompute. `1 + wire_tag` keeps `0` meaning "no AtInsert
-            // digest written" (so the default path never walks nodes).
-            self.kv_insert_algo
-                .store(1 + algo.wire_tag(), core::sync::atomic::Ordering::Relaxed);
+        if kv_digest.is_some() {
+            // Flag that this memtable carries at least one residence digest so
+            // the flush-time verify walks the nodes. The algorithm lives per
+            // node, not here.
+            self.has_at_insert_digests
+                .store(true, core::sync::atomic::Ordering::Relaxed);
         }
 
         let key = InternalKey::new(item.key.user_key, item.key.seqno, item.key.value_type);
         self.items
-            .insert_with_kv_digest(&key, &item.value, kv_digest.map(|(d, _)| d));
+            .insert_with_kv_digest(&key, &item.value, kv_digest);
 
         self.highest_seqno
             .fetch_max(item.key.seqno, core::sync::atomic::Ordering::AcqRel);
@@ -372,25 +374,23 @@ impl Memtable {
     /// [`KvChecksumComputePoint::AtInsert`](crate::runtime_config::KvChecksumComputePoint::AtInsert)
     /// residence check), called once at flush.
     ///
-    /// Returns `Ok` immediately when no `AtInsert` digest was ever inserted (the
-    /// recorded algorithm is `0`), so the default path pays nothing.
+    /// Returns `Ok` immediately when no `AtInsert` digest was ever inserted, so
+    /// the default path pays nothing.
     ///
     /// # Errors
     ///
     /// - [`crate::Error::MemtableKvChecksumMismatch`] when an entry's stored
     ///   digest diverges from the recompute (a RAM bit-flip during residence).
-    /// - [`crate::Error::FeatureUnsupported`] when the recorded algorithm is
-    ///   not compiled into this build.
+    /// - [`crate::Error::FeatureUnsupported`] when a node's algorithm is not
+    ///   compiled into this build.
     pub fn verify_kv_residence(&self) -> crate::Result<()> {
-        let tag = self
-            .kv_insert_algo
-            .load(core::sync::atomic::Ordering::Relaxed);
-        if tag == 0 {
+        if !self
+            .has_at_insert_digests
+            .load(core::sync::atomic::Ordering::Relaxed)
+        {
             return Ok(());
         }
-        let algo = crate::runtime_config::ChecksumAlgorithm::from_wire_tag(tag - 1)
-            .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
-        self.items.verify_kv_digests(algo)
+        self.items.verify_kv_digests()
     }
 
     /// Inserts a range tombstone covering `[start, end)` at the given seqno.

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -548,6 +548,37 @@ mod tests {
         assert!(mt.verify_kv_residence().is_ok());
     }
 
+    #[cfg(feature = "crc32c")]
+    #[test]
+    fn verify_kv_residence_uses_per_node_algorithm_no_drift() {
+        // Algorithm drift regression: insert one entry under Xxh3Low32, then a
+        // second under Crc32c (as if kv_checksum_algo changed mid-memtable).
+        // Both entries are intact, so the residence check must pass. It only
+        // passes if each node is verified under the algorithm it was stored
+        // with; a single per-memtable algorithm would recompute the first
+        // entry under Crc32c and falsely flag it.
+        let mt = new_memtable(0);
+
+        let a = InternalValue::from_components(b"aaa", b"va", 1, ValueType::Value);
+        let da = at_insert_digest(&a, crate::runtime_config::ChecksumAlgorithm::Xxh3Low32);
+        mt.insert_with_kv_digest(
+            a,
+            Some((da, crate::runtime_config::ChecksumAlgorithm::Xxh3Low32)),
+        );
+
+        let b = InternalValue::from_components(b"bbb", b"vb", 2, ValueType::Value);
+        let db = at_insert_digest(&b, crate::runtime_config::ChecksumAlgorithm::Crc32c);
+        mt.insert_with_kv_digest(
+            b,
+            Some((db, crate::runtime_config::ChecksumAlgorithm::Crc32c)),
+        );
+
+        assert!(
+            mt.verify_kv_residence().is_ok(),
+            "per-node algorithm must prevent drift across a mid-memtable algo change"
+        );
+    }
+
     #[test]
     #[expect(clippy::expect_used, reason = "test asserts the error via expect_err")]
     fn verify_kv_residence_detects_corruption_end_to_end() {

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -1271,6 +1271,30 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::expect_used, reason = "test helper computes a known digest")]
+    fn verify_kv_digests_rejects_non_4_byte_algorithm_tag() {
+        // AtInsert only ever stores a 4-byte algorithm. A present-digest node
+        // whose algorithm bits decode to a non-4-byte algorithm (e.g. Xxh3_64
+        // after a single-bit flip from Xxh3Low32's tag 1 to tag 0) is metadata
+        // corruption. Store the Xxh3_64 digest truncated to u32 under the
+        // 8-byte Xxh3_64 tag: the worst case where comparing the digest alone
+        // would pass. Verification must reject it on the algorithm tag instead.
+        let map = new_map();
+        let key = make_key(b"k", 1);
+        let val = make_value(b"v");
+        let item = InternalValue::new(key.clone(), val.clone());
+        #[expect(clippy::cast_possible_truncation, reason = "low 32 bits on purpose")]
+        let d64 = crate::table::block::kv_checksum::kv_digest(&item, ChecksumAlgorithm::Xxh3_64)
+            .expect("xxh3 always available") as u32;
+        map.insert_with_kv_digest(&key, &val, Some((d64, ChecksumAlgorithm::Xxh3_64)));
+
+        assert!(
+            map.verify_kv_digests().is_err(),
+            "a present digest under a non-4-byte algorithm must be rejected, not verified"
+        );
+    }
+
+    #[test]
     fn insert_and_get_single() {
         let map = new_map();
         let key = make_key(b"hello", 1);

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -306,7 +306,7 @@ impl SkipMap {
 
     /// Test-only: corrupts the first node's `value_type` low bits to an invalid
     /// discriminant (0b111), keeping the presence + algorithm bits intact.
-    /// Simulates a RAM bit-flip in the value_type byte so the residence
+    /// Simulates a RAM bit-flip in the `value_type` byte so the residence
     /// verifier can be checked to fail closed instead of panicking.
     #[cfg(test)]
     #[expect(
@@ -354,8 +354,12 @@ impl SkipMap {
             match self.node_kv_digest(node) {
                 NodeKvDigest::Absent => {}
                 NodeKvDigest::Present(stored, algo) => {
-                    let item =
-                        InternalValue::new(self.node_internal_key(node), self.node_value(node));
+                    // Decode the key fallibly: a corrupt value_type on a
+                    // digest-bearing node must fail closed here, not panic.
+                    let item = InternalValue::new(
+                        self.node_internal_key_checked(node)?,
+                        self.node_value(node),
+                    );
                     let recomputed = crate::table::block::kv_checksum::kv_digest(&item, algo)
                         .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
                     // AtInsert stores the low 32 bits; truncate the recompute the
@@ -657,6 +661,28 @@ impl SkipMap {
             seqno,
             value_type: vt,
         }
+    }
+
+    /// Like [`Self::node_internal_key`] but returns a typed error instead of
+    /// panicking when the node's `value_type` bits are not a valid discriminant.
+    ///
+    /// Used on the residence-verify path ([`Self::verify_kv_digests`]) so a node
+    /// whose metadata was corrupted in RAM fails closed with
+    /// [`crate::Error::InvalidTag`] rather than aborting the process via the
+    /// `expect` in [`Self::node_value_type`].
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "metadata is exactly OFF_TOWER (24) bytes by construction"
+    )]
+    fn node_internal_key_checked(&self, node: u32) -> crate::Result<InternalKey> {
+        let vt_byte = unsafe { self.meta(node) }[10] & VALUE_TYPE_MASK;
+        let value_type = ValueType::try_from(vt_byte)
+            .map_err(|()| crate::Error::InvalidTag(("memtable-value-type", vt_byte)))?;
+        Ok(InternalKey {
+            user_key: self.node_user_key_bytes(node).into(),
+            seqno: self.node_seqno(node),
+            value_type,
+        })
     }
 
     /// Reads the value for `node` from the lock-free value store (wait-free).

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -88,6 +88,19 @@ const fn node_size(height: usize) -> u32 {
     OFF_TOWER + (height as u32) * 4
 }
 
+/// Outcome of reading a node's insert-time per-KV digest slot
+/// (`KvChecksumComputePoint::AtInsert`).
+enum NodeKvDigest {
+    /// No digest stored (the `KV_DIGEST_PRESENT` flag is clear).
+    Absent,
+    /// A valid 4-byte digest under the recovered algorithm.
+    Present(u32, ChecksumAlgorithm),
+    /// The presence bit is set but the algorithm tag is not a 4-byte algorithm
+    /// `AtInsert` would store (corruption of the algorithm or presence bits).
+    /// Carries the offending wire tag for diagnostics.
+    CorruptAlgorithm(u8),
+}
+
 // ---------------------------------------------------------------------------
 // SkipMap
 // ---------------------------------------------------------------------------
@@ -318,22 +331,35 @@ impl SkipMap {
     pub fn verify_kv_digests(&self) -> crate::Result<()> {
         let mut node = self.first_node();
         while node != UNSET {
-            if let Some((stored, algo)) = self.node_kv_digest(node) {
-                let item = InternalValue::new(self.node_internal_key(node), self.node_value(node));
-                let recomputed = crate::table::block::kv_checksum::kv_digest(&item, algo)
-                    .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
-                // AtInsert stores the low 32 bits; truncate the recompute the
-                // same way so the comparison is width-consistent.
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "AtInsert uses a 4-byte algorithm; only the low 32 bits are stored"
-                )]
-                let got = recomputed as u32;
-                if got != stored {
-                    return Err(crate::Error::MemtableKvChecksumMismatch {
-                        seqno: item.key.seqno,
-                        got: u64::from(got),
-                        expected: u64::from(stored),
+            match self.node_kv_digest(node) {
+                NodeKvDigest::Absent => {}
+                NodeKvDigest::Present(stored, algo) => {
+                    let item =
+                        InternalValue::new(self.node_internal_key(node), self.node_value(node));
+                    let recomputed = crate::table::block::kv_checksum::kv_digest(&item, algo)
+                        .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
+                    // AtInsert stores the low 32 bits; truncate the recompute the
+                    // same way so the comparison is width-consistent.
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "AtInsert uses a 4-byte algorithm; only the low 32 bits are stored"
+                    )]
+                    let got = recomputed as u32;
+                    if got != stored {
+                        return Err(crate::Error::MemtableKvChecksumMismatch {
+                            seqno: item.key.seqno,
+                            got: u64::from(got),
+                            expected: u64::from(stored),
+                        });
+                    }
+                }
+                NodeKvDigest::CorruptAlgorithm(tag) => {
+                    // A present digest under an algorithm AtInsert never stores:
+                    // the algorithm metadata was corrupted in RAM. Refuse to
+                    // verify under it instead of risking a flipped tag passing.
+                    return Err(crate::Error::MemtableKvChecksumCorruptAlgorithm {
+                        seqno: self.node_seqno(node),
+                        tag,
                     });
                 }
             }
@@ -527,12 +553,17 @@ impl SkipMap {
         ValueType::try_from(byte).expect("valid ValueType discriminant")
     }
 
-    /// Returns the insert-time per-KV digest and the algorithm it was computed
-    /// with, or `None` if the node carries no digest (the `KV_DIGEST_PRESENT`
-    /// flag is clear). The digest is the low 32 bits of the entry's
-    /// logical-content digest; the algorithm is recovered from the `wire_tag`
-    /// packed in bits 5..=6 of the `value_type` byte, so each node verifies
-    /// under its own algorithm regardless of later config changes.
+    /// Reads a node's insert-time per-KV digest slot, distinguishing "no
+    /// digest" from "digest present but its algorithm metadata is corrupt".
+    ///
+    /// The algorithm is recovered from the `wire_tag` packed in bits 5..=6 of
+    /// the `value_type` byte, so each node verifies under its own algorithm
+    /// regardless of later config changes. `AtInsert` only ever stores a 4-byte
+    /// algorithm tag, so a present-digest node tagged with a non-4-byte or
+    /// unknown algorithm is metadata corruption (e.g. a single-bit flip in the
+    /// algorithm bits): reported as [`NodeKvDigest::CorruptAlgorithm`] rather
+    /// than silently verified under the wrong algorithm, which could let a
+    /// flipped tag pass the residence check.
     #[expect(
         clippy::indexing_slicing,
         reason = "metadata is exactly OFF_TOWER (24) bytes by construction"
@@ -541,20 +572,22 @@ impl SkipMap {
         clippy::expect_used,
         reason = "infallible: 4-byte slice always converts to [u8; 4]"
     )]
-    fn node_kv_digest(&self, node: u32) -> Option<(u32, ChecksumAlgorithm)> {
+    fn node_kv_digest(&self, node: u32) -> NodeKvDigest {
         let m = unsafe { self.meta(node) };
         if m[10] & KV_DIGEST_PRESENT == 0 {
-            return None;
+            return NodeKvDigest::Absent;
         }
         let algo_tag = (m[10] & KV_ALGO_MASK) >> KV_ALGO_SHIFT;
-        // The tag was written from a valid 4-byte algorithm's wire_tag at
-        // insert, so it always decodes; treat a corrupt tag as no digest rather
-        // than panicking (the entry then escapes residence verification, which
-        // is the conservative outcome, and the block-level checksum still
-        // covers it on disk).
-        let algo = ChecksumAlgorithm::from_wire_tag(algo_tag)?;
-        let digest = u32::from_ne_bytes(m[12..16].try_into().expect("4 bytes"));
-        Some((digest, algo))
+        match ChecksumAlgorithm::from_wire_tag(algo_tag) {
+            Some(algo) if algo.digest_size() == 4 => {
+                let digest = u32::from_ne_bytes(m[12..16].try_into().expect("4 bytes"));
+                NodeKvDigest::Present(digest, algo)
+            }
+            // Unknown tag, or a known-but-non-4-byte algorithm (Xxh3_64): a
+            // present-digest node never legitimately carries one, so this is
+            // corruption of the algorithm bits or the presence bit.
+            _ => NodeKvDigest::CorruptAlgorithm(algo_tag),
+        }
     }
 
     #[expect(

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -18,6 +18,7 @@ use super::arena::Arena;
 use super::value_store::ValueStore;
 use crate::comparator::SharedComparator;
 use crate::key::InternalKey;
+use crate::runtime_config::ChecksumAlgorithm;
 use crate::value::{InternalValue, SeqNo, UserValue};
 use crate::{UserKey, ValueType};
 
@@ -63,13 +64,20 @@ const OFF_TOWER: u32 = 24;
 
 // Per-KV insert-time digest (KvChecksumComputePoint::AtInsert): the 4-byte
 // reserved slot at +12 (otherwise alignment padding) holds the entry's 4-byte
-// digest, fixed at insert and re-checked at flush. Presence is flagged in the
-// high bit of the value_type byte (+10): ValueType discriminants are 0..=2, so
-// the low bits hold the type and bit 7 says "this node carries an insert
-// digest". A node without the flag has the slot zeroed and is never verified
-// (covers the mixed-variant memtable after an Off -> AtInsert toggle).
+// digest, fixed at insert and re-checked at flush. The value_type byte (+10)
+// packs three fields, since ValueType discriminants are only 0..=2:
+//   bits 0..=2  ValueType discriminant
+//   bits 5..=6  wire_tag of the 4-byte algorithm the digest was computed with
+//   bit  7      "this node carries an insert digest"
+// Storing the algorithm PER NODE (not once per memtable) is what makes the
+// residence check immune to a mid-memtable `kv_checksum_algo` change: each
+// node is verified under the algorithm it was stored with. A node without the
+// presence bit has the slot zeroed and is never verified (covers the
+// mixed-variant memtable after an Off -> AtInsert toggle).
 const KV_DIGEST_PRESENT: u8 = 0x80;
-const VALUE_TYPE_MASK: u8 = 0x7F;
+const VALUE_TYPE_MASK: u8 = 0x07;
+const KV_ALGO_SHIFT: u8 = 5;
+const KV_ALGO_MASK: u8 = 0x60;
 
 /// Byte size of a node with the given tower `height`.
 #[expect(
@@ -189,11 +197,13 @@ impl SkipMap {
     /// Inserts a key-value pair, optionally storing a 4-byte per-KV digest
     /// computed at insert (`KvChecksumComputePoint::AtInsert`).
     ///
-    /// `kv_digest` is the low 32 bits of the entry's logical-content digest
-    /// (`Some` under `AtInsert` with a 4-byte algorithm, `None` otherwise). When
-    /// present it is stored in the node's reserved slot and the node is flagged
-    /// for flush-time verification via [`Self::verify_kv_digests`]; when absent
-    /// the node is byte-identical to a plain insert.
+    /// `kv_digest` is `Some((digest, algo))` where `digest` is the low 32 bits
+    /// of the entry's logical-content digest under the 4-byte `algo` (the
+    /// algorithm is stored per node so a later config change cannot misverify
+    /// this entry), or `None` for a plain insert. When present the digest and
+    /// algorithm tag are stored in the node and it is flagged for flush-time
+    /// verification via [`Self::verify_kv_digests`]; when absent the node is
+    /// byte-identical to a plain insert.
     #[expect(
         clippy::indexing_slicing,
         reason = "preds/succs are [u32; MAX_HEIGHT]; level < height <= MAX_HEIGHT"
@@ -202,7 +212,7 @@ impl SkipMap {
         &self,
         key: &InternalKey,
         value: &UserValue,
-        kv_digest: Option<u32>,
+        kv_digest: Option<(u32, ChecksumAlgorithm)>,
     ) {
         let height = self.random_height();
         let node = self.alloc_node(key, value, height, kv_digest);
@@ -288,8 +298,7 @@ impl SkipMap {
 
     /// Verifies every node carrying an insert-time per-KV digest
     /// (`KvChecksumComputePoint::AtInsert`) against a recompute over its
-    /// current bytes, under `algo` (the 4-byte algorithm the digests were
-    /// stored with).
+    /// current bytes, each under the algorithm the node was stored with.
     ///
     /// A divergence means the entry's logical content changed while it sat in
     /// the memtable, i.e. a RAM bit-flip during residence; it is reported as
@@ -303,15 +312,13 @@ impl SkipMap {
     ///
     /// - [`crate::Error::MemtableKvChecksumMismatch`] when a stored digest does
     ///   not match the recompute.
-    /// - [`crate::Error::FeatureUnsupported`] when `algo` is not compiled into
-    ///   this build (cannot recompute).
-    pub fn verify_kv_digests(
-        &self,
-        algo: crate::runtime_config::ChecksumAlgorithm,
-    ) -> crate::Result<()> {
+    /// - [`crate::Error::FeatureUnsupported`] when a node's algorithm is not
+    ///   compiled into this build (cannot recompute). Config validation rejects
+    ///   selecting an uncompiled algorithm, so this is a defensive guard.
+    pub fn verify_kv_digests(&self) -> crate::Result<()> {
         let mut node = self.first_node();
         while node != UNSET {
-            if let Some(stored) = self.node_kv_digest(node) {
+            if let Some((stored, algo)) = self.node_kv_digest(node) {
                 let item = InternalValue::new(self.node_internal_key(node), self.node_value(node));
                 let recomputed = crate::table::block::kv_checksum::kv_digest(&item, algo)
                     .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
@@ -387,7 +394,7 @@ impl SkipMap {
         key: &InternalKey,
         value: &UserValue,
         height: usize,
-        kv_digest: Option<u32>,
+        kv_digest: Option<(u32, ChecksumAlgorithm)>,
     ) -> u32 {
         let key_bytes: &[u8] = &key.user_key;
 
@@ -439,9 +446,11 @@ impl SkipMap {
             let vt_byte = u8::from(key.value_type);
             // Arena memory is uninitialized — the reserved padding at +12 is
             // either the digest (when present) or zeroed, so the whole header
-            // is fully written before the node is published.
-            if let Some(d) = kv_digest {
-                meta[10] = vt_byte | KV_DIGEST_PRESENT;
+            // is fully written before the node is published. The algorithm's
+            // wire_tag is packed into bits 5..=6 of the value_type byte so the
+            // digest is verified per node under its own algorithm.
+            if let Some((d, algo)) = kv_digest {
+                meta[10] = vt_byte | KV_DIGEST_PRESENT | (algo.wire_tag() << KV_ALGO_SHIFT);
                 meta[12..16].copy_from_slice(&d.to_ne_bytes());
             } else {
                 meta[10] = vt_byte;
@@ -518,10 +527,12 @@ impl SkipMap {
         ValueType::try_from(byte).expect("valid ValueType discriminant")
     }
 
-    /// Returns the insert-time per-KV digest stored in the node's reserved
-    /// slot, or `None` if the node carries no digest (the `KV_DIGEST_PRESENT`
-    /// flag is clear). The stored value is the low 32 bits of the entry's
-    /// logical-content digest under the active 4-byte algorithm.
+    /// Returns the insert-time per-KV digest and the algorithm it was computed
+    /// with, or `None` if the node carries no digest (the `KV_DIGEST_PRESENT`
+    /// flag is clear). The digest is the low 32 bits of the entry's
+    /// logical-content digest; the algorithm is recovered from the `wire_tag`
+    /// packed in bits 5..=6 of the `value_type` byte, so each node verifies
+    /// under its own algorithm regardless of later config changes.
     #[expect(
         clippy::indexing_slicing,
         reason = "metadata is exactly OFF_TOWER (24) bytes by construction"
@@ -530,12 +541,20 @@ impl SkipMap {
         clippy::expect_used,
         reason = "infallible: 4-byte slice always converts to [u8; 4]"
     )]
-    fn node_kv_digest(&self, node: u32) -> Option<u32> {
+    fn node_kv_digest(&self, node: u32) -> Option<(u32, ChecksumAlgorithm)> {
         let m = unsafe { self.meta(node) };
         if m[10] & KV_DIGEST_PRESENT == 0 {
             return None;
         }
-        Some(u32::from_ne_bytes(m[12..16].try_into().expect("4 bytes")))
+        let algo_tag = (m[10] & KV_ALGO_MASK) >> KV_ALGO_SHIFT;
+        // The tag was written from a valid 4-byte algorithm's wire_tag at
+        // insert, so it always decodes; treat a corrupt tag as no digest rather
+        // than panicking (the entry then escapes residence verification, which
+        // is the conservative outcome, and the block-level checksum still
+        // covers it on disk).
+        let algo = ChecksumAlgorithm::from_wire_tag(algo_tag)?;
+        let digest = u32::from_ne_bytes(m[12..16].try_into().expect("4 bytes"));
+        Some((digest, algo))
     }
 
     #[expect(
@@ -1181,9 +1200,9 @@ mod tests {
         for i in 0..8u8 {
             let key = make_key(&[b'k', i], u64::from(i) + 1);
             let val = make_value(&[b'v', i, i, i]);
-            map.insert_with_kv_digest(&key, &val, Some(digest4(&key, &val, algo)));
+            map.insert_with_kv_digest(&key, &val, Some((digest4(&key, &val, algo), algo)));
         }
-        assert!(map.verify_kv_digests(algo).is_ok());
+        assert!(map.verify_kv_digests().is_ok());
     }
 
     #[test]
@@ -1197,14 +1216,14 @@ mod tests {
         let map = new_map();
         let key = make_key(b"victim", 42);
         let val = make_value(b"payload");
-        map.insert_with_kv_digest(&key, &val, Some(digest4(&key, &val, algo)));
+        map.insert_with_kv_digest(&key, &val, Some((digest4(&key, &val, algo), algo)));
 
         // Flip a bit in the (only) node's user-key bytes, simulating residence
         // corruption.
         map.test_flip_first_key_byte();
 
         let err = map
-            .verify_kv_digests(algo)
+            .verify_kv_digests()
             .expect_err("corruption must be detected");
         assert!(
             matches!(err, crate::Error::MemtableKvChecksumMismatch { .. }),
@@ -1228,14 +1247,14 @@ mod tests {
         // Digest-bearing node (post-toggle): left intact.
         let k1 = make_key(b"bbb", 2);
         let v1 = make_value(b"has-digest");
-        map.insert_with_kv_digest(&k1, &v1, Some(digest4(&k1, &v1, algo)));
+        map.insert_with_kv_digest(&k1, &v1, Some((digest4(&k1, &v1, algo), algo)));
 
         // Corrupt the FIRST node's key (the no-digest "aaa" entry sorts first).
         map.test_flip_first_key_byte();
 
         // The corrupted node has no digest, so verify skips it and passes.
         assert!(
-            map.verify_kv_digests(algo).is_ok(),
+            map.verify_kv_digests().is_ok(),
             "nodes without a stored digest must not be verified"
         );
     }
@@ -1248,7 +1267,7 @@ mod tests {
             let key = make_key(&[b'x', i], u64::from(i) + 1);
             map.insert(&key, &make_value(b"plain"));
         }
-        assert!(map.verify_kv_digests(ChecksumAlgorithm::Xxh3Low32).is_ok());
+        assert!(map.verify_kv_digests().is_ok());
     }
 
     #[test]

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -18,7 +18,7 @@ use super::arena::Arena;
 use super::value_store::ValueStore;
 use crate::comparator::SharedComparator;
 use crate::key::InternalKey;
-use crate::value::{SeqNo, UserValue};
+use crate::value::{InternalValue, SeqNo, UserValue};
 use crate::{UserKey, ValueType};
 
 use core::cmp::Ordering as CmpOrdering;
@@ -60,6 +60,16 @@ const UNSET: u32 = 0;
 // the rest are accessed via array slicing in the node_*() accessors.
 const OFF_HEIGHT: u32 = 11;
 const OFF_TOWER: u32 = 24;
+
+// Per-KV insert-time digest (KvChecksumComputePoint::AtInsert): the 4-byte
+// reserved slot at +12 (otherwise alignment padding) holds the entry's 4-byte
+// digest, fixed at insert and re-checked at flush. Presence is flagged in the
+// high bit of the value_type byte (+10): ValueType discriminants are 0..=2, so
+// the low bits hold the type and bit 7 says "this node carries an insert
+// digest". A node without the flag has the slot zeroed and is never verified
+// (covers the mixed-variant memtable after an Off -> AtInsert toggle).
+const KV_DIGEST_PRESENT: u8 = 0x80;
+const VALUE_TYPE_MASK: u8 = 0x7F;
 
 /// Byte size of a node with the given tower `height`.
 #[expect(
@@ -172,13 +182,30 @@ impl SkipMap {
     ///
     /// Multiple entries with the same `user_key` but different `seqno` are
     /// expected (MVCC).  No deduplication is performed.
+    pub fn insert(&self, key: &InternalKey, value: &UserValue) {
+        self.insert_with_kv_digest(key, value, None);
+    }
+
+    /// Inserts a key-value pair, optionally storing a 4-byte per-KV digest
+    /// computed at insert (`KvChecksumComputePoint::AtInsert`).
+    ///
+    /// `kv_digest` is the low 32 bits of the entry's logical-content digest
+    /// (`Some` under `AtInsert` with a 4-byte algorithm, `None` otherwise). When
+    /// present it is stored in the node's reserved slot and the node is flagged
+    /// for flush-time verification via [`Self::verify_kv_digests`]; when absent
+    /// the node is byte-identical to a plain insert.
     #[expect(
         clippy::indexing_slicing,
         reason = "preds/succs are [u32; MAX_HEIGHT]; level < height <= MAX_HEIGHT"
     )]
-    pub fn insert(&self, key: &InternalKey, value: &UserValue) {
+    pub fn insert_with_kv_digest(
+        &self,
+        key: &InternalKey,
+        value: &UserValue,
+        kv_digest: Option<u32>,
+    ) {
         let height = self.random_height();
-        let node = self.alloc_node(key, value, height);
+        let node = self.alloc_node(key, value, height, kv_digest);
 
         // Raise the list height if needed.
         let mut list_h = self.height.load(Ordering::Relaxed);
@@ -238,9 +265,74 @@ impl SkipMap {
         self.len.load(Ordering::Relaxed)
     }
 
+    /// Test-only: flips a bit in the first node's user-key bytes, simulating a
+    /// RAM bit-flip during memtable residence. Used to exercise
+    /// [`Self::verify_kv_digests`] end-to-end through the flush path.
+    #[cfg(test)]
+    pub(crate) fn test_flip_first_key_byte(&self) {
+        let node = self.first_node();
+        assert_ne!(node, UNSET, "skiplist must be non-empty to corrupt");
+        let off = self.node_key_offset(node);
+        // SAFETY: `off` is the first node's just-allocated key region (len >= 1).
+        unsafe {
+            if let Some(b) = self.arena.get_bytes_mut(off, 1).first_mut() {
+                *b ^= 0xFF;
+            }
+        }
+    }
+
     /// Returns `true` if the skiplist is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Verifies every node carrying an insert-time per-KV digest
+    /// (`KvChecksumComputePoint::AtInsert`) against a recompute over its
+    /// current bytes, under `algo` (the 4-byte algorithm the digests were
+    /// stored with).
+    ///
+    /// A divergence means the entry's logical content changed while it sat in
+    /// the memtable, i.e. a RAM bit-flip during residence; it is reported as
+    /// [`crate::Error::MemtableKvChecksumMismatch`] with the diverging entry's
+    /// seqno. Nodes without a stored digest (inserted under `Off` /
+    /// `AtBlockCompile`, including those before an `Off -> AtInsert` toggle in
+    /// the same memtable) are skipped. A skiplist with no insert digests at all
+    /// walks the nodes and returns `Ok` immediately.
+    ///
+    /// # Errors
+    ///
+    /// - [`crate::Error::MemtableKvChecksumMismatch`] when a stored digest does
+    ///   not match the recompute.
+    /// - [`crate::Error::FeatureUnsupported`] when `algo` is not compiled into
+    ///   this build (cannot recompute).
+    pub fn verify_kv_digests(
+        &self,
+        algo: crate::runtime_config::ChecksumAlgorithm,
+    ) -> crate::Result<()> {
+        let mut node = self.first_node();
+        while node != UNSET {
+            if let Some(stored) = self.node_kv_digest(node) {
+                let item = InternalValue::new(self.node_internal_key(node), self.node_value(node));
+                let recomputed = crate::table::block::kv_checksum::kv_digest(&item, algo)
+                    .ok_or(crate::Error::FeatureUnsupported("kv-checksum-algorithm"))?;
+                // AtInsert stores the low 32 bits; truncate the recompute the
+                // same way so the comparison is width-consistent.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "AtInsert uses a 4-byte algorithm; only the low 32 bits are stored"
+                )]
+                let got = recomputed as u32;
+                if got != stored {
+                    return Err(crate::Error::MemtableKvChecksumMismatch {
+                        seqno: item.key.seqno,
+                        got: u64::from(got),
+                        expected: u64::from(stored),
+                    });
+                }
+            }
+            node = self.next_at(node, 0);
+        }
+        Ok(())
     }
 
     /// Returns an iterator over all entries in order.
@@ -290,7 +382,13 @@ impl SkipMap {
         clippy::cast_possible_truncation,
         reason = "key_bytes.len() <= u16::MAX, value idx <= u32::MAX, height <= MAX_HEIGHT (20)"
     )]
-    fn alloc_node(&self, key: &InternalKey, value: &UserValue, height: usize) -> u32 {
+    fn alloc_node(
+        &self,
+        key: &InternalKey,
+        value: &UserValue,
+        height: usize,
+        kv_digest: Option<u32>,
+    ) -> u32 {
         let key_bytes: &[u8] = &key.user_key;
 
         // Allocate key data in the arena.
@@ -336,11 +434,20 @@ impl SkipMap {
             meta[4..8].copy_from_slice(&value_idx.to_ne_bytes());
             // Cast is safe: InternalKey::new() asserts key.len() <= u16::MAX.
             meta[8..10].copy_from_slice(&(key_bytes.len() as u16).to_ne_bytes());
-            meta[10] = u8::from(key.value_type);
+            // ValueType discriminant in the low bits; high bit (KV_DIGEST_PRESENT)
+            // flags an insert-time per-KV digest in the reserved slot below.
+            let vt_byte = u8::from(key.value_type);
+            // Arena memory is uninitialized — the reserved padding at +12 is
+            // either the digest (when present) or zeroed, so the whole header
+            // is fully written before the node is published.
+            if let Some(d) = kv_digest {
+                meta[10] = vt_byte | KV_DIGEST_PRESENT;
+                meta[12..16].copy_from_slice(&d.to_ne_bytes());
+            } else {
+                meta[10] = vt_byte;
+                meta[12..16].copy_from_slice(&[0u8; 4]);
+            }
             meta[11] = height as u8;
-            // Arena memory is uninitialized — zero the reserved padding so the
-            // whole header is fully written before the node is published.
-            meta[12..16].copy_from_slice(&[0u8; 4]);
             meta[16..24].copy_from_slice(&key.seqno.to_ne_bytes());
             // Tower slots [0, height) are NOT initialized here: `insert` writes
             // every one of them (release store) before linking the node at that
@@ -400,12 +507,35 @@ impl SkipMap {
     )]
     fn node_value_type(&self, node: u32) -> ValueType {
         let m = unsafe { self.meta(node) };
-        let byte = m[10];
+        // Mask off the KV_DIGEST_PRESENT flag (high bit): the low bits hold the
+        // ValueType discriminant, the high bit is the insert-digest presence
+        // flag and is not part of the type.
+        let byte = m[10] & VALUE_TYPE_MASK;
         debug_assert!(
             byte <= 4,
             "invalid ValueType byte {byte} at node offset {node}, meta={m:?}",
         );
         ValueType::try_from(byte).expect("valid ValueType discriminant")
+    }
+
+    /// Returns the insert-time per-KV digest stored in the node's reserved
+    /// slot, or `None` if the node carries no digest (the `KV_DIGEST_PRESENT`
+    /// flag is clear). The stored value is the low 32 bits of the entry's
+    /// logical-content digest under the active 4-byte algorithm.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "metadata is exactly OFF_TOWER (24) bytes by construction"
+    )]
+    #[expect(
+        clippy::expect_used,
+        reason = "infallible: 4-byte slice always converts to [u8; 4]"
+    )]
+    fn node_kv_digest(&self, node: u32) -> Option<u32> {
+        let m = unsafe { self.meta(node) };
+        if m[10] & KV_DIGEST_PRESENT == 0 {
+            return None;
+        }
+        Some(u32::from_ne_bytes(m[12..16].try_into().expect("4 bytes")))
     }
 
     #[expect(
@@ -1024,6 +1154,101 @@ mod tests {
 
     fn make_value(data: &[u8]) -> UserValue {
         UserValue::from(data)
+    }
+
+    use crate::runtime_config::ChecksumAlgorithm;
+
+    /// Low-32 logical digest of an entry under `algo` (the value stored at
+    /// insert under `KvChecksumComputePoint::AtInsert`).
+    fn digest4(key: &InternalKey, val: &UserValue, algo: ChecksumAlgorithm) -> u32 {
+        let item = InternalValue::new(key.clone(), val.clone());
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::expect_used,
+            reason = "4-byte algo fits u32; test helper"
+        )]
+        let d = crate::table::block::kv_checksum::kv_digest(&item, algo)
+            .expect("xxh3 always available") as u32;
+        d
+    }
+
+    #[test]
+    fn verify_kv_digests_passes_when_uncorrupted() {
+        // Every node carries the digest computed over its own bytes, so a
+        // recompute at flush matches and verify succeeds.
+        let algo = ChecksumAlgorithm::Xxh3Low32;
+        let map = new_map();
+        for i in 0..8u8 {
+            let key = make_key(&[b'k', i], u64::from(i) + 1);
+            let val = make_value(&[b'v', i, i, i]);
+            map.insert_with_kv_digest(&key, &val, Some(digest4(&key, &val, algo)));
+        }
+        assert!(map.verify_kv_digests(algo).is_ok());
+    }
+
+    #[test]
+    #[expect(clippy::expect_used, reason = "test asserts the error via expect_err")]
+    fn verify_kv_digests_detects_residence_corruption() {
+        // Simulate a RAM bit-flip during residence: store the correct digest at
+        // insert, then corrupt the entry's key bytes in the arena. The recompute
+        // over the corrupted bytes diverges from the stored digest, so verify
+        // reports a MemtableKvChecksumMismatch.
+        let algo = ChecksumAlgorithm::Xxh3Low32;
+        let map = new_map();
+        let key = make_key(b"victim", 42);
+        let val = make_value(b"payload");
+        map.insert_with_kv_digest(&key, &val, Some(digest4(&key, &val, algo)));
+
+        // Flip a bit in the (only) node's user-key bytes, simulating residence
+        // corruption.
+        map.test_flip_first_key_byte();
+
+        let err = map
+            .verify_kv_digests(algo)
+            .expect_err("corruption must be detected");
+        assert!(
+            matches!(err, crate::Error::MemtableKvChecksumMismatch { .. }),
+            "expected MemtableKvChecksumMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_kv_digests_skips_nodes_without_a_digest() {
+        // Mixed-variant memtable (Off -> AtInsert toggle): nodes inserted
+        // without a digest are never verified, even if their bytes are
+        // corrupted. Only digest-bearing nodes are checked.
+        let algo = ChecksumAlgorithm::Xxh3Low32;
+        let map = new_map();
+
+        // No-digest node (pre-toggle): corrupt it later; must be skipped.
+        let k0 = make_key(b"aaa", 1);
+        let v0 = make_value(b"no-digest");
+        map.insert_with_kv_digest(&k0, &v0, None);
+
+        // Digest-bearing node (post-toggle): left intact.
+        let k1 = make_key(b"bbb", 2);
+        let v1 = make_value(b"has-digest");
+        map.insert_with_kv_digest(&k1, &v1, Some(digest4(&k1, &v1, algo)));
+
+        // Corrupt the FIRST node's key (the no-digest "aaa" entry sorts first).
+        map.test_flip_first_key_byte();
+
+        // The corrupted node has no digest, so verify skips it and passes.
+        assert!(
+            map.verify_kv_digests(algo).is_ok(),
+            "nodes without a stored digest must not be verified"
+        );
+    }
+
+    #[test]
+    fn verify_kv_digests_no_digests_is_ok() {
+        // A memtable with only plain inserts has nothing to verify.
+        let map = new_map();
+        for i in 0..4u8 {
+            let key = make_key(&[b'x', i], u64::from(i) + 1);
+            map.insert(&key, &make_value(b"plain"));
+        }
+        assert!(map.verify_kv_digests(ChecksumAlgorithm::Xxh3Low32).is_ok());
     }
 
     #[test]

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -597,6 +597,9 @@ impl SkipMap {
         reason = "infallible: 4-byte slice always converts to [u8; 4]"
     )]
     fn node_kv_digest(&self, node: u32) -> NodeKvDigest {
+        // SAFETY: `node` is a published skiplist node; its metadata header
+        // [0..OFF_TOWER) was fully written in `alloc_node` before the node was
+        // linked (CAS with Release), so the read is valid for the map's lifetime.
         let m = unsafe { self.meta(node) };
         if m[10] & KV_DIGEST_PRESENT == 0 {
             return NodeKvDigest::Absent;
@@ -675,6 +678,9 @@ impl SkipMap {
         reason = "metadata is exactly OFF_TOWER (24) bytes by construction"
     )]
     fn node_internal_key_checked(&self, node: u32) -> crate::Result<InternalKey> {
+        // SAFETY: `node` is reached via skiplist links only after publication,
+        // so its metadata header is fully initialized; reading the value_type
+        // byte (index 10, within [0..OFF_TOWER)) is valid.
         let vt_byte = unsafe { self.meta(node) }[10] & VALUE_TYPE_MASK;
         let value_type = ValueType::try_from(vt_byte)
             .map_err(|()| crate::Error::InvalidTag(("memtable-value-type", vt_byte)))?;

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -304,6 +304,26 @@ impl SkipMap {
         }
     }
 
+    /// Test-only: corrupts the first node's `value_type` low bits to an invalid
+    /// discriminant (0b111), keeping the presence + algorithm bits intact.
+    /// Simulates a RAM bit-flip in the value_type byte so the residence
+    /// verifier can be checked to fail closed instead of panicking.
+    #[cfg(test)]
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "node metadata is exactly OFF_TOWER bytes; index 10 is the value_type byte"
+    )]
+    pub(crate) fn test_corrupt_first_node_value_type(&self) {
+        let node = self.first_node();
+        assert_ne!(node, UNSET, "skiplist must be non-empty to corrupt");
+        // SAFETY: `node` is a valid allocated node; its metadata is OFF_TOWER
+        // bytes, so index 10 (the value_type byte) is in bounds.
+        unsafe {
+            let m = self.arena.get_bytes_mut(node, OFF_TOWER);
+            m[10] = (m[10] & !VALUE_TYPE_MASK) | VALUE_TYPE_MASK; // low bits = 0b111 (invalid)
+        }
+    }
+
     /// Returns `true` if the skiplist is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -1324,6 +1344,26 @@ mod tests {
         assert!(
             map.verify_kv_digests().is_err(),
             "a present digest under a non-4-byte algorithm must be rejected, not verified"
+        );
+    }
+
+    #[test]
+    fn verify_kv_digests_fails_closed_on_corrupt_value_type() {
+        // A digest-bearing node whose value_type bits were corrupted to an
+        // invalid discriminant must surface a typed error from the residence
+        // verifier, not panic (the verifier reconstructs the key, which decodes
+        // value_type). Fail closed.
+        let algo = ChecksumAlgorithm::Xxh3Low32;
+        let map = new_map();
+        let key = make_key(b"k", 1);
+        let val = make_value(b"v");
+        map.insert_with_kv_digest(&key, &val, Some((digest4(&key, &val, algo), algo)));
+
+        map.test_corrupt_first_node_value_type();
+
+        assert!(
+            map.verify_kv_digests().is_err(),
+            "corrupt value_type on a digest-bearing node must fail closed, not panic"
         );
     }
 

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -126,9 +126,10 @@ impl RuntimeConfigHandle {
     /// `Block` granularity, `Page` granularity is rejected (only `Block` is
     /// wired), a zero shard count is rejected (no implicit RS(4,2) fallback),
     /// and `ReedSolomon` needs >= 2 parity shards (single parity is expressed
-    /// as `Xor`); (3) `kv_checksum_compute_point = AtInsert`, which is not yet
-    /// wired into the memtable / writer path — accepting it would silently
-    /// behave as `AtBlockCompile`.
+    /// as `Xor`); (3) `kv_checksum_compute_point = AtInsert` with an 8-byte
+    /// algorithm: `AtInsert` stores the digest in the skiplist node's 4-byte
+    /// reserved slot, so it requires a 4-byte algorithm (`Xxh3Low32` /
+    /// `Crc32c`); `Xxh3_64` would grow every node and is rejected.
     ///
     /// # Errors
     ///
@@ -137,7 +138,7 @@ impl RuntimeConfigHandle {
     /// - [`crate::Error::FeatureUnsupported`] when the mutator enables ECC
     ///   with an unwired / invalid scheme or granularity (`Page`, a zero shard
     ///   count, single-parity `ReedSolomon`), or sets
-    ///   `kv_checksum_compute_point = AtInsert`.
+    ///   `kv_checksum_compute_point = AtInsert` with an 8-byte algorithm.
     pub fn try_update<F>(&self, mutator: F) -> crate::Result<()>
     where
         F: FnOnce(&mut RuntimeConfig),
@@ -185,22 +186,22 @@ impl RuntimeConfigHandle {
                 _ => {}
             }
         }
-        // AtInsert (compute the per-KV digest at memtable insert and carry
-        // it through flush) is not yet wired into the memtable / writer
-        // path: accepting it would silently behave as AtBlockCompile,
-        // downgrading the caller's intent without notice. Reject it with a
-        // typed error until the carry path lands. (When wired, AtInsert
-        // will additionally require a 4-byte algorithm so the digest fits
-        // the memtable node's reserved slot.)
+        // AtInsert (compute the per-KV digest at memtable insert, then verify
+        // it against a recompute at flush to catch a RAM bit-flip during
+        // memtable residence) stores the digest in the skiplist node's 4-byte
+        // reserved slot. That slot only fits a 4-byte digest, so AtInsert
+        // requires a 4-byte algorithm (`Xxh3Low32` / `Crc32c`); the 8-byte
+        // `Xxh3_64` would grow every memtable node and is rejected. This keeps
+        // AtInsert zero-size-overhead in the memtable.
         if matches!(
             next.kv_checksum_compute_point,
             crate::runtime_config::KvChecksumComputePoint::AtInsert
-        ) {
+        ) && next.kv_checksum_algo.digest_size() != 4
+        {
             // Short, machine-matchable marker per the FeatureUnsupported
-            // contract; the "not yet wired, use AtBlockCompile" rationale lives
-            // in the comment above rather than in the error payload.
+            // contract; the 4-byte-slot rationale lives in the comment above.
             return Err(crate::Error::FeatureUnsupported(
-                "kv_checksum_compute_point=AtInsert",
+                "kv_checksum_compute_point=AtInsert requires a 4-byte algorithm",
             ));
         }
         #[cfg(feature = "std")]
@@ -362,20 +363,24 @@ mod tests {
     }
 
     #[test]
-    fn try_update_rejects_at_insert_as_not_implemented() {
+    fn try_update_rejects_at_insert_with_8_byte_algorithm() {
         use super::super::types::KvChecksumComputePoint;
 
-        // AtInsert is not yet wired into the memtable / writer path.
-        // Accepting it would silently behave as AtBlockCompile, so it must
-        // be rejected with a typed error and leave the live snapshot
-        // unchanged — regardless of the algorithm width.
+        // AtInsert stores the digest in the node's 4-byte reserved slot, so
+        // the 8-byte Xxh3_64 (the default algo) does not fit and must be
+        // rejected with a typed error, leaving the live snapshot unchanged.
         let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+        assert_eq!(
+            handle.load().kv_checksum_algo,
+            ChecksumAlgorithm::Xxh3_64,
+            "precondition: default algo is the 8-byte Xxh3_64"
+        );
         let result = handle.try_update(|c| {
             c.kv_checksum_compute_point = KvChecksumComputePoint::AtInsert;
         });
         assert!(
             matches!(result, Err(crate::Error::FeatureUnsupported(_))),
-            "AtInsert must be rejected as not-yet-implemented, got {result:?}"
+            "AtInsert + 8-byte algo must be rejected, got {result:?}"
         );
         assert_eq!(
             handle.load().kv_checksum_compute_point,
@@ -385,21 +390,30 @@ mod tests {
     }
 
     #[test]
-    fn try_update_rejects_at_insert_even_with_4_byte_algorithm() {
+    fn try_update_accepts_at_insert_with_4_byte_algorithm() {
         use super::super::types::KvChecksumComputePoint;
 
-        // Even with a 4-byte algorithm (the eventual requirement), AtInsert
-        // is rejected until the carry path is implemented — the not-yet-
-        // wired gate fires before the algorithm-width check.
-        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
-        let result = handle.try_update(|c| {
-            c.kv_checksum_algo = ChecksumAlgorithm::Xxh3Low32;
-            c.kv_checksum_compute_point = KvChecksumComputePoint::AtInsert;
-        });
-        assert!(
-            matches!(result, Err(crate::Error::FeatureUnsupported(_))),
-            "AtInsert must be rejected even with a 4-byte algorithm, got {result:?}"
-        );
+        // A 4-byte algorithm fits the node's reserved slot, so AtInsert is
+        // accepted and becomes visible on the next load.
+        for algo in [ChecksumAlgorithm::Xxh3Low32, ChecksumAlgorithm::Crc32c] {
+            // Crc32c needs the cargo feature to be a usable runtime algo, but
+            // its digest width is 4 regardless, so the config-level acceptance
+            // check is independent of the feature.
+            let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+            let result = handle.try_update(|c| {
+                c.kv_checksum_algo = algo;
+                c.kv_checksum_compute_point = KvChecksumComputePoint::AtInsert;
+            });
+            assert!(
+                result.is_ok(),
+                "AtInsert + 4-byte {algo:?} must be accepted, got {result:?}"
+            );
+            assert_eq!(
+                handle.load().kv_checksum_compute_point,
+                KvChecksumComputePoint::AtInsert,
+                "accepted AtInsert must be visible on next load for {algo:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -196,13 +196,23 @@ impl RuntimeConfigHandle {
         if matches!(
             next.kv_checksum_compute_point,
             crate::runtime_config::KvChecksumComputePoint::AtInsert
-        ) && next.kv_checksum_algo.digest_size() != 4
-        {
-            // Short, machine-matchable marker per the FeatureUnsupported
+        ) {
+            // Short, machine-matchable markers per the FeatureUnsupported
             // contract; the 4-byte-slot rationale lives in the comment above.
-            return Err(crate::Error::FeatureUnsupported(
-                "kv_checksum_compute_point=AtInsert requires a 4-byte algorithm",
-            ));
+            if next.kv_checksum_algo.digest_size() != 4 {
+                return Err(crate::Error::FeatureUnsupported(
+                    "kv_checksum_compute_point=AtInsert requires a 4-byte algorithm",
+                ));
+            }
+            // The algorithm must also be compiled in: a 4-byte algorithm whose
+            // digest cannot be computed (e.g. Crc32c without the `crc32c`
+            // feature) would silently skip residence digests at insert and fail
+            // at flush. Reject it here instead.
+            if !next.kv_checksum_algo.is_available() {
+                return Err(crate::Error::FeatureUnsupported(
+                    "kv_checksum_compute_point=AtInsert requires a compiled-in algorithm",
+                ));
+            }
         }
         #[cfg(feature = "std")]
         {
@@ -393,12 +403,11 @@ mod tests {
     fn try_update_accepts_at_insert_with_4_byte_algorithm() {
         use super::super::types::KvChecksumComputePoint;
 
-        // A 4-byte algorithm fits the node's reserved slot, so AtInsert is
-        // accepted and becomes visible on the next load.
-        for algo in [ChecksumAlgorithm::Xxh3Low32, ChecksumAlgorithm::Crc32c] {
-            // Crc32c needs the cargo feature to be a usable runtime algo, but
-            // its digest width is 4 regardless, so the config-level acceptance
-            // check is independent of the feature.
+        // Asserts AtInsert + a compiled 4-byte algorithm is accepted and
+        // visible on the next load. Xxh3Low32 is always compiled; Crc32c only
+        // when the `crc32c` feature is on (its rejection without the feature is
+        // covered by `try_update_rejects_at_insert_with_uncompiled_algorithm`).
+        let assert_accepted = |algo: ChecksumAlgorithm| {
             let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
             let result = handle.try_update(|c| {
                 c.kv_checksum_algo = algo;
@@ -406,14 +415,18 @@ mod tests {
             });
             assert!(
                 result.is_ok(),
-                "AtInsert + 4-byte {algo:?} must be accepted, got {result:?}"
+                "AtInsert + compiled 4-byte {algo:?} must be accepted, got {result:?}"
             );
             assert_eq!(
                 handle.load().kv_checksum_compute_point,
                 KvChecksumComputePoint::AtInsert,
                 "accepted AtInsert must be visible on next load for {algo:?}"
             );
-        }
+        };
+
+        assert_accepted(ChecksumAlgorithm::Xxh3Low32);
+        #[cfg(feature = "crc32c")]
+        assert_accepted(ChecksumAlgorithm::Crc32c);
     }
 
     #[cfg(not(feature = "crc32c"))]

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -126,10 +126,13 @@ impl RuntimeConfigHandle {
     /// `Block` granularity, `Page` granularity is rejected (only `Block` is
     /// wired), a zero shard count is rejected (no implicit RS(4,2) fallback),
     /// and `ReedSolomon` needs >= 2 parity shards (single parity is expressed
-    /// as `Xor`); (3) `kv_checksum_compute_point = AtInsert` with an 8-byte
-    /// algorithm: `AtInsert` stores the digest in the skiplist node's 4-byte
-    /// reserved slot, so it requires a 4-byte algorithm (`Xxh3Low32` /
-    /// `Crc32c`); `Xxh3_64` would grow every node and is rejected.
+    /// as `Xor`); (3) `kv_checksum_compute_point = AtInsert` with an algorithm
+    /// that is not a compiled-in 4-byte one. `AtInsert` stores the digest in
+    /// the skiplist node's 4-byte reserved slot, so it requires a 4-byte
+    /// algorithm (`Xxh3Low32` / `Crc32c`): the 8-byte `Xxh3_64` would grow
+    /// every node, and a 4-byte algorithm not compiled into the build (e.g.
+    /// `Crc32c` without the `crc32c` feature) cannot produce a digest. Both
+    /// are rejected.
     ///
     /// # Errors
     ///
@@ -138,7 +141,8 @@ impl RuntimeConfigHandle {
     /// - [`crate::Error::FeatureUnsupported`] when the mutator enables ECC
     ///   with an unwired / invalid scheme or granularity (`Page`, a zero shard
     ///   count, single-parity `ReedSolomon`), or sets
-    ///   `kv_checksum_compute_point = AtInsert` with an 8-byte algorithm.
+    ///   `kv_checksum_compute_point = AtInsert` with an 8-byte or
+    ///   not-compiled-in algorithm.
     pub fn try_update<F>(&self, mutator: F) -> crate::Result<()>
     where
         F: FnOnce(&mut RuntimeConfig),

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -416,6 +416,26 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "crc32c"))]
+    #[test]
+    fn try_update_rejects_at_insert_with_uncompiled_algorithm() {
+        use super::super::types::KvChecksumComputePoint;
+
+        // Crc32c is a 4-byte algorithm, but without the crc32c feature its
+        // digest cannot be computed (compute returns None). Accepting AtInsert
+        // with it would silently skip residence digests at insert and/or fail
+        // later at flush, so the config update must reject it up front.
+        let handle = RuntimeConfigHandle::new(RuntimeConfig::default());
+        let result = handle.try_update(|c| {
+            c.kv_checksum_algo = ChecksumAlgorithm::Crc32c;
+            c.kv_checksum_compute_point = KvChecksumComputePoint::AtInsert;
+        });
+        assert!(
+            matches!(result, Err(crate::Error::FeatureUnsupported(_))),
+            "AtInsert + uncompiled Crc32c must be rejected, got {result:?}"
+        );
+    }
+
     #[test]
     fn update_applies_mutation_visible_on_next_load() {
         let handle = RuntimeConfigHandle::new(RuntimeConfig::default());

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -75,6 +75,24 @@ impl ChecksumAlgorithm {
         }
     }
 
+    /// Whether this algorithm can actually compute a digest in this build.
+    ///
+    /// [`Self::Xxh3_64`] / [`Self::Xxh3Low32`] are always available;
+    /// [`Self::Crc32c`] only when the `crc32c` cargo feature is enabled (its
+    /// [`Self::compute`] returns `None` otherwise). Config validation uses this
+    /// to reject selecting an uncompiled algorithm up front, rather than
+    /// silently skipping digests or failing later at flush.
+    #[must_use]
+    pub const fn is_available(self) -> bool {
+        match self {
+            Self::Xxh3_64 | Self::Xxh3Low32 => true,
+            #[cfg(feature = "crc32c")]
+            Self::Crc32c => true,
+            #[cfg(not(feature = "crc32c"))]
+            Self::Crc32c => false,
+        }
+    }
+
     /// Compute the digest of `bytes` under this algorithm, returned as a
     /// `u64` (the low [`Self::digest_size`] bytes are the meaningful
     /// digest; wider algorithms fill more of the word).

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -187,9 +187,10 @@ impl ChecksumAlgorithm {
 /// a scrub localise which entry diverged. Catching a RAM bit-flip that
 /// corrupts an entry WHILE it sits in the memtable, before the block
 /// is compiled, additionally requires
-/// [`KvChecksumComputePoint::AtInsert`] (not yet implemented — see its
-/// docs); the digests in this implementation are computed when the
-/// block is compiled. Default [`Self::Off`] emits no per-KV footer (the
+/// [`KvChecksumComputePoint::AtInsert`], which computes the digest at
+/// insert and verifies it at flush; the default
+/// [`KvChecksumComputePoint::AtBlockCompile`] computes the digests when
+/// the block is compiled. Default [`Self::Off`] emits no per-KV footer (the
 /// `KV_CHECKSUM_FOOTER` bit clear), zero per-KV overhead.
 ///
 /// Selection granularity:
@@ -255,17 +256,20 @@ impl KvChecksumPolicy {
 /// corrupts an entry while it sits in the memtable before the block is
 /// compiled.
 ///
-/// [`Self::AtInsert`] computes the digest at memtable insert and carries it
-/// to the block, closing the memtable-residence window (the entry's digest
-/// is fixed the moment it enters RAM) at the cost of storing the digest in
-/// the memtable node.
+/// [`Self::AtInsert`] computes the digest at memtable insert and stores it in
+/// the skiplist node's 4-byte reserved slot, fixing the entry's digest the
+/// moment it enters RAM. At flush, the digest is re-derived over the entry's
+/// current bytes and compared against the stored value: a divergence means the
+/// entry was corrupted while it sat in the memtable (a RAM bit-flip during
+/// residence), surfaced as [`crate::Error::MemtableKvChecksumMismatch`]. The
+/// digest domain is logical, so the re-derivation at flush (and the digest the
+/// block writer emits) equals the carried value when the bytes are intact.
 ///
-/// **Not yet implemented:** the memtable / writer carry path is not wired,
-/// so selecting `AtInsert` via `update_runtime_config` is rejected with a
-/// typed error rather than silently behaving as `AtBlockCompile`. When the
-/// carry path lands, `AtInsert` will additionally require a 4-byte algorithm
-/// ([`ChecksumAlgorithm::Xxh3Low32`] / [`ChecksumAlgorithm::Crc32c`]) so the
-/// digest fits the node's reserved slot.
+/// `AtInsert` requires a 4-byte algorithm ([`ChecksumAlgorithm::Xxh3Low32`] /
+/// [`ChecksumAlgorithm::Crc32c`]) so the digest fits the node's reserved slot
+/// with zero size growth; selecting it with the 8-byte [`ChecksumAlgorithm::Xxh3_64`]
+/// is rejected at config-validation time. Off-by-default `AtBlockCompile`
+/// leaves the memtable node untouched (zero overhead).
 //
 // no-std: pure data — compiles under `--no-default-features --features alloc`.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
@@ -275,8 +279,9 @@ pub enum KvChecksumComputePoint {
     #[default]
     AtBlockCompile,
 
-    /// Compute at memtable insert and carry (covers the full RAM lifecycle).
-    /// Not yet implemented — rejected at config-validation time.
+    /// Compute at memtable insert and verify at flush (covers the RAM-residence
+    /// window). Requires a 4-byte algorithm; the digest lives in the node's
+    /// reserved slot, so enabling it adds no per-entry memtable bytes.
     AtInsert,
 }
 

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -655,13 +655,12 @@ pub struct RuntimeConfig {
     /// When the per-KV digest is computed:
     /// [`KvChecksumComputePoint::AtBlockCompile`] (default) at flush /
     /// compaction, or [`KvChecksumComputePoint::AtInsert`] at memtable
-    /// insert (the future memtable-residence-window mode). `AtInsert` is
-    /// NOT yet implemented: `RuntimeConfigHandle::try_update` (behind
-    /// [`crate::Tree::update_runtime_config`]) currently rejects EVERY
-    /// `AtInsert` setting with a typed error, regardless of
-    /// [`Self::kv_checksum_algo`] (both `Xxh3_64` and `Xxh3Low32`), so it
-    /// cannot be applied today. Default `AtBlockCompile` is always
-    /// accepted.
+    /// insert (the memtable-residence-window mode that catches a RAM
+    /// bit-flip while a record sits in the memtable). `AtInsert` requires a
+    /// 4-byte [`Self::kv_checksum_algo`] (`Xxh3Low32` / `Crc32c`) that is
+    /// compiled into the build; `RuntimeConfigHandle::try_update` (behind
+    /// [`crate::Tree::update_runtime_config`]) rejects `AtInsert` with the
+    /// 8-byte `Xxh3_64`, or with an uncompiled algorithm, via a typed error.
     pub kv_checksum_compute_point: KvChecksumComputePoint,
 
     /// When `true`, every manifest write reserves a 4 KiB region at

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2350,10 +2350,15 @@ impl Tree {
 
         // Per-KV residence digest (KvChecksumComputePoint::AtInsert): compute
         // the entry's 4-byte logical-content digest now, so a RAM bit-flip
-        // while it sits in the memtable is caught at flush. Reading the live
-        // snapshot is a cheap arc-swap load; under the default
-        // `AtBlockCompile` (or `Off`) the two `matches!` checks short-circuit
-        // and no digest is computed, so the hot insert path is unchanged.
+        // while it sits in the memtable is caught at flush. The digest covers
+        // the OWNED `value` and is independent of which active memtable
+        // receives it, so computing it before taking the version-history guard
+        // is correct (a concurrent rotation just routes the same value+digest
+        // into the new active memtable) AND keeps the hash out of the read-lock
+        // critical section. Reading the live snapshot is a cheap arc-swap load;
+        // under the default `AtBlockCompile` (or `Off`) the two `matches!`
+        // checks short-circuit and no digest is computed, so the hot insert
+        // path is unchanged.
         let kv_digest = {
             let rc = self.0.runtime_config.load();
             if matches!(
@@ -2374,6 +2379,10 @@ impl Tree {
             }
         };
 
+        // The `.read()` guard is a temporary that lives until the end of this
+        // statement, so the insert runs under the version-history read lock:
+        // `value` + its digest land in the current active memtable atomically,
+        // and a concurrent `rotate_memtable()` cannot seal it mid-insert.
         self.version_history
             .read()
             .latest_version()

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2346,11 +2346,39 @@ impl Tree {
     #[doc(hidden)]
     #[must_use]
     pub fn append_entry(&self, value: InternalValue) -> (u64, u64) {
+        use crate::runtime_config::{KvChecksumComputePoint, KvChecksumPolicy};
+
+        // Per-KV residence digest (KvChecksumComputePoint::AtInsert): compute
+        // the entry's 4-byte logical-content digest now, so a RAM bit-flip
+        // while it sits in the memtable is caught at flush. Reading the live
+        // snapshot is a cheap arc-swap load; under the default
+        // `AtBlockCompile` (or `Off`) the two `matches!` checks short-circuit
+        // and no digest is computed, so the hot insert path is unchanged.
+        let kv_digest = {
+            let rc = self.0.runtime_config.load();
+            if matches!(
+                rc.kv_checksum_compute_point,
+                KvChecksumComputePoint::AtInsert
+            ) && !matches!(rc.kv_checksums, KvChecksumPolicy::Off)
+            {
+                crate::table::block::kv_checksum::kv_digest(&value, rc.kv_checksum_algo).map(|d| {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "AtInsert is config-validated to a 4-byte algorithm; the digest fits u32"
+                    )]
+                    let lo = d as u32;
+                    (lo, rc.kv_checksum_algo)
+                })
+            } else {
+                None
+            }
+        };
+
         self.version_history
             .read()
             .latest_version()
             .active_memtable
-            .insert(value)
+            .insert_with_kv_digest(value, kv_digest)
     }
 
     /// Adds multiple items to the active memtable in bulk.
@@ -2362,6 +2390,24 @@ impl Tree {
     #[doc(hidden)]
     #[must_use]
     pub(crate) fn append_batch(&self, items: Vec<InternalValue>) -> (u64, u64) {
+        use crate::runtime_config::{KvChecksumComputePoint, KvChecksumPolicy};
+
+        // Per-KV residence digest under AtInsert (see `append_entry`): pass the
+        // algorithm so the bulk path fixes each entry's digest at insert. The
+        // default path passes `None` and is unchanged.
+        let kv_algo = {
+            let rc = self.0.runtime_config.load();
+            if matches!(
+                rc.kv_checksum_compute_point,
+                KvChecksumComputePoint::AtInsert
+            ) && !matches!(rc.kv_checksums, KvChecksumPolicy::Off)
+            {
+                Some(rc.kv_checksum_algo)
+            } else {
+                None
+            }
+        };
+
         // Hold the read guard for the entire insert to prevent rotate_memtable()
         // from sealing this memtable mid-batch (which could cause data loss if
         // a concurrent flush persists only a prefix of the batch).
@@ -2369,7 +2415,7 @@ impl Tree {
             .read()
             .latest_version()
             .active_memtable
-            .insert_batch(items)
+            .insert_batch_with_kv_algo(items, kv_algo)
     }
 
     /// Recovers previous state, by loading the level manifest, tables and blob files.

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -251,6 +251,102 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
     Ok(())
 }
 
+#[test]
+fn at_insert_kv_checksum_round_trips_through_flush_and_reopen() -> lsm_tree::Result<()> {
+    // KvChecksumComputePoint::AtInsert with a 4-byte algorithm: each entry's
+    // digest is computed at insert and verified at flush against a recompute.
+    // With no corruption the residence check passes and the data reads back
+    // intact through flush and reopen.
+    let folder = get_tmp_folder();
+    {
+        let tree = open_tree(folder.path());
+        tree.update_runtime_config(|cfg| {
+            cfg.kv_checksums = KvChecksumPolicy::AllLevels;
+            cfg.kv_checksum_algo = ChecksumAlgorithm::Xxh3Low32;
+            cfg.kv_checksum_compute_point =
+                lsm_tree::runtime_config::KvChecksumComputePoint::AtInsert;
+        })?;
+
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let value = format!("value{i:05}");
+            tree.insert(key.as_bytes(), value.as_bytes(), i);
+        }
+        // Flush runs the AtInsert residence verify over the sealed memtable;
+        // it must succeed (no corruption) and produce the SST.
+        tree.flush_active_memtable(0)?;
+
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+            assert_eq!(
+                got.as_deref(),
+                Some(format!("value{i:05}").as_bytes()),
+                "post-flush read of {key} under AtInsert must return its value"
+            );
+        }
+    }
+
+    // Reopen: data must read back identically (AtInsert is a residence check,
+    // not an on-disk format change beyond the per-KV footer).
+    let tree = open_tree(folder.path());
+    for i in 0..500u64 {
+        let key = format!("key{i:05}");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("value{i:05}").as_bytes()),
+            "post-reopen read of {key} must return its value"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn at_insert_handles_off_to_at_insert_toggle_mid_memtable() -> lsm_tree::Result<()> {
+    // Live toggle Off -> AtInsert within one memtable's lifetime: entries
+    // inserted before the toggle carry no digest, entries after do. The
+    // flush-time residence check must verify only the digest-bearing entries
+    // and flush the mixed-variant memtable successfully, with all data intact.
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Pre-toggle: default (no AtInsert digest).
+    for i in 0..200u64 {
+        let key = format!("key{i:05}");
+        let value = format!("value{i:05}");
+        tree.insert(key.as_bytes(), value.as_bytes(), i);
+    }
+
+    // Toggle AtInsert on with a 4-byte algorithm.
+    tree.update_runtime_config(|cfg| {
+        cfg.kv_checksums = KvChecksumPolicy::AllLevels;
+        cfg.kv_checksum_algo = ChecksumAlgorithm::Xxh3Low32;
+        cfg.kv_checksum_compute_point = lsm_tree::runtime_config::KvChecksumComputePoint::AtInsert;
+    })?;
+
+    // Post-toggle: same active memtable now also holds digest-bearing nodes.
+    for i in 200..400u64 {
+        let key = format!("key{i:05}");
+        let value = format!("value{i:05}");
+        tree.insert(key.as_bytes(), value.as_bytes(), i);
+    }
+
+    // Flush the mixed-variant memtable: verify checks only post-toggle nodes.
+    tree.flush_active_memtable(0)?;
+
+    for i in 0..400u64 {
+        let key = format!("key{i:05}");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("value{i:05}").as_bytes()),
+            "mixed-variant flush must preserve {key}"
+        );
+    }
+    Ok(())
+}
+
 /// Locks the public contract of `Tree::update_runtime_config` when
 /// the build does NOT enable the `page_ecc` cargo feature:
 /// flipping `page_ecc = true` must return the typed error AND


### PR DESCRIPTION
## Summary

Completes the per-KV protection axis by wiring `KvChecksumComputePoint::AtInsert` end to end (the remaining increment of #298; the `AtBlockCompile` tier shipped earlier in #369).

Under `AtInsert`, each entry's 4-byte per-KV digest is computed at `tree.insert` / `WriteBatch` insert, stored in the skiplist node, and verified at flush against a recompute over the entry's current bytes. A divergence means the entry was corrupted by a RAM bit-flip while it sat in the memtable, surfaced as the new `Error::MemtableKvChecksumMismatch`. This closes the memtable-residence window that `AtBlockCompile` (compute-at-flush) cannot cover.

## Design

- **Zero size growth.** The digest reuses the skiplist node's 4-byte alignment-padding slot; presence is flagged in the high bit of the `value_type` byte. A node without a digest is byte-identical to before, so `Off` / `AtBlockCompile` memtables are unchanged.
- **Off is free.** The insert path adds one cheap arc-swap config load plus two enum checks; no digest is computed unless `AtInsert` is active. On-disk format is unchanged (the footer matches `AtBlockCompile`); off-by-default, byte-identical when disabled.
- **4-byte algorithm required.** Config validation accepts `AtInsert` with `Xxh3Low32` / `Crc32c` and rejects the 8-byte `Xxh3_64` (which would not fit the reserved slot).
- **Mixed-variant memtables.** An `Off` to `AtInsert` toggle mid-memtable is handled: only digest-bearing nodes are verified at flush.
- **Separate pre-merge verify (not fused into the footer).** The residence check walks the as-inserted memtable entries. It is intentionally not folded into the writer's per-KV footer encode: the footer digest is computed over post-merge bytes (flush applies the merge operator), so fusing would false-positive on every legitimate merge. Residence corruption is a property of what was inserted, so it must be verified pre-merge. A call-site comment documents this so the pass is not fused away later.

## Testing

- Full suite: 2033 passed, 0 failed.
- New tests: skiplist unit (intact / corruption / mixed / no-digest), memtable end-to-end residence detection, config validation (4-byte accepted, 8-byte rejected), Tree integration (round-trip through flush + reopen, `Off` to `AtInsert` toggle mid-memtable).
- `cargo clippy --all-features --all-targets` clean.
- Adds a `write_throughput` bench (`off` / `at_block_compile` / `at_insert`). On a flush-heavy micro-bench `at_insert` is ~9.6% over `off`: ~3% the existing `AllLevels` footer, ~3% the per-insert digest, ~3% the residence verify pass. The verify pass cannot be removed without breaking correctness under a merge operator (see Design).

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled per-KV checksum digests for `KvChecksumComputePoint::AtInsert`, with flush-time verification to detect memtable-residency corruption.
  * Updated runtime config so `AtInsert` is accepted only with supported 4-byte checksum algorithms.
* **Bug Fixes**
  * Flush now aborts early on detected per-KV digest mismatches or invalid residency digest metadata.
* **Tests**
  * Added integration tests for `AtInsert` end-to-end behavior, including switching compute-point mid-memtable.
* **Documentation**
  * Expanded integrity documentation and refreshed configuration/feature descriptions for `AtInsert`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->