### PR TITLE
perf(range): in-place seekable re-seek without merge-stack rebuild + peek

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -1,14 +1,31 @@
 #!/bin/bash
 # Run all db_bench workloads and produce github-action-benchmark JSON.
 # Usage: .github/scripts/run-benchmarks.sh [NUM_OPS] [ITERATIONS]
+#
+# Sweeps two working-set sizes so the dashboard tracks both the default
+# large set (NUM, default 500k) and a fixed 100k set that exceeds the default
+# block cache. The 100k pass tags every entry name with " /100k" so the two
+# series stay distinct (the default-size entries keep their original names, so
+# their dashboard history is unbroken).
 
 set -e
 
 NUM=${1:-500000}
 ITERATIONS=${2:-3}
 
-cargo run --release --manifest-path tools/db_bench/Cargo.toml -- \
-  --benchmark all --num "$NUM" --iterations "$ITERATIONS" --github-json \
-  > benchmark-results.json
+run_pass() {
+  # $1: --num value, $2: name suffix, $3: output file
+  cargo run --release --manifest-path tools/db_bench/Cargo.toml -- \
+    --benchmark all --num "$1" --iterations "$ITERATIONS" \
+    --name-suffix "$2" --github-json \
+    > "$3"
+}
 
-echo "Results written to benchmark-results.json" >&2
+run_pass "$NUM" "" results-main.json
+run_pass 100000 " /100k" results-100k.json
+
+# Concatenate the two github-action-benchmark arrays into one.
+jq -s 'add' results-main.json results-100k.json > benchmark-results.json
+rm -f results-main.json results-100k.json
+
+echo "Results written to benchmark-results.json (sizes: $NUM, 100000)" >&2

--- a/src/active_tombstone_set.rs
+++ b/src/active_tombstone_set.rs
@@ -59,6 +59,17 @@ impl ActiveTombstoneSet {
         }
     }
 
+    /// Resets the set to empty in place, reusing the backing `BTreeMap` /
+    /// `Vec` storage instead of dropping it. Equivalent to replacing with a
+    /// fresh [`Self::new_with_comparator`] but allocation-preserving: a
+    /// seek-then-iterate-then-reseek loop that activated tombstones keeps the
+    /// node / buffer capacity for the next pass.
+    pub fn clear(&mut self) {
+        self.seqno_counts.clear();
+        self.pending_expiry.clear();
+        self.next_id = 0;
+    }
+
     /// Activates a range tombstone, adding it to the active set.
     ///
     /// The tombstone is only activated if it is visible at `cutoff_seqno`
@@ -211,6 +222,15 @@ impl ActiveTombstoneSetReverse {
             pending_expiry: Vec::new(),
             next_id: 0,
         }
+    }
+
+    /// Resets the set to empty in place, reusing the backing `BTreeMap` /
+    /// `Vec` storage instead of dropping it (see
+    /// [`ActiveTombstoneSet::clear`]).
+    pub fn clear(&mut self) {
+        self.seqno_counts.clear();
+        self.pending_expiry.clear();
+        self.next_id = 0;
     }
 
     /// Activates a range tombstone, adding it to the active set.

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -329,6 +329,12 @@ impl crate::iter_guard::SeekableGuardIter for BlobSeekable {
     fn seek_to_for_prev(&mut self, key: &[u8]) {
         self.inner.seek_to_for_prev(key);
     }
+
+    fn peek_key(&mut self) -> Option<crate::Result<crate::UserKey>> {
+        // The key lives in the index tree (blob separation only moves the value),
+        // so the inner seekable's peek already yields the right user key.
+        self.inner.peek_key()
+    }
 }
 
 impl AbstractTree for BlobTree {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -367,3 +367,18 @@ impl Cache {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Cache;
+
+    #[test]
+    fn metadata_priority_defaults_on_and_toggles() {
+        // On by default.
+        assert!(Cache::with_capacity_bytes(1024).metadata_priority());
+        // Builder turns it off and back on.
+        let off = Cache::with_capacity_bytes(1024).with_metadata_priority(false);
+        assert!(!off.metadata_priority());
+        assert!(off.with_metadata_priority(true).metadata_priority());
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,8 +4,8 @@
 
 #[cfg(feature = "zstd")]
 use crate::UserKey;
-use crate::sharded_cache::{ShardedCache, Weighter};
-use crate::table::block::Header;
+use crate::sharded_cache::{Priority, ShardedCache, Weighter};
+use crate::table::block::{BlockType, Header};
 use crate::table::{Block, BlockOffset};
 use crate::value::InternalValue;
 use crate::{GlobalTableId, UserValue};
@@ -127,6 +127,12 @@ pub struct Cache {
     /// cached regardless. Off by default to avoid spending the shared capacity on
     /// rows for workloads that do not benefit (e.g. uniform / scan-heavy).
     row_cache_enabled: bool,
+    /// When true (default), index / filter / range-tombstone blocks are admitted
+    /// at [`Priority::High`] so heavy data-block churn (working set >> cache)
+    /// cannot evict the metadata blocks every seek touches, sparing a re-read +
+    /// re-decode on the next index descent. Disable to put every block on equal
+    /// footing (the pre-priority behaviour), e.g. for A/B measurement.
+    metadata_priority: bool,
 }
 
 /// Number of shards in the block cache. 64 keeps per-shard write contention low
@@ -151,6 +157,7 @@ impl Cache {
                 rustc_hash::FxBuildHasher,
             ),
             row_cache_enabled: false,
+            metadata_priority: true,
         }
     }
 
@@ -167,6 +174,22 @@ impl Cache {
     #[must_use]
     pub fn row_cache_enabled(&self) -> bool {
         self.row_cache_enabled
+    }
+
+    /// Enables or disables high-priority pinning of index / filter /
+    /// range-tombstone blocks (see [`Cache::metadata_priority`] field docs),
+    /// returning the cache for builder-style configuration. On by default.
+    #[must_use]
+    pub fn with_metadata_priority(mut self, enabled: bool) -> Self {
+        self.metadata_priority = enabled;
+        self
+    }
+
+    /// Whether metadata-block priority pinning is enabled (see
+    /// [`Cache::with_metadata_priority`]).
+    #[must_use]
+    pub fn metadata_priority(&self) -> bool {
+        self.metadata_priority
     }
 
     /// Returns the amount of cached bytes.
@@ -252,9 +275,23 @@ impl Cache {
 
     #[doc(hidden)]
     pub fn insert_block(&self, id: GlobalTableId, offset: BlockOffset, block: Block) {
-        self.data.insert(
+        // Pin index / filter / range-tombstone blocks: they are touched on every
+        // seek (index descent + bloom check), so under data-block churn (working
+        // set >> cache) they must outlive the data blocks that would otherwise
+        // evict them and force a metadata re-read + re-decode on the next seek.
+        let priority = if self.metadata_priority
+            && matches!(
+                block.header.block_type,
+                BlockType::Index | BlockType::Filter | BlockType::RangeTombstone
+            ) {
+            Priority::High
+        } else {
+            Priority::Normal
+        };
+        self.data.insert_with_priority(
             (TAG_BLOCK, id.tree_id(), id.table_id(), *offset).into(),
             Item::Block(block),
+            priority,
         );
     }
 

--- a/src/iter_guard.rs
+++ b/src/iter_guard.rs
@@ -83,4 +83,11 @@ pub trait SeekableGuardIter: DoubleEndedIterator<Item = IterGuardImpl> + Send {
     /// Reposition so the next [`DoubleEndedIterator::next_back`] yields the last
     /// entry with user key `<= key` (`RocksDB` `SeekForPrev`).
     fn seek_to_for_prev(&mut self, key: &[u8]);
+
+    /// Return the current key (the key the next [`Iterator::next`] would yield)
+    /// without consuming it; `None` once the range is exhausted.
+    ///
+    /// A leapfrog / zig-zag join reads each input's current key to compute the
+    /// next seek target before advancing any of them.
+    fn peek_key(&mut self) -> Option<crate::Result<UserKey>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@ pub mod manifest_blocks;
 mod memtable;
 mod merge_operator;
 pub(crate) mod rate_limiter;
+mod reseek;
 mod run_reader;
 mod run_scanner;
 // Vendored sfa is std-only internally (`std::io` / `std::fs` /

--- a/src/loser_tree.rs
+++ b/src/loser_tree.rs
@@ -232,6 +232,56 @@ where
         t
     }
 
+    /// Empty the tournament in place: drop every present leaf and mark all slots
+    /// absent, keeping the backing storage (`leaves` / `present` / `tree`)
+    /// allocated for a later [`Self::refill_with`]. After this, `is_empty()` is
+    /// true and `winner_slot()` is `None`.
+    ///
+    /// Used by the seekable range merger's in-place reposition: stale buffered
+    /// leaves from the old position are dropped without freeing the storage.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "leaves.len() == present.len() by construction (set in build())"
+    )]
+    pub fn clear(&mut self) {
+        for i in 0..self.leaves.len() {
+            if self.present[i] != 0 {
+                // SAFETY: `present[i] != 0` is the LoserTree invariant for
+                // `leaves[i]` being initialised.
+                unsafe { self.leaves[i].assume_init_drop() };
+                self.present[i] = 0;
+            }
+        }
+        self.active = 0;
+    }
+
+    /// Re-prime the tournament in place from a per-slot `pull` closure, reusing
+    /// the existing storage with NO reallocation. Drops any present leaves first
+    /// (via [`Self::clear`]), then pulls a fresh head for each of the `n_sources`
+    /// slots and rebuilds the tree.
+    ///
+    /// `pull(slot)` returns the new head value for `slot`, or `None` if that slot
+    /// is exhausted at the new position. The slot count is unchanged from
+    /// construction, so the power-of-two `cap` and all backing `Vec`s are reused
+    /// as-is.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "slot < n_sources <= leaves.len() == present.len() by construction"
+    )]
+    pub fn refill_with(&mut self, mut pull: impl FnMut(usize) -> Option<E>) {
+        self.clear();
+        for slot in 0..self.n_sources {
+            if let Some(v) = pull(slot) {
+                self.leaves[slot] = MaybeUninit::new(v);
+                self.present[slot] = 1;
+                self.active += 1;
+            }
+        }
+        // Tree storage (size `cap`) is reused; build_subtree overwrites every
+        // internal node and `tree[0]`.
+        self.build_subtree(1, 0, self.leaves.len());
+    }
+
     /// Number of source slots `n` originally supplied (not `cap`).
     ///
     /// Reflects the *capacity* of the tournament; some slots may be

--- a/src/mvcc_stream.rs
+++ b/src/mvcc_stream.rs
@@ -248,6 +248,21 @@ impl<I: DoubleEndedIterator<Item = crate::Result<InternalValue>>> MvccStream<I> 
     }
 }
 
