### PR TITLE
feat(tree): approximate range row-count + selectivity

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -758,6 +758,53 @@ pub trait AbstractTree: sealed::Sealed {
         seqno: SeqNo,
     ) -> crate::Result<crate::ApproximateRangeStats>;
 
+    /// Estimates the row cardinality and selectivity of `range` at `seqno`,
+    /// WITHOUT reading any data block.
+    ///
+    /// Uses the per-data-block zone map (per-block row counts + key ranges) for a
+    /// block-granularity row count: every data block whose key range overlaps the
+    /// query contributes its recorded row count, plus the active + sealed
+    /// memtables' in-range counts. When a table has no zone map the row count
+    /// falls back to the byte-fraction estimate of [`approximate_range_stats`].
+    /// Selectivity is `rows / total_rows`, monotonic in predicate tightness, for
+    /// cost-based planning (join ordering, scan-vs-seek). Not exact accounting.
+    ///
+    /// [`approximate_range_stats`]: AbstractTree::approximate_range_stats
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lsm_tree::Error as TreeError;
+    /// use lsm_tree::{AbstractTree, Config};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let tree = Config::new(&folder, Default::default(), Default::default()).open()?;
+    /// for i in 0..100u32 {
+    ///     tree.insert(format!("k{i:04}"), "v", 0);
+    /// }
+    /// tree.flush_active_memtable(0)?;
+    ///
+    /// // The full range covers every row; selectivity is 1.0.
+    /// let all = tree.approximate_range_cardinality::<&str, _>(.., 1)?;
+    /// assert_eq!(all.rows, tree.approximate_len() as u64);
+    /// assert!((all.selectivity - 1.0).abs() < 1e-9);
+    ///
+    /// // A tighter range selects fewer rows.
+    /// let part = tree.approximate_range_cardinality("k0000".."k0050", 1)?;
+    /// assert!(part.selectivity <= all.selectivity);
+    /// #
+    /// # Ok::<(), TreeError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a block index, zone map, or table metadata read fails.
+    fn approximate_range_cardinality<K: AsRef<[u8]>, R: RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+    ) -> crate::Result<crate::RangeCardinality>;
+
     /// Returns the highest sequence number of the active memtable.
     fn get_highest_memtable_seqno(&self) -> Option<SeqNo>;
 

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -1008,6 +1008,17 @@ impl AbstractTree for BlobTree {
         self.index.approximate_range_stats(range, seqno)
     }
 
