### PR TITLE
feat(columnar): column-organized SST data blocks with on-flush transpose

### DIFF
--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -142,6 +142,7 @@ pub(super) fn prepare_table_writer(
         // mechanism for the on-disk index layout).
         .use_seqno_in_index(rc.seqno_in_index)
         .use_zone_map(rc.zone_map)
+        .use_columnar(rc.columnar)
         .use_disable_cow_on_sst(rc.disable_cow_on_sst_files)
         .use_bloom_policy({
             use crate::config::FilterPolicyEntry::{Bloom, None};

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -815,6 +815,18 @@ pub struct RuntimeConfig {
     /// written with, and a missing section just means no block-skip for that SST.
     pub zone_map: bool,
 
+    /// Whether new SSTs store their data column-organized (a PAX row-group per
+    /// block) instead of row-major. The entry's intrinsic fields (user key,
+    /// seqno, value type, value) become separate per-block columns, so a scan
+    /// can read keys without decoding values and each field compresses with a
+    /// structure-aware codec. Reads reconstruct the exact entries.
+    ///
+    /// Explicit opt-in, default `false` (row-major). Takes effect on the next
+    /// compaction / flush; existing SSTs keep their original layout, and the
+    /// reader picks the layout per block from the block type, so a tree can hold
+    /// both row and columnar SSTs at once.
+    pub columnar: bool,
+
     /// Index-size threshold (bytes) at or below which an SST's block index
     /// is written single-level; above it the index spills to a two-level
     /// (partitioned) layout. A single-level index is one block reached by a
@@ -923,6 +935,7 @@ impl Default for RuntimeConfig {
             auto_heal: false,
             seqno_in_index: false,
             zone_map: false,
+            columnar: false,
             index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
             disable_cow_on_sst_files: true,
             use_reflink_for_checkpoint: true,

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -119,9 +119,13 @@ impl TryFrom<u8> for CodecId {
 /// column (the seqno column) delta-encodes well; other columns get the caller's
 /// default. More type-directed choices (dictionary on keys, FOR on small
 /// widths) join here as they land.
-const fn auto_codec(type_tag: TypeTag) -> Option<CodecId> {
-    match type_tag {
-        TypeTag::Fixed(8) => Some(CodecId::Delta),
+const fn auto_codec(column_id: u16, type_tag: TypeTag) -> Option<CodecId> {
+    // Delta suits the near-monotonic seqno column specifically. Selecting by
+    // column id (not just the 8-byte width) keeps a future unrelated Fixed(8)
+    // column (hashes, random ids) from being delta-encoded by accident, which
+    // would only inflate its size.
+    match (column_id, type_tag) {
+        (COL_SEQNO, TypeTag::Fixed(8)) => Some(CodecId::Delta),
         _ => None,
     }
 }
@@ -139,6 +143,14 @@ fn read_u64_le(chunk: &[u8]) -> u64 {
 /// Delta-encodes a fixed 8-byte integer column: each value becomes its wrapping
 /// difference from the previous one (the first from zero). Same length.
 fn delta_encode_u64(data: &[u8]) -> Vec<u8> {
+    // A Fixed(8) column's length is a multiple of 8 (Column::validate enforces
+    // it before encode). Assert it so a future caller that bypasses validation
+    // fails loudly instead of silently dropping a trailing partial chunk (the
+    // decoder already rejects the same condition).
+    debug_assert!(
+        data.len().is_multiple_of(8),
+        "delta_encode_u64: input length is not a multiple of 8"
+    );
     let mut out = Vec::with_capacity(data.len());
     let mut prev = 0u64;
     for chunk in data.chunks_exact(8) {
@@ -343,7 +355,7 @@ impl ColumnBatch {
             col.validate(self.row_count)?;
             // Pick a type-directed codec (e.g. Delta on the seqno column),
             // falling back to the caller's default; record it per column.
-            let col_codec = auto_codec(col.type_tag).unwrap_or(codec);
+            let col_codec = auto_codec(col.column_id, col.type_tag).unwrap_or(codec);
             let encoded = codec_encode(col_codec, &col.data);
             let (type_tag, width) = col.type_tag.to_wire();
             out.extend_from_slice(&col.column_id.to_le_bytes());
@@ -733,6 +745,27 @@ mod tests {
         assert_eq!(
             decoded.columns[0].data, data,
             "delta column must round-trip"
+        );
+    }
+
+    #[test]
+    fn auto_codec_is_delta_only_for_the_seqno_column() {
+        // A fixed-8 column that is not the seqno column keeps the default codec
+        // (Plain): delta-encoding a non-monotonic column would only inflate it.
+        let batch = ColumnBatch {
+            row_count: 2,
+            columns: vec![Column {
+                column_id: 99, // not the intrinsic seqno column
+                type_tag: TypeTag::Fixed(8),
+                validity: None,
+                data: vec![0u8; 16],
+            }],
+        };
+        let encoded = batch.encode(CodecId::Plain).expect("encode");
+        assert_eq!(
+            encoded[12],
+            u8::from(CodecId::Plain),
+            "a non-seqno fixed-8 column must not auto-select Delta"
         );
     }
 

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -177,19 +177,28 @@ fn delta_decode_u64(data: &[u8]) -> Result<Vec<u8>> {
     Ok(out)
 }
 
-/// Encodes a column's decoded bytes under `codec`.
-fn codec_encode(codec: CodecId, data: &[u8]) -> Vec<u8> {
+/// Encodes a column's decoded bytes under `codec`. Delta requires a `Fixed(8)`
+/// column (it processes whole 8-byte values); applying it to any other type is
+/// rejected rather than silently truncating a partial trailing value.
+fn codec_encode(codec: CodecId, type_tag: TypeTag, data: &[u8]) -> Result<Vec<u8>> {
     match codec {
-        CodecId::Plain => data.to_vec(),
-        CodecId::Delta => delta_encode_u64(data),
+        CodecId::Plain => Ok(data.to_vec()),
+        CodecId::Delta if matches!(type_tag, TypeTag::Fixed(8)) => Ok(delta_encode_u64(data)),
+        CodecId::Delta => Err(Error::InvalidHeader(
+            "columnar: delta codec requires a fixed-8 column",
+        )),
     }
 }
 
-/// Decodes a column's stored bytes under `codec` back to the logical bytes.
-fn codec_decode(codec: CodecId, data: &[u8]) -> Result<Vec<u8>> {
+/// Decodes a column's stored bytes under `codec` back to the logical bytes,
+/// rejecting Delta on a non-`Fixed(8)` column (the inverse of [`codec_encode`]).
+fn codec_decode(codec: CodecId, type_tag: TypeTag, data: &[u8]) -> Result<Vec<u8>> {
     match codec {
         CodecId::Plain => Ok(data.to_vec()),
-        CodecId::Delta => delta_decode_u64(data),
+        CodecId::Delta if matches!(type_tag, TypeTag::Fixed(8)) => delta_decode_u64(data),
+        CodecId::Delta => Err(Error::InvalidHeader(
+            "columnar: delta codec requires a fixed-8 column",
+        )),
     }
 }
 
@@ -356,7 +365,7 @@ impl ColumnBatch {
             // Pick a type-directed codec (e.g. Delta on the seqno column),
             // falling back to the caller's default; record it per column.
             let col_codec = auto_codec(col.column_id, col.type_tag).unwrap_or(codec);
-            let encoded = codec_encode(col_codec, &col.data);
+            let encoded = codec_encode(col_codec, col.type_tag, &col.data)?;
             let (type_tag, width) = col.type_tag.to_wire();
             out.extend_from_slice(&col.column_id.to_le_bytes());
             out.push(type_tag);
@@ -421,7 +430,7 @@ impl ColumnBatch {
             let raw = cur.read_bytes(data_len)?;
             // Restore the column's logical bytes from its stored codec form
             // (Plain is identity; Delta runs the prefix-sum).
-            let data = codec_decode(codec, raw)?;
+            let data = codec_decode(codec, type_tag, raw)?;
             let column = Column {
                 column_id,
                 type_tag,
@@ -767,6 +776,37 @@ mod tests {
             u8::from(CodecId::Plain),
             "a non-seqno fixed-8 column must not auto-select Delta"
         );
+    }
+
+    #[test]
+    fn encode_rejects_delta_on_a_non_fixed8_column() {
+        // Forcing Delta on a Bytes column (via the fallback codec) is rejected
+        // rather than silently truncating its bytes.
+        let mut bytes_data = Vec::new();
+        bytes_data.extend_from_slice(&0u32.to_le_bytes());
+        bytes_data.extend_from_slice(&3u32.to_le_bytes());
+        bytes_data.extend_from_slice(b"abc");
+        let batch = ColumnBatch {
+            row_count: 1,
+            columns: vec![Column {
+                column_id: 50,
+                type_tag: TypeTag::Bytes,
+                validity: None,
+                data: bytes_data,
+            }],
+        };
+        assert!(batch.encode(CodecId::Delta).is_err());
+    }
+
+    #[test]
+    fn from_columnar_block_rejects_a_zero_row_block() {
+        // A zero-row columnar block is corrupt (the writer never spills empty);
+        // reconstructing it must error, not panic in the row encoder.
+        let empty = entries_to_column_batch(&[])
+            .expect("transpose")
+            .encode(CodecId::Plain)
+            .expect("encode");
+        assert!(crate::table::data_block::DataBlock::from_columnar_block(&empty, 16).is_err());
     }
 
     #[test]

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -88,12 +88,17 @@ impl TypeTag {
 pub enum CodecId {
     /// Identity: the column bytes are stored verbatim.
     Plain,
+    /// Delta: each fixed-width integer is stored as its wrapping difference from
+    /// the previous one. A near-monotonic column (e.g. the seqno column) becomes
+    /// small deltas that the terminal byte compressor squeezes far better.
+    Delta,
 }
 
 impl From<CodecId> for u8 {
     fn from(c: CodecId) -> Self {
         match c {
             CodecId::Plain => 0,
+            CodecId::Delta => 1,
         }
     }
 }
@@ -104,8 +109,75 @@ impl TryFrom<u8> for CodecId {
     fn try_from(v: u8) -> Result<Self> {
         match v {
             0 => Ok(Self::Plain),
+            1 => Ok(Self::Delta),
             _ => Err(Error::InvalidTag(("ColumnCodecId", v))),
         }
+    }
+}
+
+/// Picks a logical codec for a column from its physical type. A fixed 8-byte
+/// column (the seqno column) delta-encodes well; other columns get the caller's
+/// default. More type-directed choices (dictionary on keys, FOR on small
+/// widths) join here as they land.
+const fn auto_codec(type_tag: TypeTag) -> Option<CodecId> {
+    match type_tag {
+        TypeTag::Fixed(8) => Some(CodecId::Delta),
+        _ => None,
+    }
+}
+
+/// Reads an 8-byte little-endian chunk as a `u64` (the caller passes a
+/// `chunks_exact(8)` slice, so no indexing or fallible conversion is needed).
+fn read_u64_le(chunk: &[u8]) -> u64 {
+    let mut arr = [0u8; 8];
+    for (dst, &src) in arr.iter_mut().zip(chunk) {
+        *dst = src;
+    }
+    u64::from_le_bytes(arr)
+}
+
+/// Delta-encodes a fixed 8-byte integer column: each value becomes its wrapping
+/// difference from the previous one (the first from zero). Same length.
+fn delta_encode_u64(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    let mut prev = 0u64;
+    for chunk in data.chunks_exact(8) {
+        let v = read_u64_le(chunk);
+        out.extend_from_slice(&v.wrapping_sub(prev).to_le_bytes());
+        prev = v;
+    }
+    out
+}
+
+/// Inverse of [`delta_encode_u64`]: a running wrapping sum of the deltas.
+fn delta_decode_u64(data: &[u8]) -> Result<Vec<u8>> {
+    if !data.len().is_multiple_of(8) {
+        return Err(Error::InvalidHeader(
+            "columnar: delta column length is not a multiple of 8",
+        ));
+    }
+    let mut out = Vec::with_capacity(data.len());
+    let mut acc = 0u64;
+    for chunk in data.chunks_exact(8) {
+        acc = acc.wrapping_add(read_u64_le(chunk));
+        out.extend_from_slice(&acc.to_le_bytes());
+    }
+    Ok(out)
+}
+
+/// Encodes a column's decoded bytes under `codec`.
+fn codec_encode(codec: CodecId, data: &[u8]) -> Vec<u8> {
+    match codec {
+        CodecId::Plain => data.to_vec(),
+        CodecId::Delta => delta_encode_u64(data),
+    }
+}
+
+/// Decodes a column's stored bytes under `codec` back to the logical bytes.
+fn codec_decode(codec: CodecId, data: &[u8]) -> Result<Vec<u8>> {
+    match codec {
+        CodecId::Plain => Ok(data.to_vec()),
+        CodecId::Delta => delta_decode_u64(data),
     }
 }
 
@@ -269,18 +341,21 @@ impl ColumnBatch {
         out.extend_from_slice(&(self.columns.len() as u32).to_le_bytes());
         for col in &self.columns {
             col.validate(self.row_count)?;
+            // Pick a type-directed codec (e.g. Delta on the seqno column),
+            // falling back to the caller's default; record it per column.
+            let col_codec = auto_codec(col.type_tag).unwrap_or(codec);
+            let encoded = codec_encode(col_codec, &col.data);
             let (type_tag, width) = col.type_tag.to_wire();
             out.extend_from_slice(&col.column_id.to_le_bytes());
             out.push(type_tag);
             out.push(width);
-            out.push(codec.into());
+            out.push(col_codec.into());
             out.push(u8::from(col.validity.is_some()));
-            // Plain codec: stored bytes equal the decoded column bytes.
-            out.extend_from_slice(&(col.data.len() as u32).to_le_bytes());
+            out.extend_from_slice(&(encoded.len() as u32).to_le_bytes());
             if let Some(v) = &col.validity {
                 out.extend_from_slice(v);
             }
-            out.extend_from_slice(&col.data);
+            out.extend_from_slice(&encoded);
         }
         Ok(out)
     }
@@ -331,10 +406,10 @@ impl ColumnBatch {
             } else {
                 None
             };
-            let data = cur.read_bytes(data_len)?.to_vec();
-            // Plain codec is the identity, so the stored bytes are already the
-            // decoded column bytes; structure-aware codecs decode here.
-            let CodecId::Plain = codec;
+            let raw = cur.read_bytes(data_len)?;
+            // Restore the column's logical bytes from its stored codec form
+            // (Plain is identity; Delta runs the prefix-sum).
+            let data = codec_decode(codec, raw)?;
             let column = Column {
                 column_id,
                 type_tag,
@@ -633,6 +708,32 @@ mod tests {
             assert!(x.key.value_type == y.key.value_type, "value_type mismatch");
             assert_eq!(x.value.as_ref(), y.value.as_ref());
         }
+    }
+
+    #[test]
+    fn delta_codec_round_trips_fixed8_column() {
+        // A fixed-8 (u64) column auto-selects Delta and must round-trip exactly,
+        // including a repeat and a decrease (wrapping delta).
+        let seqnos: [u64; 5] = [100, 105, 105, 200, 199];
+        let data: Vec<u8> = seqnos.iter().flat_map(|s| s.to_le_bytes()).collect();
+        let batch = ColumnBatch {
+            row_count: 5,
+            columns: vec![Column {
+                column_id: 1,
+                type_tag: TypeTag::Fixed(8),
+                validity: None,
+                data: data.clone(),
+            }],
+        };
+        let encoded = batch.encode(CodecId::Plain).expect("encode");
+        // The codec byte (row_count 4 + col_count 4 + id 2 + type 1 + width 1 =
+        // offset 12) must record Delta, auto-selected for the fixed-8 column.
+        assert_eq!(encoded[12], u8::from(CodecId::Delta));
+        let decoded = ColumnBatch::decode(&encoded).expect("decode");
+        assert_eq!(
+            decoded.columns[0].data, data,
+            "delta column must round-trip"
+        );
     }
 
     #[test]

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -474,6 +474,14 @@ impl DataBlock {
     ) -> crate::Result<Self> {
         let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
         let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+        // The writer never spills an empty block, so a zero-row columnar block is
+        // corrupt; reject it before the row encoder, which has a non-empty
+        // precondition and would otherwise panic.
+        if entries.is_empty() {
+            return Err(crate::Error::InvalidHeader(
+                "columnar: empty reconstructed data block",
+            ));
+        }
         let mut buf = Vec::new();
         Self::encode_into(&mut buf, &entries, restart_interval, 0.0)?;
         let len = u32::try_from(buf.len())

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -462,6 +462,39 @@ impl DataBlock {
     ///
     /// Returns [`crate::Error::InvalidTrailer`] if a footer-bearing block's
     /// footer is structurally malformed.
+    /// Reconstructs a row-major data block from a loaded columnar (PAX) block:
+    /// decode the `ColumnBatch`, rebuild the entries, and re-encode them
+    /// row-major in memory so every existing row read path is reused unchanged.
+    /// The caller must have loaded `block` with `BlockType::Columnar` (its AAD /
+    /// descriptor), so this is shared by both the random-access and scan paths.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn from_columnar_block(
+        block_data: &[u8],
+        restart_interval: u8,
+    ) -> crate::Result<Self> {
+        let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
+        let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+        let mut buf = Vec::new();
+        Self::encode_into(&mut buf, &entries, restart_interval, 0.0)?;
+        let len = u32::try_from(buf.len())
+            .map_err(|_| crate::Error::InvalidHeader("columnar: re-encoded block exceeds u32"))?;
+        let header = crate::table::block::Header {
+            block_type: crate::table::block::BlockType::Data,
+            block_flags: 0,
+            checksum: crate::checksum::Checksum::from_raw(crate::hash::hash128(&buf)),
+            data_length: len,
+            uncompressed_length: len,
+        };
+        // Columnar blocks carry no per-KV checksum footer.
+        Self::from_loaded(
+            crate::table::block::Block {
+                header,
+                data: crate::Slice::from(buf),
+            },
+            false,
+        )
+    }
+
     pub(crate) fn from_loaded(block: Block, has_kv_footer: bool) -> crate::Result<Self> {
         use crate::table::block::kv_checksum;
 

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -148,6 +148,10 @@ fn create_data_block_reader(
     OwnedDataBlockIter::try_new(block, |b| b.try_iter(comparator))
 }
 
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "each bool is an independent per-SST read-path flag (kv footer, columnar, init, poisoned), not a state enum"
+)]
 pub struct Iter {
     table_id: GlobalTableId,
     path: Arc<PathBuf>,
@@ -187,6 +191,10 @@ pub struct Iter {
     #[cfg(feature = "zstd")]
     data_block_restart_interval: u8,
 
+    /// Whether this SST's data blocks are columnar (PAX); when set, each block is
+    /// read as `BlockType::Columnar` and reconstructed into a row block.
+    columnar: bool,
+
     index_initialized: bool,
 
     lo_offset: BlockOffset,
@@ -223,6 +231,7 @@ impl Iter {
         ecc: Option<crate::table::block::EccParams>,
         heal_hints: Option<Arc<crate::heal_hints::HealHints>>,
         has_kv_footer: bool,
+        columnar: bool,
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
         #[cfg(feature = "zstd")] block_layout: crate::table::block_layout::BlockLayoutMap,
@@ -243,6 +252,7 @@ impl Iter {
             ecc,
             heal_hints,
             has_kv_footer,
+            columnar,
             #[cfg(zstd_any)]
             zstd_dictionary,
             comparator,
@@ -266,6 +276,47 @@ impl Iter {
             #[cfg(feature = "metrics")]
             metrics,
         }
+    }
+
+    /// Loads and resolves a data block by handle, dispatching on the SST layout:
+    /// a columnar SST's block is read as `BlockType::Columnar` and reconstructed
+    /// into a row-major block; a row SST's block is loaded directly. The
+    /// reconstructed block is in-memory, so a fixed restart interval yields a
+    /// correct, iterable block regardless of the SST's recorded value.
+    fn load_and_resolve(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+        let block_type = if self.columnar {
+            crate::table::block::BlockType::Columnar
+        } else {
+            crate::table::block::BlockType::Data
+        };
+        let raw = load_block(
+            self.table_id,
+            &self.path,
+            &self.file_accessor,
+            &self.cache,
+            handle,
+            block_type,
+            self.compression,
+            self.encryption.as_deref(),
+            self.ecc,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+            self.heal_hints.as_ref().map(AsRef::as_ref),
+            #[cfg(feature = "metrics")]
+            &self.metrics,
+        )?;
+        if self.columnar {
+            #[cfg(feature = "columnar")]
+            {
+                const REENCODE_RESTART_INTERVAL: u8 = 16;
+                return DataBlock::from_columnar_block(&raw.data, REENCODE_RESTART_INTERVAL);
+            }
+            #[cfg(not(feature = "columnar"))]
+            {
+                return Err(crate::Error::FeatureUnsupported("columnar"));
+            }
+        }
+        DataBlock::from_loaded(raw, self.has_kv_footer)
     }
 
     pub fn set_lower_bound(&mut self, bound: Bound) {
@@ -330,6 +381,10 @@ impl Iter {
         if !partial_decode_enabled()
             || !matches!(self.compression, CompressionType::Zstd(_))
             || self.encryption.is_some()
+            // Columnar blocks have a different on-disk shape and are
+            // reconstructed whole, so the inner-block partial decode never
+            // applies to them.
+            || self.columnar
         {
             return Ok(None);
         }
@@ -591,26 +646,7 @@ impl Iterator for Iter {
             let block = if let Some(db) = partial {
                 db
             } else {
-                let raw = match load_block(
-                    self.table_id,
-                    &self.path,
-                    &self.file_accessor,
-                    &self.cache,
-                    &BlockHandle::new(handle.offset(), handle.size()),
-                    crate::table::block::BlockType::Data,
-                    self.compression,
-                    self.encryption.as_deref(),
-                    self.ecc,
-                    #[cfg(zstd_any)]
-                    self.zstd_dictionary.as_deref(),
-                    self.heal_hints.as_ref().map(AsRef::as_ref),
-                    #[cfg(feature = "metrics")]
-                    &self.metrics,
-                ) {
-                    Ok(b) => b,
-                    Err(e) => return self.poison(e),
-                };
-                match DataBlock::from_loaded(raw, self.has_kv_footer) {
+                match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
                     Ok(b) => b,
                     Err(e) => return self.poison(e),
                 }
@@ -738,26 +774,7 @@ impl DoubleEndedIterator for Iter {
             let block = if let Some(db) = partial {
                 db
             } else {
-                let raw = match load_block(
-                    self.table_id,
-                    &self.path,
-                    &self.file_accessor,
-                    &self.cache,
-                    &BlockHandle::new(handle.offset(), handle.size()),
-                    crate::table::block::BlockType::Data,
-                    self.compression,
-                    self.encryption.as_deref(),
-                    self.ecc,
-                    #[cfg(zstd_any)]
-                    self.zstd_dictionary.as_deref(),
-                    self.heal_hints.as_ref().map(AsRef::as_ref),
-                    #[cfg(feature = "metrics")]
-                    &self.metrics,
-                ) {
-                    Ok(b) => b,
-                    Err(e) => return self.poison(e),
-                };
-                match DataBlock::from_loaded(raw, self.has_kv_footer) {
+                match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
                     Ok(b) => b,
                     Err(e) => return self.poison(e),
                 }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -113,6 +113,12 @@ pub struct ParsedMeta {
     /// positional restart index when partial-decoding a block on the lazy read
     /// path (the restart heads sit every `data_block_restart_interval` entries).
     pub data_block_restart_interval: u8,
+
+    /// Whether this SST's data blocks are column-organized (PAX) rather than
+    /// row-major. Read from the optional `descriptor#columnar` property;
+    /// defaults to `false` for SSTs written without it (row-major). The reader
+    /// reconstructs row entries from a columnar block on load.
+    pub columnar: bool,
 }
 
 macro_rules! read_u8 {
@@ -270,6 +276,12 @@ impl ParsedMeta {
         // index when partial-decoding a block (lazy read path).
         let data_block_restart_interval =
             validated_restart_interval_index(read_u8!(block, b"restart_interval#data", &cmp))?;
+
+        // Optional layout descriptor: absent (older / row-major SSTs) means
+        // row-major; a non-zero byte means column-organized data blocks.
+        let columnar = block
+            .point_read(b"descriptor#columnar", SeqNo::MAX, &cmp)?
+            .is_some_and(|v| v.value.first().copied().unwrap_or(0) != 0);
 
         let id = read_u64!(block, b"table_id", &cmp);
         // Cross-check the payload's stored id against the caller's durable
@@ -450,6 +462,7 @@ impl ParsedMeta {
             ecc_params,
             ecc_unrecognized,
             data_block_restart_interval,
+            columnar,
         })
     }
 }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -278,10 +278,15 @@ impl ParsedMeta {
             validated_restart_interval_index(read_u8!(block, b"restart_interval#data", &cmp))?;
 
         // Optional layout descriptor: absent (older / row-major SSTs) means
-        // row-major; a non-zero byte means column-organized data blocks.
-        let columnar = block
-            .point_read(b"descriptor#columnar", SeqNo::MAX, &cmp)?
-            .is_some_and(|v| v.value.first().copied().unwrap_or(0) != 0);
+        // row-major; otherwise exactly one byte, non-zero meaning columnar. An
+        // empty or overlong payload is on-disk corruption, rejected here.
+        let columnar = match block.point_read(b"descriptor#columnar", SeqNo::MAX, &cmp)? {
+            None => false,
+            Some(v) => match v.value.as_ref() {
+                [b] => *b != 0,
+                _ => return Err(crate::Error::InvalidHeader("TableMeta")),
+            },
+        };
 
         let id = read_u64!(block, b"table_id", &cmp);
         // Cross-check the payload's stored id against the caller's durable

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -276,6 +276,12 @@ impl Table {
     }
 
     fn load_data_block(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+        // Columnar SSTs store each data block as a PAX `ColumnBatch`; reconstruct
+        // the row entries on load so every row read path works unchanged.
+        #[cfg(feature = "columnar")]
+        if self.metadata.columnar {
+            return self.load_columnar_data_block(handle);
+        }
         // `from_loaded` transparently strips the per-KV checksum footer when
         // this SST carries one. Footer presence is a per-SST property
         // (`kv_checksum_algo`), not a per-block header flag — data blocks omit
@@ -289,6 +295,23 @@ impl Table {
             self.zstd_dictionary.as_deref(),
         )
         .and_then(|block| DataBlock::from_loaded(block, has_kv_footer))
+    }
+
+    /// Loads a columnar data block and reconstructs it as a row-major
+    /// [`DataBlock`]: decode the `ColumnBatch`, rebuild the entries, and
+    /// re-encode them row-major in memory so the existing point-read / iterator
+    /// machinery is reused verbatim. The native column-projection read path
+    /// (decode only the referenced columns) is a later optimization.
+    #[cfg(feature = "columnar")]
+    fn load_columnar_data_block(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+        let block = self.load_block(
+            handle,
+            BlockType::Columnar,
+            self.metadata.data_block_compression,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        DataBlock::from_columnar_block(&block.data, self.metadata.data_block_restart_interval)
     }
 
     /// Returns the (possibly compressed) file size.
@@ -1215,6 +1238,8 @@ impl Table {
             self.zstd_dictionary.clone(),
             self.comparator.clone(),
             self.metadata.id,
+            self.metadata.columnar,
+            self.metadata.data_block_restart_interval,
         )
     }
 
@@ -1380,6 +1405,7 @@ impl Table {
             self.metadata.ecc_params,
             self.heal_hints.get().cloned(),
             self.metadata.kv_checksum_algo.is_some(),
+            self.metadata.columnar,
             #[cfg(zstd_any)]
             self.zstd_dictionary.clone(),
             self.comparator.clone(),

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -115,6 +115,10 @@ pub struct MultiWriter {
     /// flush / compaction uniformly emits (or omits) the `zone_map` section.
     use_zone_map: bool,
 
+    /// Preserved across writer rotation so every successor [`Writer`] of one
+    /// flush / compaction uniformly writes columnar (or row-major) data blocks.
+    use_columnar: bool,
+
     /// When `true`, each output SST has per-file copy-on-write cleared at
     /// creation (Btrfs `FS_NOCOW_FL`) so write-once SSTs avoid the
     /// copy-on-write fragmentation penalty. Preserved across rotations so every successor
@@ -195,6 +199,7 @@ impl MultiWriter {
             kv_checksum: None,
             use_seqno_in_index: false,
             use_zone_map: false,
+            use_columnar: false,
             disable_cow_on_sst: false,
             locator_entry: crate::config::LocatorPolicyEntry::None,
 
@@ -561,6 +566,13 @@ impl MultiWriter {
         self
     }
 
+    #[must_use]
+    pub fn use_columnar(mut self, columnar: bool) -> Self {
+        self.use_columnar = columnar;
+        self.writer = self.writer.use_columnar(columnar);
+        self
+    }
+
     /// Wires the resolved retrieval-ribbon locator policy entry through to the
     /// inner [`Writer`] and preserves it across rotations, so every successor
     /// table in the run emits its own per-SST locator section (or none, when
@@ -626,6 +638,7 @@ impl MultiWriter {
         }
         new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
         new_writer = new_writer.use_zone_map(self.use_zone_map);
+        new_writer = new_writer.use_columnar(self.use_columnar);
         new_writer = new_writer.use_disable_cow(self.disable_cow_on_sst);
         new_writer = new_writer.use_locator(self.locator_entry);
 

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -44,6 +44,14 @@ pub struct Scanner {
     /// Table id of the SST being scanned; threaded through to
     /// per-block reads via `BlockIdentity`.
     table_id: crate::TableId,
+
+    /// Whether this SST stores columnar (PAX) data blocks. When set, each
+    /// fetched block is read as `BlockType::Columnar` and reconstructed into a
+    /// row-major block so the scan iterator is unchanged.
+    columnar: bool,
+    /// Data-block restart interval, used to re-encode a reconstructed columnar
+    /// block (matches the value the SST recorded).
+    restart_interval: u8,
 }
 
 impl Scanner {
@@ -66,6 +74,8 @@ impl Scanner {
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
         table_id: crate::TableId,
+        columnar: bool,
+        restart_interval: u8,
     ) -> crate::Result<Self> {
         // 2 MiB buffer matches RocksDB's `compaction_readahead_size`
         // default and is large enough that the kernel can fold the
@@ -95,6 +105,8 @@ impl Scanner {
             encryption.as_deref(),
             ecc,
             has_kv_footer,
+            columnar,
+            restart_interval,
             #[cfg(zstd_any)]
             zstd_dictionary.as_deref(),
         )?;
@@ -120,9 +132,15 @@ impl Scanner {
             zstd_dictionary,
 
             table_id,
+            columnar,
+            restart_interval,
         })
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "per-block read threads each SST-level read parameter through; a config struct would add indirection without removing a caller decision"
+    )]
     fn fetch_next_block(
         reader: &mut BufReader<Box<dyn FsFile>>,
         table_id: crate::TableId,
@@ -130,13 +148,22 @@ impl Scanner {
         encryption: Option<&dyn EncryptionProvider>,
         ecc: Option<crate::table::block::EccParams>,
         has_kv_footer: bool,
+        columnar: bool,
+        restart_interval: u8,
         #[cfg(zstd_any)] zstd_dict: Option<&crate::compression::ZstdDictionary>,
     ) -> crate::Result<DataBlock> {
+        // A columnar SST's blocks are tagged (and AAD-bound) as Columnar; read
+        // them under that identity so verification / decryption matches.
+        let block_type = if columnar {
+            BlockType::Columnar
+        } else {
+            BlockType::Data
+        };
         let block = Block::from_reader(
             reader,
             crate::table::block::BlockIdentity {
                 table_id,
-                block_type: BlockType::Data,
+                block_type,
                 dict_id: compression.dict_id(),
                 window_log: 0,
             },
@@ -162,10 +189,13 @@ impl Scanner {
 
         match block {
             Ok(block) => {
-                // A data block is always BlockType::Data; `from_loaded`
-                // strips the per-KV checksum footer when this SST carries one
-                // (per-SST `has_kv_footer`, since data blocks omit the byte),
-                // so the scan path is unchanged.
+                // Columnar blocks are reconstructed into row blocks; a row block
+                // must be BlockType::Data. `from_loaded` strips the per-KV
+                // checksum footer when this SST carries one (per-SST
+                // `has_kv_footer`, since data blocks omit the byte).
+                if columnar {
+                    return Self::reconstruct_columnar(&block, restart_interval);
+                }
                 if block.header.block_type != BlockType::Data {
                     return Err(crate::Error::InvalidTag((
                         "BlockType",
@@ -176,6 +206,21 @@ impl Scanner {
                 DataBlock::from_loaded(block, has_kv_footer)
             }
             Err(e) => Err(e),
+        }
+    }
+
+    /// Reconstructs a row-major [`DataBlock`] from a loaded columnar block. With
+    /// the `columnar` feature this re-encodes the PAX block; without the feature
+    /// a columnar SST cannot be read.
+    fn reconstruct_columnar(block: &Block, restart_interval: u8) -> crate::Result<DataBlock> {
+        #[cfg(feature = "columnar")]
+        {
+            DataBlock::from_columnar_block(&block.data, restart_interval)
+        }
+        #[cfg(not(feature = "columnar"))]
+        {
+            let _ = (block, restart_interval);
+            Err(crate::Error::FeatureUnsupported("columnar"))
         }
     }
 }
@@ -202,6 +247,8 @@ impl Iterator for Scanner {
                 self.encryption.as_deref(),
                 self.ecc,
                 self.has_kv_footer,
+                self.columnar,
+                self.restart_interval,
                 #[cfg(zstd_any)]
                 self.zstd_dictionary.as_deref(),
             ) {

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1610,6 +1610,7 @@ impl Writer {
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
+            use_columnar: self.use_columnar,
             range_tombstone_count,
             created_at_nanos,
         };
@@ -1828,6 +1829,7 @@ struct MetaSectionParams<'a> {
     data_block_restart_interval: u8,
     index_block_restart_interval: u8,
     initial_level: u8,
+    use_columnar: bool,
     range_tombstone_count: u64,
     /// `created_at` snapshot taken once in `finish()`. Both MID and
     /// TAIL writes consume this same value; generating it inside
@@ -1963,6 +1965,11 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
             "data_block_hash_ratio",
             &p.data_block_hash_ratio.to_le_bytes(),
         ),
+        // Per-SST layout descriptor: whether every data block in this table is
+        // column-organized (PAX) rather than row-major. One byte for the whole
+        // homogeneous SST, so the read path learns the layout from the
+        // descriptor instead of inspecting a block header.
+        meta("descriptor#columnar", &[u8::from(p.use_columnar)]),
         // Per-SST transform descriptor: per-KV-footer presence + algorithm
         // as one byte (0 = no footer, else 1 + algo wire tag). Lets the
         // reader know the whole table's footer state without inspecting any

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -694,7 +694,11 @@ impl Writer {
     #[must_use]
     pub fn use_columnar(mut self, columnar: bool) -> Self {
         self.assert_not_started("use_columnar");
-        self.use_columnar = columnar;
+        // Without the `columnar` feature the spill branch is compiled out, so a
+        // requested columnar layout cannot be honored. Drop the flag here so the
+        // persisted `descriptor#columnar` never advertises a layout the blocks
+        // do not have (which would misroute the reader's block identity).
+        self.use_columnar = columnar && cfg!(feature = "columnar");
         self
     }
 
@@ -1601,11 +1605,18 @@ impl Writer {
             // table's data blocks (homogeneous SST), so it doubles as
             // the per-SST descriptor value — identical to the per-block
             // decision `spill_block` makes via the same expression.
-            kv_checksum_algo: self.kv_checksum.and_then(|(policy, algo)| {
-                policy
-                    .applies(self.initial_level, self.table_id)
-                    .then_some(algo)
-            }),
+            // Columnar blocks carry no per-KV footer (spill_columnar_block writes
+            // no footer flags), so a columnar SST must report no footer here
+            // rather than advertise one its blocks omit.
+            kv_checksum_algo: if self.use_columnar {
+                None
+            } else {
+                self.kv_checksum.and_then(|(policy, algo)| {
+                    policy
+                        .applies(self.initial_level, self.table_id)
+                        .then_some(algo)
+                })
+            },
             data_block_hash_ratio: self.data_block_hash_ratio,
             data_block_restart_interval: self.data_block_restart_interval,
             index_block_restart_interval: self.index_block_restart_interval,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -230,6 +230,14 @@ pub struct Writer {
     /// [`Self::use_zone_map`] before the first key is added.
     use_zone_map: bool,
 
+    /// Columnar opt-in. When `true`, each spilled data block stores its entries
+    /// column-organized (a PAX row-group of the intrinsic fields) instead of
+    /// row-major, tagged [`BlockType::Columnar`](crate::table::block::BlockType::Columnar)
+    /// so the reader reconstructs the exact entries. Default `false` (row-major).
+    /// Caller wires the live runtime config in via [`Self::use_columnar`] before
+    /// the first key is added.
+    use_columnar: bool,
+
     /// Pre-trained zstd dictionary for dictionary compression
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
@@ -350,6 +358,7 @@ impl Writer {
             kv_checksum: None,
             use_seqno_in_index: false,
             use_zone_map: false,
+            use_columnar: false,
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -680,6 +689,15 @@ impl Writer {
         self
     }
 
+    /// Enables column-organized data blocks (see [`Self::use_columnar`] field).
+    /// Must be set before the first key is written.
+    #[must_use]
+    pub fn use_columnar(mut self, columnar: bool) -> Self {
+        self.assert_not_started("use_columnar");
+        self.use_columnar = columnar;
+        self
+    }
+
     /// Wires the resolved per-level retrieval-ribbon locator policy entry.
     ///
     /// `Enabled` makes the writer accumulate a per-key `(block_id, slot)`
@@ -883,6 +901,20 @@ impl Writer {
             .then(|| self.chunk.first().map(|e| e.key.user_key.clone()))
             .flatten();
 
+        // Columnar layout: transpose the chunk into a PAX block rather than a
+        // row-major data block. Serial path only for now (the parallel pipeline
+        // assumes a Data block); columnar is opt-in.
+        #[cfg(feature = "columnar")]
+        if self.use_columnar {
+            return self.spill_columnar_block(
+                last_key,
+                last_seqno,
+                seqno_bounds,
+                item_count,
+                zone_block_min,
+            );
+        }
+
         // Decide per-block whether to emit the per-KV checksum footer.
         // `kv_checksum` is None unless the tree opted in; even then only blocks
         // whose (level, table_id) satisfy the policy carry the footer. A
@@ -987,6 +1019,61 @@ impl Writer {
         self.chunk.clear();
         self.chunk_size = 0;
 
+        Ok(())
+    }
+
+    /// Spills the current chunk as a columnar (PAX) block: transpose the entries
+    /// into a `ColumnBatch`, encode it, and write + register it like a data block
+    /// (same index handle, seqno bounds, and zone-map key range). Serial path
+    /// only; the parallel pipeline keeps producing row blocks.
+    #[cfg(feature = "columnar")]
+    fn spill_columnar_block(
+        &mut self,
+        last_key: crate::UserKey,
+        last_seqno: crate::SeqNo,
+        seqno_bounds: Option<(u64, u64)>,
+        item_count: usize,
+        zone_block_min: Option<crate::UserKey>,
+    ) -> crate::Result<()> {
+        let batch = crate::table::columnar::entries_to_column_batch(&self.chunk)?;
+        let payload = batch.encode(crate::table::columnar::CodecId::Plain)?;
+        let transform = {
+            let t = crate::table::block::BlockTransform::from_parts(
+                self.data_block_compression,
+                self.encryption.as_deref(),
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+            )?;
+            if let Some(ecc) = self.ecc {
+                t.with_ecc(ecc)
+            } else {
+                t
+            }
+        };
+        let mut prepared = Block::prepare_with_flags(
+            &payload,
+            super::block::BlockIdentity {
+                table_id: self.table_id,
+                block_type: super::block::BlockType::Columnar,
+                dict_id: self.data_block_compression.dict_id(),
+                window_log: 0,
+            },
+            &transform,
+            0, // columnar blocks carry no per-KV checksum footer
+        )?;
+        let layout = core::mem::take(&mut prepared.layout);
+        let header = prepared.write_to(&mut self.file_writer)?;
+        self.register_written_block(
+            header,
+            layout,
+            last_key,
+            last_seqno,
+            seqno_bounds,
+            item_count,
+            zone_block_min,
+        )?;
+        self.chunk.clear();
+        self.chunk_size = 0;
         Ok(())
     }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -741,6 +741,7 @@ impl AbstractTree for Tree {
 
         table_writer = table_writer.use_seqno_in_index(rc.seqno_in_index);
         table_writer = table_writer.use_zone_map(rc.zone_map);
+        table_writer = table_writer.use_columnar(rc.columnar);
         table_writer = table_writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         // `Off` (default) emits no per-KV footer and leaves the data-block
         // payload encoding unchanged (the V5 header carries a block_flags byte

--- a/tests/columnar_roundtrip.rs
+++ b/tests/columnar_roundtrip.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end round trip for a columnar tree: entries written column-organized
+//! on flush are read back exactly through the normal point-read and range
+//! paths, and tombstones still hide rows. The reader reconstructs the row
+//! entries from each PAX block on load, so the existing read machinery is
+//! reused unchanged.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::{AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, get_tmp_folder};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn value(i: u32) -> Vec<u8> {
+    format!("value-{i}-payload").into_bytes()
+}
+
+fn open_columnar(folder: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+    tree
+}
+
+#[test]
+fn columnar_tree_round_trips_through_flush() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 500u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    // Every key reads back its exact value through the columnar -> row reader.
+    for i in 0..n {
+        let got = tree
+            .get(key(i), SeqNo::MAX)
+            .expect("get")
+            .expect("key present");
+        assert_eq!(&*got, value(i).as_slice(), "value mismatch for key {i}");
+    }
+
+    // A full range scan returns every row.
+    let scanned = tree.range(key(0)..key(999_999), SeqNo::MAX, None).count();
+    assert_eq!(scanned, n as usize, "range must see every row");
+}
+
+#[test]
+fn columnar_survives_major_compaction() {
+    // Two flushes produce two columnar SSTs; a major compaction merges them
+    // (reading columnar blocks through the scan path and re-writing columnar
+    // blocks through the compaction writer). Every row must survive.
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    for i in 0..300u32 {
+        tree.insert(key(i), value(i), 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    for i in 300..600u32 {
+        tree.insert(key(i), value(i), 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 0).expect("compact");
+
+    for i in 0..600u32 {
+        let got = tree
+            .get(key(i), SeqNo::MAX)
+            .expect("get")
+            .expect("key present after compaction");
+        assert_eq!(
+            &*got,
+            value(i).as_slice(),
+            "value mismatch after compaction for key {i}"
+        );
+    }
+    let scanned = tree.range(key(0)..key(999_999), SeqNo::MAX, None).count();
+    assert_eq!(scanned, 600, "range must see every row after compaction");
+}
+
+#[test]
+fn columnar_tombstone_hides_row() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    tree.insert(key(1), value(1), 0);
+    tree.flush_active_memtable(0).expect("flush");
+    assert!(tree.get(key(1), SeqNo::MAX).expect("get").is_some());
+
+    tree.remove(key(1), 1);
+    tree.flush_active_memtable(0).expect("flush");
+    assert!(
+        tree.get(key(1), SeqNo::MAX).expect("get").is_none(),
+        "tombstone must hide the row in a columnar tree"
+    );
+}

--- a/tests/columnar_roundtrip.rs
+++ b/tests/columnar_roundtrip.rs
@@ -46,6 +46,17 @@ fn columnar_tree_round_trips_through_flush() {
     }
     tree.flush_active_memtable(0).expect("flush");
 
+    // The write path must actually have produced columnar SSTs, else this suite
+    // could pass on a row-major regression (the reader is transparent).
+    let tables: usize = tree.current_version().iter_tables().count();
+    assert!(tables > 0, "expected at least one flushed SST");
+    assert!(
+        tree.current_version()
+            .iter_tables()
+            .all(|t| t.metadata.columnar),
+        "flushed SSTs must be columnar, not row-major"
+    );
+
     // Every key reads back its exact value through the columnar -> row reader.
     for i in 0..n {
         let got = tree
@@ -76,6 +87,12 @@ fn columnar_survives_major_compaction() {
     }
     tree.flush_active_memtable(0).expect("flush");
     tree.major_compact(64 * 1024 * 1024, 0).expect("compact");
+    assert!(
+        tree.current_version()
+            .iter_tables()
+            .all(|t| t.metadata.columnar),
+        "the compacted SST must also be columnar"
+    );
 
     for i in 0..600u32 {
         let got = tree


### PR DESCRIPTION
## Summary

Makes the columnar (PAX) block format functional end to end: a tree opted into columnar stores its data column-organized on flush / compaction and reads it back exactly through the existing row API, with the seqno column delta-encoded. Builds on the merged format (#517) and transpose kernel (#523).

## What it does

- **Per-tree toggle** `RuntimeConfig.columnar` (default off). The layout is recorded per SST (`descriptor#columnar`) and chosen per block from the block type, so a tree can hold both row and columnar SSTs at once.
- **Write**: when columnar, `Writer::spill_block` transposes each chunk into a PAX `ColumnBatch` (intrinsic columns: user key, seqno, value type, value) and writes it as a `BlockType::Columnar` block, keeping the same index handle, seqno bounds, and zone-map key range.
- **Read**: every block-load path reconstructs the row entries from a columnar block on load via a shared `DataBlock::from_columnar_block` (decode the `ColumnBatch`, re-encode row-major in memory). All three paths dispatch on the SST layout: the random-access loader (point reads), the streaming scanner (compaction / merge), and the range iterator (whose inner-block partial decode is skipped for columnar blocks).
- **Codec**: a Delta logical codec, auto-selected per column for the fixed-8 seqno column (wrapping deltas + prefix-sum), recorded per column.

## Scope

The native column-projection read (decode only the referenced columns, so a key-only scan never touches the value column) is the contract of the vectorized columnar scan and is tracked in #506. This PR's reader reconstructs whole rows, so columnar storage is transparent to the existing point-read / range API.

## Testing

- `cargo nextest run --features lz4,zstd` — 2065 passed (row-major unchanged by the shared read-path changes)
- `cargo nextest run --features lz4,zstd,columnar` — 2086 passed, including round-trip-through-flush, survives-major-compaction, tombstone-hides-row, and Delta-codec round-trip
- `cargo clippy --all-features --all-targets` — clean
- no-std: `cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc,columnar` — 0 errors (decode path is core + alloc)
- `cargo test --doc --features columnar` — passes

Closes #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime configuration toggle to write new SSTs using a column-organized (PAX) layout (opt-in; existing SSTs remain unchanged).
  * Implemented columnar SST read/write support end-to-end, including metadata-driven decoding and scanning.
  * Introduced a delta compression codec for eligible fixed-width integer columns with automatic per-column selection.
* **Tests**
  * Added end-to-end tests covering flush, major compaction, and tombstone behavior for columnar SSTs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->