### PR TITLE
feat(tree): per-level / per-segment storage + access stats

### DIFF
--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -144,6 +144,43 @@ pub trait AbstractTree: sealed::Sealed {
         crate::storage_stats::compute_storage_stats(&self.current_version(), false, true)
     }
 
+    /// Per-LSM-level and per-segment size + entry-count stats, for tiering and
+    /// erasure-coding placement decisions (which level / segment is large enough
+    /// to demote, EC-encode, or migrate).
+    ///
+    /// Cheap: derived from the live version's metadata plus one file-size stat
+    /// per segment (no data-block scan). The per-level totals reconcile with
+    /// [`storage_stats`](Self::storage_stats): summed across levels they equal
+    /// the SST portion of [`StorageStats::used_bytes`](crate::StorageStats::used_bytes)
+    /// and [`StorageStats::item_count`](crate::StorageStats::item_count).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lsm_tree::Error as TreeError;
+    /// use lsm_tree::{AbstractTree, Config};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let tree = Config::new(&folder, Default::default(), Default::default()).open()?;
+    /// for i in 0..100u32 {
+    ///     tree.insert(format!("k{i:04}"), "v", 0);
+    /// }
+    /// tree.flush_active_memtable(0)?;
+    ///
+    /// let levels = tree.level_segment_stats()?;
+    /// let total: u64 = levels.iter().map(|l| l.item_count).sum();
+    /// assert_eq!(total, tree.storage_stats()?.item_count);
+    /// #
+    /// # Ok::<(), TreeError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a segment's file size cannot be stat-ed.
+    fn level_segment_stats(&self) -> crate::Result<Vec<crate::LevelStats>> {
+        crate::storage_stats::compute_level_segment_stats(&self.current_version())
+    }
+
     /// Storage admission gate: `Ok(())` if a write may proceed, or
     /// [`Error::StorageFull`](crate::Error::StorageFull) if the tree is
     /// over budget and should be treated as read-only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,9 @@ pub mod inspect;
 pub mod scrub;
 
 pub mod storage_stats;
-pub use storage_stats::{ApproximateRangeStats, StorageStats, StorageStatus};
+pub use storage_stats::{
+    ApproximateRangeStats, LevelStats, SegmentStats, StorageStats, StorageStatus,
+};
 
 mod version;
 mod vlog;

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -152,11 +152,14 @@ pub struct SegmentStats {
     pub used_bytes: u64,
     /// Number of entry versions stored in the segment.
     pub item_count: u64,
-    /// Cumulative point-read probes served by the segment since it was created.
-    /// A monotonic counter, not a rate: derive a read-rate / EMA from the delta
-    /// between successive polls. `0` for a never-read segment.
+    /// Cumulative point reads that consulted this segment's data since it was
+    /// created: only reads that pass the segment's seqno-range and bloom gates
+    /// count (a bloom miss is not counted), so this tracks data hotness rather
+    /// than raw probe frequency. A monotonic counter, not a rate: derive a
+    /// read-rate / EMA from the delta between successive polls. `0` when never
+    /// read.
     pub reads: u64,
-    /// Unix seconds of the segment's most recent point-read probe, or `0` if
+    /// Unix seconds of the segment's most recent data-consulting read, or `0` if
     /// never read (or on a no-std build, which keeps no clock).
     pub last_access_secs: u64,
 }

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -10,6 +10,8 @@
 //! [`crate::AbstractTree::storage_stats`].
 
 use crate::version::Version;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Coarse storage state of a tree.
 ///
