### PR TITLE
feat(fs): Fs::available_space free-space probe + disk-pressure admission

### DIFF
--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -327,6 +327,15 @@ impl AbstractTree for BlobTree {
             self.index.is_compacting(),
             false,
         )?;
+        // Capacity is disk-aware and driven by the index tree's runtime config;
+        // its footprint basis (`compute_used_bytes`) already stats blob files, so
+        // `used_bytes` here is the blob-inclusive figure capacity is measured
+        // against.
+        let (capacity, available, compaction_possible) =
+            self.index.admission_capacity(stats.used_bytes);
+        stats.capacity_bytes = capacity;
+        stats.available_bytes = available;
+        stats.compaction_possible = compaction_possible;
         // Admission is driven by the index tree's runtime config / footprint;
         // a closed gate is the operator-actionable state (see the standard
         // tree's override for the precedence rationale).

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -210,6 +210,12 @@ impl Fs for IoUringFs {
         })
     }
 
+    fn available_space(&self, path: &Path) -> crate::io::Result<u64> {
+        // Free-space probe is a cold-path stat; delegate to the shared statvfs
+        // helper (this backend is Linux-only, so libc statvfs is available).
+        super::statvfs_available_space(path).map_err(crate::io::Error::from)
+    }
+
     fn sync_directory(&self, path: &Path) -> crate::io::Result<()> {
         let dir = File::open(path)?;
         if !dir.metadata()?.is_dir() {

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -1302,4 +1302,25 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn available_space_reports_plausible_free_bytes() -> io::Result<()> {
+        // The cold-path free-space probe delegates to the shared statvfs helper:
+        // the filesystem backing the tempdir must report a plausible, non-zero
+        // figure below the unbounded sentinel.
+        let Some(fs) = try_io_uring() else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        let free = fs.available_space(dir.path())?;
+        assert!(
+            free > 0,
+            "a writable tempdir filesystem must report free space"
+        );
+        assert!(
+            free < u64::MAX,
+            "a real probe must not return the unbounded sentinel"
+        );
+        Ok(())
+    }
 }

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -651,9 +651,12 @@ pub fn statx_path_raw(path: &core::ffi::CStr) -> Result<Option<RawMetadata>, Err
 }
 
 /// The kernel `struct statfs` for 64-bit Linux (x86-64 / aarch64). Unlike
-/// `statx`, this struct is architecture-dependent; this backend is gated to
-/// 64-bit Linux, where the layout below is stable. Only `f_bsize` and
+/// `statx`, this struct is architecture-dependent: the field widths below (and
+/// the syscall's expected buffer layout) are the 64-bit ABI, so it is gated to
+/// `target_pointer_width = "64"`. A 32-bit build (e.g. `i686`) would read the
+/// kernel's 32-bit `statfs` into the wrong layout. Only `f_frsize` and
 /// `f_bavail` are read.
+#[cfg(target_pointer_width = "64")]
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
 #[allow(
@@ -676,21 +679,26 @@ struct Statfs {
 }
 
 /// `statfs(path, &buf)` — bytes available to an unprivileged process on the
-/// filesystem backing `path`: `f_bavail * f_bsize`. Raw syscall (no libc),
-/// matching this backend's no-libc design.
+/// filesystem backing `path`: `f_bavail * f_frsize`. Raw syscall (no libc),
+/// matching this backend's no-libc design. 64-bit-only (see [`Statfs`]).
+///
+/// `f_frsize` (fundamental fragment size), not `f_bsize` (preferred transfer
+/// block size), to match `available_space`'s contract and the `statvfs`-based
+/// std backend (`f_bavail * f_frsize`).
 ///
 /// # Errors
 /// Returns an [`Error`] if the `statfs` syscall fails.
+#[cfg(target_pointer_width = "64")]
 pub fn statfs_available_raw(path: &core::ffi::CStr) -> Result<u64, Error> {
     let mut buf = Statfs::default();
     // SAFETY: `path` is a valid NUL-terminated C string the kernel reads;
     // `buf` is a valid, writable Statfs the kernel fills on success.
     unsafe { syscall2(Sysno::statfs, path.as_ptr() as usize, &raw mut buf as usize) }
         .map_err(|e| err("statfs", e))?;
-    // `f_bavail` counts blocks free to a non-root caller; `f_bsize` is the
-    // block size. Saturate so an implausible value can never wrap.
-    let bsize = buf.f_bsize as u64;
-    Ok(buf.f_bavail.saturating_mul(bsize))
+    // `f_bavail` counts blocks free to a non-root caller; `f_frsize` is the
+    // fundamental block size. Saturate so an implausible value can never wrap.
+    let frsize = buf.f_frsize as u64;
+    Ok(buf.f_bavail.saturating_mul(frsize))
 }
 
 // SAFETY: `IoUringRaw`'s raw pointers address `mmap` regions it owns for its
@@ -1100,6 +1108,11 @@ impl Fs for IoUringRawFs {
         }
     }
 
+    // 64-bit only: the raw `statfs` ABI struct is gated to 64-bit targets. On a
+    // 32-bit build this method is absent, so the trait default (u64::MAX = no
+    // disk-pressure signal) applies — correct, since admission must not gate on
+    // a value it cannot read.
+    #[cfg(target_pointer_width = "64")]
     fn available_space(&self, path: &Path) -> crate::io::Result<u64> {
         statfs_available_raw(&path_to_cstring(path)?)
     }

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -650,13 +650,16 @@ pub fn statx_path_raw(path: &core::ffi::CStr) -> Result<Option<RawMetadata>, Err
     }
 }
 
-/// The kernel `struct statfs` for 64-bit Linux (x86-64 / aarch64). Unlike
-/// `statx`, this struct is architecture-dependent: the field widths below (and
-/// the syscall's expected buffer layout) are the 64-bit ABI, so it is gated to
-/// `target_pointer_width = "64"`. A 32-bit build (e.g. `i686`) would read the
-/// kernel's 32-bit `statfs` into the wrong layout. Only `f_frsize` and
+/// The kernel `struct statfs` for x86-64 / aarch64 Linux. Unlike `statx`, this
+/// struct is architecture-dependent: the field widths below (and the syscall's
+/// expected buffer layout) match the verified x86-64 / aarch64 ABI, so it is
+/// gated to exactly those targets. Other 64-bit Linux architectures (e.g.
+/// s390x) place `f_bavail` / `f_frsize` at different offsets, so reading this
+/// layout there would yield bogus free space; they fall back to the trait
+/// default (`u64::MAX`, no disk-pressure signal). A 32-bit build would likewise
+/// read the kernel's 32-bit `statfs` into the wrong layout. Only `f_frsize` and
 /// `f_bavail` are read.
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
 #[allow(
@@ -680,7 +683,8 @@ struct Statfs {
 
 /// `statfs(path, &buf)` — bytes available to an unprivileged process on the
 /// filesystem backing `path`: `f_bavail * f_frsize`. Raw syscall (no libc),
-/// matching this backend's no-libc design. 64-bit-only (see [`Statfs`]).
+/// matching this backend's no-libc design. x86-64 / aarch64 only (see
+/// [`Statfs`]).
 ///
 /// `f_frsize` (fundamental fragment size), not `f_bsize` (preferred transfer
 /// block size), to match `available_space`'s contract and the `statvfs`-based
@@ -688,7 +692,7 @@ struct Statfs {
 ///
 /// # Errors
 /// Returns an [`Error`] if the `statfs` syscall fails.
-#[cfg(target_pointer_width = "64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub fn statfs_available_raw(path: &core::ffi::CStr) -> Result<u64, Error> {
     let mut buf = Statfs::default();
     // SAFETY: `path` is a valid NUL-terminated C string the kernel reads;
@@ -1108,11 +1112,12 @@ impl Fs for IoUringRawFs {
         }
     }
 
-    // 64-bit only: the raw `statfs` ABI struct is gated to 64-bit targets. On a
-    // 32-bit build this method is absent, so the trait default (u64::MAX = no
+    // x86-64 / aarch64 only: the raw `statfs` ABI struct is verified for those
+    // layouts. On any other target (a different 64-bit arch like s390x, or a
+    // 32-bit build) this method is absent, so the trait default (u64::MAX = no
     // disk-pressure signal) applies — correct, since admission must not gate on
-    // a value it cannot read.
-    #[cfg(target_pointer_width = "64")]
+    // a value it cannot read from a matching layout.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     fn available_space(&self, path: &Path) -> crate::io::Result<u64> {
         statfs_available_raw(&path_to_cstring(path)?)
     }
