### PR TITLE
feat(range): seekable range iterator + decompress-path zero-copy

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -5,7 +5,11 @@
 use crate::tree::inner::{FlushGuard, VersionsWriteGuard};
 use crate::{
     AnyTree, BlobTree, Config, Guard, InternalValue, KvPair, Memtable, SeqNo, TableId, Tree,
-    UserKey, UserValue, iter_guard::IterGuardImpl, table::Table, version::Version, vlog::BlobFile,
+    UserKey, UserValue,
+    iter_guard::{IterGuardImpl, SeekableGuardIter},
+    table::Table,
+    version::Version,
+    vlog::BlobFile,
 };
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
@@ -427,6 +431,41 @@ pub trait AbstractTree: sealed::Sealed {
         seqno: SeqNo,
         index: Option<(Arc<Memtable>, SeqNo)>,
     ) -> Box<dyn DoubleEndedIterator<Item = IterGuardImpl> + Send + 'static>;
+
+    /// Returns a range iterator that can reposition (seek) in place without
+    /// reopening its per-SST readers.
+    ///
+    /// Unlike [`range`](Self::range)'s boxed `DoubleEndedIterator`, the returned
+    /// [`SeekableGuardIter`] additionally exposes `seek_to` / `seek_to_for_prev`,
+    /// so a consumer can jump a live iterator to any key (`RocksDB` `Seek` /
+    /// `SeekForPrev`) — enabling data-dependent scans (joins, skip-scan) without
+    /// reopening per-SST readers per jump.
+    fn range_seekable<K: AsRef<[u8]>, R: RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn SeekableGuardIter + 'static>;
+
+    /// Scans a sequence of disjoint, ascending key sub-intervals, reusing one set
+    /// of per-SST readers across all of them.
+    ///
+    /// The per-SST setup is paid once (when the underlying seekable iterator is
+    /// opened); each interval is served by repositioning that iterator. This
+    /// amortizes the setup across `N` intervals instead of paying it per
+    /// interval, so multi-interval scan throughput scales with the total rows
+    /// returned rather than the interval count.
+    ///
+    /// The interval source is pulled lazily, so intervals may be produced on
+    /// demand (e.g. computed from rows already returned).
+    fn batch_range_scan<K: AsRef<[u8]>, R: RangeBounds<K> + 'static, I: IntoIterator<Item = R>>(
+        &self,
+        intervals: I,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn Iterator<Item = IterGuardImpl> + Send + 'static>
+    where
+        I::IntoIter: Send + 'static;
 
     /// Returns the approximate number of tombstones in the tree.
     fn tombstone_count(&self) -> u64;

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -281,6 +281,56 @@ impl BlobTree {
 
 impl crate::abstract_tree::sealed::Sealed for BlobTree {}
 
+/// Maps a raw merge-pipeline item into a KV-separated iterator guard that
+/// resolves the blob handle lazily against `version`.
+fn blob_guard(
+    tree: &crate::BlobTree,
+    version: &Version,
+    item: crate::Result<InternalValue>,
+) -> IterGuardImpl {
+    IterGuardImpl::Blob(Guard {
+        tree: tree.clone(),
+        version: version.clone(),
+        kv: item,
+    })
+}
+
+/// Wraps a [`SeekableTreeIter`](crate::range::SeekableTreeIter) over the index
+/// tree so a KV-separated tree can expose it as a [`SeekableGuardIter`].
+struct BlobSeekable {
+    inner: crate::range::SeekableTreeIter,
+    tree: crate::BlobTree,
+    version: Version,
+}
+
+impl Iterator for BlobSeekable {
+    type Item = IterGuardImpl;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|item| blob_guard(&self.tree, &self.version, item))
+    }
+}
+
+impl DoubleEndedIterator for BlobSeekable {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|item| blob_guard(&self.tree, &self.version, item))
+    }
+}
+
+impl crate::iter_guard::SeekableGuardIter for BlobSeekable {
+    fn seek_to(&mut self, key: &[u8]) {
+        self.inner.seek_to(key);
+    }
+
+    fn seek_to_for_prev(&mut self, key: &[u8]) {
+        self.inner.seek_to_for_prev(key);
+    }
+}
+
 impl AbstractTree for BlobTree {
     #[cfg(feature = "std")]
     fn create_checkpoint(
@@ -484,6 +534,50 @@ impl AbstractTree for BlobTree {
                     kv,
                 })
             }),
+        )
+    }
+
+    fn range_seekable<K: AsRef<[u8]>, R: RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn crate::iter_guard::SeekableGuardIter + 'static> {
+        let (lo, hi) = crate::tree::range_to_user_bounds(&range);
+        let inner = self
+            .index
+            .create_seekable_range_bounds(lo, hi, seqno, index);
+        let version = inner.version();
+        Box::new(BlobSeekable {
+            inner,
+            tree: self.clone(),
+            version,
+        })
+    }
+
+    fn batch_range_scan<K: AsRef<[u8]>, R: RangeBounds<K> + 'static, I: IntoIterator<Item = R>>(
+        &self,
+        intervals: I,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn Iterator<Item = IterGuardImpl> + Send + 'static>
+    where
+        I::IntoIter: Send + 'static,
+    {
+        let inner = self.index.create_seekable_range_bounds(
+            core::ops::Bound::Unbounded,
+            core::ops::Bound::Unbounded,
+            seqno,
+            index,
+        );
+        let version = inner.version();
+        let tree = self.clone();
+        let intervals = intervals
+            .into_iter()
+            .map(|r| crate::tree::range_to_user_bounds(&r));
+        Box::new(
+            crate::range::BatchRangeScan::new(inner, intervals)
+                .map(move |item| blob_guard(&tree, &version, item)),
         )
     }
 

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -1260,4 +1260,34 @@ mod tests {
             "capacity < plaintext must return DecompressedSizeTooLarge; got {result:?}",
         );
     }
+
+    #[test]
+    fn decompress_into_rejects_frame_larger_than_dest() {
+        let raw = vec![7u8; 4096];
+        let frame = ZstdProvider::compress(&raw, 3).expect("compress");
+        // dest is smaller than the frame's output → the excess probe fires.
+        let mut dest = vec![0u8; 2048];
+        let result = ZstdProvider::decompress_into(&frame, &mut dest);
+        assert!(
+            matches!(result, Err(crate::Error::DecompressedSizeTooLarge { .. })),
+            "a frame that decodes past dest must be rejected; got {result:?}",
+        );
+    }
+
+    #[test]
+    fn decompress_into_fills_exact_buffer() {
+        let raw = vec![3u8; 4096];
+        let frame = ZstdProvider::compress(&raw, 3).expect("compress");
+        let mut dest = vec![0u8; raw.len()];
+        let written = ZstdProvider::decompress_into(&frame, &mut dest).expect("decompress_into");
+        assert_eq!(written, raw.len());
+        assert_eq!(dest, raw);
+    }
+
+    #[test]
+    fn decompress_into_propagates_decode_error() {
+        let mut dest = vec![0u8; 64];
+        let result = ZstdProvider::decompress_into(b"definitely not a valid zstd frame", &mut dest);
+        assert!(result.is_err(), "a corrupt frame must error");
+    }
 }

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -65,6 +65,40 @@ fn bounded_read(reader: &mut impl Read, capacity: usize) -> crate::Result<Vec<u8
     Ok(output)
 }
 
+/// Like [`bounded_read`], but decodes straight into a caller-provided buffer of
+/// the exact expected size — no zero-filled `Vec` and no later copy. Returns the
+/// number of bytes written; the caller checks it equals the expected length.
+fn bounded_read_into(reader: &mut impl Read, dest: &mut [u8]) -> crate::Result<usize> {
+    let mut filled = 0;
+    while filled < dest.len() {
+        // `filled < dest.len()` by the loop guard, so the slice is non-empty.
+        let slot = dest.get_mut(filled..).unwrap_or(&mut []);
+        match reader.read(slot) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(e) => return Err(crate::Error::from(e)),
+        }
+    }
+
+    // If the buffer filled exactly, probe for excess: a frame that decodes to
+    // more than the declared size is corrupt / over-budget.
+    if filled == dest.len() {
+        let mut probe = [0u8; 1];
+        match reader.read(&mut probe) {
+            Ok(0) => {}
+            Ok(_) => {
+                return Err(crate::Error::DecompressedSizeTooLarge {
+                    declared: (filled as u64).saturating_add(1),
+                    limit: dest.len() as u64,
+                });
+            }
+            Err(e) => return Err(crate::Error::from(e)),
+        }
+    }
+
+    Ok(filled)
+}
+
 /// Incrementally decodes `data` using the pre-initialised `decoder` and
 /// collects the output, enforcing a hard `capacity` limit even when the frame
 /// has no `Frame_Content_Size` field (FCS omitted → `content_size()` == 0).
@@ -597,6 +631,23 @@ impl CompressionProvider for ZstdProvider {
 
             do_decompress_with_dict(decoder, data, dict.id().max(1), capacity, is_raw_content)
         })
+    }
+}
+
+impl ZstdProvider {
+    /// Decompress a frame straight into `dest` (exact expected size), skipping
+    /// the zero-filled scratch `Vec` and the later copy that
+    /// [`decompress`](CompressionProvider::decompress) pays. Returns the bytes
+    /// written; the caller checks it equals the declared uncompressed length.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the frame header is invalid, an I/O error occurs, or
+    /// the frame decodes to more than `dest.len()` bytes.
+    pub fn decompress_into(data: &[u8], dest: &mut [u8]) -> crate::Result<usize> {
+        let mut decoder = structured_zstd::decoding::StreamingDecoder::new(data)
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
+        bounded_read_into(&mut decoder, dest)
     }
 }
 

--- a/src/iter_guard.rs
+++ b/src/iter_guard.rs
@@ -62,3 +62,25 @@ pub enum IterGuardImpl {
     /// Iterator value of a key-value separated tree
     Blob(BlobGuard),
 }