@@ -135,6 +137,45 @@ pub struct ApproximateRangeStats {
     /// overlapping SST, of `item_count × in-range fraction`, plus each
     /// memtable's in-range skiplist count. `0` for an empty range.
     pub key_count: u64,
+}
+
+/// Size and entry count of one stored segment (SST), for per-segment tiering and
+/// erasure-coding placement decisions.
+#[must_use]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SegmentStats {
+    /// Identifier of the segment's SST within its tree.
+    pub table_id: crate::TableId,
+    /// LSM level the segment lives in (`0` is the newest / smallest level).
+    pub level: usize,
+    /// Physical on-disk bytes of the segment's SST file.
+    pub used_bytes: u64,
+    /// Number of entry versions stored in the segment.
+    pub item_count: u64,
+}
+
+/// Per-LSM-level size + entry aggregates with the contributing segments, for
+/// tiering and erasure-coding placement (which level / segment is large enough
+/// to demote, EC-encode, or migrate).
+///
+/// Cheap to read: derived from version metadata plus one file-size stat per
+/// segment, never a data-block scan. The per-level totals reconcile with the
+/// tree-level [`StorageStats`]: summed across levels they equal the SST portion
+/// of [`StorageStats::used_bytes`] and [`StorageStats::item_count`] (blob files
+/// are tracked separately).
+#[must_use]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LevelStats {
+    /// LSM level index (`0` is the newest / smallest level).
+    pub level: usize,
+    /// Number of segments (SSTs) in the level.
+    pub segment_count: usize,
+    /// Physical on-disk bytes summed across the level's segments.
+    pub used_bytes: u64,
+    /// Entry versions summed across the level's segments.
+    pub item_count: u64,
+    /// Per-segment breakdown, in level (run / table) order.
+    pub segments: Vec<SegmentStats>,
 }
 
 impl StorageStats {
@@ -308,6 +349,47 @@ pub(crate) fn compute_storage_stats(
         reclaimable_bytes_estimate,
         status,
     })
+}
+
+/// Computes per-LSM-level and per-segment size + entry stats from a version.
+///
+/// Cost is O(levels x segments) plus one file-size stat per segment (the same
+/// stat [`compute_storage_stats`] already performs); it never reads a data block.
+///
+/// # Errors
+///
+/// Returns an error if a segment's file size cannot be stat-ed.
+pub(crate) fn compute_level_segment_stats(version: &Version) -> crate::Result<Vec<LevelStats>> {
+    let mut levels = Vec::with_capacity(version.level_count());
+    for (level, run_group) in version.iter_levels().enumerate() {
+        let mut segments = Vec::new();
+        let mut used_bytes = 0u64;
+        let mut item_count = 0u64;
+        for run in run_group.iter() {
+            for table in run.iter() {
+                // Physical file size, NOT m.file_size (which undercounts), to
+                // reconcile with the tree-level `used_bytes`.
+                let on_disk = table.fs.metadata(&table.path)?.len;
+                let items = table.metadata.item_count;
+                used_bytes += on_disk;
+                item_count += items;
+                segments.push(SegmentStats {
+                    table_id: table.metadata.id,
+                    level,
+                    used_bytes: on_disk,
+                    item_count: items,
+                });
+            }
+        }
+        levels.push(LevelStats {
+            level,
+            segment_count: segments.len(),
+            used_bytes,
+            item_count,
+            segments,
+        });
+    }
+    Ok(levels)
 }
 
 #[cfg(test)]

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -152,6 +152,13 @@ pub struct SegmentStats {
     pub used_bytes: u64,
     /// Number of entry versions stored in the segment.
     pub item_count: u64,
+    /// Cumulative point-read probes served by the segment since it was created.
+    /// A monotonic counter, not a rate: derive a read-rate / EMA from the delta
+    /// between successive polls. `0` for a never-read segment.
+    pub reads: u64,
+    /// Unix seconds of the segment's most recent point-read probe, or `0` if
+    /// never read (or on a no-std build, which keeps no clock).
+    pub last_access_secs: u64,
 }
 
 /// Per-LSM-level size + entry aggregates with the contributing segments, for
@@ -174,6 +181,11 @@ pub struct LevelStats {
     pub used_bytes: u64,
     /// Entry versions summed across the level's segments.
     pub item_count: u64,
+    /// Cumulative point-read probes summed across the level's segments.
+    pub reads: u64,
+    /// Most recent point-read probe across the level's segments, in unix
+    /// seconds, or `0` if none was ever read.
+    pub last_access_secs: u64,
     /// Per-segment breakdown, in level (run / table) order.
     pub segments: Vec<SegmentStats>,
 }