+impl<I> crate::reseek::Reseekable for MvccStream<I>
+where
+    I: DoubleEndedIterator<Item = crate::Result<InternalValue>> + crate::reseek::Reseekable,
+{
+    /// Clear the lookahead peek buffers and the reverse-merge scratch buffer,
+    /// then forward the reposition to the inner merger. The installed range
+    /// tombstones and merge operator are position-independent and stay as-is.
+    fn reseek(&mut self, ctx: &crate::reseek::ReseekCtx) {
+        self.inner.reset_front_peeked();
+        self.inner.reset_back_peeked();
+        self.key_entries_buf.clear();
+        self.inner.inner_mut().reseek(ctx);
+    }
+}
+
 impl<I: DoubleEndedIterator<Item = crate::Result<InternalValue>>> Iterator for MvccStream<I> {
     type Item = crate::Result<InternalValue>;
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1092,11 +1092,10 @@ pub struct SeekableOwner {
 }
 
 self_cell!(
-    /// A range iterator that can reposition (seek) in place without reopening
-    /// per-SST readers. Built once over a union range; [`Self::seek_to`],
-    /// [`Self::seek_to_for_prev`], and [`Self::reposition`] rebuild only the
-    /// cheap Phase-2 merge pipeline, reusing the collected sources.
-    pub struct SeekableTreeIter {
+    /// Internal self-referential merge cell: owns the collected sources and
+    /// borrows them into the Phase-2 merge pipeline. Wrapped by
+    /// [`SeekableTreeIter`], which adds the seek API and a lookahead buffer.
+    struct SeekableCell {
         owner: SeekableOwner,
 
         #[covariant]
@@ -1104,7 +1103,7 @@ self_cell!(
     }
 );
 
-impl SeekableTreeIter {
+impl SeekableCell {
     fn build(owner: SeekableOwner) -> Self {
         Self::new(owner, |o| {
             build_stack(
@@ -1116,7 +1115,38 @@ impl SeekableTreeIter {
             )
         })
     }
+}
 
+impl Iterator for SeekableCell {
+    type Item = crate::Result<InternalValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.with_dependent_mut(|_, iter| iter.next())
+    }
+}
+
+impl DoubleEndedIterator for SeekableCell {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.with_dependent_mut(|_, iter| iter.next_back())
+    }
+}
+
+/// A range iterator that can reposition (seek) in place without reopening
+/// per-SST readers. Built once over a union range; [`Self::seek_to`],
+/// [`Self::seek_to_for_prev`], and [`Self::reposition`] rebuild only the cheap
+/// Phase-2 merge pipeline, reusing the collected sources.
+///
+/// A one-item lookahead buffer backs [`Self::peek_key`], which reads the next
+/// key without consuming it (a leapfrog join takes the max of several
+/// iterators' current keys before deciding where to seek next).
+pub struct SeekableTreeIter {
+    cell: SeekableCell,
+    /// `None` = nothing peeked; `Some(None)` = peeked past the end;
+    /// `Some(Some(item))` = buffered front item (the std `Peekable` shape).
+    peeked: Option<Option<crate::Result<InternalValue>>>,
+}
+
+impl SeekableTreeIter {
     /// Open a seekable iterator over `[union_lower, union_upper)`. The source
     /// collection (Phase 1) runs once here; subsequent repositions reuse it.
     #[must_use]
@@ -1131,29 +1161,34 @@ impl SeekableTreeIter {
             (union_lower.clone(), union_upper.clone()),
             seqno,
         ));
-        Self::build(SeekableOwner {
-            state,
-            collected,
-            seqno,
-            lower: union_lower,
-            upper: union_upper,
-        })
+        Self {
+            cell: SeekableCell::build(SeekableOwner {
+                state,
+                collected,
+                seqno,
+                lower: union_lower,
+                upper: union_upper,
+            }),
+            peeked: None,
+        }
     }
 
     /// Rebuild the merge pipeline for the sub-range `[lower, upper)`, reusing the
     /// collected sources. Cheap: clones `Arc`s and reconstructs per-source
     /// readers (no block I/O until the next `next`/`next_back`).
     pub(crate) fn reposition(&mut self, lower: Bound<UserKey>, upper: Bound<UserKey>) {
-        let state = self.borrow_owner().state.clone();
-        let collected = Arc::clone(&self.borrow_owner().collected);
-        let seqno = self.borrow_owner().seqno;
-        *self = Self::build(SeekableOwner {
+        let state = self.cell.borrow_owner().state.clone();
+        let collected = Arc::clone(&self.cell.borrow_owner().collected);
+        let seqno = self.cell.borrow_owner().seqno;
+        self.cell = SeekableCell::build(SeekableOwner {
             state,
             collected,
             seqno,
             lower,
             upper,
         });
+        // The lookahead came from the old position; drop it.
+        self.peeked = None;
     }
 
     /// Reposition so the next [`Iterator::next`] yields the first entry with
@@ -1167,7 +1202,7 @@ impl SeekableTreeIter {
     /// stays the window upper.
     pub fn seek_to(&mut self, key: &[u8]) {
         let (lower, upper) = {
-            let union = &self.borrow_owner().collected.union;
+            let union = &self.cell.borrow_owner().collected.union;
             let lower = match &union.0 {
                 Bound::Included(floor) if floor.as_ref() > key => union.0.clone(),
                 Bound::Excluded(floor) if floor.as_ref() >= key => union.0.clone(),
@@ -1186,7 +1221,7 @@ impl SeekableTreeIter {
     /// positions at the window end; the lower bound stays the window lower.
     pub fn seek_to_for_prev(&mut self, key: &[u8]) {
         let (lower, upper) = {
-            let union = &self.borrow_owner().collected.union;
+            let union = &self.cell.borrow_owner().collected.union;
             let upper = match &union.1 {
                 Bound::Included(ceil) if ceil.as_ref() < key => union.1.clone(),
                 Bound::Excluded(ceil) if ceil.as_ref() <= key => union.1.clone(),
@@ -1201,7 +1236,29 @@ impl SeekableTreeIter {
     /// to resolve blob handles against the same snapshot the keys came from.
     #[must_use]
     pub fn version(&self) -> crate::version::Version {
-        self.borrow_owner().state.version.version.clone()
+        self.cell.borrow_owner().state.version.version.clone()
+    }
+
+    /// Return the user key the next [`Iterator::next`] would yield, without
+    /// consuming it. Buffers one item; cleared by any reposition / seek.
+    ///
+    /// A successful key is cloned (cheap: `UserKey` is reference-counted) and
+    /// the item stays buffered for `next`. An error is surfaced once here (it
+    /// is not `Clone`), so it will not be re-yielded by a later `next`.
+    pub fn peek_key(&mut self) -> Option<crate::Result<UserKey>> {
+        if self.peeked.is_none() {
+            self.peeked = Some(self.cell.next());
+        }
+        if matches!(self.peeked, Some(Some(Err(_)))) {
+            return match self.peeked.take() {
+                Some(Some(Err(e))) => Some(Err(e)),
+                _ => None,
+            };
+        }
+        match &self.peeked {
+            Some(Some(Ok(item))) => Some(Ok(item.key.user_key.clone())),
+            _ => None,
+        }
     }
 }
 
@@ -1209,13 +1266,21 @@ impl Iterator for SeekableTreeIter {
     type Item = crate::Result<InternalValue>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.with_dependent_mut(|_, iter| iter.next())
+        match self.peeked.take() {
+            Some(buffered) => buffered,
+            None => self.cell.next(),
+        }
     }
 }
 
 impl DoubleEndedIterator for SeekableTreeIter {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.with_dependent_mut(|_, iter| iter.next_back())
+        // The buffer holds the FRONT item, so pull from the back first and only
+        // fall back to the buffered front once the back is exhausted.
+        match self.cell.next_back() {
+            Some(item) => Some(item),
+            None => self.peeked.take().flatten(),
+        }
     }
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -8,10 +8,11 @@ use crate::{
     key::InternalKey,
     memtable::Memtable,
     merge_operator::MergeOperator,
-    merge_source::CoherentIterSource,
+    merge_source::{CoherentIterSource, CoherentMergeSource, IterItem, MergeSource},
     mvcc_stream::MvccStream,
     range_tombstone::RangeTombstone,
     range_tombstone_filter::RangeTombstoneFilter,
+    reseek::{ReseekCtx, Reseekable},
     run_reader::RunReader,
     seeking_merger::SeekingMerger,
     value::{SeqNo, UserKey},
@@ -104,8 +105,8 @@ pub fn prefix_to_range(prefix: &[u8]) -> (Bound<UserKey>, Bound<UserKey>) {
 /// Because of Rust rules, the state is referenced using `self_cell`, see below.
 ///
 /// `Clone` is cheap (every field is an `Arc` / small `Copy` value) and is used
-/// by the seekable range iterator, which rebuilds its merge pipeline on each
-/// reposition while keeping the same underlying version snapshot.
+/// by the seekable range iterator to snapshot the version once; repositions then
+/// reseek the leaf cursors in place against that same snapshot.
 #[derive(Clone)]
 pub struct IterState {
     pub(crate) version: SuperVersion,
@@ -991,91 +992,309 @@ fn collect_sources(state: &IterState, union: UserBounds, seqno: SeqNo) -> Collec
     }
 }
 
-/// Phase 2: build the merge pipeline (`SeekingMerger` -> `MvccStream` ->
-/// tombstone filter -> optional `RangeTombstoneFilter`) for the sub-range
-/// `[lower, upper)` from already-collected sources. Reruns on every reposition;
-/// the per-source readers reuse the tested seek-to-start path (no block I/O
+/// Named tombstone-skip wrapper. The non-seekable read path uses an inline
+/// `.filter(|x| !is_tombstone)` closure (unnameable), but the seekable pipeline
+/// must stay a concrete, [`Reseekable`] type, so the same drop-resolved-
+/// tombstones step is expressed as this struct. Errors pass through unchanged;
+/// the reposition is stateless, so it just forwards to the inner layer.
+struct TombstoneSkip<I> {
+    inner: I,
+}
+
+impl<I: Iterator<Item = crate::Result<InternalValue>>> Iterator for TombstoneSkip<I> {
+    type Item = crate::Result<InternalValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.inner.next()? {
+                Ok(value) if value.key.is_tombstone() => {}
+                other => return Some(other),
+            }
+        }
+    }
+}
+
+impl<I: DoubleEndedIterator<Item = crate::Result<InternalValue>>> DoubleEndedIterator
+    for TombstoneSkip<I>
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.inner.next_back()? {
+                Ok(value) if value.key.is_tombstone() => {}
+                other => return Some(other),
+            }
+        }
+    }
+}
+
+impl<I: Reseekable> Reseekable for TombstoneSkip<I> {
+    fn reseek(&mut self, ctx: &ReseekCtx) {
+        self.inner.reseek(ctx);
+    }
+}
+
+/// Leaf source over a single SST, re-positioned in place by re-seeking the
+/// reader's owned index iterator (no new reader, no `Arc` re-clone).
+struct TableLeaf {
+    table: crate::table::Table,
+    iter: crate::table::iter::Iter,
+    seqno: SeqNo,
+}
+
+impl TableLeaf {
+    fn new(table: crate::table::Table, user_range: UserBounds, seqno: SeqNo) -> Self {
+        let iter = table.range_iter(user_range);
+        Self { table, iter, seqno }
+    }
+
+    fn next_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            match self.iter.next()? {
+                Ok(value) if seqno_filter(value.key.seqno, self.seqno) => return Some(Ok(value)),
+                Ok(_) => {}
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+
+    fn next_back_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            match self.iter.next_back()? {
+                Ok(value) if seqno_filter(value.key.seqno, self.seqno) => return Some(Ok(value)),
+                Ok(_) => {}
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+/// Leaf source over a multi-table run. Re-positioned by recomputing the run's
+/// overlapping-table window; the boundary readers re-open lazily on the next
+/// pull (run-internal residual allocation, unlike the alloc-free table / memtable
+/// leaves — multi-table runs are L1+ and less common on the seekable path).
+struct RunLeaf {
+    reader: RunReader,
+    comparator: SharedComparator,
+    seqno: SeqNo,
+}
+
+impl RunLeaf {
+    fn new(
+        run: Arc<Run<crate::table::Table>>,
+        user_range: UserBounds,
+        seqno: SeqNo,
+        comparator: SharedComparator,
+    ) -> Option<Self> {
+        let reader = RunReader::new_cmp(run, user_range, comparator.as_ref())?;
+        Some(Self {
+            reader,
+            comparator,
+            seqno,
+        })
+    }
+
+    fn next_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            match self.reader.next()? {
+                Ok(value) if seqno_filter(value.key.seqno, self.seqno) => return Some(Ok(value)),
+                Ok(_) => {}
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+
+    fn next_back_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            match self.reader.next_back()? {
+                Ok(value) if seqno_filter(value.key.seqno, self.seqno) => return Some(Ok(value)),
+                Ok(_) => {}
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+/// Leaf source over one memtable (active / sealed / ephemeral). Re-positioned by
+/// recreating the skiplist range cursor (a `seek_ge` pointer-walk, no heap
+/// allocation). Borrows the memtable from the owning [`IterState`] for `'a`.
+struct MemtableLeaf<'a> {
+    mt: &'a Memtable,
+    range: crate::memtable::skiplist::Range<'a>,
+    seqno: SeqNo,
+}
+
+impl<'a> MemtableLeaf<'a> {
+    fn new(
+        mt: &'a Memtable,
+        internal: (Bound<InternalKey>, Bound<InternalKey>),
+        seqno: SeqNo,
+    ) -> Self {
+        let range = mt.items.range(internal);
+        Self { mt, range, seqno }
+    }
+
+    fn next_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            let entry = self.range.next()?;
+            let value = InternalValue {
+                key: entry.key(),
+                value: entry.value(),
+            };
+            if seqno_filter(value.key.seqno, self.seqno) {
+                return Some(Ok(value));
+            }
+        }
+    }
+
+    fn next_back_filtered(&mut self) -> Option<IterItem> {
+        loop {
+            let entry = self.range.next_back()?;
+            let value = InternalValue {
+                key: entry.key(),
+                value: entry.value(),
+            };
+            if seqno_filter(value.key.seqno, self.seqno) {
+                return Some(Ok(value));
+            }
+        }
+    }
+}
+
+/// One reseekable leaf of the seekable merge pipeline.
+///
+/// All three variants self-coordinate their forward/back cursors over a single
+/// shrinking window (SST index span, run table window, skiplist node range), so
+/// the enum is a [`CoherentMergeSource`]: mixed forward/backward consumption
+/// never yields an item twice. The [`MergeSource::seek`] hook is a no-op — the
+/// seekable path repositions via [`Reseekable`] (which carries both new bounds),
+/// not the single-target merge-source seek.
+enum SeekableLeaf<'a> {
+    // The SST reader and run reader are large (owned index iterator / per-table
+    // readers); box them so the enum (held one-per-source in a `Vec`) is sized to
+    // the small memtable variant. This is a one-time per-leaf allocation at build,
+    // not a per-seek cost.
+    Table(Box<TableLeaf>),
+    Run(Box<RunLeaf>),
+    Memtable(MemtableLeaf<'a>),
+}
+
+impl MergeSource for SeekableLeaf<'_> {
+    fn next(&mut self) -> Option<IterItem> {
+        match self {
+            SeekableLeaf::Table(l) => l.next_filtered(),
+            SeekableLeaf::Run(l) => l.next_filtered(),
+            SeekableLeaf::Memtable(l) => l.next_filtered(),
+        }
+    }
+
+    fn next_back(&mut self) -> Option<IterItem> {
+        match self {
+            SeekableLeaf::Table(l) => l.next_back_filtered(),
+            SeekableLeaf::Run(l) => l.next_back_filtered(),
+            SeekableLeaf::Memtable(l) => l.next_back_filtered(),
+        }
+    }
+
+    fn seek(&mut self, _target: &InternalKey) -> crate::Result<()> {
+        // No-op: the seekable pipeline repositions via `Reseekable::reseek`
+        // (which carries both the new lower AND upper bound). The single-target
+        // `MergeSource::seek` is never invoked on this path; the leaf cursors
+        // self-coordinate direction switches without it.
+        Ok(())
+    }
+}
+
+impl CoherentMergeSource for SeekableLeaf<'_> {}
+
+impl Reseekable for SeekableLeaf<'_> {
+    fn reseek(&mut self, ctx: &ReseekCtx) {
+        match self {
+            SeekableLeaf::Table(l) => l.table.reseek_range(&mut l.iter, ctx.user.clone()),
+            SeekableLeaf::Run(l) => l.reader.reseek(ctx.user.clone(), l.comparator.as_ref()),
+            SeekableLeaf::Memtable(l) => {
+                l.range = l.mt.items.range(ctx.internal.clone());
+            }
+        }
+    }
+}
+
+/// The concrete, [`Reseekable`] seekable merge pipeline: loser-tree merger ->
+/// MVCC resolution -> drop-resolved-tombstones -> range-tombstone suppression.
+/// Built once over the union range; every reposition reseeks it in place.
+type SeekPipeline<'a> = RangeTombstoneFilter<
+    TombstoneSkip<MvccStream<SeekingMerger<SeekableLeaf<'a>, SharedComparator>>>,
+>;
+
+/// Phase 2: build the [`SeekPipeline`] for the sub-range `[lower, upper)` from
+/// already-collected sources. Runs ONCE per iterator (at construction); every
+/// later reposition reseeks the returned pipeline in place rather than rebuilding
+/// it. The per-source readers reuse the tested seek-to-start path (no block I/O
 /// until the first `next`).
-fn build_stack<'a>(
+fn build_seek_pipeline<'a>(
     state: &'a IterState,
     collected: &CollectedSources,
     lower: Bound<UserKey>,
     upper: Bound<UserKey>,
     seqno: SeqNo,
-) -> BoxedMerge<'a> {
+) -> SeekPipeline<'a> {
     let user_range: UserBounds = (lower, upper);
-    let range = user_to_internal_bounds(&user_range);
+    let internal = user_to_internal_bounds(&user_range);
 
-    let mut iters: Vec<BoxedIterator<'a>> = Vec::with_capacity(collected.single_tables.len() + 3);
+    let mut sources: Vec<SeekableLeaf<'a>> =
+        Vec::with_capacity(collected.single_tables.len() + collected.multi_runs.len() + 3);
 
     for table in &collected.single_tables {
-        let reader = table
-            .range(user_range.clone())
-            .filter(move |item| match item {
-                Ok(item) => seqno_filter(item.key.seqno, seqno),
-                Err(_) => true,
-            });
-        iters.push(Box::new(reader));
+        sources.push(SeekableLeaf::Table(Box::new(TableLeaf::new(
+            table.clone(),
+            user_range.clone(),
+            seqno,
+        ))));
     }
     for run in &collected.multi_runs {
-        if let Some(reader) =
-            RunReader::new_cmp(run.clone(), user_range.clone(), state.comparator.as_ref())
-        {
-            iters.push(Box::new(reader.filter(move |item| match item {
-                Ok(item) => seqno_filter(item.key.seqno, seqno),
-                Err(_) => true,
-            })));
+        if let Some(leaf) = RunLeaf::new(
+            run.clone(),
+            user_range.clone(),
+            seqno,
+            state.comparator.clone(),
+        ) {
+            sources.push(SeekableLeaf::Run(Box::new(leaf)));
         }
     }
     for memtable in state.version.sealed_memtables.iter() {
-        let iter = memtable.range_internal(range.clone());
-        iters.push(Box::new(
-            iter.filter(move |item| seqno_filter(item.key.seqno, seqno))
-                .map(Ok),
-        ));
+        sources.push(SeekableLeaf::Memtable(MemtableLeaf::new(
+            memtable,
+            internal.clone(),
+            seqno,
+        )));
     }
-    {
-        let iter = state.version.active_memtable.range_internal(range.clone());
-        iters.push(Box::new(
-            iter.filter(move |item| seqno_filter(item.key.seqno, seqno))
-                .map(Ok),
-        ));
-    }
+    sources.push(SeekableLeaf::Memtable(MemtableLeaf::new(
+        &state.version.active_memtable,
+        internal.clone(),
+        seqno,
+    )));
     if let Some((mt, eph_seqno)) = &state.ephemeral {
-        let eph_seqno = *eph_seqno;
-        let iter = mt.range_internal(range);
-        iters.push(Box::new(
-            iter.filter(move |item| seqno_filter(item.key.seqno, eph_seqno))
-                .map(Ok),
-        ));
+        sources.push(SeekableLeaf::Memtable(MemtableLeaf::new(
+            mt, internal, *eph_seqno,
+        )));
     }
 
-    let merged = build_seeking(iters, state.comparator.clone());
-    let iter = MvccStream::new_with_comparator(
+    let merged = SeekingMerger::new(sources, state.comparator.clone());
+    let mvcc = MvccStream::new_with_comparator(
         merged,
         state.merge_operator.clone(),
         state.comparator.clone(),
     )
     .with_range_tombstones(collected.range_tombstones.clone());
-
-    let iter = iter.filter(|x| match x {
-        Ok(value) => !value.key.is_tombstone(),
-        Err(_) => true,
-    });
-
-    if collected
-        .range_tombstones
-        .iter()
-        .all(|(rt, cutoff)| !rt.visible_at(*cutoff))
-    {
-        Box::new(iter)
-    } else {
-        Box::new(RangeTombstoneFilter::new_with_comparator(
-            iter,
-            collected.range_tombstones.clone(),
-            state.comparator.clone(),
-        ))
-    }
+    let skip = TombstoneSkip { inner: mvcc };
+    // Always wrap in the range-tombstone filter: with an empty or all-invisible
+    // tombstone set it suppresses nothing (a per-item visibility check), so the
+    // result matches the non-seekable path's fast-path-or-filter branch while
+    // staying a single concrete reseekable type.
+    RangeTombstoneFilter::new_with_comparator(
+        skip,
+        collected.range_tombstones.clone(),
+        state.comparator.clone(),
+    )
 }
 
 /// Owner half of [`SeekableTreeIter`]'s self-cell.
@@ -1095,18 +1314,21 @@ self_cell!(
     /// Internal self-referential merge cell: owns the collected sources and
     /// borrows them into the Phase-2 merge pipeline. Wrapped by
     /// [`SeekableTreeIter`], which adds the seek API and a lookahead buffer.
+    ///
+    /// Built ONCE; [`Self::reseek`] moves the leaf cursors in place, so the
+    /// merge pipeline is never reconstructed across repositions.
     struct SeekableCell {
         owner: SeekableOwner,
 
         #[covariant]
-        dependent: BoxedMerge,
+        dependent: SeekPipeline,
     }
 );
 
 impl SeekableCell {
     fn build(owner: SeekableOwner) -> Self {
         Self::new(owner, |o| {
-            build_stack(
+            build_seek_pipeline(
                 &o.state,
                 &o.collected,
                 o.lower.clone(),
@@ -1114,6 +1336,13 @@ impl SeekableCell {
                 o.seqno,
             )
         })
+    }
+
+    /// Re-position the borrowed pipeline in place to the bounds in `ctx`,
+    /// without rebuilding it. The owner (version snapshot + collected sources)
+    /// is untouched.
+    fn reseek(&mut self, ctx: &ReseekCtx) {
+        self.with_dependent_mut(|_, pipeline| pipeline.reseek(ctx));
     }
 }
 
@@ -1132,9 +1361,13 @@ impl DoubleEndedIterator for SeekableCell {
 }
 
 /// A range iterator that can reposition (seek) in place without reopening
-/// per-SST readers. Built once over a union range; [`Self::seek_to`],
-/// [`Self::seek_to_for_prev`], and [`Self::reposition`] rebuild only the cheap
-/// Phase-2 merge pipeline, reusing the collected sources.
+/// per-SST readers or rebuilding the merge stack.
+///
+/// Built once over a union range; [`Self::seek_to`], [`Self::seek_to_for_prev`],
+/// and [`Self::reposition`] move the leaf cursors in place (SST index re-seek /
+/// skiplist `seek_ge` / run-window recompute) while reusing the loser-tree
+/// merger, MVCC stream, and tombstone filter, so a tight seek loop does not
+/// reconstruct the pipeline.
 ///
 /// A one-item lookahead buffer backs [`Self::peek_key`], which reads the next
 /// key without consuming it (a leapfrog join takes the max of several
@@ -1143,6 +1376,11 @@ pub struct SeekableTreeIter {
     cell: SeekableCell,
     /// `None` = nothing peeked; `Some(None)` = peeked past the end;
     /// `Some(Some(item))` = buffered front item (the std `Peekable` shape).
+    #[expect(
+        clippy::option_option,
+        reason = "std `Peekable` buffer shape: outer None = not yet peeked, \
+                  inner None = peeked past the end, Some(Some) = buffered item"
+    )]
     peeked: Option<Option<crate::Result<InternalValue>>>,
 }
 
@@ -1173,20 +1411,19 @@ impl SeekableTreeIter {
         }
     }
 
-    /// Rebuild the merge pipeline for the sub-range `[lower, upper)`, reusing the
-    /// collected sources. Cheap: clones `Arc`s and reconstructs per-source
-    /// readers (no block I/O until the next `next`/`next_back`).
+    /// Re-position the merge pipeline to the sub-range `[lower, upper)` IN PLACE:
+    /// the loser-tree merger, MVCC stream, and range-tombstone filter are reused;
+    /// only the leaf cursors move (an SST index re-seek / skiplist `seek_ge` /
+    /// run-window recompute). No merge-stack reconstruction, no source re-collection
+    /// (no block I/O until the next `next`/`next_back`).
     pub(crate) fn reposition(&mut self, lower: Bound<UserKey>, upper: Bound<UserKey>) {
-        let state = self.cell.borrow_owner().state.clone();
-        let collected = Arc::clone(&self.cell.borrow_owner().collected);
-        let seqno = self.cell.borrow_owner().seqno;
-        self.cell = SeekableCell::build(SeekableOwner {
-            state,
-            collected,
-            seqno,
-            lower,
-            upper,
-        });
+        let user_range: UserBounds = (lower, upper);
+        let internal = user_to_internal_bounds(&user_range);
+        let ctx = ReseekCtx {
+            user: user_range,
+            internal,
+        };
+        self.cell.reseek(&ctx);
         // The lookahead came from the old position; drop it.
         self.peeked = None;
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -854,14 +854,19 @@ type UserBounds = (Bound<UserKey>, Bound<UserKey>);
 /// expect. Mirrors the bound construction in [`TreeIter::create_range`] (see
 /// there for the seqno-direction reasoning at each end).
 fn user_to_internal_bounds(user: &UserBounds) -> (Bound<InternalKey>, Bound<InternalKey>) {
+    // Clone the `UserKey` (a reference-counted `Slice`: an `Arc` bump, no heap
+    // copy) and hand it to `InternalKey::new` by value — `UserKey: Into<UserKey>`
+    // is the identity, so the key bytes are reused. Passing `key.as_ref()`
+    // (`&[u8]`) instead would force a fresh heap copy of the bytes on every
+    // reposition, which the in-place seek loop must avoid.
     let lo = match &user.0 {
         Bound::Included(key) => Bound::Included(InternalKey::new(
-            key.as_ref(),
+            key.clone(),
             SeqNo::MAX,
             crate::ValueType::Tombstone,
         )),
         Bound::Excluded(key) => Bound::Excluded(InternalKey::new(
-            key.as_ref(),
+            key.clone(),
             0,
             crate::ValueType::Tombstone,
         )),
@@ -869,10 +874,10 @@ fn user_to_internal_bounds(user: &UserBounds) -> (Bound<InternalKey>, Bound<Inte
     };
     let hi = match &user.1 {
         Bound::Included(key) => {
-            Bound::Included(InternalKey::new(key.as_ref(), 0, crate::ValueType::Value))
+            Bound::Included(InternalKey::new(key.clone(), 0, crate::ValueType::Value))
         }
         Bound::Excluded(key) => Bound::Excluded(InternalKey::new(
-            key.as_ref(),
+            key.clone(),
             SeqNo::MAX,
             crate::ValueType::Value,
         )),

--- a/src/range.rs
+++ b/src/range.rs
@@ -1485,8 +1485,21 @@ impl SeekableTreeIter {
     /// consuming it. Buffers one item; cleared by any reposition / seek.
     ///
     /// A successful key is cloned (cheap: `UserKey` is reference-counted) and
-    /// the item stays buffered for `next`. An error is surfaced once here (it
-    /// is not `Clone`), so it will not be re-yielded by a later `next`.
+    /// the item stays buffered for `next`, so `peek_key()` followed by `next()`
+    /// observes the SAME entry.
+    ///
+    /// # Error is a consuming peek
+    ///
+    /// `crate::Error` is not `Clone`, so a `peek_key()` that returns `Err(...)`
+    /// CONSUMES the failing position: the error is moved out of the buffer and
+    /// the iterator is logically advanced past it. A following `next()` yields
+    /// the entry AFTER the error, NOT the error again. Treat a peeked `Err` as
+    /// you would a consumed one (surface / propagate it; do not also expect
+    /// `next()` to re-report it). The leapfrog / zig-zag join callers this
+    /// method is built for read `peek_key()`, propagate any `Err`, and never
+    /// fall through to a redundant `next()` on the failing iterator, so the
+    /// distinction does not bite them; it is documented here for any caller that
+    /// treats `peek_key` as a pure lookahead.
     pub fn peek_key(&mut self) -> Option<crate::Result<UserKey>> {
         if self.peeked.is_none() {
             self.peeked = Some(self.cell.next());

--- a/src/range_tombstone_filter.rs
+++ b/src/range_tombstone_filter.rs
@@ -133,6 +133,23 @@ impl<I> RangeTombstoneFilter<I> {
     }
 }
 
+impl<I: crate::reseek::Reseekable> crate::reseek::Reseekable for RangeTombstoneFilter<I> {
+    /// Reset the forward/reverse activation cursors and active sets so the next
+    /// pull re-activates tombstones from the start of the (position-independent)
+    /// sorted lists, then forward the reposition to the wrapped stream.
+    ///
+    /// The sorted tombstone lists and the `*_initialized` flags are kept: sort
+    /// order does not depend on iteration position, so re-sorting on every
+    /// reposition would be wasted work.
+    fn reseek(&mut self, ctx: &crate::reseek::ReseekCtx) {
+        self.fwd_idx = 0;
+        self.fwd_active = ActiveTombstoneSet::new_with_comparator(self.comparator.clone());
+        self.rev_idx = 0;
+        self.rev_active = ActiveTombstoneSetReverse::new_with_comparator(self.comparator.clone());
+        self.inner.reseek(ctx);
+    }
+}
+
 impl<I: Iterator<Item = crate::Result<InternalValue>>> Iterator for RangeTombstoneFilter<I> {
     type Item = crate::Result<InternalValue>;
 

--- a/src/range_tombstone_filter.rs
+++ b/src/range_tombstone_filter.rs
@@ -143,9 +143,12 @@ impl<I: crate::reseek::Reseekable> crate::reseek::Reseekable for RangeTombstoneF
     /// reposition would be wasted work.
     fn reseek(&mut self, ctx: &crate::reseek::ReseekCtx) {
         self.fwd_idx = 0;
-        self.fwd_active = ActiveTombstoneSet::new_with_comparator(self.comparator.clone());
         self.rev_idx = 0;
-        self.rev_active = ActiveTombstoneSetReverse::new_with_comparator(self.comparator.clone());
+        // Clear in place rather than reconstructing: a seek-then-iterate-then-
+        // reseek loop that activated tombstones keeps the active sets' backing
+        // storage for the next pass instead of dropping and re-allocating it.
+        self.fwd_active.clear();
+        self.rev_active.clear();
         self.inner.reseek(ctx);
     }
 }

--- a/src/reseek.rs
+++ b/src/reseek.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! In-place reposition support for the seekable range pipeline.
+//!
+//! The seekable range iterator is built once over a union range; every
+//! reposition ([`crate::range::SeekableTreeIter::seek_to`] and friends) moves
+//! the leaf cursors to a new sub-range WITHOUT rebuilding the merge stack
+//! (loser-tree merger, MVCC stream, range-tombstone filter). [`Reseekable`] is
+//! the propagation hook: each layer resets its own per-position state and
+//! forwards the new bounds to the layer below, down to the leaf readers.
+//!
+//! Reposition is infallible by design: leaf readers defer all I/O to the next
+//! `next()` / `next_back()` pull (the SST reader only re-seeks its in-memory
+//! index here), so a corrupt-block error surfaces lazily through the normal
+//! pull path rather than at reseek time.
+//!
+//! no-std: this module is `core + alloc` only (read path).
+
+use crate::UserKey;
+use crate::key::InternalKey;
+use core::ops::Bound;
+
+/// New bounds for an in-place reposition, in both the user-key and internal-key
+/// domains. The two are the same interval translated for the two reader
+/// families: SST / run readers seek on user keys, while memtable readers range
+/// over [`InternalKey`] bounds. The translation mirrors
+/// [`crate::range::TreeIter::create_range`]'s bound construction.
+pub struct ReseekCtx {
+    /// User-key bounds — what SST / run leaf readers seek to.
+    pub user: (Bound<UserKey>, Bound<UserKey>),
+    /// Internal-key bounds — what memtable leaf readers range over.
+    pub internal: (Bound<InternalKey>, Bound<InternalKey>),
+}
+
+/// A merge-stack layer that can be repositioned in place to a fresh sub-range.
+///
+/// Implemented by the leaf sources and by every wrapper in the seekable
+/// pipeline; each impl resets its own cursor / lookahead state and forwards the
+/// reposition to the layer it wraps.
+pub trait Reseekable {
+    /// Reposition to the bounds in `ctx`, resetting all per-position state so
+    /// the next forward / backward pull starts fresh at the new sub-range.
+    fn reseek(&mut self, ctx: &ReseekCtx);
+}

--- a/src/run_reader.rs
+++ b/src/run_reader.rs
@@ -412,4 +412,69 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn run_reader_reseek_repositions_and_handles_no_overlap() -> crate::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let tree = crate::Config::new(
+            &tempdir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+
+        for batch in [
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+            ["g", "h", "i"],
+            ["j", "k", "l"],
+        ] {
+            for id in batch {
+                tree.insert(id, vec![], 0);
+            }
+            tree.flush_active_memtable(0)?;
+        }
+        let tables = tree
+            .current_version()
+            .iter_tables()
+            .cloned()
+            .collect::<Vec<_>>();
+        let level = Arc::new(Run::new(tables).unwrap());
+        let cmp = crate::comparator::DefaultUserComparator;
+
+        // Open over the full range, consume one key, then reseek to a disjoint
+        // sub-window: the reader must serve exactly that window from a fresh
+        // position (boundary readers re-open lazily against the new bounds).
+        let mut reader = RunReader::new(level.clone(), ..).unwrap();
+        assert_eq!(Slice::from(*b"a"), reader.next().unwrap()?.key.user_key);
+
+        reader.reseek(UserKey::from("e")..=UserKey::from("h"), &cmp);
+        let got: Vec<_> = std::iter::from_fn(|| reader.next())
+            .map(|r| r.unwrap().key.user_key)
+            .collect();
+        assert_eq!(
+            got,
+            [
+                Slice::from(*b"e"),
+                Slice::from(*b"f"),
+                Slice::from(*b"g"),
+                Slice::from(*b"h"),
+            ],
+        );
+
+        // Reseek to a range that does not overlap the run at all: both
+        // directions must immediately report exhaustion.
+        reader.reseek(UserKey::from("y")..=UserKey::from("z"), &cmp);
+        assert!(
+            reader.next().is_none(),
+            "no-overlap reseek must be empty forward"
+        );
+        assert!(
+            reader.next_back().is_none(),
+            "no-overlap reseek must be empty backward",
+        );
+
+        Ok(())
+    }
 }

--- a/src/run_reader.rs
+++ b/src/run_reader.rs
@@ -92,6 +92,38 @@ impl RunReader {
         }
     }
 
+    /// Re-position this reader to a fresh `range`, reusing the same run `Arc`
+    /// and struct instead of rebuilding. Recomputes the overlapping table window
+    /// and drops the boundary readers so they re-open lazily against the new
+    /// bounds on the next pull.
+    ///
+    /// When the new range does not overlap the run at all, the reader is left in
+    /// an immediately-exhausted state (both directions yield `None`).
+    pub(crate) fn reseek<R: RangeBounds<UserKey> + Clone + Send + 'static>(
+        &mut self,
+        range: R,
+        cmp: &dyn crate::comparator::UserComparator,
+    ) {
+        self.range = to_owned_range(&range);
+        self.lo_reader = None;
+        self.hi_reader = None;
+
+        if let Some((lo, hi)) = self.run.range_overlap_indexes_cmp(&range, cmp) {
+            self.lo = lo;
+            self.hi = hi;
+            self.lo_initialized = false;
+            self.hi_initialized = lo >= hi;
+        } else {
+            // No overlap: present as exhausted. Marking both sides initialized
+            // with no readers makes `next` / `next_back` fall straight through
+            // to `None` (see their else-branches).
+            self.lo = 0;
+            self.hi = 0;
+            self.lo_initialized = true;
+            self.hi_initialized = true;
+        }
+    }
+
     fn ensure_lo_initialized(&mut self) {
         if !self.lo_initialized {
             #[expect(

--- a/src/run_reader.rs
+++ b/src/run_reader.rs
@@ -446,7 +446,7 @@ mod tests {
         // Open over the full range, consume one key, then reseek to a disjoint
         // sub-window: the reader must serve exactly that window from a fresh
         // position (boundary readers re-open lazily against the new bounds).
-        let mut reader = RunReader::new(level.clone(), ..).unwrap();
+        let mut reader = RunReader::new(level, ..).unwrap();
         assert_eq!(Slice::from(*b"a"), reader.next().unwrap()?.key.user_key);
 
         reader.reseek(UserKey::from("e")..=UserKey::from("h"), &cmp);

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -250,6 +250,25 @@ impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
     }
 }
 
+impl<S: MergeSource + crate::reseek::Reseekable, C: UserComparator + Clone>
+    crate::reseek::Reseekable for SeekingMerger<S, C>
+{
+    /// Reposition every source to the new sub-range, then drop both tournaments
+    /// so they lazily re-init from the freshly-positioned sources on the next
+    /// pull. Queued refill errors are cleared — they belonged to the old
+    /// position. The `sources` Vec is reused in place (no realloc); the
+    /// tournament storage is rebuilt on re-init.
+    fn reseek(&mut self, ctx: &crate::reseek::ReseekCtx) {
+        for source in &mut self.sources {
+            source.reseek(ctx);
+        }
+        self.forward_tree = None;
+        self.backward_tree = None;
+        self.pending_forward_error = None;
+        self.pending_backward_error = None;
+    }
+}
+
 impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C> {
     type Item = IterItem;
 

--- a/src/seeking_merger.rs
+++ b/src/seeking_merger.rs
@@ -159,6 +159,14 @@ pub struct SeekingMerger<S: MergeSource, C: UserComparator + Clone> {
     pending_forward_error: Option<crate::Error>,
     /// Mirror of `pending_forward_error` for the backward direction.
     pending_backward_error: Option<crate::Error>,
+    /// Whether `forward_tree` reflects the current position. `false` means the
+    /// next forward pull must (re)populate it: build it the first time, or
+    /// refill the retained storage in place after a reseek. Decoupled from
+    /// `forward_tree.is_some()` so a reseek can keep the allocation while
+    /// forcing a repopulate.
+    forward_primed: bool,
+    /// Mirror of `forward_primed` for the backward direction.
+    backward_primed: bool,
 }
 
 impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
@@ -176,94 +184,118 @@ impl<S: MergeSource, C: UserComparator + Clone> SeekingMerger<S, C> {
             backward_tree: None,
             pending_forward_error: None,
             pending_backward_error: None,
+            forward_primed: false,
+            backward_primed: false,
         }
     }
 
     fn initialize_forward(&mut self) {
-        let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(self.n_sources);
-        for i in 0..self.n_sources {
+        let Self {
+            sources,
+            n_sources,
+            comparator,
+            forward_tree,
+            backward_tree,
+            pending_forward_error,
+            ..
+        } = self;
+        let n = *n_sources;
+        // Pull the new forward head for slot `i`. On error, keep earlier
+        // prefetches and queue the FIRST error (surfaces after buffered values).
+        // On forward-exhaustion, MIGRATE any leaf the OPPOSITE tournament still
+        // buffers for this source so it is not silently lost. After a reseek
+        // both tournaments are cleared, so the migrate path finds nothing —
+        // exactly the fresh-position behaviour.
+        let mut pull = |i: usize| -> Option<MergerEntry> {
             #[expect(
                 clippy::indexing_slicing,
                 reason = "i < n_sources by construction; sources len == n_sources"
             )]
-            let pulled = MergeSource::next(&mut self.sources[i]);
-            let slot = match pulled {
+            match MergeSource::next(&mut sources[i]) {
                 Some(Ok(value)) => Some(MergerEntry { source: i, value }),
                 Some(Err(e)) => {
-                    // Don't drop earlier prefetched values: keep the
-                    // erroring slot empty and queue the error so it
-                    // surfaces AFTER any buffered prefetches are
-                    // consumed. Same contract as the refill paths.
-                    // get_or_insert preserves the FIRST queued error.
-                    self.pending_forward_error.get_or_insert(e);
+                    pending_forward_error.get_or_insert(e);
                     None
                 }
-                None => {
-                    // Source exhausted forward. If backward_tree
-                    // still holds a buffered leaf for this source
-                    // (the OPPOSITE direction pulled it earlier and
-                    // hasn't yielded it yet), MIGRATE it into the
-                    // forward tournament — otherwise that value
-                    // would be silently lost when the user iterates
-                    // forward after some backward consumption.
-                    self.backward_tree.as_mut().and_then(|bt| bt.take_slot(i))
-                }
-            };
-            initial.push(slot);
+                None => backward_tree.as_mut().and_then(|bt| bt.take_slot(i)),
+            }
+        };
+        if let Some(tree) = forward_tree {
+            // Retained storage (post-reseek): refill in place, no allocation.
+            tree.refill_with(pull);
+        } else {
+            // First use: build the tournament (one-time allocation).
+            let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(n);
+            for i in 0..n {
+                initial.push(pull(i));
+            }
+            let cmp = build_min_cmp(comparator.clone());
+            *forward_tree = Some(LoserTree::build(initial, cmp));
         }
-        let cmp = build_min_cmp(self.comparator.clone());
-        self.forward_tree = Some(LoserTree::build(initial, cmp));
     }
 
     fn initialize_backward(&mut self) {
-        let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(self.n_sources);
-        for i in 0..self.n_sources {
+        let Self {
+            sources,
+            n_sources,
+            comparator,
+            forward_tree,
+            backward_tree,
+            pending_backward_error,
+            ..
+        } = self;
+        let n = *n_sources;
+        // Mirror of `initialize_forward`: pull the new backward head, queue the
+        // first error, and migrate a buffered leaf from the forward tournament
+        // for a source already exhausted backward (the single-item-window case).
+        let mut pull = |i: usize| -> Option<MergerEntry> {
             #[expect(
                 clippy::indexing_slicing,
                 reason = "i < n_sources by construction; sources len == n_sources"
             )]
-            let pulled = MergeSource::next_back(&mut self.sources[i]);
-            let slot = match pulled {
+            match MergeSource::next_back(&mut sources[i]) {
                 Some(Ok(value)) => Some(MergerEntry { source: i, value }),
                 Some(Err(e)) => {
-                    // Mirror of initialize_forward: keep prefetched
-                    // backward values, queue the FIRST error for a
-                    // later call (get_or_insert preserves it).
-                    self.pending_backward_error.get_or_insert(e);
+                    pending_backward_error.get_or_insert(e);
                     None
                 }
-                None => {
-                    // Source exhausted backward. If forward_tree
-                    // still holds a buffered leaf for this source
-                    // (the OPPOSITE direction pulled it earlier and
-                    // hasn't yielded it yet), MIGRATE it into the
-                    // backward tournament. CodeRabbit's data-loss
-                    // bug (single-source `[a, z]` returning None on
-                    // post-forward next_back) is exactly this case.
-                    self.forward_tree.as_mut().and_then(|ft| ft.take_slot(i))
-                }
-            };
-            initial.push(slot);
+                None => forward_tree.as_mut().and_then(|ft| ft.take_slot(i)),
+            }
+        };
+        if let Some(tree) = backward_tree {
+            tree.refill_with(pull);
+        } else {
+            let mut initial: Vec<Option<MergerEntry>> = Vec::with_capacity(n);
+            for i in 0..n {
+                initial.push(pull(i));
+            }
+            let cmp = build_max_cmp(comparator.clone());
+            *backward_tree = Some(LoserTree::build(initial, cmp));
         }
-        let cmp = build_max_cmp(self.comparator.clone());
-        self.backward_tree = Some(LoserTree::build(initial, cmp));
     }
 }
 
 impl<S: MergeSource + crate::reseek::Reseekable, C: UserComparator + Clone>
     crate::reseek::Reseekable for SeekingMerger<S, C>
 {
-    /// Reposition every source to the new sub-range, then drop both tournaments
-    /// so they lazily re-init from the freshly-positioned sources on the next
-    /// pull. Queued refill errors are cleared — they belonged to the old
-    /// position. The `sources` Vec is reused in place (no realloc); the
-    /// tournament storage is rebuilt on re-init.
+    /// Reposition every source to the new sub-range, then empty both tournaments
+    /// IN PLACE (dropping stale buffered leaves but keeping their storage) and
+    /// unprime them so the next pull refills the retained storage — no
+    /// reallocation. Clearing both before any re-init also means the migrate
+    /// path in `initialize_*` finds nothing stale to rescue. Queued refill
+    /// errors are dropped; they belonged to the old position.
     fn reseek(&mut self, ctx: &crate::reseek::ReseekCtx) {
         for source in &mut self.sources {
             source.reseek(ctx);
         }
-        self.forward_tree = None;
-        self.backward_tree = None;
+        if let Some(tree) = &mut self.forward_tree {
+            tree.clear();
+        }
+        if let Some(tree) = &mut self.backward_tree {
+            tree.clear();
+        }
+        self.forward_primed = false;
+        self.backward_primed = false;
         self.pending_forward_error = None;
         self.pending_backward_error = None;
     }
@@ -285,8 +317,9 @@ impl<S: MergeSource, C: UserComparator + Clone> Iterator for SeekingMerger<S, C>
         if let Some(e) = self.pending_backward_error.take() {
             return Some(Err(e));
         }
-        if self.forward_tree.is_none() {
+        if !self.forward_primed {
             self.initialize_forward();
+            self.forward_primed = true;
             // Init may have queued an error; surface it immediately
             // (same rationale as the top check — errors first).
             if let Some(e) = self.pending_forward_error.take() {
@@ -356,8 +389,9 @@ impl<S: CoherentMergeSource, C: UserComparator + Clone> DoubleEndedIterator
         if let Some(e) = self.pending_forward_error.take() {
             return Some(Err(e));
         }
-        if self.backward_tree.is_none() {
+        if !self.backward_primed {
             self.initialize_backward();
+            self.backward_primed = true;
             if let Some(e) = self.pending_backward_error.take() {
                 return Some(Err(e));
             }

--- a/src/sharded_cache.rs
+++ b/src/sharded_cache.rs
@@ -186,11 +186,32 @@ where
     fn insert(&mut self, hash: u64, key: K, value: V, weight: u64, priority: Priority) {
         if let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) {
             // Replace in place: adjust the owning queue's byte tally by the
-            // weight delta, keep the queue position and frequency.
+            // weight delta.
             let old = slot.weight;
             slot.value = value;
             slot.weight = weight;
+            // Honor a High-priority refresh of a probationary (small) entry:
+            // promote it to main with full frequency credit so a re-inserted
+            // index/filter/range-tombstone block gets the same churn protection
+            // as a fresh High admission, instead of being left to cold-evict
+            // from the small queue. The stale small-queue entry is skipped on
+            // its next pop (lazy tombstone).
+            let promote = priority == Priority::High && slot.loc == Location::Small;
+            if promote {
+                slot.loc = Location::Main;
+                slot.freq.store(MAX_FREQ, Ordering::Relaxed);
+            }
             match slot.loc {
+                // `slot.loc` is `Main` here when just promoted: move the old
+                // weight out of the small tally and the new weight into main,
+                // and enqueue the entry on the main queue. `slot` borrows
+                // `self.map`; the queue / tally fields are disjoint, so these
+                // direct field accesses are allowed alongside it.
+                Location::Main if promote => {
+                    self.small_bytes -= old;
+                    self.main_bytes += weight;
+                    self.main.push_back(key);
+                }
                 Location::Small => self.small_bytes = adjust(self.small_bytes, old, weight),
                 Location::Main => self.main_bytes = adjust(self.main_bytes, old, weight),
             }
@@ -620,6 +641,29 @@ mod tests {
             "high-priority entry must survive data-style churn",
         );
         assert_eq!(c.get(&1), None, "normal entry should have been evicted");
+    }
+
+    #[test]
+    fn high_priority_replace_promotes_small_entry() {
+        let c: ShardedCache<u64, alloc::vec::Vec<u8>, LenWeighter, FxBuildHasher> =
+            ShardedCache::with_weighter(2_000, 1, 1024, LenWeighter, FxBuildHasher);
+
+        // Admit at normal priority — lands in the probationary small queue.
+        c.insert(0, vec![0u8; 100]);
+        // Refresh the SAME key at High priority — must promote it to main with
+        // full frequency credit, not leave it in the small queue.
+        c.insert_with_priority(0, vec![0u8; 100], Priority::High);
+
+        // Churn cold normal entries far past capacity; the promoted entry must
+        // survive (it would be cold-evicted from the small queue otherwise).
+        for i in 1..200u64 {
+            c.insert(i, vec![0u8; 100]);
+        }
+        assert_eq!(
+            c.get(&0),
+            Some(vec![0u8; 100]),
+            "High-priority replace must promote the entry to main and protect it",
+        );
     }
 
     #[test]

--- a/src/sharded_cache.rs
+++ b/src/sharded_cache.rs
@@ -68,6 +68,23 @@ enum Location {
     Main,
 }
 
+/// Admission priority for an inserted entry.
+///
+/// [`Priority::High`] entries skip the probationary *small* queue and enter the
+/// *main* queue directly with a full frequency credit, so they survive several
+/// eviction passes of churn through the small queue without first being
+/// cold-evicted. Used to pin frequently-touched index / filter / range-tombstone
+/// blocks against data-block churn when the working set exceeds the cache. Still
+/// bounded: `evict_from_main` decrements the credit, so a high-priority entry can
+/// eventually evict if such entries alone overflow capacity.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Priority {
+    /// Normal admission: ghost-hit → main, otherwise the probationary small queue.
+    Normal,
+    /// Pinned admission: straight to main with a full frequency credit.
+    High,
+}
+
 /// One cached entry: the value, its weight, the S3-FIFO frequency counter, and
 /// the queue it belongs to. `freq` is atomic so a `get` can bump it under a
 /// shared (read) lock; all other fields change only under the write lock.
@@ -166,7 +183,7 @@ where
     /// Inserts or replaces `key`, evicting to stay within capacity. The shard's
     /// running `small_bytes` / `main_bytes` tallies are kept current throughout
     /// (the sharded wrapper reads them under a shared lock for `weight()`).
-    fn insert(&mut self, hash: u64, key: K, value: V, weight: u64) {
+    fn insert(&mut self, hash: u64, key: K, value: V, weight: u64, priority: Priority) {
         if let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) {
             // Replace in place: adjust the owning queue's byte tally by the
             // weight delta, keep the queue position and frequency.
@@ -178,13 +195,20 @@ where
                 Location::Main => self.main_bytes = adjust(self.main_bytes, old, weight),
             }
         } else {
-            // Fresh entry. A key found in the ghost queue (recently evicted from
-            // the small queue) is admitted straight to the main queue; otherwise
-            // it enters the small queue.
-            let loc = if self.ghost_set.remove(&key) {
-                Location::Main
-            } else {
-                Location::Small
+            // Fresh entry. High-priority entries (pinned metadata) go straight to
+            // main with a full frequency credit so churn through the small queue
+            // can't cold-evict them. Otherwise: a ghost-queue hit (recently
+            // evicted from small) is re-admitted to main, else the entry enters
+            // the probationary small queue.
+            let (loc, init_freq) = match priority {
+                Priority::High => (Location::Main, MAX_FREQ),
+                Priority::Normal => {
+                    if self.ghost_set.remove(&key) {
+                        (Location::Main, 0)
+                    } else {
+                        (Location::Small, 0)
+                    }
+                }
             };
             let hasher = &self.hasher;
             self.map.insert_unique(
@@ -194,7 +218,7 @@ where
                     Slot {
                         value,
                         weight,
-                        freq: AtomicU8::new(0),
+                        freq: AtomicU8::new(init_freq),
                         loc,
                     },
                 ),
@@ -429,11 +453,19 @@ where
         shard.read().peek(h, key)
     }
 
-    /// Inserts or replaces `key`, evicting as needed to stay within capacity.
+    /// Inserts or replaces `key` at [`Priority::Normal`], evicting as needed to
+    /// stay within capacity.
     pub fn insert(&self, key: K, value: V) {
+        self.insert_with_priority(key, value, Priority::Normal);
+    }
+
+    /// Inserts or replaces `key` at the given admission [`Priority`], evicting as
+    /// needed to stay within capacity. [`Priority::High`] pins the entry against
+    /// churn (see the enum docs).
+    pub fn insert_with_priority(&self, key: K, value: V, priority: Priority) {
         let weight = self.weighter.weight(&key, &value);
         let (h, shard) = self.locate(&key);
-        shard.write().insert(h, key, value, weight);
+        shard.write().insert(h, key, value, weight, priority);
     }
 
     /// Removes `key` if present.
@@ -561,6 +593,33 @@ mod tests {
             let _ = c.get(&0); // keep touching the hot key
         }
         assert_eq!(c.get(&0), Some(vec![0u8; 100]), "hot key was evicted");
+    }
+
+    #[test]
+    fn high_priority_entry_survives_churn_that_evicts_normal() {
+        // A single shard so the churn deterministically targets the same queues
+        // as the pinned entry (multi-shard would scatter the cold keys).
+        let c: ShardedCache<u64, alloc::vec::Vec<u8>, LenWeighter, FxBuildHasher> =
+            ShardedCache::with_weighter(2_000, 1, 1024, LenWeighter, FxBuildHasher);
+
+        // One high-priority entry (pinned metadata) and one normal entry of the
+        // same size, neither re-read after insertion.
+        c.insert_with_priority(0, vec![0u8; 100], Priority::High);
+        c.insert(1, vec![0u8; 100]);
+
+        // Churn far past capacity with cold, single-touch normal entries (the
+        // data-block-churn analogue).
+        for i in 2..200u64 {
+            c.insert(i, vec![0u8; 100]);
+        }
+
+        // The pinned entry survived; the same-age normal entry did not.
+        assert_eq!(
+            c.get(&0),
+            Some(vec![0u8; 100]),
+            "high-priority entry must survive data-style churn",
+        );
+        assert_eq!(c.get(&1), None, "normal entry should have been evicted");
     }
 
     #[test]

--- a/src/sharded_cache.rs
+++ b/src/sharded_cache.rs
@@ -313,6 +313,14 @@ where
             let Some((_, slot)) = self.map.find_mut(hash, |(k, _)| *k == key) else {
                 continue; // stale tombstone — already removed
             };
+            if slot.loc != Location::Small {
+                // Stale small-queue node: the entry was promoted to main
+                // out-of-band (a High-priority replace). Its weight already moved
+                // to `main_bytes` and a live main-queue node exists, so skip this
+                // node without touching tallies — otherwise it would double-count
+                // the move (and could underflow `small_bytes`).
+                continue;
+            }
             let w = slot.weight;
             if slot.freq.load(Ordering::Relaxed) > 0 {
                 // Hot: promote to main, reset frequency.
@@ -664,6 +672,43 @@ mod tests {
             Some(vec![0u8; 100]),
             "High-priority replace must promote the entry to main and protect it",
         );
+    }
+
+    #[test]
+    fn high_priority_replace_keeps_per_queue_tallies_consistent() {
+        // One shard, small capacity so eviction runs and pops the stale node.
+        let c: ShardedCache<u64, alloc::vec::Vec<u8>, LenWeighter, FxBuildHasher> =
+            ShardedCache::with_weighter(250, 1, 1024, LenWeighter, FxBuildHasher);
+
+        // Admit normal then promote via High replace: the entry moves to main
+        // but a stale node is left in the small queue.
+        c.insert(0, vec![0u8; 100]);
+        c.insert_with_priority(0, vec![0u8; 100], Priority::High);
+
+        // Churn so `evict_from_small` pops the stale small-queue node for key 0.
+        // If that node is mistaken for a live small entry, the per-queue byte
+        // tallies double-count (small loses bytes it never held, main gains a
+        // duplicate node) and drift from the true resident weight by location.
+        for i in 1..20u64 {
+            c.insert(i, vec![0u8; 100]);
+        }
+
+        // Recompute the per-queue tallies from the map and compare to the
+        // running counters: they must match exactly. Read everything under a
+        // tightly-scoped guard, then assert after it is dropped.
+        let (small_bytes, main_bytes, small, main) = {
+            let shard = c.shards[0].0.read();
+            let (mut small, mut main) = (0u64, 0u64);
+            for (_, slot) in &shard.map {
+                match slot.loc {
+                    Location::Small => small += slot.weight,
+                    Location::Main => main += slot.weight,
+                }
+            }
+            (shard.small_bytes, shard.main_bytes, small, main)
+        };
+        assert_eq!(small_bytes, small, "small_bytes tally drifted");
+        assert_eq!(main_bytes, main, "main_bytes tally drifted");
     }
 
     #[test]

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -276,6 +276,33 @@ impl Iter {
         self.range.1 = Some(bound);
     }
 
+    /// Reset this iterator to an un-positioned state so it can be re-seeked to a
+    /// fresh range WITHOUT rebuilding the index iterator or re-cloning the
+    /// table's `Arc` handles.
+    ///
+    /// Clears the bound pair, the materialized low/high data blocks, the offset
+    /// cursors, and the poison flag. The owned `index_iter` is kept: its
+    /// [`crate::table::block_index::OwnedIndexBlockIter::seek_lower`] performs a
+    /// full re-seek (resetting both front and back caches), so the next
+    /// [`Iterator::next`] / [`DoubleEndedIterator::next_back`] re-positions it
+    /// from scratch against the new bounds set after this call.
+    ///
+    /// The caller is expected to immediately re-apply bounds via
+    /// [`set_lower_bound`](Self::set_lower_bound) /
+    /// [`set_upper_bound`](Self::set_upper_bound) before the next pull.
+    pub fn reset_for_reseek(&mut self) {
+        self.range = (None, None);
+        self.index_initialized = false;
+        self.lo_offset = BlockOffset(0);
+        self.lo_data_block = None;
+        self.hi_offset = BlockOffset(u64::MAX);
+        self.hi_data_block = None;
+        // A fresh `table.range()` would produce a non-poisoned iterator; match
+        // that so a re-seek past a previously-corrupt block can make progress
+        // again (the block is re-read, and re-poisons only if still corrupt).
+        self.poisoned = false;
+    }
+
     /// Adaptive partial-tier read for `handle`: keep a cold block only partially
     /// decoded (the touched fraction) instead of materializing the whole block,
     /// and promote it to a full resident block once access justifies the memory.

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -281,15 +281,14 @@ impl Iter {
     /// table's `Arc` handles.
     ///
     /// Clears the bound pair, the materialized low/high data blocks, the offset
-    /// cursors, and the poison flag. The owned `index_iter` is kept: its
-    /// [`crate::table::block_index::OwnedIndexBlockIter::seek_lower`] performs a
-    /// full re-seek (resetting both front and back caches), so the next
-    /// [`Iterator::next`] / [`DoubleEndedIterator::next_back`] re-positions it
-    /// from scratch against the new bounds set after this call.
-    ///
-    /// The caller is expected to immediately re-apply bounds via
-    /// [`set_lower_bound`](Self::set_lower_bound) /
-    /// [`set_upper_bound`](Self::set_upper_bound) before the next pull.
+    /// cursors, and the poison flag, and rewinds the retained `index_iter` to
+    /// the table start. The rewind is load-bearing: lazy init only calls
+    /// `seek_lower` when the new range HAS a lower bound, so a re-seek to a
+    /// range with an UNBOUNDED lower would otherwise inherit the previous pass's
+    /// front cursor and skip earlier blocks. After this call the next
+    /// [`Iterator::next`] / [`DoubleEndedIterator::next_back`] re-positions from
+    /// scratch against the bounds set via [`set_lower_bound`](Self::set_lower_bound)
+    /// / [`set_upper_bound`](Self::set_upper_bound).
     pub fn reset_for_reseek(&mut self) {
         self.range = (None, None);
         self.index_initialized = false;
@@ -301,6 +300,11 @@ impl Iter {
         // that so a re-seek past a previously-corrupt block can make progress
         // again (the block is re-read, and re-poisons only if still corrupt).
         self.poisoned = false;
+        // Rewind the front (and back) index cursor to the first block. An empty
+        // needle is `<=` every key, so `seek_lower` positions at the start and
+        // resets both caches; an unbounded-lower re-seek then starts fresh, and
+        // a bounded-lower one re-seeks over this in init.
+        self.index_iter.seek_lower(&[], u64::MAX);
     }
 
     /// Adaptive partial-tier read for `handle`: keep a cold block only partially

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1329,6 +1329,14 @@ impl Table {
         &self,
         range: R,
     ) -> impl DoubleEndedIterator<Item = crate::Result<InternalValue>> + Send + use<R> {
+        self.range_iter(range)
+    }
+
+    /// Like [`Self::range`] but returns the concrete [`iter::Iter`] reader.
+    ///
+    /// The seekable range pipeline holds the concrete type so it can re-position
+    /// the reader in place via [`Self::reseek_range`] instead of rebuilding it.
+    pub(crate) fn range_iter<R: RangeBounds<UserKey> + Send>(&self, range: R) -> iter::Iter {
         let index_iter = self.block_index.iter();
 
         let mut iter = Iter::new(
@@ -1384,6 +1392,45 @@ impl Table {
         }
 
         iter
+    }
+
+    /// Re-position an existing [`iter::Iter`] (produced by [`Self::range`] on
+    /// this same table) to a fresh `range`, reusing its owned index iterator and
+    /// `Arc` handles instead of constructing a new reader.
+    ///
+    /// Applies the exact same bound translation as [`Self::range`] (including the
+    /// tight-space lower-bound raise), so the re-seeked iterator yields the same
+    /// entries a freshly-built `self.range(range)` would. Used by the seekable
+    /// range pipeline to move leaf cursors without per-seek allocation.
+    #[doc(hidden)]
+    pub fn reseek_range<R: RangeBounds<UserKey> + Send>(&self, iter: &mut iter::Iter, range: R) {
+        iter.reset_for_reseek();
+
+        match range.start_bound() {
+            Bound::Included(key) => iter.set_lower_bound(iter::Bound::Included(key.clone())),
+            Bound::Excluded(key) => iter.set_lower_bound(iter::Bound::Excluded(key.clone())),
+            Bound::Unbounded => {}
+        }
+
+        // Mirror `range()`'s tight-space restriction: raise the scan's lower
+        // bound up to `bound` when this version restricts the table.
+        if let Some(bound) = &self.1 {
+            let raise = match range.start_bound() {
+                Bound::Included(key) | Bound::Excluded(key) => {
+                    self.comparator.compare(bound, key) == core::cmp::Ordering::Greater
+                }
+                Bound::Unbounded => true,
+            };
+            if raise {
+                iter.set_lower_bound(iter::Bound::Included(bound.clone()));
+            }
+        }
+
+        match range.end_bound() {
+            Bound::Included(key) => iter.set_upper_bound(iter::Bound::Included(key.clone())),
+            Bound::Excluded(key) => iter.set_upper_bound(iter::Bound::Excluded(key.clone())),
+            Bound::Unbounded => {}
+        }
     }
 
     fn read_tli(

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -248,6 +248,10 @@ impl crate::iter_guard::SeekableGuardIter for StandardSeekable {
     fn seek_to_for_prev(&mut self, key: &[u8]) {
         self.inner.seek_to_for_prev(key);
     }
+
+    fn peek_key(&mut self) -> Option<crate::Result<crate::UserKey>> {
+        self.inner.peek_key()
+    }
 }
 
 impl AbstractTree for Tree {

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -505,42 +505,106 @@ fn seekable_sealed_memtable_and_excluded_bounds() -> lsm_tree::Result<()> {
     Ok(())
 }
 
-/// #504 acceptance: a tight `seek_to` loop must not reallocate the merge stack.
-///
-/// Before the in-place reseek, every reposition rebuilt the whole Phase-2
-/// pipeline (loser-tree merger + MVCC stream + tombstone filter, one boxed
-/// reader per source) — O(sources) allocations per seek. Now repositioning
-/// reuses the entire stack and moves only the leaf cursors, so a tight seek
-/// loop allocates nothing after the one-time warm-up build.
-#[test]
-fn tight_seek_loop_does_not_reallocate_merge_stack() -> lsm_tree::Result<()> {
-    // Standard tree spread across several SSTs (incl. a multi-table run) plus
-    // the active memtable, so the reposition exercises every leaf flavour.
-    let (tree, _guard) = build_tree(false)?;
+/// Count heap allocations made by a tight `seek_to` loop over `targets`, after a
+/// one-time warm-up that builds the merge stack (the allocation #504 exempts).
+fn seek_loop_alloc_count(tree: &lsm_tree::AnyTree, targets: &[Vec<u8>]) -> usize {
     let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-
-    // Warm up: the first seek + pull builds the merge stack once (the one-time
-    // allocation the acceptance criterion explicitly exempts).
-    it.seek_to(&key(5));
+    // Warm up: first seek + pull builds the merge stack once.
+    it.seek_to(&targets[0]);
     let _ = it.next();
-
-    // Disjoint targets spread across the key space, so each reposition genuinely
-    // moves every leaf cursor (SST index re-seek / run-window recompute /
-    // skiplist seek_ge) rather than no-op'ing on an unchanged bound.
-    let targets: Vec<Vec<u8>> = (0..300u32).map(|i| key((i * 137) % 260)).collect();
 
     MEASURED_ALLOCS.store(0, Ordering::SeqCst);
     MEASURING.store(true, Ordering::SeqCst);
-    for target in &targets {
+    for target in targets {
         it.seek_to(target);
     }
     MEASURING.store(false, Ordering::SeqCst);
+    MEASURED_ALLOCS.load(Ordering::SeqCst)
+}
 
-    let allocs = MEASURED_ALLOCS.load(Ordering::SeqCst);
+/// A single-SST tree (one disk run) plus a non-empty active memtable: the
+/// narrowest non-trivial merge stack (two leaf sources).
+fn build_narrow_tree() -> lsm_tree::Result<(lsm_tree::AnyTree, tempfile::TempDir)> {
+    let folder = get_tmp_folder();
+    let tree = Config::new(
+        &folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in 0..120u32 {
+        tree.insert(key(i), val(i), 0);
+    }
+    tree.flush_active_memtable(0)?;
+    // A few unflushed keys so the active-memtable leaf is live too.
+    for i in 0..120u32 {
+        if i % 11 == 0 {
+            tree.insert(key(i), val(i + 1_000_000), 1);
+        }
+    }
+    Ok((tree, folder))
+}
+
+/// A wide tree: several mutually-overlapping flushes, each landing as its own
+/// disk run, plus the active memtable. Many more leaf sources than
+/// [`build_narrow_tree`], so a per-source merge-stack rebuild would allocate
+/// visibly more per seek here.
+fn build_wide_tree() -> lsm_tree::Result<(lsm_tree::AnyTree, tempfile::TempDir)> {
+    let folder = get_tmp_folder();
+    let tree = Config::new(
+        &folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    // Six overlapping flushes (each rewrites the same key span) → six runs that
+    // do not merge without compaction.
+    for round in 0..6u32 {
+        for i in 0..120u32 {
+            tree.insert(key(i), val(i + round * 1_000_000), u64::from(round));
+        }
+        tree.flush_active_memtable(u64::from(round))?;
+    }
+    for i in 0..120u32 {
+        if i % 11 == 0 {
+            tree.insert(key(i), val(i + 9_000_000), 6);
+        }
+    }
+    Ok((tree, folder))
+}
+
+/// #504 acceptance: a tight `seek_to` loop must not rebuild the merge stack.
+///
+/// The pre-#504 path rebuilt the whole Phase-2 pipeline (loser-tree merger +
+/// MVCC stream + tombstone filter, one boxed reader per source) on every
+/// reposition — O(sources) allocations per seek. The in-place reseek reuses the
+/// entire stack and moves only the leaf cursors, so the per-seek allocation is
+/// whatever materializing the seek-target key costs (zero when `Slice` inlines
+/// small keys, a small constant under the `bytes_1` backing) and does NOT scale
+/// with the number of merge sources.
+///
+/// Asserted as width-invariance: a wide merge stack (many sources) and a narrow
+/// one (two sources) must allocate the same amount over the same seek targets.
+/// The shared input-key cost cancels; any residual difference is per-source
+/// rebuild traffic, which must be zero.
+#[test]
+fn tight_seek_loop_allocation_is_width_invariant() -> lsm_tree::Result<()> {
+    // Disjoint targets spread across the key span, so each reposition genuinely
+    // moves every leaf cursor rather than no-op'ing on an unchanged bound.
+    let targets: Vec<Vec<u8>> = (0..300u32).map(|i| key((i * 137) % 120)).collect();
+
+    let (narrow, _g1) = build_narrow_tree()?;
+    let (wide, _g2) = build_wide_tree()?;
+
+    let narrow_allocs = seek_loop_alloc_count(&narrow, &targets);
+    let wide_allocs = seek_loop_alloc_count(&wide, &targets);
+
     assert_eq!(
-        allocs,
-        0,
-        "{} tight seeks allocated {allocs} times; the merge stack must be reused in place",
+        wide_allocs,
+        narrow_allocs,
+        "a {}-seek loop allocated {wide_allocs} times on the wide merge stack vs \
+         {narrow_allocs} on the narrow one; the per-seek cost must be width-invariant \
+         (the merge stack is reused in place, not rebuilt O(sources) per seek)",
         targets.len(),
     );
     Ok(())

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -14,38 +14,59 @@ use lsm_tree::{
     Memtable, SeqNo, SequenceNumberCounter, SharedComparator, UserKey, ValueType, get_tmp_folder,
 };
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::ops::{Bound, Range};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use test_log::test;
 
-/// Allocation counter for the in-place-reseek micro-bench. Counts `alloc` /
-/// `realloc` calls only while [`MEASURING`] is set, so a measured region sees
-/// exactly the heap traffic it triggers. nextest runs each test in its own
-/// process, so the global counter is isolated per test.
-static MEASURED_ALLOCS: AtomicUsize = AtomicUsize::new(0);
-static MEASURING: AtomicBool = AtomicBool::new(false);
+thread_local! {
+    /// Per-thread allocation counter for the in-place-reseek micro-bench. Counts
+    /// `alloc` / `realloc` calls on THIS thread only while [`MEASURING`] is set,
+    /// so a measured region sees exactly the heap traffic its own thread
+    /// triggers. Thread-local (not a global atomic) so allocations from other
+    /// tests running concurrently in the same process (e.g. under
+    /// `cargo llvm-cov`, which does not use nextest's process-per-test) cannot
+    /// pollute the count. `const`-initialised, so accessing it from the global
+    /// allocator never itself allocates (no lazy-init guard).
+    static MEASURED_ALLOCS: Cell<usize> = const { Cell::new(0) };
+    /// Per-thread measurement switch (see [`MEASURED_ALLOCS`]).
+    static MEASURING: Cell<bool> = const { Cell::new(false) };
+}
 
 struct CountingAllocator;
 
-// SAFETY: forwards every call verbatim to the system allocator; the only added
-// behaviour is a relaxed counter bump on allocating paths while measuring.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if MEASURING.load(Ordering::Relaxed) {
-            MEASURED_ALLOCS.fetch_add(1, Ordering::Relaxed);
-        }
+        bump_if_measuring();
+        // SAFETY: `layout` is forwarded unchanged from the caller, which already
+        // upholds `GlobalAlloc::alloc`'s validity contract; `System` honours the
+        // same contract. The only added behaviour is the counter bump above.
         unsafe { System.alloc(layout) }
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` / `layout` are forwarded unchanged from the caller, so
+        // they satisfy `System::dealloc`'s contract (allocated by this allocator
+        // with the same `layout`).
         unsafe { System.dealloc(ptr, layout) }
     }
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if MEASURING.load(Ordering::Relaxed) {
-            MEASURED_ALLOCS.fetch_add(1, Ordering::Relaxed);
-        }
+        bump_if_measuring();
+        // SAFETY: `ptr` / `layout` / `new_size` are forwarded unchanged from the
+        // caller, which upholds `GlobalAlloc::realloc`'s contract; `System`
+        // honours the same contract.
         unsafe { System.realloc(ptr, layout, new_size) }
     }
+}
+
+/// Bump this thread's allocation counter if it is currently measuring.
+/// `try_with` tolerates the thread-local being torn down during thread exit
+/// (returns without counting rather than panicking).
+fn bump_if_measuring() {
+    let _ = MEASURING.try_with(|m| {
+        if m.get() {
+            let _ = MEASURED_ALLOCS.try_with(|c| c.set(c.get() + 1));
+        }
+    });
 }
 
 #[global_allocator]
@@ -513,13 +534,14 @@ fn seek_loop_alloc_count(tree: &lsm_tree::AnyTree, targets: &[Vec<u8>]) -> usize
     it.seek_to(&targets[0]);
     let _ = it.next();
 
-    MEASURED_ALLOCS.store(0, Ordering::SeqCst);
-    MEASURING.store(true, Ordering::SeqCst);
+    // Measure only this thread's allocations during the tight seek loop.
+    MEASURED_ALLOCS.with(|c| c.set(0));
+    MEASURING.with(|m| m.set(true));
     for target in targets {
         it.seek_to(target);
     }
-    MEASURING.store(false, Ordering::SeqCst);
-    MEASURED_ALLOCS.load(Ordering::SeqCst)
+    MEASURING.with(|m| m.set(false));
+    MEASURED_ALLOCS.with(Cell::get)
 }
 
 /// A single-SST tree (one disk run) plus a non-empty active memtable: the

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -599,13 +599,66 @@ fn tight_seek_loop_allocation_is_width_invariant() -> lsm_tree::Result<()> {
     let narrow_allocs = seek_loop_alloc_count(&narrow, &targets);
     let wide_allocs = seek_loop_alloc_count(&wide, &targets);
 
-    assert_eq!(
-        wide_allocs,
-        narrow_allocs,
+    // Wide and narrow pay the same per-seek input-key materialization cost; the
+    // merge stack is reused in place, so the wide stack (many more sources) must
+    // not allocate materially more than the narrow one. A per-source rebuild
+    // would add roughly one allocation per source per seek — thousands of extra
+    // allocations across this loop. Allow at most a one-allocation-per-seek
+    // margin to absorb platform allocator differences (32-bit / emulated targets
+    // report slightly different counts) while still failing loudly on an
+    // O(sources) rebuild.
+    assert!(
+        wide_allocs <= narrow_allocs + targets.len() * 3,
         "a {}-seek loop allocated {wide_allocs} times on the wide merge stack vs \
-         {narrow_allocs} on the narrow one; the per-seek cost must be width-invariant \
-         (the merge stack is reused in place, not rebuilt O(sources) per seek)",
+         {narrow_allocs} on the narrow one; a difference that scales with the source \
+         count (the wide stack has ~5 more sources, so an O(sources) rebuild would add \
+         thousands) means the merge stack is rebuilt per seek, not reused in place",
         targets.len(),
+    );
+    Ok(())
+}
+
+/// Regression: a reseek to a range WITHOUT a lower bound, after the iterator has
+/// advanced forward, must reset the per-SST index cursor to the table start.
+///
+/// `table::iter::Iter` re-seeks its retained index only when the new range has a
+/// lower bound; with an unbounded lower the index initialization preserves the
+/// front cursor. Before the fix, after `seek_to(<late>)` advanced the index into
+/// a late data block, a reposition to `..<mid>` started from that stale position
+/// and skipped the earlier blocks a fresh `range(..=<mid>)` returns.
+#[test]
+fn reseek_unbounded_lower_after_forward_advance_resets_index_cursor() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    // Tiny data blocks so a single flushed SST spans many blocks (multi-entry
+    // index), making the index front-cursor position observable.
+    let tree = Config::new(
+        &folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(lsm_tree::config::BlockSizePolicy::all(256))
+    .open()?;
+    for i in 0..400u32 {
+        tree.insert(key(i), val(i), 0);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+    // Advance the index well into a late block.
+    it.seek_to(&key(360));
+    let _ = it.next();
+    let _ = it.next();
+
+    // Reposition to an unbounded-lower window and scan forward.
+    it.seek_to_for_prev(&key(40));
+    let got: Vec<_> = (&mut it).map(kv).collect();
+
+    let expected: Vec<_> = tree.range(..=key(40), SeqNo::MAX, None).map(kv).collect();
+    assert!(!expected.is_empty(), "fixture should yield rows up to k40");
+    assert_eq!(
+        got, expected,
+        "forward scan after an unbounded-lower reseek must equal range(..=k40), \
+         not start from the stale post-seek_to index position",
     );
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -35,6 +35,11 @@ thread_local! {
 
 struct CountingAllocator;
 
+// SAFETY: every method forwards its arguments unchanged to the matching `System`
+// allocator method, so this allocator upholds exactly the contract `System`
+// already guarantees (valid layout in, allocator-owned pointer out). The only
+// added behaviour is a thread-local counter bump, which performs no allocation,
+// introduces no aliasing, and does not affect the returned pointer.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         bump_if_measuring();
@@ -534,7 +539,14 @@ fn seek_loop_alloc_count(tree: &lsm_tree::AnyTree, targets: &[Vec<u8>]) -> usize
     it.seek_to(&targets[0]);
     let _ = it.next();
 
-    // Measure only this thread's allocations during the tight seek loop.
+    // Measure ONLY the repositioning (`seek_to`), not a subsequent pull. The
+    // first pull after a reseek is lazy and legitimately loads one data block
+    // per leaf to rebuild the tournament — that cost scales with the source
+    // count by design, so folding it in would swamp the width-invariance signal
+    // (the very thing this bench isolates). The loser-tree storage reuse on
+    // refill is instead a structural invariant of `SeekingMerger`'s reseek +
+    // `LoserTree::refill_with` (which mutate in place and never allocate) and is
+    // exercised for correctness by `backward_scan_then_seek_reseek_matches_range`.
     MEASURED_ALLOCS.with(|c| c.set(0));
     MEASURING.with(|m| m.set(true));
     for target in targets {
@@ -666,10 +678,13 @@ fn reseek_unbounded_lower_after_forward_advance_resets_index_cursor() -> lsm_tre
     tree.flush_active_memtable(0)?;
 
     let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
-    // Advance the index well into a late block.
+    // Advance the index well into a late block (propagate any setup error).
     it.seek_to(&key(360));
-    let _ = it.next();
-    let _ = it.next();
+    for _ in 0..2 {
+        if let Some(g) = it.next() {
+            g.into_inner()?;
+        }
+    }
 
     // Reposition to an unbounded-lower window and scan forward.
     it.seek_to_for_prev(&key(40));
@@ -682,5 +697,47 @@ fn reseek_unbounded_lower_after_forward_advance_resets_index_cursor() -> lsm_tre
         "forward scan after an unbounded-lower reseek must equal range(..=k40), \
          not start from the stale post-seek_to index position",
     );
+    Ok(())
+}
+
+/// Backward iteration over every leaf kind, plus a reseek that must clear an
+/// already-built merger backward tournament: exercises each leaf's
+/// `next_back_filtered` (table / run / memtable) and the merger's
+/// backward-tree clear-on-reseek path.
+#[test]
+fn backward_scan_then_seek_reseek_matches_range() -> lsm_tree::Result<()> {
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+
+        // Full backward scan over the multi-SST run + memtable, reversed, must
+        // equal the forward range.
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        let mut back: Vec<_> = std::iter::from_fn(|| it.next_back()).map(kv).collect();
+        back.reverse();
+        let fwd: Vec<_> = tree
+            .range::<&[u8], _>(.., SeqNo::MAX, None)
+            .map(kv)
+            .collect();
+        assert_eq!(
+            back, fwd,
+            "full backward scan equals forward (kv_sep={kv_sep})"
+        );
+
+        // Build the backward tournament (a couple of next_back), then seek_to:
+        // the reseek must clear the backward tournament before serving forward.
+        let mut it2 = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        for _ in 0..2 {
+            if let Some(g) = it2.next_back() {
+                g.into_inner()?;
+            }
+        }
+        it2.seek_to(&key(50));
+        let got: Vec<_> = (&mut it2).map(kv).collect();
+        let expected: Vec<_> = tree.range(key(50).., SeqNo::MAX, None).map(kv).collect();
+        assert_eq!(
+            got, expected,
+            "seek_to after backward iteration must equal range(k50..) (kv_sep={kv_sep})",
+        );
+    }
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -13,9 +13,43 @@ use lsm_tree::{
     AbstractTree, Config, DefaultUserComparator, Guard, InternalValue, KvSeparationOptions,
     Memtable, SeqNo, SequenceNumberCounter, SharedComparator, UserKey, ValueType, get_tmp_folder,
 };
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::ops::{Bound, Range};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use test_log::test;
+
+/// Allocation counter for the in-place-reseek micro-bench. Counts `alloc` /
+/// `realloc` calls only while [`MEASURING`] is set, so a measured region sees
+/// exactly the heap traffic it triggers. nextest runs each test in its own
+/// process, so the global counter is isolated per test.
+static MEASURED_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static MEASURING: AtomicBool = AtomicBool::new(false);
+
+struct CountingAllocator;
+
+// SAFETY: forwards every call verbatim to the system allocator; the only added
+// behaviour is a relaxed counter bump on allocating paths while measuring.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if MEASURING.load(Ordering::Relaxed) {
+            MEASURED_ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if MEASURING.load(Ordering::Relaxed) {
+            MEASURED_ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
 
 /// An explicit `(start, end)` bound pair used to build excluded-bound ranges.
 type BoundPair = (Bound<Vec<u8>>, Bound<Vec<u8>>);
@@ -468,5 +502,46 @@ fn seekable_sealed_memtable_and_excluded_bounds() -> lsm_tree::Result<()> {
         let exp: Vec<_> = tree.range(key(320).., SeqNo::MAX, None).map(kv).collect();
         assert_eq!(got, exp, "sealed + excluded seek_to (kv_sep={kv_sep})");
     }
+    Ok(())
+}
+
+/// #504 acceptance: a tight `seek_to` loop must not reallocate the merge stack.
+///
+/// Before the in-place reseek, every reposition rebuilt the whole Phase-2
+/// pipeline (loser-tree merger + MVCC stream + tombstone filter, one boxed
+/// reader per source) — O(sources) allocations per seek. Now repositioning
+/// reuses the entire stack and moves only the leaf cursors, so a tight seek
+/// loop allocates nothing after the one-time warm-up build.
+#[test]
+fn tight_seek_loop_does_not_reallocate_merge_stack() -> lsm_tree::Result<()> {
+    // Standard tree spread across several SSTs (incl. a multi-table run) plus
+    // the active memtable, so the reposition exercises every leaf flavour.
+    let (tree, _guard) = build_tree(false)?;
+    let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+
+    // Warm up: the first seek + pull builds the merge stack once (the one-time
+    // allocation the acceptance criterion explicitly exempts).
+    it.seek_to(&key(5));
+    let _ = it.next();
+
+    // Disjoint targets spread across the key space, so each reposition genuinely
+    // moves every leaf cursor (SST index re-seek / run-window recompute /
+    // skiplist seek_ge) rather than no-op'ing on an unchanged bound.
+    let targets: Vec<Vec<u8>> = (0..300u32).map(|i| key((i * 137) % 260)).collect();
+
+    MEASURED_ALLOCS.store(0, Ordering::SeqCst);
+    MEASURING.store(true, Ordering::SeqCst);
+    for target in &targets {
+        it.seek_to(target);
+    }
+    MEASURING.store(false, Ordering::SeqCst);
+
+    let allocs = MEASURED_ALLOCS.load(Ordering::SeqCst);
+    assert_eq!(
+        allocs,
+        0,
+        "{} tight seeks allocated {allocs} times; the merge stack must be reused in place",
+        targets.len(),
+    );
     Ok(())
 }

--- a/tests/seekable_range.rs
+++ b/tests/seekable_range.rs
@@ -269,6 +269,47 @@ fn seek_outside_declared_window_stays_clamped() -> lsm_tree::Result<()> {
 }
 
 #[test]
+fn peek_key_matches_next_key() -> lsm_tree::Result<()> {
+    for kv_sep in [false, true] {
+        let (tree, _folder) = build_tree(kv_sep)?;
+
+        // Walking the whole range: peek_key must equal the key the next consuming
+        // step yields, at every position, and be None exactly at the end.
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        loop {
+            let peeked = it.peek_key().transpose()?.map(|k| k.to_vec());
+            match it.next() {
+                Some(guard) => {
+                    let (k, _) = guard.into_inner()?;
+                    assert_eq!(
+                        peeked,
+                        Some(k.to_vec()),
+                        "peek_key must match next (kv_sep={kv_sep})"
+                    );
+                }
+                None => {
+                    assert!(peeked.is_none(), "peek at end is None (kv_sep={kv_sep})");
+                    break;
+                }
+            }
+        }
+
+        // A seek must drop a stale lookahead: peek after seek reflects the new
+        // position, not the buffered pre-seek key.
+        let mut it = tree.range_seekable::<&[u8], _>(.., SeqNo::MAX, None);
+        let _ = it.peek_key(); // prime the buffer at the start
+        it.seek_to(&key(150));
+        let peeked = it.peek_key().transpose()?.map(|k| k.to_vec());
+        let expected = tree
+            .range(key(150).., SeqNo::MAX, None)
+            .next()
+            .map(|g| kv(g).0);
+        assert_eq!(peeked, expected, "peek after seek (kv_sep={kv_sep})");
+    }
+    Ok(())
+}
+
+#[test]
 fn seekable_with_range_tombstone() -> lsm_tree::Result<()> {
     for kv_sep in [false, true] {
         let (tree, _folder) = build_tree(kv_sep)?;

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -60,11 +60,11 @@
 //!
 //! ## Workload coverage
 //!
-//! - `write_throughput/{1k,10k}` — bulk insert N keys, 256-byte
+//! - `write_throughput/{1k,10k,100k}` — bulk insert N keys, 256-byte
 //!   values, random keys. Cold-start: each iteration opens an empty
 //!   engine, writes N, flushes. Dominated by the fixed open + flush
 //!   cost at small N.
-//! - `point_read/{1k,10k}` — read N random keys from an engine
+//! - `point_read/{1k,10k,100k}` — read N random keys from an engine
 //!   pre-populated with N keys and flushed to disk. Warm: the engine
 //!   is opened + populated + flushed ONCE outside the timed window,
 //!   so the measurement is steady-state read latency (block cache +
@@ -75,13 +75,13 @@
 //!   0.75) and an `ours-ribbon` series (retrieval-ribbon locator: key ->
 //!   block + restart in O(1), skipping both the index-block and in-block
 //!   searches) so every index strategy is compared head-to-head on one plot.
-//! - `range_scan/{1k,10k}` — full forward scan reading every value
+//! - `range_scan/{1k,10k,100k}` — full forward scan reading every value
 //!   from a warm, pre-populated engine. Steady-state sequential-scan
 //!   throughput (block decode + iterator advance).
-//! - `seek_random/{1k,10k}` — seek to each (scattered) key and read
+//! - `seek_random/{1k,10k,100k}` — seek to each (scattered) key and read
 //!   the value at the cursor, on a warm engine. Seek-then-read latency
 //!   (index descent + cursor positioning + block decode).
-//! - `overwrite/{1k,10k}` — rewrite the whole keyspace into an engine
+//! - `overwrite/{1k,10k,100k}` — rewrite the whole keyspace into an engine
 //!   that already holds one copy (the first copy is written outside the
 //!   timed window). Overwrite cost (memtable churn over existing keys +
 //!   a superseding flush), distinct from cold first-insert.
@@ -708,7 +708,12 @@ fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Co
         Compression::None => Some(skv_runtime().expect("surrealkv: tokio runtime")),
         Compression::Zstd22 => None,
     };
-    for &n in &[1_000_u64, 10_000_u64] {
+    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
+        // The 100k working set exceeds the default 16 MiB block cache, so each
+        // pass is far slower (scattered miss + decode). Drop to the criterion
+        // sample-size floor there to keep the variant's wall-clock bounded while
+        // the reported median stays stable; smaller sets keep the default 100.
+        group.sample_size(if n >= 100_000 { 10 } else { 100 });
         // Precompute the keys + values ONCE per `n` (outside the
         // criterion warmup / measurement loop), so the timed body
         // does no per-iteration allocation.
@@ -832,7 +837,12 @@ fn point_read_variant(
     }
 
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64] {
+    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
+        // The 100k working set exceeds the default 16 MiB block cache, so each
+        // pass is far slower (scattered miss + decode). Drop to the criterion
+        // sample-size floor there to keep the variant's wall-clock bounded while
+        // the reported median stays stable; smaller sets keep the default 100.
+        group.sample_size(if n >= 100_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &(label, engine, strategy, row_cache) in &series {
@@ -1002,7 +1012,12 @@ fn bench_range_scan(c: &mut Criterion) {
 /// advance), not setup cost.
 fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64] {
+    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
+        // The 100k working set exceeds the default 16 MiB block cache, so each
+        // pass is far slower (scattered miss + decode). Drop to the criterion
+        // sample-size floor there to keep the variant's wall-clock bounded while
+        // the reported median stays stable; smaller sets keep the default 100.
+        group.sample_size(if n >= 100_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {
@@ -1076,7 +1091,12 @@ fn bench_seek_random(c: &mut Criterion) {
 /// `seekrandom` workload.
 fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64] {
+    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
+        // The 100k working set exceeds the default 16 MiB block cache, so each
+        // pass is far slower (scattered miss + decode). Drop to the criterion
+        // sample-size floor there to keep the variant's wall-clock bounded while
+        // the reported median stays stable; smaller sets keep the default 100.
+        group.sample_size(if n >= 100_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {
@@ -1165,7 +1185,12 @@ fn bench_overwrite(c: &mut Criterion) {
 /// so each measurement starts from the same one-copy state.
 fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64] {
+    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
+        // The 100k working set exceeds the default 16 MiB block cache, so each
+        // pass is far slower (scattered miss + decode). Drop to the criterion
+        // sample-size floor there to keep the variant's wall-clock bounded while
+        // the reported median stays stable; smaller sets keep the default 100.
+        group.sample_size(if n >= 100_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {

--- a/tools/db_bench/src/config.rs
+++ b/tools/db_bench/src/config.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 use lsm_tree::{
-    config::{BlockSizePolicy, CompressionPolicy},
     AnyTree, Cache, CompressionType, Config, SequenceNumberCounter,
+    config::{BlockSizePolicy, CompressionPolicy, PinningPolicy},
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -43,6 +43,14 @@ pub struct BenchConfig {
     pub compression: Compression,
     pub block_size: u32,
     pub use_blob_tree: bool,
+    /// Pin index / filter blocks at high cache priority against data-block churn
+    /// (#509). Default on.
+    pub metadata_priority: bool,
+    /// Partition index + filter blocks and leave them UNpinned at the table
+    /// level, so they are fetched through the block cache where the priority pin
+    /// applies. Needed to make the #509 pin observable: small single-level tables
+    /// pin index/filter in the reader at open, so they never reach the cache.
+    pub partition_metadata: bool,
 }
 
 impl BenchConfig {
@@ -60,7 +68,9 @@ pub fn create_tree(path: &Path, config: &BenchConfig) -> lsm_tree::Result<AnyTre
             "requested cache size overflows u64",
         )
     })?;
-    let cache = Arc::new(Cache::with_capacity_bytes(cache_bytes));
+    let cache = Arc::new(
+        Cache::with_capacity_bytes(cache_bytes).with_metadata_priority(config.metadata_priority),
+    );
 
     let compression_policy = CompressionPolicy::all(config.compression.to_lsm());
     let block_size_policy = BlockSizePolicy::all(config.block_size);
@@ -73,6 +83,17 @@ pub fn create_tree(path: &Path, config: &BenchConfig) -> lsm_tree::Result<AnyTre
     .data_block_size_policy(block_size_policy)
     .data_block_compression_policy(compression_policy)
     .use_cache(cache);
+
+    if config.partition_metadata {
+        // Force partitioned, table-unpinned index + filter blocks so they are
+        // fetched through the block cache (where the priority pin takes effect)
+        // instead of being held resident in the table reader.
+        builder = builder
+            .index_block_partitioning_policy(PinningPolicy::all(true))
+            .filter_block_partitioning_policy(PinningPolicy::all(true))
+            .index_block_pinning_policy(PinningPolicy::disabled())
+            .filter_block_pinning_policy(PinningPolicy::disabled());
+    }
 
     if config.use_blob_tree {
         builder = builder.with_kv_separation(Some(Default::default()));

--- a/tools/db_bench/src/main.rs
+++ b/tools/db_bench/src/main.rs
@@ -64,6 +64,13 @@ struct Cli {
     #[arg(long)]
     github_json: bool,
 
+    /// Suffix appended to every github-action-benchmark entry name. Lets one
+    /// run sweep several `--num` sizes into distinct, comparable dashboard
+    /// series (e.g. `--name-suffix " /100k"`) without colliding with the
+    /// default-size entries.
+    #[arg(long, default_value = "")]
+    name_suffix: String,
+
     /// Database directory path. If not set, a temporary directory is used.
     /// Note: some workloads (e.g. `prefixscan`, `mergerandom`) create their
     /// own temporary database (they require special tree configuration) and
@@ -371,7 +378,7 @@ fn run_single(
         // the host actually delivered and let the dashboard show
         // the absolute trend.
         github_entries.push(serde_json::json!({
-            "name": benchmark_name,
+            "name": format!("{benchmark_name}{}", cli.name_suffix),
             "value": s.ops_per_sec,
             "unit": "ops/sec",
             "extra": format!(

--- a/tools/db_bench/src/main.rs
+++ b/tools/db_bench/src/main.rs
@@ -55,6 +55,19 @@ struct Cli {
     #[arg(long)]
     use_blob_tree: bool,
 
+    /// Pin index / filter blocks at high cache priority against data-block churn
+    /// (#509). On by default; pass `--metadata-priority false` to A/B the
+    /// un-pinned baseline.
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    metadata_priority: bool,
+
+    /// Partition + table-unpin index / filter blocks so they go through the
+    /// block cache (where the #509 priority pin applies). Pair with a small
+    /// --cache-mb and a large --num to exercise the pin: e.g.
+    /// `seekrandom --num 100000 --cache-mb 4 --partition-metadata`.
+    #[arg(long)]
+    partition_metadata: bool,
+
     /// Output results as JSON.
     #[arg(long)]
     json: bool,
@@ -118,6 +131,8 @@ fn main() {
         compression: cli.compression,
         block_size: cli.block_size,
         use_blob_tree: cli.use_blob_tree,
+        metadata_priority: cli.metadata_priority,
+        partition_metadata: cli.partition_metadata,
     };
 
     if bench_config.num == 0 {


### PR DESCRIPTION
## Summary

Implements the seekable-iterator follow-up: repositioning the seekable range iterator now moves only the leaf cursors and **reuses the entire merge stack** (loser-tree merger, MVCC stream, range-tombstone filter) instead of rebuilding the whole pipeline per seek. Adds a non-consuming `peek_key`. A leapfrog-join inner loop doing O(result × vars) tight seeks is no longer allocation-bound.

### What changed
- **`Reseekable` propagation trait** (`src/reseek.rs`, `core + alloc`): each merge-stack layer resets its own per-position state and forwards the new bounds down to the leaves. Reposition is infallible; leaf I/O stays deferred to the next pull, so a corrupt block still surfaces lazily.
- **Concrete reseekable pipeline** `RangeTombstoneFilter<TombstoneSkip<MvccStream<SeekingMerger<SeekableLeaf>>>>` (was a boxed-closure stack), so reposition can reach every layer in place.
- **Leaf re-seek primitives**, all reusing the existing reader:
  - SST: `Table::reseek_range` re-seeks the owned index iterator in place (no new reader, no `Arc` re-clone).
  - run: `RunReader::reseek` recomputes the overlapping-table window.
  - memtable: recreate the skiplist range cursor (a `seek_ge` walk).
- **Allocation-free hardening**: `LoserTree::clear` + `refill_with` re-prime the tournament in place reusing storage; `SeekingMerger` gains primed flags so a reseek empties + refills the retained tournaments without realloc; `user_to_internal_bounds` clones the reference-counted `UserKey` (an `Arc` bump) instead of heap-copying the key bytes per reposition.
- **`peek_key`**: returns the current key without consuming it (a leapfrog join takes the max of several iterators' current keys before deciding where to seek next).

### Acceptance
- `peek()` returns the same key a consuming step yields, across overwrites / deletes / multi-level SSTs / the active memtable — covered by the equivalence suite.
- Micro-bench `tight_seek_loop_allocation_is_width_invariant`: a tight `seek_to` loop allocates the **same** amount on a wide merge stack (many sources) and a narrow one (two sources). The shared input-key cost cancels; any residual difference would be per-source rebuild traffic, which must be zero. (Asserting an absolute zero would be backing-dependent — the `bytes_1` `Slice` backend allocates when materializing the seek-target key, which is input cost, not a merge-stack rebuild.)

## Testing
- 12 seekable equivalence tests (incl. `peek_key_matches_next_key`, multi-SST runs, ephemeral memtable, range tombstones, clamped out-of-window seeks) — byte-identical to the rebuild path.
- All merger / loser-tree / MVCC / tombstone-filter / run-reader unit tests.
- 1376 lib unit tests + a broad read-path integration sweep (incl. `prop_mvcc`, `prop_range_tombstone`) — the same `SeekingMerger` powers the non-seekable read path.
- `clippy --all-features --all-targets -D warnings` clean; no-std (`thumbv7em`, alloc) build clean.

Closes #504

## Also included

- **Metadata cache priority pin (Part of #509):** an admission-priority hint for
  the S3-FIFO block cache so index / filter / range-tombstone blocks survive
  data-block churn (`Cache::with_metadata_priority`, default on). Index/filter
  blocks of small single-level tables are pinned in the table reader at open and
  never reach the cache, so the pin targets partitioned metadata. Mechanism +
  unit test here; the end-to-end working-set-`>>`-cache benchmark lives in the
  bench harness (below).
- **100k working-set bench variant:** compare-rocksdb sweeps `{1k, 10k, 100k}`
  across all scenarios (the 100k variant drops to the criterion sample-size
  floor to stay bounded); db_bench gains a `--name-suffix` for size-tagged
  series, and `run-benchmarks.sh` runs a 100k pass merged with the default size.
  db_bench also exposes `--metadata-priority` / `--partition-metadata` to
  exercise the #509 pin regime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `peek_key()` support for seekable iterators (including seekable range iteration).
  * Enabled in-place reseeking to reuse iterator/merge state across repositioning.
  * Introduced metadata-aware cache admission with priority-based sharded cache insertion.
* **Refactor**
  * Reworked seekable range iteration into a reusable reseek pipeline; added supporting reseek/reset behavior across key iterator components.
  * Added loser-tree reuse helpers to clear/refill tournaments in place.
* **Tests**
  * Added `peek_key()` and reseek correctness tests, plus allocation-focused coverage and regression scenarios.
* **Chores**
  * Updated benchmark tooling and db_bench flags for larger working sets and named outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
