### PR TITLE
feat(storage): storage introspection API (capacity, K/V shape, remaining estimate)

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -98,6 +98,25 @@ pub trait AbstractTree: sealed::Sealed {
     #[doc(hidden)]
     fn current_version(&self) -> Version;
 
+    /// Returns a read-only snapshot of the tree's on-disk storage footprint:
+    /// total used bytes, entry count, the average shape of a stored entry
+    /// (average key / value bytes), and an estimate of how many more
+    /// average-shaped entries fit in a byte budget (see
+    /// [`StorageStats::estimated_remaining_entries`]).
+    ///
+    /// Computed from the live version's table + blob metadata plus one
+    /// size-stat per live file; it never reads a data block. The default
+    /// implementation reports [`StorageStatus::Healthy`]; the standard tree
+    /// overrides it to report [`StorageStatus::CompactionInProgress`] while a
+    /// compaction runs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a live file's size cannot be stat-ed.
+    fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
+        crate::storage_stats::compute_storage_stats(&self.current_version(), false)
+    }
+
     /// Proactively verifies every block's XXH3 checksum across every SST in
     /// the tree's current version — a scrubber for catching bit rot before it
     /// surfaces as a user-visible read failure (cron / scrub jobs).

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -137,7 +137,7 @@ pub trait AbstractTree: sealed::Sealed {
     ///
     /// Returns an error if a live file's size cannot be stat-ed.
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
-        crate::storage_stats::compute_storage_stats(&self.current_version(), false)
+        crate::storage_stats::compute_storage_stats(&self.current_version(), false, true)
     }
 
     /// Proactively verifies every block's XXH3 checksum across every SST in

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -102,13 +102,36 @@ pub trait AbstractTree: sealed::Sealed {
     /// total used bytes, entry count, the average shape of a stored entry
     /// (average key / value bytes), and an estimate of how many more
     /// average-shaped entries fit in a byte budget (see
-    /// [`StorageStats::estimated_remaining_entries`]).
+    /// [`StorageStats::estimated_remaining_entries`](crate::StorageStats::estimated_remaining_entries)).
     ///
     /// Computed from the live version's table + blob metadata plus one
     /// size-stat per live file; it never reads a data block. The default
-    /// implementation reports [`StorageStatus::Healthy`]; the standard tree
-    /// overrides it to report [`StorageStatus::CompactionInProgress`] while a
+    /// implementation reports [`StorageStatus::Healthy`](crate::StorageStatus::Healthy);
+    /// the standard tree overrides it to report
+    /// [`StorageStatus::CompactionInProgress`](crate::StorageStatus::CompactionInProgress) while a
     /// compaction runs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lsm_tree::Error as TreeError;
+    /// use lsm_tree::{AbstractTree, Config};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let tree = Config::new(&folder, Default::default(), Default::default()).open()?;
+    ///
+    /// for i in 0..100u64 {
+    ///     tree.insert(format!("key{i:04}"), "value", i);
+    /// }
+    /// tree.flush_active_memtable(0)?;
+    ///
+    /// let stats = tree.storage_stats()?;
+    /// assert_eq!(stats.item_count, 100);
+    /// // Roughly how many more average-shaped entries fit in another 1 MiB.
+    /// let _headroom = stats.estimated_remaining_entries(1024 * 1024);
+    /// #
+    /// # Ok::<(), TreeError>(())
+    /// ```
     ///
     /// # Errors
     ///

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -317,6 +317,18 @@ impl AbstractTree for BlobTree {
         self.index.current_version()
     }
 
+    fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
+        // Forward the index tree's compaction state (the default impl would
+        // always report idle), and mark value bytes as NOT user values: large
+        // values are KV-separated into blob files, so the SST records only
+        // indirection pointers.
+        crate::storage_stats::compute_storage_stats(
+            &self.current_version(),
+            self.index.is_compacting(),
+            false,
+        )
+    }
+
     #[cfg(feature = "metrics")]
     fn metrics(&self) -> &Arc<crate::Metrics> {
         self.index.metrics()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,6 +422,9 @@ pub mod inspect;
 #[cfg(feature = "std")]
 pub mod scrub;
 
+pub mod storage_stats;
+pub use storage_stats::{StorageStats, StorageStatus};
+
 mod version;
 mod vlog;
 

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -97,19 +97,27 @@ impl StorageStats {
 /// [`StorageStatus::Healthy`]; the caller supplies it because compaction state
 /// is engine-internal.
 ///
-/// `used_bytes` is the true on-disk file size of every live table (one
-/// metadata stat per file), not the writer's `Metadata::file_size`: the latter
-/// records `file_pos` BEFORE the meta block and footer were appended, so it
-/// undercounts the physical file by hundreds to thousands of bytes per table.
+/// `value_bytes_are_user_values` must be `false` for a KV-separated
+/// (`BlobTree`) tree: there the SST records a small indirection pointer per
+/// large value, not the user value, so the per-table value-byte sum measures
+/// pointers and the value average would misreport. When `false`,
+/// [`StorageStats::avg_value_bytes`] is forced to `None`. Key bytes are never
+/// separated, so [`StorageStats::avg_key_bytes`] stays exact either way.
+///
+/// `used_bytes` is the true on-disk file size of every live table and blob
+/// file (one metadata stat per file), not the writer's `Metadata::file_size`
+/// or [`crate::version::Version::blob_files`]' compressed-payload sum: those
+/// undercount the physical file by the meta block / footer / blob trailer.
 /// Statting matches the figure `Tree::create_checkpoint` reports, so the two
 /// agree on disk reality.
 ///
 /// # Errors
 ///
-/// Returns an error if a live table's size cannot be stat-ed.
+/// Returns an error if a live table or blob file's size cannot be stat-ed.
 pub(crate) fn compute_storage_stats(
     version: &Version,
     is_compacting: bool,
+    value_bytes_are_user_values: bool,
 ) -> crate::Result<StorageStats> {
     let mut used_bytes = 0u64;
     let mut item_count = 0u64;
@@ -138,7 +146,11 @@ pub(crate) fn compute_storage_stats(
         }
     }
 
-    used_bytes = used_bytes.saturating_add(version.blob_files.on_disk_size());
+    // Physical blob-file size (metadata + trailer included), NOT
+    // BlobFileList::on_disk_size() which sums only the compressed payload.
+    for blob in version.blob_files.iter() {
+        used_bytes = used_bytes.saturating_add(blob.0.fs.metadata(&blob.0.path)?.len);
+    }
 
     let avg_entry_on_disk_bytes = if item_count == 0 {
         0
@@ -146,11 +158,11 @@ pub(crate) fn compute_storage_stats(
         used_bytes / item_count
     };
 
-    let (avg_key_bytes, avg_value_bytes) = if all_have_shape && item_count > 0 {
-        (Some(sum_key / item_count), Some(sum_value / item_count))
-    } else {
-        (None, None)
-    };
+    let have_shape = all_have_shape && item_count > 0;
+    let avg_key_bytes = have_shape.then(|| sum_key / item_count);
+    // Value bytes are only meaningful when not KV-separated (see param doc).
+    let avg_value_bytes =
+        (have_shape && value_bytes_are_user_values).then(|| sum_value / item_count);
 
     let reclaimable_bytes_estimate = reclaimable_entries.saturating_mul(avg_entry_on_disk_bytes);
 
@@ -220,7 +232,7 @@ mod tests {
             clippy::unwrap_used,
             reason = "compute_storage_stats cannot fail on an empty in-memory version (no file to stat)"
         )]
-        let busy = compute_storage_stats(&version, true).unwrap();
+        let busy = compute_storage_stats(&version, true, true).unwrap();
         assert_eq!(busy.status, StorageStatus::CompactionInProgress);
         assert_eq!(busy.used_bytes, 0);
         assert_eq!(busy.item_count, 0);
@@ -232,7 +244,7 @@ mod tests {
             clippy::unwrap_used,
             reason = "compute_storage_stats cannot fail on an empty in-memory version (no file to stat)"
         )]
-        let idle = compute_storage_stats(&version, false).unwrap();
+        let idle = compute_storage_stats(&version, false, true).unwrap();
         assert_eq!(idle.status, StorageStatus::Healthy);
     }
 }

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -173,6 +173,7 @@ pub(crate) fn compute_storage_stats(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test code")]
 mod tests {
     use super::*;
 
@@ -205,5 +206,26 @@ mod tests {
         // yields 0 rather than dividing by zero.
         let stats = stats_with_avg(0);
         assert_eq!(stats.estimated_remaining_entries(1_000_000), 0);
+    }
+
+    #[test]
+    fn compute_on_empty_version_maps_compaction_flag_to_status() {
+        use crate::TreeType;
+        use crate::version::Version;
+
+        // An empty version has no tables, so no file is stat-ed: the call is
+        // pure and exercises only the status mapping and the zero-table path.
+        let version = Version::new(0, TreeType::Standard);
+
+        let busy = compute_storage_stats(&version, true).unwrap();
+        assert_eq!(busy.status, StorageStatus::CompactionInProgress);
+        assert_eq!(busy.used_bytes, 0);
+        assert_eq!(busy.item_count, 0);
+        assert_eq!(busy.table_count, 0);
+        assert_eq!(busy.avg_key_bytes, None);
+        assert_eq!(busy.estimated_remaining_entries(1_000_000), 0);
+
+        let idle = compute_storage_stats(&version, false).unwrap();
+        assert_eq!(idle.status, StorageStatus::Healthy);
     }
 }

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Read-only storage introspection: how much is stored, the average shape of a
+//! stored entry, and an estimate of how many more entries fit in a byte budget.
+//!
+//! Computed from the live version's table + blob-file metadata plus one
+//! size-stat per live file (the same accounting `Tree::create_checkpoint`
+//! uses), so it never touches the data blocks. See
+//! [`crate::AbstractTree::storage_stats`].
+
+use crate::version::Version;
+
+/// Coarse storage state of a tree.
+///
+/// This release reports [`Self::Healthy`] and [`Self::CompactionInProgress`].
+/// The capacity-dependent variants are populated once storage admission control
+/// (a configured byte quota / disk-free probe) lands; they are defined now so
+/// the enum stays stable across that work.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum StorageStatus {
+    /// Normal operation: writes and a full compaction are available.
+    Healthy,
+    /// Enough free space for a normal (full) compaction.
+    FullCompactionAvailable,
+    /// Not enough space for a full compaction, but the opt-in tight-space
+    /// (incremental-reclaim) compaction mode can still run.
+    TightCompactionAvailable,
+    /// Out of space: the tree is read-only until space is freed or the quota
+    /// is raised.
+    ReadOnlyOutOfSpace,
+    /// A compaction is currently running.
+    CompactionInProgress,
+}
+
+/// A point-in-time snapshot of a tree's on-disk storage footprint and the
+/// average shape of a stored entry.
+///
+/// All byte figures are on-disk (post-compression, including any per-block
+/// overhead and blob files). Averages are over every stored entry version, so
+/// they pair with [`Self::item_count`].
+#[must_use]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct StorageStats {
+    /// Total on-disk bytes of all live SSTs plus blob files.
+    pub used_bytes: u64,
+
+    /// Number of live entries (all versions) across all live SSTs.
+    pub item_count: u64,
+
+    /// Number of live SSTs.
+    pub table_count: u64,
+
+    /// Average on-disk bytes per entry (`used_bytes / item_count`), or `0` when
+    /// the tree is empty. This is the figure
+    /// [`Self::estimated_remaining_entries`] divides a budget by.
+    pub avg_entry_on_disk_bytes: u64,
+
+    /// Average user-key byte length per entry, or `None` if any live table was
+    /// written before per-table key/value byte sums were recorded (the average
+    /// key/value split is only exact when every table carries the figures).
+    pub avg_key_bytes: Option<u64>,
+
+    /// Average value byte length per entry, or `None` under the same condition
+    /// as [`Self::avg_key_bytes`].
+    pub avg_value_bytes: Option<u64>,
+
+    /// Estimated bytes a full compaction could reclaim, from the
+    /// weak-tombstone-reclaimable entry count times the average on-disk entry
+    /// size. An estimate, not an exact figure.
+    pub reclaimable_bytes_estimate: u64,
+
+    /// Coarse storage state.
+    pub status: StorageStatus,
+}
+
+impl StorageStats {
+    /// Approximately how many more average-shaped entries fit in `budget_bytes`,
+    /// using [`Self::avg_entry_on_disk_bytes`].
+    ///
+    /// Returns `0` when the average entry size is unknown (an empty tree), since
+    /// there is no basis for the estimate.
+    #[must_use]
+    pub fn estimated_remaining_entries(&self, budget_bytes: u64) -> u64 {
+        if self.avg_entry_on_disk_bytes == 0 {
+            0
+        } else {
+            budget_bytes / self.avg_entry_on_disk_bytes
+        }
+    }
+}
+
+/// Computes [`StorageStats`] from a live version's table + blob-file metadata.
+///
+/// `is_compacting` selects [`StorageStatus::CompactionInProgress`] vs
+/// [`StorageStatus::Healthy`]; the caller supplies it because compaction state
+/// is engine-internal.
+///
+/// `used_bytes` is the true on-disk file size of every live table (one
+/// metadata stat per file), not the writer's `Metadata::file_size`: the latter
+/// records `file_pos` BEFORE the meta block and footer were appended, so it
+/// undercounts the physical file by hundreds to thousands of bytes per table.
+/// Statting matches the figure `Tree::create_checkpoint` reports, so the two
+/// agree on disk reality.
+///
+/// # Errors
+///
+/// Returns an error if a live table's size cannot be stat-ed.
+pub(crate) fn compute_storage_stats(
+    version: &Version,
+    is_compacting: bool,
+) -> crate::Result<StorageStats> {
+    let mut used_bytes = 0u64;
+    let mut item_count = 0u64;
+    let mut table_count = 0u64;
+    let mut reclaimable_entries = 0u64;
+    let mut sum_key = 0u64;
+    let mut sum_value = 0u64;
+    // The key/value split is only exact when EVERY live table records the byte
+    // sums; a single legacy table without them makes the average unrepresentable.
+    let mut all_have_shape = true;
+
+    for table in version.iter_tables() {
+        let m = &table.metadata;
+        // Physical file size, NOT m.file_size (which undercounts — see above).
+        let on_disk = table.fs.metadata(&table.path)?.len;
+        used_bytes = used_bytes.saturating_add(on_disk);
+        item_count = item_count.saturating_add(m.item_count);
+        table_count += 1;
+        reclaimable_entries = reclaimable_entries.saturating_add(m.weak_tombstone_reclaimable);
+        match (m.sum_user_key_bytes, m.sum_value_bytes) {
+            (Some(k), Some(v)) => {
+                sum_key = sum_key.saturating_add(k);
+                sum_value = sum_value.saturating_add(v);
+            }
+            _ => all_have_shape = false,
+        }
+    }
+
+    used_bytes = used_bytes.saturating_add(version.blob_files.on_disk_size());
+
+    let avg_entry_on_disk_bytes = if item_count == 0 {
+        0
+    } else {
+        used_bytes / item_count
+    };
+
+    let (avg_key_bytes, avg_value_bytes) = if all_have_shape && item_count > 0 {
+        (Some(sum_key / item_count), Some(sum_value / item_count))
+    } else {
+        (None, None)
+    };
+
+    let reclaimable_bytes_estimate = reclaimable_entries.saturating_mul(avg_entry_on_disk_bytes);
+
+    let status = if is_compacting {
+        StorageStatus::CompactionInProgress
+    } else {
+        StorageStatus::Healthy
+    };
+
+    Ok(StorageStats {
+        used_bytes,
+        item_count,
+        table_count,
+        avg_entry_on_disk_bytes,
+        avg_key_bytes,
+        avg_value_bytes,
+        reclaimable_bytes_estimate,
+        status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats_with_avg(avg_entry_on_disk_bytes: u64) -> StorageStats {
+        StorageStats {
+            used_bytes: 0,
+            item_count: 0,
+            table_count: 0,
+            avg_entry_on_disk_bytes,
+            avg_key_bytes: None,
+            avg_value_bytes: None,
+            reclaimable_bytes_estimate: 0,
+            status: StorageStatus::Healthy,
+        }
+    }
+
+    #[test]
+    fn estimated_remaining_entries_divides_budget_by_average() {
+        // budget / avg_entry_on_disk: 1000 bytes at 50 bytes/entry = 20 entries.
+        let stats = stats_with_avg(50);
+        assert_eq!(stats.estimated_remaining_entries(1000), 20);
+        // Partial entries round down (integer division).
+        assert_eq!(stats.estimated_remaining_entries(1049), 20);
+        assert_eq!(stats.estimated_remaining_entries(0), 0);
+    }
+
+    #[test]
+    fn estimated_remaining_entries_is_zero_when_average_is_unknown() {
+        // An empty tree has no average to extrapolate from, so any budget
+        // yields 0 rather than dividing by zero.
+        let stats = stats_with_avg(0);
+        assert_eq!(stats.estimated_remaining_entries(1_000_000), 0);
+    }
+}

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -173,7 +173,6 @@ pub(crate) fn compute_storage_stats(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "test code")]
 mod tests {
     use super::*;
 
@@ -217,6 +216,10 @@ mod tests {
         // pure and exercises only the status mapping and the zero-table path.
         let version = Version::new(0, TreeType::Standard);
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "compute_storage_stats cannot fail on an empty in-memory version (no file to stat)"
+        )]
         let busy = compute_storage_stats(&version, true).unwrap();
         assert_eq!(busy.status, StorageStatus::CompactionInProgress);
         assert_eq!(busy.used_bytes, 0);
@@ -225,6 +228,10 @@ mod tests {
         assert_eq!(busy.avg_key_bytes, None);
         assert_eq!(busy.estimated_remaining_entries(1_000_000), 0);
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "compute_storage_stats cannot fail on an empty in-memory version (no file to stat)"
+        )]
         let idle = compute_storage_stats(&version, false).unwrap();
         assert_eq!(idle.status, StorageStatus::Healthy);
     }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -626,6 +626,33 @@ mod tests {
         assert!(result.is_ok(), "valid meta must parse: {result:?}");
     }
 