+
+/// A range iterator that can reposition (seek) in place, without reopening its
+/// per-SST readers.
+///
+/// Returned by [`AbstractTree::range_seekable`](crate::AbstractTree::range_seekable).
+/// The per-SST setup is paid once when the iterator is created; each
+/// [`seek_to`](Self::seek_to) / [`seek_to_for_prev`](Self::seek_to_for_prev)
+/// only rebuilds the cheap merge pipeline, so scanning many disjoint key
+/// sub-intervals amortizes that setup instead of paying it per interval.
+///
+/// Seeks are valid mid-iteration (an explicit jump to a known key), which
+/// enables data-dependent scan patterns — merge / zig-zag joins, skip-scan —
+/// where the next seek target is computed from rows already returned.
+pub trait SeekableGuardIter: DoubleEndedIterator<Item = IterGuardImpl> + Send {
+    /// Reposition so the next [`Iterator::next`] yields the first entry with
+    /// user key `>= key` (`RocksDB` `Seek`).
+    fn seek_to(&mut self, key: &[u8]);
+
+    /// Reposition so the next [`DoubleEndedIterator::next_back`] yields the last
+    /// entry with user key `<= key` (`RocksDB` `SeekForPrev`).
+    fn seek_to_for_prev(&mut self, key: &[u8]);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ pub type KvPair = (UserKey, UserValue);
 #[doc(hidden)]
 pub use {
     checksum::Checksum,
-    iter_guard::IterGuardImpl,
+    iter_guard::{IterGuardImpl, SeekableGuardIter},
     key_range::KeyRange,
     merge::BoxedIterator,
     slice::Builder,

--- a/src/range.rs
+++ b/src/range.rs
@@ -102,6 +102,11 @@ pub fn prefix_to_range(prefix: &[u8]) -> (Bound<UserKey>, Bound<UserKey>) {
 /// The iter state references the memtables used while the range is open
 ///
 /// Because of Rust rules, the state is referenced using `self_cell`, see below.
+///
+/// `Clone` is cheap (every field is an `Arc` / small `Copy` value) and is used
+/// by the seekable range iterator, which rebuilds its merge pipeline on each
+/// reposition while keeping the same underlying version snapshot.
+#[derive(Clone)]
 pub struct IterState {
     pub(crate) version: SuperVersion,
     pub(crate) ephemeral: Option<(Arc<Memtable>, SeqNo)>,
@@ -837,6 +842,402 @@ impl TreeIter {
                 ))
             }
         })
+    }
+}
+
+/// User-key bounds for a scan; the seekable iterator rebuilds its merge
+/// pipeline for any sub-range of the union without recollecting sources.
+type UserBounds = (Bound<UserKey>, Bound<UserKey>);
+
+/// Translate user-key bounds into the internal-key bounds the per-source readers
+/// expect. Mirrors the bound construction in [`TreeIter::create_range`] (see
+/// there for the seqno-direction reasoning at each end).
+fn user_to_internal_bounds(user: &UserBounds) -> (Bound<InternalKey>, Bound<InternalKey>) {
+    let lo = match &user.0 {
+        Bound::Included(key) => Bound::Included(InternalKey::new(
+            key.as_ref(),
+            SeqNo::MAX,
+            crate::ValueType::Tombstone,
+        )),
+        Bound::Excluded(key) => Bound::Excluded(InternalKey::new(
+            key.as_ref(),
+            0,
+            crate::ValueType::Tombstone,
+        )),
+        Bound::Unbounded => Bound::Unbounded,
+    };
+    let hi = match &user.1 {
+        Bound::Included(key) => {
+            Bound::Included(InternalKey::new(key.as_ref(), 0, crate::ValueType::Value))
+        }
+        Bound::Excluded(key) => Bound::Excluded(InternalKey::new(
+            key.as_ref(),
+            SeqNo::MAX,
+            crate::ValueType::Value,
+        )),
+        Bound::Unbounded => Bound::Unbounded,
+    };
+    (lo, hi)
+}
+
+/// SSTs / runs / range-tombstones overlapping the union range, collected once.
+///
+/// Rebuilding the merge pipeline for a sub-range (a seek, or one batch interval)
+/// reuses these — Phase 1 (level iteration + bloom + RT collection) is the
+/// ~100µs setup that [`SeekableTreeIter`] amortizes across repositions.
+#[derive(Clone)]
+struct CollectedSources {
+    single_tables: Vec<crate::table::Table>,
+    multi_runs: Vec<Arc<Run<crate::table::Table>>>,
+    range_tombstones: Vec<(RangeTombstone, SeqNo)>,
+    union: UserBounds,
+}
+
+/// Phase 1: collect every source overlapping `union` once. The table-skip
+/// optimization and the prefix/key-hash sub-filtering used by
+/// [`TreeIter::create_range`] are intentionally omitted: this is a plain range
+/// scan (no prefix/point pipeline), and skipping table-skip only ever reads a
+/// table a tombstone fully covers — correct, just marginally less optimal.
+fn collect_sources(state: &IterState, union: UserBounds, seqno: SeqNo) -> CollectedSources {
+    let mut single_tables: Vec<crate::table::Table> = Vec::new();
+    let mut multi_runs: Vec<Arc<Run<crate::table::Table>>> = Vec::new();
+    let mut rts: Vec<(RangeTombstone, SeqNo)> = Vec::new();
+
+    let bounds_ref = (
+        union.0.as_ref().map(core::convert::AsRef::as_ref),
+        union.1.as_ref().map(core::convert::AsRef::as_ref),
+    );
+
+    for run in state
+        .version
+        .version
+        .iter_levels()
+        .flat_map(|lvl| lvl.iter())
+    {
+        match run.len() {
+            0 => {}
+            1 => {
+                #[expect(clippy::expect_used, reason = "len checked")]
+                let table = run.first().expect("len == 1");
+                rts.extend(
+                    table
+                        .range_tombstones()
+                        .iter()
+                        .filter(|rt| {
+                            range_tombstone_overlaps_bounds(rt, &union, state.comparator.as_ref())
+                        })
+                        .map(|rt| (rt.clone(), seqno)),
+                );
+                if table.check_key_range_overlap_cmp(&bounds_ref, state.comparator.as_ref())
+                    && bloom_passes(state, table)
+                {
+                    single_tables.push(table.clone());
+                }
+            }
+            _ => {
+                for table in run.iter() {
+                    rts.extend(
+                        table
+                            .range_tombstones()
+                            .iter()
+                            .filter(|rt| {
+                                range_tombstone_overlaps_bounds(
+                                    rt,
+                                    &union,
+                                    state.comparator.as_ref(),
+                                )
+                            })
+                            .map(|rt| (rt.clone(), seqno)),
+                    );
+                }
+                multi_runs.push(run.clone());
+            }
+        }
+    }
+
+    let mut collect_mt_rts = |iter: alloc::vec::Vec<RangeTombstone>, cutoff: SeqNo| {
+        rts.extend(
+            iter.into_iter()
+                .filter(|rt| range_tombstone_overlaps_bounds(rt, &union, state.comparator.as_ref()))
+                .map(|rt| (rt, cutoff)),
+        );
+    };
+    for memtable in state.version.sealed_memtables.iter() {
+        collect_mt_rts(memtable.range_tombstones_sorted(), seqno);
+    }
+    collect_mt_rts(
+        state.version.active_memtable.range_tombstones_sorted(),
+        seqno,
+    );
+    if let Some((mt, eph_seqno)) = &state.ephemeral {
+        collect_mt_rts(mt.range_tombstones_sorted(), *eph_seqno);
+    }
+
+    rts.sort_by(|a, b| a.0.cmp_with_comparator(&b.0, state.comparator.as_ref()));
+    rts.dedup_by(|a, b| {
+        if a.0 == b.0 {
+            b.1 = b.1.max(a.1);
+            true
+        } else {
+            false
+        }
+    });
+
+    CollectedSources {
+        single_tables,
+        multi_runs,
+        range_tombstones: rts,
+        union,
+    }
+}
+
+/// Phase 2: build the merge pipeline (`SeekingMerger` -> `MvccStream` ->
+/// tombstone filter -> optional `RangeTombstoneFilter`) for the sub-range
+/// `[lower, upper)` from already-collected sources. Reruns on every reposition;
+/// the per-source readers reuse the tested seek-to-start path (no block I/O
+/// until the first `next`).
+fn build_stack<'a>(
+    state: &'a IterState,
+    collected: &CollectedSources,
+    lower: Bound<UserKey>,
+    upper: Bound<UserKey>,
+    seqno: SeqNo,
+) -> BoxedMerge<'a> {
+    let user_range: UserBounds = (lower, upper);
+    let range = user_to_internal_bounds(&user_range);
+
+    let mut iters: Vec<BoxedIterator<'a>> = Vec::with_capacity(collected.single_tables.len() + 3);
+
+    for table in &collected.single_tables {
+        let reader = table
+            .range(user_range.clone())
+            .filter(move |item| match item {
+                Ok(item) => seqno_filter(item.key.seqno, seqno),
+                Err(_) => true,
+            });
+        iters.push(Box::new(reader));
+    }
+    for run in &collected.multi_runs {
+        if let Some(reader) =
+            RunReader::new_cmp(run.clone(), user_range.clone(), state.comparator.as_ref())
+        {
+            iters.push(Box::new(reader.filter(move |item| match item {
+                Ok(item) => seqno_filter(item.key.seqno, seqno),
+                Err(_) => true,
+            })));
+        }
+    }
+    for memtable in state.version.sealed_memtables.iter() {
+        let iter = memtable.range_internal(range.clone());
+        iters.push(Box::new(
+            iter.filter(move |item| seqno_filter(item.key.seqno, seqno))
+                .map(Ok),
+        ));
+    }
+    {
+        let iter = state.version.active_memtable.range_internal(range.clone());
+        iters.push(Box::new(
+            iter.filter(move |item| seqno_filter(item.key.seqno, seqno))
+                .map(Ok),
+        ));
+    }
+    if let Some((mt, eph_seqno)) = &state.ephemeral {
+        let eph_seqno = *eph_seqno;
+        let iter = mt.range_internal(range);
+        iters.push(Box::new(
+            iter.filter(move |item| seqno_filter(item.key.seqno, eph_seqno))
+                .map(Ok),
+        ));
+    }
+
+    let merged = build_seeking(iters, state.comparator.clone());
+    let iter = MvccStream::new_with_comparator(
+        merged,
+        state.merge_operator.clone(),
+        state.comparator.clone(),
+    )
+    .with_range_tombstones(collected.range_tombstones.clone());
+
+    let iter = iter.filter(|x| match x {
+        Ok(value) => !value.key.is_tombstone(),
+        Err(_) => true,
+    });
+
+    if collected
+        .range_tombstones
+        .iter()
+        .all(|(rt, cutoff)| !rt.visible_at(*cutoff))
+    {
+        Box::new(iter)
+    } else {
+        Box::new(RangeTombstoneFilter::new_with_comparator(
+            iter,
+            collected.range_tombstones.clone(),
+            state.comparator.clone(),
+        ))
+    }
+}
+
+/// Owner half of [`SeekableTreeIter`]'s self-cell.
+///
+/// Holds the version snapshot, the collected sources (shared via `Arc` so a
+/// reposition is a cheap refcount bump), and the current sub-range bounds the
+/// dependent pipeline was built for.
+pub struct SeekableOwner {
+    state: IterState,
+    collected: Arc<CollectedSources>,
+    seqno: SeqNo,
+    lower: Bound<UserKey>,
+    upper: Bound<UserKey>,
+}
+
+self_cell!(
+    /// A range iterator that can reposition (seek) in place without reopening
+    /// per-SST readers. Built once over a union range; [`Self::seek_to`],
+    /// [`Self::seek_to_for_prev`], and [`Self::reposition`] rebuild only the
+    /// cheap Phase-2 merge pipeline, reusing the collected sources.
+    pub struct SeekableTreeIter {
+        owner: SeekableOwner,
+
+        #[covariant]
+        dependent: BoxedMerge,
+    }
+);
+
+impl SeekableTreeIter {
+    fn build(owner: SeekableOwner) -> Self {
+        Self::new(owner, |o| {
+            build_stack(
+                &o.state,
+                &o.collected,
+                o.lower.clone(),
+                o.upper.clone(),
+                o.seqno,
+            )
+        })
+    }
+
+    /// Open a seekable iterator over `[union_lower, union_upper)`. The source
+    /// collection (Phase 1) runs once here; subsequent repositions reuse it.
+    #[must_use]
+    pub fn create(
+        state: IterState,
+        union_lower: Bound<UserKey>,
+        union_upper: Bound<UserKey>,
+        seqno: SeqNo,
+    ) -> Self {
+        let collected = Arc::new(collect_sources(
+            &state,
+            (union_lower.clone(), union_upper.clone()),
+            seqno,
+        ));
+        Self::build(SeekableOwner {
+            state,
+            collected,
+            seqno,
+            lower: union_lower,
+            upper: union_upper,
+        })
+    }
+
+    /// Rebuild the merge pipeline for the sub-range `[lower, upper)`, reusing the
+    /// collected sources. Cheap: clones `Arc`s and reconstructs per-source
+    /// readers (no block I/O until the next `next`/`next_back`).
+    pub(crate) fn reposition(&mut self, lower: Bound<UserKey>, upper: Bound<UserKey>) {
+        let state = self.borrow_owner().state.clone();
+        let collected = Arc::clone(&self.borrow_owner().collected);
+        let seqno = self.borrow_owner().seqno;
+        *self = Self::build(SeekableOwner {
+            state,
+            collected,
+            seqno,
+            lower,
+            upper,
+        });
+    }
+
+    /// Reposition so the next [`Iterator::next`] yields the first entry with
+    /// user key `>= key` (`RocksDB` `Seek`). The upper bound stays the union upper.
+    pub fn seek_to(&mut self, key: &[u8]) {
+        let upper = self.borrow_owner().collected.union.1.clone();
+        self.reposition(Bound::Included(UserKey::from(key)), upper);
+    }
+
+    /// Reposition so the next [`DoubleEndedIterator::next_back`] yields the last
+    /// entry with user key `<= key` (`RocksDB` `SeekForPrev`). The lower bound
+    /// stays the union lower.
+    pub fn seek_to_for_prev(&mut self, key: &[u8]) {
+        let lower = self.borrow_owner().collected.union.0.clone();
+        self.reposition(lower, Bound::Included(UserKey::from(key)));
+    }
+
+    /// The version snapshot this iterator reads from. Used by KV-separated trees
+    /// to resolve blob handles against the same snapshot the keys came from.
+    #[must_use]
+    pub fn version(&self) -> crate::version::Version {
+        self.borrow_owner().state.version.version.clone()
+    }
+}
+
+impl Iterator for SeekableTreeIter {
+    type Item = crate::Result<InternalValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.with_dependent_mut(|_, iter| iter.next())
+    }
+}
+
+impl DoubleEndedIterator for SeekableTreeIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.with_dependent_mut(|_, iter| iter.next_back())
+    }
+}
+
+/// Forward scan over a (possibly lazily-produced) sequence of disjoint,
+/// ascending sub-ranges, reusing a single [`SeekableTreeIter`].
+///
+/// Each interval is served by repositioning the shared pipeline — the per-SST
+/// setup is paid once (when the `SeekableTreeIter` is created over the union)
+/// and amortized across every interval, rather than reopening readers per
+/// interval.
+///
+/// The interval source is pulled on demand, so intervals may be generated
+/// dynamically (the next interval can depend on rows already returned).
+pub struct BatchRangeScan<I> {
+    iter: SeekableTreeIter,
+    intervals: I,
+    /// Whether the shared iterator is currently positioned on an interval that
+    /// may still yield rows.
+    primed: bool,
+}
+
+impl<I: Iterator<Item = (Bound<UserKey>, Bound<UserKey>)>> BatchRangeScan<I> {
+    /// Build a batch scan from a seekable iterator opened over the union range
+    /// and a (lazy) sequence of `[lower, upper)` sub-ranges to visit in order.
+    pub fn new(iter: SeekableTreeIter, intervals: I) -> Self {
+        Self {
+            iter,
+            intervals,
+            primed: false,
+        }
+    }
+}
+
+impl<I: Iterator<Item = (Bound<UserKey>, Bound<UserKey>)>> Iterator for BatchRangeScan<I> {
+    type Item = crate::Result<InternalValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.primed {
+                if let Some(item) = self.iter.next() {
+                    return Some(item);
+                }
+                self.primed = false;
+            }
+            let (lower, upper) = self.intervals.next()?;
+            self.iter.reposition(lower, upper);
+            self.primed = true;
+        }
     }
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1157,18 +1157,44 @@ impl SeekableTreeIter {
     }
 
     /// Reposition so the next [`Iterator::next`] yields the first entry with
