### PR TITLE
feat: per-block zone-map section

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -2,30 +2,18 @@
 # Run all db_bench workloads and produce github-action-benchmark JSON.
 # Usage: .github/scripts/run-benchmarks.sh [NUM_OPS] [ITERATIONS]
 #
-# Sweeps two working-set sizes so the dashboard tracks both the default
-# large set (NUM, default 500k) and a fixed 100k set that exceeds the default
-# block cache. The 100k pass tags every entry name with " /100k" so the two
-# series stay distinct (the default-size entries keep their original names, so
-# their dashboard history is unbroken).
+# Single working-set sweep at NUM (default 500k). The head-to-head size sweep
+# (1k/10k/70k vs RocksDB + SurrealKV) lives in the separate `compare-rocksdb`
+# harness, not here — this dashboard tracks the single-engine trend only.
 
 set -e
 
 NUM=${1:-500000}
 ITERATIONS=${2:-3}
 
-run_pass() {
-  # $1: --num value, $2: name suffix, $3: output file
-  cargo run --release --manifest-path tools/db_bench/Cargo.toml -- \
-    --benchmark all --num "$1" --iterations "$ITERATIONS" \
-    --name-suffix "$2" --github-json \
-    > "$3"
-}
+cargo run --release --manifest-path tools/db_bench/Cargo.toml -- \
+  --benchmark all --num "$NUM" --iterations "$ITERATIONS" \
+  --github-json \
+  > benchmark-results.json
 
-run_pass "$NUM" "" results-main.json
-run_pass 100000 " /100k" results-100k.json
-
-# Concatenate the two github-action-benchmark arrays into one.
-jq -s 'add' results-main.json results-100k.json > benchmark-results.json
-rm -f results-main.json results-100k.json
-
-echo "Results written to benchmark-results.json (sizes: $NUM, 100000)" >&2
+echo "Results written to benchmark-results.json (num: $NUM)" >&2

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -149,7 +149,7 @@ pub trait AbstractTree: sealed::Sealed {
     /// over budget and should be treated as read-only.
     ///
     /// Opt-in: returns `Ok(())` unless
-    /// [`storage_admission_check`](crate::RuntimeConfig::storage_admission_check)
+    /// [`storage_admission_check`](crate::runtime_config::RuntimeConfig::storage_admission_check)
     /// is enabled. The predicate is computed (not latched), so once space is
     /// freed — the budget raised, a compaction reclaiming space, or disk freed —
     /// the next call admits again with no restart.

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -202,7 +202,7 @@ impl BlobTree {
         })
     }
 