+    /// Backward compatibility: an SST written before the per-table key/value
+    /// byte sums existed has no `key_bytes#sum` / `value_bytes#sum` meta keys
+    /// (`valid_meta_items` omits them, mirroring an older writer). The parse
+    /// must succeed with both fields `None`, never error.
+    #[test]
+    fn load_with_handle_missing_key_value_byte_sums_parses_as_none() {
+        let items = valid_meta_items();
+        let parsed = load_meta_from_items(&items).unwrap();
+        assert_eq!(parsed.sum_user_key_bytes, None);
+        assert_eq!(parsed.sum_value_bytes, None);
+    }
+
+    /// When present, the byte sums round-trip through the meta block as
+    /// `Some(_)`.
+    #[test]
+    fn load_with_handle_key_value_byte_sums_present_round_trip() {
+        let mut items = valid_meta_items();
+        items.push(meta("key_bytes#sum", &320u64.to_le_bytes()));
+        items.push(meta("value_bytes#sum", &640u64.to_le_bytes()));
+        // The meta block is a sorted KV block; re-sort after appending.
+        items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
+
+        let parsed = load_meta_from_items(&items).unwrap();
+        assert_eq!(parsed.sum_user_key_bytes, Some(320));
+        assert_eq!(parsed.sum_value_bytes, Some(640));
+    }
+
     /// Missing `table_version` must return `Err(InvalidHeader)`, not panic.
     #[test]
     fn load_with_handle_missing_table_version_returns_err() {

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -54,6 +54,16 @@ pub struct ParsedMeta {
     pub weak_tombstone_count: u64,
     pub weak_tombstone_reclaimable: u64,
 
+    /// Sum of user-key byte lengths across all entries in this table (every
+    /// version), or `None` for tables written before this field existed.
+    /// Used by storage introspection to report the average key size; callers
+    /// fall back to a file-size estimate when absent.
+    pub sum_user_key_bytes: Option<u64>,
+
+    /// Sum of value byte lengths across all entries in this table (every
+    /// version), or `None` for tables written before this field existed.
+    pub sum_value_bytes: Option<u64>,
+
     pub data_block_compression: CompressionType,
     pub index_block_compression: CompressionType,
 
@@ -402,6 +412,22 @@ impl ParsedMeta {
             }
         };
 
+        // Optional shape fields (absent on tables written before storage
+        // introspection support; callers fall back to a file-size estimate).
+        // Present-but-wrong-width is corrupt meta, so require exactly 8 bytes.
+        let read_opt_u64 = |key: &[u8]| -> crate::Result<Option<u64>> {
+            match block.point_read(key, SeqNo::MAX, &cmp)? {
+                Some(item) => {
+                    let bytes = <[u8; 8]>::try_from(&item.value[..])
+                        .map_err(|_| crate::Error::InvalidHeader("TableMeta"))?;
+                    Ok(Some(u64::from_le_bytes(bytes)))
+                }
+                None => Ok(None),
+            }
+        };
+        let sum_user_key_bytes = read_opt_u64(b"key_bytes#sum")?;
+        let sum_value_bytes = read_opt_u64(b"value_bytes#sum")?;
+
         Ok(Self {
             id,
             created_at,
@@ -415,6 +441,8 @@ impl ParsedMeta {
             tombstone_count,
             weak_tombstone_count,
             weak_tombstone_reclaimable,
+            sum_user_key_bytes,
+            sum_value_bytes,
             data_block_compression,
             index_block_compression,
             kv_checksum_algo,

--- a/src/table/writer/meta.rs
+++ b/src/table/writer/meta.rs
@@ -23,6 +23,14 @@ pub struct Metadata {
     /// Written key count (unique keys)
     pub key_count: usize,
 
+    /// Sum of user-key byte lengths across all written entries (every version,
+    /// pairs with `item_count`). Drives the average-entry-shape introspection.
+    pub sum_user_key_bytes: u64,
+
+    /// Sum of value byte lengths across all written entries (every version,
+    /// pairs with `item_count`).
+    pub sum_value_bytes: u64,
+
     /// Current file position of writer
     pub file_pos: BlockOffset,
 
@@ -59,6 +67,8 @@ impl Default for Metadata {
             weak_tombstone_count: 0,
             weak_tombstone_reclaimable_count: 0,
             key_count: 0,
+            sum_user_key_bytes: 0,
+            sum_value_bytes: 0,
             file_pos: BlockOffset(0),
             uncompressed_size: 0,
 

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -725,6 +725,11 @@ impl Writer {
         let user_key = item.key.user_key.clone();
         let value_len = item.value.len();
 
+        // Per-entry shape accounting (pairs with item_count: counts every
+        // version). usize -> u64 is a widening cast on every supported target.
+        self.meta.sum_user_key_bytes += user_key.len() as u64;
+        self.meta.sum_value_bytes += value_len as u64;
+
         if item.is_tombstone() {
             self.meta.tombstone_count += 1;
         }
@@ -1393,6 +1398,8 @@ impl Writer {
             weak_tombstone_count: self.meta.weak_tombstone_count as u64,
             weak_tombstone_reclaimable: self.meta.weak_tombstone_reclaimable_count as u64,
             key_count: self.meta.key_count as u64,
+            sum_user_key_bytes: self.meta.sum_user_key_bytes,
+            sum_value_bytes: self.meta.sum_value_bytes,
             uncompressed_size: self.meta.uncompressed_size,
             first_key,
             last_key,
@@ -1613,6 +1620,8 @@ struct MetaSectionParams<'a> {
     weak_tombstone_count: u64,
     weak_tombstone_reclaimable: u64,
     key_count: u64,
+    sum_user_key_bytes: u64,
+    sum_value_bytes: u64,
     uncompressed_size: u64,
     first_key: &'a [u8],
     last_key: &'a [u8],
@@ -1788,6 +1797,7 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         meta("item_count", &p.item_count.to_le_bytes()),
         meta("key#max", p.last_key),
         meta("key#min", p.first_key),
+        meta("key_bytes#sum", &p.sum_user_key_bytes.to_le_bytes()),
         meta("key_count", &p.key_count.to_le_bytes()),
         meta("prefix_truncation#data", &[1]),
         meta("prefix_truncation#index", &[1]),
@@ -1810,6 +1820,7 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         meta("table_version", &[3u8]),
         meta("tombstone_count", &p.tombstone_count.to_le_bytes()),
         meta("user_data_size", &p.uncompressed_size.to_le_bytes()),
+        meta("value_bytes#sum", &p.sum_value_bytes.to_le_bytes()),
         meta(
             "weak_tombstone_count",
             &p.weak_tombstone_count.to_le_bytes(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -309,7 +309,12 @@ impl AbstractTree for Tree {
     }
 
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
-        crate::storage_stats::compute_storage_stats(&self.current_version(), self.is_compacting())
+        // Standard tree: SST values ARE user values (no KV separation).
+        crate::storage_stats::compute_storage_stats(
+            &self.current_version(),
+            self.is_compacting(),
+            true,
+        )
     }
 
     fn get_flush_lock(&self) -> FlushGuard<'_> {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -308,6 +308,10 @@ impl AbstractTree for Tree {
         self.version_history.read().latest_version().version
     }
 
+    fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
+        crate::storage_stats::compute_storage_stats(&self.current_version(), self.is_compacting())
+    }
+
     fn get_flush_lock(&self) -> FlushGuard<'_> {
         self.flush_lock.lock()
     }

--- a/tests/storage_stats.rs
+++ b/tests/storage_stats.rs
@@ -8,7 +8,8 @@
 // `AbstractTree` is used for its trait methods (`insert`,
 // `flush_active_memtable`, `storage_stats`, `create_checkpoint`).
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+    AbstractTree, AnyTree, BlobTree, Config, KvSeparationOptions, SequenceNumberCounter,
+    StorageStatus, get_tmp_folder,
 };
 
 fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
@@ -22,6 +23,21 @@ fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
     match any {
         AnyTree::Standard(t) => t,
         AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+fn open_blob_tree(path: &std::path::Path) -> BlobTree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Blob(t) => t,
+        AnyTree::Standard(_) => panic!("expected Blob tree"),
     }
 }
 
@@ -104,6 +120,44 @@ fn storage_stats_survive_flush_and_reopen() -> lsm_tree::Result<()> {
     assert_eq!(stats.avg_key_bytes, Some(8));
     assert_eq!(stats.avg_value_bytes, Some(10));
     assert!(stats.used_bytes > 0);
+
+    Ok(())
+}
+
+#[test]
+fn storage_stats_blob_tree_counts_physical_bytes_and_hides_value_average() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_blob_tree(folder.path());
+
+    // Large values cross the separation threshold and land in blob files, so
+    // the SST stores only a small indirection pointer per entry.
+    let n = 200u64;
+    let value = vec![b'v'; 256];
+    for i in 0..n {
+        tree.insert(format!("key{i:05}").as_bytes(), &value, i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let stats = tree.storage_stats()?;
+    assert_eq!(stats.item_count, n);
+    assert!(stats.used_bytes > 0);
+
+    // used_bytes must include the PHYSICAL blob-file footprint (metadata +
+    // trailer), so it agrees with the checkpoint total which links the real
+    // files. A payload-only blob figure would undercount here.
+    let cp_dir = get_tmp_folder();
+    let cp_path = cp_dir.path().join("checkpoint");
+    let info = tree.create_checkpoint(&cp_path)?;
+    assert_eq!(
+        stats.used_bytes, info.total_bytes,
+        "blob-tree used_bytes must match the checkpoint total"
+    );
+
+    // Keys are never separated, so the key average is still exact.
+    assert_eq!(stats.avg_key_bytes, Some(8));
+    // Values ARE separated: the SST records indirection pointers, not user
+    // values, so the value average is not representable and must be None.
+    assert_eq!(stats.avg_value_bytes, None);
 
     Ok(())
 }

--- a/tests/storage_stats.rs
+++ b/tests/storage_stats.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end tests for `AbstractTree::storage_stats`: used-byte accounting
+//! (cross-checked against the checkpoint total), the average K/V shape recorded
+//! per table, and the remaining-capacity estimate.
+
+// `AbstractTree` is used for its trait methods (`insert`,
+// `flush_active_memtable`, `storage_stats`, `create_checkpoint`).
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+};
+
+fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+#[test]
+fn storage_stats_reports_shape_and_capacity_after_flush() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // 500 unique entries, fixed shape: 8-byte keys ("key00000"), 10-byte values
+    // ("value00000"). One version each, so item_count == 500 and the averages
+    // are exact.
+    let n = 500u64;
+    for i in 0..n {
+        let key = format!("key{i:05}");
+        let value = format!("value{i:05}");
+        assert_eq!(key.len(), 8);
+        assert_eq!(value.len(), 10);
+        tree.insert(key.as_bytes(), value.as_bytes(), i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let stats = tree.storage_stats()?;
+
+    assert_eq!(stats.item_count, n, "every inserted entry is counted");
+    assert!(stats.table_count >= 1, "at least one SST after flush");
+    assert!(stats.used_bytes > 0);
+    assert_eq!(
+        stats.status,
+        StorageStatus::Healthy,
+        "no compaction running"
+    );
+
+    // Exact average shape from the per-table byte sums.
+    assert_eq!(stats.avg_key_bytes, Some(8), "8-byte keys");
+    assert_eq!(stats.avg_value_bytes, Some(10), "10-byte values");
+
+    // Average on-disk entry size is positive and the remaining-capacity
+    // estimate is self-consistent: a budget equal to the current usage fits
+    // about as many more entries as are already stored (integer rounding aside).
+    assert!(stats.avg_entry_on_disk_bytes > 0);
+    let est = stats.estimated_remaining_entries(stats.used_bytes);
+    assert!(
+        est.abs_diff(n) <= n / 10,
+        "estimate {est} should be within ~10% of {n}"
+    );
+
+    // Cross-check used_bytes against the checkpoint's independently-computed
+    // total (a different code path summing the same live files).
+    let cp_dir = get_tmp_folder();
+    let cp_path = cp_dir.path().join("checkpoint");
+    let info = tree.create_checkpoint(&cp_path)?;
+    assert_eq!(
+        stats.used_bytes, info.total_bytes,
+        "storage_stats used_bytes must match the checkpoint total"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn storage_stats_empty_tree_has_zero_usage_and_no_estimate() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    let stats = tree.storage_stats()?;
+    assert_eq!(stats.used_bytes, 0);
+    assert_eq!(stats.item_count, 0);
+    assert_eq!(stats.table_count, 0);
+    assert_eq!(stats.avg_entry_on_disk_bytes, 0);
+    // No basis to extrapolate from an empty tree.
+    assert_eq!(stats.estimated_remaining_entries(1_000_000), 0);
+    Ok(())
+}

--- a/tests/storage_stats.rs
+++ b/tests/storage_stats.rs
@@ -82,6 +82,33 @@ fn storage_stats_reports_shape_and_capacity_after_flush() -> lsm_tree::Result<()
 }
 
 #[test]
+fn storage_stats_survive_flush_and_reopen() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    {
+        let tree = open_tree(folder.path());
+        for i in 0..200u64 {
+            tree.insert(
+                format!("key{i:05}").as_bytes(),
+                format!("value{i:05}").as_bytes(),
+                i,
+            );
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Reopen forces the per-table byte sums to be read back from the on-disk
+    // meta block (not the in-memory writer metadata), proving they round-trip.
+    let reopened = open_tree(folder.path());
+    let stats = reopened.storage_stats()?;
+    assert_eq!(stats.item_count, 200);
+    assert_eq!(stats.avg_key_bytes, Some(8));
+    assert_eq!(stats.avg_value_bytes, Some(10));
+    assert!(stats.used_bytes > 0);
+
+    Ok(())
+}
+
+#[test]
 fn storage_stats_empty_tree_has_zero_usage_and_no_estimate() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path());


### PR DESCRIPTION
## Summary

Adds a read-only `AbstractTree::storage_stats() -> Result<StorageStats>` so operators and embedded callers can ask a tree what it stores and how much more fits, without touching a data block.

`StorageStats` reports:
- `used_bytes` — true physical on-disk size of every live SST + blob file
- `item_count`, `table_count`
- `avg_entry_on_disk_bytes` (`used_bytes / item_count`)
- `avg_key_bytes` / `avg_value_bytes` (`Option<u64>` — exact average K/V shape from new per-table byte sums; `None` if any live table predates the accumulators)
- `reclaimable_bytes_estimate` (from weak-tombstone-reclaimable counters)
- `status: StorageStatus`

`StorageStats::estimated_remaining_entries(budget_bytes)` divides a byte budget by the average on-disk entry size to estimate how many more average-shaped entries fit.

`StorageStatus` enum (`Healthy`, `FullCompactionAvailable`, `TightCompactionAvailable`, `ReadOnlyOutOfSpace`, `CompactionInProgress`) is defined now; this PR returns the baseline (`Healthy` / `CompactionInProgress`). The capacity-dependent variants are populated by the storage-admission follow-ups.

## Key decision

`used_bytes` is the physical file size (one `Fs::metadata().len` stat per live table, matching what `create_checkpoint` reports), **not** the writer's `Metadata::file_size`. The latter records `file_pos` before the meta block and footer were appended, so it undercounts the physical file by hundreds to thousands of bytes per table. An integration test cross-checks `used_bytes` against the checkpoint total.

## Backward compatibility

The two new `TableMetadata` fields are additive optional meta-block entries. Older SSTs without them still open and report stats; the average K/V split simply reports `None` (the on-disk average is always available).

## Testing

- Unit: byte-sum parse-as-`None` on legacy SSTs and `Some` round-trip; compaction-flag-to-status mapping on an empty version; `estimated_remaining_entries` math + zero-item edge case.
- Integration: average shape after flush; survives flush + reopen (read back from the on-disk meta block); `used_bytes == checkpoint total_bytes`.
- `cargo nextest run` 1830 passed; `--all-features` 2127 passed; clippy `--all-features --all-targets` clean; doctest passes.

Part of #482. Closes #483.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced storage introspection API to query on-disk usage metrics and storage health status
  * Provides disk byte usage, live entry/table counts, average per-entry key/value sizes, and estimated compaction-reclaimable space
  * Added estimation tool to calculate remaining entries within a byte budget
  * Full backward compatibility; statistics persist across tree reopenings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->