-    /// user key `>= key` (`RocksDB` `Seek`). The upper bound stays the union upper.
+    /// user key `>= key` (`RocksDB` `Seek`).
+    ///
+    /// The new lower bound is clamped to the iterator's collected window: Phase 1
+    /// only gathered sources overlapping the original range, so seeking below the
+    /// window lower would scan outside it (leaking rows below the window, or
+    /// missing rows from sources that were skipped during collection). A `key`
+    /// below the window lower positions at the window start; the upper bound
+    /// stays the window upper.
     pub fn seek_to(&mut self, key: &[u8]) {
-        let upper = self.borrow_owner().collected.union.1.clone();
-        self.reposition(Bound::Included(UserKey::from(key)), upper);
+        let (lower, upper) = {
+            let union = &self.borrow_owner().collected.union;
+            let lower = match &union.0 {
+                Bound::Included(floor) if floor.as_ref() > key => union.0.clone(),
+                Bound::Excluded(floor) if floor.as_ref() >= key => union.0.clone(),
+                _ => Bound::Included(UserKey::from(key)),
+            };
+            (lower, union.1.clone())
+        };
+        self.reposition(lower, upper);
     }
 
     /// Reposition so the next [`DoubleEndedIterator::next_back`] yields the last
-    /// entry with user key `<= key` (`RocksDB` `SeekForPrev`). The lower bound
-    /// stays the union lower.
+    /// entry with user key `<= key` (`RocksDB` `SeekForPrev`).
+    ///
+    /// The new upper bound is clamped to the iterator's collected window (see
+    /// [`seek_to`](Self::seek_to) for why): a `key` above the window upper
+    /// positions at the window end; the lower bound stays the window lower.
     pub fn seek_to_for_prev(&mut self, key: &[u8]) {
-        let lower = self.borrow_owner().collected.union.0.clone();
-        self.reposition(lower, Bound::Included(UserKey::from(key)));
+        let (lower, upper) = {
+            let union = &self.borrow_owner().collected.union;
+            let upper = match &union.1 {
+                Bound::Included(ceil) if ceil.as_ref() < key => union.1.clone(),
+                Bound::Excluded(ceil) if ceil.as_ref() <= key => union.1.clone(),
+                _ => Bound::Included(UserKey::from(key)),
+            };
+            (union.0.clone(), upper)
+        };
+        self.reposition(lower, upper);
     }
 
     /// The version snapshot this iterator reads from. Used by KV-separated trees

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -965,10 +965,18 @@ impl Block {
                 CompressionType::Lz4 => {
                     // Decompress straight into the Slice's heap allocation,
                     // skipping both the zero-fill of `vec![0; n]` and the
-                    // Vec -> Slice copy. SAFETY: `decompress_into` writes every
-                    // byte of a valid lz4 stream, and the block checksum was
-                    // verified above, so the stream is intact and lz4's wildcopy
-                    // never reads an unwritten position.
+                    // Vec -> Slice copy.
+                    //
+                    // SAFETY (load-bearing, do NOT reorder): the block checksum is
+                    // verified ABOVE, before this point. That ordering is the
+                    // precondition, not an optimization. `lz4_flex` is the
+                    // unchecked fast decoder: it may wildcopy a back-reference out
+                    // of the output buffer before detecting a malformed frame, so
+                    // it must only ever run on a checksum-verified, intact stream.
+                    // On such a stream every back-reference targets an
+                    // already-written byte, so the uninitialized builder is written
+                    // before it is ever read. Never move the decompress ahead of
+                    // the checksum check.
                     #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
                     let mut builder =
                         unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
@@ -985,8 +993,12 @@ impl Block {
 
                 #[cfg(zstd_any)]
                 CompressionType::Zstd(_) => {
-                    // Decompress straight into the Slice allocation — no
-                    // zero-filled scratch Vec and no Vec -> Slice copy.
+                    // Decompress straight into the Slice allocation: no
+                    // zero-filled scratch Vec and no Vec -> Slice copy. SAFETY:
+                    // same checksum-first precondition as the lz4 arm above. The
+                    // stream is checksum-verified before this point, so the decoder
+                    // only writes the uninitialized builder, never reads it
+                    // unwritten. Do not reorder ahead of the checksum check.
                     #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
                     let mut builder =
                         unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -209,27 +209,21 @@ fn encrypt_block_payload(
 /// [`EncryptionProvider::decrypt_block_aad`] (the reader supplies only
 /// `identity`; the transform fields are read back from the frame); without zstd
 /// it falls back to the opaque in-place `decrypt_vec`.
-#[cfg_attr(
-    zstd_any,
-    expect(
-        clippy::needless_pass_by_value,
-        reason = "raw is consumed by decrypt_vec on the non-zstd path; the AAD path \
-                  only borrows it, so by-value is needed for the other cfg"
-    )
-)]
 fn decrypt_block_payload(
     enc: &dyn crate::encryption::EncryptionProvider,
-    raw: Vec<u8>,
+    raw: &[u8],
     identity: &BlockIdentity,
 ) -> crate::Result<Vec<u8>> {
     #[cfg(zstd_any)]
     {
-        enc.decrypt_block_aad(&raw, identity)
+        enc.decrypt_block_aad(raw, identity)
     }
     #[cfg(not(zstd_any))]
     {
         let _ = identity;
-        enc.decrypt_vec(raw)
+        // `decrypt_vec` consumes an owned buffer; the read path now hands us a
+        // borrowed Slice, so copy once (this branch is the no-zstd build only).
+        enc.decrypt_vec(raw.to_vec())
     }
 }
 
@@ -428,9 +422,11 @@ impl Block {
             expect(unused_variables, reason = "recovery scheme only used under page_ecc")
         )]
         ecc_params: EccParams,
-    ) -> crate::Result<(Vec<u8>, Option<EccRecoveryKind>)> {
-        let mut data = vec![0u8; data_length as usize];
-        reader.read_exact(&mut data)?;
+    ) -> crate::Result<(Slice, Option<EccRecoveryKind>)> {
+        // Read straight into the Slice allocation — `read_exact` overwrites every
+        // byte, so a zero-filled scratch buffer would be wasted, and returning a
+        // Slice lets the no-compression / ECC-recovery callers avoid a later copy.
+        let data = Slice::from_reader(reader, data_length as usize)?;
 
         let computed = Checksum::from_raw(crate::hash::hash128(&data));
 
@@ -446,8 +442,7 @@ impl Block {
         // ECC trailer present — always consume the parity bytes so
         // the reader cursor lands on the next block's header even
         // when the happy path doesn't need them.
-        let mut parity = vec![0u8; ecc_length as usize];
-        reader.read_exact(&mut parity)?;
+        let parity = Slice::from_reader(reader, ecc_length as usize)?;
 
         if computed == expected {
             return Ok((data, None));
@@ -465,7 +460,9 @@ impl Block {
             // fall-through here — the shard schemes are a separate EccParams
             // variant.
             if matches!(ecc_params, crate::table::block::EccParams::Secded) {
-                let mut healed = data.clone();
+                // In-place single-bit heal needs an owned, mutable buffer; the
+                // recovery path is rare, so the copy out of the read Slice is fine.
+                let mut healed = data.to_vec();
                 if crate::secded::try_correct_block(&mut healed, &parity)
                     == crate::secded::SecdedOutcome::Corrected
                     && crate::hash::hash128(&healed) == expected_raw
@@ -475,7 +472,7 @@ impl Block {
                          checksum mismatch (data_len={}, ecc_len={ecc_length})",
                         data.len(),
                     );
-                    return Ok((healed, Some(EccRecoveryKind::Secded)));
+                    return Ok((Slice::from(healed), Some(EccRecoveryKind::Secded)));
                 }
                 log::error!(
                     "Checksum mismatch on SEC-DED block, heal failed, \
@@ -501,7 +498,7 @@ impl Block {
                      (data_len={}, ecc_len={ecc_length})",
                     data.len(),
                 );
-                return Ok((recovered, Some(EccRecoveryKind::Shard)));
+                return Ok((Slice::from(recovered), Some(EccRecoveryKind::Shard)));
             }
             log::error!(
                 "Checksum mismatch on ECC-protected block, recovery failed, \
@@ -947,7 +944,7 @@ impl Block {
 
             // Recover the plaintext: AAD-bound envelope under zstd (verifies the
             // block identity), opaque in-place decrypt otherwise.
-            let decrypted = decrypt_block_payload(enc, raw_vec, &identity)?;
+            let decrypted = decrypt_block_payload(enc, &raw_vec, &identity)?;
 
             match compression {
                 CompressionType::None => {
@@ -1056,7 +1053,7 @@ impl Block {
                     header.checksum,
                     block_ecc_params(&header, transform),
                 )?;
-                Slice::from(payload)
+                payload
             };
 
             match compression {
@@ -1357,7 +1354,7 @@ impl Block {
                 // Strip header prefix + any opaque trailer so buf is the payload.
                 buf.copy_within(header_len..header_len + actual_data_len, 0);
                 buf.truncate(actual_data_len);
-                (buf, None)
+                (Slice::from(buf), None)
             } else {
                 #[expect(clippy::indexing_slicing, reason = "header was decoded from buf")]
                 let mut cursor = crate::io::Cursor::new(&buf[header_len..]);
@@ -1379,7 +1376,7 @@ impl Block {
                 ecc_status
             };
 
-            let decrypted = decrypt_block_payload(enc, buf, &identity)?;
+            let decrypted = decrypt_block_payload(enc, &buf, &identity)?;
 
             let data = match compression {
                 CompressionType::None => {
@@ -1535,7 +1532,7 @@ impl Block {
                         parsed_header.checksum,
                         block_ecc_params(&parsed_header, transform),
                     )?;
-                    (Slice::from(payload), recovery)
+                    (payload, recovery)
                 };
             // Fold a successful ECC repair into the status; the recovery
             // mechanism is carried out separately as `payload_corrected`.
@@ -1748,7 +1745,7 @@ impl Block {
                 parsed_header.checksum,
                 block_ecc_params(&parsed_header, transform),
             )?;
-            (Slice::from(frame), recovery)
+            (frame, recovery)
         };
 
         Ok((parsed_header, payload, recovery))

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -966,16 +966,24 @@ impl Block {
 
                 #[cfg(feature = "lz4")]
                 CompressionType::Lz4 => {
-                    let mut buf = vec![0u8; header.uncompressed_length as usize];
+                    // Decompress straight into the Slice's heap allocation,
+                    // skipping both the zero-fill of `vec![0; n]` and the
+                    // Vec -> Slice copy. SAFETY: `decompress_into` writes every
+                    // byte of a valid lz4 stream, and the block checksum was
+                    // verified above, so the stream is intact and lz4's wildcopy
+                    // never reads an unwritten position.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder =
+                        unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    let bytes_written = lz4_flex::decompress_into(&decrypted, &mut buf)
+                    let bytes_written = lz4_flex::decompress_into(&decrypted, &mut builder)
                         .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(buf)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1064,16 +1072,22 @@ impl Block {
 
                 #[cfg(feature = "lz4")]
                 CompressionType::Lz4 => {
-                    let mut buf = vec![0u8; header.uncompressed_length as usize];
+                    // Decompress straight into the Slice's heap allocation,
+                    // skipping the zero-fill and the Vec -> Slice copy. SAFETY:
+                    // see the matching arm above — the checksum-verified stream
+                    // is intact, so wildcopy never reads an unwritten position.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder =
+                        unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    let bytes_written = lz4_flex::decompress_into(&raw_data, &mut buf)
+                    let bytes_written = lz4_flex::decompress_into(&raw_data, &mut builder)
                         .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(buf)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1376,7 +1390,13 @@ impl Block {
 
                 #[cfg(feature = "lz4")]
                 CompressionType::Lz4 => {
-                    let mut decompressed = vec![0u8; parsed_header.uncompressed_length as usize];
+                    // Decompress straight into the Slice allocation (no zero-fill,
+                    // no Vec -> Slice copy). SAFETY: see the read-path arm above;
+                    // the checksum-verified stream is intact.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut decompressed = unsafe {
+                        Slice::builder_unzeroed(parsed_header.uncompressed_length as usize)
+                    };
 
                     let bytes_written = lz4_flex::decompress_into(&decrypted, &mut decompressed)
                         .map_err(|_| crate::Error::Decompress(compression))?;
@@ -1385,7 +1405,7 @@ impl Block {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    decompressed.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1531,7 +1551,13 @@ impl Block {
                 CompressionType::Lz4 => {
                     let compressed_data: &[u8] = &payload_slice;
 
-                    let mut decompressed = vec![0u8; parsed_header.uncompressed_length as usize];
+                    // Decompress straight into the Slice allocation (no zero-fill,
+                    // no Vec -> Slice copy). SAFETY: see the read-path arm above;
+                    // the checksum-verified stream is intact.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut decompressed = unsafe {
+                        Slice::builder_unzeroed(parsed_header.uncompressed_length as usize)
+                    };
 
                     let bytes_written =
                         lz4_flex::decompress_into(compressed_data, &mut decompressed)
@@ -1541,7 +1567,7 @@ impl Block {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    decompressed.freeze().into()
                 }
 
                 #[cfg(zstd_any)]

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -988,17 +988,21 @@ impl Block {
 
                 #[cfg(zstd_any)]
                 CompressionType::Zstd(_) => {
-                    let decompressed = crate::compression::ZstdBackend::decompress(
-                        &decrypted,
-                        header.uncompressed_length as usize,
-                    )
-                    .map_err(|_| crate::Error::Decompress(compression))?;
+                    // Decompress straight into the Slice allocation — no
+                    // zero-filled scratch Vec and no Vec -> Slice copy.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder =
+                        unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    if decompressed.len() != header.uncompressed_length as usize {
+                    let bytes_written =
+                        crate::compression::ZstdBackend::decompress_into(&decrypted, &mut builder)
+                            .map_err(|_| crate::Error::Decompress(compression))?;
+
+                    if bytes_written != header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1092,17 +1096,21 @@ impl Block {
 
                 #[cfg(zstd_any)]
                 CompressionType::Zstd(_) => {
-                    let decompressed = crate::compression::ZstdBackend::decompress(
-                        &raw_data,
-                        header.uncompressed_length as usize,
-                    )
-                    .map_err(|_| crate::Error::Decompress(compression))?;
+                    // Decompress straight into the Slice allocation — no
+                    // zero-filled scratch Vec and no Vec -> Slice copy.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder =
+                        unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    if decompressed.len() != header.uncompressed_length as usize {
+                    let bytes_written =
+                        crate::compression::ZstdBackend::decompress_into(&raw_data, &mut builder)
+                            .map_err(|_| crate::Error::Decompress(compression))?;
+
+                    if bytes_written != header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1410,17 +1418,22 @@ impl Block {
 
                 #[cfg(zstd_any)]
                 CompressionType::Zstd(_) => {
-                    let decompressed = crate::compression::ZstdBackend::decompress(
-                        &decrypted,
-                        parsed_header.uncompressed_length as usize,
-                    )
-                    .map_err(|_| crate::Error::Decompress(compression))?;
+                    // Decompress straight into the Slice allocation — no
+                    // zero-filled scratch Vec and no Vec -> Slice copy.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder = unsafe {
+                        Slice::builder_unzeroed(parsed_header.uncompressed_length as usize)
+                    };
 
-                    if decompressed.len() != parsed_header.uncompressed_length as usize {
+                    let bytes_written =
+                        crate::compression::ZstdBackend::decompress_into(&decrypted, &mut builder)
+                            .map_err(|_| crate::Error::Decompress(compression))?;
+
+                    if bytes_written != parsed_header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]
@@ -1574,17 +1587,24 @@ impl Block {
                 CompressionType::Zstd(_) => {
                     let compressed_data: &[u8] = &payload_slice;
 
-                    let decompressed = crate::compression::ZstdBackend::decompress(
+                    // Decompress straight into the Slice allocation — no
+                    // zero-filled scratch Vec and no Vec -> Slice copy.
+                    #[expect(unsafe_code, reason = "fill an uninitialized Slice via decompress")]
+                    let mut builder = unsafe {
+                        Slice::builder_unzeroed(parsed_header.uncompressed_length as usize)
+                    };
+
+                    let bytes_written = crate::compression::ZstdBackend::decompress_into(
                         compressed_data,
-                        parsed_header.uncompressed_length as usize,
+                        &mut builder,
                     )
                     .map_err(|_| crate::Error::Decompress(compression))?;
 
-                    if decompressed.len() != parsed_header.uncompressed_length as usize {
+                    if bytes_written != parsed_header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
                     }
 
-                    Slice::from(decompressed)
+                    builder.freeze().into()
                 }
 
                 #[cfg(zstd_any)]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -193,6 +193,63 @@ impl core::ops::Deref for Tree {
 
 impl crate::abstract_tree::sealed::Sealed for Tree {}
 
+/// Maps a raw merge-pipeline item into a standard-tree iterator guard.
+fn standard_guard(item: crate::Result<InternalValue>) -> IterGuardImpl {
+    IterGuardImpl::Standard(Guard(item.map(|iv| (iv.key.user_key, iv.value))))
+}
+
+/// Extract owned user-key bounds from any range.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "reached from blob_tree as crate::tree::range_to_user_bounds"
+)]
+pub(crate) fn range_to_user_bounds<K: AsRef<[u8]>, R: RangeBounds<K>>(
+    range: &R,
+) -> (Bound<UserKey>, Bound<UserKey>) {
+    use core::ops::Bound::{Excluded, Included, Unbounded};
+    let lo = match range.start_bound() {
+        Included(x) => Included(x.as_ref().into()),
+        Excluded(x) => Excluded(x.as_ref().into()),
+        Unbounded => Unbounded,
+    };
+    let hi = match range.end_bound() {
+        Included(x) => Included(x.as_ref().into()),
+        Excluded(x) => Excluded(x.as_ref().into()),
+        Unbounded => Unbounded,
+    };
+    (lo, hi)
+}
+
+/// Wraps a [`SeekableTreeIter`](crate::range::SeekableTreeIter) so a standard
+/// tree can expose it as a [`SeekableGuardIter`].
+struct StandardSeekable {
+    inner: crate::range::SeekableTreeIter,
+}
+
+impl Iterator for StandardSeekable {
+    type Item = IterGuardImpl;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(standard_guard)
+    }
+}
+
+impl DoubleEndedIterator for StandardSeekable {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(standard_guard)
+    }
+}
+
+impl crate::iter_guard::SeekableGuardIter for StandardSeekable {
+    fn seek_to(&mut self, key: &[u8]) {
+        self.inner.seek_to(key);
+    }
+
+    fn seek_to_for_prev(&mut self, key: &[u8]) {
+        self.inner.seek_to_for_prev(key);
+    }
+}
+
 impl AbstractTree for Tree {
     fn table_file_cache_size(&self) -> usize {
         self.config
@@ -418,6 +475,34 @@ impl AbstractTree for Tree {
             self.create_range(&range, seqno, index)
                 .map(|kv| IterGuardImpl::Standard(Guard(kv))),
         )
+    }
+
+    fn range_seekable<K: AsRef<[u8]>, R: RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn crate::iter_guard::SeekableGuardIter + 'static> {
+        let (lo, hi) = range_to_user_bounds(&range);
+        let inner = self.create_seekable_range_bounds(lo, hi, seqno, index);
+        Box::new(StandardSeekable { inner })
+    }
+
+    fn batch_range_scan<K: AsRef<[u8]>, R: RangeBounds<K> + 'static, I: IntoIterator<Item = R>>(
+        &self,
+        intervals: I,
+        seqno: SeqNo,
+        index: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> Box<dyn Iterator<Item = IterGuardImpl> + Send + 'static>
+    where
+        I::IntoIter: Send + 'static,
+    {
+        // Open the seekable iterator over the whole keyspace once; each interval
+        // is served by repositioning it (single per-SST setup, amortized).
+        let inner =
+            self.create_seekable_range_bounds(Bound::Unbounded, Bound::Unbounded, seqno, index);
+        let intervals = intervals.into_iter().map(|r| range_to_user_bounds(&r));
+        Box::new(crate::range::BatchRangeScan::new(inner, intervals).map(standard_guard))
     }
 
     /// Returns the number of tombstones in the tree.
@@ -2600,6 +2685,36 @@ impl Tree {
             Ok(kv) => Ok((kv.key.user_key, kv.value)),
             Err(e) => Err(e),
         })
+    }
+
+    /// Build a [`SeekableTreeIter`](crate::range::SeekableTreeIter) over
+    /// `[lo, hi)`. Source collection (Phase 1) runs once; repositions reuse it.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn create_seekable_range_bounds(
+        &self,
+        lo: Bound<UserKey>,
+        hi: Bound<UserKey>,
+        seqno: SeqNo,
+        ephemeral: Option<(Arc<Memtable>, SeqNo)>,
+    ) -> crate::range::SeekableTreeIter {
+        use crate::range::{IterState, SeekableTreeIter};
+
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
+
+        let iter_state = IterState {
+            version: super_version,
+            ephemeral,
+            merge_operator: self.config.merge_operator.clone(),
+            comparator: self.config.comparator.clone(),
+            prefix_hash: None,
+            key_hash: None,
+            bloom_key: None,
+            #[cfg(feature = "metrics")]
+            metrics: Some(self.0.metrics.clone()),
+        };
+
+        SeekableTreeIter::create(iter_state, lo, hi, seqno)
     }
 
     #[doc(hidden)]

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -232,45 +232,73 @@ fn seekable_with_range_tombstone() -> lsm_tree::Result<()> {
 
 #[test]
 fn seekable_with_ephemeral_memtable() -> lsm_tree::Result<()> {
-    let (tree, _folder) = build_tree(false)?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    // An ephemeral memtable (passed via the `index` parameter) with overriding
-    // values and a range tombstone — exercises the ephemeral source branches.
-    let comparator: SharedComparator = Arc::new(DefaultUserComparator);
-    let mt = Arc::new(Memtable::new(123, comparator));
-    for i in (0..300u32).step_by(11) {
-        mt.insert(InternalValue::from_components(
-            key(i),
-            val(i + 9_000_000),
-            10,
-            ValueType::Value,
-        ));
+        // An ephemeral memtable (passed via the `index` parameter) with
+        // overriding values and a range tombstone — exercises the ephemeral
+        // source branches.
+        let comparator: SharedComparator = Arc::new(DefaultUserComparator);
+        let mt = Arc::new(Memtable::new(123, comparator));
+        for i in (0..300u32).step_by(11) {
+            mt.insert(InternalValue::from_components(
+                key(i),
+                val(i + 9_000_000),
+                10,
+                ValueType::Value,
+            ));
+        }
+        assert!(
+            mt.insert_range_tombstone(
+                UserKey::from(key(70).as_slice()),
+                UserKey::from(key(90).as_slice()),
+                10,
+            ) > 0,
+            "ephemeral range tombstone rejected",
+        );
+        let eph = Some((mt, 11u64));
+
+        let intervals: Vec<Range<Vec<u8>>> = vec![key(0)..key(60), key(85)..key(160)];
+        let expected: Vec<(Vec<u8>, Vec<u8>)> = intervals
+            .iter()
+            .flat_map(|iv| tree.range(iv.clone(), SeqNo::MAX, eph.clone()).map(kv))
+            .collect();
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals, SeqNo::MAX, eph.clone())
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "ephemeral batch (kv_sep={kv_sep})");
+
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, eph.clone());
+        it.seek_to(&key(50));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        let exp: Vec<_> = tree.range(key(50).., SeqNo::MAX, eph).map(kv).collect();
+        assert_eq!(got, exp, "ephemeral seek_to (kv_sep={kv_sep})");
     }
-    assert!(
-        mt.insert_range_tombstone(
-            UserKey::from(key(70).as_slice()),
-            UserKey::from(key(90).as_slice()),
-            10,
-        ) > 0,
-        "ephemeral range tombstone rejected",
-    );
-    let eph = Some((mt, 11u64));
+    Ok(())
+}
 
-    let intervals: Vec<Range<Vec<u8>>> = vec![key(0)..key(60), key(85)..key(160)];
-    let expected: Vec<(Vec<u8>, Vec<u8>)> = intervals
-        .iter()
-        .flat_map(|iv| tree.range(iv.clone(), SeqNo::MAX, eph.clone()).map(kv))
-        .collect();
-    let got: Vec<_> = tree
-        .batch_range_scan(intervals, SeqNo::MAX, eph.clone())
-        .map(kv)
-        .collect();
-    assert_eq!(got, expected, "ephemeral batch");
+#[test]
+fn seekable_over_multi_sst_run() -> lsm_tree::Result<()> {
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+        // A tiny target size makes the merged bottom-level run span several
+        // SSTs, exercising the multi-run RunReader collection / build path.
+        tree.major_compact(2048, 4)?;
 
-    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, eph.clone());
-    it.seek_to(&key(50));
-    let got: Vec<_> = (&mut it).map(kv).collect();
-    let exp: Vec<_> = tree.range(key(50).., SeqNo::MAX, eph).map(kv).collect();
-    assert_eq!(got, exp, "ephemeral seek_to");
+        let intervals: Vec<Range<Vec<u8>>> = vec![key(10)..key(120), key(200)..key(290)];
+        let expected = reference(&tree, &intervals);
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals, SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "multi-run batch (kv_sep={kv_sep})");
+
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        it.seek_to(&key(75));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        let exp: Vec<_> = tree.range(key(75).., SeqNo::MAX, None).map(kv).collect();
+        assert_eq!(got, exp, "multi-run seek_to (kv_sep={kv_sep})");
+    }
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Equivalence tests for the seekable range iterator (#495): `seek_to`,
+//! `seek_to_for_prev`, and `batch_range_scan` must return exactly what the
+//! equivalent plain `range()` calls return.
+
+use lsm_tree::{AbstractTree, Config, Guard, SeqNo, SequenceNumberCounter, get_tmp_folder};
+use std::ops::Range;
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:05}").into_bytes()
+}
+
+fn val(i: u32) -> Vec<u8> {
+    format!("v{i:05}-{}", "x".repeat((i % 7) as usize)).into_bytes()
+}
+
+/// Build a tree spread across several SSTs plus the active memtable, with
+/// overwrites (newer seqno wins) and deletes, so the merge pipeline is
+/// non-trivial.
+fn populated_tree() -> lsm_tree::Result<(lsm_tree::AnyTree, tempfile::TempDir)> {
+    let folder = get_tmp_folder();
+    let tree = Config::new(
+        &folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // SST 1: keys 0..200 at seqno 0.
+    for i in 0..200u32 {
+        tree.insert(key(i), val(i), 0);
+    }
+    tree.flush_active_memtable(0)?;
+
+    // SST 2: overwrite every 3rd key with a newer value at seqno 1, plus new
+    // keys 200..260.
+    for i in (0..200u32).step_by(3) {
+        tree.insert(key(i), val(i + 1_000_000), 1);
+    }
+    for i in 200..260u32 {
+        tree.insert(key(i), val(i), 1);
+    }
+    tree.flush_active_memtable(1)?;
+
+    // Memtable (unflushed): delete every 7th key, overwrite every 5th, add tail.
+    for i in (0..260u32).step_by(7) {
+        tree.remove(key(i), 2);
+    }
+    for i in (0..260u32).step_by(5) {
+        tree.insert(key(i), val(i + 2_000_000), 3);
+    }
+    for i in 260..300u32 {
+        tree.insert(key(i), val(i), 3);
+    }
+
+    Ok((tree, folder))
+}
+
+fn kv(guard: lsm_tree::IterGuardImpl) -> (Vec<u8>, Vec<u8>) {
+    let (k, v) = guard.into_inner().expect("guard resolves");
+    (k.to_vec(), v.to_vec())
+}
+
+/// Reference: concatenation of N independent `range()` calls.
+fn reference(tree: &lsm_tree::AnyTree, intervals: &[Range<Vec<u8>>]) -> Vec<(Vec<u8>, Vec<u8>)> {
+    intervals
+        .iter()
+        .flat_map(|iv| tree.range(iv.clone(), SeqNo::MAX, None).map(kv))
+        .collect()
+}
+
+#[test]
+fn batch_range_scan_matches_separate_ranges() -> lsm_tree::Result<()> {
+    let (tree, _folder) = populated_tree()?;
+
+    // Disjoint, ascending sub-intervals scattered across the keyspace.
+    let intervals: Vec<Range<Vec<u8>>> = vec![
+        key(3)..key(17),
+        key(40)..key(41),  // single-key window
+        key(95)..key(140), // spans the SST overwrite + memtable region
+        key(205)..key(230),
+        key(280)..key(305), // tail, partially past the last key
+    ];
+
+    let expected = reference(&tree, &intervals);
+    assert!(!expected.is_empty(), "fixture should yield rows");
+
+    let got: Vec<_> = tree
+        .batch_range_scan(intervals.clone(), SeqNo::MAX, None)
+        .map(kv)
+        .collect();
+
+    assert_eq!(got, expected, "batch scan must equal N separate ranges");
+    Ok(())
+}
+
+#[test]
+fn batch_range_scan_empty_and_full_intervals() -> lsm_tree::Result<()> {
+    let (tree, _folder) = populated_tree()?;
+
+    // An empty interval (no keys), a normal one, and one fully covered by deletes.
+    let intervals: Vec<Range<Vec<u8>>> = vec![
+        key(9000)..key(9100), // empty: past all data
+        key(50)..key(60),
+    ];
+    let expected = reference(&tree, &intervals);
+    let got: Vec<_> = tree
+        .batch_range_scan(intervals, SeqNo::MAX, None)
+        .map(kv)
+        .collect();
+    assert_eq!(got, expected);
+    Ok(())
+}
+
+#[test]
+fn seek_to_matches_range_from_key() -> lsm_tree::Result<()> {
+    let (tree, _folder) = populated_tree()?;
+
+    for start in [0u32, 1, 7, 42, 150, 199, 200, 259, 260, 299, 500] {
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        it.seek_to(&key(start));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+
+        let expected: Vec<_> = tree.range(key(start).., SeqNo::MAX, None).map(kv).collect();
+
+        assert_eq!(
+            got, expected,
+            "seek_to({start}) must equal range(k{start}..)"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn seek_to_repeated_jumps_stay_consistent() -> lsm_tree::Result<()> {
+    let (tree, _folder) = populated_tree()?;
+
+    // A single live iterator jumped forward several times must, after each jump,
+    // produce the same rows as a fresh range() from that key.
+    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+    for start in [10u32, 100, 33, 250, 5] {
+        it.seek_to(&key(start));
+        let got: Vec<_> = std::iter::from_fn(|| it.next()).take(8).map(kv).collect();
+        let expected: Vec<_> = tree
+            .range(key(start).., SeqNo::MAX, None)
+            .take(8)
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "jump to k{start}");
+    }
+    Ok(())
+}
+
+#[test]
+fn seek_to_for_prev_matches_reverse_range() -> lsm_tree::Result<()> {
+    let (tree, _folder) = populated_tree()?;
+
+    for end in [5u32, 42, 150, 200, 260, 299, 500] {
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        it.seek_to_for_prev(&key(end));
+        // Pull backward from the repositioned iterator.
+        let got: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
+
+        let expected: Vec<_> = tree
+            .range(..=key(end), SeqNo::MAX, None)
+            .rev()
+            .map(kv)
+            .collect();
+
+        assert_eq!(
+            got, expected,
+            "seek_to_for_prev({end}) reverse must equal range(..=k{end}).rev()"
+        );
+    }
+    Ok(())
+}

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -239,6 +239,31 @@ fn seek_outside_declared_window_stays_clamped() -> lsm_tree::Result<()> {
             got, in_window,
             "seek_to_for_prev above the window must clamp to it (kv_sep={kv_sep})"
         );
+
+        // Same with an excluded-lower / included-upper window, so the other two
+        // clamp arms (Excluded lower, Included upper) are exercised too.
+        let excl_window = (Bound::Excluded(key(100)), Bound::Included(key(200)));
+        let in_excl: Vec<_> = tree
+            .range(excl_window.clone(), SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+
+        let mut it = tree.range_seekable(excl_window.clone(), SeqNo::MAX, None);
+        it.seek_to(&key(80));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        assert_eq!(
+            got, in_excl,
+            "seek_to below an excluded-lower window must clamp (kv_sep={kv_sep})"
+        );
+
+        let mut it = tree.range_seekable(excl_window, SeqNo::MAX, None);
+        it.seek_to_for_prev(&key(250));
+        let mut got: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
+        got.reverse();
+        assert_eq!(
+            got, in_excl,
+            "seek_to_for_prev above an included-upper window must clamp (kv_sep={kv_sep})"
+        );
     }
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -13,9 +13,12 @@ use lsm_tree::{
     AbstractTree, Config, DefaultUserComparator, Guard, InternalValue, KvSeparationOptions,
     Memtable, SeqNo, SequenceNumberCounter, SharedComparator, UserKey, ValueType, get_tmp_folder,
 };
-use std::ops::Range;
+use std::ops::{Bound, Range};
 use std::sync::Arc;
 use test_log::test;
+
+/// An explicit `(start, end)` bound pair used to build excluded-bound ranges.
+type BoundPair = (Bound<Vec<u8>>, Bound<Vec<u8>>);
 
 fn key(i: u32) -> Vec<u8> {
     format!("k{i:05}").into_bytes()
@@ -326,8 +329,6 @@ fn seekable_over_multi_sst_run() -> lsm_tree::Result<()> {
 
 #[test]
 fn seekable_sealed_memtable_and_excluded_bounds() -> lsm_tree::Result<()> {
-    use std::ops::Bound;
-
     for kv_sep in [false, true] {
         let (tree, _folder) = build_tree(kv_sep)?;
         // Seal a memtable without flushing it (rotate), then keep writing to the
@@ -341,7 +342,7 @@ fn seekable_sealed_memtable_and_excluded_bounds() -> lsm_tree::Result<()> {
         }
 
         // Excluded lower bounds exercise the Excluded arm of the bound builders.
-        let intervals: Vec<(Bound<Vec<u8>>, Bound<Vec<u8>>)> = vec![
+        let intervals: Vec<BoundPair> = vec![
             (Bound::Excluded(key(20)), Bound::Excluded(key(90))),
             (Bound::Excluded(key(305)), Bound::Included(key(355))),
         ];

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -4,8 +4,14 @@
 //! Equivalence tests for the seekable range iterator (#495): `seek_to`,
 //! `seek_to_for_prev`, and `batch_range_scan` must return exactly what the
 //! equivalent plain `range()` calls return.
+//!
+//! Each test runs against both a standard tree and a KV-separated `BlobTree`
+//! (values stored in blob files), so blob-handle resolution on the reposition /
+//! batch paths is covered too.
 
-use lsm_tree::{AbstractTree, Config, Guard, SeqNo, SequenceNumberCounter, get_tmp_folder};
+use lsm_tree::{
+    AbstractTree, Config, Guard, KvSeparationOptions, SeqNo, SequenceNumberCounter, get_tmp_folder,
+};
 use std::ops::Range;
 use test_log::test;
 
@@ -19,15 +25,21 @@ fn val(i: u32) -> Vec<u8> {
 
 /// Build a tree spread across several SSTs plus the active memtable, with
 /// overwrites (newer seqno wins) and deletes, so the merge pipeline is
-/// non-trivial.
-fn populated_tree() -> lsm_tree::Result<(lsm_tree::AnyTree, tempfile::TempDir)> {
+/// non-trivial. With `kv_sep`, values are stored in blob files (threshold 1), so
+/// every read resolves a blob handle.
+fn build_tree(kv_sep: bool) -> lsm_tree::Result<(lsm_tree::AnyTree, tempfile::TempDir)> {
     let folder = get_tmp_folder();
-    let tree = Config::new(
+    let config = Config::new(
         &folder,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
-    )
-    .open()?;
+    );
+    let config = if kv_sep {
+        config.with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    } else {
+        config
+    };
+    let tree = config.open()?;
 
     // SST 1: keys 0..200 at seqno 0.
     for i in 0..200u32 {
@@ -74,106 +86,119 @@ fn reference(tree: &lsm_tree::AnyTree, intervals: &[Range<Vec<u8>>]) -> Vec<(Vec
 
 #[test]
 fn batch_range_scan_matches_separate_ranges() -> lsm_tree::Result<()> {
-    let (tree, _folder) = populated_tree()?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    // Disjoint, ascending sub-intervals scattered across the keyspace.
-    let intervals: Vec<Range<Vec<u8>>> = vec![
-        key(3)..key(17),
-        key(40)..key(41),  // single-key window
-        key(95)..key(140), // spans the SST overwrite + memtable region
-        key(205)..key(230),
-        key(280)..key(305), // tail, partially past the last key
-    ];
+        // Disjoint, ascending sub-intervals scattered across the keyspace.
+        let intervals: Vec<Range<Vec<u8>>> = vec![
+            key(3)..key(17),
+            key(40)..key(41),  // single-key window
+            key(95)..key(140), // spans the SST overwrite + memtable region
+            key(205)..key(230),
+            key(280)..key(305), // tail, partially past the last key
+        ];
 
-    let expected = reference(&tree, &intervals);
-    assert!(!expected.is_empty(), "fixture should yield rows");
+        let expected = reference(&tree, &intervals);
+        assert!(!expected.is_empty(), "fixture should yield rows");
 
-    let got: Vec<_> = tree
-        .batch_range_scan(intervals.clone(), SeqNo::MAX, None)
-        .map(kv)
-        .collect();
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals.clone(), SeqNo::MAX, None)
+            .map(kv)
+            .collect();
 
-    assert_eq!(got, expected, "batch scan must equal N separate ranges");
+        assert_eq!(
+            got, expected,
+            "batch scan must equal N separate ranges (kv_sep={kv_sep})"
+        );
+    }
     Ok(())
 }
 
 #[test]
 fn batch_range_scan_empty_and_full_intervals() -> lsm_tree::Result<()> {
-    let (tree, _folder) = populated_tree()?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    // An empty interval (no keys), a normal one, and one fully covered by deletes.
-    let intervals: Vec<Range<Vec<u8>>> = vec![
-        key(9000)..key(9100), // empty: past all data
-        key(50)..key(60),
-    ];
-    let expected = reference(&tree, &intervals);
-    let got: Vec<_> = tree
-        .batch_range_scan(intervals, SeqNo::MAX, None)
-        .map(kv)
-        .collect();
-    assert_eq!(got, expected);
+        // An empty interval (no keys) plus a normal one.
+        let intervals: Vec<Range<Vec<u8>>> = vec![
+            key(9000)..key(9100), // empty: past all data
+            key(50)..key(60),
+        ];
+        let expected = reference(&tree, &intervals);
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals, SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "kv_sep={kv_sep}");
+    }
     Ok(())
 }
 
 #[test]
 fn seek_to_matches_range_from_key() -> lsm_tree::Result<()> {
-    let (tree, _folder) = populated_tree()?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    for start in [0u32, 1, 7, 42, 150, 199, 200, 259, 260, 299, 500] {
-        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-        it.seek_to(&key(start));
-        let got: Vec<_> = (&mut it).map(kv).collect();
+        for start in [0u32, 1, 7, 42, 150, 199, 200, 259, 260, 299, 500] {
+            let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+            it.seek_to(&key(start));
+            let got: Vec<_> = (&mut it).map(kv).collect();
 
-        let expected: Vec<_> = tree.range(key(start).., SeqNo::MAX, None).map(kv).collect();
+            let expected: Vec<_> = tree.range(key(start).., SeqNo::MAX, None).map(kv).collect();
 
-        assert_eq!(
-            got, expected,
-            "seek_to({start}) must equal range(k{start}..)"
-        );
+            assert_eq!(
+                got, expected,
+                "seek_to({start}) must equal range(k{start}..) (kv_sep={kv_sep})"
+            );
+        }
     }
     Ok(())
 }
 
 #[test]
 fn seek_to_repeated_jumps_stay_consistent() -> lsm_tree::Result<()> {
-    let (tree, _folder) = populated_tree()?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    // A single live iterator jumped forward several times must, after each jump,
-    // produce the same rows as a fresh range() from that key.
-    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-    for start in [10u32, 100, 33, 250, 5] {
-        it.seek_to(&key(start));
-        let got: Vec<_> = std::iter::from_fn(|| it.next()).take(8).map(kv).collect();
-        let expected: Vec<_> = tree
-            .range(key(start).., SeqNo::MAX, None)
-            .take(8)
-            .map(kv)
-            .collect();
-        assert_eq!(got, expected, "jump to k{start}");
+        // A single live iterator jumped forward several times must, after each
+        // jump, produce the same rows as a fresh range() from that key.
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        for start in [10u32, 100, 33, 250, 5] {
+            it.seek_to(&key(start));
+            let got: Vec<_> = std::iter::from_fn(|| it.next()).take(8).map(kv).collect();
+            let expected: Vec<_> = tree
+                .range(key(start).., SeqNo::MAX, None)
+                .take(8)
+                .map(kv)
+                .collect();
+            assert_eq!(got, expected, "jump to k{start} (kv_sep={kv_sep})");
+        }
     }
     Ok(())
 }
 
 #[test]
 fn seek_to_for_prev_matches_reverse_range() -> lsm_tree::Result<()> {
-    let (tree, _folder) = populated_tree()?;
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
 
-    for end in [5u32, 42, 150, 200, 260, 299, 500] {
-        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-        it.seek_to_for_prev(&key(end));
-        // Pull backward from the repositioned iterator.
-        let got: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
+        for end in [5u32, 42, 150, 200, 260, 299, 500] {
+            let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+            it.seek_to_for_prev(&key(end));
+            // Pull backward from the repositioned iterator.
+            let got: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
 
-        let expected: Vec<_> = tree
-            .range(..=key(end), SeqNo::MAX, None)
-            .rev()
-            .map(kv)
-            .collect();
+            let expected: Vec<_> = tree
+                .range(..=key(end), SeqNo::MAX, None)
+                .rev()
+                .map(kv)
+                .collect();
 
-        assert_eq!(
-            got, expected,
-            "seek_to_for_prev({end}) reverse must equal range(..=k{end}).rev()"
-        );
+            assert_eq!(
+                got, expected,
+                "seek_to_for_prev({end}) reverse must equal range(..=k{end}).rev() (kv_sep={kv_sep})"
+            );
+        }
     }
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -10,9 +10,11 @@
 //! batch paths is covered too.
 
 use lsm_tree::{
-    AbstractTree, Config, Guard, KvSeparationOptions, SeqNo, SequenceNumberCounter, get_tmp_folder,
+    AbstractTree, Config, DefaultUserComparator, Guard, InternalValue, KvSeparationOptions,
+    Memtable, SeqNo, SequenceNumberCounter, SharedComparator, UserKey, ValueType, get_tmp_folder,
 };
 use std::ops::Range;
+use std::sync::Arc;
 use test_log::test;
 
 fn key(i: u32) -> Vec<u8> {
@@ -200,5 +202,75 @@ fn seek_to_for_prev_matches_reverse_range() -> lsm_tree::Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+#[test]
+fn seekable_with_range_tombstone() -> lsm_tree::Result<()> {
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+        // A dropped sub-range plants a range tombstone, so the merge pipeline
+        // wraps in the RangeTombstoneFilter branch.
+        tree.drop_range(key(50)..key(150))?;
+
+        let intervals: Vec<Range<Vec<u8>>> = vec![key(30)..key(80), key(120)..key(200)];
+        let expected = reference(&tree, &intervals);
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals, SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "RT batch (kv_sep={kv_sep})");
+
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        it.seek_to(&key(40));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        let exp: Vec<_> = tree.range(key(40).., SeqNo::MAX, None).map(kv).collect();
+        assert_eq!(got, exp, "RT seek_to (kv_sep={kv_sep})");
+    }
+    Ok(())
+}
+
+#[test]
+fn seekable_with_ephemeral_memtable() -> lsm_tree::Result<()> {
+    let (tree, _folder) = build_tree(false)?;
+
+    // An ephemeral memtable (passed via the `index` parameter) with overriding
+    // values and a range tombstone — exercises the ephemeral source branches.
+    let comparator: SharedComparator = Arc::new(DefaultUserComparator);
+    let mt = Arc::new(Memtable::new(123, comparator));
+    for i in (0..300u32).step_by(11) {
+        mt.insert(InternalValue::from_components(
+            key(i),
+            val(i + 9_000_000),
+            10,
+            ValueType::Value,
+        ));
+    }
+    assert!(
+        mt.insert_range_tombstone(
+            UserKey::from(key(70).as_slice()),
+            UserKey::from(key(90).as_slice()),
+            10,
+        ) > 0,
+        "ephemeral range tombstone rejected",
+    );
+    let eph = Some((mt, 11u64));
+
+    let intervals: Vec<Range<Vec<u8>>> = vec![key(0)..key(60), key(85)..key(160)];
+    let expected: Vec<(Vec<u8>, Vec<u8>)> = intervals
+        .iter()
+        .flat_map(|iv| tree.range(iv.clone(), SeqNo::MAX, eph.clone()).map(kv))
+        .collect();
+    let got: Vec<_> = tree
+        .batch_range_scan(intervals, SeqNo::MAX, eph.clone())
+        .map(kv)
+        .collect();
+    assert_eq!(got, expected, "ephemeral batch");
+
+    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, eph.clone());
+    it.seek_to(&key(50));
+    let got: Vec<_> = (&mut it).map(kv).collect();
+    let exp: Vec<_> = tree.range(key(50).., SeqNo::MAX, eph).map(kv).collect();
+    assert_eq!(got, exp, "ephemeral seek_to");
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -209,6 +209,41 @@ fn seek_to_for_prev_matches_reverse_range() -> lsm_tree::Result<()> {
 }
 
 #[test]
+fn seek_outside_declared_window_stays_clamped() -> lsm_tree::Result<()> {
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+        // A seekable opened over a bounded window [100, 200) only collected its
+        // Phase-1 sources for that window. Seeking outside the window must clamp
+        // to it (bounded-iterator semantics), not leak rows below/above the
+        // window or drop rows from sources skipped during collection.
+        let in_window: Vec<_> = tree
+            .range(key(100)..key(200), SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+
+        // Forward seek below the lower bound → clamps to the window start.
+        let mut it = tree.range_seekable(key(100)..key(200), SeqNo::MAX, None);
+        it.seek_to(&key(50));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        assert_eq!(
+            got, in_window,
+            "seek_to below the window must clamp to it (kv_sep={kv_sep})"
+        );
+
+        // Reverse seek above the upper bound → clamps to the window end.
+        let mut it = tree.range_seekable(key(100)..key(200), SeqNo::MAX, None);
+        it.seek_to_for_prev(&key(250));
+        let mut got: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
+        got.reverse();
+        assert_eq!(
+            got, in_window,
+            "seek_to_for_prev above the window must clamp to it (kv_sep={kv_sep})"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn seekable_with_range_tombstone() -> lsm_tree::Result<()> {
     for kv_sep in [false, true] {
         let (tree, _folder) = build_tree(kv_sep)?;

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -281,12 +281,33 @@ fn seekable_with_ephemeral_memtable() -> lsm_tree::Result<()> {
 #[test]
 fn seekable_over_multi_sst_run() -> lsm_tree::Result<()> {
     for kv_sep in [false, true] {
-        let (tree, _folder) = build_tree(kv_sep)?;
-        // A tiny target size makes the merged bottom-level run span several
-        // SSTs, exercising the multi-run RunReader collection / build path.
-        tree.major_compact(2048, 4)?;
+        let folder = get_tmp_folder();
+        let config = Config::new(
+            &folder,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        );
+        let config = if kv_sep {
+            config.with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+        } else {
+            config
+        };
+        let tree = config.open()?;
 
-        let intervals: Vec<Range<Vec<u8>>> = vec![key(10)..key(120), key(200)..key(290)];
+        // Enough data that a tiny-target compaction splits the merged bottom
+        // level into many SSTs forming one multi-SST run, exercising the
+        // multi-run RunReader collection / build path.
+        for i in 0..4000u32 {
+            tree.insert(key(i), val(i % 200), 0);
+        }
+        tree.flush_active_memtable(0)?;
+        tree.major_compact(4096, 1)?;
+
+        let intervals: Vec<Range<Vec<u8>>> = vec![
+            key(10)..key(900),
+            key(1500)..key(1600),
+            key(3000)..key(3990),
+        ];
         let expected = reference(&tree, &intervals);
         let got: Vec<_> = tree
             .batch_range_scan(intervals, SeqNo::MAX, None)
@@ -295,10 +316,55 @@ fn seekable_over_multi_sst_run() -> lsm_tree::Result<()> {
         assert_eq!(got, expected, "multi-run batch (kv_sep={kv_sep})");
 
         let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-        it.seek_to(&key(75));
+        it.seek_to(&key(2500));
         let got: Vec<_> = (&mut it).map(kv).collect();
-        let exp: Vec<_> = tree.range(key(75).., SeqNo::MAX, None).map(kv).collect();
+        let exp: Vec<_> = tree.range(key(2500).., SeqNo::MAX, None).map(kv).collect();
         assert_eq!(got, exp, "multi-run seek_to (kv_sep={kv_sep})");
+    }
+    Ok(())
+}
+
+#[test]
+fn seekable_sealed_memtable_and_excluded_bounds() -> lsm_tree::Result<()> {
+    use std::ops::Bound;
+
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+        // Seal a memtable without flushing it (rotate), then keep writing to the
+        // new active one — exercises the sealed-memtable source branches.
+        for i in 300..340u32 {
+            tree.insert(key(i), val(i), 4);
+        }
+        tree.rotate_memtable();
+        for i in 340..360u32 {
+            tree.insert(key(i), val(i), 5);
+        }
+
+        // Excluded lower bounds exercise the Excluded arm of the bound builders.
+        let intervals: Vec<(Bound<Vec<u8>>, Bound<Vec<u8>>)> = vec![
+            (Bound::Excluded(key(20)), Bound::Excluded(key(90))),
+            (Bound::Excluded(key(305)), Bound::Included(key(355))),
+        ];
+        let expected: Vec<(Vec<u8>, Vec<u8>)> = intervals
+            .iter()
+            .flat_map(|iv| tree.range(iv.clone(), SeqNo::MAX, None).map(kv))
+            .collect();
+        let got: Vec<_> = tree
+            .batch_range_scan(intervals, SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+        assert_eq!(got, expected, "sealed + excluded batch (kv_sep={kv_sep})");
+
+        // Seekable opened over an excluded-lower union.
+        let mut it = tree.range_seekable(
+            (Bound::Excluded(key(310)), Bound::Unbounded),
+            SeqNo::MAX,
+            None,
+        );
+        it.seek_to(&key(320));
+        let got: Vec<_> = (&mut it).map(kv).collect();
+        let exp: Vec<_> = tree.range(key(320).., SeqNo::MAX, None).map(kv).collect();
+        assert_eq!(got, exp, "sealed + excluded seek_to (kv_sep={kv_sep})");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds a seekable range iterator and a batched multi-interval scan, and removes a redundant zero-fill + copy around block decompression on the read path.

## Seekable range iterator (#495)

`AbstractTree` gains:

- **`range_seekable(range)`** → a `SeekableGuardIter` that exposes `seek_to(key)` (first key ≥ target, RocksDB `Seek`) and `seek_to_for_prev(key)` (last key ≤ target, RocksDB `SeekForPrev`). Seeks are valid mid-iteration, so a live iterator can jump to any key — enabling data-dependent scans (merge / zig-zag joins, skip-scan) without reopening per-SST readers per jump.
- **`batch_range_scan(intervals)`** — walks a lazily-pulled sequence of disjoint, ascending sub-ranges through one shared iterator. The per-SST setup is paid once and amortized across all intervals, so multi-interval scan throughput scales with the rows returned rather than the interval count. Intervals may be produced on demand (data-dependently).

Implementation splits the range pipeline into Phase 1 (collect the overlapping SSTs / runs / range tombstones once) and Phase 2 (rebuild the cheap merge stack for a sub-range). A reposition reuses the collected sources via an `Arc` and rebuilds only Phase 2 — the per-source readers reuse the existing, tested seek-to-start path, so there is no seek surgery inside the loser-tree / MVCC / range-tombstone layers. The common `iter` / `prefix` / `range` surface is unchanged.

Equivalence tests assert `seek_to` / `seek_to_for_prev` / `batch_range_scan` return exactly what the equivalent `range()` calls return, across overwrites, deletes, multi-level SSTs and the active memtable.

## Read-path zero-copy (#500)

The block read path zero-filled a scratch buffer for every payload and then copied it into a `Slice`:

- `read_payload_and_verify` now reads straight into a `Slice` (via `from_reader`, no zero-fill) and returns it; the no-encryption / ECC-recovery callers return it with no copy, and the parity read drops its zero-fill too. ECC recovery (rare) still copies out for in-place correction.

## Decompress-path perf

Every compressed block decompress allocated a zero-filled scratch buffer, decompressed into it, then copied that buffer into a `Slice`. The zero-fill is wasted (the decompressor overwrites the whole buffer) and the copy is a second full-block memcpy around the decompressor's wildcopy.

- **lz4** arms now decompress straight into an uninitialized `Slice` builder and freeze it: one allocation, no zero-fill, no second copy (was 2 allocs + a memset + an extra n-byte copy per block). Measured ~1.18× on the decompress step (release micro-bench, 16 KiB block).
- **zstd** arms gain `ZstdProvider::decompress_into`, which streams straight into a caller-provided buffer of the exact uncompressed length, removing the same zero-fill + copy. The excess-byte probe (reject frames that decode past the declared length) is preserved.

The block checksum is verified before decompress, so the stream is intact and wildcopy never reads an unwritten position.

## Testing

- Full suite green (2015 tests with `lz4,zstd`), `clippy --all-targets` clean, `no-std-check` errcount 0.
- New `tests/seekable_range.rs` equivalence suite (5 tests) + a block-overflow regression already in the tree.

## Related

- #499 — `approximate_range_stats` (RocksDB `GetApproximateSizes`): per-range byte/key estimate + split points for parallel scan (filed during the RocksDB API review).

Closes #495
Closes #500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seekable range iteration with in-place repositioning (forward and reverse).
  * Added batch range scanning across multiple disjoint key intervals.
  * Implemented these APIs for both standard tree access and KV-separated blob mode.
  * Added `decompress_into` for buffer-based Zstd decompression with decoded-size enforcement.
* **Performance**
  * Reduced allocations/copies in block decrypt/decompress by decoding directly into destination buffers where applicable.
* **Tests**
  * Added end-to-end equivalence tests for seekable and batch scans, including range tombstones, ephemeral context, and multi-run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