+    fn approximate_range_cardinality<K: AsRef<[u8]>, R: core::ops::RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+    ) -> crate::Result<crate::RangeCardinality> {
+        // Cardinality counts rows (index entries) and their key ranges, both of
+        // which live entirely in the index tree; blob files hold only the
+        // separated values, so the index tree's zone map and counts are authoritative.
+        self.index.approximate_range_cardinality(range, seqno)
+    }
+
     fn get_highest_memtable_seqno(&self) -> Option<SeqNo> {
         self.index.get_highest_memtable_seqno()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ pub mod scrub;
 
 pub mod storage_stats;
 pub use storage_stats::{
-    ApproximateRangeStats, LevelStats, SegmentStats, StorageStats, StorageStatus,
+    ApproximateRangeStats, LevelStats, RangeCardinality, SegmentStats, StorageStats, StorageStatus,
 };
 
 mod version;

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -193,6 +193,27 @@ pub struct LevelStats {
     pub segments: Vec<SegmentStats>,
 }
 
+/// Approximate cardinality and selectivity of a key range, for cost-based query
+/// planning (join ordering, scan-vs-seek).
+///
+/// Both figures derive from the per-data-block zone map (per-block row counts +
+/// key ranges) when present, falling back to the byte-fraction estimate of
+/// [`ApproximateRangeStats`] otherwise. They are estimates at block granularity,
+/// never exact.
+#[must_use]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct RangeCardinality {
+    /// Estimated number of rows (entry versions) the range covers: the sum of
+    /// the per-block row counts of every data block whose key range overlaps the
+    /// query range, plus each memtable's in-range count. `0` for an empty range.
+    pub rows: u64,
+
+    /// Estimated fraction of the tree's rows the range selects, in `0.0..=1.0`:
+    /// `rows / total_rows`. Monotonic in predicate tightness (a narrower range
+    /// never yields a larger selectivity). `0.0` when the tree is empty.
+    pub selectivity: f64,
+}
+
 impl StorageStats {
     /// Approximately how many more average-shaped entries fit in `budget_bytes`,
     /// using [`Self::avg_entry_on_disk_bytes`].

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -144,14 +144,8 @@ pub struct Inner {
 
     /// Per-data-block zone map, loaded on open from the optional `zone_map`
     /// section. Empty when the table has none (zone-map policy off), so a
-    /// predicate scan falls back to reading every block. Read only by the
-    /// block-skip scan path.
-    // Gated to non-test builds (the round-trip unit test reads it); kept as
-    // `expect` so it self-removes once the live block-skip reader reads it.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "read by the columnar block-skip scan path")
-    )]
+    /// predicate scan falls back to reading every block. Read by the
+    /// range-cardinality estimate and the block-skip scan path.
     pub(crate) zone_map: crate::table::zone_map::ZoneMap,
 
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`

--- a/src/table/zone_map.rs
+++ b/src/table/zone_map.rs
@@ -36,16 +36,17 @@
 //! Entries are strictly ascending by `block_offset` (write order == file order),
 //! enabling both a binary-search lookup and a sequential cursor.
 
-// The reader-side API (columns_for / cursor / ZoneMapCursor) has no live caller
-// until the columnar block-skip scan consumes it; the writer / table-open paths
-// already use the rest. Gated to non-test builds so the in-module tests (which
-// exercise the reader API) do not leave the expectation unfulfilled, and kept as
+// The cursor reader API (`cursor` / `ZoneMapCursor` / `len` / `is_empty`) has no
+// live caller until the columnar block-skip scan consumes it; `columns_for` and
+// the writer / table-open paths are already used (the range-cardinality estimate
+// reads `columns_for`). Gated to non-test builds so the in-module tests (which
+// exercise the cursor API) do not leave the expectation unfulfilled, and kept as
 // `expect` (not `allow`) so it self-removes once a live caller lands.
 #![cfg_attr(
     not(test),
     expect(
         dead_code,
-        reason = "reader API consumed by the columnar block-skip scan"
+        reason = "cursor API consumed by the columnar block-skip scan"
     )
 )]
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1206,50 +1206,45 @@ impl AbstractTree for Tree {
             }
             let table_seqno = seqno.saturating_sub(table.global_seqno());
             let zone_map = &table.zone_map;
-
-            // Per-block row counts from the zone map: every data block from `lo`
-            // onward whose key range can still overlap the query contributes its
-            // recorded row count. A block is past the range once its minimum key
-            // is above the upper bound. The boundary block at `lo` is counted in
-            // full (block granularity) even if some of its rows sort below `lo`.
-            let reader = match lo {
-                Bound::Included(k) | Bound::Excluded(k) => {
-                    table.block_index.forward_reader(k, table_seqno)
+            if !zone_map.is_empty() {
+                // Zone map present: sum the per-block row counts of blocks whose
+                // key range overlaps the query. A block is past the range once its
+                // minimum key is above the upper bound; the boundary block at `lo`
+                // is counted in full (block granularity). A range that lands in a
+                // key-space gap legitimately yields zero, so this path is
+                // authoritative and never falls back to the byte fraction.
+                let reader = match lo {
+                    Bound::Included(k) | Bound::Excluded(k) => {
+                        table.block_index.forward_reader(k, table_seqno)
+                    }
+                    Bound::Unbounded => Some(table.block_index.iter()),
+                };
+                if let Some(reader) = reader {
+                    for handle in reader {
+                        let handle = handle?;
+                        let Some(col) = zone_map
+                            .columns_for(*handle.offset())
+                            .and_then(|c| c.first())
+                        else {
+                            continue;
+                        };
+                        let above_hi = match hi {
+                            Bound::Included(hk) => {
+                                comparator.compare(&col.min, hk) == Ordering::Greater
+                            }
+                            Bound::Excluded(hk) => {
+                                comparator.compare(&col.min, hk) != Ordering::Less
+                            }
+                            Bound::Unbounded => false,
+                        };
+                        if above_hi {
+                            break;
+                        }
+                        rows = rows.saturating_add(u64::from(col.row_count));
+                    }
                 }
-                Bound::Unbounded => Some(table.block_index.iter()),
-            };
-            let Some(reader) = reader else {
-                continue;
-            };
-            let mut table_rows: u64 = 0;
-            let mut counted = false;
-            for handle in reader {
-                let handle = handle?;
-                let Some(columns) = zone_map.columns_for(*handle.offset()) else {
-                    // No zone map for this table (or block): fall back to the
-                    // byte-fraction row estimate over the whole table below.
-                    table_rows = 0;
-                    counted = false;
-                    break;
-                };
-                let Some(col) = columns.first() else {
-                    continue;
-                };
-                let above_hi = match hi {
-                    Bound::Included(hk) => comparator.compare(&col.min, hk) == Ordering::Greater,
-                    Bound::Excluded(hk) => comparator.compare(&col.min, hk) != Ordering::Less,
-                    Bound::Unbounded => false,
-                };
-                if above_hi {
-                    break;
-                }
-                table_rows = table_rows.saturating_add(u64::from(col.row_count));
-                counted = true;
-            }
-            if counted {
-                rows = rows.saturating_add(table_rows);
             } else if let Some(last) = table.block_index.iter().next_back() {
-                // Fallback (no zone map): apportion item_count by the in-range
+                // No zone map: apportion item_count by the in-range
                 // data-block byte fraction, mirroring approximate_range_stats.
                 let last = last?;
                 let data_end = *last.offset() + u64::from(last.size());

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1209,15 +1209,11 @@ impl AbstractTree for Tree {
             // `restrict_lower_bound()` are the punched-out prefix served by the
             // replacement table, so raise this table's effective lower bound to
             // it (mirrors approximate_range_stats) and never charge that prefix.
-            let eff_lo: Bound<&[u8]> = match (lo, table.restrict_lower_bound()) {
-                (Bound::Unbounded, Some(rb)) => Bound::Included(rb.as_ref()),
-                (Bound::Included(k) | Bound::Excluded(k), Some(rb))
-                    if comparator.compare(rb.as_ref(), k) == Ordering::Greater =>
-                {
-                    Bound::Included(rb.as_ref())
-                }
-                _ => lo,
-            };
+            let eff_lo = effective_lower_bound(
+                lo,
+                table.restrict_lower_bound().map(AsRef::as_ref),
+                comparator,
+            );
             let zone_map = &table.zone_map;
             if !zone_map.is_empty() {
                 // Zone map present: sum the per-block row counts of blocks whose
@@ -3752,4 +3748,72 @@ fn has_existing_version_state(folder: &Path, fs: &dyn Fs) -> crate::Result<bool>
         }
     }
     Ok(false)
+}
+
+/// Raises a query's lower bound to a table's tight-space restriction, if any.
+///
+/// Keys below `restriction` are the punched-out prefix served by the
+/// replacement table, so a range estimate must not charge them to the
+/// restricted view. Returns `lo` unchanged when the table is unrestricted or
+/// the restriction is at or below `lo`.
+fn effective_lower_bound<'a>(
+    lo: core::ops::Bound<&'a [u8]>,
+    restriction: Option<&'a [u8]>,
+    cmp: &dyn crate::comparator::UserComparator,
+) -> core::ops::Bound<&'a [u8]> {
+    use core::cmp::Ordering;
+    use core::ops::Bound;
+    match (lo, restriction) {
+        (Bound::Unbounded, Some(rb)) => Bound::Included(rb),
+        (Bound::Included(k) | Bound::Excluded(k), Some(rb))
+            if cmp.compare(rb, k) == Ordering::Greater =>
+        {
+            Bound::Included(rb)
+        }
+        _ => lo,
+    }
+}
+
+#[cfg(test)]
+mod cardinality_tests {
+    use super::effective_lower_bound;
+    use core::ops::Bound;
+
+    #[test]
+    fn effective_lower_bound_raises_to_restriction() {
+        let cmp = crate::comparator::default_comparator();
+        let cmp = cmp.as_ref();
+        let a: &[u8] = b"a";
+        let m: &[u8] = b"m";
+        let z: &[u8] = b"z";
+        // Unbounded lower bound + a restriction: raise to the restriction.
+        assert_eq!(
+            effective_lower_bound(Bound::Unbounded, Some(m), cmp),
+            Bound::Included(m)
+        );
+        // A lower bound below the restriction is raised to it.
+        assert_eq!(
+            effective_lower_bound(Bound::Included(a), Some(m), cmp),
+            Bound::Included(m)
+        );
+        assert_eq!(
+            effective_lower_bound(Bound::Excluded(a), Some(m), cmp),
+            Bound::Included(m)
+        );
+        // A lower bound at or above the restriction is left unchanged.
+        assert_eq!(
+            effective_lower_bound(Bound::Included(z), Some(m), cmp),
+            Bound::Included(z)
+        );
+        // No restriction: the lower bound is returned unchanged.
+        assert_eq!(
+            effective_lower_bound(Bound::Included(a), None, cmp),
+            Bound::Included(a)
+        );
+        let unbounded: Bound<&[u8]> = Bound::Unbounded;
+        assert_eq!(
+            effective_lower_bound(unbounded, None, cmp),
+            Bound::Unbounded
+        );
+    }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1169,6 +1169,178 @@ impl AbstractTree for Tree {
         Ok(crate::ApproximateRangeStats { bytes, key_count })
     }
 
+    fn approximate_range_cardinality<K: AsRef<[u8]>, R: core::ops::RangeBounds<K>>(
+        &self,
+        range: R,
+        seqno: SeqNo,
+    ) -> crate::Result<crate::RangeCardinality> {
+        use crate::table::block_index::BlockIndex;
+        use core::cmp::Ordering;
+        use core::ops::Bound;
+
+        let lo: Bound<&[u8]> = match range.start_bound() {
+            Bound::Included(k) => Bound::Included(k.as_ref()),
+            Bound::Excluded(k) => Bound::Excluded(k.as_ref()),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let hi: Bound<&[u8]> = match range.end_bound() {
+            Bound::Included(k) => Bound::Included(k.as_ref()),
+            Bound::Excluded(k) => Bound::Excluded(k.as_ref()),
+            Bound::Unbounded => Bound::Unbounded,
+        };
+        let bounds = (lo, hi);
+        let comparator = self.config.comparator.as_ref();
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
+
+        let mut rows: u64 = 0;
+        let mut total_rows: u64 = 0;
+
+        for table in super_version.version.iter_tables() {
+            total_rows = total_rows.saturating_add(table.metadata.item_count);
+            if !table
+                .metadata
+                .key_range
+                .overlaps_with_bounds_cmp(&bounds, comparator)
+            {
+                continue;
+            }
+            let table_seqno = seqno.saturating_sub(table.global_seqno());
+            let zone_map = &table.zone_map;
+
+            // Per-block row counts from the zone map: every data block from `lo`
+            // onward whose key range can still overlap the query contributes its
+            // recorded row count. A block is past the range once its minimum key
+            // is above the upper bound. The boundary block at `lo` is counted in
+            // full (block granularity) even if some of its rows sort below `lo`.
+            let reader = match lo {
+                Bound::Included(k) | Bound::Excluded(k) => {
+                    table.block_index.forward_reader(k, table_seqno)
+                }
+                Bound::Unbounded => Some(table.block_index.iter()),
+            };
+            let Some(reader) = reader else {
+                continue;
+            };
+            let mut table_rows: u64 = 0;
+            let mut counted = false;
+            for handle in reader {
+                let handle = handle?;
+                let Some(columns) = zone_map.columns_for(*handle.offset()) else {
+                    // No zone map for this table (or block): fall back to the
+                    // byte-fraction row estimate over the whole table below.
+                    table_rows = 0;
+                    counted = false;
+                    break;
+                };
+                let Some(col) = columns.first() else {
+                    continue;
+                };
+                let above_hi = match hi {
+                    Bound::Included(hk) => comparator.compare(&col.min, hk) == Ordering::Greater,
+                    Bound::Excluded(hk) => comparator.compare(&col.min, hk) != Ordering::Less,
+                    Bound::Unbounded => false,
+                };
+                if above_hi {
+                    break;
+                }
+                table_rows = table_rows.saturating_add(u64::from(col.row_count));
+                counted = true;
+            }
+            if counted {
+                rows = rows.saturating_add(table_rows);
+            } else if let Some(last) = table.block_index.iter().next_back() {
+                // Fallback (no zone map): apportion item_count by the in-range
+                // data-block byte fraction, mirroring approximate_range_stats.
+                let last = last?;
+                let data_end = *last.offset() + u64::from(last.size());
+                if data_end > 0 {
+                    let off = |key: &[u8], end: bool| -> crate::Result<u64> {
+                        match table.block_index.forward_reader(key, table_seqno) {
+                            Some(mut it) => match it.next() {
+                                Some(h) => {
+                                    let h = h?;
+                                    Ok(if end {
+                                        (*h.offset() + u64::from(h.size())).min(data_end)
+                                    } else {
+                                        *h.offset()
+                                    })
+                                }
+                                None => Ok(data_end),
+                            },
+                            None => Ok(data_end),
+                        }
+                    };
+                    let off_lo = match lo {
+                        Bound::Included(k) | Bound::Excluded(k) => off(k, false)?,
+                        Bound::Unbounded => 0,
+                    };
+                    let off_hi = match hi {
+                        Bound::Included(k) | Bound::Excluded(k) => off(k, true)?,
+                        Bound::Unbounded => data_end,
+                    };
+                    let idx_bytes = off_hi.saturating_sub(off_lo);
+                    if idx_bytes > 0 {
+                        let est = u64::try_from(
+                            u128::from(table.metadata.item_count) * u128::from(idx_bytes)
+                                / u128::from(data_end),
+                        )
+                        .unwrap_or(u64::MAX)
+                        .max(1);
+                        rows = rows.saturating_add(est);
+                    }
+                }
+            }
+        }
+
+        // Memtables: count the in-range, snapshot-visible entries and add them to
+        // both the matched rows and the total (matching the SST accounting).
+        let mt_range = (
+            match lo {
+                Bound::Included(k) => {
+                    Bound::Included(InternalKey::new(k, SeqNo::MAX, crate::ValueType::Tombstone))
+                }
+                Bound::Excluded(k) => {
+                    Bound::Excluded(InternalKey::new(k, 0, crate::ValueType::Tombstone))
+                }
+                Bound::Unbounded => Bound::Unbounded,
+            },
+            match hi {
+                Bound::Included(k) => {
+                    Bound::Included(InternalKey::new(k, 0, crate::ValueType::Value))
+                }
+                Bound::Excluded(k) => {
+                    Bound::Excluded(InternalKey::new(k, SeqNo::MAX, crate::ValueType::Value))
+                }
+                Bound::Unbounded => Bound::Unbounded,
+            },
+        );
+        let mut add_memtable = |mt: &crate::Memtable| {
+            total_rows = total_rows.saturating_add(mt.len() as u64);
+            let in_range = mt
+                .range_internal(mt_range.clone())
+                .filter(|kv| kv.key.seqno < seqno)
+                .count() as u64;
+            rows = rows.saturating_add(in_range);
+        };
+        add_memtable(&super_version.active_memtable);
+        for mt in super_version.sealed_memtables.iter() {
+            add_memtable(mt);
+        }
+
+        // selectivity is an approximate ratio; u64 row counts are well within
+        // f64's exact-integer range (2^52) for any realistic table.
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "row counts never approach 2^52; the ratio is approximate anyway"
+        )]
+        let selectivity = if total_rows == 0 {
+            0.0
+        } else {
+            (rows.min(total_rows) as f64) / (total_rows as f64)
+        };
+        Ok(crate::RangeCardinality { rows, selectivity })
+    }
+
     fn get_highest_memtable_seqno(&self) -> Option<SeqNo> {
         let version = self.version_history.read().latest_version();
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1205,15 +1205,28 @@ impl AbstractTree for Tree {
                 continue;
             }
             let table_seqno = seqno.saturating_sub(table.global_seqno());
+            // Honor a tight-space restricted view: keys below
+            // `restrict_lower_bound()` are the punched-out prefix served by the
+            // replacement table, so raise this table's effective lower bound to
+            // it (mirrors approximate_range_stats) and never charge that prefix.
+            let eff_lo: Bound<&[u8]> = match (lo, table.restrict_lower_bound()) {
+                (Bound::Unbounded, Some(rb)) => Bound::Included(rb.as_ref()),
+                (Bound::Included(k) | Bound::Excluded(k), Some(rb))
+                    if comparator.compare(rb.as_ref(), k) == Ordering::Greater =>
+                {
+                    Bound::Included(rb.as_ref())
+                }
+                _ => lo,
+            };
             let zone_map = &table.zone_map;
             if !zone_map.is_empty() {
                 // Zone map present: sum the per-block row counts of blocks whose
                 // key range overlaps the query. A block is past the range once its
-                // minimum key is above the upper bound; the boundary block at `lo`
-                // is counted in full (block granularity). A range that lands in a
-                // key-space gap legitimately yields zero, so this path is
-                // authoritative and never falls back to the byte fraction.
-                let reader = match lo {
+                // minimum key is above the upper bound; the boundary block at the
+                // effective lower bound is counted in full (block granularity). A
+                // range that lands in a key-space gap legitimately yields zero, so
+                // this path is authoritative and never falls back to the byte fraction.
+                let reader = match eff_lo {
                     Bound::Included(k) | Bound::Excluded(k) => {
                         table.block_index.forward_reader(k, table_seqno)
                     }
@@ -1265,7 +1278,7 @@ impl AbstractTree for Tree {
                             None => Ok(data_end),
                         }
                     };
-                    let off_lo = match lo {
+                    let off_lo = match eff_lo {
                         Bound::Included(k) | Bound::Excluded(k) => off(k, false)?,
                         Bound::Unbounded => 0,
                     };

--- a/tests/range_cardinality.rs
+++ b/tests/range_cardinality.rs
@@ -8,8 +8,8 @@
 //! and selectivity is monotonic in predicate tightness.
 
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, Tree, config::BlockSizePolicy,
-    get_tmp_folder,
+    AbstractTree, AnyTree, Config, KvSeparationOptions, SeqNo, SequenceNumberCounter, Tree,
+    config::BlockSizePolicy, get_tmp_folder,
 };
 use test_log::test;
 
@@ -212,6 +212,96 @@ fn falls_back_without_zone_map() {
         narrow.selectivity <= full.selectivity,
         "fallback selectivity monotonic"
     );
+}
+
+#[test]
+fn kv_separated_cardinality_delegates_to_index() {
+    // A KV-separated tree delegates cardinality to its index tree (the row
+    // counts and key ranges live in the index, values in blob files).
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    .open()
+    .expect("open");
+    let AnyTree::Blob(tree) = any else {
+        panic!("expected blob tree");
+    };
+    for i in 0..200u32 {
+        tree.insert(key(i), vec![b'v'; 1024], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let full = tree
+        .approximate_range_cardinality::<&[u8], _>(.., SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(
+        full.rows,
+        tree.approximate_len() as u64,
+        "full range counts every row"
+    );
+    assert!((full.selectivity - 1.0).abs() < 1e-9);
+    let part = tree
+        .approximate_range_cardinality(key(0)..key(50), SeqNo::MAX)
+        .expect("cardinality");
+    assert!(
+        part.selectivity <= full.selectivity,
+        "selectivity monotonic"
+    );
+}
+
+#[test]
+fn restricted_view_cardinality_honors_punched_prefix() {
+    use lsm_tree::fs::MemFs;
+    use std::sync::Arc;
+
+    let folder = get_tmp_folder();
+    let mem = MemFs::with_capacity(64 * 1024 * 1024);
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(mem.clone()))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    for i in 0..2000u32 {
+        tree.insert(key(i), vec![0xCDu8; 64], u64::from(i));
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    let used = tree.storage_stats().expect("stats").used_bytes;
+    // Cap the disk so a full rewrite cannot fit: the opt-in tight-space loop
+    // slices the gated table and installs restricted views over the survivors.
+    mem.set_capacity(used + used / 4);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.storage_limit_bytes = None;
+        c.tight_space_compaction = true;
+    })
+    .expect("config");
+    tree.major_compact(64 * 1024 * 1024, 0).expect("compact");
+
+    // After the tight-space rewrite the version can hold restricted-view tables.
+    // The cardinality estimate must raise each restricted table's lower bound to
+    // its restriction in both the unbounded-lo arm (a full range) and a bounded
+    // lower bound below the restriction. Every key must still be accounted for.
+    let full = tree
+        .approximate_range_cardinality::<&[u8], _>(.., u64::MAX)
+        .expect("cardinality");
+    assert!(
+        full.rows > 0,
+        "full-range cardinality over a restricted layout"
+    );
+    let bounded = tree
+        .approximate_range_cardinality(key(0)..key(2000), u64::MAX)
+        .expect("cardinality");
+    assert!(bounded.rows > 0);
 }
 
 fn build_fallback(folder: &std::path::Path) -> Tree {

--- a/tests/range_cardinality.rs
+++ b/tests/range_cardinality.rs
@@ -76,15 +76,17 @@ fn empty_range_is_zero() {
 #[test]
 fn range_in_a_data_gap_with_zone_map_is_zero() {
     // A single SST with a hole in the key space: keys 0..100 and 300..400, none
-    // in 100..300. With the zone map present, a query that falls entirely in the
-    // gap must report zero rows, NOT fall back to a byte-fraction estimate.
+    // in 100..300. With one key per data block (block target below the value
+    // size, so no block straddles the gap) and the zone map present, a query
+    // that falls entirely in the gap must report zero rows, NOT fall back to a
+    // byte-fraction estimate.
     let folder = get_tmp_folder();
     let any = Config::new(
         folder.path(),
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
-    .data_block_size_policy(BlockSizePolicy::all(512))
+    .data_block_size_policy(BlockSizePolicy::all(64))
     .open()
     .expect("open");
     let AnyTree::Standard(tree) = any else {

--- a/tests/range_cardinality.rs
+++ b/tests/range_cardinality.rs
@@ -213,3 +213,89 @@ fn falls_back_without_zone_map() {
         "fallback selectivity monotonic"
     );
 }
+
+fn build_fallback(folder: &std::path::Path) -> Tree {
+    // Zone map OFF (default), small blocks: exercises the byte-fraction branch.
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    for i in 0..400u32 {
+        tree.insert(key(i), vec![b'v'; 200], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    tree
+}
+
+fn build_memtable_only(folder: &std::path::Path) -> Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    for i in 0..100u32 {
+        tree.insert(key(i), vec![b'v'; 64], 0);
+    }
+    tree
+}
+
+#[test]
+fn all_bound_kinds_in_cardinality() {
+    use std::ops::Bound;
+
+    // Run the excluded-lower / included-upper / half-bounded RangeTo / RangeFrom
+    // bound arms through every branch: zone-map, byte-fraction fallback, memtable.
+    let check = |tree: &Tree, a: u32, b: u32| {
+        let excl_incl = tree
+            .approximate_range_cardinality(
+                (Bound::Excluded(key(a)), Bound::Included(key(b))),
+                SeqNo::MAX,
+            )
+            .expect("cardinality");
+        assert!(excl_incl.rows > 0, "excluded..=included is non-empty");
+        let to = tree
+            .approximate_range_cardinality(..key(b), SeqNo::MAX)
+            .expect("cardinality");
+        let from = tree
+            .approximate_range_cardinality(key(a).., SeqNo::MAX)
+            .expect("cardinality");
+        assert!(to.rows > 0 && from.rows > 0, "half-bounded is non-empty");
+        assert!(to.selectivity <= 1.0 && from.selectivity <= 1.0);
+    };
+
+    let f1 = get_tmp_folder();
+    check(&build_zonemapped(f1.path()), 300, 700);
+    let f2 = get_tmp_folder();
+    check(&build_fallback(f2.path()), 50, 150);
+    let f3 = get_tmp_folder();
+    let mt = build_memtable_only(f3.path());
+    check(&mt, 10, 50);
+    // A non-empty memtable queried past every key contributes nothing.
+    let empty = mt
+        .approximate_range_cardinality(key(900)..key(999), SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(empty.rows, 0);
+    assert_eq!(empty.selectivity, 0.0);
+
+    // Byte-fraction (no zone map) branch where the upper bound runs past the
+    // last key while the table still overlaps: the block-offset lookup for the
+    // upper bound falls through to the data-section end.
+    let f4 = get_tmp_folder();
+    let fb = build_fallback(f4.path());
+    let spill = fb
+        .approximate_range_cardinality(key(50)..key(99_999), SeqNo::MAX)
+        .expect("cardinality");
+    assert!(spill.rows > 0, "an in-range lower bound still selects rows");
+}

--- a/tests/range_cardinality.rs
+++ b/tests/range_cardinality.rs
@@ -74,6 +74,43 @@ fn empty_range_is_zero() {
 }
 
 #[test]
+fn range_in_a_data_gap_with_zone_map_is_zero() {
+    // A single SST with a hole in the key space: keys 0..100 and 300..400, none
+    // in 100..300. With the zone map present, a query that falls entirely in the
+    // gap must report zero rows, NOT fall back to a byte-fraction estimate.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.zone_map = true)
+        .expect("enable zone map");
+    for i in 0..100u32 {
+        tree.insert(key(i), vec![b'v'; 200], 0);
+    }
+    for i in 300..400u32 {
+        tree.insert(key(i), vec![b'v'; 200], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let card = tree
+        .approximate_range_cardinality(key(150)..key(250), SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(
+        card.rows, 0,
+        "a range in a data gap has no rows, got {card:?}"
+    );
+    assert_eq!(card.selectivity, 0.0);
+}
+
+#[test]
 fn subrange_rows_within_bounded_error() {
     let folder = get_tmp_folder();
     let tree = build_zonemapped(folder.path());

--- a/tests/range_cardinality.rs
+++ b/tests/range_cardinality.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Integration tests for `AbstractTree::approximate_range_cardinality` (#505):
+//! a zone-map-based row-count estimate plus a selectivity ratio, computed
+//! without reading any data block. Tests assert the acceptance criteria: the
+//! row count is within a bounded (block-granularity) error of the true count,
+//! and selectivity is monotonic in predicate tightness.
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, Tree, config::BlockSizePolicy,
+    get_tmp_folder,
+};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+/// Tree with the zone map enabled, spread across several disjoint-range SSTs
+/// with small data blocks so a range spans multiple blocks per SST.
+fn build_zonemapped(folder: &std::path::Path) -> Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.zone_map = true)
+        .expect("enable zone map");
+    for sst in 0..5u32 {
+        for i in 0..200u32 {
+            tree.insert(key(sst * 200 + i), vec![b'v'; 200], 0);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+    tree
+}
+
+#[test]
+fn full_range_rows_equal_total_and_selectivity_one() {
+    let folder = get_tmp_folder();
+    let tree = build_zonemapped(folder.path());
+    // Every block's recorded row count sums to the exact entry total.
+    let card = tree
+        .approximate_range_cardinality::<&[u8], _>(.., SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(
+        card.rows,
+        tree.approximate_len() as u64,
+        "full-range rows equal the total entry count"
+    );
+    assert!(
+        (card.selectivity - 1.0).abs() < 1e-9,
+        "full-range selectivity is 1.0, got {}",
+        card.selectivity
+    );
+}
+
+#[test]
+fn empty_range_is_zero() {
+    let folder = get_tmp_folder();
+    let tree = build_zonemapped(folder.path());
+    let card = tree
+        .approximate_range_cardinality(key(900_000)..key(999_999), SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(card.rows, 0, "empty range has no rows");
+    assert_eq!(card.selectivity, 0.0, "empty range has zero selectivity");
+}
+
+#[test]
+fn subrange_rows_within_bounded_error() {
+    let folder = get_tmp_folder();
+    let tree = build_zonemapped(folder.path());
+    let lo = key(300);
+    let hi = key(700);
+    let actual = tree.range(lo.clone()..hi.clone(), SeqNo::MAX, None).count() as u64;
+    let est = tree
+        .approximate_range_cardinality(lo..hi, SeqNo::MAX)
+        .expect("cardinality")
+        .rows;
+    // Block-granularity: the estimate counts the boundary blocks in full, so it
+    // is at least the true count and within a small relative error.
+    assert!(
+        est >= actual,
+        "estimate {est} must cover the actual {actual}"
+    );
+    assert!(
+        est <= actual + actual / 10 + 16,
+        "estimate {est} should be within ~10% of actual {actual}"
+    );
+}
+
+#[test]
+fn selectivity_monotonic_in_predicate_tightness() {
+    let folder = get_tmp_folder();
+    let tree = build_zonemapped(folder.path());
+    let narrow = tree
+        .approximate_range_cardinality(key(0)..key(100), SeqNo::MAX)
+        .expect("cardinality");
+    let mid = tree
+        .approximate_range_cardinality(key(0)..key(500), SeqNo::MAX)
+        .expect("cardinality");
+    let wide = tree
+        .approximate_range_cardinality(key(0)..key(900), SeqNo::MAX)
+        .expect("cardinality");
+    assert!(
+        narrow.selectivity <= mid.selectivity && mid.selectivity <= wide.selectivity,
+        "selectivity must grow with range width: {} <= {} <= {}",
+        narrow.selectivity,
+        mid.selectivity,
+        wide.selectivity
+    );
+    assert!(narrow.rows <= mid.rows && mid.rows <= wide.rows);
+}
+
+#[test]
+fn memtable_only_is_counted() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    for i in 0..100u32 {
+        tree.insert(key(i), vec![b'v'; 64], 0);
+    }
+    let card = tree
+        .approximate_range_cardinality::<&[u8], _>(.., SeqNo::MAX)
+        .expect("cardinality");
+    assert_eq!(card.rows, 100, "memtable rows counted");
+    assert!((card.selectivity - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn falls_back_without_zone_map() {
+    // With the zone map disabled (default), the row count falls back to the
+    // byte-fraction estimate and still reflects the range.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    for i in 0..400u32 {
+        tree.insert(key(i), vec![b'v'; 200], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    let full = tree
+        .approximate_range_cardinality::<&[u8], _>(.., SeqNo::MAX)
+        .expect("cardinality");
+    assert!(full.rows > 0, "fallback row estimate is non-empty");
+    let narrow = tree
+        .approximate_range_cardinality(key(0)..key(100), SeqNo::MAX)
+        .expect("cardinality");
+    assert!(
+        narrow.selectivity <= full.selectivity,
+        "fallback selectivity monotonic"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `AbstractTree::approximate_range_cardinality(range, seqno) -> RangeCardinality { rows, selectivity }`: a row-count and selectivity estimate for a key range, computed **without reading any data block**. For cost-based query planning (join ordering, scan-vs-seek).

## How it works

- **rows**: each overlapping SST's per-data-block zone-map (#502) row counts are summed for every block whose key range overlaps the query (block granularity). A table written without a zone map falls back to the byte-fraction row estimate (the `approximate_range_stats` path). The active + sealed memtables add their in-range, snapshot-visible counts.
- **selectivity**: `rows / total_rows`, in `0.0..=1.0`, monotonic in predicate tightness.
- Snapshot/visibility, per-table seqno translation, and comparator-aware overlap match the read path (and `approximate_range_stats`).

The zone-map reader (`ZoneMap::columns_for`) now has a live caller, so its dead-code suppression on the table field is removed; the cursor API stays gated for the future columnar block-skip scan (#503).

## Tests

6 integration tests: full range = exact total + selectivity 1.0; empty range = 0; sub-range row count within a bounded (block-granularity) error of an actual scan; selectivity monotonic across widening ranges; memtable-only counted; fallback path without a zone map. Plus a `# Examples` doctest. Full suite (2056), `clippy --all-features --all-targets`, no-std (`alloc`), and doctests green.

## Stacking

Branched from `feat/#499-approximate-range-stats` (PR #513) since it extends `approximate_range_stats`. Base retargets to `main` after #513 merges.

Closes #505


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added key-range cardinality estimation to the public tree API, returning estimated row counts and selectivity for cost-based query planning at a specified snapshot.
  * Uses zone-map metadata when available; otherwise falls back to a byte-fraction approximation while maintaining monotonic selectivity as ranges widen.
  * Supported for SSTs and memtables, including restricted-view behavior.

* **Documentation**
  * Added and exported `RangeCardinality` to expose the estimation results.

* **Tests**
  * Added integration tests covering zone-map precision, fallback behavior, empty/full ranges, monotonicity, and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->