-    /// Resolves a single key against a pre-acquired [`SuperVersion`].
+    /// Resolves a single key against a pre-acquired [`SuperVersion`](crate::version::SuperVersion).
     fn resolve_key(
         &self,
         super_version: &crate::version::SuperVersion,
@@ -296,7 +296,7 @@ fn blob_guard(
 }
 
 /// Wraps a [`SeekableTreeIter`](crate::range::SeekableTreeIter) over the index
-/// tree so a KV-separated tree can expose it as a [`SeekableGuardIter`].
+/// tree so a KV-separated tree can expose it as a [`SeekableGuardIter`](crate::iter_guard::SeekableGuardIter).
 struct BlobSeekable {
     inner: crate::range::SeekableTreeIter,
     tree: crate::BlobTree,

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -15,7 +15,7 @@
 //!    removal are held back until the checkpoint is complete.
 //! 2. Flush the active memtable so all live data is in SSTs.
 //! 3. Snapshot the current `Version`; iterate its tables (and blob files,
-//!    for [`BlobTree`]) and hard-link each one into `target/tables/` (or
+//!    for [`BlobTree`](crate::blob_tree::BlobTree)) and hard-link each one into `target/tables/` (or
 //!    `target/blobs/`).
 //! 4. Copy the manifest, version file (`v<id>`), and `current` pointer.
 //! 5. Drop the pause guard — queued deletions run.

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -141,6 +141,7 @@ pub(super) fn prepare_table_writer(
         // output SSTs in the new index format (compaction is the migration
         // mechanism for the on-disk index layout).
         .use_seqno_in_index(rc.seqno_in_index)
+        .use_zone_map(rc.zone_map)
         .use_disable_cow_on_sst(rc.disable_cow_on_sst_files)
         .use_bloom_policy({
             use crate::config::FilterPolicyEntry::{Bloom, None};

--- a/src/compaction/seqno_zeroer.rs
+++ b/src/compaction/seqno_zeroer.rs
@@ -27,7 +27,7 @@
 //! latest entry below the watermark (no snapshot reads below the watermark), and
 //! a newer version (real seqno > 0) always wins the merge over the zeroed one.
 //! Older-version ambiguity cannot arise at the last level for the same reason
-//! [`CompactionStream::evict_tombstones`] relies on: the last level is the
+//! [`CompactionStream::evict_tombstones`](crate::compaction::stream::CompactionStream::evict_tombstones) relies on: the last level is the
 //! authoritative bottom.
 
 use crate::active_tombstone_set::ActiveTombstoneSet;

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -255,7 +255,7 @@ enum SpaceGate {
 /// **Layer 2 (physical free space, per destination volume).** SST output lands
 /// in `sst_dest_level`'s volume; KV-separated blob relocation lands in the
 /// primary blobs volume. The two are budgeted **independently only when they are
-/// proven to be on different physical volumes** ([`Fs::volume_id`] reports
+/// proven to be on different physical volumes** ([`Fs::volume_id`](crate::fs::Fs::volume_id) reports
 /// distinct device ids) — then a full cold-tier route never stalls a hot-level
 /// merge. Otherwise (same volume, or independence not proven) their transient
 /// peak is the **combined sum** on the tighter volume: checking them

--- a/src/compression/zstd_backend.rs
+++ b/src/compression/zstd_backend.rs
@@ -20,8 +20,8 @@ use std::io::Read;
 ///
 /// A dictionary blob that begins with these four bytes is a fully trained,
 /// finalized zstd dictionary containing entropy tables and must be parsed
-/// with [`Dictionary::decode_dict`]. A blob without this prefix is treated
-/// as raw content and is loaded via [`Dictionary::from_raw_content`].
+/// with `Dictionary::decode_dict`. A blob without this prefix is treated
+/// as raw content and is loaded via `Dictionary::from_raw_content`.
 const DICT_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
 
 /// Read at most `capacity` bytes from `reader` into a pre-allocated buffer,
@@ -306,7 +306,7 @@ fn do_decompress_with_dict(
 }
 
 /// Extract the inner-block layout (cumulative decompressed END offsets) from a
-/// just-emitted frame's [`FrameEmitInfo`].
+/// just-emitted frame's `FrameEmitInfo`.
 ///
 /// Returns an empty `Vec` when the frame has fewer than two inner blocks
 /// (nothing to partial-decode), when the encoder did not capture layout
@@ -334,7 +334,7 @@ fn inner_block_layout(
     ends
 }
 
-/// Runs `f` with a thread-local [`FrameCompressor`] cached by `level` (rebuilt
+/// Runs `f` with a thread-local `FrameCompressor` cached by `level` (rebuilt
 /// only on a level change). Shared by [`ZstdProvider::compress`] and
 /// `compress_with_layout` so interleaving them at the same level reuses one
 /// compressor instead of maintaining two separate thread-local caches.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -532,7 +532,7 @@ pub struct Config {
     /// When `true` (the default), [`Config::open`] and [`Config::repair`]
     /// acquire an exclusive cross-process lock on a `LOCK` file in the tree
     /// directory (an advisory OS file lock) and hold it for the lifetime of the
-    /// [`Tree`](crate::Tree) (open) or the duration of the call (repair). A
+    /// [`Tree`] (open) or the duration of the call (repair). A
     /// second process attempting to open / repair the same directory fails fast
     /// with [`Error::Locked`](crate::Error::Locked) instead of racing on the
     /// manifest. Set `false` via [`Config::with_directory_lock`] only when the

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -5,7 +5,7 @@
 //!
 //! While a [`DeletionPause`] is *active* (refcount ≥ 1), the [`Drop`]
 //! implementations on tables and blob files do not call
-//! [`Fs::remove_file`](crate::fs::Fs::remove_file) immediately. Instead they
+//! [`Fs::remove_file`] immediately. Instead they
 //! enqueue `(fs, path)` for later removal. Compaction may continue producing
 //! obsolete files; their physical deletion is just deferred.
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -366,9 +366,9 @@ pub enum Error {
     /// A write was declined by the storage admission gate because accepting it
     /// could push the tree's live footprint past its effective budget.
     ///
-    /// Only produced when [`storage_admission_check`](crate::RuntimeConfig::storage_admission_check)
+    /// Only produced when [`storage_admission_check`](crate::runtime_config::RuntimeConfig::storage_admission_check)
     /// is enabled. The predicate is computed, not latched: raising
-    /// [`storage_limit_bytes`](crate::RuntimeConfig::storage_limit_bytes),
+    /// [`storage_limit_bytes`](crate::runtime_config::RuntimeConfig::storage_limit_bytes),
     /// freeing disk, or a compaction reclaiming space clears the read-only
     /// state on the next check with no restart. Internal flush / compaction are
     /// never gated (reserved headroom), so the engine can always reclaim space.

--- a/src/heal_hints.rs
+++ b/src/heal_hints.rs
@@ -21,7 +21,7 @@
 //! that) so the read path can record a hint in O(log n) (a `BTreeSet` insert,
 //! n = pending SSTs, only on the cold corrected path), and the compaction picker
 //! drains the whole set in one place. The set dedups by
-//! [`GlobalTableId`](crate::GlobalTableId): many corrected block-reads against
+//! [`GlobalTableId`]: many corrected block-reads against
 //! the same SST enqueue it once.
 
 use crate::GlobalTableId;

--- a/src/key_range.rs
+++ b/src/key_range.rs
@@ -56,8 +56,8 @@ impl KeyRange {
 
     /// Returns `true` if the key falls within this key range.
     ///
-    /// Uses lexicographic ordering. See [`overlaps_with_key_range_cmp`] and
-    /// [`contains_range_cmp`] for custom comparator support; a `contains_key_cmp`
+    /// Uses lexicographic ordering. See [`Self::overlaps_with_key_range_cmp`] and
+    /// [`Self::contains_range_cmp`] for custom comparator support; a `contains_key_cmp`
     /// variant can be added when needed (#116).
     #[must_use]
     pub fn contains_key(&self, key: &[u8]) -> bool {
@@ -73,7 +73,7 @@ impl KeyRange {
         start1 <= start2 && end1 >= end2
     }
 
-    /// Like [`contains_range`], but uses a custom comparator for key ordering.
+    /// Like [`Self::contains_range`], but uses a custom comparator for key ordering.
     #[must_use]
     pub fn contains_range_cmp(
         &self,
@@ -94,7 +94,7 @@ impl KeyRange {
         end1 >= start2 && start1 <= end2
     }
 
-    /// Like [`overlaps_with_key_range`], but uses a custom comparator for key ordering.
+    /// Like [`Self::overlaps_with_key_range`], but uses a custom comparator for key ordering.
     #[must_use]
     pub fn overlaps_with_key_range_cmp(
         &self,
@@ -265,7 +265,7 @@ impl KeyRange {
         Self(min.clone(), max.clone())
     }
 
-    /// Like [`aggregate`], but uses a custom comparator for key ordering.
+    /// Like [`Self::aggregate`], but uses a custom comparator for key ordering.
     pub fn aggregate_cmp<'a>(
         mut iter: impl Iterator<Item = &'a Self>,
         cmp: &dyn crate::comparator::UserComparator,

--- a/src/manifest_blocks/reader.rs
+++ b/src/manifest_blocks/reader.rs
@@ -71,13 +71,13 @@ pub struct ManifestArchiveReader {
     /// and to support reopening in tests.
     path: PathBuf,
 
-    /// Open file handle, positioned arbitrarily; [`read_section`]
+    /// Open file handle, positioned arbitrarily; [`Self::read_section`]
     /// seeks each time and reads exactly one Block per call so
     /// successive lookups do not depend on the cursor.
     file: Box<dyn FsFile>,
 
     /// Verified footer payload — the table of contents that every
-    /// [`read_section`] / [`section`] lookup consults.
+    /// [`Self::read_section`] / [`Self::section`] lookup consults.
     footer: FooterPayload,
 
     /// Path that produced the footer: `Tail` (preferred) or `Head`

--- a/src/manifest_blocks/writer.rs
+++ b/src/manifest_blocks/writer.rs
@@ -71,7 +71,7 @@ pub struct ManifestArchiveWriter {
     /// opened without `Config::encryption`.
     encryption: Option<Arc<dyn EncryptionProvider>>,
 
-    /// Section currently open via [`start`]. Buffered in memory
+    /// Section currently open via [`Self::start`]. Buffered in memory
     /// until the next `start` or `finish` flushes it into a Block.
     current_section: Option<CurrentSection>,
 

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -8,7 +8,7 @@
 //! bulk deallocation when the memtable is dropped.  Concurrent skiplist
 //! traversal is lock-free (atomic loads on next-pointers); inserts use CAS with
 //! retry on tower links.  Values are stored in a lock-free segmented
-//! [`ValueStore`](super::value_store::ValueStore) — reads are wait-free.
+//! [`ValueStore`] — reads are wait-free.
 //!
 //! The design follows the arena-skiplist pattern used by Pebble/CockroachDB
 //! and Badger, adapted for Rust's ownership model and the lsm-tree
@@ -729,7 +729,7 @@ impl SkipMap {
         unsafe { self.tower_atomic(node, level).load(Ordering::Acquire) }
     }
 
-    /// The first data node (head.next[0]), or UNSET if empty.
+    /// The first data node (`head.next[0]`), or UNSET if empty.
     fn first_node(&self) -> u32 {
         self.next_at(self.head, 0)
     }
@@ -768,7 +768,7 @@ impl SkipMap {
     /// Compares two nodes by key without allocating (reads raw arena bytes).
     ///
     /// Ordering: `(user_key via comparator, Reverse(seqno))`.  `value_type` is
-    /// intentionally excluded — it is not part of [`InternalKey::Ord`] or
+    /// intentionally excluded — it is not part of `InternalKey::Ord` or
     /// [`InternalKey::compare_with`], and `(user_key, seqno)` is unique per entry.
     fn compare_nodes(&self, a: u32, b: u32) -> CmpOrdering {
         let a_uk = self.node_user_key_bytes(a);

--- a/src/range.rs
+++ b/src/range.rs
@@ -1369,7 +1369,7 @@ impl DoubleEndedIterator for SeekableCell {
 /// per-SST readers or rebuilding the merge stack.
 ///
 /// Built once over a union range; [`Self::seek_to`], [`Self::seek_to_for_prev`],
-/// and [`Self::reposition`] move the leaf cursors in place (SST index re-seek /
+/// and `Self::reposition` move the leaf cursors in place (SST index re-seek /
 /// skiplist `seek_ge` / run-window recompute) while reusing the loser-tree
 /// merger, MVCC stream, and tombstone filter, so a tight seek loop does not
 /// reconstruct the pipeline.

--- a/src/run_reader.rs
+++ b/src/run_reader.rs
@@ -43,7 +43,7 @@ pub struct RunReader {
 impl RunReader {
     /// Creates a new `RunReader` using default lexicographic key ordering.
     ///
-    /// For trees with a custom [`crate::comparator::UserComparator`], use [`new_cmp`] instead.
+    /// For trees with a custom [`crate::comparator::UserComparator`], use [`Self::new_cmp`] instead.
     #[must_use]
     #[cfg_attr(
         not(test),
@@ -56,7 +56,7 @@ impl RunReader {
         Self::new_cmp(run, range, &crate::comparator::DefaultUserComparator)
     }
 
-    /// Like [`new`], but uses a custom comparator for key ordering.
+    /// Like [`Self::new`], but uses a custom comparator for key ordering.
     #[must_use]
     pub fn new_cmp<R: RangeBounds<UserKey> + Clone + Send + 'static>(
         run: Arc<Run<Table>>,

--- a/src/runtime_config/handle.rs
+++ b/src/runtime_config/handle.rs
@@ -20,7 +20,7 @@
 //!   that load the same starting snapshot will see the second
 //!   `store` overwrite the first, losing the first writer's
 //!   mutation. Callers needing lost-update avoidance must serialize
-//!   at the call site (see [`RuntimeConfigHandle::update`]).
+//!   at the call site (see [`RuntimeConfigHandle::try_update`]).
 
 use super::types::RuntimeConfig;
 use alloc::sync::Arc;

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -866,9 +866,9 @@ pub struct RuntimeConfig {
     /// computes an admission state and the gated write path always admits, so
     /// there is zero overhead and behaviour is unchanged. When `true`, the
     /// engine maintains a cached read-only predicate (see
-    /// [`crate::Tree::write_admission`]) driven by [`Self::storage_limit_bytes`]
+    /// [`crate::AbstractTree::write_admission`]) driven by [`Self::storage_limit_bytes`]
     /// (and, once wired, the filesystem free-space probe), and the gated write
-    /// path ([`crate::Tree::try_insert`] / batch apply) declines writes with
+    /// path ([`crate::AbstractTree::try_insert`] / batch apply) declines writes with
     /// [`crate::Error::StorageFull`] while the tree is over budget.
     ///
     /// Toggle takes effect on the next admission check.

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -805,6 +805,16 @@ pub struct RuntimeConfig {
     /// current setting over time.
     pub seqno_in_index: bool,
 
+    /// Whether new SSTs carry the optional `zone_map` section: per-data-block
+    /// per-column statistics (for row blocks, the block's key min / max + row
+    /// count) that let a predicate scan skip blocks that cannot match without
+    /// reading them. Kept parallel to the index, so a point read pays nothing.
+    ///
+    /// Explicit opt-in, default `false` (no section emitted). Takes effect on
+    /// the next compaction / flush; existing SSTs keep whatever they were
+    /// written with, and a missing section just means no block-skip for that SST.
+    pub zone_map: bool,
+
     /// Index-size threshold (bytes) at or below which an SST's block index
     /// is written single-level; above it the index spills to a two-level
     /// (partitioned) layout. A single-level index is one block reached by a
@@ -912,6 +922,7 @@ impl Default for RuntimeConfig {
             ecc_granularity: EccGranularity::Block,
             auto_heal: false,
             seqno_in_index: false,
+            zone_map: false,
             index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
             disable_cow_on_sst_files: true,
             use_reflink_for_checkpoint: true,

--- a/src/scan_since.rs
+++ b/src/scan_since.rs
@@ -8,7 +8,7 @@
 
 use crate::{SeqNo, Slice};
 
-/// A single change event emitted by [`Tree::scan_since_seqno`].
+/// A single change event emitted by [`Tree::scan_since_seqno`](crate::Tree::scan_since_seqno).
 ///
 /// Each event carries the sequence number at which the change was committed.
 /// Events are emitted in increasing seqno order, so a downstream consumer

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -19,12 +19,12 @@
 //!
 //! # Layering: a primitive, not a daemon
 //!
-//! This module exposes the scrub *pass* ([`patrol_scrub`]); it does not own a
+//! This module exposes the scrub *pass* ([`patrol_scrub`](crate::scrub::patrol_scrub)); it does not own a
 //! timer thread or any cluster awareness. Like the auto-heal rewrite it feeds
 //! (drive with [`EccHeal`](crate::compaction::EccHeal) over
 //! [`Tree::heal_hints`](crate::Tree::heal_hints)), the *cadence* and the
 //! *leader-only* gating in a clustered deployment are the caller's concern: run
-//! [`patrol_scrub`] on a schedule from the cluster leader only, since a healing
+//! [`patrol_scrub`](crate::scrub::patrol_scrub) on a schedule from the cluster leader only, since a healing
 //! recompaction is a background mutation. The pass is off by default; it costs
 //! nothing until called.
 //!
@@ -36,8 +36,8 @@
 //! # Throttle
 //!
 //! A scrub competes with production reads for disk bandwidth, so
-//! [`PatrolScrubOptions::throttle`] makes each worker pause between SSTs to cap
-//! I/O pressure, and [`PatrolScrubOptions::parallelism`] bounds how many SSTs
+//! [`PatrolScrubOptions::throttle`](crate::scrub::PatrolScrubOptions::throttle) makes each worker pause between SSTs to cap
+//! I/O pressure, and [`PatrolScrubOptions::parallelism`](crate::scrub::PatrolScrubOptions::parallelism) bounds how many SSTs
 //! are scrubbed concurrently. The pass deliberately bypasses the block cache in
 //! both directions: it re-reads the medium (a cached clean copy would hide an
 //! on-disk fault) and never evicts the live working set with cold blocks.

--- a/src/secded.rs
+++ b/src/secded.rs
@@ -11,9 +11,9 @@
 //!
 //! # Pluggable shapes
 //!
-//! [`SecdedCodec`] abstracts the word geometry so alternative shapes (wider
+//! [`SecdedCodec`](crate::secded::SecdedCodec) abstracts the word geometry so alternative shapes (wider
 //! words for lower overhead, narrower for denser correction) can be added
-//! without touching the read/write paths. The default, [`Hsiao7264`], is the
+//! without touching the read/write paths. The default, [`Hsiao7264`](crate::secded::Hsiao7264), is the
 //! industry-standard DRAM ECC shape: 8 check bits protect a 64-bit data word
 //! (12.5% overhead), with a Hsiao parity-check matrix (all columns odd-weight
 //! and distinct) so a single-bit error yields an odd nonzero syndrome that

--- a/src/sharded_cache.rs
+++ b/src/sharded_cache.rs
@@ -13,13 +13,13 @@
 //!   lock-free read path: a *read* only bumps the entry's frequency counter and
 //!   never reorders a queue (promotion small→main happens lazily at eviction
 //!   time, keyed on that counter), unlike LRU which must move the entry to the
-//!   MRU end on every hit. The frequency counter is an [`AtomicU8`], so reads
+//!   MRU end on every hit. The frequency counter is an [`AtomicU8`](core::sync::atomic::AtomicU8), so reads
 //!   run under a *shared* lock and proceed concurrently.
 //! - **Concurrency:** N shards (key hash high-bits → shard), each behind an
 //!   `RwLock` that is `parking_lot::RwLock` under `std` (small, userspace
 //!   fast-path) and `spin::RwLock` under `no_std`. `get` / `peek` take the read
 //!   lock; `insert` / `remove` / eviction take the write lock. The total
-//!   resident weight is an [`AtomicU64`] so `size()` is lock-free.
+//!   resident weight is an [`AtomicU64`](core::sync::atomic::AtomicU64) so `size()` is lock-free.
 //!
 //! Full lock-free eviction (concurrent S3-FIFO queues with epoch reclamation)
 //! was rejected: it is `std`-only (no mature `no_std` epoch GC) and a large UB

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -185,7 +185,7 @@ pub(crate) fn full_compaction_demand_bytes(version: &Version) -> u64 {
 ///
 /// `used_bytes` is the true on-disk file size of every live table and blob
 /// file (one metadata stat per file), not the writer's `Metadata::file_size`
-/// or [`crate::version::Version::blob_files`]' compressed-payload sum: those
+/// or `crate::version::Version::blob_files`' compressed-payload sum: those
 /// undercount the physical file by the meta block / footer / blob trailer.
 /// Statting matches the figure `Tree::create_checkpoint` reports, so the two
 /// agree on disk reality.

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -29,7 +29,7 @@ use crate::io::Cursor;
 /// call for every case and lets the decode fuse with the caller's bounds checks
 /// and constants. Reads through a plain slice index (no `Cursor::read_u8`
 /// `read_exact`-per-byte) and rejects an overlong (> 64-bit) encoding, matching
-/// [`VarintReader::read_u64_varint`].
+/// `VarintReader::read_u64_varint`.
 ///
 /// On a truncated buffer (`?` on the bounds-checked load) or an overlong
 /// encoding it returns `None` from the **enclosing** function, so every call

--- a/src/table/block/identity.rs
+++ b/src/table/block/identity.rs
@@ -27,7 +27,7 @@
 //! **Field requirements.** Production call sites SHOULD populate
 //! every field with the real value from their local context. Test
 //! call sites that don't exercise AAD-sensitive paths may use
-//! [`BlockIdentity::for_test`] which defaults `dict_id` and
+//! `BlockIdentity::for_test` which defaults `dict_id` and
 //! `window_log` to zero.
 //!
 //! **Allowed zero exceptions in production code** (each individually

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -152,7 +152,7 @@ fn compression_tag_byte(compression: CompressionType) -> u8 {
 /// Seal a (post-compression) block payload for the on-disk encryption envelope.
 ///
 /// Under zstd builds this is the AAD-bound `MetadataFrame ‖ BodyFrame` envelope
-/// ([`EncryptionProvider::encrypt_block_aad`]) binding the block identity +
+/// ([`EncryptionProvider::encrypt_block_aad`](crate::EncryptionProvider::encrypt_block_aad)) binding the block identity +
 /// transform context. Without zstd the wire-format frame is unavailable, so it
 /// falls back to the opaque `[nonce ‖ ciphertext ‖ tag]` form. `owned` is the
 /// compressor's output (reused in-place on the opaque path); `borrow` is the
@@ -206,7 +206,7 @@ fn encrypt_block_payload(
 
 /// Inverse of [`encrypt_block_payload`]: recover the plaintext from the on-disk
 /// envelope. Under zstd builds it verifies the AAD binding via
-/// [`EncryptionProvider::decrypt_block_aad`] (the reader supplies only
+/// [`EncryptionProvider::decrypt_block_aad`](crate::EncryptionProvider::decrypt_block_aad) (the reader supplies only
 /// `identity`; the transform fields are read back from the frame); without zstd
 /// it falls back to the opaque in-place `decrypt_vec`.
 fn decrypt_block_payload(

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -54,6 +54,13 @@ pub enum BlockType {
     /// block-skip without bloating the index entries. Absent unless
     /// `seqno_in_index` is on.
     SeqnoBounds,
+    /// Optional per-table zone-map section: maps each data block's file offset
+    /// to per-column `(min, max, null_count, row_count)` statistics, letting a
+    /// range / analytical scan skip a block whose stats prove no predicate
+    /// match without decoding it. Kept parallel to the index (like
+    /// [`Self::SeqnoBounds`]) so point reads never load it. Off by default;
+    /// absent unless the zone-map policy is enabled.
+    ZoneMap,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -77,6 +84,7 @@ impl From<BlockType> for u8 {
             BlockType::BlockLayout => 7,
             BlockType::Locator => 8,
             BlockType::SeqnoBounds => 9,
+            BlockType::ZoneMap => 10,
         }
     }
 }
@@ -96,6 +104,7 @@ impl TryFrom<u8> for BlockType {
             7 => Ok(Self::BlockLayout),
             8 => Ok(Self::Locator),
             9 => Ok(Self::SeqnoBounds),
+            10 => Ok(Self::ZoneMap),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -124,6 +133,7 @@ mod tests {
             (7, BlockType::BlockLayout),
             (8, BlockType::Locator),
             (9, BlockType::SeqnoBounds),
+            (10, BlockType::ZoneMap),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -142,9 +152,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 10 is the first
+        // not a silent coercion to a known variant. 11 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(10).is_err());
+        assert!(BlockType::try_from(11).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -128,6 +128,14 @@ pub struct Inner {
     /// per-entry filter. Read only by the seqno-scoped scan path.
     pub(crate) seqno_bounds: crate::table::seqno_bounds::SeqnoBoundsMap,
 
+    /// Per-data-block zone map, loaded on open from the optional `zone_map`
+    /// section. Empty when the table has none (zone-map policy off), so a
+    /// predicate scan falls back to reading every block. Read only by the
+    /// block-skip scan path.
+    // `expect` self-removes once the block-skip reader reads this field.
+    #[expect(dead_code, reason = "read by the block-skip scan path (wired next)")]
+    pub(crate) zone_map: crate::table::zone_map::ZoneMap,
+
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy
     /// enabled; lets a point read resolve a key to its data block in O(1),

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -158,7 +158,7 @@ pub struct Inner {
     /// [`Table::install_deletion_pause`](super::Table::install_deletion_pause)
     /// after the table is registered with a tree. When `Some` and active,
     /// the [`Drop`] impl defers the underlying `remove_file` call so that
-    /// an in-progress [`Tree::create_checkpoint`](crate::Tree::create_checkpoint)
+    /// an in-progress [`Tree::create_checkpoint`](crate::AbstractTree::create_checkpoint)
     /// can hard-link the file before it disappears.
     // `once_cell::race::OnceBox` rather than `std::sync::OnceLock` so
     // this field doesn't pin the type to `std` — OnceBox is no-std +

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -132,8 +132,12 @@ pub struct Inner {
     /// section. Empty when the table has none (zone-map policy off), so a
     /// predicate scan falls back to reading every block. Read only by the
     /// block-skip scan path.
-    // `expect` self-removes once the block-skip reader reads this field.
-    #[expect(dead_code, reason = "read by the block-skip scan path (wired next)")]
+    // Gated to non-test builds (the round-trip unit test reads it); kept as
+    // `expect` so it self-removes once the live block-skip reader reads it.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "read by the columnar block-skip scan path")
+    )]
     pub(crate) zone_map: crate::table::zone_map::ZoneMap,
 
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1918,42 +1918,55 @@ impl Table {
 
         // Load the optional seqno-bounds section (parallel to the index; powers
         // the scan_since_seqno block-skip). Absent unless seqno_in_index was on.
+        //
+        // Best-effort, like the zone map below: the seqno-bounds section is
+        // derived, non-authoritative metadata, so a corrupt / unreadable section
+        // disables the block-skip (falling back to a full per-entry filter)
+        // rather than failing the whole table open.
         let seqno_bounds = if let Some(sb_handle) = regions.seqno_bounds {
-            let block = Block::from_file(
-                file_handle.as_ref(),
-                sb_handle,
-                crate::table::block::BlockIdentity {
-                    table_id: metadata.id,
-                    block_type: BlockType::SeqnoBounds,
-                    dict_id: 0,
-                    window_log: 0,
-                },
-                &{
-                    let t = match encryption.as_deref() {
-                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
-                        None => crate::table::block::BlockTransform::PLAIN,
-                    };
-                    if let Some(ecc) = metadata.ecc_params {
-                        t.with_ecc(ecc)
-                    } else {
-                        t
-                    }
-                },
-            )?;
-            if block.header.block_type != BlockType::SeqnoBounds {
-                return Err(crate::Error::InvalidTag((
-                    "BlockType",
-                    block.header.block_type.into(),
-                )));
-            }
-            let map = crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)?;
-            if !map.is_empty() {
-                log::trace!("Loaded {} seqno-bounds entries", map.len());
-            }
-            map
+            let load = || -> crate::Result<crate::table::seqno_bounds::SeqnoBoundsMap> {
+                let block = Block::from_file(
+                    file_handle.as_ref(),
+                    sb_handle,
+                    crate::table::block::BlockIdentity {
+                        table_id: metadata.id,
+                        block_type: BlockType::SeqnoBounds,
+                        dict_id: 0,
+                        window_log: 0,
+                    },
+                    &{
+                        let t = match encryption.as_deref() {
+                            Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                            None => crate::table::block::BlockTransform::PLAIN,
+                        };
+                        if let Some(ecc) = metadata.ecc_params {
+                            t.with_ecc(ecc)
+                        } else {
+                            t
+                        }
+                    },
+                )?;
+                if block.header.block_type != BlockType::SeqnoBounds {
+                    return Err(crate::Error::InvalidTag((
+                        "BlockType",
+                        block.header.block_type.into(),
+                    )));
+                }
+                crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)
+            };
+            load().unwrap_or_else(|e| {
+                log::warn!(
+                    "seqno-bounds section for table {:?} is unreadable ({e}); disabling seqno block-skip",
+                    metadata.id
+                );
+                crate::table::seqno_bounds::SeqnoBoundsMap::default()
+            })
         } else {
             crate::table::seqno_bounds::SeqnoBoundsMap::default()
         };
+        if !seqno_bounds.is_empty() {
+            log::trace!("Loaded {} seqno-bounds entries", seqno_bounds.len());
+        }
 
         // Load the optional zone-map section (parallel to the index; powers the
         // predicate-based block-skip). Absent unless the zone-map policy was on.

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1957,39 +1957,49 @@ impl Table {
 
         // Load the optional zone-map section (parallel to the index; powers the
         // predicate-based block-skip). Absent unless the zone-map policy was on.
+        //
+        // Best-effort: the zone map is DERIVED, non-authoritative metadata. A
+        // corrupt or unreadable section disables block-skip for this table (an
+        // empty map) rather than failing the whole `Table::recover` — turning an
+        // optimization's bit-rot into a hard availability loss would be wrong.
         let zone_map = if let Some(zm_handle) = regions.zone_map {
-            let block = Block::from_file(
-                file_handle.as_ref(),
-                zm_handle,
-                crate::table::block::BlockIdentity {
-                    table_id: metadata.id,
-                    block_type: BlockType::ZoneMap,
-                    dict_id: 0,
-                    window_log: 0,
-                },
-                &{
-                    let t = match encryption.as_deref() {
-                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
-                        None => crate::table::block::BlockTransform::PLAIN,
-                    };
-                    if let Some(ecc) = metadata.ecc_params {
-                        t.with_ecc(ecc)
-                    } else {
-                        t
-                    }
-                },
-            )?;
-            if block.header.block_type != BlockType::ZoneMap {
-                return Err(crate::Error::InvalidTag((
-                    "BlockType",
-                    block.header.block_type.into(),
-                )));
-            }
-            let map = crate::table::zone_map::ZoneMap::decode(&block.data)?;
-            if !map.is_empty() {
-                log::trace!("Loaded zone-map for {} blocks", map.len());
-            }
-            map
+            let load = || -> crate::Result<crate::table::zone_map::ZoneMap> {
+                let block = Block::from_file(
+                    file_handle.as_ref(),
+                    zm_handle,
+                    crate::table::block::BlockIdentity {
+                        table_id: metadata.id,
+                        block_type: BlockType::ZoneMap,
+                        dict_id: 0,
+                        window_log: 0,
+                    },
+                    &{
+                        let t = match encryption.as_deref() {
+                            Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                            None => crate::table::block::BlockTransform::PLAIN,
+                        };
+                        if let Some(ecc) = metadata.ecc_params {
+                            t.with_ecc(ecc)
+                        } else {
+                            t
+                        }
+                    },
+                )?;
+                if block.header.block_type != BlockType::ZoneMap {
+                    return Err(crate::Error::InvalidTag((
+                        "BlockType",
+                        block.header.block_type.into(),
+                    )));
+                }
+                crate::table::zone_map::ZoneMap::decode(&block.data)
+            };
+            load().unwrap_or_else(|e| {
+                log::warn!(
+                    "zone-map section for table {:?} is unreadable ({e}); disabling block-skip",
+                    metadata.id
+                );
+                crate::table::zone_map::ZoneMap::default()
+            })
         } else {
             crate::table::zone_map::ZoneMap::default()
         };

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -21,6 +21,7 @@ mod scanner;
 pub(crate) mod seqno_bounds;
 pub mod util;
 pub mod writer;
+pub(crate) mod zone_map;
 
 #[cfg(test)]
 #[allow(

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1955,6 +1955,45 @@ impl Table {
             crate::table::seqno_bounds::SeqnoBoundsMap::default()
         };
 
+        // Load the optional zone-map section (parallel to the index; powers the
+        // predicate-based block-skip). Absent unless the zone-map policy was on.
+        let zone_map = if let Some(zm_handle) = regions.zone_map {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                zm_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_type: BlockType::ZoneMap,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::ZoneMap {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            let map = crate::table::zone_map::ZoneMap::decode(&block.data)?;
+            if !map.is_empty() {
+                log::trace!("Loaded zone-map for {} blocks", map.len());
+            }
+            map
+        } else {
+            crate::table::zone_map::ZoneMap::default()
+        };
+
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
@@ -2057,6 +2096,7 @@ impl Table {
                 range_tombstones,
                 block_layout,
                 seqno_bounds,
+                zone_map,
                 locator_index,
                 encryption,
 

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -111,6 +111,10 @@ pub struct MultiWriter {
     /// section.
     use_seqno_in_index: bool,
 
+    /// Preserved like `use_seqno_in_index` so every successor [`Writer`] of one
+    /// flush / compaction uniformly emits (or omits) the `zone_map` section.
+    use_zone_map: bool,
+
     /// When `true`, each output SST has per-file copy-on-write cleared at
     /// creation (Btrfs `FS_NOCOW_FL`) so write-once SSTs avoid the
     /// copy-on-write fragmentation penalty. Preserved across rotations so every successor
@@ -190,6 +194,7 @@ impl MultiWriter {
 
             kv_checksum: None,
             use_seqno_in_index: false,
+            use_zone_map: false,
             disable_cow_on_sst: false,
             locator_entry: crate::config::LocatorPolicyEntry::None,
 
@@ -547,6 +552,15 @@ impl MultiWriter {
         self
     }
 
+    /// Enables the `zone_map` section on this writer and every successor it
+    /// rotates to, so all SSTs of one flush / compaction emit it.
+    #[must_use]
+    pub fn use_zone_map(mut self, zone_map: bool) -> Self {
+        self.use_zone_map = zone_map;
+        self.writer = self.writer.use_zone_map(zone_map);
+        self
+    }
+
     /// Wires the resolved retrieval-ribbon locator policy entry through to the
     /// inner [`Writer`] and preserves it across rotations, so every successor
     /// table in the run emits its own per-SST locator section (or none, when
@@ -611,6 +625,7 @@ impl MultiWriter {
             new_writer = new_writer.use_kv_checksums(policy, algo);
         }
         new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
+        new_writer = new_writer.use_zone_map(self.use_zone_map);
         new_writer = new_writer.use_disable_cow(self.disable_cow_on_sst);
         new_writer = new_writer.use_locator(self.locator_entry);
 

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -93,6 +93,11 @@ pub struct ParsedRegions {
     /// `[seqno_min, seqno_max]` for the `scan_since_seqno` block-skip, kept
     /// parallel to the index so point reads pay nothing for it.
     pub seqno_bounds: Option<BlockHandle>,
+    /// Optional zone-map section (the `zone_map` section). Present only when the
+    /// zone-map policy is enabled; maps each data block's offset to its
+    /// per-column `(min, max, null_count, row_count)` stats for predicate-based
+    /// block-skip, kept parallel to the index so point reads pay nothing for it.
+    pub zone_map: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -146,6 +151,10 @@ impl ParsedRegions {
                 .transpose()?,
             seqno_bounds: toc
                 .section(b"seqno_bounds")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            zone_map: toc
+                .section(b"zone_map")
                 .map(toc_entry_to_handle)
                 .transpose()?,
             linked_blob_files: toc

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3519,3 +3519,62 @@ fn parallel_compression_matches_serial_output() -> crate::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn zone_map_section_roundtrips_one_entry_per_block() -> crate::Result<()> {
+    // 200 keys with frequent block rotation force many data blocks, so the
+    // section must carry several entries that survive write + reopen.
+    let items: Vec<crate::InternalValue> = (0..200u32)
+        .map(|i| {
+            crate::InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                0,
+                crate::ValueType::Value,
+            )
+        })
+        .collect();
+
+    test_with_table(
+        &items,
+        |table| {
+            let zm = &table.zone_map;
+            assert!(!zm.is_empty(), "zone map should be populated when enabled");
+            assert!(
+                zm.len() >= 2,
+                "rotation should yield several blocks, got {}",
+                zm.len()
+            );
+            Ok(())
+        },
+        Some(20),
+        Some(|w: Writer| w.use_zone_map(true)),
+    )
+}
+
+#[test]
+fn zone_map_absent_without_policy() -> crate::Result<()> {
+    let items: Vec<crate::InternalValue> = (0..50u32)
+        .map(|i| {
+            crate::InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                b"v".to_vec(),
+                0,
+                crate::ValueType::Value,
+            )
+        })
+        .collect();
+
+    test_with_table(
+        &items,
+        |table| {
+            assert!(
+                table.zone_map.is_empty(),
+                "no zone map should be loaded without the policy"
+            );
+            Ok(())
+        },
+        None,
+        None::<fn(Writer) -> Writer>,
+    )
+}

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3606,7 +3606,7 @@ fn zone_map_corrupt_section_falls_back_instead_of_failing_open() -> crate::Resul
     // Corrupt one byte inside the zone-map section block on disk so its
     // checksum / AEAD rejects it on the next open.
     let mut bytes = std::fs::read(&file)?;
-    let corrupt_at = (zm_handle.offset().0 as usize) + 4;
+    let corrupt_at = usize::try_from(zm_handle.offset().0).expect("offset fits usize") + 4;
     *bytes
         .get_mut(corrupt_at)
         .expect("corruption offset within file") ^= 0xFF;

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3553,6 +3553,82 @@ fn zone_map_section_roundtrips_one_entry_per_block() -> crate::Result<()> {
 }
 
 #[test]
+fn zone_map_corrupt_section_falls_back_instead_of_failing_open() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let checksum = {
+        let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_zone_map(true);
+        for i in 0..200u32 {
+            if i % 20 == 0 {
+                writer.spill_block()?;
+            }
+            writer.write(crate::InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                b"v".to_vec(),
+                0,
+                crate::ValueType::Value,
+            ))?;
+        }
+        writer.finish()?.expect("table written").1
+    };
+
+    let recover = || -> crate::Result<Table> {
+        #[cfg(feature = "metrics")]
+        let metrics = Arc::new(Metrics::default());
+        Table::recover(
+            file.clone(),
+            checksum,
+            0,
+            0,
+            0,
+            Arc::new(Cache::with_capacity_bytes(1_000_000)),
+            Some(Arc::new(DescriptorTable::new(10))),
+            Arc::new(StdFs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            metrics,
+        )
+    };
+
+    // First open: the zone-map section is present and populated.
+    let zm_handle = {
+        let table = recover()?;
+        assert!(!table.zone_map.is_empty(), "zone map should be populated");
+        table.regions.zone_map.expect("zone-map section present")
+    };
+
+    // Corrupt one byte inside the zone-map section block on disk so its
+    // checksum / AEAD rejects it on the next open.
+    let mut bytes = std::fs::read(&file)?;
+    let corrupt_at = (zm_handle.offset().0 as usize) + 4;
+    *bytes
+        .get_mut(corrupt_at)
+        .expect("corruption offset within file") ^= 0xFF;
+    std::fs::write(&file, &bytes)?;
+
+    // Second open: a corrupt OPTIONAL zone-map is derived, non-authoritative
+    // metadata — it must NOT fail table open. It degrades to no block-skip (an
+    // empty map), and the rest of the table still loads intact.
+    let table = recover()?;
+    assert!(
+        table.zone_map.is_empty(),
+        "corrupt zone-map section should disable block-skip, not fail open"
+    );
+    assert_eq!(
+        table.metadata.item_count, 200,
+        "the rest of the table must still load with a corrupt zone map"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn zone_map_absent_without_policy() -> crate::Result<()> {
     let items: Vec<crate::InternalValue> = (0..50u32)
         .map(|i| {

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -113,7 +113,8 @@ pub fn load_block(
             | BlockType::ManifestFooter
             | BlockType::BlockLayout
             | BlockType::Locator
-            | BlockType::SeqnoBounds => {}
+            | BlockType::SeqnoBounds
+            | BlockType::ZoneMap => {}
         }
 
         return Ok(block);
@@ -207,7 +208,8 @@ pub fn load_block(
         | BlockType::ManifestFooter
         | BlockType::BlockLayout
         | BlockType::Locator
-        | BlockType::SeqnoBounds => {}
+        | BlockType::SeqnoBounds
+        | BlockType::ZoneMap => {}
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -203,7 +203,7 @@ pub struct Writer {
     /// When `Some((policy, algo))`, each data block whose `(level,
     /// table_id)` satisfies `policy.applies` is emitted with a per-entry
     /// checksum footer under `algo` and the `KV_CHECKSUM_FOOTER` flag set
-    /// (the block role stays [`BlockType::Data`]). Wired from the tree's
+    /// (the block role stays [`BlockType::Data`](crate::table::block::BlockType::Data)). Wired from the tree's
     /// runtime `kv_checksums` config via [`Self::use_kv_checksums`].
     kv_checksum: Option<(
         crate::runtime_config::KvChecksumPolicy,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -53,6 +53,9 @@ struct HandleMeta {
     last_seqno: crate::SeqNo,
     seqno_bounds: Option<(u64, u64)>,
     item_count: usize,
+    /// The block's first (min) user key, captured for the zone-map synthetic
+    /// column. `Some` only when the zone-map policy is on (else no clone).
+    zone_block_min: Option<UserKey>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, core::hash::Hash)]
@@ -148,6 +151,13 @@ pub struct Writer {
     /// Empty when `use_seqno_in_index` is off (section absent, zero extra bytes).
     seqno_bounds_section: Vec<(BlockOffset, (u64, u64))>,
 
+    /// Per-data-block zone-map stats, accumulated in write order when
+    /// `use_zone_map` is on and serialized into the optional `zone_map` SST
+    /// section at finish. Kept parallel to the index (like
+    /// [`Self::seqno_bounds_section`]) so a point read never loads it. Empty when
+    /// `use_zone_map` is off (section absent, zero extra bytes).
+    zone_map_section: Vec<(BlockOffset, Vec<crate::table::zone_map::ColumnStats>)>,
+
     /// Resolved retrieval-ribbon locator settings for this table, or `None`
     /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
     /// `Some` makes the writer accumulate a per-key locator and emit the
@@ -210,6 +220,15 @@ pub struct Writer {
     /// runtime config into this field via [`Self::use_seqno_in_index`]
     /// before the first key is added.
     use_seqno_in_index: bool,
+
+    /// Zone-map opt-in (the zone-map policy). When `true`, the writer records
+    /// each data block's per-column stats (for row blocks: a single synthetic
+    /// column with the block's key min / max + row count) and emits them in the
+    /// optional parallel `zone_map` SST section, letting a predicate scan skip
+    /// blocks that cannot match without reading them. Default `false` (no section
+    /// emitted). Caller wires the live runtime config in via
+    /// [`Self::use_zone_map`] before the first key is added.
+    use_zone_map: bool,
 
     /// Pre-trained zstd dictionary for dictionary compression
     #[cfg(zstd_any)]
@@ -298,6 +317,7 @@ impl Writer {
 
             block_layouts: Vec::new(),
             seqno_bounds_section: Vec::new(),
+            zone_map_section: Vec::new(),
 
             locator: None,
             locators: Vec::new(),
@@ -329,6 +349,7 @@ impl Writer {
 
             kv_checksum: None,
             use_seqno_in_index: false,
+            use_zone_map: false,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -646,6 +667,19 @@ impl Writer {
         self
     }
 
+    /// Enables the zone-map section: the writer records each data block's stats
+    /// (for row blocks, a synthetic column with the block's key min / max + row
+    /// count) and emits the optional `zone_map` section at finish, for
+    /// predicate-based block-skip. Must be fixed before the first key (the
+    /// section must cover every block); a mid-write toggle would leave some
+    /// blocks unrecorded. Default off.
+    #[must_use]
+    pub fn use_zone_map(mut self, zone_map: bool) -> Self {
+        self.assert_not_started("use_zone_map");
+        self.use_zone_map = zone_map;
+        self
+    }
+
     /// Wires the resolved per-level retrieval-ribbon locator policy entry.
     ///
     /// `Enabled` makes the writer accumulate a per-key `(block_id, slot)`
@@ -841,6 +875,13 @@ impl Writer {
                     (min.min(e.key.seqno), max.max(e.key.seqno))
                 })
         });
+        // Block's first (min) key for the zone-map synthetic column; cloned only
+        // when the policy is on. The chunk is non-empty here (early return
+        // above), so `first()` is `Some`.
+        let zone_block_min = self
+            .use_zone_map
+            .then(|| self.chunk.first().map(|e| e.key.user_key.clone()))
+            .flatten();
 
         // Decide per-block whether to emit the per-KV checksum footer.
         // `kv_checksum` is None unless the tree opted in; even then only blocks
@@ -876,6 +917,7 @@ impl Writer {
                 last_seqno,
                 seqno_bounds,
                 item_count,
+                zone_block_min,
             });
             // Track in-flight uncompressed bytes for the rotation size hint
             // (file_pos only advances once the block is drained and written).
@@ -938,6 +980,7 @@ impl Writer {
             last_seqno,
             seqno_bounds,
             item_count,
+            zone_block_min,
         )?;
 
         // IMPORTANT: Clear chunk after everything else
@@ -984,6 +1027,10 @@ impl Writer {
     /// Records a just-written data block: index entry (with optional seqno
     /// bounds), metadata counters, back link, and the running last key. Single
     /// source of truth for both the serial and parallel write paths.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "cohesive per-written-block fields; a param struct adds indirection without clarity"
+    )]
     fn register_written_block(
         &mut self,
         header: crate::table::block::Header,
@@ -992,6 +1039,7 @@ impl Writer {
         last_seqno: crate::SeqNo,
         seqno_bounds: Option<(u64, u64)>,
         item_count: usize,
+        zone_block_min: Option<UserKey>,
     ) -> crate::Result<()> {
         self.meta.uncompressed_size += u64::from(header.uncompressed_length);
 
@@ -1019,6 +1067,23 @@ impl Writer {
         if let Some((seqno_min, seqno_max)) = seqno_bounds {
             self.seqno_bounds_section
                 .push((self.meta.file_pos, (seqno_min, seqno_max)));
+        }
+        // Zone-map entry for this block (parallel section keyed by file offset,
+        // like seqno_bounds). A row block records one synthetic column with the
+        // block's key range; the row count never approaches `u32::MAX` (a data
+        // block holds at most a few thousand entries), so the cap is defensive.
+        if let Some(min_key) = zone_block_min {
+            let row_count = u32::try_from(item_count).unwrap_or(u32::MAX);
+            let columns = alloc::vec![crate::table::zone_map::ColumnStats {
+                column_id: 0,
+                type_tag: 0,
+                codec_id: 0,
+                null_count: 0,
+                row_count,
+                min: min_key.to_vec(),
+                max: last_key.to_vec(),
+            }];
+            self.zone_map_section.push((self.meta.file_pos, columns));
         }
         self.index_writer.register_data_block(handle)?;
 
@@ -1083,6 +1148,7 @@ impl Writer {
             meta.last_seqno,
             meta.seqno_bounds,
             meta.item_count,
+            meta.zone_block_min,
         )
     }
 
@@ -1253,6 +1319,39 @@ impl Writer {
                 crate::table::block::BlockIdentity {
                     table_id: self.table_id,
                     block_type: crate::table::block::BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
+
+        // Write the optional zone-map section (only when the policy is on and at
+        // least one block was written). Parallel to the index, keyed by
+        // data-block offset; absent otherwise, so a point read pays nothing.
+        if !self.zone_map_section.is_empty() {
+            self.file_writer.start("zone_map")?;
+            self.block_buffer.clear();
+            crate::table::zone_map::encode_zone_map(
+                &mut self.block_buffer,
+                &self.zone_map_section,
+            )?;
+            Block::write_into(
+                &mut self.file_writer,
+                &self.block_buffer,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_type: crate::table::block::BlockType::ZoneMap,
                     dict_id: 0,
                     window_log: 0,
                 },

--- a/src/table/zone_map.rs
+++ b/src/table/zone_map.rs
@@ -36,11 +36,18 @@
 //! Entries are strictly ascending by `block_offset` (write order == file order),
 //! enabling both a binary-search lookup and a sequential cursor.
 
-// The codec lands before its consumers (writer emit, regions parse, reader
-// predicate-skip). `expect` rather than `allow` so this self-removes: once every
-// item is wired the lint stops firing and the unfulfilled expectation forces the
-// attribute's deletion.
-#![expect(dead_code, reason = "consumed by writer / regions / reader wiring")]
+// The reader-side API (columns_for / cursor / ZoneMapCursor) has no live caller
+// until the columnar block-skip scan consumes it; the writer / table-open paths
+// already use the rest. Gated to non-test builds so the in-module tests (which
+// exercise the reader API) do not leave the expectation unfulfilled, and kept as
+// `expect` (not `allow`) so it self-removes once a live caller lands.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "reader API consumed by the columnar block-skip scan"
+    )
+)]
 
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
@@ -320,11 +327,12 @@ mod tests {
         encode_zone_map(&mut buf, &blocks).expect("encode");
         let map = ZoneMap::decode(&buf).expect("decode");
         assert_eq!(map.len(), 3);
-        assert_eq!(map.columns_for(0), Some(blocks[0].1.as_slice()));
-        assert_eq!(map.columns_for(4096), Some(blocks[1].1.as_slice()));
-        assert_eq!(map.columns_for(9000), Some(blocks[2].1.as_slice()));
+        for (offset, columns) in &blocks {
+            assert_eq!(map.columns_for(offset.0), Some(columns.as_slice()));
+        }
         // Whole-block synthetic column (row block) carries the value range.
-        let c = &map.columns_for(0).expect("present")[0];
+        let first = map.columns_for(0).expect("present");
+        let c = first.first().expect("one column");
         assert_eq!(c.column_id, 0);
         assert_eq!(c.min, b"aaa");
         assert_eq!(c.max, b"mmm");

--- a/src/table/zone_map.rs
+++ b/src/table/zone_map.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Per-SST zone-map section: a parallel `(data-block offset -> per-column
+//! statistics)` map that lets a range / analytical scan skip a data block whose
+//! stats prove no predicate match, WITHOUT decoding it.
+//!
+//! Kept parallel to the index (like [`crate::table::seqno_bounds`]) rather than
+//! inline in the block footer or index entries: per-block stats inline would
+//! bloat every point-read probe, so they live in this optional section that
+//! only a scan loads. A point read never touches it.
+//!
+//! Off by default + emitted only when the zone-map policy is enabled, so a table
+//! written without it carries zero extra bytes. Offset-keyed (not ordinal) so a
+//! lookup cannot mis-map if block iteration order ever shifts.
+//!
+//! # Wire layout
+//!
+//! ```text
+//! [count: u32 LE]
+//! count × [
+//!   block_offset: u64 LE
+//!   n_columns:    u16 LE
+//!   n_columns × [
+//!     column_id:  u32 LE
+//!     type_tag:   u8        // comparable-encoding type of min/max
+//!     codec_id:   u8        // column codec (0 for row blocks)
+//!     null_count: u32 LE
+//!     row_count:  u32 LE
+//!     min_len: u32 LE, min: [u8; min_len]   // column comparable encoding
+//!     max_len: u32 LE, max: [u8; max_len]
+//!   ]
+//! ]
+//! ```
+//!
+//! Entries are strictly ascending by `block_offset` (write order == file order),
+//! enabling both a binary-search lookup and a sequential cursor.
+
+// The codec lands before its consumers (writer emit, regions parse, reader
+// predicate-skip). `expect` rather than `allow` so this self-removes: once every
+// item is wired the lint stops firing and the unfulfilled expectation forces the
+// attribute's deletion.
+#![expect(dead_code, reason = "consumed by writer / regions / reader wiring")]
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
+use super::BlockOffset;
+
+/// Per-column statistics for one data block. The engine treats `min` / `max` as
+/// opaque comparable-encoded byte arrays tagged by `type_tag` + `codec_id`; it
+/// never interprets them beyond ordered comparison against a predicate bound.
+///
+/// A row-organized block records a single synthetic column (`column_id == 0`)
+/// carrying the whole-block value min / max; a columnar block records one entry
+/// per stored column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnStats {
+    /// Stable identifier of the column within its (row group) block. `0` is the
+    /// synthetic whole-value column for row-organized blocks.
+    pub column_id: u32,
+    /// Comparable-encoding type tag of `min` / `max` (opaque to the engine).
+    pub type_tag: u8,
+    /// Column codec id (opaque to the engine; `0` for row blocks).
+    pub codec_id: u8,
+    /// Number of null values in this column within the block.
+    pub null_count: u32,
+    /// Number of rows in this column within the block.
+    pub row_count: u32,
+    /// Minimum value, in the column's comparable encoding.
+    pub min: Vec<u8>,
+    /// Maximum value, in the column's comparable encoding.
+    pub max: Vec<u8>,
+}
+
+/// Serialize the per-data-block zone-map into the `zone_map` section. `blocks[i]`
+/// is `(block_offset, columns)` for one data block, in write (ascending-offset)
+/// order.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidHeader`] if the block count, a per-block column
+/// count, or a min / max length does not fit its wire width. Validating at
+/// encode time fails fast at the source rather than deferring to the decoder.
+pub fn encode_zone_map(
+    out: &mut Vec<u8>,
+    blocks: &[(BlockOffset, Vec<ColumnStats>)],
+) -> crate::Result<()> {
+    const ERR: crate::Error = crate::Error::InvalidHeader("ZoneMap");
+
+    let count = u32::try_from(blocks.len()).map_err(|_| ERR)?;
+    out.extend_from_slice(&count.to_le_bytes());
+    for (offset, columns) in blocks {
+        let n_columns = u16::try_from(columns.len()).map_err(|_| ERR)?;
+        out.extend_from_slice(&offset.0.to_le_bytes());
+        out.extend_from_slice(&n_columns.to_le_bytes());
+        for c in columns {
+            let min_len = u32::try_from(c.min.len()).map_err(|_| ERR)?;
+            let max_len = u32::try_from(c.max.len()).map_err(|_| ERR)?;
+            out.extend_from_slice(&c.column_id.to_le_bytes());
+            out.push(c.type_tag);
+            out.push(c.codec_id);
+            out.extend_from_slice(&c.null_count.to_le_bytes());
+            out.extend_from_slice(&c.row_count.to_le_bytes());
+            out.extend_from_slice(&min_len.to_le_bytes());
+            out.extend_from_slice(&c.min);
+            out.extend_from_slice(&max_len.to_le_bytes());
+            out.extend_from_slice(&c.max);
+        }
+    }
+    Ok(())
+}
+
+/// Decoded `zone_map` section: a lookup from a data block's file offset to its
+/// per-column statistics. Empty when the table has no zone map (the section was
+/// absent), in which case every lookup returns `None` and the scan falls back to
+/// reading every block.
+#[derive(Debug, Default, Clone)]
+pub struct ZoneMap {
+    /// `(block_offset, columns)`, sorted ascending by offset for binary-search
+    /// lookup and a forward cursor.
+    entries: Vec<(u64, Vec<ColumnStats>)>,
+}
+
+/// Smallest possible wire size of one block entry: `block_offset` (8) +
+/// `n_columns` (2), with zero columns. Used to bound the speculative capacity
+/// against a corrupt count before allocating.
+const MIN_ENTRY_SIZE: usize = 8 + 2;
+
+impl ZoneMap {
+    /// Decode a `zone_map` section payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidHeader`] if the payload is truncated, the
+    /// block entries are not strictly ascending by offset, or trailing bytes
+    /// remain after the declared count (a corrupt section must surface rather
+    /// than silently mis-skip a block).
+    pub fn decode(bytes: &[u8]) -> crate::Result<Self> {
+        const ERR: crate::Error = crate::Error::InvalidHeader("ZoneMap");
+
+        fn take<'a>(r: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+            if r.len() < n {
+                return None;
+            }
+            let (head, tail) = r.split_at(n);
+            *r = tail;
+            Some(head)
+        }
+        fn read_u8(r: &mut &[u8]) -> Option<u8> {
+            take(r, 1)?.first().copied()
+        }
+        fn read_u16(r: &mut &[u8]) -> Option<u16> {
+            let b: [u8; 2] = take(r, 2)?.try_into().ok()?;
+            Some(u16::from_le_bytes(b))
+        }
+        fn read_u32(r: &mut &[u8]) -> Option<u32> {
+            let b: [u8; 4] = take(r, 4)?.try_into().ok()?;
+            Some(u32::from_le_bytes(b))
+        }
+        fn read_u64(r: &mut &[u8]) -> Option<u64> {
+            let b: [u8; 8] = take(r, 8)?.try_into().ok()?;
+            Some(u64::from_le_bytes(b))
+        }
+
+        let mut r = bytes;
+        let count = read_u32(&mut r).ok_or(ERR)?;
+        // Bound the speculative allocation: a count claiming more block entries
+        // than the smallest-possible-entry size could fill is corrupt, so a bad
+        // count cannot trigger a multi-GB pre-allocation instead of a clean error.
+        match (count as usize).checked_mul(MIN_ENTRY_SIZE) {
+            Some(needed) if needed <= r.len() => {}
+            _ => return Err(ERR),
+        }
+        let mut entries: Vec<(u64, Vec<ColumnStats>)> = Vec::with_capacity(count as usize);
+        let mut prev: Option<u64> = None;
+        for _ in 0..count {
+            let offset = read_u64(&mut r).ok_or(ERR)?;
+            if prev.is_some_and(|p| offset <= p) {
+                return Err(ERR);
+            }
+            prev = Some(offset);
+            let n_columns = read_u16(&mut r).ok_or(ERR)?;
+            let mut columns = Vec::with_capacity(n_columns as usize);
+            for _ in 0..n_columns {
+                let column_id = read_u32(&mut r).ok_or(ERR)?;
+                let type_tag = read_u8(&mut r).ok_or(ERR)?;
+                let codec_id = read_u8(&mut r).ok_or(ERR)?;
+                let null_count = read_u32(&mut r).ok_or(ERR)?;
+                let row_count = read_u32(&mut r).ok_or(ERR)?;
+                let min_len = read_u32(&mut r).ok_or(ERR)? as usize;
+                let min = take(&mut r, min_len).ok_or(ERR)?.to_vec();
+                let max_len = read_u32(&mut r).ok_or(ERR)? as usize;
+                let max = take(&mut r, max_len).ok_or(ERR)?.to_vec();
+                columns.push(ColumnStats {
+                    column_id,
+                    type_tag,
+                    codec_id,
+                    null_count,
+                    row_count,
+                    min,
+                    max,
+                });
+            }
+            entries.push((offset, columns));
+        }
+        // No trailing bytes: leftover means a wrong count or padded / corrupt
+        // section, so reject rather than accept a mis-sized parse.
+        if !r.is_empty() {
+            return Err(ERR);
+        }
+        Ok(Self { entries })
+    }
+
+    /// The per-column stats for the data block at `offset`, or `None` if the
+    /// block was not recorded (table without a zone map, or a non-data block).
+    #[must_use]
+    pub fn columns_for(&self, offset: u64) -> Option<&[ColumnStats]> {
+        let idx = self
+            .entries
+            .binary_search_by_key(&offset, |(o, _)| *o)
+            .ok()?;
+        self.entries.get(idx).map(|(_, c)| c.as_slice())
+    }
+
+    /// A forward cursor for in-order block iteration (the range / columnar scan
+    /// access pattern): amortized O(1) per lookup when offsets are visited
+    /// ascending, instead of a binary search per block.
+    #[must_use]
+    pub fn cursor(&self) -> ZoneMapCursor<'_> {
+        ZoneMapCursor {
+            entries: &self.entries,
+            pos: 0,
+        }
+    }
+
+    /// Whether any per-block stats are recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Number of recorded data blocks.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Forward cursor over a [`ZoneMap`], optimized for ascending-offset block
+/// iteration. A lookup at an offset at or ahead of the cursor advances linearly;
+/// a backward jump (random seek) falls back to a binary search and repositions.
+pub struct ZoneMapCursor<'a> {
+    entries: &'a [(u64, Vec<ColumnStats>)],
+    pos: usize,
+}
+
+impl<'a> ZoneMapCursor<'a> {
+    /// The per-column stats for the data block at `offset`, advancing the cursor.
+    /// Returns `None` if the offset was not recorded.
+    pub fn columns_for(&mut self, offset: u64) -> Option<&'a [ColumnStats]> {
+        let at_or_ahead = self
+            .entries
+            .get(self.pos)
+            .is_some_and(|(o, _)| *o <= offset);
+        if at_or_ahead {
+            // Fast path: walk forward to the first entry >= offset.
+            while self.entries.get(self.pos).is_some_and(|(o, _)| *o < offset) {
+                self.pos += 1;
+            }
+        } else {
+            // Backward jump or first lookup: binary-search and reposition.
+            match self.entries.binary_search_by_key(&offset, |(o, _)| *o) {
+                Ok(i) => self.pos = i,
+                Err(i) => {
+                    self.pos = i;
+                    return None;
+                }
+            }
+        }
+        self.entries
+            .get(self.pos)
+            .filter(|(o, _)| *o == offset)
+            .map(|(_, c)| c.as_slice())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::*;
+
+    fn col(id: u32, min: &[u8], max: &[u8], nulls: u32, rows: u32) -> ColumnStats {
+        ColumnStats {
+            column_id: id,
+            type_tag: 1,
+            codec_id: 0,
+            null_count: nulls,
+            row_count: rows,
+            min: min.to_vec(),
+            max: max.to_vec(),
+        }
+    }
+
+    fn sample() -> Vec<(BlockOffset, Vec<ColumnStats>)> {
+        vec![
+            (BlockOffset(0), vec![col(0, b"aaa", b"mmm", 0, 100)]),
+            (
+                BlockOffset(4096),
+                vec![col(0, b"n", b"z", 2, 50), col(1, &[], b"\xff\xff", 5, 50)],
+            ),
+            (BlockOffset(9000), vec![col(0, b"", b"", 0, 1)]),
+        ]
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let blocks = sample();
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &blocks).expect("encode");
+        let map = ZoneMap::decode(&buf).expect("decode");
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.columns_for(0), Some(blocks[0].1.as_slice()));
+        assert_eq!(map.columns_for(4096), Some(blocks[1].1.as_slice()));
+        assert_eq!(map.columns_for(9000), Some(blocks[2].1.as_slice()));
+        // Whole-block synthetic column (row block) carries the value range.
+        let c = &map.columns_for(0).expect("present")[0];
+        assert_eq!(c.column_id, 0);
+        assert_eq!(c.min, b"aaa");
+        assert_eq!(c.max, b"mmm");
+        assert_eq!(c.row_count, 100);
+        // An offset between recorded blocks is absent.
+        assert_eq!(map.columns_for(1), None);
+        assert_eq!(map.columns_for(5000), None);
+    }
+
+    #[test]
+    fn empty_section_round_trips() {
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &[]).expect("encode");
+        let map = ZoneMap::decode(&buf).expect("decode");
+        assert!(map.is_empty());
+        assert_eq!(map.columns_for(0), None);
+    }
+
+    #[test]
+    fn cursor_matches_binary_search_forward_and_backward() {
+        let blocks = sample();
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &blocks).expect("encode");
+        let map = ZoneMap::decode(&buf).expect("decode");
+
+        // Forward in-order iteration: cursor agrees with the binary-search lookup.
+        let mut cur = map.cursor();
+        for off in [0u64, 4096, 9000] {
+            assert_eq!(cur.columns_for(off), map.columns_for(off));
+        }
+        // A missed offset advances without matching, then the next real one hits.
+        let mut cur = map.cursor();
+        assert_eq!(cur.columns_for(100), None);
+        assert_eq!(cur.columns_for(4096), map.columns_for(4096));
+        // Backward jump falls back to binary search.
+        assert_eq!(cur.columns_for(0), map.columns_for(0));
+    }
+
+    #[test]
+    fn decode_rejects_non_ascending_offsets() {
+        // Two entries with descending offsets must be rejected.
+        let blocks = vec![
+            (BlockOffset(9000), vec![col(0, b"a", b"b", 0, 1)]),
+            (BlockOffset(0), vec![col(0, b"a", b"b", 0, 1)]),
+        ];
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &blocks).expect("encode");
+        assert!(ZoneMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_trailing_bytes() {
+        let blocks = sample();
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &blocks).expect("encode");
+        buf.push(0xAB); // one stray byte past the declared count
+        assert!(ZoneMap::decode(&buf).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_truncated_payload() {
+        let blocks = sample();
+        let mut buf = Vec::new();
+        encode_zone_map(&mut buf, &blocks).expect("encode");
+        buf.truncate(buf.len() - 1); // drop a byte from the last max field
+        assert!(ZoneMap::decode(&buf).is_err());
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -10,7 +10,7 @@ use core::time::Duration;
 /// blob files, and for FIFO TTL expiry) through this trait. Under `std` the
 /// built-in [`SystemClock`] is used automatically. Under `no_std` there is no
 /// ambient system clock, so a consumer (e.g. a WASM host exposing `Date.now()`)
-/// injects one once via [`set_clock`] before opening a tree.
+/// injects one once via `set_clock` before opening a tree.
 ///
 /// # Examples
 ///
@@ -63,7 +63,7 @@ impl Clock for SystemClock {
 /// Gets the unix timestamp as a duration (wall-clock time since the epoch).
 ///
 /// Reads through the active [`Clock`]: the built-in [`SystemClock`] under
-/// `std`, or the caller-registered clock under `no_std` (see [`set_clock`]).
+/// `std`, or the caller-registered clock under `no_std` (see `set_clock`).
 /// Until a `no_std` clock is registered the value is [`Duration::ZERO`]
 /// (epoch), which disables TTL expiry rather than expiring everything.
 pub fn unix_timestamp() -> Duration {

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -144,6 +144,7 @@ impl<'a> Ingestion<'a> {
         writer = writer.use_sync_mode(tree.config.sync_mode);
 
         writer = writer.use_seqno_in_index(rc.seqno_in_index);
+        writer = writer.use_zone_map(rc.zone_map);
         writer = writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
         writer = writer.use_locator(tree.config.locator_policy.get(INITIAL_CANONICAL_LEVEL));

--- a/src/tree/inner.rs
+++ b/src/tree/inner.rs
@@ -125,7 +125,7 @@ pub struct TreeInner {
     pub(crate) _directory_lock: Option<Box<dyn crate::fs::FsFile>>,
 
     /// Tree-wide gate that defers SST / blob-file deletions while a
-    /// [`Tree::create_checkpoint`](crate::Tree::create_checkpoint) is in
+    /// [`Tree::create_checkpoint`](crate::AbstractTree::create_checkpoint) is in
     /// flight. Acquired by checkpoint code via
     /// [`DeletionPause::acquire`]; consulted by [`Drop`] impls on
     /// [`Table`](crate::Table) and [`BlobFile`](crate::BlobFile).

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -221,7 +221,7 @@ pub(crate) fn range_to_user_bounds<K: AsRef<[u8]>, R: RangeBounds<K>>(
 }
 
 /// Wraps a [`SeekableTreeIter`](crate::range::SeekableTreeIter) so a standard
-/// tree can expose it as a [`SeekableGuardIter`].
+/// tree can expose it as a [`SeekableGuardIter`](crate::iter_guard::SeekableGuardIter).
 struct StandardSeekable {
     inner: crate::range::SeekableTreeIter,
 }
@@ -1636,7 +1636,7 @@ impl Tree {
         Ok(Some(wrap(entry.value)))
     }
 
-    /// Like [`Tree::resolve_or_passthrough`], but returns a [`PinnableSlice`]
+    /// Like [`Tree::resolve_or_passthrough`], but returns a [`PinnableSlice`](crate::PinnableSlice)
     /// that may keep the decompressed block buffer alive.
     fn resolve_or_passthrough_pinned(
         super_version: &SuperVersion,
@@ -2036,7 +2036,7 @@ impl Tree {
     /// Resolves a single internal entry into a user value, handling tombstones,
     /// range tombstone suppression, and merge operand resolution.
     /// Resolves an entry for `multi_get`: tombstone filter, RT suppression,
-    /// merge operand resolution. Delegates to [`resolve_pinned_entry`] with
+    /// merge operand resolution. Delegates to [`Self::resolve_pinned_entry`] with
     /// `Owned` wrapping, then extracts the value.
     fn resolve_entry(
         super_version: &SuperVersion,
@@ -2294,7 +2294,7 @@ impl Tree {
     /// occupied by an LSM-tree, including the previous configuration.
     /// If not, a new tree will be initialized with the given config.
     ///
-    /// After recovering a previous state, use [`Tree::set_active_memtable`]
+    /// After recovering a previous state, use `Tree::set_active_memtable`
     /// to fill the memtable with data from a write-ahead log for full durability.
     ///
     /// # Errors
@@ -2424,7 +2424,7 @@ impl Tree {
     }
 
     /// Computed storage admission predicate backing
-    /// [`AbstractTree::write_admission`](crate::AbstractTree::write_admission).
+    /// [`AbstractTree::write_admission`].
     ///
     /// Cheap: reads in-memory size accounting only (no syscall). Returns
     /// `Ok(())` unless admission control is enabled AND a budget is set AND the
@@ -3326,7 +3326,7 @@ impl Tree {
     ///
     /// The previous implementation used `std::fs::read_dir` + `to_string_lossy()`,
     /// which silently skipped non-UTF-8 filenames. `Fs::read_dir` returns
-    /// `InvalidData` for such entries instead (see [`FsDirEntry`] docs), so this
+    /// `InvalidData` for such entries instead (see [`FsDirEntry`](crate::fs::FsDirEntry) docs), so this
     /// function now fails fast on non-UTF-8 names. This is intentional: version
     /// files are always `v{u64}` — any non-UTF-8 entry indicates filesystem
     /// corruption and should surface as an error rather than be silently ignored.

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -740,6 +740,7 @@ impl AbstractTree for Tree {
         table_writer = table_writer.use_sync_mode(self.config.sync_mode);
 
         table_writer = table_writer.use_seqno_in_index(rc.seqno_in_index);
+        table_writer = table_writer.use_zone_map(rc.zone_map);
         table_writer = table_writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         // `Off` (default) emits no per-KV footer and leaves the data-block
         // payload encoding unchanged (the V5 header carries a block_flags byte

--- a/src/value.rs
+++ b/src/value.rs
@@ -34,7 +34,7 @@ pub struct InternalValue {
 }
 
 impl InternalValue {
-    /// Creates a new [`Value`].
+    /// Creates a new [`Self`].
     ///
     /// # Panics
     ///
@@ -51,7 +51,7 @@ impl InternalValue {
         Self { key, value }
     }
 
-    /// Creates a new [`Value`].
+    /// Creates a new [`Self`].
     ///
     /// # Panics
     ///

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -31,7 +31,7 @@
 //! # Wire format
 //!
 //! A `VersionEdit` is serialized as the payload of a single
-//! [`framing`](super::framing) record (`len + xxh3_64 + payload`), so a
+//! [`framing`] record (`len + xxh3_64 + payload`), so a
 //! power-loss-truncated or bit-flipped trailing edit is detected and dropped on
 //! replay (the torn tail is never applied). The payload is:
 //!

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -190,7 +190,7 @@ impl Level {
         }
     }
 
-    /// Like [`aggregate_key_range`], but uses a custom comparator for key ordering.
+    /// Like [`Self::aggregate_key_range`], but uses a custom comparator for key ordering.
     ///
     /// Per-run aggregation via [`Run::aggregate_key_range`] is comparator-correct
     /// because runs are sorted in comparator order (ensured by `push_cmp`), so

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -130,7 +130,7 @@ fn parse_restrictions_section(
 /// here too — a torn or corrupted trailing size-hint can be
 /// recovered through the head mirror without first tripping the
 /// CURRENT-pointer validation), then recomputes the canonical
-/// footer digest via [`current_digest::compute`] over the parsed
+/// footer digest via [`current_digest::compute`](crate::manifest_blocks::current_digest::compute) over the parsed
 /// footer payload and compares it against the stamped checksum.
 /// Mismatch surfaces as [`crate::Error::ChecksumMismatch`].
 ///

--- a/src/version/run.rs
+++ b/src/version/run.rs
@@ -100,7 +100,7 @@ impl<T: Ranged> Run<T> {
     /// byte ordering.
     ///
     /// Only correct when the tree uses the default (lexicographic) comparator.
-    /// For custom comparators, use [`push_cmp`] instead.
+    /// For custom comparators, use [`Self::push_cmp`] instead.
     pub fn push_lexicographic(&mut self, item: T) {
         self.0.push(item);
 
@@ -110,9 +110,9 @@ impl<T: Ranged> Run<T> {
 
     /// Pushes a table and re-sorts using a custom comparator for key ordering.
     ///
-    /// Re-sorts the entire run on each call (mirrors [`push_lexicographic`]
+    /// Re-sorts the entire run on each call (mirrors [`Self::push_lexicographic`]
     /// behavior). Acceptable for typical run sizes (<100 tables); for bulk
-    /// insertion use [`extend`] followed by [`sort_by_cmp`].
+    /// insertion use [`Self::extend`] followed by [`Self::sort_by_cmp`].
     pub fn push_cmp(&mut self, item: T, cmp: &dyn UserComparator) {
         self.0.push(item);
         self.sort_by_cmp(cmp);
@@ -120,14 +120,14 @@ impl<T: Ranged> Run<T> {
 
     /// Sorts the run by min key using the provided user comparator.
     ///
-    /// Use after [`extend`] to re-establish ordering in a single pass.
+    /// Use after [`Self::extend`] to re-establish ordering in a single pass.
     pub fn sort_by_cmp(&mut self, cmp: &dyn UserComparator) {
         self.0
             .sort_by(|a, b| cmp.compare(a.key_range().min(), b.key_range().min()));
     }
 
     /// Appends items without re-sorting. Callers must ensure the run remains
-    /// sorted (e.g. via [`sort_by_cmp`] after all items are added).
+    /// sorted (e.g. via [`Self::sort_by_cmp`] after all items are added).
     pub fn extend(&mut self, items: Vec<T>) {
         self.0.extend(items);
     }
@@ -150,7 +150,7 @@ impl<T: Ranged> Run<T> {
         self.0.get(idx).filter(|x| x.key_range().min() <= &key)
     }
 
-    /// Like [`get_for_key`], but uses a custom comparator for key ordering.
+    /// Like [`Self::get_for_key`], but uses a custom comparator for key ordering.
     ///
     /// # Precondition (guaranteed by construction)
     ///
@@ -186,7 +186,7 @@ impl<T: Ranged> Run<T> {
     /// Returns the sub slice of tables in the run that have
     /// a key range overlapping the input key range.
     ///
-    /// Uses lexicographic ordering. For custom comparators, use [`get_overlapping_cmp`].
+    /// Uses lexicographic ordering. For custom comparators, use [`Self::get_overlapping_cmp`].
     pub fn get_overlapping<'a>(&'a self, key_range: &'a KeyRange) -> &'a [T] {
         let range = key_range.min()..=key_range.max();
 
@@ -197,9 +197,9 @@ impl<T: Ranged> Run<T> {
         self.get(lo..=hi).unwrap_or_default()
     }
 
-    /// Like [`get_overlapping`], but uses a custom comparator for key ordering.
+    /// Like [`Self::get_overlapping`], but uses a custom comparator for key ordering.
     ///
-    /// Lifetime on `key_range` mirrors [`get_overlapping`] for API consistency.
+    /// Lifetime on `key_range` mirrors [`Self::get_overlapping`] for API consistency.
     pub fn get_overlapping_cmp<'a>(
         &'a self,
         key_range: &'a KeyRange,
@@ -228,7 +228,7 @@ impl<T: Ranged> Run<T> {
             .unwrap_or_default()
     }
 
-    /// Like [`get_contained`], but uses a custom comparator for key ordering.
+    /// Like [`Self::get_contained`], but uses a custom comparator for key ordering.
     pub fn get_contained_cmp<'a>(
         &'a self,
         key_range: &KeyRange,
@@ -301,7 +301,7 @@ impl<T: Ranged> Run<T> {
         Some((lo, hi))
     }
 
-    /// Like [`range_overlap_indexes`], but uses a custom comparator for key ordering.
+    /// Like [`Self::range_overlap_indexes`], but uses a custom comparator for key ordering.
     pub fn range_overlap_indexes_cmp<K: AsRef<[u8]>, R: RangeBounds<K>>(
         &self,
         key_range: &R,

--- a/src/vlog/accessor.rs
+++ b/src/vlog/accessor.rs
@@ -26,7 +26,7 @@ impl<'a> Accessor<'a> {
         }
     }
 
-    /// Supplies the zstd dictionary for [`CompressionType::ZstdDict`] blob reads.
+    /// Supplies the zstd dictionary for [`CompressionType::ZstdDict`](crate::CompressionType::ZstdDict) blob reads.
     #[cfg(zstd_any)]
     #[must_use]
     pub fn with_dict(mut self, dict: Option<&'a crate::compression::ZstdDictionary>) -> Self {

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -49,7 +49,7 @@ pub struct Inner {
     /// marked here with that absolute data-section offset; once every reader
     /// holding it drops, this view's [`Drop`] reclaims the consumed
     /// `[data_start, offset)` data frames via
-    /// [`Fs::punch_hole`](crate::fs::Fs::punch_hole) and LEAVES the file in
+    /// [`Fs::punch_hole`] and LEAVES the file in
     /// place (the restricted view still serves the suffix). Mirrors
     /// `table::Inner::punch_on_drop`. Distinct from [`Self::is_deleted`].
     pub(crate) punch_on_drop: portable_atomic::AtomicU64,
@@ -77,7 +77,7 @@ pub struct Inner {
     /// [`Table::install_background_deleter`](crate::Table) for the contract:
     /// when present (and no checkpoint pause is active) the [`Drop`] impl frees
     /// the blob file's blocks synchronously via
-    /// [`Fs::truncate_file`](crate::fs::Fs::truncate_file) and hands the
+    /// [`Fs::truncate_file`] and hands the
     /// directory-entry `unlink` to this deleter, off the foreground path.
     // std-only (the deleter spawns a thread); see Table::Inner for rationale.
     #[cfg(feature = "std")]
@@ -285,7 +285,7 @@ impl BlobFile {
     /// relocation loop installs the re-opened view in the new version and arms
     /// the prior view to punch its consumed prefix once its readers drain, so a
     /// stale blob file is reclaimed in place while the suffix keeps serving the
-    /// not-yet-relocated entries — the blob analog of [`Table::reopen_restricted`].
+    /// not-yet-relocated entries — the blob analog of [`Table::reopen_restricted`](crate::Table::reopen_restricted).
     ///
     /// # Errors
     ///

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -16,7 +16,7 @@
 //! and become individually visible to concurrent readers as they are written.
 //! Atomic batch visibility requires the **caller** to publish the batch seqno
 //! (via `visible_seqno.fetch_max(batch_seqno + 1)`) only **after**
-//! [`AbstractTree::apply_batch`] returns. This is the same pattern used by
+//! [`AbstractTree::apply_batch`](crate::AbstractTree::apply_batch) returns. This is the same pattern used by
 //! fjall's keyspace for single-writer batches.
 
 use crate::{UserKey, UserValue, ValueType, value::InternalValue};

--- a/tests/runtime_config_integration.rs
+++ b/tests/runtime_config_integration.rs
@@ -252,6 +252,68 @@ fn seqno_in_index_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> 
 }
 
 #[test]
+fn zone_map_round_trips_through_disk_and_reopen() -> lsm_tree::Result<()> {
+    // With `zone_map` enabled, the writer emits the parallel `zone_map` SST
+    // section (per-data-block stats). The data must read back identically:
+    // flush, point-read, reopen, point-read again. Reopen is the load-bearing
+    // step — it re-parses the on-disk index and the zone-map section from
+    // scratch, so a broken decode surfaces as a read failure.
+    let folder = get_tmp_folder();
+
+    {
+        let tree = open_tree(folder.path());
+        tree.update_runtime_config(|cfg| {
+            cfg.zone_map = true;
+        })?;
+
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let value = format!("value{i:05}");
+            tree.insert(key.as_bytes(), value.as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+
+        // The per-block zone-map path is only exercised with more than one data
+        // block; fail loudly if a future default collapses this to one block.
+        let data_blocks: u64 = tree
+            .current_version()
+            .iter_tables()
+            .map(|t| t.metadata.data_block_count)
+            .sum();
+        assert!(
+            data_blocks > 1,
+            "test must produce >1 data block to exercise the zone map, got {data_blocks}",
+        );
+
+        for i in 0..500u64 {
+            let key = format!("key{i:05}");
+            let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+            assert_eq!(
+                got.as_deref(),
+                Some(format!("value{i:05}").as_bytes()),
+                "post-flush read of {key} must return its value"
+            );
+        }
+    }
+
+    // Reopen: the index blocks and the zone-map section are decoded fresh from
+    // disk. A broken section decode would fail table open or corrupt reads.
+    let tree = open_tree(folder.path());
+    for i in 0..500u64 {
+        let key = format!("key{i:05}");
+        let got = tree.get(key.as_bytes(), SeqNo::MAX)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(format!("value{i:05}").as_bytes()),
+            "post-reopen read of {key} must return its value"
+        );
+    }
+    assert!(tree.get(b"key99999", SeqNo::MAX)?.is_none());
+
+    Ok(())
+}
+
+#[test]
 fn at_insert_kv_checksum_round_trips_through_flush_and_reopen() -> lsm_tree::Result<()> {
     // KvChecksumComputePoint::AtInsert with a 4-byte algorithm: each entry's
     // digest is computed at insert and verified at flush against a recompute.

--- a/tools/compare-rocksdb/benches/compare.rs
+++ b/tools/compare-rocksdb/benches/compare.rs
@@ -60,11 +60,11 @@
 //!
 //! ## Workload coverage
 //!
-//! - `write_throughput/{1k,10k,100k}` — bulk insert N keys, 256-byte
+//! - `write_throughput/{1k,10k,70k}` — bulk insert N keys, 256-byte
 //!   values, random keys. Cold-start: each iteration opens an empty
 //!   engine, writes N, flushes. Dominated by the fixed open + flush
 //!   cost at small N.
-//! - `point_read/{1k,10k,100k}` — read N random keys from an engine
+//! - `point_read/{1k,10k,70k}` — read N random keys from an engine
 //!   pre-populated with N keys and flushed to disk. Warm: the engine
 //!   is opened + populated + flushed ONCE outside the timed window,
 //!   so the measurement is steady-state read latency (block cache +
@@ -75,13 +75,13 @@
 //!   0.75) and an `ours-ribbon` series (retrieval-ribbon locator: key ->
 //!   block + restart in O(1), skipping both the index-block and in-block
 //!   searches) so every index strategy is compared head-to-head on one plot.
-//! - `range_scan/{1k,10k,100k}` — full forward scan reading every value
+//! - `range_scan/{1k,10k,70k}` — full forward scan reading every value
 //!   from a warm, pre-populated engine. Steady-state sequential-scan
 //!   throughput (block decode + iterator advance).
-//! - `seek_random/{1k,10k,100k}` — seek to each (scattered) key and read
+//! - `seek_random/{1k,10k,70k}` — seek to each (scattered) key and read
 //!   the value at the cursor, on a warm engine. Seek-then-read latency
 //!   (index descent + cursor positioning + block decode).
-//! - `overwrite/{1k,10k,100k}` — rewrite the whole keyspace into an engine
+//! - `overwrite/{1k,10k,70k}` — rewrite the whole keyspace into an engine
 //!   that already holds one copy (the first copy is written outside the
 //!   timed window). Overwrite cost (memtable churn over existing keys +
 //!   a superseding flush), distinct from cold first-insert.
@@ -708,12 +708,12 @@ fn write_throughput_variant(c: &mut Criterion, group_name: &str, compression: Co
         Compression::None => Some(skv_runtime().expect("surrealkv: tokio runtime")),
         Compression::Zstd22 => None,
     };
-    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
-        // The 100k working set exceeds the default 16 MiB block cache, so each
+    for &n in &[1_000_u64, 10_000_u64, 70_000_u64] {
+        // The 70k working set exceeds the default 16 MiB block cache, so each
         // pass is far slower (scattered miss + decode). Drop to the criterion
         // sample-size floor there to keep the variant's wall-clock bounded while
         // the reported median stays stable; smaller sets keep the default 100.
-        group.sample_size(if n >= 100_000 { 10 } else { 100 });
+        group.sample_size(if n >= 70_000 { 10 } else { 100 });
         // Precompute the keys + values ONCE per `n` (outside the
         // criterion warmup / measurement loop), so the timed body
         // does no per-iteration allocation.
@@ -837,12 +837,12 @@ fn point_read_variant(
     }
 
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
-        // The 100k working set exceeds the default 16 MiB block cache, so each
+    for &n in &[1_000_u64, 10_000_u64, 70_000_u64] {
+        // The 70k working set exceeds the default 16 MiB block cache, so each
         // pass is far slower (scattered miss + decode). Drop to the criterion
         // sample-size floor there to keep the variant's wall-clock bounded while
         // the reported median stays stable; smaller sets keep the default 100.
-        group.sample_size(if n >= 100_000 { 10 } else { 100 });
+        group.sample_size(if n >= 70_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &(label, engine, strategy, row_cache) in &series {
@@ -1012,12 +1012,12 @@ fn bench_range_scan(c: &mut Criterion) {
 /// advance), not setup cost.
 fn range_scan_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
-        // The 100k working set exceeds the default 16 MiB block cache, so each
+    for &n in &[1_000_u64, 10_000_u64, 70_000_u64] {
+        // The 70k working set exceeds the default 16 MiB block cache, so each
         // pass is far slower (scattered miss + decode). Drop to the criterion
         // sample-size floor there to keep the variant's wall-clock bounded while
         // the reported median stays stable; smaller sets keep the default 100.
-        group.sample_size(if n >= 100_000 { 10 } else { 100 });
+        group.sample_size(if n >= 70_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {
@@ -1091,12 +1091,12 @@ fn bench_seek_random(c: &mut Criterion) {
 /// `seekrandom` workload.
 fn seek_random_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
-        // The 100k working set exceeds the default 16 MiB block cache, so each
+    for &n in &[1_000_u64, 10_000_u64, 70_000_u64] {
+        // The 70k working set exceeds the default 16 MiB block cache, so each
         // pass is far slower (scattered miss + decode). Drop to the criterion
         // sample-size floor there to keep the variant's wall-clock bounded while
         // the reported median stays stable; smaller sets keep the default 100.
-        group.sample_size(if n >= 100_000 { 10 } else { 100 });
+        group.sample_size(if n >= 70_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {
@@ -1185,12 +1185,12 @@ fn bench_overwrite(c: &mut Criterion) {
 /// so each measurement starts from the same one-copy state.
 fn overwrite_variant(c: &mut Criterion, group_name: &str, compression: Compression) {
     let mut group = c.benchmark_group(group_name);
-    for &n in &[1_000_u64, 10_000_u64, 100_000_u64] {
-        // The 100k working set exceeds the default 16 MiB block cache, so each
+    for &n in &[1_000_u64, 10_000_u64, 70_000_u64] {
+        // The 70k working set exceeds the default 16 MiB block cache, so each
         // pass is far slower (scattered miss + decode). Drop to the criterion
         // sample-size floor there to keep the variant's wall-clock bounded while
         // the reported median stays stable; smaller sets keep the default 100.
-        group.sample_size(if n >= 100_000 { 10 } else { 100 });
+        group.sample_size(if n >= 70_000 { 10 } else { 100 });
         let inputs = WorkloadInputs::build(n);
         group.throughput(Throughput::Elements(n));
         for &engine in engines_for(compression) {

--- a/tools/db_bench/src/main.rs
+++ b/tools/db_bench/src/main.rs
@@ -77,13 +77,6 @@ struct Cli {
     #[arg(long)]
     github_json: bool,
 
-    /// Suffix appended to every github-action-benchmark entry name. Lets one
-    /// run sweep several `--num` sizes into distinct, comparable dashboard
-    /// series (e.g. `--name-suffix " /100k"`) without colliding with the
-    /// default-size entries.
-    #[arg(long, default_value = "")]
-    name_suffix: String,
-
     /// Database directory path. If not set, a temporary directory is used.
     /// Note: some workloads (e.g. `prefixscan`, `mergerandom`) create their
     /// own temporary database (they require special tree configuration) and
@@ -393,7 +386,7 @@ fn run_single(
         // the host actually delivered and let the dashboard show
         // the absolute trend.
         github_entries.push(serde_json::json!({
-            "name": format!("{benchmark_name}{}", cli.name_suffix),
+            "name": benchmark_name.clone(),
             "value": s.ops_per_sec,
             "unit": "ops/sec",
             "extra": format!(

--- a/tools/db_bench/src/workloads/fillrandom.rs
+++ b/tools/db_bench/src/workloads/fillrandom.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{make_random_key, make_value};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;

--- a/tools/db_bench/src/workloads/fillseq.rs
+++ b/tools/db_bench/src/workloads/fillseq.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{make_sequential_key, make_value};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;

--- a/tools/db_bench/src/workloads/mergerandom.rs
+++ b/tools/db_bench/src/workloads/mergerandom.rs
@@ -1,13 +1,13 @@
 use crate::config::BenchConfig;
 use crate::db::make_sequential_key;
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{
-    config::{BlockSizePolicy, CompressionPolicy},
     AbstractTree, AnyTree, Cache, Config, MergeOperator, SequenceNumberCounter, UserValue,
+    config::{BlockSizePolicy, CompressionPolicy},
 };
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 /// Counter merge operator: sums i64 operands.
@@ -150,7 +150,9 @@ impl Workload for MergeRandom {
 
                 eprintln!(
                     "Merged {} operands over {} hot keys, counter verified: {actual} (expected {expected}), {} tables",
-                    config.num, hot_keys, tree.table_count(),
+                    config.num,
+                    hot_keys,
+                    tree.table_count(),
                 );
             }
             None => {

--- a/tools/db_bench/src/workloads/mod.rs
+++ b/tools/db_bench/src/workloads/mod.rs
@@ -11,8 +11,8 @@ pub mod seekrandom;
 use crate::config::BenchConfig;
 use crate::reporter::Reporter;
 use lsm_tree::AnyTree;
-use std::sync::atomic::AtomicU64;
 use std::sync::Barrier;
+use std::sync::atomic::AtomicU64;
 
 /// All benchmark workloads implement this trait.
 pub trait Workload {

--- a/tools/db_bench/src/workloads/overwrite.rs
+++ b/tools/db_bench/src/workloads/overwrite.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{make_sequential_key, make_value, prefill_sequential};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree};
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tools/db_bench/src/workloads/prefixscan.rs
+++ b/tools/db_bench/src/workloads/prefixscan.rs
@@ -1,14 +1,14 @@
 use crate::config::BenchConfig;
 use crate::db::{prefill_prefix_keys, read_seqno};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{
-    config::{BlockSizePolicy, CompressionPolicy},
     AbstractTree, AnyTree, Cache, Config, Guard, PrefixExtractor, SequenceNumberCounter,
+    config::{BlockSizePolicy, CompressionPolicy},
 };
 use rand::Rng;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::Instant;
 
 pub struct PrefixScan;

--- a/tools/db_bench/src/workloads/readrandom.rs
+++ b/tools/db_bench/src/workloads/readrandom.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{fill_sequential_key, prefill_sequential, read_seqno};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree};
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tools/db_bench/src/workloads/readseq.rs
+++ b/tools/db_bench/src/workloads/readseq.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{make_sequential_key, prefill_sequential, read_seqno};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree, Guard};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;

--- a/tools/db_bench/src/workloads/readwhilewriting.rs
+++ b/tools/db_bench/src/workloads/readwhilewriting.rs
@@ -28,7 +28,8 @@ impl Workload for ReadWhileWriting {
         let max_readers = usize::try_from(config.num.max(1)).unwrap_or(usize::MAX);
         let reader_count = std::cmp::min(threads - 1, max_readers);
         threads = reader_count + 1; // recompute for barrier
-        // Distribute ops across readers, giving remainder to the last reader.
+        // Distribute ops across readers, giving one extra op to each of the
+        // first `remainder` readers (see `i < remainder` below).
         // reader_count is always small (< --threads), safe to cast on all targets.
         let base_ops = config.num / reader_count as u64;
         let remainder = config.num % reader_count as u64;

--- a/tools/db_bench/src/workloads/readwhilewriting.rs
+++ b/tools/db_bench/src/workloads/readwhilewriting.rs
@@ -4,8 +4,8 @@ use crate::reporter::Reporter;
 use crate::workloads::Workload;
 use lsm_tree::{AbstractTree, AnyTree};
 use rand::Rng;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Barrier;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 pub struct ReadWhileWriting;
@@ -28,8 +28,8 @@ impl Workload for ReadWhileWriting {
         let max_readers = usize::try_from(config.num.max(1)).unwrap_or(usize::MAX);
         let reader_count = std::cmp::min(threads - 1, max_readers);
         threads = reader_count + 1; // recompute for barrier
-                                    // Distribute ops across readers, giving remainder to the last reader.
-                                    // reader_count is always small (< --threads), safe to cast on all targets.
+        // Distribute ops across readers, giving remainder to the last reader.
+        // reader_count is always small (< --threads), safe to cast on all targets.
         let base_ops = config.num / reader_count as u64;
         let remainder = config.num % reader_count as u64;
         let barrier = Barrier::new(threads);

--- a/tools/db_bench/src/workloads/seekrandom.rs
+++ b/tools/db_bench/src/workloads/seekrandom.rs
@@ -1,7 +1,7 @@
 use crate::config::BenchConfig;
 use crate::db::{fill_sequential_key, prefill_sequential, read_seqno};
 use crate::reporter::Reporter;
-use crate::workloads::{run_threaded, Workload};
+use crate::workloads::{Workload, run_threaded};
 use lsm_tree::{AbstractTree, AnyTree, Guard};
 use rand::Rng;
 use std::sync::atomic::AtomicU64;


### PR DESCRIPTION
## Summary

Adds the optional per-SST **zone-map section**: per-data-block, per-column statistics (for row blocks, one synthetic column with the block's key min/max + row count) kept **parallel to the index** like `seqno_bounds`, so a point read never loads it. Wired end-to-end through the runtime config → flush / compaction → table writer. Off by default.

This is the foundation for predicate-based block-skip; the **live predicate-driven skip** itself lands in #506 (it needs a column/value predicate — for row blocks the index already skips by key range). Reader API (`columns_for` + a forward cursor) is ready for #503 / #506 to consume.

## What

- New `BlockType::ZoneMap` + `src/table/zone_map.rs` codec (`ColumnStats`, `encode`/`decode`, binary-search lookup + forward cursor).
- `ParsedRegions.zone_map` recognized in the TOC; loaded on table open into `Inner.zone_map` (graceful-empty when absent).
- Writer accumulates per-block stats (first key threaded through both serial + parallel paths) and emits the section at finish; `use_zone_map` builder on `Writer` + `MultiWriter` (rotation-carried).
- `RuntimeConfig.zone_map` flag (default off) wired through ingest, flush, and compaction.

## Integrity

- **AAD:** the block type is bound into the AEAD AAD, so a `ZoneMap` block cannot be substituted for another type.
- **ECC / checksum:** flows through the same `BlockTransform` as `seqno_bounds` (XXH3-128 + optional Reed-Solomon parity).
- **Recovery:** derived / non-authoritative; a missing or unreadable section defaults to empty (no skip), never a load failure.

## Tests

- Codec unit tests (round-trip, empty, cursor vs binary-search, reject non-ascending / trailing / truncated).
- Table-level round-trip (`zone_map_section_roundtrips_one_entry_per_block`, `zone_map_absent_without_policy`).
- Tree-level integration round-trip through flush + reopen (`zone_map_round_trips_through_disk_and_reopen`).
- Full suite green (2041 tests), `clippy --all-features --all-targets` clean, no-std errcount 0, doctests green.

## Also in this PR

- `ci(bench)`: cap the compare-rocksdb head-to-head size sweep at 70k (the 100k sweep overran the 60-minute CI job timeout so the overlay reports never published) + single-pass db_bench.
- `docs`: resolve ~80 pre-existing broken intra-doc links crate-wide so `cargo doc --document-private-items --all-features -D warnings` is clean (documentation only).

Closes #502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zone-map support for tables, including an optional SST “zone-map” section with per-data-block per-column min/max and row/null counts.
  * Introduced `zone_map` configuration, propagated via table writers, and new block type to store/recognize zone-map data.
* **Bug Fixes**
  * Improved recovery behavior: corrupted or missing zone-map data now degrades gracefully instead of failing open.
* **Tests**
  * Added unit tests and an end-to-end integration test to verify zone-map round-trips through disk and reopen.
* **Chores**
  * Simplified benchmark runner to emit a single result file; updated benchmark naming and workload coverage.
* **Documentation**
  * Refreshed many rustdoc/intra-doc links and formatting across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->