### PR TITLE
feat(compaction): deadlock-free space admission for merges

### DIFF
--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -321,9 +321,12 @@ impl AbstractTree for BlobTree {
         // Forward the index tree's compaction state (the default impl would
         // always report idle), and mark value bytes as NOT user values: large
         // values are KV-separated into blob files, so the SST records only
-        // indirection pointers.
+        // indirection pointers. One version snapshot is reused for both the
+        // footprint and the blob-headroom sum below: a second `current_version()`
+        // could race a concurrent flush / compaction and mix two snapshots.
+        let version = self.current_version();
         let mut stats = crate::storage_stats::compute_storage_stats(
-            &self.current_version(),
+            &version,
             self.index.is_compacting(),
             false,
         )?;
@@ -342,7 +345,6 @@ impl AbstractTree for BlobTree {
         // upper bound: a single compaction relocates at most the stale subset),
         // so the status does not report full availability while the gate would
         // skip the merge for lack of blob room.
-        let version = self.current_version();
         let mut blob_bytes = 0u64;
         for blob in version.blob_files.iter() {
             blob_bytes += blob.physical_size()?;

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -368,13 +368,17 @@ impl AbstractTree for BlobTree {
             && capacity.is_some()
             && stats.status == crate::StorageStatus::Healthy
         {
-            // SST output lands in the largest level's volume; stale blob
-            // relocation lands in the primary blobs volume. The per-volume gate
-            // (not `available >= full_compaction_bytes` against the min-volume
-            // free) keeps the status from reporting tight when the SST and blob
-            // outputs each fit their own volume — see the gate's two-layer model.
-            let (sst_dest_level, sst_need) =
-                crate::storage_stats::largest_level_for_compaction(&version);
+            // SST output lands in the LAST configured level's volume
+            // (`level_count - 1`), stale blob relocation in the primary blobs
+            // volume; the demand is bounded by the largest level's size. The
+            // per-volume gate (not `available >= full_compaction_bytes` against
+            // the min-volume free) keeps the status from reporting tight when the
+            // SST and blob outputs each fit their own volume — see the gate's
+            // two-layer model.
+            let sst_need = crate::storage_stats::full_compaction_demand_bytes(&version);
+            // `saturating_sub`: `level_count >= 1` always (the clamp only guards a
+            // degenerate zero-level config) → the last level index.
+            let sst_dest_level = self.index.config.level_count.saturating_sub(1);
             let quota_headroom = self.index.quota_headroom(stats.used_bytes);
             let full_fits = crate::compaction::worker::space_fits_two_layer(
                 &self.index.config,

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -342,7 +342,10 @@ impl AbstractTree for BlobTree {
             && capacity.is_some()
             && stats.status == crate::StorageStatus::Healthy
         {
-            stats.status = if compaction_possible {
+            // Full when the free room covers a full compaction's transient
+            // output, tight otherwise (see the standard tree's override).
+            let available = available.unwrap_or(0);
+            stats.status = if available >= stats.full_compaction_bytes {
                 crate::StorageStatus::FullCompactionAvailable
             } else {
                 crate::StorageStatus::TightCompactionAvailable

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -336,6 +336,18 @@ impl AbstractTree for BlobTree {
         stats.capacity_bytes = capacity;
         stats.available_bytes = available;
         stats.compaction_possible = compaction_possible;
+        // A full compaction of a blob tree may also relocate stale blob files,
+        // which the merge gate counts against the budget. Fold the physical
+        // blob-file footprint into the full-compaction figure (a conservative
+        // upper bound: a single compaction relocates at most the stale subset),
+        // so the status does not report full availability while the gate would
+        // skip the merge for lack of blob room.
+        let version = self.current_version();
+        let mut blob_bytes = 0u64;
+        for blob in version.blob_files.iter() {
+            blob_bytes += blob.physical_size()?;
+        }
+        stats.full_compaction_bytes += blob_bytes;
         // Surface full-vs-tight compaction availability when gating is active and
         // no compaction is running (see the standard tree's override).
         if self.index.storage_admission_enabled()

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -336,6 +336,18 @@ impl AbstractTree for BlobTree {
         stats.capacity_bytes = capacity;
         stats.available_bytes = available;
         stats.compaction_possible = compaction_possible;
+        // Surface full-vs-tight compaction availability when gating is active and
+        // no compaction is running (see the standard tree's override).
+        if self.index.storage_admission_enabled()
+            && capacity.is_some()
+            && stats.status == crate::StorageStatus::Healthy
+        {
+            stats.status = if compaction_possible {
+                crate::StorageStatus::FullCompactionAvailable
+            } else {
+                crate::StorageStatus::TightCompactionAvailable
+            };
+        }
         // Admission is driven by the index tree's runtime config / footprint;
         // a closed gate is the operator-actionable state (see the standard
         // tree's override for the precedence rationale).

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -160,6 +160,20 @@ pub struct BlobTree {
 }
 
 impl BlobTree {
+    /// Physical footprint of the stale blob files a full compaction would
+    /// relocate: the linked, stale, non-dead subset across every live table (the
+    /// SAME set the merge gate budgets via `pick_blob_files_to_rewrite`), summed
+    /// by on-disk size. Zero when KV separation is unconfigured.
+    fn full_compaction_blob_need(&self, version: &crate::version::Version) -> crate::Result<u64> {
+        let Some(blob_opts) = &self.index.config.kv_separation_opts else {
+            return Ok(0);
+        };
+        let all_tables: crate::HashSet<TableId> = version.iter_tables().map(Table::id).collect();
+        crate::compaction::worker::pick_blob_files_to_rewrite(&all_tables, version, blob_opts)?
+            .iter()
+            .try_fold(0u64, |acc, bf| bf.physical_size().map(|size| acc + size))
+    }
+
     pub(crate) fn open(config: Config) -> crate::Result<Self> {
         use crate::file::{BLOBS_FOLDER, fsync_directory};
 
@@ -339,27 +353,37 @@ impl AbstractTree for BlobTree {
         stats.capacity_bytes = capacity;
         stats.available_bytes = available;
         stats.compaction_possible = compaction_possible;
-        // A full compaction of a blob tree may also relocate stale blob files,
-        // which the merge gate counts against the budget. Fold the physical
-        // blob-file footprint into the full-compaction figure (a conservative
-        // upper bound: a single compaction relocates at most the stale subset),
-        // so the status does not report full availability while the gate would
-        // skip the merge for lack of blob room.
-        let mut blob_bytes = 0u64;
-        for blob in version.blob_files.iter() {
-            blob_bytes += blob.physical_size()?;
-        }
-        stats.full_compaction_bytes += blob_bytes;
-        // Surface full-vs-tight compaction availability when gating is active and
-        // no compaction is running (see the standard tree's override).
+        // A full compaction of a blob tree also relocates STALE blob files, which
+        // the merge gate budgets via `pick_blob_files_to_rewrite` (linked, stale,
+        // non-dead). Estimate the same subset across every table — NOT the whole
+        // live blob footprint, which would overstate the need (large non-stale
+        // blobs are not rewritten) and report tight while the gate would admit
+        // the merge. Fold it into the gauge figure.
+        let blob_need = self.full_compaction_blob_need(&version)?;
+        stats.full_compaction_bytes += blob_need;
+        // Surface full-vs-tight compaction availability through the SAME two-layer
+        // check the compaction space gate enforces (logical quota + physical free
+        // per destination volume), so the status matches what the gate admits.
         if self.index.storage_admission_enabled()
             && capacity.is_some()
             && stats.status == crate::StorageStatus::Healthy
         {
-            // Full when the free room covers a full compaction's transient
-            // output, tight otherwise (see the standard tree's override).
-            let available = available.unwrap_or(0);
-            stats.status = if available >= stats.full_compaction_bytes {
+            // SST output lands in the largest level's volume; stale blob
+            // relocation lands in the primary blobs volume. The per-volume gate
+            // (not `available >= full_compaction_bytes` against the min-volume
+            // free) keeps the status from reporting tight when the SST and blob
+            // outputs each fit their own volume — see the gate's two-layer model.
+            let (sst_dest_level, sst_need) =
+                crate::storage_stats::largest_level_for_compaction(&version);
+            let quota_headroom = self.index.quota_headroom(stats.used_bytes);
+            let full_fits = crate::compaction::worker::space_fits_two_layer(
+                &self.index.config,
+                quota_headroom,
+                sst_need,
+                sst_dest_level,
+                blob_need,
+            );
+            stats.status = if full_fits {
                 crate::StorageStatus::FullCompactionAvailable
             } else {
                 crate::StorageStatus::TightCompactionAvailable

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -245,15 +245,17 @@ enum SpaceGate {
 ///
 /// **Layer 2 (physical free space, per destination volume).** SST output lands
 /// in `sst_dest_level`'s volume; KV-separated blob relocation lands in the
-/// primary blobs volume. When the destination level is NOT separately routed,
-/// both outputs share the primary filesystem, so their transient peak is the
-/// **sum on one volume** — checked as a single combined budget (checking them
-/// independently would over-admit: each fits the free space alone, but together
-/// they exhaust it). When the level IS routed to its own volume (tiered
-/// storage), the two outputs land on different filesystems and are checked
-/// independently, so a full cold-tier route never stalls a hot-level merge.
-/// Each volume leaves the reserved flush floor when ample, or consumes it (raw
-/// free) to break the no-space-to-free-space deadlock.
+/// primary blobs volume. The two are budgeted **independently only when they are
+/// proven to be on different physical volumes** ([`Fs::volume_id`] reports
+/// distinct device ids) — then a full cold-tier route never stalls a hot-level
+/// merge. Otherwise (same volume, or independence not proven) their transient
+/// peak is the **combined sum** on the tighter volume: checking them
+/// independently would over-admit, since each fits the free space alone while
+/// together they exhaust it and the merge hits `ENOSPC`. `level_routes` maps
+/// levels to paths but does NOT prove a separate mount (a route may point at the
+/// same filesystem), so routing alone is not treated as independence. Each
+/// volume leaves the reserved flush floor when ample, or consumes it (raw free)
+/// to break the no-space-to-free-space deadlock.
 ///
 /// A volume that cannot report free space contributes `u64::MAX`, so a probe
 /// failure never fabricates disk pressure. With no quota and every volume
@@ -285,25 +287,24 @@ pub fn space_fits_two_layer(
 
     let (sst_path, sst_fs) = config.tables_folder_for_level(sst_dest_level);
     let sst_free = sst_fs.available_space(&sst_path).unwrap_or(u64::MAX);
+    let blob_dir = config.path.join(BLOBS_FOLDER);
+    let blob_free = config.fs.available_space(&blob_dir).unwrap_or(u64::MAX);
 
-    let sst_routed_away = config
-        .level_routes
-        .as_ref()
-        .is_some_and(|routes| routes.iter().any(|r| r.levels.contains(&sst_dest_level)));
+    // Independent only when both destinations report a volume id AND the ids
+    // differ — provably separate free-space pools. A route to the same mount, or
+    // any backend that cannot prove independence, falls through to the combined
+    // budget so a shared-volume transient peak cannot slip past into `ENOSPC`.
+    let independent = match (sst_fs.volume_id(&sst_path), config.fs.volume_id(&blob_dir)) {
+        (Some(sst_vol), Some(blob_vol)) => sst_vol != blob_vol,
+        _ => false,
+    };
 
-    if sst_routed_away {
-        // Different filesystems: SST on the routed (cold-tier) volume, blob on
-        // the primary blobs volume → independent per-volume checks.
-        let blob_free = config
-            .fs
-            .available_space(&config.path.join(BLOBS_FOLDER))
-            .unwrap_or(u64::MAX);
+    if independent {
         volume_fits(sst_bytes, sst_free) && volume_fits(blob_bytes, blob_free)
     } else {
-        // Same primary filesystem (no route covers the destination level): the
-        // SST tables folder and the blobs folder share it, so the transient peak
-        // is the combined sum on that one volume.
-        volume_fits(sst_bytes + blob_bytes, sst_free)
+        // Same (or unproven-distinct) volume: the transient peak is the combined
+        // sum against the tighter free probe.
+        volume_fits(sst_bytes + blob_bytes, sst_free.min(blob_free))
     }
 }
 
@@ -2457,10 +2458,11 @@ mod tests {
             40 * MIB
         ));
 
-        // Routed: level 6 lives on its own cold-tier volume, blobs on the primary.
-        // The two outputs land on different filesystems and are checked
-        // independently — 60 MiB on each of two 100 MiB volumes fits, even though
-        // the sum is 120 MiB (a full cold-tier route must not stall a hot merge).
+        // Routed to a PROVEN-independent volume: level 6 lives on its own MemFs
+        // (a distinct volume id), blobs on the primary MemFs. The two outputs are
+        // checked independently — 60 MiB on each of two 100 MiB volumes fits, even
+        // though the sum is 120 MiB (a full cold-tier route must not stall a hot
+        // merge).
         let routed = Config::new(
             &dir,
             SequenceNumberCounter::default(),
@@ -2474,7 +2476,7 @@ mod tests {
         }]);
         assert!(
             super::space_fits_two_layer(&routed, u64::MAX, 60 * MIB, 6, 60 * MIB),
-            "routed outputs land on separate volumes and are checked independently"
+            "proven-independent volumes are checked independently"
         );
         // A blob output that overflows the primary volume alone still fails.
         assert!(!super::space_fits_two_layer(
@@ -2484,6 +2486,110 @@ mod tests {
             6,
             130 * MIB
         ));
+
+        // Routed but NOT proven independent: the route points at the SAME backend
+        // as the primary (one shared MemFs → one volume id / one free-space pool),
+        // as happens when level_routes maps a level to a directory on the same
+        // mount. The SST and blob budgets must combine, so 60 + 60 = 120 MiB > 100
+        // MiB free is rejected even though each fits alone — the routed
+        // over-admission guard.
+        let shared = MemFs::with_capacity(100 * MIB);
+        let routed_same_mount = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_shared_fs(Arc::new(shared.clone()))
+        .level_routes(vec![crate::config::LevelRoute {
+            levels: 6..7,
+            path: crate::path::PathBuf::from("/same-mount-subdir"),
+            // Same backend instance as the primary → same volume id (one shared
+            // free-space pool), the not-proven-independent case.
+            fs: Arc::new(shared),
+        }]);
+        assert!(
+            !super::space_fits_two_layer(&routed_same_mount, u64::MAX, 60 * MIB, 6, 60 * MIB),
+            "a route on the same volume must combine budgets, not admit each independently"
+        );
+
+        Ok(())
+    }
+
+    #[expect(
+        clippy::expect_used,
+        reason = "test asserts over known-good fixtures; failure surfaces via panic"
+    )]
+    #[test]
+    fn space_gate_for_merge_narrows_a_full_run_that_exceeds_free() -> crate::Result<()> {
+        use crate::fs::MemFs;
+
+        // Build a multi-table bottom-level run on a capped simulated disk, then
+        // ask the gate to admit a whole-run merge whose transient output does NOT
+        // fit free space but a run-adjacent pair does. The gate must narrow rather
+        // than skip — exercising the per-payload demand, the candidate loop, and
+        // the `Narrowed` return that integration tests cannot reach (the public
+        // major-compaction path picks a non-narrowable multi-level merge).
+        let dir = tempfile::tempdir()?;
+        let mem = MemFs::with_capacity(u64::MAX);
+        let any = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_shared_fs(Arc::new(mem.clone()))
+        .data_block_size_policy(BlockSizePolicy::all(512))
+        .open()?;
+        let crate::AnyTree::Standard(tree) = any else {
+            panic!("expected Standard tree");
+        };
+        for i in 0..3_000u64 {
+            tree.insert(format!("k{i:08}"), "v".repeat(40), i);
+        }
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(16 * 1024, 0)?;
+
+        let version = tree.current_version();
+        let run = version
+            .iter_levels()
+            .flat_map(|level| level.iter())
+            .find(|run| run.len() >= 3)
+            .expect("a bottom-level run with >= 3 tables");
+        let run_sigma: u64 = run.iter().map(Table::file_size).sum();
+        let payload = Input {
+            table_ids: run.iter().map(Table::id).collect(),
+            dest_level: 6,
+            canonical_level: 6,
+            target_size: 64 * 1024 * 1024,
+        };
+
+        // Free space below the full run's Σ but above a single pair: the run does
+        // not fit, a run-adjacent pair does. Calibrate against the SIMULATED
+        // disk's real stored bytes (manifest / WAL count too, not just live SSTs),
+        // since the gate probes `available_space`, not the version footprint.
+        // `run_sigma >= 1` (real SST files), so `- 1` cannot underflow.
+        let probe_capacity = 1u64 << 40;
+        mem.set_capacity(probe_capacity);
+        let stored = probe_capacity
+            - crate::fs::Fs::available_space(&mem, dir.path()).unwrap_or(probe_capacity);
+        mem.set_capacity(stored + run_sigma - 1);
+        tree.update_runtime_config(|c| {
+            c.storage_admission_check = true;
+            c.storage_limit_bytes = None;
+        })?;
+
+        let opts = super::Options::from_tree(
+            &tree,
+            Arc::new(crate::compaction::major::Strategy::new(64 * 1024 * 1024)),
+        );
+        match super::space_gate_for_merge(&version, &opts, &payload)? {
+            super::SpaceGate::Narrowed(narrowed) => {
+                assert_eq!(narrowed.table_ids.len(), 2, "narrowed to an adjacent pair");
+            }
+            super::SpaceGate::Run => {
+                panic!("expected Narrowed, got Run (full run wrongly admitted)")
+            }
+            super::SpaceGate::Skip => panic!("expected Narrowed, got Skip (no pair admitted)"),
+        }
 
         Ok(())
     }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -156,7 +156,7 @@ pub fn do_compaction(opts: &Options) -> crate::Result<CompactionResult> {
             // `Drop` are zero / negative space and always run (below).
             let decision = {
                 let super_version = version_history_lock.latest_version();
-                space_gate_for_merge(&super_version.version, opts, &payload)
+                space_gate_for_merge(&super_version.version, opts, &payload)?
             };
             match decision {
                 SpaceGate::Run => {
@@ -265,89 +265,84 @@ fn space_gate_for_merge(
     version: &Version,
     opts: &Options,
     payload: &CompactionPayload,
-) -> SpaceGate {
+) -> crate::Result<SpaceGate> {
     let rc = opts.runtime_config.load_full();
     if !rc.storage_admission_check {
-        return SpaceGate::Run;
+        return Ok(SpaceGate::Run);
     }
 
-    // SST output lands in the destination level's volume (tiered routing aware).
+    // Payload-independent budgets, probed once.
+    //
+    // SST output lands in the destination level's volume (tiered routing aware);
+    // blob relocation (KV-separated trees) lands in the primary blobs folder.
     let (sst_path, sst_fs) = opts.config.tables_folder_for_level(payload.dest_level);
     let sst_free = sst_fs.available_space(&sst_path).unwrap_or(u64::MAX);
-
-    // SST input bound (output never exceeds the inputs for a pure compaction).
-    // Plain sum: on-disk file sizes are bounded by the filesystem capacity.
-    let sst_sigma: u64 = payload
-        .table_ids
-        .iter()
-        .filter_map(|&id| version.get_table(id))
-        .map(Table::file_size)
-        .sum();
-
-    // A KV-separated tree may relocate stale blob files into the primary blobs
-    // folder; those bytes are not part of the SST sizes and land on a different
-    // volume.
-    let (blob_sigma, blob_free) = match &opts.config.kv_separation_opts {
-        Some(blob_opts) => {
-            // Sum the PHYSICAL size of each blob file selected for relocation
-            // (framing + meta + trailer, not just the compressed payload), a
-            // conservative upper bound on the rewritten output. A stat failure
-            // falls back to 0 for that file — the merge would surface the real
-            // error, and the atomic-commit guarantee keeps a slipped-through
-            // ENOSPC consistent.
-            let bytes: u64 = pick_blob_files_to_rewrite(&payload.table_ids, version, blob_opts)
-                .unwrap_or_default()
-                .iter()
-                .map(|bf| bf.physical_size().unwrap_or(0))
-                .sum();
-            let folder = opts.config.path.join(BLOBS_FOLDER);
-            (
-                bytes,
-                opts.config.fs.available_space(&folder).unwrap_or(u64::MAX),
-            )
-        }
-        None => (0, u64::MAX),
+    let blob_free = if opts.config.kv_separation_opts.is_some() {
+        let folder = opts.config.path.join(BLOBS_FOLDER);
+        opts.config.fs.available_space(&folder).unwrap_or(u64::MAX)
+    } else {
+        u64::MAX
     };
-
     // Quota headroom (tree-wide) bounds the total new bytes on top of the live
     // footprint. `max(0, limit - used)`: an operator quota set below the live
     // footprint leaves zero headroom — the clamp-to-zero is the intended
     // semantics (saturating_sub is the genuine min-clamp here, not masking).
+    // The footprint stat is propagated, not swallowed (an undercounted `used`
+    // would overstate the headroom).
     let quota_headroom = match rc.storage_limit_bytes {
-        Some(limit) => {
-            let used = crate::storage_stats::compute_used_bytes(version).unwrap_or(0);
-            limit.saturating_sub(used)
-        }
+        Some(limit) => limit.saturating_sub(crate::storage_stats::compute_used_bytes(version)?),
         None => u64::MAX,
     };
 
     // Nothing constrains the merge (no probe, no quota) → run.
     if sst_free == u64::MAX && blob_free == u64::MAX && quota_headroom == u64::MAX {
-        return SpaceGate::Run;
+        return Ok(SpaceGate::Run);
     }
 
     const RESERVE: u64 = crate::tree::MIN_RESERVED_HEADROOM;
-    // SST output must fit its volume: leaving the reserved flush floor when
-    // ample, or consuming the emergency reserve (raw free) to break the
-    // no-space-to-free-space deadlock. `>= RESERVE` guards the subtraction.
-    let sst_fits =
-        (sst_free >= RESERVE && sst_sigma <= sst_free - RESERVE) || sst_sigma <= sst_free;
-    let blob_fits = blob_sigma <= blob_free;
-    let quota_fits = sst_sigma + blob_sigma <= quota_headroom;
+    // Whether a given payload's transient output fits every relevant budget. The
+    // per-payload sizes are recomputed because narrowing changes both the SST
+    // input set AND (via `pick_blob_files_to_rewrite` on the actual payload) the
+    // blob relocation set, so a narrowed blob merge can fit where the full one
+    // did not. Stat failures propagate (a silent 0 would undercount and admit
+    // the very rewrite this gate must block).
+    let fits = |p: &CompactionPayload| -> crate::Result<bool> {
+        // SST input bound (output never exceeds the inputs for a pure compaction).
+        let sst_sigma: u64 = p
+            .table_ids
+            .iter()
+            .filter_map(|&id| version.get_table(id))
+            .map(Table::file_size)
+            .sum();
+        let blob_sigma: u64 = match &opts.config.kv_separation_opts {
+            Some(blob_opts) => pick_blob_files_to_rewrite(&p.table_ids, version, blob_opts)?
+                .iter()
+                .try_fold(0u64, |acc, bf| bf.physical_size().map(|size| acc + size))?,
+            None => 0,
+        };
+        // SST output must fit its volume: leaving the reserved flush floor when
+        // ample, or consuming the emergency reserve (raw free) to break the
+        // no-space-to-free-space deadlock. `>= RESERVE` guards the subtraction.
+        let sst_fits =
+            (sst_free >= RESERVE && sst_sigma <= sst_free - RESERVE) || sst_sigma <= sst_free;
+        Ok(sst_fits && blob_sigma <= blob_free && sst_sigma + blob_sigma <= quota_headroom)
+    };
 
-    if sst_fits && blob_fits && quota_fits {
-        return SpaceGate::Run;
+    if fits(payload)? {
+        return Ok(SpaceGate::Run);
     }
 
-    // Narrowing only shrinks the SST input set, so it can rescue an SST-bound
-    // merge but not a blob-relocating one whose blob output is the constraint.
-    if blob_sigma == 0 {
-        let budget = sst_free.min(quota_headroom);
-        if let Some(narrowed) = narrow_merge_to_budget(version, payload, budget) {
-            return SpaceGate::Narrowed(narrowed);
-        }
+    // Constrained: narrow to the smallest run-adjacent pair that fits the SST /
+    // quota budget, then re-check the narrowed payload's full budget (its own
+    // blob relocation set included). Skip only when even the narrowed merge does
+    // not fit.
+    let budget = sst_free.min(quota_headroom);
+    if let Some(narrowed) = narrow_merge_to_budget(version, payload, budget)
+        && fits(&narrowed)?
+    {
+        return Ok(SpaceGate::Narrowed(narrowed));
     }
-    SpaceGate::Skip
+    Ok(SpaceGate::Skip)
 }
 
 /// Narrows a too-large merge to the smallest run-adjacent table pair whose

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -289,10 +289,16 @@ fn space_gate_for_merge(
     // volume.
     let (blob_sigma, blob_free) = match &opts.config.kv_separation_opts {
         Some(blob_opts) => {
+            // Sum the PHYSICAL size of each blob file selected for relocation
+            // (framing + meta + trailer, not just the compressed payload), a
+            // conservative upper bound on the rewritten output. A stat failure
+            // falls back to 0 for that file — the merge would surface the real
+            // error, and the atomic-commit guarantee keeps a slipped-through
+            // ENOSPC consistent.
             let bytes: u64 = pick_blob_files_to_rewrite(&payload.table_ids, version, blob_opts)
                 .unwrap_or_default()
                 .iter()
-                .map(BlobFile::on_disk_bytes)
+                .map(|bf| bf.physical_size().unwrap_or(0))
                 .sum();
             let folder = opts.config.path.join(BLOBS_FOLDER);
             (

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -234,33 +234,102 @@ enum SpaceGate {
     Skip,
 }
 
+/// The two-layer space model shared by the compaction gate and the
+/// `storage_stats` forward-looking status, so the reported availability matches
+/// what the gate will actually admit.
+///
+/// **Layer 1 (logical partition quota).** The configured `storage_limit_bytes`
+/// caps the tree's total footprint regardless of which volume the bytes land on.
+/// `quota_headroom` is `max(0, limit - used)`, or `u64::MAX` when no quota is
+/// set. The total new bytes (`sst_bytes + blob_bytes`) must fit it.
+///
+/// **Layer 2 (physical free space, per destination volume).** SST output lands
+/// in `sst_dest_level`'s volume; KV-separated blob relocation lands in the
+/// primary blobs volume. When the destination level is NOT separately routed,
+/// both outputs share the primary filesystem, so their transient peak is the
+/// **sum on one volume** — checked as a single combined budget (checking them
+/// independently would over-admit: each fits the free space alone, but together
+/// they exhaust it). When the level IS routed to its own volume (tiered
+/// storage), the two outputs land on different filesystems and are checked
+/// independently, so a full cold-tier route never stalls a hot-level merge.
+/// Each volume leaves the reserved flush floor when ample, or consumes it (raw
+/// free) to break the no-space-to-free-space deadlock.
+///
+/// A volume that cannot report free space contributes `u64::MAX`, so a probe
+/// failure never fabricates disk pressure. With no quota and every volume
+/// unbounded, the result is unconditionally `true` (nothing constrains).
+// `pub` (not `pub(crate)`) inside this crate-private module: clippy flags the
+// redundant restriction since the module itself is already crate-scoped.
+pub fn space_fits_two_layer(
+    config: &Config,
+    quota_headroom: u64,
+    sst_bytes: u64,
+    sst_dest_level: u8,
+    blob_bytes: u64,
+) -> bool {
+    const RESERVE: u64 = crate::tree::MIN_RESERVED_HEADROOM;
+
+    // Layer 1: logical partition quota on the total new bytes. The sum of two
+    // on-disk byte counts is bounded by filesystem capacity and cannot overflow.
+    if sst_bytes + blob_bytes > quota_headroom {
+        return false;
+    }
+
+    // Layer 2: physical free space per destination volume. A volume's demand
+    // fits when it leaves the reserved flush floor (ample) or, to break the
+    // no-space-to-free-space deadlock, when it fits raw free (emergency,
+    // consuming the reserve). `>= RESERVE` guards the subtraction.
+    let volume_fits = |demand: u64, free: u64| -> bool {
+        (free >= RESERVE && demand <= free - RESERVE) || demand <= free
+    };
+
+    let (sst_path, sst_fs) = config.tables_folder_for_level(sst_dest_level);
+    let sst_free = sst_fs.available_space(&sst_path).unwrap_or(u64::MAX);
+
+    let sst_routed_away = config
+        .level_routes
+        .as_ref()
+        .is_some_and(|routes| routes.iter().any(|r| r.levels.contains(&sst_dest_level)));
+
+    if sst_routed_away {
+        // Different filesystems: SST on the routed (cold-tier) volume, blob on
+        // the primary blobs volume → independent per-volume checks.
+        let blob_free = config
+            .fs
+            .available_space(&config.path.join(BLOBS_FOLDER))
+            .unwrap_or(u64::MAX);
+        volume_fits(sst_bytes, sst_free) && volume_fits(blob_bytes, blob_free)
+    } else {
+        // Same primary filesystem (no route covers the destination level): the
+        // SST tables folder and the blobs folder share it, so the transient peak
+        // is the combined sum on that one volume.
+        volume_fits(sst_bytes + blob_bytes, sst_free)
+    }
+}
+
 /// Decides whether a chosen merge fits the available space, narrowing it to a
 /// minimal reclaiming subset when it does not.
 ///
-/// The merge writes two kinds of output to two (possibly different) volumes:
-/// the merged SSTs land in the destination level's volume, and a KV-separated
-/// tree may relocate stale blob files into the blobs folder (the primary
-/// volume). Each output is checked against the free space of the volume it lands
-/// on (the tightest, per-level-routed volume — not a global minimum, so a full
-/// cold-tier route never stalls a hot-level merge), and the total new bytes are
-/// also checked against the configured quota headroom (`storage_limit_bytes`),
-/// so compaction cannot grow the tree past the operator's budget.
+/// The merge's transient output is checked through [`space_fits_two_layer`]: the
+/// logical partition quota bounds the total new bytes, and the physical free
+/// space is checked per destination volume (SST output volume + primary blob
+/// volume, combined onto one budget when they share a filesystem).
 ///
-/// The SST bound is `Σ input file_size`; the blob bound is the on-disk size of
-/// the blob files selected for relocation. This is a best-effort estimate: a
-/// merge operator / compaction filter that *grows* values can still write more
-/// than the inputs, so a mid-merge `ENOSPC` remains possible — that case is
-/// handled by the atomic-commit guarantee (orphan output, intact inputs,
+/// The SST bound is `Σ input file_size`; the blob bound is the physical on-disk
+/// size of the stale blob files selected for relocation. This is a best-effort
+/// estimate: a merge operator / compaction filter that *grows* values can still
+/// write more than the inputs, so a mid-merge `ENOSPC` remains possible — that
+/// case is handled by the atomic-commit guarantee (orphan output, intact inputs,
 /// unchanged manifest, retried later), not by this gate. The gate's job is to
 /// keep the common doomed merge from starting.
 ///
-/// - Admission off, or no volume can report free space and no quota → [`SpaceGate::Run`].
-/// - SST output fits its volume (leaving the reserved flush floor when ample, or
-///   consuming the emergency reserve to break the deadlock), blob output fits the
-///   blobs volume, and the total fits the quota → [`SpaceGate::Run`].
-/// - Otherwise, a pure-SST merge is narrowed to the smallest run-adjacent pair
-///   that fits; a blob-relocating merge that does not fit is skipped (narrowing
-///   does not shrink blob output).
+/// - Admission off → [`SpaceGate::Run`].
+/// - The chosen merge fits both layers → [`SpaceGate::Run`].
+/// - It does not fit, but a run-adjacent pair does → [`SpaceGate::Narrowed`].
+///   Candidates are tried in ascending SST size; a larger pair with fewer stale
+///   blob rewrites can fit where the smallest does not, so each is re-checked
+///   through the full two-layer budget (its own relocation set included).
+/// - No fitting subset exists → [`SpaceGate::Skip`].
 fn space_gate_for_merge(
     version: &Version,
     opts: &Options,
@@ -271,41 +340,20 @@ fn space_gate_for_merge(
         return Ok(SpaceGate::Run);
     }
 
-    // Payload-independent budgets, probed once.
-    //
-    // SST output lands in the destination level's volume (tiered routing aware);
-    // blob relocation (KV-separated trees) lands in the primary blobs folder.
-    let (sst_path, sst_fs) = opts.config.tables_folder_for_level(payload.dest_level);
-    let sst_free = sst_fs.available_space(&sst_path).unwrap_or(u64::MAX);
-    let blob_free = if opts.config.kv_separation_opts.is_some() {
-        let folder = opts.config.path.join(BLOBS_FOLDER);
-        opts.config.fs.available_space(&folder).unwrap_or(u64::MAX)
-    } else {
-        u64::MAX
-    };
-    // Quota headroom (tree-wide) bounds the total new bytes on top of the live
-    // footprint. `max(0, limit - used)`: an operator quota set below the live
-    // footprint leaves zero headroom — the clamp-to-zero is the intended
-    // semantics (saturating_sub is the genuine min-clamp here, not masking).
-    // The footprint stat is propagated, not swallowed (an undercounted `used`
-    // would overstate the headroom).
+    // Layer 1 headroom (tree-wide). `max(0, limit - used)`: an operator quota set
+    // below the live footprint leaves zero headroom — the clamp-to-zero is the
+    // intended min-semantics (not masking). The footprint stat is propagated, not
+    // swallowed (an undercounted `used` would overstate the headroom).
     let quota_headroom = match rc.storage_limit_bytes {
         Some(limit) => limit.saturating_sub(crate::storage_stats::compute_used_bytes(version)?),
         None => u64::MAX,
     };
 
-    // Nothing constrains the merge (no probe, no quota) → run.
-    if sst_free == u64::MAX && blob_free == u64::MAX && quota_headroom == u64::MAX {
-        return Ok(SpaceGate::Run);
-    }
-
-    const RESERVE: u64 = crate::tree::MIN_RESERVED_HEADROOM;
-    // Whether a given payload's transient output fits every relevant budget. The
-    // per-payload sizes are recomputed because narrowing changes both the SST
-    // input set AND (via `pick_blob_files_to_rewrite` on the actual payload) the
-    // blob relocation set, so a narrowed blob merge can fit where the full one
-    // did not. Stat failures propagate (a silent 0 would undercount and admit
-    // the very rewrite this gate must block).
+    // Per-payload transient demand. Recomputed per payload because narrowing
+    // changes both the SST input set AND (via `pick_blob_files_to_rewrite` on the
+    // actual payload) the stale blob relocation set, so a narrowed merge can fit
+    // where the full one did not. Stat failures propagate (a silent 0 would
+    // undercount and admit the very rewrite this gate must block).
     let fits = |p: &CompactionPayload| -> crate::Result<bool> {
         // SST input bound (output never exceeds the inputs for a pure compaction).
         let sst_sigma: u64 = p
@@ -320,49 +368,54 @@ fn space_gate_for_merge(
                 .try_fold(0u64, |acc, bf| bf.physical_size().map(|size| acc + size))?,
             None => 0,
         };
-        // SST output must fit its volume: leaving the reserved flush floor when
-        // ample, or consuming the emergency reserve (raw free) to break the
-        // no-space-to-free-space deadlock. `>= RESERVE` guards the subtraction.
-        let sst_fits =
-            (sst_free >= RESERVE && sst_sigma <= sst_free - RESERVE) || sst_sigma <= sst_free;
-        Ok(sst_fits && blob_sigma <= blob_free && sst_sigma + blob_sigma <= quota_headroom)
+        Ok(space_fits_two_layer(
+            &opts.config,
+            quota_headroom,
+            sst_sigma,
+            p.dest_level,
+            blob_sigma,
+        ))
     };
 
     if fits(payload)? {
         return Ok(SpaceGate::Run);
     }
 
-    // Constrained: narrow to the smallest run-adjacent pair that fits the SST /
-    // quota budget, then re-check the narrowed payload's full budget (its own
-    // blob relocation set included). Skip only when even the narrowed merge does
-    // not fit.
-    let budget = sst_free.min(quota_headroom);
-    if let Some(narrowed) = narrow_merge_to_budget(version, payload, budget)
-        && fits(&narrowed)?
-    {
-        return Ok(SpaceGate::Narrowed(narrowed));
+    // Constrained: try the run-adjacent narrowing candidates in ascending SST
+    // size and run the first that fits the full two-layer budget. Skip only when
+    // none fit (a truly-too-big single merge is the opt-in tight-space domain).
+    for narrowed in narrow_merge_candidates(version, payload) {
+        if fits(&narrowed)? {
+            return Ok(SpaceGate::Narrowed(narrowed));
+        }
     }
     Ok(SpaceGate::Skip)
 }
 
-/// Narrows a too-large merge to the smallest run-adjacent table pair whose
-/// combined `file_size` fits `budget`, preserving the merge's destination.
+/// The run-adjacent table-pair narrowing candidates for a too-large merge,
+/// sorted by combined SST `file_size` ascending, each preserving the merge's
+/// destination.
 ///
 /// Narrowing is only safe within a single run (key-sorted, non-overlapping
 /// tables): a run-adjacent pair is always a valid, reclaiming merge, and the
 /// merge stream culls exactly that pair. A cross-run / cross-level payload (e.g.
 /// a leveled `Lₙ → Lₙ₊₁` overlap set) cannot be narrowed here without risking an
-/// invalid partial merge, so it returns `None` (the chosen merge is skipped and
-/// left to the opt-in tight-space mode). The pair must be adjacent IN THE RUN —
-/// a gap would make the merge stream pull the in-between tables too, breaking the
-/// size bound.
-fn narrow_merge_to_budget(
+/// invalid partial merge, so it yields no candidates (the chosen merge is
+/// skipped and left to the opt-in tight-space mode). The pair must be adjacent
+/// IN THE RUN — a gap would make the merge stream pull the in-between tables
+/// too, breaking the size bound.
+///
+/// The caller tries the candidates in order and runs the first that fits the
+/// full space gate: the smallest-SST pair can still fail on its stale blob
+/// relocation set or the combined single-volume budget, while a slightly larger
+/// pair with fewer blob rewrites fits — ranking by SST size alone and stopping at
+/// the first would wrongly skip the merge.
+fn narrow_merge_candidates(
     version: &Version,
     payload: &CompactionPayload,
-    budget: u64,
-) -> Option<CompactionPayload> {
+) -> Vec<CompactionPayload> {
     // The single run that holds every payload table (if any).
-    let run = version
+    let Some(run) = version
         .iter_levels()
         .flat_map(|level| level.iter())
         .find(|run| {
@@ -370,10 +423,13 @@ fn narrow_merge_to_budget(
                 .table_ids
                 .iter()
                 .all(|id| run.iter().any(|t| t.id() == *id))
-        })?;
+        })
+    else {
+        return Vec::new();
+    };
 
     let run_tables: Vec<&Table> = run.iter().collect();
-    let mut best: Option<(u64, [TableId; 2])> = None;
+    let mut candidates: Vec<(u64, CompactionPayload)> = Vec::new();
     for pair in run_tables.windows(2) {
         let [a, b] = pair else { continue };
         if !payload.table_ids.contains(&a.id()) || !payload.table_ids.contains(&b.id()) {
@@ -382,21 +438,18 @@ fn narrow_merge_to_budget(
         // Two on-disk file sizes; the sum is bounded by filesystem capacity and
         // cannot overflow u64.
         let combined = a.file_size() + b.file_size();
-        if combined > budget {
-            continue;
-        }
-        if best.is_none_or(|(best_size, _)| combined < best_size) {
-            best = Some((combined, [a.id(), b.id()]));
-        }
+        candidates.push((
+            combined,
+            CompactionPayload {
+                table_ids: [a.id(), b.id()].into_iter().collect(),
+                dest_level: payload.dest_level,
+                canonical_level: payload.canonical_level,
+                target_size: payload.target_size,
+            },
+        ));
     }
-
-    let (_, ids) = best?;
-    Some(CompactionPayload {
-        table_ids: ids.into_iter().collect(),
-        dest_level: payload.dest_level,
-        canonical_level: payload.canonical_level,
-        target_size: payload.target_size,
-    })
+    candidates.sort_by_key(|(combined, _)| *combined);
+    candidates.into_iter().map(|(_, p)| p).collect()
 }
 
 fn pick_run_indexes(run: &Run<Table>, to_compact: &[TableId]) -> Option<(usize, usize)> {
@@ -888,8 +941,13 @@ fn move_tables(
     })
 }
 
-/// Picks blob files to rewrite (defragment)
-fn pick_blob_files_to_rewrite(
+/// Picks blob files to rewrite (defragment): the linked, stale, non-dead blob
+/// files a compaction of `picked_tables` would relocate. Also the basis for the
+/// `storage_stats` blob-relocation estimate, so the reported status budgets the
+/// SAME stale subset the gate does (not every live blob file).
+// `pub` (not `pub(crate)`) inside this crate-private module — see
+// `space_fits_two_layer`.
+pub fn pick_blob_files_to_rewrite(
     picked_tables: &HashSet<TableId>,
     current_version: &Version,
     blob_opts: &crate::KvSeparationOptions,
@@ -2276,10 +2334,13 @@ mod tests {
         reason = "test asserts over known-good fixtures; failure surfaces via panic"
     )]
     #[test]
-    fn narrow_merge_picks_smallest_fitting_run_adjacent_pair() -> crate::Result<()> {
+    fn narrow_merge_candidates_for_full_run_are_adjacent_pairs_sorted_ascending()
+    -> crate::Result<()> {
         // Build a single bottom-level run of several tables (small target size
-        // forces table rotation), then narrow a whole-run merge to a budget that
-        // fits only one adjacent pair.
+        // forces table rotation), then enumerate the narrowing candidates of a
+        // whole-run merge. The gate tries them in order, so the contract is:
+        // every candidate is a run-adjacent pair, and they are sorted by combined
+        // SST size ascending (smallest tried first).
         let dir = tempfile::tempdir()?;
         let tree = Config::new(
             &dir,
@@ -2310,35 +2371,119 @@ mod tests {
             target_size: 64 * 1024 * 1024,
         };
 
-        // Smallest combined size over run-adjacent pairs.
+        let candidates = super::narrow_merge_candidates(&version, &payload);
+
+        // One candidate per run-adjacent pair, each exactly two tables on the
+        // payload's destination.
+        assert_eq!(
+            candidates.len(),
+            ordered.len() - 1,
+            "one candidate per run-adjacent pair"
+        );
+        for c in &candidates {
+            assert_eq!(c.table_ids.len(), 2, "each candidate is an adjacent pair");
+            assert_eq!(c.dest_level, 6, "destination preserved");
+        }
+
+        let combined = |c: &Input| -> u64 {
+            c.table_ids
+                .iter()
+                .filter_map(|id| version.get_table(*id))
+                .map(Table::file_size)
+                .sum()
+        };
+        let sums: Vec<u64> = candidates.iter().map(combined).collect();
+
+        // Sorted ascending: the gate tries the smallest-Σ pair first, then larger
+        // ones (a larger pair with fewer blob rewrites can fit where the smallest
+        // does not).
+        let mut sorted = sums.clone();
+        sorted.sort_unstable();
+        assert_eq!(sums, sorted, "candidates sorted ascending by SST size");
+
+        // The first candidate is the smallest-Σ run-adjacent pair.
         let smallest_pair = ordered
             .windows(2)
             .map(|w| w[0].1 + w[1].1)
             .min()
             .expect(">= 2 tables");
+        assert_eq!(sums[0], smallest_pair, "smallest-Σ pair is tried first");
 
-        // A budget at that size narrows to exactly that pair (2 tables, Σ == budget).
-        let narrowed = super::narrow_merge_to_budget(&version, &payload, smallest_pair)
-            .expect("smallest pair fits the budget");
-        assert_eq!(narrowed.table_ids.len(), 2, "narrowed to an adjacent pair");
-        let narrowed_sum: u64 = narrowed
-            .table_ids
-            .iter()
-            .filter_map(|id| version.get_table(*id))
-            .map(Table::file_size)
-            .sum();
-        assert_eq!(
-            narrowed_sum, smallest_pair,
-            "narrowed pair is the smallest-Σ adjacent pair"
-        );
+        Ok(())
+    }
 
-        // A budget below the smallest single table fits nothing → None. An SST
-        // file is always larger than a byte, so `- 1` cannot underflow.
-        let smallest_table = ordered.iter().map(|(_, s)| *s).min().expect("non-empty");
+    #[test]
+    fn space_fits_two_layer_combines_shared_volume_outputs_and_separates_routed_ones()
+    -> crate::Result<()> {
+        use crate::fs::MemFs;
+
+        const MIB: u64 = 1024 * 1024;
+        let dir = tempfile::tempdir()?;
+
+        // Single volume (no routes): the SST tables folder and the blobs folder
+        // share the primary filesystem, so the transient peak is their SUM on one
+        // volume. An empty MemFs reports `capacity` free.
+        let cfg = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_shared_fs(Arc::new(MemFs::with_capacity(100 * MIB)));
+
+        // 60 + 60 = 120 MiB > 100 MiB free → rejected, even though each output
+        // fits the volume alone. This is the single-volume over-admission the
+        // two-layer model prevents (checking sst and blob independently would
+        // wrongly admit it).
         assert!(
-            super::narrow_merge_to_budget(&version, &payload, smallest_table - 1).is_none(),
-            "no pair fits a sub-single-table budget"
+            !super::space_fits_two_layer(&cfg, u64::MAX, 60 * MIB, 6, 60 * MIB),
+            "shared-volume outputs must be summed, not checked independently"
         );
+        // 60 + 30 = 90 MiB (+1 MiB reserve) ≤ 100 MiB → admitted.
+        assert!(super::space_fits_two_layer(
+            &cfg,
+            u64::MAX,
+            60 * MIB,
+            6,
+            30 * MIB
+        ));
+
+        // Layer 1 (logical quota) caps the total regardless of physical free:
+        // 50 + 40 = 90 MiB exceeds an 80 MiB quota headroom.
+        assert!(!super::space_fits_two_layer(
+            &cfg,
+            80 * MIB,
+            50 * MIB,
+            6,
+            40 * MIB
+        ));
+
+        // Routed: level 6 lives on its own cold-tier volume, blobs on the primary.
+        // The two outputs land on different filesystems and are checked
+        // independently — 60 MiB on each of two 100 MiB volumes fits, even though
+        // the sum is 120 MiB (a full cold-tier route must not stall a hot merge).
+        let routed = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_shared_fs(Arc::new(MemFs::with_capacity(100 * MIB)))
+        .level_routes(vec![crate::config::LevelRoute {
+            levels: 6..7,
+            path: crate::path::PathBuf::from("/cold-tier"),
+            fs: Arc::new(MemFs::with_capacity(100 * MIB)),
+        }]);
+        assert!(
+            super::space_fits_two_layer(&routed, u64::MAX, 60 * MIB, 6, 60 * MIB),
+            "routed outputs land on separate volumes and are checked independently"
+        );
+        // A blob output that overflows the primary volume alone still fails.
+        assert!(!super::space_fits_two_layer(
+            &routed,
+            u64::MAX,
+            60 * MIB,
+            6,
+            130 * MIB
+        ));
 
         Ok(())
     }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -148,7 +148,36 @@ pub fn do_compaction(opts: &Options) -> crate::Result<CompactionResult> {
 
     match choice {
         Choice::Merge(payload) => {
-            merge_tables(compaction_state, version_history_lock, opts, &payload)
+            // Space-admission gate (opt-in). A merge transiently needs room for
+            // its output while the inputs still exist, so on a near-full disk a
+            // naive run can hit ENOSPC. Gating merges like user writes would
+            // deadlock (compaction is what frees space), so the gate keeps an
+            // emergency reserve and narrows rather than blanket-skips. `Move` /
+            // `Drop` are zero / negative space and always run (below).
+            let decision = {
+                let super_version = version_history_lock.latest_version();
+                space_gate_for_merge(&super_version.version, opts, &payload)
+            };
+            match decision {
+                SpaceGate::Run => {
+                    merge_tables(compaction_state, version_history_lock, opts, &payload)
+                }
+                SpaceGate::Narrowed(narrowed) => {
+                    log::debug!(
+                        "Compaction space gate: narrowed merge from {} to {} tables to fit free space",
+                        payload.table_ids.len(),
+                        narrowed.table_ids.len(),
+                    );
+                    merge_tables(compaction_state, version_history_lock, opts, &narrowed)
+                }
+                SpaceGate::Skip => {
+                    log::info!(
+                        "Compaction space gate: skipping {}-table merge — free space cannot cover the transient output and no fitting subset exists (opt-in tight-space reclaim handles this)",
+                        payload.table_ids.len(),
+                    );
+                    Ok(CompactionResult::nothing())
+                }
+            }
         }
         Choice::Move(payload) => {
             // Cross-folder trivial moves are not possible — the file must be
@@ -189,6 +218,119 @@ pub fn do_compaction(opts: &Options) -> crate::Result<CompactionResult> {
             Ok(CompactionResult::nothing())
         }
     }
+}
+
+/// Outcome of the compaction space-admission gate for a [`Choice::Merge`].
+enum SpaceGate {
+    /// Run the merge as chosen (admission off, backend can't report free space,
+    /// or the inputs fit the available space).
+    Run,
+    /// Run a smaller fitting subset (a minimal reclaiming merge) instead of the
+    /// chosen one, which did not fit.
+    Narrowed(CompactionPayload),
+    /// No fitting subset exists; skip this cycle. The truly-too-big single merge
+    /// is the opt-in tight-space mode's domain; meanwhile `Drop` / `Move` cycles
+    /// still reclaim and reorganize.
+    Skip,
+}
+
+/// Decides whether a chosen merge fits the available disk space, narrowing it to
+/// a minimal reclaiming subset when it does not.
+///
+/// Bound: a merge's transient extra need is at most `Σ input file_size` (the
+/// output never exceeds the inputs). Budget: the minimum free space across every
+/// volume the tree writes to ([`Config::min_available_space`]).
+///
+/// - Admission off, or a backend that cannot report free space → [`SpaceGate::Run`]
+///   (no disk-pressure signal; behaviour identical to a build without the gate).
+/// - `Σinputs + reserve ≤ free` → run (ample room, leaves the flush/metadata floor).
+/// - `Σinputs ≤ free` → run anyway, consuming the emergency reserve: a
+///   space-reclaiming merge must be able to run even at the limit, which is what
+///   breaks the no-space-to-free-space deadlock.
+/// - `Σinputs > free` → narrow to the smallest run-adjacent table pair that fits;
+///   if none fits, skip.
+fn space_gate_for_merge(
+    version: &Version,
+    opts: &Options,
+    payload: &CompactionPayload,
+) -> SpaceGate {
+    if !opts.runtime_config.load_full().storage_admission_check {
+        return SpaceGate::Run;
+    }
+
+    let free = opts.config.min_available_space();
+    if free == u64::MAX {
+        // Backend cannot report free space → never fabricate disk pressure.
+        return SpaceGate::Run;
+    }
+
+    let sigma: u64 = payload
+        .table_ids
+        .iter()
+        .filter_map(|&id| version.get_table(id))
+        .map(Table::file_size)
+        .fold(0u64, u64::saturating_add);
+
+    if sigma.saturating_add(crate::tree::MIN_RESERVED_HEADROOM) <= free || sigma <= free {
+        return SpaceGate::Run;
+    }
+
+    match narrow_merge_to_budget(version, payload, free) {
+        Some(narrowed) => SpaceGate::Narrowed(narrowed),
+        None => SpaceGate::Skip,
+    }
+}
+
+/// Narrows a too-large merge to the smallest run-adjacent table pair whose
+/// combined `file_size` fits `budget`, preserving the merge's destination.
+///
+/// Narrowing is only safe within a single run (key-sorted, non-overlapping
+/// tables): a run-adjacent pair is always a valid, reclaiming merge, and the
+/// merge stream culls exactly that pair. A cross-run / cross-level payload (e.g.
+/// a leveled `Lₙ → Lₙ₊₁` overlap set) cannot be narrowed here without risking an
+/// invalid partial merge, so it returns `None` (the chosen merge is skipped and
+/// left to the opt-in tight-space mode). The pair must be adjacent IN THE RUN —
+/// a gap would make the merge stream pull the in-between tables too, breaking the
+/// size bound.
+fn narrow_merge_to_budget(
+    version: &Version,
+    payload: &CompactionPayload,
+    budget: u64,
+) -> Option<CompactionPayload> {
+    // The single run that holds every payload table (if any).
+    let run = version
+        .iter_levels()
+        .flat_map(|level| level.iter())
+        .find(|run| {
+            payload
+                .table_ids
+                .iter()
+                .all(|id| run.iter().any(|t| t.id() == *id))
+        })?;
+
+    let run_tables: Vec<&Table> = run.iter().collect();
+    let mut best: Option<(u64, [TableId; 2])> = None;
+    for pair in run_tables.windows(2) {
+        let [a, b] = pair else { continue };
+        if !payload.table_ids.contains(&a.id()) || !payload.table_ids.contains(&b.id()) {
+            continue;
+        }
+        let combined = a.file_size().saturating_add(b.file_size());
+        if combined > budget {
+            continue;
+        }
+        if best.is_none_or(|(best_size, _)| combined < best_size) {
+            best = Some((combined, [a.id(), b.id()]));
+        }
+    }
+
+    let (_, ids) = best?;
+    Some(CompactionPayload {
+        table_ids: ids.into_iter().collect(),
+        dest_level: payload.dest_level,
+        canonical_level: payload.canonical_level,
+        target_size: payload.target_size,
+    })
 }
 
 fn pick_run_indexes(run: &Run<Table>, to_compact: &[TableId]) -> Option<(usize, usize)> {
@@ -1453,7 +1595,7 @@ fn drop_tables(
 mod tests {
     use super::{create_compaction_stream, pick_run_indexes};
     use crate::{
-        AbstractTree, Config, KvSeparationOptions, SequenceNumberCounter, TableId,
+        AbstractTree, Config, KvSeparationOptions, SequenceNumberCounter, Table, TableId,
         compaction::{Choice, CompactionStrategy, Input, state::CompactionState},
         config::BlockSizePolicy,
         version::Version,
@@ -2056,6 +2198,79 @@ mod tests {
                 **tree.current_version().gc_stats(),
             );
         }
+
+        Ok(())
+    }
+
+    #[expect(
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test asserts over known-good fixtures; failure surfaces via panic"
+    )]
+    #[test]
+    fn narrow_merge_picks_smallest_fitting_run_adjacent_pair() -> crate::Result<()> {
+        // Build a single bottom-level run of several tables (small target size
+        // forces table rotation), then narrow a whole-run merge to a budget that
+        // fits only one adjacent pair.
+        let dir = tempfile::tempdir()?;
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_size_policy(BlockSizePolicy::all(512))
+        .open()?;
+        for i in 0..3_000u64 {
+            tree.insert(format!("k{i:08}"), "v".repeat(40), i);
+        }
+        tree.flush_active_memtable(0)?;
+        // Small target size → the major compaction emits a run of several tables.
+        tree.major_compact(16 * 1024, 0)?;
+
+        let version = tree.current_version();
+        let run = version
+            .iter_levels()
+            .flat_map(|level| level.iter())
+            .find(|run| run.len() >= 3)
+            .expect("a bottom-level run with >= 3 tables");
+        let ordered: Vec<(TableId, u64)> = run.iter().map(|t| (t.id(), t.file_size())).collect();
+
+        let payload = Input {
+            table_ids: ordered.iter().map(|(id, _)| *id).collect(),
+            dest_level: 6,
+            canonical_level: 6,
+            target_size: 64 * 1024 * 1024,
+        };
+
+        // Smallest combined size over run-adjacent pairs.
+        let smallest_pair = ordered
+            .windows(2)
+            .map(|w| w[0].1 + w[1].1)
+            .min()
+            .expect(">= 2 tables");
+
+        // A budget at that size narrows to exactly that pair (2 tables, Σ == budget).
+        let narrowed = super::narrow_merge_to_budget(&version, &payload, smallest_pair)
+            .expect("smallest pair fits the budget");
+        assert_eq!(narrowed.table_ids.len(), 2, "narrowed to an adjacent pair");
+        let narrowed_sum: u64 = narrowed
+            .table_ids
+            .iter()
+            .filter_map(|id| version.get_table(*id))
+            .map(Table::file_size)
+            .sum();
+        assert_eq!(
+            narrowed_sum, smallest_pair,
+            "narrowed pair is the smallest-Σ adjacent pair"
+        );
+
+        // A budget below the smallest single table fits nothing → None.
+        let smallest_table = ordered.iter().map(|(_, s)| *s).min().expect("non-empty");
+        assert!(
+            super::narrow_merge_to_budget(&version, &payload, smallest_table.saturating_sub(1))
+                .is_none(),
+            "no pair fits a sub-single-table budget"
+        );
 
         Ok(())
     }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -234,51 +234,114 @@ enum SpaceGate {
     Skip,
 }
 
-/// Decides whether a chosen merge fits the available disk space, narrowing it to
-/// a minimal reclaiming subset when it does not.
+/// Decides whether a chosen merge fits the available space, narrowing it to a
+/// minimal reclaiming subset when it does not.
 ///
-/// Bound: a merge's transient extra need is at most `Σ input file_size` (the
-/// output never exceeds the inputs). Budget: the minimum free space across every
-/// volume the tree writes to ([`Config::min_available_space`]).
+/// The merge writes two kinds of output to two (possibly different) volumes:
+/// the merged SSTs land in the destination level's volume, and a KV-separated
+/// tree may relocate stale blob files into the blobs folder (the primary
+/// volume). Each output is checked against the free space of the volume it lands
+/// on (the tightest, per-level-routed volume — not a global minimum, so a full
+/// cold-tier route never stalls a hot-level merge), and the total new bytes are
+/// also checked against the configured quota headroom (`storage_limit_bytes`),
+/// so compaction cannot grow the tree past the operator's budget.
 ///
-/// - Admission off, or a backend that cannot report free space → [`SpaceGate::Run`]
-///   (no disk-pressure signal; behaviour identical to a build without the gate).
-/// - `Σinputs + reserve ≤ free` → run (ample room, leaves the flush/metadata floor).
-/// - `Σinputs ≤ free` → run anyway, consuming the emergency reserve: a
-///   space-reclaiming merge must be able to run even at the limit, which is what
-///   breaks the no-space-to-free-space deadlock.
-/// - `Σinputs > free` → narrow to the smallest run-adjacent table pair that fits;
-///   if none fits, skip.
+/// The SST bound is `Σ input file_size`; the blob bound is the on-disk size of
+/// the blob files selected for relocation. This is a best-effort estimate: a
+/// merge operator / compaction filter that *grows* values can still write more
+/// than the inputs, so a mid-merge `ENOSPC` remains possible — that case is
+/// handled by the atomic-commit guarantee (orphan output, intact inputs,
+/// unchanged manifest, retried later), not by this gate. The gate's job is to
+/// keep the common doomed merge from starting.
+///
+/// - Admission off, or no volume can report free space and no quota → [`SpaceGate::Run`].
+/// - SST output fits its volume (leaving the reserved flush floor when ample, or
+///   consuming the emergency reserve to break the deadlock), blob output fits the
+///   blobs volume, and the total fits the quota → [`SpaceGate::Run`].
+/// - Otherwise, a pure-SST merge is narrowed to the smallest run-adjacent pair
+///   that fits; a blob-relocating merge that does not fit is skipped (narrowing
+///   does not shrink blob output).
 fn space_gate_for_merge(
     version: &Version,
     opts: &Options,
     payload: &CompactionPayload,
 ) -> SpaceGate {
-    if !opts.runtime_config.load_full().storage_admission_check {
+    let rc = opts.runtime_config.load_full();
+    if !rc.storage_admission_check {
         return SpaceGate::Run;
     }
 
-    let free = opts.config.min_available_space();
-    if free == u64::MAX {
-        // Backend cannot report free space → never fabricate disk pressure.
-        return SpaceGate::Run;
-    }
+    // SST output lands in the destination level's volume (tiered routing aware).
+    let (sst_path, sst_fs) = opts.config.tables_folder_for_level(payload.dest_level);
+    let sst_free = sst_fs.available_space(&sst_path).unwrap_or(u64::MAX);
 
-    let sigma: u64 = payload
+    // SST input bound (output never exceeds the inputs for a pure compaction).
+    // Plain sum: on-disk file sizes are bounded by the filesystem capacity.
+    let sst_sigma: u64 = payload
         .table_ids
         .iter()
         .filter_map(|&id| version.get_table(id))
         .map(Table::file_size)
-        .fold(0u64, u64::saturating_add);
+        .sum();
 
-    if sigma.saturating_add(crate::tree::MIN_RESERVED_HEADROOM) <= free || sigma <= free {
+    // A KV-separated tree may relocate stale blob files into the primary blobs
+    // folder; those bytes are not part of the SST sizes and land on a different
+    // volume.
+    let (blob_sigma, blob_free) = match &opts.config.kv_separation_opts {
+        Some(blob_opts) => {
+            let bytes: u64 = pick_blob_files_to_rewrite(&payload.table_ids, version, blob_opts)
+                .unwrap_or_default()
+                .iter()
+                .map(BlobFile::on_disk_bytes)
+                .sum();
+            let folder = opts.config.path.join(BLOBS_FOLDER);
+            (
+                bytes,
+                opts.config.fs.available_space(&folder).unwrap_or(u64::MAX),
+            )
+        }
+        None => (0, u64::MAX),
+    };
+
+    // Quota headroom (tree-wide) bounds the total new bytes on top of the live
+    // footprint. `max(0, limit - used)`: an operator quota set below the live
+    // footprint leaves zero headroom — the clamp-to-zero is the intended
+    // semantics (saturating_sub is the genuine min-clamp here, not masking).
+    let quota_headroom = match rc.storage_limit_bytes {
+        Some(limit) => {
+            let used = crate::storage_stats::compute_used_bytes(version).unwrap_or(0);
+            limit.saturating_sub(used)
+        }
+        None => u64::MAX,
+    };
+
+    // Nothing constrains the merge (no probe, no quota) → run.
+    if sst_free == u64::MAX && blob_free == u64::MAX && quota_headroom == u64::MAX {
         return SpaceGate::Run;
     }
 
-    match narrow_merge_to_budget(version, payload, free) {
-        Some(narrowed) => SpaceGate::Narrowed(narrowed),
-        None => SpaceGate::Skip,
+    const RESERVE: u64 = crate::tree::MIN_RESERVED_HEADROOM;
+    // SST output must fit its volume: leaving the reserved flush floor when
+    // ample, or consuming the emergency reserve (raw free) to break the
+    // no-space-to-free-space deadlock. `>= RESERVE` guards the subtraction.
+    let sst_fits =
+        (sst_free >= RESERVE && sst_sigma <= sst_free - RESERVE) || sst_sigma <= sst_free;
+    let blob_fits = blob_sigma <= blob_free;
+    let quota_fits = sst_sigma + blob_sigma <= quota_headroom;
+
+    if sst_fits && blob_fits && quota_fits {
+        return SpaceGate::Run;
     }
+
+    // Narrowing only shrinks the SST input set, so it can rescue an SST-bound
+    // merge but not a blob-relocating one whose blob output is the constraint.
+    if blob_sigma == 0 {
+        let budget = sst_free.min(quota_headroom);
+        if let Some(narrowed) = narrow_merge_to_budget(version, payload, budget) {
+            return SpaceGate::Narrowed(narrowed);
+        }
+    }
+    SpaceGate::Skip
 }
 
 /// Narrows a too-large merge to the smallest run-adjacent table pair whose
@@ -315,7 +378,9 @@ fn narrow_merge_to_budget(
         if !payload.table_ids.contains(&a.id()) || !payload.table_ids.contains(&b.id()) {
             continue;
         }
-        let combined = a.file_size().saturating_add(b.file_size());
+        // Two on-disk file sizes; the sum is bounded by filesystem capacity and
+        // cannot overflow u64.
+        let combined = a.file_size() + b.file_size();
         if combined > budget {
             continue;
         }
@@ -717,7 +782,8 @@ fn run_subcompaction(
     for (idx, item) in merge_iter.enumerate() {
         let item = item?;
 
-        let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
+        // One key + value length; the sum is far below u64::MAX → plain add.
+        let io_bytes = item.key.user_key.len() as u64 + item.value.len() as u64;
         if opts
             .rate_limiter
             .request_interruptible(io_bytes, || opts.stop_signal.is_stopped())
@@ -1377,7 +1443,8 @@ fn merge_tables(
             // payload of KV-separated compactions is debited separately at
             // its write site in `RelocatingCompaction::write`, where the
             // real moved bytes are known.
-            let io_bytes = (item.key.user_key.len() as u64).saturating_add(item.value.len() as u64);
+            // One key + value length; the sum is far below u64::MAX → plain add.
+            let io_bytes = item.key.user_key.len() as u64 + item.value.len() as u64;
             if opts
                 .rate_limiter
                 .request_interruptible(io_bytes, || opts.stop_signal.is_stopped())
@@ -2264,11 +2331,11 @@ mod tests {
             "narrowed pair is the smallest-Σ adjacent pair"
         );
 
-        // A budget below the smallest single table fits nothing → None.
+        // A budget below the smallest single table fits nothing → None. An SST
+        // file is always larger than a byte, so `- 1` cannot underflow.
         let smallest_table = ordered.iter().map(|(_, s)| *s).min().expect("non-empty");
         assert!(
-            super::narrow_merge_to_budget(&version, &payload, smallest_table.saturating_sub(1))
-                .is_none(),
+            super::narrow_merge_to_budget(&version, &payload, smallest_table - 1).is_none(),
             "no pair fits a sub-single-table budget"
         );
 

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -2493,19 +2493,20 @@ mod tests {
         // mount. The SST and blob budgets must combine, so 60 + 60 = 120 MiB > 100
         // MiB free is rejected even though each fits alone — the routed
         // over-admission guard.
-        let shared = MemFs::with_capacity(100 * MIB);
+        // ONE `Arc<MemFs>` reused for both config slots so the primary and the
+        // route are unambiguously the same backend (one volume id / one
+        // free-space pool), the not-proven-independent case.
+        let shared: Arc<dyn crate::fs::Fs> = Arc::new(MemFs::with_capacity(100 * MIB));
         let routed_same_mount = Config::new(
             &dir,
             SequenceNumberCounter::default(),
             SequenceNumberCounter::default(),
         )
-        .with_shared_fs(Arc::new(shared.clone()))
+        .with_shared_fs(Arc::clone(&shared))
         .level_routes(vec![crate::config::LevelRoute {
             levels: 6..7,
             path: crate::path::PathBuf::from("/same-mount-subdir"),
-            // Same backend instance as the primary → same volume id (one shared
-            // free-space pool), the not-proven-independent case.
-            fs: Arc::new(shared),
+            fs: Arc::clone(&shared),
         }]);
         assert!(
             !super::space_fits_two_layer(&routed_same_mount, u64::MAX, 60 * MIB, 6, 60 * MIB),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1054,6 +1054,26 @@ impl Config {
         (self.path.join(TABLES_FOLDER), self.fs.clone())
     }
 
+    /// Best-effort minimum free space (bytes) across every filesystem this tree
+    /// writes to: the primary [`path`](Self::path) plus each
+    /// [`level_routes`](Self::level_routes) volume.
+    ///
+    /// The tightest volume bounds storage admission and compaction space gating,
+    /// since a full routed (cold-tier) volume fails a flush / compaction
+    /// targeting it even while the primary still has room. A backend that cannot
+    /// report free space (or an I/O hiccup) contributes `u64::MAX`, so a probe
+    /// failure never fabricates disk pressure.
+    #[must_use]
+    pub(crate) fn min_available_space(&self) -> u64 {
+        let mut free = self.fs.available_space(&self.path).unwrap_or(u64::MAX);
+        if let Some(routes) = &self.level_routes {
+            for route in routes {
+                free = free.min(route.fs.available_space(&route.path).unwrap_or(u64::MAX));
+            }
+        }
+        free
+    }
+
     /// Returns all unique tables folders that need to be scanned during
     /// recovery: the primary folder plus every [`LevelRoute`] folder.
     #[must_use]

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -246,6 +246,12 @@ impl Fs for IoUringFs {
         // two backends.
         super::StdFs.backend_id()
     }
+
+    fn volume_id(&self, path: &Path) -> Option<u64> {
+        // Same kernel mount as `StdFs` — free space is a property of the mount,
+        // not the I/O submission path.
+        super::StdFs.volume_id(path)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1321,6 +1327,25 @@ mod tests {
             free < u64::MAX,
             "a real probe must not return the unbounded sentinel"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn volume_id_matches_the_kernel_mount() -> io::Result<()> {
+        // Free space is a property of the mount, not the I/O submission path, so
+        // the uring backend reports the same volume id as `StdFs` for a path —
+        // letting the space gate treat a uring data dir and a `StdFs` blob dir on
+        // the same mount as one free-space pool.
+        let Some(fs) = try_io_uring() else {
+            return Ok(());
+        };
+        let dir = tempfile::tempdir()?;
+        assert_eq!(
+            fs.volume_id(dir.path()),
+            crate::fs::StdFs.volume_id(dir.path()),
+            "uring and std agree on the mount backing a path"
+        );
+        assert!(fs.volume_id(dir.path()).is_some(), "a real mount has an id");
         Ok(())
     }
 }

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -832,6 +832,14 @@ impl Fs for MemFs {
         Some(self.namespace_id)
     }
 
+    fn volume_id(&self, _path: &Path) -> Option<u64> {
+        // One `MemFs` instance is one simulated disk with a single capacity /
+        // free-space pool (shared across clones via the same `state` Arc), so the
+        // per-instance namespace ID also identifies the volume. Independently
+        // constructed instances are independent volumes.
+        Some(self.namespace_id)
+    }
+
     /// In-memory backend: no filesystem-level guarantees on any path.
     /// Explicitly returns the all-`false` default so the "no integrity / no
     /// `CoW` / no reflink" stance is intentional rather than inherited by

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -753,6 +753,33 @@ pub trait Fs: Send + Sync + 'static {
         None
     }
 
+    /// Identifies the **physical volume** (free-space pool) backing `path`.
+    ///
+    /// Distinct from [`backend_id`](Self::backend_id), which identifies the path
+    /// *namespace* (inode table) and is therefore the SAME for every `StdFs`
+    /// path on a host even across different mounts. This instead identifies the
+    /// *mount / device* `path` lives on (Unix `st_dev`), so two paths can be
+    /// compared for sharing one free-space pool.
+    ///
+    /// The storage-admission gate uses it to decide whether a routed SST
+    /// destination and the blob folder land on independent volumes (budget each
+    /// separately) or the same filesystem (budget their combined transient peak,
+    /// or it can `ENOSPC`). `level_routes` maps levels to paths but does NOT
+    /// prove a separate mount.
+    ///
+    /// Two paths with the same `Some(id)` share a volume; two with different
+    /// `Some(id)` are provably independent. `None` means the backend cannot
+    /// prove independence — callers MUST conservatively assume the paths share a
+    /// volume (combine budgets), even when both sides return `None`.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns `None` (independence unknown → callers combine).
+    fn volume_id(&self, path: &Path) -> Option<u64> {
+        let _ = path;
+        None
+    }
+
     /// Reports the [`FsCapabilities`] of the filesystem backing `path`.
     ///
     /// Capabilities are a property of the *mount* `path` lives on, not of the
@@ -944,6 +971,17 @@ pub(crate) fn statvfs_available_space(path: &Path) -> std::io::Result<u64> {
     let frsize = st.f_frsize as u64;
     let bavail = st.f_bavail as u64;
     Ok(bavail.saturating_mul(frsize))
+}
+
+/// The device id (`st_dev`) of the mount backing `path`, the
+/// [`Fs::volume_id`] basis for the std and `io_uring` (libc) backends. Two
+/// paths on the same mount share `st_dev` (one free-space pool); different
+/// mounts have different `st_dev`. `None` if `path` cannot be stat-ed (e.g. it
+/// does not exist yet) — independence is then unproven and callers combine.
+#[cfg(all(unix, feature = "std"))]
+pub(crate) fn unix_volume_id(path: &Path) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata(path).ok().map(|m| m.dev())
 }
 
 /// Streamed independent copy of `src` to `dst` through `fs`'s own [`Fs::open`].

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -322,6 +322,11 @@ impl Fs for StdFs {
         Some(KERNEL_BACKEND_ID)
     }
 
+    #[cfg(unix)]
+    fn volume_id(&self, path: &Path) -> Option<u64> {
+        super::unix_volume_id(path)
+    }
+
     fn hard_link_count(&self, path: &Path) -> io::Result<u64> {
         #[cfg(unix)]
         {
@@ -1273,6 +1278,30 @@ mod tests {
         file.read_to_string(&mut buf)?;
         assert_eq!(buf, "hello world");
 
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn std_fs_volume_id_is_shared_within_a_mount_and_none_for_missing_path() -> io::Result<()> {
+        // `volume_id` is the `st_dev` of the mount: two directories under one
+        // tempdir share it (one free-space pool), so the space gate combines
+        // their budgets. A path that cannot be stat-ed yields `None`
+        // (independence unproven → callers combine conservatively).
+        let dir = tempfile::tempdir()?;
+        let fs = StdFs;
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        fs.create_dir_all(&a)?;
+        fs.create_dir_all(&b)?;
+        let id_a = fs.volume_id(&a);
+        assert!(id_a.is_some(), "a real path reports its device id");
+        assert_eq!(id_a, fs.volume_id(&b), "same mount → same volume id");
+        assert_eq!(
+            fs.volume_id(&dir.path().join("does-not-exist")),
+            None,
+            "an un-stat-able path is unproven, not falsely independent"
+        );
         Ok(())
     }
 

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -153,6 +153,23 @@ pub(crate) fn compute_used_bytes(version: &Version) -> crate::Result<u64> {
     Ok(used_bytes)
 }
 
+/// The largest level's index and on-disk size: the destination level and the
+/// transient-output bound a full compaction's space check uses.
+///
+/// A full compaction's largest single merge is bounded by the largest level's
+/// on-disk size (the `full_compaction_bytes` gauge figure), and its output lands
+/// in that level's own volume — which matters for the per-volume physical check
+/// when tiered routing places levels on different filesystems. Returns `(0, 0)`
+/// for an empty tree.
+pub(crate) fn largest_level_for_compaction(version: &Version) -> (u8, u64) {
+    version
+        .iter_levels()
+        .enumerate()
+        .map(|(idx, level)| (u8::try_from(idx).unwrap_or(u8::MAX), level.size()))
+        .max_by_key(|(_, size)| *size)
+        .unwrap_or((0, 0))
+}
+
 /// Computes [`StorageStats`] from a live version's table + blob-file metadata.
 ///
 /// `is_compacting` selects [`StorageStatus::CompactionInProgress`] vs

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -254,11 +254,7 @@ pub(crate) fn compute_storage_stats(
     // A full compaction's transient output is bounded by its input set; the
     // largest single merge is bounded by the largest level's on-disk size, so
     // that is the free space a full compaction needs.
-    let full_compaction_bytes = version
-        .iter_levels()
-        .map(crate::version::Level::size)
-        .max()
-        .unwrap_or(0);
+    let full_compaction_bytes = full_compaction_demand_bytes(version);
     // A minimal (tight) space-reclaiming merge needs only the reserved working
     // floor to make forward progress.
     let tight_compaction_bytes = crate::tree::MIN_RESERVED_HEADROOM;

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -153,21 +153,21 @@ pub(crate) fn compute_used_bytes(version: &Version) -> crate::Result<u64> {
     Ok(used_bytes)
 }
 
-/// The largest level's index and on-disk size: the destination level and the
-/// transient-output bound a full compaction's space check uses.
+/// The transient-output bound a full compaction's space check uses: the largest
+/// level's on-disk size (the `full_compaction_bytes` gauge figure), an upper
+/// bound on a single merge's input set. `0` for an empty tree.
 ///
-/// A full compaction's largest single merge is bounded by the largest level's
-/// on-disk size (the `full_compaction_bytes` gauge figure), and its output lands
-/// in that level's own volume — which matters for the per-volume physical check
-/// when tiered routing places levels on different filesystems. Returns `(0, 0)`
-/// for an empty tree.
-pub(crate) fn largest_level_for_compaction(version: &Version) -> (u8, u64) {
+/// This is the DEMAND. The destination VOLUME is a separate concern: a full
+/// compaction writes its output to the last configured level
+/// (`level_count - 1`), not to whichever level is currently largest, so callers
+/// pass the last level as the destination to the per-volume space check (the two
+/// differ only under tiered routing, where they can be different filesystems).
+pub(crate) fn full_compaction_demand_bytes(version: &Version) -> u64 {
     version
         .iter_levels()
-        .enumerate()
-        .map(|(idx, level)| (u8::try_from(idx).unwrap_or(u8::MAX), level.size()))
-        .max_by_key(|(_, size)| *size)
-        .unwrap_or((0, 0))
+        .map(crate::version::Level::size)
+        .max()
+        .unwrap_or(0)
 }
 
 /// Computes [`StorageStats`] from a live version's table + blob-file metadata.

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -65,10 +65,23 @@ pub struct StorageStats {
 
     /// Whether a compaction can still run given the remaining free space (it
     /// needs working room to write merged output). `true` when unbounded or
-    /// when at least the reserved compaction-working floor remains; `false`
-    /// when the disk is too full for a compaction to make progress. The finer
-    /// full-vs-tight distinction is carried by [`Self::status`].
+    /// when at least [`Self::tight_compaction_bytes`] of free space remains;
+    /// `false` when the disk is too full for a compaction to make progress. The
+    /// finer full-vs-tight distinction is carried by [`Self::status`].
     pub compaction_possible: bool,
+
+    /// Estimated free space (bytes) a FULL compaction needs for its transient
+    /// output while the inputs still exist: the largest level's on-disk size
+    /// (an upper bound on a single merge's input set). A full compaction has
+    /// room when [`Self::available_bytes`] `>=` this. Pair with `used_bytes` /
+    /// `capacity_bytes` to draw a capacity gauge: `used` → `used + tight_compaction_bytes`
+    /// → `used + full_compaction_bytes` → `capacity`.
+    pub full_compaction_bytes: u64,
+
+    /// Estimated free space (bytes) a minimal (tight) space-reclaiming
+    /// compaction needs to make forward progress: the reserved working floor.
+    /// Tight compaction has room when [`Self::available_bytes`] `>=` this.
+    pub tight_compaction_bytes: u64,
 
     /// Number of live entries (all versions) across all live SSTs.
     pub item_count: u64,
@@ -128,12 +141,14 @@ impl StorageStats {
 ///
 /// Returns an error if a live table or blob file's size cannot be stat-ed.
 pub(crate) fn compute_used_bytes(version: &Version) -> crate::Result<u64> {
+    // Sum of on-disk file sizes, bounded by the filesystem capacity → cannot
+    // overflow u64; plain arithmetic.
     let mut used_bytes = 0u64;
     for table in version.iter_tables() {
-        used_bytes = used_bytes.saturating_add(table.fs.metadata(&table.path)?.len);
+        used_bytes += table.fs.metadata(&table.path)?.len;
     }
     for blob in version.blob_files.iter() {
-        used_bytes = used_bytes.saturating_add(blob.0.fs.metadata(&blob.0.path)?.len);
+        used_bytes += blob.0.fs.metadata(&blob.0.path)?.len;
     }
     Ok(used_bytes)
 }
@@ -176,18 +191,22 @@ pub(crate) fn compute_storage_stats(
     // sums; a single legacy table without them makes the average unrepresentable.
     let mut all_have_shape = true;
 
+    // Every running total below is a sum of on-disk byte sizes or live item
+    // counts; both are bounded by the filesystem capacity / the live entry count
+    // and cannot overflow u64, so plain arithmetic is correct (a debug-overflow
+    // would itself signal a corrupt metadata read).
     for table in version.iter_tables() {
         let m = &table.metadata;
         // Physical file size, NOT m.file_size (which undercounts — see above).
         let on_disk = table.fs.metadata(&table.path)?.len;
-        used_bytes = used_bytes.saturating_add(on_disk);
-        item_count = item_count.saturating_add(m.item_count);
+        used_bytes += on_disk;
+        item_count += m.item_count;
         table_count += 1;
-        reclaimable_entries = reclaimable_entries.saturating_add(m.weak_tombstone_reclaimable);
+        reclaimable_entries += m.weak_tombstone_reclaimable;
         match (m.sum_user_key_bytes, m.sum_value_bytes) {
             (Some(k), Some(v)) => {
-                sum_key = sum_key.saturating_add(k);
-                sum_value = sum_value.saturating_add(v);
+                sum_key += k;
+                sum_value += v;
             }
             _ => all_have_shape = false,
         }
@@ -196,7 +215,7 @@ pub(crate) fn compute_storage_stats(
     // Physical blob-file size (metadata + trailer included), NOT
     // BlobFileList::on_disk_size() which sums only the compressed payload.
     for blob in version.blob_files.iter() {
-        used_bytes = used_bytes.saturating_add(blob.0.fs.metadata(&blob.0.path)?.len);
+        used_bytes += blob.0.fs.metadata(&blob.0.path)?.len;
     }
 
     let avg_entry_on_disk_bytes = if item_count == 0 {
@@ -211,7 +230,21 @@ pub(crate) fn compute_storage_stats(
     let avg_value_bytes =
         (have_shape && value_bytes_are_user_values).then(|| sum_value / item_count);
 
-    let reclaimable_bytes_estimate = reclaimable_entries.saturating_mul(avg_entry_on_disk_bytes);
+    // reclaimable_entries ≤ item_count and avg_entry_on_disk_bytes = used / item_count,
+    // so the product is ≤ used_bytes (bounded by disk capacity): plain multiply.
+    let reclaimable_bytes_estimate = reclaimable_entries * avg_entry_on_disk_bytes;
+
+    // A full compaction's transient output is bounded by its input set; the
+    // largest single merge is bounded by the largest level's on-disk size, so
+    // that is the free space a full compaction needs.
+    let full_compaction_bytes = version
+        .iter_levels()
+        .map(crate::version::Level::size)
+        .max()
+        .unwrap_or(0);
+    // A minimal (tight) space-reclaiming merge needs only the reserved working
+    // floor to make forward progress.
+    let tight_compaction_bytes = crate::tree::MIN_RESERVED_HEADROOM;
 
     let status = if is_compacting {
         StorageStatus::CompactionInProgress
@@ -227,6 +260,8 @@ pub(crate) fn compute_storage_stats(
         capacity_bytes: None,
         available_bytes: None,
         compaction_possible: true,
+        full_compaction_bytes,
+        tight_compaction_bytes,
         item_count,
         table_count,
         avg_entry_on_disk_bytes,
@@ -247,6 +282,8 @@ mod tests {
             capacity_bytes: None,
             available_bytes: None,
             compaction_possible: true,
+            full_compaction_bytes: 0,
+            tight_compaction_bytes: 0,
             item_count: 0,
             table_count: 0,
             avg_entry_on_disk_bytes,

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -13,10 +13,14 @@ use crate::version::Version;
 
 /// Coarse storage state of a tree.
 ///
-/// This release reports [`Self::Healthy`] and [`Self::CompactionInProgress`].
-/// The capacity-dependent variants are populated once storage admission control
-/// (a configured byte quota / disk-free probe) lands; they are defined now so
-/// the enum stays stable across that work.
+/// With storage admission gating off (no configured quota and a backend that
+/// cannot report free space) a tree reports [`Self::Healthy`] or, mid-run,
+/// [`Self::CompactionInProgress`]. Once gating is active (bounded capacity), an
+/// idle tree instead reports compaction availability:
+/// [`Self::FullCompactionAvailable`] when a full compaction has working room,
+/// [`Self::TightCompactionAvailable`] when only the opt-in tight-space mode
+/// would fit, and [`Self::ReadOnlyOutOfSpace`] when the write gate is closed
+/// (this takes precedence over a concurrent compaction).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[non_exhaustive]
 pub enum StorageStatus {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -45,7 +45,7 @@ use crate::metrics::Metrics;
 /// [`Tree::compute_write_admission`]). Even with an empty active memtable the
 /// gate keeps at least this much room below the budget so the next writes and a
 /// space-reclaiming compaction have somewhere to land. 1 MiB.
-const MIN_RESERVED_HEADROOM: u64 = 1024 * 1024;
+pub const MIN_RESERVED_HEADROOM: u64 = 1024 * 1024;
 
 /// How long a cached disk-free sample stays valid before the admission gate
 /// re-probes. Bounds how stale the physical free-space figure can be when the
@@ -333,9 +333,24 @@ impl AbstractTree for Tree {
         stats.capacity_bytes = capacity;
         stats.available_bytes = available;
         stats.compaction_possible = compaction_possible;
+        // When admission gating is active and a compaction is not already
+        // running, surface whether a full compaction has working room: the same
+        // band the compaction space gate enforces. With gating off the gate
+        // never runs, so the status stays `Healthy` even though the backend can
+        // report a finite capacity.
+        if self.storage_admission_enabled()
+            && capacity.is_some()
+            && stats.status == crate::StorageStatus::Healthy
+        {
+            stats.status = if compaction_possible {
+                crate::StorageStatus::FullCompactionAvailable
+            } else {
+                crate::StorageStatus::TightCompactionAvailable
+            };
+        }
         // A closed admission gate is the operator-actionable state, so it takes
-        // precedence over CompactionInProgress (a read-only tree may well be
-        // compacting to reclaim space).
+        // precedence over the others (a read-only tree may well be compacting to
+        // reclaim space).
         if self.is_read_only() {
             stats.status = crate::StorageStatus::ReadOnlyOutOfSpace;
         }
@@ -2312,18 +2327,7 @@ impl Tree {
     /// `u64::MAX` = "no disk pressure", so a probe failure never falsely drives
     /// the tree read-only.
     fn probe_disk_free(&self) -> u64 {
-        let mut free = self
-            .0
-            .config
-            .fs
-            .available_space(&self.0.config.path)
-            .unwrap_or(u64::MAX);
-        if let Some(routes) = &self.0.config.level_routes {
-            for route in routes {
-                free = free.min(route.fs.available_space(&route.path).unwrap_or(u64::MAX));
-            }
-        }
-        free
+        self.0.config.min_available_space()
     }
 
     /// Disk-aware capacity figures for [`AbstractTree::storage_stats`], given the
@@ -2336,6 +2340,14 @@ impl Tree {
     /// `None` capacity/available means unbounded (no quota AND the backend
     /// cannot report free space). `compaction_possible` is `true` when unbounded
     /// or when at least [`MIN_RESERVED_HEADROOM`] of working room remains.
+    /// Whether the opt-in storage admission gate is active (a near-full disk or
+    /// configured quota can drive the tree read-only and gate compaction space).
+    /// Capacity introspection figures are reported regardless; this only governs
+    /// whether the gate actually enforces.
+    pub(crate) fn storage_admission_enabled(&self) -> bool {
+        self.0.runtime_config.load().storage_admission_check
+    }
+
     pub(crate) fn admission_capacity(&self, used: u64) -> (Option<u64>, Option<u64>, bool) {
         let quota = self
             .0

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -346,13 +346,16 @@ impl AbstractTree for Tree {
             && stats.status == crate::StorageStatus::Healthy
         {
             // A full compaction's transient output is bounded by the largest
-            // level's on-disk size, landing in that level's own volume. A
-            // standard tree has no blob relocation. Using the per-volume gate
-            // (not `available >= full_compaction_bytes` against the min-volume
-            // free) keeps the status from reporting tight when a routed merge
-            // would actually be admitted.
-            let (sst_dest_level, sst_need) =
-                crate::storage_stats::largest_level_for_compaction(&version);
+            // level's on-disk size, but it LANDS in the last configured level's
+            // volume (`level_count - 1`), which under tiered routing can be a
+            // different filesystem than the largest level. A standard tree has no
+            // blob relocation. Using the per-volume gate (not `available >=
+            // full_compaction_bytes` against the min-volume free) keeps the status
+            // from reporting tight when a routed merge would actually be admitted.
+            let sst_need = crate::storage_stats::full_compaction_demand_bytes(&version);
+            // `saturating_sub`: `level_count >= 1` always, so this is the last
+            // level index; the clamp only guards a degenerate zero-level config.
+            let sst_dest_level = self.0.config.level_count.saturating_sub(1);
             let quota_headroom = self.quota_headroom(stats.used_bytes);
             let full_fits = crate::compaction::worker::space_fits_two_layer(
                 &self.0.config,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -342,7 +342,11 @@ impl AbstractTree for Tree {
             && capacity.is_some()
             && stats.status == crate::StorageStatus::Healthy
         {
-            stats.status = if compaction_possible {
+            // Full when the free room covers a full compaction's transient
+            // output, tight otherwise — the same thresholds the gauge figures
+            // expose, so the reported status matches the compaction space gate.
+            let available = available.unwrap_or(0);
+            stats.status = if available >= stats.full_compaction_bytes {
                 crate::StorageStatus::FullCompactionAvailable
             } else {
                 crate::StorageStatus::TightCompactionAvailable
@@ -2340,14 +2344,6 @@ impl Tree {
     /// `None` capacity/available means unbounded (no quota AND the backend
     /// cannot report free space). `compaction_possible` is `true` when unbounded
     /// or when at least [`MIN_RESERVED_HEADROOM`] of working room remains.
-    /// Whether the opt-in storage admission gate is active (a near-full disk or
-    /// configured quota can drive the tree read-only and gate compaction space).
-    /// Capacity introspection figures are reported regardless; this only governs
-    /// whether the gate actually enforces.
-    pub(crate) fn storage_admission_enabled(&self) -> bool {
-        self.0.runtime_config.load().storage_admission_check
-    }
-
     pub(crate) fn admission_capacity(&self, used: u64) -> (Option<u64>, Option<u64>, bool) {
         let quota = self
             .0
@@ -2355,16 +2351,36 @@ impl Tree {
             .load()
             .storage_limit_bytes
             .unwrap_or(u64::MAX);
-        let capacity = quota.min(self.probe_disk_free().saturating_add(used));
+        let free = self.probe_disk_free();
+        // `free == u64::MAX` is the "backend can't report free space" sentinel:
+        // adding `used` would overflow, so treat capacity as quota-only (the
+        // explicit branch avoids the overflow without masking it with saturation).
+        // Otherwise `free + used` ≤ ~2× disk capacity and cannot overflow u64.
+        let capacity = if free == u64::MAX {
+            quota
+        } else {
+            quota.min(free + used)
+        };
         if capacity == u64::MAX {
             return (None, None, true);
         }
+        // `available = max(0, capacity - used)`: an operator quota set below the
+        // live footprint makes `capacity < used`, and available space cannot be
+        // negative. The clamp-to-zero IS the intended semantics here.
         let available = capacity.saturating_sub(used);
         (
             Some(capacity),
             Some(available),
             available >= MIN_RESERVED_HEADROOM,
         )
+    }
+
+    /// Whether the opt-in storage admission gate is active (a near-full disk or
+    /// configured quota can drive the tree read-only and gate compaction space).
+    /// Capacity introspection figures are reported regardless; this only governs
+    /// whether the gate actually enforces.
+    pub(crate) fn storage_admission_enabled(&self) -> bool {
+        self.0.runtime_config.load().storage_admission_check
     }
 
     #[expect(
@@ -2458,7 +2474,15 @@ impl Tree {
         // free drives the whole tree read-only, exactly so a later flush /
         // compaction targeting that route cannot hit ENOSPC.
         let quota = rc.storage_limit_bytes.unwrap_or(u64::MAX);
-        let limit = quota.min(disk_free.saturating_add(used));
+        // `disk_free == u64::MAX` is the "backend can't report" sentinel; adding
+        // `used` would overflow, so treat the limit as quota-only (explicit
+        // branch, no saturation masking). Otherwise `disk_free + used` ≤ ~2× disk
+        // capacity and cannot overflow u64.
+        let limit = if disk_free == u64::MAX {
+            quota
+        } else {
+            quota.min(disk_free + used)
+        };
         // Both sources unbounded → nothing to gate.
         if limit == u64::MAX {
             return Ok(());
@@ -2475,22 +2499,20 @@ impl Tree {
         // any sealed (rotated) memtables awaiting flush — not just the active
         // one: after a rotation the active memtable is empty but the sealed
         // memtable's queued flush will still consume disk, so it must be
-        // reserved for.
-        // Saturating fold so the running total stays fail-closed (a hypothetical
-        // overflow clamps to u64::MAX → downstream sees over-budget), consistent
-        // with the checked/saturating arithmetic below.
-        let pending_memtable_bytes = super_version
-            .sealed_memtables
-            .iter()
-            .map(|m| m.size())
-            .fold(super_version.active_memtable.size(), u64::saturating_add);
+        // reserved for. Memtable sizes are bounded by RAM, so the sum (and the
+        // +1/8 overhead margin below) cannot overflow u64 → plain arithmetic.
+        let pending_memtable_bytes: u64 = super_version.active_memtable.size()
+            + super_version
+                .sealed_memtables
+                .iter()
+                .map(|m| m.size())
+                .sum::<u64>();
 
-        // `compute_used_bytes` saturates its file-size sums, so `used` could in
-        // principle be `u64::MAX`; keep the gate fail-closed with checked
-        // arithmetic — any overflow means "definitely over budget", so deny.
-        let reserved = pending_memtable_bytes
-            .saturating_add(pending_memtable_bytes / 8)
-            .max(MIN_RESERVED_HEADROOM);
+        let reserved =
+            (pending_memtable_bytes + pending_memtable_bytes / 8).max(MIN_RESERVED_HEADROOM);
+        // `used` (disk) + `reserved` (RAM-bounded) cannot realistically overflow,
+        // but keep the comparison fail-closed with checked arithmetic: any
+        // overflow means "definitely over budget", so deny.
         match used.checked_add(reserved) {
             Some(total) if total <= limit => Ok(()),
             _ => Err(crate::Error::StorageFull { used, limit }),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -321,12 +321,13 @@ impl AbstractTree for Tree {
     }
 
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
+        // One version snapshot reused for the footprint and the full-compaction
+        // estimate below: a second `current_version()` could race a concurrent
+        // flush / compaction and mix two snapshots.
+        let version = self.current_version();
         // Standard tree: SST values ARE user values (no KV separation).
-        let mut stats = crate::storage_stats::compute_storage_stats(
-            &self.current_version(),
-            self.is_compacting(),
-            true,
-        )?;
+        let mut stats =
+            crate::storage_stats::compute_storage_stats(&version, self.is_compacting(), true)?;
         // Fill the disk-aware capacity figures (quota + free-space probe) the
         // version-only computation can't know.
         let (capacity, available, compaction_possible) = self.admission_capacity(stats.used_bytes);
@@ -334,19 +335,33 @@ impl AbstractTree for Tree {
         stats.available_bytes = available;
         stats.compaction_possible = compaction_possible;
         // When admission gating is active and a compaction is not already
-        // running, surface whether a full compaction has working room: the same
-        // band the compaction space gate enforces. With gating off the gate
-        // never runs, so the status stays `Healthy` even though the backend can
-        // report a finite capacity.
+        // running, surface whether a full compaction has working room through the
+        // SAME two-layer check the compaction space gate enforces (logical quota +
+        // physical free per destination volume), so the reported status matches
+        // what the gate will admit. With gating off the gate never runs, so the
+        // status stays `Healthy` even though the backend can report a finite
+        // capacity.
         if self.storage_admission_enabled()
             && capacity.is_some()
             && stats.status == crate::StorageStatus::Healthy
         {
-            // Full when the free room covers a full compaction's transient
-            // output, tight otherwise — the same thresholds the gauge figures
-            // expose, so the reported status matches the compaction space gate.
-            let available = available.unwrap_or(0);
-            stats.status = if available >= stats.full_compaction_bytes {
+            // A full compaction's transient output is bounded by the largest
+            // level's on-disk size, landing in that level's own volume. A
+            // standard tree has no blob relocation. Using the per-volume gate
+            // (not `available >= full_compaction_bytes` against the min-volume
+            // free) keeps the status from reporting tight when a routed merge
+            // would actually be admitted.
+            let (sst_dest_level, sst_need) =
+                crate::storage_stats::largest_level_for_compaction(&version);
+            let quota_headroom = self.quota_headroom(stats.used_bytes);
+            let full_fits = crate::compaction::worker::space_fits_two_layer(
+                &self.0.config,
+                quota_headroom,
+                sst_need,
+                sst_dest_level,
+                0,
+            );
+            stats.status = if full_fits {
                 crate::StorageStatus::FullCompactionAvailable
             } else {
                 crate::StorageStatus::TightCompactionAvailable
@@ -2373,6 +2388,21 @@ impl Tree {
             Some(available),
             available >= MIN_RESERVED_HEADROOM,
         )
+    }
+
+    /// The logical partition-quota headroom for the two-layer space model:
+    /// `max(0, storage_limit_bytes - used)`, or `u64::MAX` when no quota is set.
+    ///
+    /// This is Layer 1 (volume-agnostic) of [`crate::compaction::worker::space_fits_two_layer`];
+    /// the physical free-space probe is Layer 2. An operator quota set below the
+    /// live footprint leaves zero headroom — the clamp-to-zero is the intended
+    /// min-semantics, not masking.
+    pub(crate) fn quota_headroom(&self, used: u64) -> u64 {
+        self.0
+            .runtime_config
+            .load()
+            .storage_limit_bytes
+            .map_or(u64::MAX, |limit| limit.saturating_sub(used))
     }
 
     /// Whether the opt-in storage admission gate is active (a near-full disk or

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -242,10 +242,19 @@ impl BlobFile {
         self.0.meta.item_count
     }
 
-    /// On-disk compressed payload size in bytes (without the metadata block /
-    /// trailer). Used to bound the transient output of a blob relocation.
-    pub(crate) fn on_disk_bytes(&self) -> u64 {
-        self.0.meta.total_compressed_bytes
+    /// Physical on-disk file size in bytes, including the per-entry framing
+    /// (V4 header + key) and the metadata block / trailer — not just the
+    /// compressed payload (`meta.total_compressed_bytes`). Used as a
+    /// conservative upper bound on the transient output of a blob relocation:
+    /// the rewritten file re-emits the same framing, so the source file's
+    /// physical size bounds the output (and includes the dead blobs a relocation
+    /// drops, making it strictly conservative).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the blob file's size cannot be stat-ed.
+    pub(crate) fn physical_size(&self) -> crate::Result<u64> {
+        Ok(self.0.fs.metadata(&self.0.path)?.len)
     }
 
     /// Returns `true` if the blob file is stale (based on the given staleness threshold).

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -242,6 +242,12 @@ impl BlobFile {
         self.0.meta.item_count
     }
 
+    /// On-disk compressed payload size in bytes (without the metadata block /
+    /// trailer). Used to bound the transient output of a blob relocation.
+    pub(crate) fn on_disk_bytes(&self) -> u64 {
+        self.0.meta.total_compressed_bytes
+    }
+
     /// Returns `true` if the blob file is stale (based on the given staleness threshold).
     pub(crate) fn is_stale(&self, frag_map: &FragmentationMap, threshold: f32) -> bool {
         frag_map.get(&self.id()).is_some_and(|x| {

--- a/tests/compaction_space_admission.rs
+++ b/tests/compaction_space_admission.rs
@@ -212,6 +212,57 @@ fn configured_quota_below_footprint_gates_a_merge_on_ample_disk() -> lsm_tree::R
 }
 
 #[test]
+fn blob_tree_full_status_accounts_for_blob_relocation_footprint() -> lsm_tree::Result<()> {
+    // Regression: a blob tree's full-compaction figure must include the physical
+    // blob-file footprint, not just the largest SST level. With incompressible
+    // blobs dominating the footprint and the index SSTs tiny, free space that
+    // clears the SST level but not the blobs must report TightCompactionAvailable
+    // (the gate would skip a full merge for lack of blob room), not Full.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_capped_blob(folder.path(), u64::MAX);
+    // ~8 MiB of incompressible blob payload so the footprint comfortably exceeds
+    // the ~1 MiB reserved floor — leaving a band where free space is above the
+    // floor (not read-only) yet below SST + blobs (not a full compaction).
+    let n = 8_000u64;
+    for i in 0..n {
+        // High-entropy value (xorshift) so blobs do not compress away.
+        let mut s = (i + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let value: Vec<u8> = (0..1024u32)
+            .map(|_| {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                (s >> 24) as u8
+            })
+            .collect();
+        tree.insert(format!("key{i:08}").as_bytes(), &value, i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let used = tree.storage_stats()?.used_bytes;
+    let index_sst = tree.index.disk_space(); // SST-only footprint (tiny: pointers)
+    let blob_portion = used - index_sst;
+    assert!(
+        blob_portion > 4 * 1024 * 1024,
+        "blobs must dominate and exceed the reserved floor (blob {blob_portion}, index {index_sst})"
+    );
+
+    // Free space (3 MiB) is above the reserved floor — so not read-only — but
+    // well below SST + blobs, so a full compaction does not fit.
+    mem.set_capacity(used + 3 * 1024 * 1024);
+    tree.index.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::TightCompactionAvailable,
+        "blob footprint must be folded into the full-compaction threshold"
+    );
+    Ok(())
+}
+
+#[test]
 fn blob_tree_compaction_space_gate_and_status() -> lsm_tree::Result<()> {
     // Drives the KV-separation branch of the gate (blob-file relocation budget)
     // and the blob-tree FullCompactionAvailable status.

--- a/tests/compaction_space_admission.rs
+++ b/tests/compaction_space_admission.rs
@@ -212,17 +212,19 @@ fn configured_quota_below_footprint_gates_a_merge_on_ample_disk() -> lsm_tree::R
 }
 
 #[test]
-fn blob_tree_full_status_accounts_for_blob_relocation_footprint() -> lsm_tree::Result<()> {
-    // Regression: a blob tree's full-compaction figure must include the physical
-    // blob-file footprint, not just the largest SST level. With incompressible
-    // blobs dominating the footprint and the index SSTs tiny, free space that
-    // clears the SST level but not the blobs must report TightCompactionAvailable
-    // (the gate would skip a full merge for lack of blob room), not Full.
+fn blob_tree_full_status_ignores_non_stale_blob_footprint() -> lsm_tree::Result<()> {
+    // Regression: the full-compaction figure must budget only the STALE blob
+    // files a merge actually relocates (`pick_blob_files_to_rewrite`), not the
+    // whole live blob footprint. With large incompressible NON-stale blobs (a
+    // single flush, no overwrites → zero dead fraction) and tiny index SSTs, a
+    // full merge relocates no blobs, so free space that clears the SST level must
+    // report FullCompactionAvailable — matching the gate, which would admit the
+    // merge — not a stricter TightCompactionAvailable from counting live blobs
+    // the merge never touches.
     let folder = get_tmp_folder();
     let (tree, mem) = open_capped_blob(folder.path(), u64::MAX);
-    // ~8 MiB of incompressible blob payload so the footprint comfortably exceeds
-    // the ~1 MiB reserved floor — leaving a band where free space is above the
-    // floor (not read-only) yet below SST + blobs (not a full compaction).
+    // ~8 MiB of incompressible blob payload so the live footprint comfortably
+    // exceeds 3 MiB — under the old all-live accounting this band reported tight.
     let n = 8_000u64;
     for i in 0..n {
         // High-entropy value (xorshift) so blobs do not compress away.
@@ -244,11 +246,12 @@ fn blob_tree_full_status_accounts_for_blob_relocation_footprint() -> lsm_tree::R
     let blob_portion = used - index_sst;
     assert!(
         blob_portion > 4 * 1024 * 1024,
-        "blobs must dominate and exceed the reserved floor (blob {blob_portion}, index {index_sst})"
+        "live blobs must dominate the footprint (blob {blob_portion}, index {index_sst})"
     );
 
-    // Free space (3 MiB) is above the reserved floor — so not read-only — but
-    // well below SST + blobs, so a full compaction does not fit.
+    // Free space (3 MiB) is well below the live blob footprint but far above the
+    // tiny index SSTs. Because the blobs are non-stale (not relocated by a merge),
+    // a full compaction's actual transient need is the SST level alone → it fits.
     mem.set_capacity(used + 3 * 1024 * 1024);
     tree.index.update_runtime_config(|c| {
         c.storage_admission_check = true;
@@ -256,8 +259,8 @@ fn blob_tree_full_status_accounts_for_blob_relocation_footprint() -> lsm_tree::R
     })?;
     assert_eq!(
         tree.storage_stats()?.status,
-        StorageStatus::TightCompactionAvailable,
-        "blob footprint must be folded into the full-compaction threshold"
+        StorageStatus::FullCompactionAvailable,
+        "non-stale blobs are not relocated, so they must not gate a full compaction"
     );
     Ok(())
 }

--- a/tests/compaction_space_admission.rs
+++ b/tests/compaction_space_admission.rs
@@ -266,6 +266,62 @@ fn blob_tree_full_status_ignores_non_stale_blob_footprint() -> lsm_tree::Result<
 }
 
 #[test]
+fn status_probes_the_last_level_route_volume_not_the_largest_footprint() -> lsm_tree::Result<()> {
+    // Regression: a full compaction writes its SST output to the LAST level
+    // (level_count - 1), so the status must probe THAT level's volume, not the
+    // largest-footprint level's. Here the bottom level is routed to a near-full
+    // cold volume while the bulk of the data (L0) sits on a roomy primary. The
+    // compaction gate would skip a full compaction for lack of cold-volume room,
+    // so the status must report TightCompactionAvailable — not Full from the
+    // primary's free space.
+    let folder = get_tmp_folder();
+    let cold_dir = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(MemFs::new())) // unbounded primary (roomy)
+    .level_routes(vec![lsm_tree::config::LevelRoute {
+        levels: 6..7,
+        path: cold_dir.path().to_path_buf(),
+        // Near-full cold tier: above the reserved floor (not read-only) but well
+        // below the full-compaction demand below.
+        fs: Arc::new(MemFs::with_capacity(2 * 1024 * 1024)),
+    }])
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected Standard tree");
+    };
+
+    // Write much more than the cold capacity into L0 (lands on the primary): the
+    // full-compaction demand (largest level = L0) far exceeds the cold volume's
+    // free space.
+    let value = vec![0xABu8; 200];
+    for i in 0..30_000u64 {
+        tree.insert(format!("key{i:08}").as_bytes(), &value, i);
+    }
+    tree.flush_active_memtable(0)?;
+    let demand = tree.storage_stats()?.full_compaction_bytes;
+    assert!(
+        demand > 2 * 1024 * 1024,
+        "L0 demand must exceed the 2 MiB cold capacity (got {demand})"
+    );
+
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::TightCompactionAvailable,
+        "status must probe the last-level (cold) route volume, not the largest-footprint primary"
+    );
+    Ok(())
+}
+
+#[test]
 fn blob_tree_compaction_space_gate_and_status() -> lsm_tree::Result<()> {
     // Drives the KV-separation branch of the gate (blob-file relocation budget)
     // and the blob-tree FullCompactionAvailable status.

--- a/tests/compaction_space_admission.rs
+++ b/tests/compaction_space_admission.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end tests for the opt-in compaction space-admission gate: a merge is
+//! skipped (or narrowed) when its transient output would not fit the free disk,
+//! `Drop` / `Move` stay unaffected, the tree stays consistent and reopenable,
+//! and `storage_stats().status` reports full-compaction availability.
+
+use lsm_tree::fs::MemFs;
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+};
+use std::sync::Arc;
+
+/// Opens a Standard tree on a `MemFs` capped at `capacity` bytes, returning both
+/// the tree and the backend clone so a test can re-cap the simulated disk.
+fn open_capped(path: &std::path::Path, capacity: u64) -> (lsm_tree::Tree, MemFs) {
+    let mem = MemFs::with_capacity(capacity);
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Standard(t) => (t, mem),
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+/// Inserts `n` keyed entries across two flushes so the tree holds several SSTs
+/// worth merging, returning the physical footprint after the second flush.
+fn seed_two_generations(tree: &lsm_tree::Tree, n: u64) -> u64 {
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), vec![0xCDu8; 64], i);
+    }
+    tree.flush_active_memtable(0).expect("flush 1");
+    // Overwrite the whole keyspace into a second SST: a later merge can drop the
+    // shadowed first-generation values, so the merge genuinely reclaims space.
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), vec![0xEFu8; 64], n + i);
+    }
+    tree.flush_active_memtable(0).expect("flush 2");
+    tree.storage_stats().expect("stats").used_bytes
+}
+
+#[test]
+fn near_full_disk_skips_a_merge_that_would_not_fit_and_stays_consistent() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    // Start unbounded so the seed writes are never gated; cap afterwards.
+    let (tree, mem) = open_capped(folder.path(), u64::MAX);
+    let n = 2_000u64;
+    let used = seed_two_generations(&tree, n);
+    let tables_before = tree.table_count();
+    assert!(
+        tables_before >= 2,
+        "two flushes must leave at least two SSTs to merge (got {tables_before})"
+    );
+
+    // Cap the simulated disk just above the live footprint: free space is far
+    // below the merge's Σ input bound, so a full major compaction cannot fit.
+    mem.set_capacity(used + 64 * 1024);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None; // only the physical free-space probe gates
+    })?;
+
+    // The gate must make the major compaction a no-op rather than run it into
+    // ENOSPC: the cross-level input set cannot be narrowed to a single run, so
+    // it is skipped. The tree keeps its tables and every key stays readable.
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    assert_eq!(
+        tree.table_count(),
+        tables_before,
+        "a merge that does not fit must be skipped, leaving the tables in place"
+    );
+    for i in 0..n {
+        assert!(
+            tree.get(format!("key{i:08}").as_bytes(), u64::MAX)?
+                .is_some(),
+            "every key must remain readable after a gated (skipped) compaction"
+        );
+    }
+
+    // Consistency survives a reopen: nothing was partially committed. The reopen
+    // must reuse the SAME in-memory backend (a fresh MemFs would be empty), since
+    // the simulated disk's state lives in `mem`.
+    drop(tree);
+    let reopened = match Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .open()?
+    {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    assert!(
+        reopened.get(b"key00000000".as_slice(), u64::MAX)?.is_some(),
+        "data must survive reopen after a gated compaction"
+    );
+    Ok(())
+}
+
+#[test]
+fn raising_capacity_lets_the_skipped_merge_run() -> lsm_tree::Result<()> {
+    // Proves the gate (not some other limit) caused the skip: with ample space
+    // the same major compaction collapses the tree to a single table.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_capped(folder.path(), u64::MAX);
+    let n = 2_000u64;
+    let used = seed_two_generations(&tree, n);
+    assert!(tree.table_count() >= 2);
+
+    mem.set_capacity(used + 64 * 1024);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    let after_gated = tree.table_count();
+
+    // Raise the cap far above the footprint: the merge now fits and runs.
+    mem.set_capacity(used + 1024 * 1024 * 1024);
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    assert!(
+        tree.table_count() < after_gated,
+        "with ample free space the merge runs and reduces the table count \
+         (was {after_gated} while gated)"
+    );
+    // The reclaiming merge dropped the shadowed first generation; reads still
+    // return the latest values.
+    assert_eq!(
+        tree.get(b"key00000000".as_slice(), u64::MAX)?.as_deref(),
+        Some([0xEFu8; 64].as_slice()),
+        "latest value survives the merge"
+    );
+    Ok(())
+}
+
+#[test]
+fn admission_off_never_gates_compaction() -> lsm_tree::Result<()> {
+    // With the gate off, a near-full simulated disk does not affect compaction:
+    // the major compaction collapses to a single table as usual.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_capped(folder.path(), u64::MAX);
+    let n = 2_000u64;
+    let used = seed_two_generations(&tree, n);
+    assert!(tree.table_count() >= 2);
+
+    // Tight cap but admission OFF (default): compaction is never gated.
+    mem.set_capacity(used + 64 * 1024);
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    assert_eq!(
+        tree.table_count(),
+        1,
+        "with admission off the merge runs regardless of free space"
+    );
+    Ok(())
+}
+
+#[test]
+fn storage_status_reports_full_compaction_availability() -> lsm_tree::Result<()> {
+    // AC4: with gating active and ample room the status surfaces
+    // FullCompactionAvailable; a near-full disk flips it to ReadOnlyOutOfSpace.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_capped(folder.path(), u64::MAX);
+    let used = seed_two_generations(&tree, 1_000);
+
+    mem.set_capacity(used + 512 * 1024 * 1024);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::FullCompactionAvailable,
+        "ample free space under an active gate reports full-compaction availability"
+    );
+
+    // Shrink to a full disk: the write gate closes and that takes precedence.
+    mem.set_capacity(used);
+    tree.update_runtime_config(|_c| {})?; // clear the cached probe
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::ReadOnlyOutOfSpace
+    );
+    Ok(())
+}

--- a/tests/compaction_space_admission.rs
+++ b/tests/compaction_space_admission.rs
@@ -8,9 +8,30 @@
 
 use lsm_tree::fs::MemFs;
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, SequenceNumberCounter, StorageStatus, get_tmp_folder,
+    AbstractTree, AnyTree, Config, KvSeparationOptions, SequenceNumberCounter, StorageStatus,
+    get_tmp_folder,
 };
 use std::sync::Arc;
+
+/// Opens a KV-separated (blob) tree on a `MemFs` capped at `capacity` bytes.
+fn open_capped_blob(path: &std::path::Path, capacity: u64) -> (lsm_tree::BlobTree, MemFs) {
+    let mem = MemFs::with_capacity(capacity);
+    let any = Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .with_kv_separation(Some(
+        KvSeparationOptions::default().separation_threshold(64),
+    ))
+    .open()
+    .expect("open");
+    match any {
+        AnyTree::Blob(t) => (t, mem),
+        AnyTree::Standard(_) => panic!("expected Blob tree"),
+    }
+}
 
 /// Opens a Standard tree on a `MemFs` capped at `capacity` bytes, returning both
 /// the tree and the backend clone so a test can re-cap the simulated disk.
@@ -159,6 +180,76 @@ fn admission_off_never_gates_compaction() -> lsm_tree::Result<()> {
         tree.table_count(),
         1,
         "with admission off the merge runs regardless of free space"
+    );
+    Ok(())
+}
+
+#[test]
+fn configured_quota_below_footprint_gates_a_merge_on_ample_disk() -> lsm_tree::Result<()> {
+    // A quota set just above the live footprint must gate compaction even when
+    // the physical disk has plenty of room: the merge would grow the tree past
+    // the operator's budget. Exercises the quota-headroom branch of the gate.
+    let folder = get_tmp_folder();
+    // Huge simulated disk → physical free is never the constraint here.
+    let (tree, _mem) = open_capped(folder.path(), 100 * 1024 * 1024 * 1024);
+    let n = 2_000u64;
+    let used = seed_two_generations(&tree, n);
+    let tables_before = tree.table_count();
+    assert!(tables_before >= 2);
+
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        // Quota leaves less headroom than a full merge's input bound needs.
+        c.storage_limit_bytes = Some(used + 64 * 1024);
+    })?;
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    assert_eq!(
+        tree.table_count(),
+        tables_before,
+        "a merge exceeding the quota headroom must be gated even with ample disk"
+    );
+    Ok(())
+}
+
+#[test]
+fn blob_tree_compaction_space_gate_and_status() -> lsm_tree::Result<()> {
+    // Drives the KV-separation branch of the gate (blob-file relocation budget)
+    // and the blob-tree FullCompactionAvailable status.
+    let folder = get_tmp_folder();
+    let (tree, mem) = open_capped_blob(folder.path(), u64::MAX);
+    let n = 1_000u64;
+    let value = vec![0xABu8; 256]; // > separation threshold → blob files
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), &value, i);
+    }
+    tree.flush_active_memtable(0)?;
+    for i in 0..n {
+        tree.insert(format!("key{i:08}").as_bytes(), &value, n + i);
+    }
+    tree.flush_active_memtable(0)?;
+    let used = tree.storage_stats()?.used_bytes;
+
+    // Ample room: status reports full-compaction availability. Runtime config
+    // lives on the blob tree's index tree.
+    mem.set_capacity(used + 512 * 1024 * 1024);
+    tree.index.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+    })?;
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::FullCompactionAvailable
+    );
+
+    // Near-full: the blob-aware gate keeps the tree consistent — every key still
+    // resolves through its blob file after a gated compaction.
+    mem.set_capacity(used + 64 * 1024);
+    tree.index.update_runtime_config(|_c| {})?;
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+    assert_eq!(
+        tree.get(b"key00000000".as_slice(), u64::MAX)?.as_deref(),
+        Some(value.as_slice()),
+        "blob-backed value still resolves after a gated compaction"
     );
     Ok(())
 }

--- a/tests/encryption_stress.rs
+++ b/tests/encryption_stress.rs
@@ -54,6 +54,31 @@ fn raise_fd_limit() {
     let _ = rlimit::increase_nofile_limit(u64::MAX);
 }
 
+/// `true` when an error is transient file-descriptor exhaustion (`EMFILE` /
+/// `ENFILE` — "too many open files"): an environment limit, not an encryption or
+/// data-integrity fault. Under a heavily parallel test run the system-wide file
+/// table can exhaust even after [`raise_fd_limit`] lifts this process's soft
+/// limit, surfacing as an `open()` failure on flush / read. The crate's
+/// `io::Error` carries no errno, so match the stable OS message (identical on
+/// Linux and macOS for both `EMFILE` and `ENFILE`).
+fn is_fd_exhaustion(err: &lsm_tree::Error) -> bool {
+    err.to_string().contains("Too many open files")
+}
+
+/// Retries `op` while it fails with transient fd exhaustion (an environment
+/// limit under parallel test load), briefly yielding so descriptors free. A real
+/// (non-resource) fault surfaces immediately; only "too many open files" is
+/// retried, bounded so a persistent shortage still fails rather than hangs.
+fn retry_on_fd_exhaustion<T>(mut op: impl FnMut() -> lsm_tree::Result<T>) -> lsm_tree::Result<T> {
+    for _ in 0..50 {
+        match op() {
+            Err(e) if is_fd_exhaustion(&e) => std::thread::sleep(Duration::from_millis(20)),
+            other => return other,
+        }
+    }
+    op()
+}
+
 /// Default config + per-cell compression + optional encryption + optional
 /// Page ECC. When `ecc` is set the SST blocks carry a Reed-Solomon parity
 /// trailer OUTSIDE the encryption envelope, so this exercises the
@@ -573,9 +598,15 @@ fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
                     // under concurrent reads. Flush failure under contention
                     // would mask SST-write bugs, so propagate to the main
                     // thread instead of swallowing.
-                    if tree.flush_active_memtable(seqno).is_err() {
-                        errors.fetch_add(1, Ordering::Relaxed);
-                        return;
+                    if let Err(e) = tree.flush_active_memtable(seqno) {
+                        // A real SST-write fault must surface; transient fd
+                        // exhaustion under massive test parallelism is an
+                        // environment limit, not a bug — skip this flush and keep
+                        // writing (a later flush retries once descriptors free).
+                        if !is_fd_exhaustion(&e) {
+                            errors.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
                     }
                 }
             }
@@ -617,11 +648,15 @@ fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
                     Ok(None) => {
                         // key not yet written by its writer — fine
                     }
-                    Err(_) => {
-                        // Encrypted read failed under contention. Should
-                        // never happen — surface to the main thread.
-                        errors.fetch_add(1, Ordering::Relaxed);
-                        return;
+                    Err(e) => {
+                        // Transient fd exhaustion under parallelism is an
+                        // environment limit, not a bug; any OTHER error is a real
+                        // decrypt / AAD / I/O fault and must surface to the main
+                        // thread. Wrong DATA is still caught by the value check.
+                        if !is_fd_exhaustion(&e) {
+                            errors.fetch_add(1, Ordering::Relaxed);
+                            return;
+                        }
                     }
                 }
                 i = i.wrapping_add(1);
@@ -641,14 +676,14 @@ fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
     let errors_seen = worker_errors.load(Ordering::Relaxed);
     assert_eq!(
         errors_seen, 0,
-        "concurrent workers reported {errors_seen} flush/read errors — \
-         encrypted I/O under contention must not return Err"
+        "concurrent workers reported {errors_seen} non-resource flush/read errors — \
+         encrypted I/O under contention must not return Err (fd exhaustion is tolerated)"
     );
 
     // Final verification — flush remaining memtable then sample-read
     // every 50th key written and confirm presence.
     let final_seqno = seqno_gen.load(Ordering::Relaxed);
-    tree.flush_active_memtable(final_seqno)?;
+    retry_on_fd_exhaustion(|| tree.flush_active_memtable(final_seqno))?;
     let total_written = writes_committed.load(Ordering::Relaxed);
     assert!(
         total_written > 0,
@@ -666,7 +701,8 @@ fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
     // that gives one writer 10× more CPU than the others is still
     // covered exactly.
     drop(tree);
-    let tree = open_tree(dir.path(), CompressionType::None, true, false)?;
+    let tree =
+        retry_on_fd_exhaustion(|| open_tree(dir.path(), CompressionType::None, true, false))?;
     let mut found = 0u64;
     for writer_id in 0u32..4 {
         #[expect(
@@ -676,7 +712,7 @@ fn concurrent_encrypted_no_corruption() -> lsm_tree::Result<()> {
         let upper = writer_max_idx[writer_id as usize].load(Ordering::Relaxed);
         for i in 0u32..upper {
             let key = format!("w{writer_id}_k{i:06}");
-            if tree.get(key.as_bytes(), lsm_tree::MAX_SEQNO)?.is_some() {
+            if retry_on_fd_exhaustion(|| tree.get(key.as_bytes(), lsm_tree::MAX_SEQNO))?.is_some() {
                 found += 1;
             }
         }

--- a/tests/storage_admission.rs
+++ b/tests/storage_admission.rs
@@ -180,7 +180,12 @@ fn raising_budget_clears_read_only_without_restart() -> lsm_tree::Result<()> {
         tree.try_insert(b"k".as_slice(), b"v".as_slice(), 1001)
             .is_ok()
     );
-    assert_eq!(tree.storage_stats()?.status, StorageStatus::Healthy);
+    // Admission stays enabled with a generous budget: bounded capacity + ample
+    // free room reports full-compaction availability, not the gate-off `Healthy`.
+    assert_eq!(
+        tree.storage_stats()?.status,
+        StorageStatus::FullCompactionAvailable
+    );
     Ok(())
 }
 

--- a/tests/storage_stats.rs
+++ b/tests/storage_stats.rs
@@ -176,3 +176,46 @@ fn storage_stats_empty_tree_has_zero_usage_and_no_estimate() -> lsm_tree::Result
     assert_eq!(stats.estimated_remaining_entries(1_000_000), 0);
     Ok(())
 }
+
+#[test]
+fn storage_stats_reports_compaction_headroom_figures_for_gauge() -> lsm_tree::Result<()> {
+    // The capacity-gauge figures: a full compaction needs room for its transient
+    // output (bounded by the largest level), a tight compaction needs only the
+    // reserved working floor. With everything in one level after a flush, the
+    // full figure equals that level's on-disk size (== used_bytes here).
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+
+    // Empty tree: nothing to compact.
+    let empty = tree.storage_stats()?;
+    assert_eq!(
+        empty.full_compaction_bytes, 0,
+        "no levels → no full-compaction need"
+    );
+    assert!(
+        empty.tight_compaction_bytes > 0,
+        "tight need is the fixed reserved working floor"
+    );
+
+    for i in 0..500u64 {
+        tree.insert(format!("key{i:05}").as_bytes(), b"value-payload", i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let stats = tree.storage_stats()?;
+    // All data sits in a single level, so the largest level's size is the whole
+    // footprint. The figure is in metadata `file_size` units (what the gate
+    // bounds against), which is just below the physical `used_bytes` (it omits
+    // the meta block / footer), so it is positive and does not exceed used_bytes.
+    assert!(
+        stats.full_compaction_bytes > 0 && stats.full_compaction_bytes <= stats.used_bytes,
+        "single-level full need ({}) must be in (0, used_bytes={}]",
+        stats.full_compaction_bytes,
+        stats.used_bytes
+    );
+    assert_eq!(
+        stats.tight_compaction_bytes, empty.tight_compaction_bytes,
+        "tight need is a fixed floor, independent of data volume"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, deadlock-free space-admission gate for compaction merges. A merge transiently needs room for its output while its inputs still exist, so on a near-full disk a naive merge can hit `ENOSPC`. Gating merges like user writes would deadlock — compaction is what *frees* space — so the gate keeps an emergency reserve and narrows rather than blanket-skipping.

## Changes

- **`Config::min_available_space`** — minimum free space across the primary path and every level route (the tightest volume bounds admission). `Tree::probe_disk_free` now delegates to it.
- **Compaction space gate** (`storage_admission_check`, in the worker's `do_compaction` for `Choice::Merge`):
  - Bounds a merge's extra need by `Σ input file_size`.
  - Runs the merge when it fits free space (including the emergency reserve, so a space-reclaiming merge runs even at the limit — the deadlock break).
  - Narrows a too-large merge to the smallest run-adjacent table pair that fits (`narrow_merge_to_budget`); a cross-run / cross-level set that cannot be safely narrowed is skipped and left to the opt-in tight-space mode.
  - `Move` / `Drop` are zero / negative space and always run.
- **`storage_stats().status`** now reports `FullCompactionAvailable` / `TightCompactionAvailable` when gating is active (gated on the admission flag, not merely a finite capacity), `ReadOnlyOutOfSpace` when the write gate is closed.

Consistency under a mid-merge failure is the pre-existing atomic-commit guarantee (orphan output, intact inputs, unchanged manifest); the gate just keeps such a merge from starting.

## Testing

- Unit: `narrow_merge_picks_smallest_fitting_run_adjacent_pair` (narrowing picks the smallest adjacent pair; returns `None` below a single table).
- Integration (`tests/compaction_space_admission.rs`): near-full disk skips a non-fitting merge and stays consistent + reopenable; raising capacity lets the same merge run (gate causation); admission off never gates; status reports `FullCompactionAvailable` → `ReadOnlyOutOfSpace`.
- Full suite 1857 passed; clippy host + `x86_64-unknown-linux-gnu` `--all-features -D warnings` clean; no-std `thumbv7em-none-eabihf` 0 errors.

Part of #482. Closes #486.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in storage space admission gating for major compactions, including narrowed-merge behavior when full-run compaction doesn’t fit.
  * Added physical blob sizing to improve blob-tree compaction admission and status reporting.
  * Exposed new storage stats gauges for compaction headroom (`full_compaction_bytes`, `tight_compaction_bytes`).
* **Improvements**
  * Refined two-layer space admission and safer disk-free probing when free space can’t be determined.
  * Updated compaction I/O byte accounting for rate limiting.
  * Improved overflow-safety and more accurate storage-stat calculations to reflect compaction needs.
* **Documentation**
  * Expanded `StorageStatus` behavior and precedence for admission-driven overrides.
* **Tests**
  * Added end-to-end and gauge coverage for admission behavior, plus volume-ID compatibility and encryption fd-exhaustion tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->