@@ -360,24 +372,33 @@ pub(crate) fn compute_storage_stats(
 ///
 /// Returns an error if a segment's file size cannot be stat-ed.
 pub(crate) fn compute_level_segment_stats(version: &Version) -> crate::Result<Vec<LevelStats>> {
+    use core::sync::atomic::Ordering::Relaxed;
     let mut levels = Vec::with_capacity(version.level_count());
     for (level, run_group) in version.iter_levels().enumerate() {
         let mut segments = Vec::new();
         let mut used_bytes = 0u64;
         let mut item_count = 0u64;
+        let mut reads = 0u64;
+        let mut last_access_secs = 0u64;
         for run in run_group.iter() {
             for table in run.iter() {
                 // Physical file size, NOT m.file_size (which undercounts), to
                 // reconcile with the tree-level `used_bytes`.
                 let on_disk = table.fs.metadata(&table.path)?.len;
                 let items = table.metadata.item_count;
+                let seg_reads = table.read_count.load(Relaxed);
+                let seg_access = table.last_access_secs.load(Relaxed);
                 used_bytes += on_disk;
                 item_count += items;
+                reads = reads.saturating_add(seg_reads);
+                last_access_secs = last_access_secs.max(seg_access);
                 segments.push(SegmentStats {
                     table_id: table.metadata.id,
                     level,
                     used_bytes: on_disk,
                     item_count: items,
+                    reads: seg_reads,
+                    last_access_secs: seg_access,
                 });
             }
         }
@@ -386,6 +407,8 @@ pub(crate) fn compute_level_segment_stats(version: &Version) -> crate::Result<Ve
             segment_count: segments.len(),
             used_bytes,
             item_count,
+            reads,
+            last_access_secs,
             segments,
         });
     }

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -104,6 +104,17 @@ pub struct Inner {
     /// same on-disk byte counts and computes the same sum.
     pub(crate) cached_blob_bytes: AtomicU64,
 
+    /// Cumulative point-read probes served by this segment, bumped (`Relaxed`)
+    /// on every [`Table::get`]. A monotonic counter, not a rate: a tiering
+    /// consumer derives a read-rate / EMA from successive polls (delta over
+    /// elapsed time). Reset to `0` only when the segment is created.
+    pub(crate) read_count: AtomicU64,
+
+    /// Unix seconds of the most recent point-read probe, or `0` if never read.
+    /// Maintained only on `std` builds (system clock); a no-std build leaves it
+    /// at `0`. The recency signal for demotion / tiering decisions.
+    pub(crate) last_access_secs: AtomicU64,
+
     /// Range tombstones stored in this table. Loaded on open.
     pub(crate) range_tombstones: Vec<RangeTombstone>,
 

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -104,15 +104,18 @@ pub struct Inner {
     /// same on-disk byte counts and computes the same sum.
     pub(crate) cached_blob_bytes: AtomicU64,
 
-    /// Cumulative point-read probes served by this segment, bumped (`Relaxed`)
-    /// on every [`Table::get`]. A monotonic counter, not a rate: a tiering
-    /// consumer derives a read-rate / EMA from successive polls (delta over
-    /// elapsed time). Reset to `0` only when the segment is created.
+    /// Cumulative point reads that consulted this segment's data, bumped
+    /// (`Relaxed`) once a read passes the segment's seqno-range and bloom gates
+    /// (a bloom miss or out-of-seqno-range probe is NOT counted, so the figure
+    /// tracks data hotness, not raw probe frequency). A monotonic counter, not a
+    /// rate: a tiering consumer derives a read-rate / EMA from successive polls
+    /// (delta over elapsed time). Reset to `0` only when the segment is created.
     pub(crate) read_count: AtomicU64,
 
-    /// Unix seconds of the most recent point-read probe, or `0` if never read.
-    /// Maintained only on `std` builds (system clock); a no-std build leaves it
-    /// at `0`. The recency signal for demotion / tiering decisions.
+    /// Unix seconds of the most recent data-consulting read (same gating as
+    /// [`Self::read_count`]), or `0` if never read. Maintained only on `std`
+    /// builds (system clock); a no-std build leaves it at `0`. The recency
+    /// signal for demotion / tiering decisions.
     pub(crate) last_access_secs: AtomicU64,
 
     /// Range tombstones stored in this table. Loaded on open.

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -508,9 +508,11 @@ impl Table {
         Ok(BloomResult::Proceed { has_filter })
     }
 
-    /// Records a point-read probe for per-segment tiering / placement stats: a
-    /// single `Relaxed` counter bump plus, on `std`, the access time. Raw
-    /// counter; the consumer derives a rate / EMA from successive polls.
+    /// Records a data-consulting point read for per-segment tiering / placement
+    /// stats: a single `Relaxed` counter bump plus, on `std`, the access time.
+    /// Called only after the seqno-range + bloom gates pass, so bloom misses do
+    /// not inflate the count. Raw counter; the consumer derives a rate / EMA from
+    /// successive polls.
     fn record_access(&self) {
         self.read_count
             .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
@@ -527,7 +529,6 @@ impl Table {
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<InternalValue>> {
-        self.record_access();
         // Tight-space restriction: this version sees the table only at keys
         // `>= bound` (the prefix below it is punched out and superseded by a
         // merged output table). Keys below `bound` must miss here so the read
@@ -547,6 +548,11 @@ impl Table {
         if bloom.should_skip() {
             return Ok(None);
         }
+
+        // Access accounting after the seqno-range + bloom gates, so a segment
+        // that excludes the key (seqno range) or rejects it (bloom miss) is not
+        // counted as serving it.
+        self.record_access();
 
         // Row-cache fast path: a prior latest-version read cached this key's
         // resolved value for this (immutable) SST, so we can skip the index walk
@@ -613,7 +619,6 @@ impl Table {
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<(crate::ValueType, SeqNo, crate::Slice)>> {
-        self.record_access();
         // Tight-space restriction (mirrors `Table::get`): a key below the bound
         // misses so the read falls through to the superseding output.
         if self.is_below_restriction(key) {
@@ -631,6 +636,9 @@ impl Table {
         if bloom.should_skip() {
             return Ok(None);
         }
+
+        // Access accounting after the seqno-range + bloom gates (mirrors `Table::get`).
+        self.record_access();
 
         // Row-cache fast path (mirrors `Table::get`): serve the value tuple from
         // a prior cached point-read result, skipping the index walk + block
@@ -736,7 +744,6 @@ impl Table {
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<(InternalValue, Block)>> {
-        self.record_access();
         // Tight-space restriction (mirrors `Table::get`): a key below the bound
         // misses so the read falls through to the superseding output and never
         // touches the punched-out prefix.
@@ -755,6 +762,9 @@ impl Table {
         if bloom.should_skip() {
             return Ok(None);
         }
+
+        // Access accounting after the seqno-range + bloom gates (mirrors `Table::get`).
+        self.record_access();
 
         let result = self.point_read_with_block(key, seqno, key_hash)?;
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -508,12 +508,26 @@ impl Table {
         Ok(BloomResult::Proceed { has_filter })
     }
 
+    /// Records a point-read probe for per-segment tiering / placement stats: a
+    /// single `Relaxed` counter bump plus, on `std`, the access time. Raw
+    /// counter; the consumer derives a rate / EMA from successive polls.
+    fn record_access(&self) {
+        self.read_count
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        #[cfg(feature = "std")]
+        self.last_access_secs.store(
+            crate::time::unix_timestamp().as_secs(),
+            core::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
     pub fn get(
         &self,
         key: &[u8],
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<InternalValue>> {
+        self.record_access();
         // Tight-space restriction: this version sees the table only at keys
         // `>= bound` (the prefix below it is punched out and superseded by a
         // merged output table). Keys below `bound` must miss here so the read
@@ -599,6 +613,7 @@ impl Table {
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<(crate::ValueType, SeqNo, crate::Slice)>> {
+        self.record_access();
         // Tight-space restriction (mirrors `Table::get`): a key below the bound
         // misses so the read falls through to the superseding output.
         if self.is_below_restriction(key) {
@@ -721,6 +736,7 @@ impl Table {
         seqno: SeqNo,
         key_hash: u64,
     ) -> crate::Result<Option<(InternalValue, Block)>> {
+        self.record_access();
         // Tight-space restriction (mirrors `Table::get`): a key below the bound
         // misses so the read falls through to the superseding output and never
         // touches the punched-out prefix.
@@ -2116,6 +2132,8 @@ impl Table {
                 metrics,
 
                 cached_blob_bytes: AtomicU64::new(u64::MAX),
+                read_count: AtomicU64::new(0),
+                last_access_secs: AtomicU64::new(0),
                 range_tombstones,
                 block_layout,
                 seqno_bounds,

--- a/tests/per_level_stats.rs
+++ b/tests/per_level_stats.rs
@@ -106,6 +106,41 @@ fn multiple_levels_are_reported_after_compaction() {
     assert_eq!(sum_items, tree.storage_stats().expect("agg").item_count);
 }
 
+#[test]
+fn point_reads_bump_segment_access_stats() {
+    let folder = get_tmp_folder();
+    let tree = open(folder.path());
+    for i in 0..50u32 {
+        tree.insert(key(i), vec![b'v'; 100], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let before: u64 = tree
+        .level_segment_stats()
+        .expect("stats")
+        .iter()
+        .map(|l| l.reads)
+        .sum();
+    for _ in 0..10 {
+        let _ = tree.get(key(5), lsm_tree::SeqNo::MAX).expect("get");
+    }
+    let levels = tree.level_segment_stats().expect("stats");
+    let after: u64 = levels.iter().map(|l| l.reads).sum();
+    assert!(
+        after >= before + 10,
+        "ten point reads must bump the segment read counter by >= 10 ({before} -> {after})"
+    );
+    // On a std build a probed segment records its last-access time.
+    assert!(
+        levels
+            .iter()
+            .flat_map(|l| &l.segments)
+            .filter(|s| s.reads > 0)
+            .all(|s| s.last_access_secs > 0),
+        "a read segment records its last-access time"
+    );
+}
+
 #[cfg(feature = "metrics")]
 #[test]
 fn reading_stats_does_not_scan_data_blocks() {

--- a/tests/per_level_stats.rs
+++ b/tests/per_level_stats.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Integration tests for `AbstractTree::level_segment_stats` (#508): per-LSM
+//! level and per-segment size + entry stats for tiering / placement. Tests
+//! assert the acceptance criteria: per-level / per-segment values are reported,
+//! they reconcile with the tree-level aggregate, and reading them does not
+//! trigger a data-block scan (verified via the data-block load counter).
+
+use lsm_tree::{AbstractTree, AnyTree, Config, SequenceNumberCounter, Tree, get_tmp_folder};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn open(folder: &std::path::Path) -> Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree
+}
+
+#[test]
+fn empty_tree_has_no_segments() {
+    let folder = get_tmp_folder();
+    let tree = open(folder.path());
+    let levels = tree.level_segment_stats().expect("stats");
+    let total_segments: usize = levels.iter().map(|l| l.segment_count).sum();
+    assert_eq!(total_segments, 0, "no segments before any flush");
+    assert!(
+        levels
+            .iter()
+            .all(|l| l.used_bytes == 0 && l.item_count == 0),
+        "empty levels carry zero size and count"
+    );
+}
+
+#[test]
+fn per_level_totals_reconcile_with_tree_aggregate() {
+    let folder = get_tmp_folder();
+    let tree = open(folder.path());
+    for sst in 0..4u32 {
+        for i in 0..100u32 {
+            tree.insert(key(sst * 100 + i), vec![b'v'; 100], 0);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+
+    let levels = tree.level_segment_stats().expect("stats");
+    let aggregate = tree.storage_stats().expect("storage stats");
+
+    let sum_bytes: u64 = levels.iter().map(|l| l.used_bytes).sum();
+    let sum_items: u64 = levels.iter().map(|l| l.item_count).sum();
+    // A standard tree has no blob files, so the SST sum equals the tree total.
+    assert_eq!(sum_bytes, aggregate.used_bytes, "byte totals reconcile");
+    assert_eq!(sum_items, aggregate.item_count, "item totals reconcile");
+
+    // Each level's aggregate equals the sum over its own segments.
+    for level in &levels {
+        let seg_bytes: u64 = level.segments.iter().map(|s| s.used_bytes).sum();
+        let seg_items: u64 = level.segments.iter().map(|s| s.item_count).sum();
+        assert_eq!(level.used_bytes, seg_bytes, "level bytes = sum of segments");
+        assert_eq!(level.item_count, seg_items, "level items = sum of segments");
+        assert_eq!(level.segment_count, level.segments.len());
+        assert!(
+            level.segments.iter().all(|s| s.level == level.level),
+            "each segment carries its level index"
+        );
+    }
+}
+
+#[test]
+fn multiple_levels_are_reported_after_compaction() {
+    let folder = get_tmp_folder();
+    let tree = open(folder.path());
+    // Several L0 SSTs, then compact them down a level.
+    for sst in 0..4u32 {
+        for i in 0..100u32 {
+            tree.insert(key(sst * 100 + i), vec![b'v'; 100], 0);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+    tree.major_compact(u64::MAX, 1_000).expect("compact");
+    // A fresh L0 SST on top of the compacted level.
+    for i in 1000..1100u32 {
+        tree.insert(key(i), vec![b'v'; 100], 1_000);
+    }
+    tree.flush_active_memtable(1_000).expect("flush");
+
+    let levels = tree.level_segment_stats().expect("stats");
+    let populated = levels.iter().filter(|l| l.segment_count > 0).count();
+    assert!(
+        populated >= 2,
+        "expected segments across at least two levels, got {populated}"
+    );
+    // Reconciliation still holds across the multi-level layout.
+    let sum_items: u64 = levels.iter().map(|l| l.item_count).sum();
+    assert_eq!(sum_items, tree.storage_stats().expect("agg").item_count);
+}
+
+#[cfg(feature = "metrics")]
+#[test]
+fn reading_stats_does_not_scan_data_blocks() {
+    let folder = get_tmp_folder();
+    let tree = open(folder.path());
+    for sst in 0..3u32 {
+        for i in 0..100u32 {
+            tree.insert(key(sst * 100 + i), vec![b'v'; 100], 0);
+        }
+        tree.flush_active_memtable(0).expect("flush");
+    }
+    let before = tree.metrics().data_block_load_count();
+    let _ = tree.level_segment_stats().expect("stats");
+    let after = tree.metrics().data_block_load_count();
+    assert_eq!(
+        before, after,
+        "computing per-level stats must not load any data block"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `AbstractTree::level_segment_stats() -> Vec<LevelStats>`: per-LSM-level and per-segment size + entry counts + read-access stats, for tiering and erasure-coding placement decisions (which level / segment is large / hot enough to demote, EC-encode, or migrate).

## How it works

- **Size + count** (`LevelStats` / `SegmentStats`): per-level and per-segment physical on-disk bytes + entry count, derived from version metadata plus one file-size stat per segment. Never reads a data block. The per-level totals reconcile with the tree-level `StorageStats` (their sum equals the SST portion of `used_bytes` / `item_count`).
- **Access stats**: a `Relaxed` `AtomicU64` `read_count` bumped on every point-read funnel (`get` / `get_value` / `get_with_block`), plus the last-access unix time on std builds. The engine keeps a monotonic counter only; a tiering consumer derives a read-rate / EMA from the delta between successive polls (no decay constant in the engine, no hot-path float). The clock store is std-gated, so a no-std build keeps the counter and leaves last-access at zero.

## Tests

- `per_level_totals_reconcile_with_tree_aggregate` (sum across levels = tree-level total), `multiple_levels_are_reported_after_compaction`, `empty_tree_has_no_segments`, `point_reads_bump_segment_access_stats` (point reads bump the per-segment counter + last-access), and `reading_stats_does_not_scan_data_blocks` (metrics-gated: zero data-block loads). Full suite (2054), `clippy --all-features --all-targets`, no-std (`alloc`), and doctests green.

Closes #508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added `level_segment_stats` to provide detailed per-LSM-level and per-segment storage statistics (sizes and item counts), reconciling with existing storage statistics.
* Exposed new public statistics types (`LevelStats`, `SegmentStats`) for richer introspection.
* Segments now track read activity via per-segment counters and (when available) last-access timestamps, updated on relevant point reads.

## Tests
* Added integration coverage to validate stat correctness after inserts/flush/compaction and to confirm metrics builds avoid unnecessary data-block loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->