### PR TITLE
feat(storage): opt-in write admission control

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -1076,6 +1076,35 @@ pub trait AbstractTree: sealed::Sealed {
         Ok(self.remove(key, seqno))
     }
 
+    /// Admission-gated [`remove_weak`](Self::remove_weak). See
+    /// [`try_insert`](Self::try_insert).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the admission gate
+    /// is closed.
+    fn try_remove_weak<K: Into<UserKey>>(&self, key: K, seqno: SeqNo) -> crate::Result<(u64, u64)> {
+        self.write_admission()?;
+        Ok(self.remove_weak(key, seqno))
+    }
+
+    /// Admission-gated [`remove_range`](Self::remove_range). See
+    /// [`try_insert`](Self::try_insert).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the admission gate
+    /// is closed.
+    fn try_remove_range<K: Into<UserKey>>(
+        &self,
+        start: K,
+        end: K,
+        seqno: SeqNo,
+    ) -> crate::Result<u64> {
+        self.write_admission()?;
+        Ok(self.remove_range(start, end, seqno))
+    }
+
     /// Removes an item from the tree.
     ///
     /// Returns the added item's size and new size of the memtable.

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -151,8 +151,10 @@ pub trait AbstractTree: sealed::Sealed {
     /// the next call admits again with no restart.
     ///
     /// Intended as a cheap pre-check the caller consults before applying a
-    /// write batch (it reads in-memory size accounting, no syscall). Internal
-    /// flush / compaction are never gated, so the engine can always reclaim.
+    /// write batch. The footprint is cached per version, so the check is a
+    /// constant-time read on the common path and only re-measures when a new
+    /// version is installed (flush / compaction). Internal flush / compaction
+    /// are never gated, so the engine can always reclaim.
     ///
     /// # Errors
     ///
@@ -166,8 +168,16 @@ pub trait AbstractTree: sealed::Sealed {
     /// [`write_admission`](Self::write_admission)). Convenience for callers that
     /// want a boolean rather than a `Result`. Always `false` unless admission
     /// control is enabled and the tree is over budget.
+    ///
+    /// Only [`Error::StorageFull`](crate::Error::StorageFull) counts as
+    /// read-only: an unrelated admission error (e.g. an I/O failure while
+    /// measuring the footprint) is NOT an out-of-space condition and must not be
+    /// reported as one.
     fn is_read_only(&self) -> bool {
-        self.write_admission().is_err()
+        matches!(
+            self.write_admission(),
+            Err(crate::Error::StorageFull { .. })
+        )
     }
 
     /// Proactively verifies every block's XXH3 checksum across every SST in

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -140,6 +140,36 @@ pub trait AbstractTree: sealed::Sealed {
         crate::storage_stats::compute_storage_stats(&self.current_version(), false, true)
     }
 
+    /// Storage admission gate: `Ok(())` if a write may proceed, or
+    /// [`Error::StorageFull`](crate::Error::StorageFull) if the tree is
+    /// over budget and should be treated as read-only.
+    ///
+    /// Opt-in: returns `Ok(())` unless
+    /// [`storage_admission_check`](crate::RuntimeConfig::storage_admission_check)
+    /// is enabled. The predicate is computed (not latched), so once space is
+    /// freed — the budget raised, a compaction reclaiming space, or disk freed —
+    /// the next call admits again with no restart.
+    ///
+    /// Intended as a cheap pre-check the caller consults before applying a
+    /// write batch (it reads in-memory size accounting, no syscall). Internal
+    /// flush / compaction are never gated, so the engine can always reclaim.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the live footprint
+    /// plus reserved headroom exceeds the effective budget.
+    fn write_admission(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    /// `true` when the admission gate is currently closed (see
+    /// [`write_admission`](Self::write_admission)). Convenience for callers that
+    /// want a boolean rather than a `Result`. Always `false` unless admission
+    /// control is enabled and the tree is over budget.
+    fn is_read_only(&self) -> bool {
+        self.write_admission().is_err()
+    }
+
     /// Proactively verifies every block's XXH3 checksum across every SST in
     /// the tree's current version — a scrubber for catching bit rot before it
     /// surfaces as a user-visible read failure (cron / scrub jobs).
@@ -989,6 +1019,62 @@ pub trait AbstractTree: sealed::Sealed {
         value: V,
         seqno: SeqNo,
     ) -> (u64, u64);
+
+    /// Admission-gated [`insert`](Self::insert): consults
+    /// [`write_admission`](Self::write_admission) first and declines with
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the tree is over
+    /// budget, otherwise inserts and returns the same `(added_bytes,
+    /// memtable_size)` tuple. This is the write entry a space-aware caller uses
+    /// so over-budget writes are refused up front rather than failing a flush
+    /// later; bare [`insert`](Self::insert) stays infallible for callers that
+    /// do not opt into admission control.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the admission gate
+    /// is closed.
+    fn try_insert<K: Into<UserKey>, V: Into<UserValue>>(
+        &self,
+        key: K,
+        value: V,
+        seqno: SeqNo,
+    ) -> crate::Result<(u64, u64)> {
+        self.write_admission()?;
+        Ok(self.insert(key, value, seqno))
+    }
+
+    /// Admission-gated [`merge`](Self::merge). See
+    /// [`try_insert`](Self::try_insert).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the admission gate
+    /// is closed.
+    fn try_merge<K: Into<UserKey>, V: Into<UserValue>>(
+        &self,
+        key: K,
+        operand: V,
+        seqno: SeqNo,
+    ) -> crate::Result<(u64, u64)> {
+        self.write_admission()?;
+        Ok(self.merge(key, operand, seqno))
+    }
+
+    /// Admission-gated [`remove`](Self::remove). See
+    /// [`try_insert`](Self::try_insert).
+    ///
+    /// Note a tombstone is itself a write that consumes space; an over-budget
+    /// tree refuses it too. Reclaim space via compaction (never gated) rather
+    /// than relying on deletes when already read-only.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::StorageFull`](crate::Error::StorageFull) when the admission gate
+    /// is closed.
+    fn try_remove<K: Into<UserKey>>(&self, key: K, seqno: SeqNo) -> crate::Result<(u64, u64)> {
+        self.write_admission()?;
+        Ok(self.remove(key, seqno))
+    }
 
     /// Removes an item from the tree.
     ///

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -322,11 +322,24 @@ impl AbstractTree for BlobTree {
         // always report idle), and mark value bytes as NOT user values: large
         // values are KV-separated into blob files, so the SST records only
         // indirection pointers.
-        crate::storage_stats::compute_storage_stats(
+        let mut stats = crate::storage_stats::compute_storage_stats(
             &self.current_version(),
             self.index.is_compacting(),
             false,
-        )
+        )?;
+        // Admission is driven by the index tree's runtime config / footprint;
+        // a closed gate is the operator-actionable state (see the standard
+        // tree's override for the precedence rationale).
+        if self.index.is_read_only() {
+            stats.status = crate::StorageStatus::ReadOnlyOutOfSpace;
+        }
+        Ok(stats)
+    }
+
+    fn write_admission(&self) -> crate::Result<()> {
+        // Admission state lives on the index tree (which holds the runtime
+        // config and the SST footprint); forward to it.
+        self.index.write_admission()
     }
 
     #[cfg(feature = "metrics")]

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -338,7 +338,10 @@ impl AbstractTree for BlobTree {
 
     fn write_admission(&self) -> crate::Result<()> {
         // Admission state lives on the index tree (which holds the runtime
-        // config and the SST footprint); forward to it.
+        // config). The forward is blob-aware: the index tree's version IS this
+        // blob tree's version (current_version() delegates here), and the gate's
+        // footprint basis (`storage_stats::compute_used_bytes`) stats live
+        // tables AND blob files, so blob bytes count toward the budget.
         self.index.write_admission()
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -362,6 +362,23 @@ pub enum Error {
         /// the message string.
         kind: &'static str,
     },
+
+    /// A write was declined by the storage admission gate because accepting it
+    /// could push the tree's live footprint past its effective budget.
+    ///
+    /// Only produced when [`storage_admission_check`](crate::RuntimeConfig::storage_admission_check)
+    /// is enabled. The predicate is computed, not latched: raising
+    /// [`storage_limit_bytes`](crate::RuntimeConfig::storage_limit_bytes),
+    /// freeing disk, or a compaction reclaiming space clears the read-only
+    /// state on the next check with no restart. Internal flush / compaction are
+    /// never gated (reserved headroom), so the engine can always reclaim space.
+    StorageFull {
+        /// Live on-disk bytes at the time of the check.
+        used: u64,
+
+        /// Effective byte budget that `used` (plus reserved headroom) exceeded.
+        limit: u64,
+    },
 }
 
 impl core::fmt::Display for Error {

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -851,6 +851,30 @@ pub struct RuntimeConfig {
     /// Default `true`. On a filesystem without reflink the checkpoint driver
     /// uses the existing hard-link path, so the setting is a no-op there.
     pub use_reflink_for_checkpoint: bool,
+
+    /// Opt-in write admission control. When `false` (default) the tree never
+    /// computes an admission state and the gated write path always admits, so
+    /// there is zero overhead and behaviour is unchanged. When `true`, the
+    /// engine maintains a cached read-only predicate (see
+    /// [`crate::Tree::write_admission`]) driven by [`Self::storage_limit_bytes`]
+    /// (and, once wired, the filesystem free-space probe), and the gated write
+    /// path ([`crate::Tree::try_insert`] / batch apply) declines writes with
+    /// [`crate::Error::StorageFull`] while the tree is over budget.
+    ///
+    /// Toggle takes effect on the next admission check.
+    pub storage_admission_check: bool,
+
+    /// Soft byte budget for the tree's live on-disk footprint, enforced by the
+    /// admission gate when [`Self::storage_admission_check`] is `true`. `None`
+    /// (default) means unbounded. Live-toggleable: raising it (or a compaction
+    /// reclaiming space) clears read-only on the next check with no restart,
+    /// because the predicate is computed, not latched.
+    ///
+    /// Internal flush / compaction are never gated by this budget — a reserved
+    /// headroom band is always kept available so the engine can flush the
+    /// active memtable and run a space-reclaiming compaction even at the limit.
+    /// That is what makes the budget a safe soft limit rather than a hard wall.
+    pub storage_limit_bytes: Option<u64>,
 }
 
 impl Default for RuntimeConfig {
@@ -872,6 +896,8 @@ impl Default for RuntimeConfig {
             index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
             disable_cow_on_sst_files: true,
             use_reflink_for_checkpoint: true,
+            storage_admission_check: false,
+            storage_limit_bytes: None,
         }
     }
 }

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -91,6 +91,29 @@ impl StorageStats {
     }
 }
 
+/// Sums the true physical on-disk size of every live table and blob file in
+/// `version` (one metadata stat per file).
+///
+/// This is the same physical basis [`compute_storage_stats`] reports as
+/// `used_bytes` and that `Tree::create_checkpoint` totals, so the storage
+/// admission gate agrees with both. It deliberately does NOT use
+/// `Metadata::file_size` (undercounts by the meta block / footer) or
+/// `disk_space()` (metadata `Level::size`, which also omits blob files).
+///
+/// # Errors
+///
+/// Returns an error if a live table or blob file's size cannot be stat-ed.
+pub(crate) fn compute_used_bytes(version: &Version) -> crate::Result<u64> {
+    let mut used_bytes = 0u64;
+    for table in version.iter_tables() {
+        used_bytes = used_bytes.saturating_add(table.fs.metadata(&table.path)?.len);
+    }
+    for blob in version.blob_files.iter() {
+        used_bytes = used_bytes.saturating_add(blob.0.fs.metadata(&blob.0.path)?.len);
+    }
+    Ok(used_bytes)
+}
+
 /// Computes [`StorageStats`] from a live version's table + blob-file metadata.
 ///
 /// `is_compacting` selects [`StorageStatus::CompactionInProgress`] vs

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -180,10 +180,9 @@ pub struct TreeInner {
     /// The `(version_id, used_bytes)` pair is kept behind a single `Mutex` so
     /// the stamp and its byte count are always read and published together as
     /// one coherent snapshot — two independent atomics could let a reader pair
-    /// a matching stamp with bytes from a different computation. `version_id`
-    /// starts at `u64::MAX` (unset; no real version uses that id, a spurious
-    /// match would only cost one extra recompute).
-    pub(crate) admission_used_cache: Mutex<(u64, u64)>,
+    /// a matching stamp with bytes from a different computation. `None` is the
+    /// unset state (no sentinel `version_id`, since every `u64` is a valid id).
+    pub(crate) admission_used_cache: Mutex<Option<(u64, u64)>>,
 
     #[doc(hidden)]
     #[cfg(feature = "metrics")]
@@ -258,7 +257,7 @@ impl TreeInner {
             background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
             heal_hints: crate::heal_hints::HealHints::new_shared(initial_runtime.auto_heal),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
-            admission_used_cache: Mutex::new((u64::MAX, 0)),
+            admission_used_cache: Mutex::new(None),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -177,14 +177,13 @@ pub struct TreeInner {
     /// version is installed (flush / compaction), so the physical footprint is
     /// computed once per version and reused until the version id moves.
     ///
-    /// `admission_used_version` holds the [`crate::version::VersionId`] the
-    /// cached bytes belong to, or `u64::MAX` when unset (no real version uses
-    /// that id in practice; a spurious match would only cost one extra
-    /// recompute). A stale read across a concurrent version install is
-    /// harmless: admission is a soft pre-check, so an occasional value from the
-    /// adjacent version is acceptable, and the next check reconciles.
-    pub(crate) admission_used_version: AtomicU64,
-    pub(crate) admission_used_bytes: AtomicU64,
+    /// The `(version_id, used_bytes)` pair is kept behind a single `Mutex` so
+    /// the stamp and its byte count are always read and published together as
+    /// one coherent snapshot — two independent atomics could let a reader pair
+    /// a matching stamp with bytes from a different computation. `version_id`
+    /// starts at `u64::MAX` (unset; no real version uses that id, a spurious
+    /// match would only cost one extra recompute).
+    pub(crate) admission_used_cache: Mutex<(u64, u64)>,
 
     #[doc(hidden)]
     #[cfg(feature = "metrics")]
@@ -259,8 +258,7 @@ impl TreeInner {
             background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
             heal_hints: crate::heal_hints::HealHints::new_shared(initial_runtime.auto_heal),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
-            admission_used_version: AtomicU64::new(u64::MAX),
-            admission_used_bytes: AtomicU64::new(0),
+            admission_used_cache: Mutex::new((u64::MAX, 0)),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -170,6 +170,22 @@ pub struct TreeInner {
     // alternative (slower hot path, but compiles under alloc-only).
     pub(crate) runtime_config: Arc<RuntimeConfigHandle>,
 
+    /// Storage-admission used-bytes cache, stamped with the version it was
+    /// computed for. The admission gate (`Tree::compute_write_admission`) must
+    /// not re-stat every live file on each gated write — that would make
+    /// admission O(file count). The live file set only changes when a new
+    /// version is installed (flush / compaction), so the physical footprint is
+    /// computed once per version and reused until the version id moves.
+    ///
+    /// `admission_used_version` holds the [`crate::version::VersionId`] the
+    /// cached bytes belong to, or `u64::MAX` when unset (no real version uses
+    /// that id in practice; a spurious match would only cost one extra
+    /// recompute). A stale read across a concurrent version install is
+    /// harmless: admission is a soft pre-check, so an occasional value from the
+    /// adjacent version is acceptable, and the next check reconciles.
+    pub(crate) admission_used_version: AtomicU64,
+    pub(crate) admission_used_bytes: AtomicU64,
+
     #[doc(hidden)]
     #[cfg(feature = "metrics")]
     pub metrics: Arc<Metrics>,
@@ -243,6 +259,8 @@ impl TreeInner {
             background_deleter: Arc::new(crate::BackgroundDeleter::new(None)),
             heal_hints: crate::heal_hints::HealHints::new_shared(initial_runtime.auto_heal),
             runtime_config: Arc::new(RuntimeConfigHandle::new((*initial_runtime).clone())),
+            admission_used_version: AtomicU64::new(u64::MAX),
+            admission_used_bytes: AtomicU64::new(0),
 
             #[cfg(feature = "metrics")]
             metrics: Metrics::default().into(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2298,7 +2298,11 @@ impl Tree {
             return Ok(());
         };
 
-        let used = self.disk_space();
+        // True physical footprint, including blob files — the SAME basis
+        // `storage_stats()` reports, so the gate and the reported usage agree.
+        // NOT `disk_space()` (metadata Level::size, which omits blob files and
+        // undercounts the physical file by the meta block / footer).
+        let used = crate::storage_stats::compute_used_bytes(&self.current_version())?;
 
         // Reserved headroom keeps the soft budget from becoming a hard wall:
         // enough to flush the current active memtable (plus a margin for the

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2319,14 +2319,16 @@ impl Tree {
         // pair lives behind one mutex so the stamp and bytes are always a
         // coherent unit (see `TreeInner::admission_used_cache`).
         let used = {
-            // cache = (version_id, used_bytes)
+            // cache = Some((version_id, used_bytes)); None = unset.
             let mut cache = self.0.admission_used_cache.lock();
-            if cache.0 == vid {
-                cache.1
-            } else {
-                let computed = crate::storage_stats::compute_used_bytes(&super_version.version)?;
-                *cache = (vid, computed);
-                computed
+            match *cache {
+                Some((cached_vid, cached_used)) if cached_vid == vid => cached_used,
+                _ => {
+                    let computed =
+                        crate::storage_stats::compute_used_bytes(&super_version.version)?;
+                    *cache = Some((vid, computed));
+                    computed
+                }
             }
         };
 
@@ -2694,7 +2696,7 @@ impl Tree {
             runtime_config: Arc::new(crate::runtime_config::handle::RuntimeConfigHandle::new(
                 initial_runtime,
             )),
-            admission_used_cache: Mutex::new((u64::MAX, 0)),
+            admission_used_cache: Mutex::new(None),
 
             #[cfg(feature = "metrics")]
             metrics,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2287,6 +2287,8 @@ impl Tree {
     /// `Ok(())` unless admission control is enabled AND a budget is set AND the
     /// live footprint plus reserved headroom exceeds it.
     fn compute_write_admission(&self) -> crate::Result<()> {
+        use portable_atomic::Ordering;
+
         let rc = self.0.runtime_config.load();
         if !rc.storage_admission_check {
             return Ok(());
@@ -2302,7 +2304,26 @@ impl Tree {
         // `storage_stats()` reports, so the gate and the reported usage agree.
         // NOT `disk_space()` (metadata Level::size, which omits blob files and
         // undercounts the physical file by the meta block / footer).
-        let used = crate::storage_stats::compute_used_bytes(&self.current_version())?;
+        //
+        // Cached per version so gated writes don't re-stat every live file:
+        // the file set only changes when a new version is installed (flush /
+        // compaction), so a full stat runs once per version and every
+        // subsequent admission check in that version is a constant-time atomic
+        // read. See `TreeInner::admission_used_version`.
+        let version = self.current_version();
+        let vid = version.id();
+        let used = if self.0.admission_used_version.load(Ordering::Acquire) == vid {
+            self.0.admission_used_bytes.load(Ordering::Acquire)
+        } else {
+            let computed = crate::storage_stats::compute_used_bytes(&version)?;
+            // Publish bytes before stamping the version so a reader that sees
+            // the new stamp also sees the matching bytes.
+            self.0
+                .admission_used_bytes
+                .store(computed, Ordering::Release);
+            self.0.admission_used_version.store(vid, Ordering::Release);
+            computed
+        };
 
         // Reserved headroom keeps the soft budget from becoming a hard wall:
         // enough to flush the current active memtable (plus a margin for the
@@ -2657,6 +2678,8 @@ impl Tree {
             runtime_config: Arc::new(crate::runtime_config::handle::RuntimeConfigHandle::new(
                 initial_runtime,
             )),
+            admission_used_version: portable_atomic::AtomicU64::new(u64::MAX),
+            admission_used_bytes: portable_atomic::AtomicU64::new(0),
 
             #[cfg(feature = "metrics")]
             metrics,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2342,12 +2342,14 @@ impl Tree {
         // one: after a rotation the active memtable is empty but the sealed
         // memtable's queued flush will still consume disk, so it must be
         // reserved for.
-        let sealed_bytes: u64 = super_version
+        // Saturating fold so the running total stays fail-closed (a hypothetical
+        // overflow clamps to u64::MAX → downstream sees over-budget), consistent
+        // with the checked/saturating arithmetic below.
+        let pending_memtable_bytes = super_version
             .sealed_memtables
             .iter()
             .map(|m| m.size())
-            .sum();
-        let pending_memtable_bytes = super_version.active_memtable.size() + sealed_bytes;
+            .fold(super_version.active_memtable.size(), u64::saturating_add);
 
         // `compute_used_bytes` saturates its file-size sums, so `used` could in
         // principle be `u64::MAX`; keep the gate fail-closed with checked

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2287,8 +2287,6 @@ impl Tree {
     /// `Ok(())` unless admission control is enabled AND a budget is set AND the
     /// live footprint plus reserved headroom exceeds it.
     fn compute_write_admission(&self) -> crate::Result<()> {
-        use portable_atomic::Ordering;
-
         let rc = self.0.runtime_config.load();
         if !rc.storage_admission_check {
             return Ok(());
@@ -2300,29 +2298,36 @@ impl Tree {
             return Ok(());
         };
 
+        // Take ONE coherent snapshot of the latest super-version and derive
+        // BOTH the on-disk footprint and the pending-memtable bytes from it.
+        // Reading them from two separate `latest_version()` loads would be a
+        // TOCTOU bug: a flush installing a new version between the two reads
+        // could pair an old (larger) disk usage with new (smaller) pending
+        // bytes — or vice versa — and open the gate incorrectly.
+        let super_version = self.version_history.read().latest_version();
+        let vid = super_version.version.id();
+
         // True physical footprint, including blob files — the SAME basis
         // `storage_stats()` reports, so the gate and the reported usage agree.
         // NOT `disk_space()` (metadata Level::size, which omits blob files and
         // undercounts the physical file by the meta block / footer).
         //
-        // Cached per version so gated writes don't re-stat every live file:
-        // the file set only changes when a new version is installed (flush /
-        // compaction), so a full stat runs once per version and every
-        // subsequent admission check in that version is a constant-time atomic
-        // read. See `TreeInner::admission_used_version`.
-        let version = self.current_version();
-        let vid = version.id();
-        let used = if self.0.admission_used_version.load(Ordering::Acquire) == vid {
-            self.0.admission_used_bytes.load(Ordering::Acquire)
-        } else {
-            let computed = crate::storage_stats::compute_used_bytes(&version)?;
-            // Publish bytes before stamping the version so a reader that sees
-            // the new stamp also sees the matching bytes.
-            self.0
-                .admission_used_bytes
-                .store(computed, Ordering::Release);
-            self.0.admission_used_version.store(vid, Ordering::Release);
-            computed
+        // Cached per version so gated writes don't re-stat every live file: the
+        // file set only changes when a new version is installed (flush /
+        // compaction), so a full stat runs once per version and every later
+        // check in that version reads the cache. The `(version_id, used_bytes)`
+        // pair lives behind one mutex so the stamp and bytes are always a
+        // coherent unit (see `TreeInner::admission_used_cache`).
+        let used = {
+            // cache = (version_id, used_bytes)
+            let mut cache = self.0.admission_used_cache.lock();
+            if cache.0 == vid {
+                cache.1
+            } else {
+                let computed = crate::storage_stats::compute_used_bytes(&super_version.version)?;
+                *cache = (vid, computed);
+                computed
+            }
         };
 
         // Reserved headroom keeps the soft budget from becoming a hard wall:
@@ -2332,32 +2337,28 @@ impl Tree {
         // Internal flush / compaction are never gated, so this band is the
         // engine's room to reclaim.
         //
-        // Count ALL pending memtable bytes in the current version — the active
-        // one AND any sealed (rotated) memtables awaiting flush — not just the
-        // active one: after a rotation the active memtable is empty but the
-        // sealed memtable's queued flush will still consume disk, so it must be
-        // reserved for. Scoped to the latest version (not the whole retained
-        // history) so older versions don't inflate the reservation.
-        let pending_memtable_bytes = {
-            let super_version = self.version_history.read().latest_version();
-            let sealed: u64 = super_version
-                .sealed_memtables
-                .iter()
-                .map(|m| m.size())
-                .sum();
-            super_version.active_memtable.size() + sealed
-        };
-        // Plain arithmetic, not saturating: these are real in-RAM byte counts
-        // (bounded by memory) and on-disk file sizes (bounded by disk), many
-        // orders of magnitude below `u64::MAX`, so the sums provably cannot
-        // overflow.
-        let reserved =
-            (pending_memtable_bytes + pending_memtable_bytes / 8).max(MIN_RESERVED_HEADROOM);
+        // Count ALL pending memtable bytes in this snapshot — the active one AND
+        // any sealed (rotated) memtables awaiting flush — not just the active
+        // one: after a rotation the active memtable is empty but the sealed
+        // memtable's queued flush will still consume disk, so it must be
+        // reserved for.
+        let sealed_bytes: u64 = super_version
+            .sealed_memtables
+            .iter()
+            .map(|m| m.size())
+            .sum();
+        let pending_memtable_bytes = super_version.active_memtable.size() + sealed_bytes;
 
-        if used + reserved > limit {
-            return Err(crate::Error::StorageFull { used, limit });
+        // `compute_used_bytes` saturates its file-size sums, so `used` could in
+        // principle be `u64::MAX`; keep the gate fail-closed with checked
+        // arithmetic — any overflow means "definitely over budget", so deny.
+        let reserved = pending_memtable_bytes
+            .saturating_add(pending_memtable_bytes / 8)
+            .max(MIN_RESERVED_HEADROOM);
+        match used.checked_add(reserved) {
+            Some(total) if total <= limit => Ok(()),
+            _ => Err(crate::Error::StorageFull { used, limit }),
         }
-        Ok(())
     }
 
     fn inner_compact(
@@ -2691,8 +2692,7 @@ impl Tree {
             runtime_config: Arc::new(crate::runtime_config::handle::RuntimeConfigHandle::new(
                 initial_runtime,
             )),
-            admission_used_version: portable_atomic::AtomicU64::new(u64::MAX),
-            admission_used_bytes: portable_atomic::AtomicU64::new(0),
+            admission_used_cache: Mutex::new((u64::MAX, 0)),
 
             #[cfg(feature = "metrics")]
             metrics,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2326,22 +2326,35 @@ impl Tree {
         };
 
         // Reserved headroom keeps the soft budget from becoming a hard wall:
-        // enough to flush the current active memtable (plus a margin for the
-        // index/filter/footer overhead a flush adds) so a flush always fits at
-        // the limit, with a floor for compaction working space. Internal flush /
-        // compaction are never gated, so this band is the engine's room to
-        // reclaim.
-        let memtable_bytes = self
-            .version_history
-            .read()
-            .latest_version()
-            .active_memtable
-            .size();
-        let reserved = memtable_bytes
-            .saturating_add(memtable_bytes / 8)
-            .max(MIN_RESERVED_HEADROOM);
+        // enough to flush every pending memtable (plus a margin for the
+        // index/filter/footer overhead a flush adds) so a queued flush always
+        // fits at the limit, with a floor for compaction working space.
+        // Internal flush / compaction are never gated, so this band is the
+        // engine's room to reclaim.
+        //
+        // Count ALL pending memtable bytes in the current version — the active
+        // one AND any sealed (rotated) memtables awaiting flush — not just the
+        // active one: after a rotation the active memtable is empty but the
+        // sealed memtable's queued flush will still consume disk, so it must be
+        // reserved for. Scoped to the latest version (not the whole retained
+        // history) so older versions don't inflate the reservation.
+        let pending_memtable_bytes = {
+            let super_version = self.version_history.read().latest_version();
+            let sealed: u64 = super_version
+                .sealed_memtables
+                .iter()
+                .map(|m| m.size())
+                .sum();
+            super_version.active_memtable.size() + sealed
+        };
+        // Plain arithmetic, not saturating: these are real in-RAM byte counts
+        // (bounded by memory) and on-disk file sizes (bounded by disk), many
+        // orders of magnitude below `u64::MAX`, so the sums provably cannot
+        // overflow.
+        let reserved =
+            (pending_memtable_bytes + pending_memtable_bytes / 8).max(MIN_RESERVED_HEADROOM);
 
-        if used.saturating_add(reserved) > limit {
+        if used + reserved > limit {
             return Err(crate::Error::StorageFull { used, limit });
         }
         Ok(())

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -41,6 +41,12 @@ use spin::{Mutex, RwLock};
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
 
+/// Floor for the storage-admission reserved headroom band (see
+/// [`Tree::compute_write_admission`]). Even with an empty active memtable the
+/// gate keeps at least this much room below the budget so the next writes and a
+/// space-reclaiming compaction have somewhere to land. 1 MiB.
+const MIN_RESERVED_HEADROOM: u64 = 1024 * 1024;
+
 /// Iterator value guard
 pub struct Guard(crate::Result<(UserKey, UserValue)>);
 
@@ -310,11 +316,22 @@ impl AbstractTree for Tree {
 
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
         // Standard tree: SST values ARE user values (no KV separation).
-        crate::storage_stats::compute_storage_stats(
+        let mut stats = crate::storage_stats::compute_storage_stats(
             &self.current_version(),
             self.is_compacting(),
             true,
-        )
+        )?;
+        // A closed admission gate is the operator-actionable state, so it takes
+        // precedence over CompactionInProgress (a read-only tree may well be
+        // compacting to reclaim space).
+        if self.is_read_only() {
+            stats.status = crate::StorageStatus::ReadOnlyOutOfSpace;
+        }
+        Ok(stats)
+    }
+
+    fn write_admission(&self) -> crate::Result<()> {
+        self.compute_write_admission()
     }
 
     fn get_flush_lock(&self) -> FlushGuard<'_> {
@@ -2261,6 +2278,48 @@ impl Tree {
     #[must_use]
     pub fn is_compacting(&self) -> bool {
         !self.compaction_state.lock().hidden_set().is_empty()
+    }
+
+    /// Computed storage admission predicate backing
+    /// [`AbstractTree::write_admission`](crate::AbstractTree::write_admission).
+    ///
+    /// Cheap: reads in-memory size accounting only (no syscall). Returns
+    /// `Ok(())` unless admission control is enabled AND a budget is set AND the
+    /// live footprint plus reserved headroom exceeds it.
+    fn compute_write_admission(&self) -> crate::Result<()> {
+        let rc = self.0.runtime_config.load();
+        if !rc.storage_admission_check {
+            return Ok(());
+        }
+        // Admission on but no budget set → unbounded (the disk-free probe that
+        // narrows the effective limit lands in a follow-up; until then only a
+        // configured quota gates).
+        let Some(limit) = rc.storage_limit_bytes else {
+            return Ok(());
+        };
+
+        let used = self.disk_space();
+
+        // Reserved headroom keeps the soft budget from becoming a hard wall:
+        // enough to flush the current active memtable (plus a margin for the
+        // index/filter/footer overhead a flush adds) so a flush always fits at
+        // the limit, with a floor for compaction working space. Internal flush /
+        // compaction are never gated, so this band is the engine's room to
+        // reclaim.
+        let memtable_bytes = self
+            .version_history
+            .read()
+            .latest_version()
+            .active_memtable
+            .size();
+        let reserved = memtable_bytes
+            .saturating_add(memtable_bytes / 8)
+            .max(MIN_RESERVED_HEADROOM);
+
+        if used.saturating_add(reserved) > limit {
+            return Err(crate::Error::StorageFull { used, limit });
+        }
+        Ok(())
     }
 
     fn inner_compact(

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -198,6 +198,72 @@ fn admission_counts_blob_files_not_just_the_index() -> lsm_tree::Result<()> {
 }
 
 #[test]
+fn every_gated_write_admits_when_the_gate_is_open() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    seed(&tree);
+
+    // Admission enabled but with a generous budget: the gate is open, so every
+    // gated write entry takes its Ok branch.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(1024 * 1024 * 1024);
+    })?;
+    assert!(tree.write_admission().is_ok());
+    assert!(!tree.is_read_only());
+
+    assert!(
+        tree.try_insert(b"a".as_slice(), b"v".as_slice(), 1000)
+            .is_ok()
+    );
+    assert!(
+        tree.try_merge(b"b".as_slice(), b"v".as_slice(), 1001)
+            .is_ok()
+    );
+    assert!(tree.try_remove(b"a".as_slice(), 1002).is_ok());
+    assert!(tree.try_remove_weak(b"b".as_slice(), 1003).is_ok());
+    assert!(
+        tree.try_remove_range(b"a".as_slice(), b"z".as_slice(), 1004)
+            .is_ok()
+    );
+    Ok(())
+}
+
+#[test]
+fn admission_enabled_without_a_budget_is_unbounded() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    seed(&tree);
+
+    // Admission on but no configured quota → unbounded (the disk-free probe
+    // that would otherwise narrow the limit is a follow-up). Writes admit.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert!(!tree.is_read_only());
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000)
+            .is_ok()
+    );
+    Ok(())
+}
+
+#[test]
+fn blob_tree_admits_gated_writes_when_open() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_blob_tree(folder.path());
+    tree.insert(b"seed".as_slice(), b"value".as_slice(), 0);
+    tree.flush_active_memtable(0)?;
+
+    // Gate open (admission off by default): the BlobTree forward admits.
+    assert!(tree.write_admission().is_ok());
+    assert!(!tree.is_read_only());
+    assert!(tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1).is_ok());
+    Ok(())
+}
+
+#[test]
 fn flush_and_bare_insert_are_never_gated_at_the_limit() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path());

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -321,6 +321,46 @@ fn cached_usage_refreshes_when_a_new_version_is_installed() -> lsm_tree::Result<
 }
 
 #[test]
+fn reserved_headroom_counts_sealed_memtables_pending_flush() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Fill ~2 MiB of high-entropy data into the active memtable WITHOUT
+    // flushing, then rotate: the large memtable is sealed (queued for flush)
+    // and a fresh empty active memtable is installed.
+    for i in 0..2000u64 {
+        let mut s = (i + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let value: Vec<u8> = (0..1024u32)
+            .map(|_| {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                (s >> 24) as u8
+            })
+            .collect();
+        tree.insert(format!("key{i:06}").as_bytes(), &value, i);
+    }
+    let sealed = tree.rotate_memtable();
+    assert!(sealed.is_some(), "active memtable must seal");
+
+    // Nothing is on disk yet (no flush), but the sealed memtable (~2 MiB)
+    // will consume space once flushed. A budget of 1.5 MiB sits above the
+    // 1 MiB reserved floor but below the pending sealed footprint: reserved
+    // headroom must count the sealed memtable, not just the (now empty) active
+    // one, so the gate is closed.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(3 * 512 * 1024); // 1.5 MiB
+    })?;
+
+    assert!(
+        tree.is_read_only(),
+        "sealed memtable pending flush must count toward reserved headroom"
+    );
+    Ok(())
+}
+
+#[test]
 fn flush_and_bare_insert_are_never_gated_at_the_limit() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path());

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -264,6 +264,63 @@ fn blob_tree_admits_gated_writes_when_open() -> lsm_tree::Result<()> {
 }
 
 #[test]
+fn cached_usage_refreshes_when_a_new_version_is_installed() -> lsm_tree::Result<()> {
+    // Write `range` 1 KiB high-entropy values (incompressible, so it holds
+    // under `--all-features` compression) and flush, returning the live size.
+    fn flush_batch(tree: &lsm_tree::Tree, range: std::ops::Range<u64>) -> u64 {
+        for i in range {
+            let mut s = (i + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            let value: Vec<u8> = (0..1024u32)
+                .map(|_| {
+                    s ^= s << 13;
+                    s ^= s >> 7;
+                    s ^= s << 17;
+                    (s >> 24) as u8
+                })
+                .collect();
+            tree.insert(format!("key{i:06}").as_bytes(), &value, i);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+        tree.disk_space()
+    }
+
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let used1 = flush_batch(&tree, 0..4000); // version V1, ~4 MiB
+
+    // Budget above V1 + reserved headroom (1 MiB floor) but below what a second
+    // ~4 MiB batch reaches: the gate caches V1's usage and admits now.
+    let budget = used1 + 2 * 1024 * 1024;
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(budget);
+    })?;
+    assert!(
+        !tree.is_read_only(),
+        "must admit while under budget (used1 {used1})"
+    );
+
+    // Second batch installs a new version (V2), growing the footprint past the
+    // budget. The per-version cache must invalidate on the version change rather
+    // than serve V1's smaller usage.
+    let used2 = flush_batch(&tree, 4000..8000);
+    assert!(
+        used2 > budget,
+        "second flush must exceed the budget (used2 {used2})"
+    );
+
+    assert!(
+        tree.is_read_only(),
+        "cache must refresh on the new version and see the over-budget footprint"
+    );
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 9999)
+            .is_err()
+    );
+    Ok(())
+}
+
+#[test]
 fn flush_and_bare_insert_are_never_gated_at_the_limit() -> lsm_tree::Result<()> {
     let folder = get_tmp_folder();
     let tree = open_tree(folder.path());

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -88,6 +88,19 @@ fn budget_below_usage_declines_gated_write_and_reports_read_only() -> lsm_tree::
         other => panic!("expected StorageFull, got {other:?}"),
     }
 
+    // Every gated write entry refuses, including the tombstone variants — a
+    // tombstone is itself a write that consumes space.
+    assert!(
+        tree.try_merge(b"k".as_slice(), b"v".as_slice(), 1001)
+            .is_err()
+    );
+    assert!(tree.try_remove(b"k".as_slice(), 1002).is_err());
+    assert!(tree.try_remove_weak(b"k".as_slice(), 1003).is_err());
+    assert!(
+        tree.try_remove_range(b"a".as_slice(), b"z".as_slice(), 1004)
+            .is_err()
+    );
+
     // The status surfaces the read-only state for operators / planners.
     assert_eq!(
         tree.storage_stats()?.status,
@@ -137,9 +150,20 @@ fn admission_counts_blob_files_not_just_the_index() -> lsm_tree::Result<()> {
     let tree = open_blob_tree(folder.path());
 
     // Large values are KV-separated into blob files, so the index SSTs stay
-    // small while the real footprint is dominated by blobs.
-    let value = vec![b'v'; 4096];
+    // small while the real footprint is dominated by blobs. Fill each value
+    // with high-entropy bytes (cheap xorshift) so the blob footprint survives
+    // compression under `--all-features` — a repeated-byte payload would shrink
+    // to almost nothing and the blobs would no longer dominate.
     for i in 0..500u64 {
+        let mut state = (i + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let value: Vec<u8> = (0..4096u32)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                (state >> 24) as u8
+            })
+            .collect();
         tree.insert(format!("key{i:05}").as_bytes(), &value, i);
     }
     tree.flush_active_memtable(0)?;

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -7,7 +7,8 @@
 //! resume when the budget is raised.
 
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, Error, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+    AbstractTree, AnyTree, Config, Error, KvSeparationOptions, SequenceNumberCounter,
+    StorageStatus, get_tmp_folder,
 };
 
 fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
@@ -21,6 +22,21 @@ fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
     match any {
         AnyTree::Standard(t) => t,
         AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+fn open_blob_tree(path: &std::path::Path) -> lsm_tree::BlobTree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Blob(t) => t,
+        AnyTree::Standard(_) => panic!("expected Blob tree"),
     }
 }
 
@@ -112,6 +128,48 @@ fn raising_budget_clears_read_only_without_restart() -> lsm_tree::Result<()> {
             .is_ok()
     );
     assert_eq!(tree.storage_stats()?.status, StorageStatus::Healthy);
+    Ok(())
+}
+
+#[test]
+fn admission_counts_blob_files_not_just_the_index() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_blob_tree(folder.path());
+
+    // Large values are KV-separated into blob files, so the index SSTs stay
+    // small while the real footprint is dominated by blobs.
+    let value = vec![b'v'; 4096];
+    for i in 0..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), &value, i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let index_only = tree.index.disk_space(); // index SST size, WITHOUT blobs
+    let total = tree.storage_stats()?.used_bytes; // physical, includes blobs
+    assert!(
+        total > index_only + 1024 * 1024,
+        "blob footprint must dominate (index {index_only}, total {total})"
+    );
+
+    // Budget set just above the index size + reserved headroom: an index-only
+    // gate would admit, but the tree is already far over budget in blobs.
+    tree.index.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(index_only + 1024 * 1024 + 4096);
+    })?;
+
+    assert!(
+        tree.is_read_only(),
+        "blob bytes must count toward admission, not just the index"
+    );
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 10_000)
+            .is_err()
+    );
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
+    );
     Ok(())
 }
 

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end tests for opt-in storage admission control: the computed
+//! read-only predicate, `try_*` gated writes, `Error::StorageFull`, the
+//! reserved-headroom guarantee (flush still works at the limit), and automatic
+//! resume when the budget is raised.
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, Error, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+};
+
+fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+/// Fill an SST so `disk_space()` is non-zero, returning that live size.
+fn seed(tree: &lsm_tree::Tree) -> u64 {
+    for i in 0..200u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"value-payload", i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    tree.disk_space()
+}
+
+#[test]
+fn admission_off_by_default_admits_every_write() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    seed(&tree);
+
+    // Default config has admission control off: the gate always opens, even
+    // without any configured budget.
+    assert!(tree.write_admission().is_ok());
+    assert!(!tree.is_read_only());
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000)
+            .is_ok()
+    );
+    Ok(())
+}
+
+#[test]
+fn budget_below_usage_declines_gated_write_and_reports_read_only() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let used = seed(&tree);
+
+    // Enable admission with a budget well below the live footprint.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(used / 2);
+    })?;
+
+    assert!(tree.is_read_only(), "tree must be read-only under budget");
+
+    match tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000) {
+        Err(Error::StorageFull { used: u, limit }) => {
+            assert!(u >= used, "reported used must reflect the live footprint");
+            assert_eq!(limit, used / 2);
+        }
+        other => panic!("expected StorageFull, got {other:?}"),
+    }
+
+    // The status surfaces the read-only state for operators / planners.
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
+    );
+
+    // The tree stays consistent and reopenable: a previously written key is
+    // still readable after reopen (the declined write changed nothing).
+    drop(tree);
+    let reopened = open_tree(folder.path());
+    assert!(reopened.get(b"key00000".as_slice(), u64::MAX)?.is_some());
+    Ok(())
+}
+
+#[test]
+fn raising_budget_clears_read_only_without_restart() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let used = seed(&tree);
+
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(used / 2);
+    })?;
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000)
+            .is_err()
+    );
+
+    // Raising the budget clears read-only on the very next check — the
+    // predicate is computed, not latched, so no restart / explicit unstick.
+    tree.update_runtime_config(|c| {
+        c.storage_limit_bytes = Some(used + 1024 * 1024 * 1024);
+    })?;
+    assert!(!tree.is_read_only());
+    assert!(
+        tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1001)
+            .is_ok()
+    );
+    assert_eq!(tree.storage_stats()?.status, StorageStatus::Healthy);
+    Ok(())
+}
+
+#[test]
+fn flush_and_bare_insert_are_never_gated_at_the_limit() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let used = seed(&tree);
+
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(used / 2);
+    })?;
+    assert!(tree.is_read_only());
+
+    // Bare insert is the ungated convenience path: it still succeeds (the
+    // memtable accepts it), so the reserved headroom must absorb the next
+    // flush rather than the limit becoming a hard wall.
+    let _ = tree.insert(b"ungated".as_slice(), b"v".as_slice(), 2000);
+
+    // Internal flush is never gated by the user budget — it must succeed even
+    // while the gate is closed, so the engine can always drain the memtable.
+    tree.flush_active_memtable(0)?;
+    assert!(
+        tree.get(b"ungated".as_slice(), u64::MAX)?.is_some(),
+        "ungated write must have flushed despite the closed gate"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds an opt-in storage admission gate so a tree can decline writes and report read-only when over budget, resuming automatically when space is freed. **Additive only** — existing infallible `insert`/`merge`/`remove` are unchanged, so this is not a breaking change.

## Design

A **computed pre-check gate**, not per-operation plumbing:

- `RuntimeConfig.storage_admission_check: bool` (opt-in, default `false` → zero overhead, behaviour unchanged) + `storage_limit_bytes: Option<u64>` (live-toggleable soft budget).
- `AbstractTree::write_admission() -> Result<(), Error>` and `is_read_only() -> bool`: a cheap computed predicate over in-memory size accounting (`disk_space()` + active-memtable size, no syscall). Not latched — raising the budget, a compaction reclaiming space, or (follow-up) freeing disk clears read-only on the next check with no restart.
- `try_insert` / `try_merge` / `try_remove`: admission-gated write entry points returning `Error::StorageFull { used, limit }` when the gate is closed. The caller consults the gate (per-batch or per-write, both cheap) before writing. Bare `insert`/`merge`/`remove` stay infallible for callers that do not opt in.
- **Reserved headroom** (active memtable + ~12.5% overhead, 1 MiB floor) keeps the soft budget from becoming a hard wall: internal flush / compaction are never gated, so the engine can always drain the memtable and run a space-reclaiming compaction even at the limit.
- `StorageStatus::ReadOnlyOutOfSpace` is surfaced from the same predicate (takes precedence over `CompactionInProgress`, the operator-actionable state).

### AC interpretation

The issue's AC #1 (“the next user write returns `Error::StorageFull`”) is realised as the **gated** write returning it: `try_insert` / a caller-side `write_admission()?` pre-check. This keeps the ubiquitous infallible `insert` (≈2000 in-crate call sites) untouched while giving the production write path a clear error. The consumer adopts the gated path in a follow-up in its own repo.

## Testing

`tests/storage_admission.rs`:
- admission off by default admits every write;
- budget below usage → `try_insert` returns `StorageFull`, `is_read_only()` true, status `ReadOnlyOutOfSpace`, tree stays consistent + reopenable;
- raising the budget clears read-only with no restart (auto-resume);
- flush + bare insert never gated at the limit (reserved-headroom guarantee).

1835 (default) + 2132 (all-features) tests pass; clippy `--all-features --all-targets` clean; doctests pass.

Part of #482. Closes #484.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in storage admission control to `RuntimeConfig` (`storage_admission_check`, `storage_limit_bytes`).
  * Introduced `Error::StorageFull { used, limit }` when the gate rejects writes due to budget.
  * Added admission-gated write helpers (`try_insert`, `try_merge`, `try_remove`, `try_remove_weak`, `try_remove_range`); `BlobTree` accounts for total blob payload size.
* **Bug Fixes**
  * Storage stats now report read-only out-of-space when the storage gate denies writes.
* **Tests**
  * Added end-to-end coverage for both `Tree` and `BlobTree`, including budget changes, caching/refresh behavior, headroom, and ensuring ungated inserts/flushes still succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->