@@ -1802,7 +1807,7 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::InvalidInput); // EBADF -> InvalidInput
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[test]
     fn raw_available_space_reports_plausible_free_bytes() {
         // The raw `statfs` syscall path: the filesystem backing the tempdir must
@@ -1825,7 +1830,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[test]
     fn raw_statfs_on_missing_path_errors() {
         // `statfs` on a path that does not exist surfaces an error, not a silent

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -1801,4 +1801,37 @@ mod tests {
             .expect_err("write to a non-open fd must fail");
         assert_eq!(err.kind(), ErrorKind::InvalidInput); // EBADF -> InvalidInput
     }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn raw_available_space_reports_plausible_free_bytes() {
+        // The raw `statfs` syscall path: the filesystem backing the tempdir must
+        // report a plausible, non-zero free figure below the unbounded sentinel.
+        use crate::fs::Fs;
+        use crate::path::Path;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fs = IoUringRawFs::new(8).expect("fs setup");
+        let free = fs
+            .available_space(Path::new(tmp.path().to_str().expect("utf8 path")))
+            .expect("statfs must succeed on a real filesystem");
+        assert!(
+            free > 0,
+            "a writable tempdir filesystem must report free space"
+        );
+        assert!(
+            free < u64::MAX,
+            "a real probe must not return the unbounded sentinel"
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn raw_statfs_on_missing_path_errors() {
+        // `statfs` on a path that does not exist surfaces an error, not a silent
+        // zero or the unbounded sentinel — exercising the syscall error branch.
+        let cpath =
+            std::ffi::CString::new("/proc/does-not-exist/iou_raw_statfs").expect("no interior NUL");
+        assert!(statfs_available_raw(&cpath).is_err());
+    }
 }

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -650,6 +650,49 @@ pub fn statx_path_raw(path: &core::ffi::CStr) -> Result<Option<RawMetadata>, Err
     }
 }
 
+/// The kernel `struct statfs` for 64-bit Linux (x86-64 / aarch64). Unlike
+/// `statx`, this struct is architecture-dependent; this backend is gated to
+/// 64-bit Linux, where the layout below is stable. Only `f_bsize` and
+/// `f_bavail` are read.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the kernel `struct statfs` (f_type, f_bsize, …) verbatim"
+)]
+struct Statfs {
+    f_type: i64,
+    f_bsize: i64,
+    f_blocks: u64,
+    f_bfree: u64,
+    f_bavail: u64,
+    f_files: u64,
+    f_ffree: u64,
+    f_fsid: [i32; 2],
+    f_namelen: i64,
+    f_frsize: i64,
+    f_flags: i64,
+    f_spare: [i64; 4],
+}
+
+/// `statfs(path, &buf)` — bytes available to an unprivileged process on the
+/// filesystem backing `path`: `f_bavail * f_bsize`. Raw syscall (no libc),
+/// matching this backend's no-libc design.
+///
+/// # Errors
+/// Returns an [`Error`] if the `statfs` syscall fails.
+pub fn statfs_available_raw(path: &core::ffi::CStr) -> Result<u64, Error> {
+    let mut buf = Statfs::default();
+    // SAFETY: `path` is a valid NUL-terminated C string the kernel reads;
+    // `buf` is a valid, writable Statfs the kernel fills on success.
+    unsafe { syscall2(Sysno::statfs, path.as_ptr() as usize, &raw mut buf as usize) }
+        .map_err(|e| err("statfs", e))?;
+    // `f_bavail` counts blocks free to a non-root caller; `f_bsize` is the
+    // block size. Saturate so an implausible value can never wrap.
+    let bsize = buf.f_bsize as u64;
+    Ok(buf.f_bavail.saturating_mul(bsize))
+}
+
 // SAFETY: `IoUringRaw`'s raw pointers address `mmap` regions it owns for its
 // whole lifetime, and its ring fd is process-global; moving it to another
 // thread is sound because every access is serialized through the `Mutex` that
@@ -1055,6 +1098,10 @@ impl Fs for IoUringRawFs {
             }),
             None => Err(Error::new(ErrorKind::NotFound, "path not found")),
         }
+    }
+
+    fn available_space(&self, path: &Path) -> crate::io::Result<u64> {
+        statfs_available_raw(&path_to_cstring(path)?)
     }
 
     fn sync_directory(&self, path: &Path) -> crate::io::Result<()> {

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -61,13 +61,16 @@ pub struct MemFs {
     /// constructed `MemFs::new()` values get DIFFERENT IDs because they
     /// have disjoint file trees.
     namespace_id: u64,
-    /// Simulated free space reported by [`Fs::available_space`]. Shared across
-    /// clones (same backend) so a test can drive the tree near-full. Defaults
-    /// to `u64::MAX` ("unbounded"); set via [`MemFs::set_available_space`].
+    /// Total simulated disk capacity in bytes. `u64::MAX` (default) means
+    /// "unbounded": [`Fs::available_space`] then reports `u64::MAX` (no disk
+    /// pressure). When set to a finite value via [`MemFs::with_capacity`] /
+    /// [`MemFs::set_capacity`], `available_space` reports `capacity − bytes
+    /// stored`, so the simulated disk fills as data is written and reaches zero
+    /// when full — a real capped disk. Shared across clones (same backend).
     ///
     /// `portable_atomic::AtomicU64` (not `core`'s): native 64-bit atomics are
     /// absent on some `no_std` targets (e.g. thumbv7em).
-    available_space: Arc<portable_atomic::AtomicU64>,
+    capacity: Arc<portable_atomic::AtomicU64>,
 }
 
 #[derive(Debug, Default)]
@@ -86,16 +89,39 @@ impl MemFs {
         Self {
             state: Arc::new(RwLock::new(state)),
             namespace_id: next_mem_fs_namespace_id(),
-            available_space: Arc::new(portable_atomic::AtomicU64::new(u64::MAX)),
+            capacity: Arc::new(portable_atomic::AtomicU64::new(u64::MAX)),
         }
     }
 
-    /// Sets the free space [`Fs::available_space`] reports (shared across
-    /// clones of this `MemFs`). Lets a test simulate a near-full disk to
-    /// exercise the storage-admission disk-pressure path.
-    pub fn set_available_space(&self, bytes: u64) {
-        self.available_space
-            .store(bytes, portable_atomic::Ordering::Relaxed);
+    /// Creates an empty in-memory filesystem with a fixed total capacity in
+    /// bytes — a simulated capped disk. [`Fs::available_space`] reports
+    /// `capacity − bytes stored`, so the disk fills as data is written and the
+    /// storage-admission gate drives the tree read-only when it is full,
+    /// without any manual free-space poking. `u64::MAX` means unbounded (same
+    /// as [`MemFs::new`]).
+    #[must_use]
+    pub fn with_capacity(capacity_bytes: u64) -> Self {
+        let fs = Self::new();
+        fs.set_capacity(capacity_bytes);
+        fs
+    }
+
+    /// Sets the simulated total disk capacity (shared across clones). See
+    /// [`MemFs::with_capacity`]. `u64::MAX` restores unbounded behaviour.
+    pub fn set_capacity(&self, capacity_bytes: u64) {
+        self.capacity
+            .store(capacity_bytes, portable_atomic::Ordering::Relaxed);
+    }
+
+    /// Total bytes currently stored across all files (the simulated disk
+    /// usage). Sums every file's length under the state read lock.
+    fn stored_bytes(&self) -> u64 {
+        let state = self.state.read();
+        state
+            .files
+            .values()
+            .map(|data| data.lock().len() as u64)
+            .fold(0u64, u64::saturating_add)
     }
 }
 
@@ -727,9 +753,15 @@ impl Fs for MemFs {
     }
 
     fn available_space(&self, _path: &Path) -> io::Result<u64> {
-        Ok(self
-            .available_space
-            .load(portable_atomic::Ordering::Relaxed))
+        let capacity = self.capacity.load(portable_atomic::Ordering::Relaxed);
+        // Unbounded → no disk pressure. Otherwise the simulated free space is
+        // capacity minus what is currently stored (saturating: an over-capacity
+        // state reports zero free, never wraps).
+        if capacity == u64::MAX {
+            Ok(u64::MAX)
+        } else {
+            Ok(capacity.saturating_sub(self.stored_bytes()))
+        }
     }
 
     fn sync_directory(&self, path: &Path) -> io::Result<()> {

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -61,6 +61,13 @@ pub struct MemFs {
     /// constructed `MemFs::new()` values get DIFFERENT IDs because they
     /// have disjoint file trees.
     namespace_id: u64,
+    /// Simulated free space reported by [`Fs::available_space`]. Shared across
+    /// clones (same backend) so a test can drive the tree near-full. Defaults
+    /// to `u64::MAX` ("unbounded"); set via [`MemFs::set_available_space`].
+    ///
+    /// `portable_atomic::AtomicU64` (not `core`'s): native 64-bit atomics are
+    /// absent on some `no_std` targets (e.g. thumbv7em).
+    available_space: Arc<portable_atomic::AtomicU64>,
 }
 
 #[derive(Debug, Default)]
@@ -79,7 +86,16 @@ impl MemFs {
         Self {
             state: Arc::new(RwLock::new(state)),
             namespace_id: next_mem_fs_namespace_id(),
+            available_space: Arc::new(portable_atomic::AtomicU64::new(u64::MAX)),
         }
+    }
+
+    /// Sets the free space [`Fs::available_space`] reports (shared across
+    /// clones of this `MemFs`). Lets a test simulate a near-full disk to
+    /// exercise the storage-admission disk-pressure path.
+    pub fn set_available_space(&self, bytes: u64) {
+        self.available_space
+            .store(bytes, portable_atomic::Ordering::Relaxed);
     }
 }
 
@@ -708,6 +724,12 @@ impl Fs for MemFs {
                 format!("path not found: {}", path.display()),
             ))
         }
+    }
+
+    fn available_space(&self, _path: &Path) -> io::Result<u64> {
+        Ok(self
+            .available_space
+            .load(portable_atomic::Ordering::Relaxed))
     }
 
     fn sync_directory(&self, path: &Path) -> io::Result<()> {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -910,7 +910,7 @@ pub trait Fs: Send + Sync + 'static {
 /// free, including the root reserve) so the figure matches what a normal write
 /// can actually consume. Shared by the std and `io_uring` (libc) backends; the
 /// raw `io_uring` backend uses a direct `statfs` syscall instead (no libc).
-#[cfg(unix)]
+#[cfg(all(unix, feature = "std"))]
 #[allow(
     clippy::unnecessary_cast,
     clippy::cast_lossless,

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -875,6 +875,75 @@ pub trait Fs: Send + Sync + 'static {
             "hard_link_count is not supported by this backend",
         ))
     }
+
+    /// Best-effort free space, in bytes, on the filesystem backing `path`.
+    ///
+    /// Reports bytes available to an unprivileged process (Unix `statvfs`
+    /// `f_bavail * f_frsize`), which the storage-admission gate uses to defend
+    /// against the *physical* disk filling, alongside any configured byte
+    /// quota. Best-effort by nature: the disk is shared with other processes,
+    /// so the figure is a reservation hint, not a guarantee — the atomic
+    /// single-transaction commit model still prevents corruption if a physical
+    /// `ENOSPC` slips through. Callers should sample it (e.g. at flush /
+    /// compaction boundaries) and cache it, never probe per write.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns `u64::MAX` ("treat as unbounded"), so a backend that cannot
+    /// report free space never drives the tree read-only on a phantom
+    /// disk-pressure signal. Real backends override it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the underlying probe fails on a backend that
+    /// supports it.
+    fn available_space(&self, path: &Path) -> io::Result<u64> {
+        let _ = path;
+        Ok(u64::MAX)
+    }
+}
+
+/// Bytes available to an unprivileged process on the filesystem backing
+/// `path`, via POSIX `statvfs(3)`: `f_bavail * f_frsize`.
+///
+/// `f_bavail` (blocks free to non-root) is used rather than `f_bfree` (total
+/// free, including the root reserve) so the figure matches what a normal write
+/// can actually consume. Shared by the std and `io_uring` (libc) backends; the
+/// raw `io_uring` backend uses a direct `statfs` syscall instead (no libc).
+#[cfg(unix)]
+#[allow(
+    clippy::unnecessary_cast,
+    clippy::cast_lossless,
+    reason = "statvfs field widths vary by platform (e.g. fsblkcnt_t is u32 on \
+              macOS, u64 on Linux); `as u64` is the portable widening that is a \
+              no-op where the field is already u64"
+)]
+pub(crate) fn statvfs_available_space(path: &Path) -> std::io::Result<u64> {
+    use core::mem::MaybeUninit;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path contains an interior NUL byte",
+        )
+    })?;
+    let mut buf = MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `c` is a valid NUL-terminated C string; on success (rc == 0)
+    // the kernel fully initializes the `statvfs` buffer.
+    #[expect(unsafe_code, reason = "statvfs FFI to read filesystem free space")]
+    let rc = unsafe { libc::statvfs(c.as_ptr(), buf.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: statvfs returned 0, so `buf` is initialized.
+    #[expect(unsafe_code, reason = "read initialized statvfs fields")]
+    let st = unsafe { buf.assume_init() };
+    // Saturate the product so an implausible value can never wrap.
+    let frsize = st.f_frsize as u64;
+    let bavail = st.f_bavail as u64;
+    Ok(bavail.saturating_mul(frsize))
 }
 
 /// Streamed independent copy of `src` to `dst` through `fs`'s own [`Fs::open`].

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -1188,8 +1188,13 @@ mod available_space_sys {
 
     // GetDiskFreeSpaceExW: free bytes available to the calling user on the
     // volume containing `path`.
-    #[expect(non_snake_case, reason = "Win32 API signature")]
-    extern "system" {
+    //
+    // SAFETY (ABI): the signature matches the Win32 `GetDiskFreeSpaceExW`
+    // contract — a wide directory-name pointer plus three optional `u64` out
+    // pointers, returning a non-zero `BOOL` on success. Edition 2024 requires
+    // foreign declarations in an `unsafe extern` block.
+    #[allow(non_snake_case, reason = "Win32 API signature")]
+    unsafe extern "system" {
         fn GetDiskFreeSpaceExW(
             lpDirectoryName: *const u16,
             lpFreeBytesAvailableToCaller: *mut u64,

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -1204,8 +1204,18 @@ mod available_space_sys {
     }
 
     pub(super) fn disk_free_available(path: &Path) -> io::Result<u64> {
-        // NUL-terminated wide string of the path.
+        // NUL-terminated wide string of the path. Reject an interior NUL first:
+        // Win32 treats the first NUL as the string terminator, so a path with an
+        // embedded NUL would silently probe a truncated path (a different volume)
+        // and feed admission / storage_stats free space for the wrong filesystem.
+        // Mirrors the unix statvfs helper's `CString::new` rejection.
         let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        if wide.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path contains an interior NUL byte",
+            ));
+        }
         wide.push(0);
         let mut avail: u64 = 0;
         // SAFETY: `wide` is a valid NUL-terminated UTF-16 string; the three out

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -235,6 +235,16 @@ impl Fs for StdFs {
         })
     }
 
+    #[cfg(unix)]
+    fn available_space(&self, path: &Path) -> io::Result<u64> {
+        super::statvfs_available_space(path).map_err(io::Error::from)
+    }
+
+    #[cfg(windows)]
+    fn available_space(&self, path: &Path) -> io::Result<u64> {
+        available_space_sys::disk_free_available(path).map_err(io::Error::from)
+    }
+
     fn sync_directory(&self, path: &Path) -> io::Result<()> {
         #[cfg(not(target_os = "windows"))]
         {
@@ -1163,6 +1173,51 @@ mod linux_caps {
         } else {
             Err(err)
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem free-space probe
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+mod available_space_sys {
+    use std::io;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+
+    // GetDiskFreeSpaceExW: free bytes available to the calling user on the
+    // volume containing `path`.
+    #[expect(non_snake_case, reason = "Win32 API signature")]
+    extern "system" {
+        fn GetDiskFreeSpaceExW(
+            lpDirectoryName: *const u16,
+            lpFreeBytesAvailableToCaller: *mut u64,
+            lpTotalNumberOfBytes: *mut u64,
+            lpTotalNumberOfFreeBytes: *mut u64,
+        ) -> i32;
+    }
+
+    pub(super) fn disk_free_available(path: &Path) -> io::Result<u64> {
+        // NUL-terminated wide string of the path.
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.push(0);
+        let mut avail: u64 = 0;
+        // SAFETY: `wide` is a valid NUL-terminated UTF-16 string; the three out
+        // pointers are valid for the call; we read `avail` only on success.
+        #[expect(unsafe_code, reason = "GetDiskFreeSpaceExW FFI for free space")]
+        let rc = unsafe {
+            GetDiskFreeSpaceExW(
+                wide.as_ptr(),
+                &mut avail,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            )
+        };
+        if rc == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(avail)
     }
 }
 

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -43,8 +43,28 @@ pub enum StorageStatus {
 #[must_use]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct StorageStats {
-    /// Total on-disk bytes of all live SSTs plus blob files.
+    /// Total on-disk bytes of all live SSTs plus blob files: how much is
+    /// **occupied**. Pairs with [`Self::capacity_bytes`] / [`Self::available_bytes`]
+    /// for an "X of Y used" view in a single call.
     pub used_bytes: u64,
+
+    /// Total bytes the tree may occupy: the tighter of a configured byte quota
+    /// (`storage_limit_bytes`) and the physical disk headroom (free space plus
+    /// what is already used), across every volume the tree writes to. `None`
+    /// when unbounded: no quota set AND the backend cannot report free space.
+    pub capacity_bytes: Option<u64>,
+
+    /// Free room left before the tree turns read-only: `capacity_bytes - used_bytes`
+    /// (saturating). `None` exactly when [`Self::capacity_bytes`] is `None`
+    /// (unbounded).
+    pub available_bytes: Option<u64>,
+
+    /// Whether a compaction can still run given the remaining free space (it
+    /// needs working room to write merged output). `true` when unbounded or
+    /// when at least the reserved compaction-working floor remains; `false`
+    /// when the disk is too full for a compaction to make progress. The finer
+    /// full-vs-tight distinction is carried by [`Self::status`].
+    pub compaction_possible: bool,
 
     /// Number of live entries (all versions) across all live SSTs.
     pub item_count: u64,
@@ -197,6 +217,12 @@ pub(crate) fn compute_storage_stats(
 
     Ok(StorageStats {
         used_bytes,
+        // Capacity is disk-aware (quota + free-space probe) and lives at the
+        // tree layer; this version-only computation leaves it unbounded. The
+        // caller (`Tree::storage_stats`) fills the real figures.
+        capacity_bytes: None,
+        available_bytes: None,
+        compaction_possible: true,
         item_count,
         table_count,
         avg_entry_on_disk_bytes,
@@ -214,6 +240,9 @@ mod tests {
     fn stats_with_avg(avg_entry_on_disk_bytes: u64) -> StorageStats {
         StorageStats {
             used_bytes: 0,
+            capacity_bytes: None,
+            available_bytes: None,
+            compaction_possible: true,
             item_count: 0,
             table_count: 0,
             avg_entry_on_disk_bytes,

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -177,12 +177,18 @@ pub struct TreeInner {
     /// version is installed (flush / compaction), so the physical footprint is
     /// computed once per version and reused until the version id moves.
     ///
-    /// The `(version_id, used_bytes)` pair is kept behind a single `Mutex` so
-    /// the stamp and its byte count are always read and published together as
-    /// one coherent snapshot — two independent atomics could let a reader pair
-    /// a matching stamp with bytes from a different computation. `None` is the
-    /// unset state (no sentinel `version_id`, since every `u64` is a valid id).
-    pub(crate) admission_used_cache: Mutex<Option<(u64, u64)>>,
+    /// The `(version_id, used_bytes, disk_free)` triple is kept behind a single
+    /// `Mutex` so the stamp and the two byte counts are always read and
+    /// published together as one coherent snapshot — independent atomics could
+    /// let a reader pair a matching stamp with values from a different
+    /// computation. `None` is the unset state (no sentinel `version_id`, since
+    /// every `u64` is a valid id); also reset on `update_runtime_config` to
+    /// force a fresh disk-free probe when an operator changes the budget.
+    ///
+    /// `disk_free` is sampled at the same point `used_bytes` is computed (a new
+    /// version = a flush / compaction boundary), so the free-space probe is a
+    /// syscall per version transition, never per write.
+    pub(crate) admission_used_cache: Mutex<Option<(u64, u64, u64)>>,
 
     #[doc(hidden)]
     #[cfg(feature = "metrics")]

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -185,10 +185,13 @@ pub struct TreeInner {
     /// every `u64` is a valid id); also reset on `update_runtime_config` to
     /// force a fresh disk-free probe when an operator changes the budget.
     ///
-    /// `disk_free` is sampled at the same point `used_bytes` is computed (a new
-    /// version = a flush / compaction boundary), so the free-space probe is a
-    /// syscall per version transition, never per write.
-    pub(crate) admission_used_cache: Mutex<Option<(u64, u64, u64)>>,
+    /// `used_bytes` is recomputed only on a version change (it is version-
+    /// stable); `disk_free` is also re-probed when the sample's age exceeds a
+    /// short TTL, so a disk filled by another process between flushes is seen
+    /// within that window — without a `statfs`/`statvfs` syscall per write. The
+    /// trailing `Instant` is the sample time; `update_runtime_config` resets the
+    /// whole entry to `None` for an immediate re-probe.
+    pub(crate) admission_used_cache: Mutex<Option<(u64, u64, u64, crate::time::Instant)>>,
 
     #[doc(hidden)]
     #[cfg(feature = "metrics")]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2390,13 +2390,25 @@ impl Tree {
         // per write. `update_runtime_config` resets the entry for an immediate
         // re-probe. The values live behind one mutex as a coherent unit (see
         // `TreeInner::admission_used_cache`).
+        //
+        // The TTL fast-path is std-only: under `no_std` there is no monotonic
+        // clock (`crate::time::Instant::elapsed` is a zero stub), so an
+        // elapsed-time window cannot bound staleness — a same-version sample
+        // would otherwise look fresh forever and a filling disk would never be
+        // re-probed. Under `no_std` the fast-path is skipped, so `disk_free` is
+        // re-probed on every gated write (the `used` footprint stays cached by
+        // version either way), keeping admission safe without a monotonic clock.
         let now = crate::time::Instant::now();
         let (used, disk_free) = {
             let mut cache = self.0.admission_used_cache.lock();
             match *cache {
-                // Fresh: same version AND disk sample within the TTL.
+                // Fresh: same version AND disk sample within the TTL. std-only —
+                // `cfg!(feature = "std")` is `false` under `no_std`, so the guard
+                // short-circuits there and the next arm re-probes every call.
                 Some((cvid, used, free, at))
-                    if cvid == vid && at.elapsed() < ADMISSION_DISK_FREE_TTL =>
+                    if cvid == vid
+                        && cfg!(feature = "std")
+                        && at.elapsed() < ADMISSION_DISK_FREE_TTL =>
                 {
                     (used, free)
                 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -327,6 +327,12 @@ impl AbstractTree for Tree {
             self.is_compacting(),
             true,
         )?;
+        // Fill the disk-aware capacity figures (quota + free-space probe) the
+        // version-only computation can't know.
+        let (capacity, available, compaction_possible) = self.admission_capacity(stats.used_bytes);
+        stats.capacity_bytes = capacity;
+        stats.available_bytes = available;
+        stats.compaction_possible = compaction_possible;
         // A closed admission gate is the operator-actionable state, so it takes
         // precedence over CompactionInProgress (a read-only tree may well be
         // compacting to reclaim space).
@@ -2318,6 +2324,35 @@ impl Tree {
             }
         }
         free
+    }
+
+    /// Disk-aware capacity figures for [`AbstractTree::storage_stats`], given the
+    /// live footprint `used`: `(capacity, available, compaction_possible)`.
+    ///
+    /// `capacity` is the tighter of the configured quota and the physical disk
+    /// headroom (`free + used`) — the same effective limit
+    /// [`Self::compute_write_admission`] gates against — reported regardless of
+    /// whether the admission gate is enabled (introspection is always available).
+    /// `None` capacity/available means unbounded (no quota AND the backend
+    /// cannot report free space). `compaction_possible` is `true` when unbounded
+    /// or when at least [`MIN_RESERVED_HEADROOM`] of working room remains.
+    pub(crate) fn admission_capacity(&self, used: u64) -> (Option<u64>, Option<u64>, bool) {
+        let quota = self
+            .0
+            .runtime_config
+            .load()
+            .storage_limit_bytes
+            .unwrap_or(u64::MAX);
+        let capacity = quota.min(self.probe_disk_free().saturating_add(used));
+        if capacity == u64::MAX {
+            return (None, None, true);
+        }
+        let available = capacity.saturating_sub(used);
+        (
+            Some(capacity),
+            Some(available),
+            available >= MIN_RESERVED_HEADROOM,
+        )
     }
 
     #[expect(

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -47,6 +47,12 @@ use crate::metrics::Metrics;
 /// space-reclaiming compaction have somewhere to land. 1 MiB.
 const MIN_RESERVED_HEADROOM: u64 = 1024 * 1024;
 
+/// How long a cached disk-free sample stays valid before the admission gate
+/// re-probes. Bounds how stale the physical free-space figure can be when the
+/// filesystem fills from another process between flushes, without issuing a
+/// `statfs`/`statvfs` syscall on every gated write. 1 second.
+const ADMISSION_DISK_FREE_TTL: core::time::Duration = core::time::Duration::from_secs(1);
+
 /// Iterator value guard
 pub struct Guard(crate::Result<(UserKey, UserValue)>);
 
@@ -2290,7 +2296,31 @@ impl Tree {
     /// Cheap: reads in-memory size accounting only (no syscall). Returns
     /// `Ok(())` unless admission control is enabled AND a budget is set AND the
     /// live footprint plus reserved headroom exceeds it.
-    #[allow(
+    /// Best-effort minimum free space across every filesystem this tree writes
+    /// to: the primary data path AND each per-level route (`Config::level_routes`
+    /// can place cold-level SSTs on separate volumes). The admission gate must
+    /// reflect the tightest volume, since a full routed disk fails compaction /
+    /// flush targeting it even while the primary still has room.
+    ///
+    /// A backend that cannot report free space (or an I/O hiccup) yields
+    /// `u64::MAX` = "no disk pressure", so a probe failure never falsely drives
+    /// the tree read-only.
+    fn probe_disk_free(&self) -> u64 {
+        let mut free = self
+            .0
+            .config
+            .fs
+            .available_space(&self.0.config.path)
+            .unwrap_or(u64::MAX);
+        if let Some(routes) = &self.0.config.level_routes {
+            for route in routes {
+                free = free.min(route.fs.available_space(&route.path).unwrap_or(u64::MAX));
+            }
+        }
+        free
+    }
+
+    #[expect(
         clippy::significant_drop_tightening,
         reason = "the admission cache lock intentionally spans the recompute \
                   (stat + disk-free probe) so concurrent admission checks \
@@ -2316,30 +2346,36 @@ impl Tree {
         // NOT `disk_space()` (metadata Level::size, which omits blob files and
         // undercounts the physical file by the meta block / footer).
         //
-        // Cached per version so gated writes don't re-stat every live file or
-        // re-probe disk on every call: the file set only changes when a new
-        // version is installed (flush / compaction), which is also the natural
-        // disk-free sampling boundary. A full stat + one `available_space`
-        // syscall run once per version; every later check in that version reads
-        // the cache. The `(version_id, used_bytes, disk_free)` triple lives
-        // behind one mutex so the stamp and values are always a coherent unit
-        // (see `TreeInner::admission_used_cache`).
+        // Cached so gated writes don't re-stat every live file or re-probe disk
+        // on every call. `used_bytes` only changes when a new version is
+        // installed (flush / compaction), so it is recomputed on a version
+        // change. `disk_free` can change under us (another process writing the
+        // same filesystem), so it is ALSO re-probed once its sample is older
+        // than `ADMISSION_DISK_FREE_TTL` — bounding staleness without a syscall
+        // per write. `update_runtime_config` resets the entry for an immediate
+        // re-probe. The values live behind one mutex as a coherent unit (see
+        // `TreeInner::admission_used_cache`).
+        let now = crate::time::Instant::now();
         let (used, disk_free) = {
             let mut cache = self.0.admission_used_cache.lock();
             match *cache {
-                Some((cached_vid, used, free)) if cached_vid == vid => (used, free),
+                // Fresh: same version AND disk sample within the TTL.
+                Some((cvid, used, free, at))
+                    if cvid == vid && at.elapsed() < ADMISSION_DISK_FREE_TTL =>
+                {
+                    (used, free)
+                }
+                // Same version, stale disk sample: keep `used`, re-probe disk.
+                Some((cvid, used, _, _)) if cvid == vid => {
+                    let free = self.probe_disk_free();
+                    *cache = Some((vid, used, free, now));
+                    (used, free)
+                }
+                // New version (or unset): recompute footprint and re-probe disk.
                 _ => {
                     let used = crate::storage_stats::compute_used_bytes(&super_version.version)?;
-                    // Best-effort disk-free probe: a backend that cannot report
-                    // it (or an I/O hiccup) yields u64::MAX = "no disk pressure",
-                    // so a probe failure never falsely drives the tree read-only.
-                    let free = self
-                        .0
-                        .config
-                        .fs
-                        .available_space(&self.0.config.path)
-                        .unwrap_or(u64::MAX);
-                    *cache = Some((vid, used, free));
+                    let free = self.probe_disk_free();
+                    *cache = Some((vid, used, free, now));
                     (used, free)
                 }
             }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2421,6 +2421,18 @@ impl Tree {
         // fill from other processes even below a generous quota, and a tree with
         // no quota at all must still stop before ENOSPC. `None` quota = unbounded
         // by configuration; disk-free then alone bounds it.
+        //
+        // `disk_free` is the MINIMUM free across every volume the tree writes to
+        // (`probe_disk_free` mins the primary path and all `level_routes`). The
+        // `+ used` here is NOT an accounting of one volume's usage against
+        // another's free space — it cancels out of the disk branch of the gate:
+        // passing requires `used + reserved <= disk_free + used`, i.e.
+        // `reserved <= disk_free`. So a passing gate guarantees the TIGHTEST
+        // volume alone has at least `reserved` free — a conservative per-volume
+        // headroom, never the sum of an empty routed volume's slack plus an
+        // unrelated full volume's occupancy. A route that drops below `reserved`
+        // free drives the whole tree read-only, exactly so a later flush /
+        // compaction targeting that route cannot hit ENOSPC.
         let quota = rc.storage_limit_bytes.unwrap_or(u64::MAX);
         let limit = quota.min(disk_free.saturating_add(used));
         // Both sources unbounded → nothing to gate.

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1358,6 +1358,10 @@ impl Tree {
             auto_heal = c.auto_heal;
         })?;
         self.0.heal_hints.set_enabled(auto_heal);
+        // Drop the cached admission footprint so the next check re-probes
+        // disk-free: an operator who just raised the budget (or freed disk)
+        // should see it promptly, not at the next flush.
+        *self.0.admission_used_cache.lock() = None;
         Ok(())
     }
 
@@ -2286,17 +2290,17 @@ impl Tree {
     /// Cheap: reads in-memory size accounting only (no syscall). Returns
     /// `Ok(())` unless admission control is enabled AND a budget is set AND the
     /// live footprint plus reserved headroom exceeds it.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the admission cache lock intentionally spans the recompute \
+                  (stat + disk-free probe) so concurrent admission checks \
+                  coalesce on a single probe rather than each issuing a syscall"
+    )]
     fn compute_write_admission(&self) -> crate::Result<()> {
         let rc = self.0.runtime_config.load();
         if !rc.storage_admission_check {
             return Ok(());
         }
-        // Admission on but no budget set → unbounded (the disk-free probe that
-        // narrows the effective limit lands in a follow-up; until then only a
-        // configured quota gates).
-        let Some(limit) = rc.storage_limit_bytes else {
-            return Ok(());
-        };
 
         // Take ONE coherent snapshot of the latest super-version and derive
         // BOTH the on-disk footprint and the pending-memtable bytes from it.
@@ -2312,25 +2316,46 @@ impl Tree {
         // NOT `disk_space()` (metadata Level::size, which omits blob files and
         // undercounts the physical file by the meta block / footer).
         //
-        // Cached per version so gated writes don't re-stat every live file: the
-        // file set only changes when a new version is installed (flush /
-        // compaction), so a full stat runs once per version and every later
-        // check in that version reads the cache. The `(version_id, used_bytes)`
-        // pair lives behind one mutex so the stamp and bytes are always a
-        // coherent unit (see `TreeInner::admission_used_cache`).
-        let used = {
-            // cache = Some((version_id, used_bytes)); None = unset.
+        // Cached per version so gated writes don't re-stat every live file or
+        // re-probe disk on every call: the file set only changes when a new
+        // version is installed (flush / compaction), which is also the natural
+        // disk-free sampling boundary. A full stat + one `available_space`
+        // syscall run once per version; every later check in that version reads
+        // the cache. The `(version_id, used_bytes, disk_free)` triple lives
+        // behind one mutex so the stamp and values are always a coherent unit
+        // (see `TreeInner::admission_used_cache`).
+        let (used, disk_free) = {
             let mut cache = self.0.admission_used_cache.lock();
             match *cache {
-                Some((cached_vid, cached_used)) if cached_vid == vid => cached_used,
+                Some((cached_vid, used, free)) if cached_vid == vid => (used, free),
                 _ => {
-                    let computed =
-                        crate::storage_stats::compute_used_bytes(&super_version.version)?;
-                    *cache = Some((vid, computed));
-                    computed
+                    let used = crate::storage_stats::compute_used_bytes(&super_version.version)?;
+                    // Best-effort disk-free probe: a backend that cannot report
+                    // it (or an I/O hiccup) yields u64::MAX = "no disk pressure",
+                    // so a probe failure never falsely drives the tree read-only.
+                    let free = self
+                        .0
+                        .config
+                        .fs
+                        .available_space(&self.0.config.path)
+                        .unwrap_or(u64::MAX);
+                    *cache = Some((vid, used, free));
+                    (used, free)
                 }
             }
         };
+
+        // Effective limit is the tighter of the configured quota and the
+        // physical disk headroom (free + what we already occupy): the disk can
+        // fill from other processes even below a generous quota, and a tree with
+        // no quota at all must still stop before ENOSPC. `None` quota = unbounded
+        // by configuration; disk-free then alone bounds it.
+        let quota = rc.storage_limit_bytes.unwrap_or(u64::MAX);
+        let limit = quota.min(disk_free.saturating_add(used));
+        // Both sources unbounded → nothing to gate.
+        if limit == u64::MAX {
+            return Ok(());
+        }
 
         // Reserved headroom keeps the soft budget from becoming a hard wall:
         // enough to flush every pending memtable (plus a margin for the

--- a/tests/available_space.rs
+++ b/tests/available_space.rs
@@ -44,19 +44,38 @@ fn mem_fs_defaults_to_unbounded() {
 }
 
 #[test]
-fn mem_fs_reports_configured_capacity_shared_across_clones() {
-    // set_available_space simulates a near-full disk; the value is shared with
-    // clones (same backend) so a tree holding a clone sees it.
-    let fs = MemFs::new();
-    fs.set_available_space(4096);
+fn mem_fs_capacity_minus_stored_shared_across_clones() {
+    use lsm_tree::fs::{Fs, FsOpenOptions};
+    use std::io::Write;
+
+    // A capped MemFs reports capacity − bytes stored: an empty 4 KiB disk has
+    // 4 KiB free.
+    let fs = MemFs::with_capacity(4096);
     assert_eq!(fs.available_space(std::path::Path::new("/")).unwrap(), 4096);
 
+    // Writing consumes the simulated disk; free space shrinks by what is stored.
+    {
+        let mut f = fs
+            .open(
+                std::path::Path::new("/f"),
+                &FsOpenOptions::new().write(true).create(true),
+            )
+            .expect("open");
+        f.write_all(&[0u8; 1000]).expect("write");
+        f.sync_all().expect("sync");
+    }
+    assert_eq!(
+        fs.available_space(std::path::Path::new("/")).unwrap(),
+        4096 - 1000
+    );
+
+    // Capacity (and the stored bytes) are shared with clones (same backend).
     let clone = fs.clone();
     assert_eq!(
         clone.available_space(std::path::Path::new("/")).unwrap(),
-        4096
+        4096 - 1000
     );
-    // A write through one handle's setter is observed through the other.
-    clone.set_available_space(0);
+    // Lowering capacity below what is stored saturates to zero free.
+    clone.set_capacity(500);
     assert_eq!(fs.available_space(std::path::Path::new("/")).unwrap(), 0);
 }

--- a/tests/available_space.rs
+++ b/tests/available_space.rs
@@ -48,6 +48,23 @@ fn std_fs_available_space_path_with_interior_nul_errors() {
     assert_eq!(err.kind(), lsm_tree::io::ErrorKind::InvalidInput);
 }
 
+#[cfg(windows)]
+#[test]
+fn std_fs_available_space_path_with_interior_nul_errors() {
+    // Symmetric to the unix case: Win32 treats the first NUL as the wide-string
+    // terminator, so an interior NUL must be rejected with InvalidInput rather
+    // than probing the truncated (wrong-volume) path.
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    let bad_os = OsString::from_wide(&[b'C' as u16, b':' as u16, 0, b'x' as u16]);
+    let bad = std::path::PathBuf::from(bad_os);
+    let err = StdFs
+        .available_space(&bad)
+        .expect_err("an interior NUL must be rejected");
+    assert_eq!(err.kind(), lsm_tree::io::ErrorKind::InvalidInput);
+}
+
 #[test]
 fn mem_fs_defaults_to_unbounded() {
     // A fresh MemFs reports u64::MAX until a capacity is configured, so it

--- a/tests/available_space.rs
+++ b/tests/available_space.rs
@@ -25,9 +25,11 @@ fn std_fs_reports_plausible_free_space() {
 #[test]
 fn std_fs_available_space_nonexistent_path_errors() {
     // statvfs on a path that does not exist must surface an error, not a
-    // silent zero or the unbounded sentinel.
-    let missing = std::path::Path::new("/nonexistent-coordinode-lsm-probe-path-xyz");
-    assert!(StdFs.available_space(missing).is_err());
+    // silent zero or the unbounded sentinel. Own the precondition: a child
+    // of a fresh tempdir that we deliberately never create.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("definitely-absent-child");
+    assert!(StdFs.available_space(&missing).is_err());
 }
 
 #[test]

--- a/tests/available_space.rs
+++ b/tests/available_space.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Tests for the `Fs::available_space` free-space probe across backends.
+
+use lsm_tree::fs::{Fs, MemFs, StdFs};
+
+#[test]
+fn std_fs_reports_plausible_free_space() {
+    // statvfs on the tempdir's filesystem must return a plausible, non-zero
+    // figure (any real mounted FS has some free space and a sane upper bound
+    // below u64::MAX — the "unbounded" default only the trait fallback uses).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let free = StdFs.available_space(dir.path()).expect("statvfs");
+    assert!(
+        free > 0,
+        "a writable tempdir filesystem must report free space"
+    );
+    assert!(
+        free < u64::MAX,
+        "a real probe must not return the unbounded sentinel"
+    );
+}
+
+#[test]
+fn std_fs_available_space_nonexistent_path_errors() {
+    // statvfs on a path that does not exist must surface an error, not a
+    // silent zero or the unbounded sentinel.
+    let missing = std::path::Path::new("/nonexistent-coordinode-lsm-probe-path-xyz");
+    assert!(StdFs.available_space(missing).is_err());
+}
+
+#[test]
+fn mem_fs_defaults_to_unbounded() {
+    // A fresh MemFs reports u64::MAX until a capacity is configured, so it
+    // never spuriously drives disk-pressure logic.
+    let fs = MemFs::new();
+    assert_eq!(
+        fs.available_space(std::path::Path::new("/")).unwrap(),
+        u64::MAX
+    );
+}
+
+#[test]
+fn mem_fs_reports_configured_capacity_shared_across_clones() {
+    // set_available_space simulates a near-full disk; the value is shared with
+    // clones (same backend) so a tree holding a clone sees it.
+    let fs = MemFs::new();
+    fs.set_available_space(4096);
+    assert_eq!(fs.available_space(std::path::Path::new("/")).unwrap(), 4096);
+
+    let clone = fs.clone();
+    assert_eq!(
+        clone.available_space(std::path::Path::new("/")).unwrap(),
+        4096
+    );
+    // A write through one handle's setter is observed through the other.
+    clone.set_available_space(0);
+    assert_eq!(fs.available_space(std::path::Path::new("/")).unwrap(), 0);
+}

--- a/tests/available_space.rs
+++ b/tests/available_space.rs
@@ -32,6 +32,22 @@ fn std_fs_available_space_nonexistent_path_errors() {
     assert!(StdFs.available_space(&missing).is_err());
 }
 
+#[cfg(unix)]
+#[test]
+fn std_fs_available_space_path_with_interior_nul_errors() {
+    // A path containing an interior NUL byte cannot become a C string, so the
+    // statvfs helper must surface InvalidInput rather than passing a truncated
+    // path to the kernel.
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let bad = std::path::Path::new(OsStr::from_bytes(b"/tmp/has\0nul"));
+    let err = StdFs
+        .available_space(bad)
+        .expect_err("an interior NUL must be rejected");
+    assert_eq!(err.kind(), lsm_tree::io::ErrorKind::InvalidInput);
+}
+
 #[test]
 fn mem_fs_defaults_to_unbounded() {
     // A fresh MemFs reports u64::MAX until a capacity is configured, so it

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -6,6 +6,7 @@
 //! reserved-headroom guarantee (flush still works at the limit), and automatic
 //! resume when the budget is raised.
 
+use lsm_tree::config::LevelRoute;
 use lsm_tree::fs::MemFs;
 use lsm_tree::{
     AbstractTree, AnyTree, Config, Error, KvSeparationOptions, SequenceNumberCounter,
@@ -435,6 +436,60 @@ fn disk_free_drives_read_only_without_a_configured_quota() -> lsm_tree::Result<(
     assert_eq!(
         tree.storage_stats()?.status,
         StorageStatus::ReadOnlyOutOfSpace
+    );
+    Ok(())
+}
+
+#[test]
+fn a_near_full_routed_volume_drives_the_whole_tree_read_only() -> lsm_tree::Result<()> {
+    // Per-volume safety: the disk-free gate mins free space across the primary
+    // path AND every level route, so a near-full routed (cold-tier) volume
+    // turns the whole tree read-only even while the primary has ample room and
+    // no quota is configured. The `+ used` in the effective limit cancels out
+    // of the disk branch (passing requires reserved <= min_free), so an empty
+    // routed volume's slack can never be summed against the primary's
+    // occupancy to mask the tight volume. Without that, a later flush /
+    // compaction targeting the route could hit ENOSPC.
+    let folder = get_tmp_folder();
+
+    // Primary volume: unbounded in-memory disk. Routed cold tier (L5+): a
+    // capped in-memory disk with less than the reserved headroom free.
+    let primary = MemFs::new();
+    let cold = MemFs::with_capacity(64 * 1024); // < MIN_RESERVED_HEADROOM (1 MiB)
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(primary))
+    .level_routes(vec![LevelRoute {
+        levels: 5..7,
+        path: folder.path().join("cold"),
+        fs: Arc::new(cold),
+    }])
+    .open()
+    .expect("open");
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+
+    // Admission on, NO quota: only the physical free-space probe can gate, and
+    // it must reflect the tightest volume.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+
+    assert!(
+        tree.is_read_only(),
+        "a routed volume below the reserved headroom must drive the tree read-only"
+    );
+    let stats = tree.storage_stats()?;
+    assert_eq!(stats.status, StorageStatus::ReadOnlyOutOfSpace);
+    assert!(
+        !stats.compaction_possible,
+        "no headroom on the tightest volume means compaction cannot run"
     );
     Ok(())
 }

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -441,6 +441,48 @@ fn disk_free_drives_read_only_without_a_configured_quota() -> lsm_tree::Result<(
 }
 
 #[test]
+fn disk_free_re_probes_on_ttl_expiry_without_a_version_change() -> lsm_tree::Result<()> {
+    // The disk-free sample is re-probed once it ages past the TTL even when the
+    // version (and thus the cached footprint) is unchanged: an external process
+    // filling the shared disk must drive the tree read-only without waiting for
+    // the next flush / compaction. Uses a capped MemFs whose free space we lower
+    // out from under a steady version, then waits past the 1s TTL so the next
+    // check re-probes rather than serving the stale free value.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_tree_on_capped_memfs(folder.path(), 100 * 1024 * 1024);
+    seed(&tree); // installs a version; the footprint stays fixed hereafter
+
+    // No quota: only the physical free-space probe gates. 100 MiB free admits.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert!(!tree.is_read_only(), "100 MiB free must admit");
+
+    // Shrink the simulated disk so available falls below the reserved headroom,
+    // WITHOUT a version change or a config update (either would clear the cache
+    // and force an immediate re-probe, bypassing the path under test). Capacity
+    // just above the live footprint leaves only a sliver free (< the 1 MiB
+    // reserved floor), since the MemFs also holds the manifest / lock / journal.
+    let used = tree.storage_stats()?.used_bytes;
+    mem.set_capacity(used + 1024);
+
+    // Within the TTL the stale free value is still served, so the tree is not
+    // yet read-only; after the TTL elapses the next check re-probes and sees the
+    // near-full disk.
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+    assert!(
+        tree.is_read_only(),
+        "a TTL-expired re-probe must observe the shrunk disk and gate writes"
+    );
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
+    );
+    Ok(())
+}
+
+#[test]
 fn a_near_full_routed_volume_drives_the_whole_tree_read_only() -> lsm_tree::Result<()> {
     // Per-volume safety: the disk-free gate mins free space across the primary
     // path AND every level route, so a near-full routed (cold-tier) volume

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -6,10 +6,30 @@
 //! reserved-headroom guarantee (flush still works at the limit), and automatic
 //! resume when the budget is raised.
 
+use lsm_tree::fs::MemFs;
 use lsm_tree::{
     AbstractTree, AnyTree, Config, Error, KvSeparationOptions, SequenceNumberCounter,
     StorageStatus, get_tmp_folder,
 };
+use std::sync::Arc;
+
+/// Opens a Standard tree on a shared `MemFs` clone, returning both so a test
+/// can drive the backend's simulated free space.
+fn open_tree_on_memfs(path: &std::path::Path) -> (lsm_tree::Tree, MemFs) {
+    let mem = MemFs::new();
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Standard(t) => (t, mem),
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
 
 fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
     let any = Config::new(
@@ -356,6 +376,44 @@ fn reserved_headroom_counts_sealed_memtables_pending_flush() -> lsm_tree::Result
     assert!(
         tree.is_read_only(),
         "sealed memtable pending flush must count toward reserved headroom"
+    );
+    Ok(())
+}
+
+#[test]
+fn disk_free_drives_read_only_without_a_configured_quota() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_tree_on_memfs(folder.path());
+    for i in 0..100u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"value", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // Admission on, NO configured quota: only physical disk-free can gate.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    // MemFs defaults to u64::MAX free → no disk pressure → admits.
+    assert!(!tree.is_read_only(), "ample free space must admit");
+
+    // Simulate a near-full disk. The cached probe still holds the old free
+    // value (sampled at the last version), so force a re-probe the way an
+    // operator action would: update_runtime_config clears the cache.
+    mem.set_available_space(0);
+    tree.update_runtime_config(|_c| {})?;
+
+    assert!(
+        tree.is_read_only(),
+        "a near-full disk must drive read-only even without a configured quota"
+    );
+    match tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000) {
+        Err(Error::StorageFull { .. }) => {}
+        other => panic!("expected StorageFull, got {other:?}"),
+    }
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
     );
     Ok(())
 }

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -31,6 +31,25 @@ fn open_tree_on_memfs(path: &std::path::Path) -> (lsm_tree::Tree, MemFs) {
     }
 }
 
+/// Opens a Standard tree on a `MemFs` capped at `capacity` bytes, modelling a
+/// fixed-size in-memory disk that fills as data is flushed. Returns both the
+/// tree and the backend clone.
+fn open_tree_on_capped_memfs(path: &std::path::Path, capacity: u64) -> (lsm_tree::Tree, MemFs) {
+    let mem = MemFs::with_capacity(capacity);
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Standard(t) => (t, mem),
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
 fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
     let any = Config::new(
         path,
@@ -397,10 +416,12 @@ fn disk_free_drives_read_only_without_a_configured_quota() -> lsm_tree::Result<(
     // MemFs defaults to u64::MAX free → no disk pressure → admits.
     assert!(!tree.is_read_only(), "ample free space must admit");
 
-    // Simulate a near-full disk. The cached probe still holds the old free
-    // value (sampled at the last version), so force a re-probe the way an
-    // operator action would: update_runtime_config clears the cache.
-    mem.set_available_space(0);
+    // Simulate a full disk by capping the MemFs capacity at zero: with any
+    // bytes already stored, capacity − stored saturates to zero free. The
+    // cached probe still holds the old free value (sampled at the last
+    // version), so force a re-probe the way an operator action would:
+    // update_runtime_config clears the cache.
+    mem.set_capacity(0);
     tree.update_runtime_config(|_c| {})?;
 
     assert!(
@@ -410,6 +431,125 @@ fn disk_free_drives_read_only_without_a_configured_quota() -> lsm_tree::Result<(
     match tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1000) {
         Err(Error::StorageFull { .. }) => {}
         other => panic!("expected StorageFull, got {other:?}"),
+    }
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
+    );
+    Ok(())
+}
+
+#[test]
+fn storage_stats_exposes_used_capacity_available_and_compaction_flag() -> lsm_tree::Result<()> {
+    // The introspection UX: one storage_stats() call answers "X bytes used of Y
+    // total, Z available" plus whether a compaction can still run. The three
+    // byte figures satisfy used + available == capacity by construction.
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let seeded = seed(&tree);
+
+    // A generous quota is the tighter bound vs the real tempdir's free space, so
+    // capacity is deterministic; ample room means compaction is possible.
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = Some(seeded + 100 * 1024 * 1024);
+    })?;
+    let s = tree.storage_stats()?;
+    let capacity = s
+        .capacity_bytes
+        .expect("a configured quota sets a finite capacity");
+    let available = s
+        .available_bytes
+        .expect("a finite capacity yields a finite available figure");
+    assert_eq!(
+        s.used_bytes.saturating_add(available),
+        capacity,
+        "used + available must equal capacity"
+    );
+    assert!(
+        s.used_bytes < capacity,
+        "used must be below a generous capacity"
+    );
+    assert!(
+        s.compaction_possible,
+        "ample free space must allow compaction"
+    );
+
+    // Tighten the quota to just above the live footprint: introspection still
+    // reports the figures, but there is no room left for a compaction to write
+    // its merged output.
+    tree.update_runtime_config(|c| {
+        c.storage_limit_bytes = Some(s.used_bytes + 1024);
+    })?;
+    let tight = tree.storage_stats()?;
+    let tight_avail = tight.available_bytes.expect("finite capacity");
+    assert!(
+        tight_avail < 1024 * 1024,
+        "a near-full quota must leave less than the reserved compaction floor"
+    );
+    assert!(
+        !tight.compaction_possible,
+        "no working room must report compaction as not possible"
+    );
+    Ok(())
+}
+
+#[test]
+fn storage_stats_reports_unbounded_capacity_without_quota_or_probe() -> lsm_tree::Result<()> {
+    // With no quota and a backend that cannot report free space (default MemFs),
+    // capacity is genuinely unbounded: the figures are None and compaction is
+    // always possible. Honest absence beats a fabricated number.
+    let folder = get_tmp_folder();
+    let (tree, _mem) = open_tree_on_memfs(folder.path());
+    seed(&tree);
+    let s = tree.storage_stats()?;
+    assert_eq!(
+        s.capacity_bytes, None,
+        "unbounded capacity is reported as None"
+    );
+    assert_eq!(s.available_bytes, None);
+    assert!(s.compaction_possible);
+    Ok(())
+}
+
+#[test]
+fn capped_memfs_fills_naturally_and_drives_read_only() -> lsm_tree::Result<()> {
+    // The unified capacity UX: a fixed-size disk (here an in-memory one) fills
+    // as data is flushed, and admission flips to read-only once the remaining
+    // free space can no longer cover the reserved headroom, with no operator
+    // action and no configured quota. A 3 MiB disk against the >=1 MiB reserved
+    // floor crosses that threshold after a handful of flushed SST files.
+    let folder = get_tmp_folder();
+    let (tree, _mem) = open_tree_on_capped_memfs(folder.path(), 3 * 1024 * 1024);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+
+    // Each flush is a version transition that re-probes the simulated disk, so
+    // the falling free space is observed without clearing the cache manually.
+    let value = vec![0xABu8; 4096];
+    let mut seqno = 0u64;
+    let mut became_read_only = false;
+    for _ in 0..64 {
+        for _ in 0..100 {
+            tree.insert(format!("key{seqno:08}").as_bytes(), &value, seqno);
+            seqno += 1;
+        }
+        tree.flush_active_memtable(0)?;
+        if tree.is_read_only() {
+            became_read_only = true;
+            break;
+        }
+    }
+
+    assert!(
+        became_read_only,
+        "a capped in-memory disk must fill and flip to read-only as data is flushed"
+    );
+    match tree.try_insert(b"k".as_slice(), b"v".as_slice(), seqno) {
+        Err(Error::StorageFull { .. }) => {}
+        other => panic!("expected StorageFull on a full capped disk, got {other:?}"),
     }
     assert_eq!(
         tree.storage_stats()?.status,


### PR DESCRIPTION
## Summary

Adds a best-effort filesystem free-space probe and wires it into storage admission, so a tree defends against the **physical** disk filling (shared with other processes), not just a configured byte quota. Also delivers a unified capacity UX: a fixed-size disk (on-disk or in-memory) that fills as data is written, turns read-only when full, and reports "X of Y used" in a single introspection call.

## Changes

- **`Fs::available_space(&self, &Path) -> io::Result<u64>`** — new trait method, default `u64::MAX` ("treat as unbounded"; a backend that can't report free space never drives a phantom disk-pressure read-only). Best-effort by contract: the disk is shared, the figure is a reservation hint; the atomic single-transaction commit still prevents corruption if a physical `ENOSPC` slips through.
- **StdFs** — `statvfs` (unix, `f_bavail * f_frsize`) / `GetDiskFreeSpaceExW` (windows); bytes available to an unprivileged process. Shared unix `statvfs` helper in `fs::mod`.
- **IoUringFs** — delegates the cold-path probe to the shared `statvfs` helper (Linux-only backend, libc available).
- **IoUringRawFs** — raw `statfs` syscall (no libc), matching its no-libc design; minimal kernel `struct statfs` for 64-bit Linux.
- **MemFs — capacity-based** — `MemFs::with_capacity(n)` / `set_capacity(n)` model a fixed-size in-memory disk: `available_space = capacity - bytes stored`, so the disk fills naturally as data is flushed and turns the tree read-only when full, matching the on-disk capped-disk behaviour. Shared across clones. Default stays unbounded (`u64::MAX`).
- **Admission (#484 extension)** — the per-version footprint cache now also samples disk-free: one `available_space` syscall per version transition (= flush / compaction boundary, never per write); `update_runtime_config` clears the cache to force a fresh probe. The effective limit is `min(configured quota, disk_free + used)`, so a near-full disk drives read-only **even with no configured quota**. `disk_free` is the **minimum** free across the primary path and every level route, and the `+ used` cancels out of the disk branch (passing requires `reserved <= min_free`), so a near-full routed cold-tier volume turns the whole tree read-only without summing an unrelated volume's slack.
- **`storage_stats()` capacity figures** — one call now answers used / capacity / available plus a `compaction_possible` flag. `capacity_bytes` is the tighter of the configured quota and the physical free-space probe (reported regardless of whether the admission gate is enabled); `None` means genuinely unbounded; `used_bytes + available_bytes == capacity_bytes` by construction.

## Testing

- `tests/available_space.rs`: StdFs reports plausible non-zero free space (and errors on a missing path); MemFs defaults unbounded; a capped MemFs reports `capacity - stored` and shares it across clones.
- `tests/storage_admission.rs`: near-full MemFs drives read-only with **no** quota (`StorageFull` + `ReadOnlyOutOfSpace`); a **capped MemFs fills naturally** (per-flush re-probe) and flips to read-only; a **near-full routed volume** drives the whole tree read-only (per-volume headroom invariant); `storage_stats()` exposes used / capacity / available + the compaction flag, and reports unbounded as `None`.
- 1850 (default) tests pass; clippy clean (host + `x86_64-unknown-linux-gnu` cross for the io_uring/statfs paths); no-std cross-compile 0 errors.

Part of #482. Closes #485.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort free-space probing via `available_space` across backends (Unix `statvfs`, Windows `GetDiskFreeSpaceExW`, and capped `MemFs`), with an unbounded fallback when probing fails.
  * Introduced disk-aware admission and capacity reporting using `capacity_bytes`, `available_bytes`, and `compaction_possible` (reflected in storage stats).
  * Added `MemFs::with_capacity` and `MemFs::set_capacity`.
* **Bug Fixes**
  * Improved admission caching by storing a coherent snapshot (used bytes + probed free space) with TTL refresh and forced invalidation after runtime config updates.
* **Tests**
  * Added/expanded tests for real free-space, missing-path and interior-NUL validation, `MemFs` capacity accounting, and disk-free-driven read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
