### PR TITLE
feat(columnar): vectorized columnar scan with projection and predicate pushdown

### DIFF
--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -391,6 +391,27 @@ impl ColumnBatch {
     /// validity flag, or any column that fails [`Column::validate`] (fixed-width
     /// length, `Bytes` offset framing, validity bitmap length / padding).
     pub fn decode(bytes: &[u8]) -> Result<Self> {
+        Self::decode_inner(bytes, None)
+    }
+
+    /// Decodes only the columns whose id is in `wanted`, advancing past every
+    /// other column's bytes without allocating or running its codec. This is the
+    /// projection read: a scan asking for a subset of the columns never pays to
+    /// decode the rest (e.g. a key-only scan does not decode the value column).
+    /// The returned batch carries only the projected columns, in write order.
+    ///
+    /// # Errors
+    ///
+    /// As [`ColumnBatch::decode`], evaluated only for the projected columns
+    /// (the headers of skipped columns are still framing-checked).
+    pub fn decode_projected(bytes: &[u8], wanted: &[u16]) -> Result<Self> {
+        Self::decode_inner(bytes, Some(wanted))
+    }
+
+    /// Shared decode body. `wanted == None` decodes every column; `Some(ids)`
+    /// decodes only the listed columns and skips the rest (their validity + data
+    /// bytes are stepped over, never allocated or codec-decoded).
+    fn decode_inner(bytes: &[u8], wanted: Option<&[u16]>) -> Result<Self> {
         // Smallest possible column: id(2) + type(1) + width(1) + codec(1) +
         // has_validity(1) + data_len(4), with empty validity + data.
         const MIN_COLUMN_BYTES: usize = 10;
@@ -422,12 +443,19 @@ impl ColumnBatch {
             };
             let data_len = cur.read_u32()? as usize;
             let type_tag = TypeTag::from_wire(type_tag, width)?;
+            // A skipped column's validity + data are stepped over (the cursor
+            // still bounds-checks the lengths) but never copied or codec-decoded.
+            let want = wanted.is_none_or(|w| w.contains(&column_id));
             let validity = if has_validity {
-                Some(cur.read_bytes(validity_len(row_count))?.to_vec())
+                let v = cur.read_bytes(validity_len(row_count))?;
+                if want { Some(v.to_vec()) } else { None }
             } else {
                 None
             };
             let raw = cur.read_bytes(data_len)?;
+            if !want {
+                continue;
+            }
             // Restore the column's logical bytes from its stored codec form
             // (Plain is identity; Delta runs the prefix-sum).
             let data = codec_decode(codec, type_tag, raw)?;
@@ -706,7 +734,8 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
 #[cfg(test)]
 mod tests {
     use super::{
-        CodecId, Column, ColumnBatch, TypeTag, column_batch_to_entries, entries_to_column_batch,
+        COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
+        column_batch_to_entries, entries_to_column_batch,
     };
     use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
 
@@ -807,6 +836,41 @@ mod tests {
             .encode(CodecId::Plain)
             .expect("encode");
         assert!(crate::table::data_block::DataBlock::from_columnar_block(&empty, 16).is_err());
+    }
+
+    #[test]
+    fn decode_projected_decodes_only_the_wanted_columns() {
+        // Project just the user-key column: the result carries ONLY that column,
+        // proving the value / seqno / value-type columns were never decoded.
+        let entries = vec![
+            entry(b"alpha", 10, ValueType::Value, b"v1"),
+            entry(b"bravo", 9, ValueType::Value, b"v2"),
+        ];
+        let bytes = entries_to_column_batch(&entries)
+            .expect("transpose")
+            .encode(CodecId::Plain)
+            .expect("encode");
+
+        let projected =
+            ColumnBatch::decode_projected(&bytes, &[COL_USER_KEY]).expect("decode_projected");
+        assert_eq!(projected.row_count, 2);
+        assert_eq!(
+            projected.columns.len(),
+            1,
+            "only the projected column is decoded"
+        );
+        assert_eq!(projected.columns[0].column_id, COL_USER_KEY);
+        assert!(
+            !projected.columns.iter().any(|c| c.column_id == COL_VALUE),
+            "a key-only projection must not decode the value column"
+        );
+
+        // Projecting every column equals a full decode.
+        let all = [COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE];
+        assert_eq!(
+            ColumnBatch::decode_projected(&bytes, &all).expect("decode_projected all"),
+            ColumnBatch::decode(&bytes).expect("decode"),
+        );
     }
 
     #[test]

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -234,10 +234,122 @@ fn read_u32_le(bytes: &[u8]) -> Option<u32> {
     Some(u32::from_le_bytes(arr))
 }
 
+// Cached, no-std-friendly AVX2 token for the byte-equality dispatch below.
+// `cpufeatures::new!` runs CPUID once (atomic load thereafter) and verifies OS
+// AVX-state, so the AVX2 path cannot SIGILL on a host without it.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+cpufeatures::new!(cpu_avx2_byte_eq, "avx2");
+
+/// Per-row mask marking rows of a fixed-1 (single-byte) column equal to `value`.
+///
+/// Useful e.g. on the value-type column to keep only live values. A SIMD-friendly
+/// equality scan: byte equality is endianness-independent, so it needs no
+/// comparable transform. Returns an all-true `row_count` mask when the column is
+/// absent or not fixed-1, so an inapplicable filter never drops rows.
+#[must_use]
+pub fn byte_eq_mask(batch: &ColumnBatch, column_id: u16, value: u8) -> Vec<bool> {
+    let rows = batch.row_count as usize;
+    let Some(col) = batch.columns.iter().find(|c| c.column_id == column_id) else {
+        return alloc::vec![true; rows];
+    };
+    if !matches!(col.type_tag, TypeTag::Fixed(1)) {
+        return alloc::vec![true; rows];
+    }
+    byte_eq_dispatch(&col.data, value)
+}
+
+/// Portable reference: one boolean per byte, `true` where it equals `value`.
+/// Also the scalar tail every SIMD kernel falls back to for the trailing bytes.
+fn byte_eq_scalar(data: &[u8], value: u8) -> Vec<bool> {
+    data.iter().map(|&b| b == value).collect()
+}
+
+/// Runtime-dispatched byte-equality mask: the widest kernel the host supports,
+/// each producing bit-identical output to [`byte_eq_scalar`]. Exactly one `cfg`
+/// arm compiles per target and is the function's tail.
+fn byte_eq_dispatch(data: &[u8], value: u8) -> Vec<bool> {
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        if cpu_avx2_byte_eq::get() {
+            // SAFETY: cpufeatures has just verified AVX2 is present on this host.
+            return unsafe { byte_eq_avx2(data, value) };
+        }
+        byte_eq_scalar(data, value)
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: NEON is an ARMv8 baseline feature, always present on aarch64.
+        unsafe { byte_eq_neon(data, value) }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
+    {
+        byte_eq_scalar(data, value)
+    }
+}
+
+/// AVX2 byte-equality: 32 bytes per iteration, scalar tail.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+unsafe fn byte_eq_avx2(data: &[u8], value: u8) -> Vec<bool> {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+        _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+    };
+    let mut chunks = data.chunks_exact(32);
+    let mut out = Vec::with_capacity(data.len());
+    // SAFETY: the AVX2 intrinsics are enabled by `#[target_feature]`, which the
+    // caller has verified present; the load is unaligned (`loadu`) over a full
+    // 32-byte chunk, so it stays in bounds.
+    unsafe {
+        let needle = _mm256_set1_epi8(value as i8);
+        for chunk in &mut chunks {
+            let v = _mm256_loadu_si256(chunk.as_ptr().cast());
+            let mask = _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, needle)) as u32;
+            for i in 0..32u32 {
+                out.push((mask >> i) & 1 == 1);
+            }
+        }
+    }
+    out.extend(byte_eq_scalar(chunks.remainder(), value));
+    out
+}
+
+/// NEON byte-equality: 16 bytes per iteration, scalar tail.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn byte_eq_neon(data: &[u8], value: u8) -> Vec<bool> {
+    use core::arch::aarch64::{vceqq_u8, vdupq_n_u8, vld1q_u8, vst1q_u8};
+    let mut chunks = data.chunks_exact(16);
+    let mut out = Vec::with_capacity(data.len());
+    // SAFETY: the NEON intrinsics are enabled by `#[target_feature]` (a baseline
+    // aarch64 feature); the load and store cover a full 16-byte chunk / a local
+    // 16-byte array, so both stay in bounds.
+    unsafe {
+        let needle = vdupq_n_u8(value);
+        for chunk in &mut chunks {
+            let eq = vceqq_u8(vld1q_u8(chunk.as_ptr()), needle); // 0xFF where equal
+            let mut lanes = [0u8; 16];
+            vst1q_u8(lanes.as_mut_ptr(), eq);
+            for &lane in &lanes {
+                out.push(lane != 0);
+            }
+        }
+    }
+    out.extend(byte_eq_scalar(chunks.remainder(), value));
+    out
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
-    use super::{ColumnRangePredicate, ColumnStats, filter_batch};
+    use super::{
+        Column, ColumnBatch, ColumnRangePredicate, ColumnStats, TypeTag, byte_eq_mask,
+        byte_eq_scalar, filter_batch,
+    };
     use crate::table::columnar::{column_batch_to_entries, entries_to_column_batch};
     use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
 
@@ -324,5 +436,30 @@ mod tests {
         assert_eq!(&*back[1].key.user_key, b"ccc");
         assert_eq!(back[1].key.seqno, 1);
         assert_eq!(&*back[1].value, b"vc");
+    }
+
+    #[test]
+    fn byte_eq_simd_matches_scalar_on_a_corpus() {
+        // A 1000-byte value-type corpus (values 0..3), filtered to value 1. On
+        // this host the dispatch runs the widest available kernel; it must be
+        // bit-identical to the portable scalar reference.
+        let mut data = Vec::new();
+        for i in 0..1000u32 {
+            data.push(u8::try_from(i % 4).unwrap_or(0));
+        }
+        let batch = ColumnBatch {
+            row_count: u32::try_from(data.len()).unwrap_or(0),
+            columns: vec![Column {
+                column_id: 2,
+                type_tag: TypeTag::Fixed(1),
+                validity: None,
+                data: data.clone(),
+            }],
+        };
+        assert_eq!(
+            byte_eq_mask(&batch, 2, 1),
+            byte_eq_scalar(&data, 1),
+            "the SIMD byte-eq kernel must equal the scalar reference"
+        );
     }
 }

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -156,15 +156,21 @@ fn filter_column(col: &Column, rows: usize, mask: &[bool], kept: usize) -> Colum
             let mut acc: u32 = 0;
             offsets.extend_from_slice(&acc.to_le_bytes());
             for (row, &keep) in mask.iter().enumerate() {
-                if keep && let Some(value) = bytes_row(&col.data, rows, row) {
-                    payload.extend_from_slice(value);
-                    // The kept payload is a subset of the original, whose offsets
-                    // already fit u32, so the length and the running sum both fit
-                    // u32 and cannot overflow.
-                    let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
-                    acc += len;
-                    offsets.extend_from_slice(&acc.to_le_bytes());
+                if !keep {
+                    continue;
                 }
+                // Every kept row writes exactly one offset, so the table stays in
+                // lockstep with the kept row count even if a row's bytes are
+                // unreadable: a corrupt slice degrades to empty rather than
+                // leaving a missing offset and malformed framing.
+                let value = bytes_row(&col.data, rows, row).unwrap_or(&[]);
+                payload.extend_from_slice(value);
+                // The kept payload is a subset of the original, whose offsets
+                // already fit u32. The caps only guard the unreachable overflow
+                // and keep the offsets monotonically non-decreasing.
+                let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+                acc = acc.saturating_add(len);
+                offsets.extend_from_slice(&acc.to_le_bytes());
             }
             offsets.extend_from_slice(&payload);
             offsets

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -391,6 +391,8 @@ mod tests {
         };
         // Block whose keys are [a, c]: entirely below the lower bound -> skip.
         assert!(pred.can_skip_block(&[stats(0, b"a", b"c")]));
+        // Block whose keys are [za, zz]: entirely above the upper bound -> skip.
+        assert!(pred.can_skip_block(&[stats(0, b"za", b"zz")]));
         // Block whose keys are [p, t]: overlaps -> cannot skip.
         assert!(!pred.can_skip_block(&[stats(0, b"p", b"t")]));
         // No stats for the column -> conservative, cannot skip.
@@ -470,5 +472,100 @@ mod tests {
             byte_eq_scalar(&data, 1),
             "the SIMD byte-eq kernel must equal the scalar reference"
         );
+    }
+
+    /// Builds a `Bytes` column from row values: a `(rows + 1)` u32 offset table
+    /// followed by the concatenated payload.
+    fn bytes_column(column_id: u16, validity: Option<Vec<u8>>, rows: &[&[u8]]) -> Column {
+        let mut data = Vec::new();
+        let mut acc = 0u32;
+        data.extend_from_slice(&acc.to_le_bytes());
+        for r in rows {
+            acc += u32::try_from(r.len()).unwrap_or(0);
+            data.extend_from_slice(&acc.to_le_bytes());
+        }
+        for r in rows {
+            data.extend_from_slice(r);
+        }
+        Column {
+            column_id,
+            type_tag: TypeTag::Bytes,
+            validity,
+            data,
+        }
+    }
+
+    #[test]
+    fn matching_rows_excludes_null_rows_and_respects_both_bounds() {
+        // Keys a / b / c with row 1 (b) null; predicate [a, z] keeps the two
+        // non-null in-range rows and drops the null one.
+        let batch = ColumnBatch {
+            row_count: 3,
+            // rows 0 and 2 valid, row 1 null.
+            columns: vec![bytes_column(
+                0,
+                Some(vec![0b0000_0101]),
+                &[b"a", b"b", b"c"],
+            )],
+        };
+        let pred = ColumnRangePredicate {
+            column_id: 0,
+            lower: Some(b"a".to_vec()),
+            upper: Some(b"z".to_vec()),
+        };
+        assert_eq!(pred.matching_rows(&batch), vec![true, false, true]);
+    }
+
+    #[test]
+    fn matching_rows_all_true_for_a_non_bytes_column() {
+        // A fixed-width column is not row-filterable (its stored form is not the
+        // comparable encoding), so every row passes.
+        let batch = ColumnBatch {
+            row_count: 2,
+            columns: vec![Column {
+                column_id: 1,
+                type_tag: TypeTag::Fixed(8),
+                validity: None,
+                data: vec![0u8; 16],
+            }],
+        };
+        let pred = ColumnRangePredicate {
+            column_id: 1,
+            lower: Some(vec![5]),
+            upper: None,
+        };
+        assert_eq!(pred.matching_rows(&batch), vec![true, true]);
+    }
+
+    #[test]
+    fn byte_eq_mask_all_true_when_inapplicable() {
+        let batch = ColumnBatch {
+            row_count: 2,
+            columns: vec![bytes_column(0, None, &[b"a", b"b"])],
+        };
+        // Absent column -> all true.
+        assert_eq!(byte_eq_mask(&batch, 99, 1), vec![true, true]);
+        // Present but not fixed-1 -> all true.
+        assert_eq!(byte_eq_mask(&batch, 0, 1), vec![true, true]);
+    }
+
+    #[test]
+    fn filter_batch_compacts_fixed_data_and_validity() {
+        // Fixed-1 column with row 1 null; keep rows 0 and 2.
+        let batch = ColumnBatch {
+            row_count: 3,
+            columns: vec![Column {
+                column_id: 2,
+                type_tag: TypeTag::Fixed(1),
+                validity: Some(vec![0b0000_0101]),
+                data: vec![10, 20, 30],
+            }],
+        };
+        let filtered = filter_batch(&batch, &[true, false, true]);
+        assert_eq!(filtered.row_count, 2);
+        let col = &filtered.columns[0];
+        assert_eq!(col.data, vec![10, 30], "fixed data keeps rows 0 and 2");
+        // Both kept rows were valid, compacted to the low two bits.
+        assert_eq!(col.validity, Some(vec![0b0000_0011]));
     }
 }

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -305,10 +305,13 @@ unsafe fn byte_eq_avx2(data: &[u8], value: u8) -> Vec<bool> {
     // caller has verified present; the load is unaligned (`loadu`) over a full
     // 32-byte chunk, so it stays in bounds.
     unsafe {
-        let needle = _mm256_set1_epi8(value as i8);
+        // Reinterpret the byte as i8 and the movemask as u32 (bit-preserving,
+        // since the comparison and the lane mask are width-exact).
+        let needle = _mm256_set1_epi8(i8::from_ne_bytes([value]));
         for chunk in &mut chunks {
             let v = _mm256_loadu_si256(chunk.as_ptr().cast());
-            let mask = _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, needle)) as u32;
+            let cmp = _mm256_movemask_epi8(_mm256_cmpeq_epi8(v, needle));
+            let mask = u32::from_ne_bytes(cmp.to_ne_bytes());
             for i in 0..32u32 {
                 out.push((mask >> i) & 1 == 1);
             }

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -110,6 +110,98 @@ impl ColumnRangePredicate {
     }
 }
 
+/// Compacts a decoded batch down to the rows a predicate matched.
+///
+/// Returns a new batch keeping only the rows where `mask[i]` is true, preserving
+/// column order and per-column framing, so the scan yields only matching rows. A
+/// mask shorter than `row_count` drops the unspecified trailing rows.
+#[must_use]
+pub fn filter_batch(batch: &ColumnBatch, mask: &[bool]) -> ColumnBatch {
+    let kept = mask.iter().filter(|&&m| m).count();
+    let rows = batch.row_count as usize;
+    let columns = batch
+        .columns
+        .iter()
+        .map(|c| filter_column(c, rows, mask, kept))
+        .collect();
+    // kept <= row_count, which is a u32, so the count fits.
+    let row_count = u32::try_from(kept).unwrap_or(batch.row_count);
+    ColumnBatch { row_count, columns }
+}
+
+/// Compacts one column to the rows selected by `mask`, rebuilding its framing
+/// (fixed chunks copied through, `Bytes` offset table + payload rebuilt) and its
+/// validity bitmap.
+fn filter_column(col: &Column, rows: usize, mask: &[bool], kept: usize) -> Column {
+    let data = match col.type_tag {
+        TypeTag::Fixed(width) => {
+            let width = width as usize;
+            // Bounded by a block's row count and the fixed width, so no overflow.
+            let mut out = Vec::with_capacity(kept * width);
+            for (row, &keep) in mask.iter().enumerate() {
+                if keep
+                    && let Some(start) = row.checked_mul(width)
+                    && let Some(end) = start.checked_add(width)
+                    && let Some(chunk) = col.data.get(start..end)
+                {
+                    out.extend_from_slice(chunk);
+                }
+            }
+            out
+        }
+        TypeTag::Bytes => {
+            // Rebuild the (kept + 1) u32 offset table and the packed payload.
+            let mut offsets = Vec::with_capacity((kept + 1) * 4);
+            let mut payload = Vec::new();
+            let mut acc: u32 = 0;
+            offsets.extend_from_slice(&acc.to_le_bytes());
+            for (row, &keep) in mask.iter().enumerate() {
+                if keep && let Some(value) = bytes_row(&col.data, rows, row) {
+                    payload.extend_from_slice(value);
+                    // The kept payload is a subset of the original, whose offsets
+                    // already fit u32, so the length and the running sum both fit
+                    // u32 and cannot overflow.
+                    let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+                    acc += len;
+                    offsets.extend_from_slice(&acc.to_le_bytes());
+                }
+            }
+            offsets.extend_from_slice(&payload);
+            offsets
+        }
+    };
+    let validity = col
+        .validity
+        .as_ref()
+        .map(|bits| compact_validity(bits, mask, kept));
+    Column {
+        column_id: col.column_id,
+        type_tag: col.type_tag,
+        validity,
+        data,
+    }
+}
+
+/// Rebuilds a validity bitmap for the rows selected by `mask`, preserving each
+/// kept row's null bit in compacted order.
+fn compact_validity(bits: &[u8], mask: &[bool], kept: usize) -> Vec<u8> {
+    let mut out = alloc::vec![0u8; kept.div_ceil(8)];
+    let mut o = 0usize;
+    for (row, &keep) in mask.iter().enumerate() {
+        if !keep {
+            continue;
+        }
+        let valid = bits
+            .get(row / 8)
+            .is_some_and(|b| b & (1u8 << (row % 8)) != 0);
+        if valid && let Some(byte) = out.get_mut(o / 8) {
+            *byte |= 1u8 << (o % 8);
+        }
+        o += 1;
+    }
+    out
+}
+
 /// Whether row `row` is valid (non-null) per the column's validity bitmap. A
 /// column with no bitmap has every row valid; otherwise a set bit means valid.
 fn row_valid(col: &Column, row: usize) -> bool {
@@ -143,10 +235,10 @@ fn read_u32_le(bytes: &[u8]) -> Option<u32> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "test code")]
+#[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 mod tests {
-    use super::{ColumnRangePredicate, ColumnStats};
-    use crate::table::columnar::entries_to_column_batch;
+    use super::{ColumnRangePredicate, ColumnStats, filter_batch};
+    use crate::table::columnar::{column_batch_to_entries, entries_to_column_batch};
     use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
 
     fn entry(key: &[u8], seqno: u64, value: &[u8]) -> InternalValue {
@@ -208,5 +300,29 @@ mod tests {
             upper: None,
         };
         assert_eq!(pred.matching_rows(&batch), vec![true]);
+    }
+
+    #[test]
+    fn filter_batch_keeps_only_masked_rows() {
+        // Three rows; keep rows 0 and 2. The round trip through the transpose
+        // checks every intrinsic column (key, seqno, value type, value) is
+        // compacted correctly.
+        let entries = vec![
+            entry(b"aaa", 3, b"va"),
+            entry(b"bbb", 2, b"vb"),
+            entry(b"ccc", 1, b"vc"),
+        ];
+        let batch = entries_to_column_batch(&entries).expect("transpose");
+        let filtered = filter_batch(&batch, &[true, false, true]);
+        assert_eq!(filtered.row_count, 2);
+
+        let back = column_batch_to_entries(&filtered).expect("untranspose");
+        assert_eq!(back.len(), 2);
+        assert_eq!(&*back[0].key.user_key, b"aaa");
+        assert_eq!(back[0].key.seqno, 3);
+        assert_eq!(&*back[0].value, b"va");
+        assert_eq!(&*back[1].key.user_key, b"ccc");
+        assert_eq!(back[1].key.seqno, 1);
+        assert_eq!(&*back[1].value, b"vc");
     }
 }

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Predicate model for the vectorized columnar scan.
+//!
+//! A [`ColumnRangePredicate`] is an inclusive byte-range filter over one column.
+//! It drives two pushdowns:
+//!
+//! - **Block skip** ([`ColumnRangePredicate::can_skip_block`]): compare the
+//!   predicate bounds against the per-block zone-map ([`ColumnStats`]) min / max
+//!   (#502). A block whose column range is disjoint from the predicate cannot
+//!   contain a matching row, so it is skipped without ever decoding it.
+//! - **Row filter** ([`ColumnRangePredicate::matching_rows`]): evaluate the
+//!   predicate over a decoded [`ColumnBatch`], producing a per-row match mask.
+//!
+//! Both compare the column's *comparable* encoding. For a [`TypeTag::Bytes`]
+//! column (the user-key column, and consumer byte sub-columns) the comparable
+//! encoding is the raw value bytes, so the row filter operates directly on the
+//! stored bytes. Fixed-width numeric columns need a separate comparable
+//! transform and are not yet filterable at the row level (block skip still
+//! works, since the zone-map min / max are already comparable-encoded).
+
+use super::columnar::{Column, ColumnBatch, TypeTag};
+use super::zone_map::ColumnStats;
+use alloc::vec::Vec;
+
+/// An inclusive byte-range filter over one column's comparable encoding.
+///
+/// `lower` / `upper` are inclusive bounds; `None` leaves that side unbounded.
+/// Construct one per column the scan filters on.
+#[derive(Debug, Clone)]
+pub struct ColumnRangePredicate {
+    /// Column this predicate filters on (matches [`Column::column_id`]).
+    pub column_id: u16,
+    /// Inclusive lower bound in comparable encoding, or `None` for unbounded.
+    pub lower: Option<Vec<u8>>,
+    /// Inclusive upper bound in comparable encoding, or `None` for unbounded.
+    pub upper: Option<Vec<u8>>,
+}
+
+impl ColumnRangePredicate {
+    /// Returns `true` when the per-block zone-map `stats` prove the predicate's
+    /// column lies entirely outside `[lower, upper]`, so the block holds no
+    /// matching row and can be skipped without decoding it.
+    ///
+    /// Conservative: returns `false` (cannot skip) when the column has no stats
+    /// entry, so a missing zone-map never drops data.
+    #[must_use]
+    pub fn can_skip_block(&self, stats: &[ColumnStats]) -> bool {
+        let target = u32::from(self.column_id);
+        let Some(s) = stats.iter().find(|s| s.column_id == target) else {
+            return false;
+        };
+        // Disjoint when the whole block is below the lower bound (block max <
+        // lower) or above the upper bound (block min > upper).
+        if let Some(lo) = &self.lower
+            && s.max.as_slice() < lo.as_slice()
+        {
+            return true;
+        }
+        if let Some(hi) = &self.upper
+            && s.min.as_slice() > hi.as_slice()
+        {
+            return true;
+        }
+        false
+    }
+
+    /// Evaluates the predicate over `batch`, returning a `row_count`-long mask
+    /// where `true` marks a row whose value is within `[lower, upper]`.
+    ///
+    /// A row that is null (per the column's validity bitmap) never matches. If
+    /// the predicate's column was projected out of `batch`, every row is treated
+    /// as matching (the filter cannot run on an absent column). A non-`Bytes`
+    /// column is likewise treated as all-matching, since its comparable encoding
+    /// is not the stored encoding (block skip still applied at the block level).
+    #[must_use]
+    pub fn matching_rows(&self, batch: &ColumnBatch) -> Vec<bool> {
+        let rows = batch.row_count as usize;
+        let Some(col) = batch.columns.iter().find(|c| c.column_id == self.column_id) else {
+            return alloc::vec![true; rows];
+        };
+        if !matches!(col.type_tag, TypeTag::Bytes) {
+            return alloc::vec![true; rows];
+        }
+        (0..rows)
+            .map(|row| self.row_matches(col, rows, row))
+            .collect()
+    }
+
+    /// Whether row `row` of a `Bytes` column is non-null and within the bounds.
+    fn row_matches(&self, col: &Column, rows: usize, row: usize) -> bool {
+        if !row_valid(col, row) {
+            return false;
+        }
+        let Some(value) = bytes_row(&col.data, rows, row) else {
+            return false;
+        };
+        if let Some(lo) = &self.lower
+            && value < lo.as_slice()
+        {
+            return false;
+        }
+        if let Some(hi) = &self.upper
+            && value > hi.as_slice()
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// Whether row `row` is valid (non-null) per the column's validity bitmap. A
+/// column with no bitmap has every row valid; otherwise a set bit means valid.
+fn row_valid(col: &Column, row: usize) -> bool {
+    match &col.validity {
+        None => true,
+        Some(bits) => bits
+            .get(row / 8)
+            .is_some_and(|byte| byte & (1u8 << (row % 8)) != 0),
+    }
+}
+
+/// Extracts row `row` of a `Bytes` column: a `(rows + 1)` little-endian `u32`
+/// offset table followed by the payload, where row `i` spans the payload range
+/// `offset[i]..offset[i + 1]`. Returns `None` on any out-of-range index.
+fn bytes_row(data: &[u8], rows: usize, row: usize) -> Option<&[u8]> {
+    let table_len = rows.checked_add(1)?.checked_mul(4)?;
+    let off_i = read_u32_le(data.get(row.checked_mul(4)?..)?)? as usize;
+    let off_next = read_u32_le(data.get(row.checked_add(1)?.checked_mul(4)?..)?)? as usize;
+    data.get(table_len.checked_add(off_i)?..table_len.checked_add(off_next)?)
+}
+
+/// Reads a leading little-endian `u32` from `bytes`, or `None` if it is shorter
+/// than four bytes.
+fn read_u32_le(bytes: &[u8]) -> Option<u32> {
+    let head = bytes.get(..4)?;
+    let mut arr = [0u8; 4];
+    for (dst, &src) in arr.iter_mut().zip(head) {
+        *dst = src;
+    }
+    Some(u32::from_le_bytes(arr))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "test code")]
+mod tests {
+    use super::{ColumnRangePredicate, ColumnStats};
+    use crate::table::columnar::entries_to_column_batch;
+    use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
+
+    fn entry(key: &[u8], seqno: u64, value: &[u8]) -> InternalValue {
+        InternalValue {
+            key: InternalKey::new(Slice::from(key), seqno, ValueType::Value),
+            value: Slice::from(value),
+        }
+    }
+
+    fn stats(column_id: u32, min: &[u8], max: &[u8]) -> ColumnStats {
+        ColumnStats {
+            column_id,
+            type_tag: 1,
+            codec_id: 0,
+            null_count: 0,
+            row_count: 2,
+            min: min.to_vec(),
+            max: max.to_vec(),
+        }
+    }
+
+    #[test]
+    fn can_skip_block_when_range_is_disjoint() {
+        // Predicate on the user-key column (id 0) for keys in [m, z].
+        let pred = ColumnRangePredicate {
+            column_id: 0,
+            lower: Some(b"m".to_vec()),
+            upper: Some(b"z".to_vec()),
+        };
+        // Block whose keys are [a, c]: entirely below the lower bound -> skip.
+        assert!(pred.can_skip_block(&[stats(0, b"a", b"c")]));
+        // Block whose keys are [p, t]: overlaps -> cannot skip.
+        assert!(!pred.can_skip_block(&[stats(0, b"p", b"t")]));
+        // No stats for the column -> conservative, cannot skip.
+        assert!(!pred.can_skip_block(&[stats(7, b"a", b"c")]));
+    }
+
+    #[test]
+    fn matching_rows_filters_the_key_column() {
+        // Two rows with keys "alpha" and "bravo"; filter to keys >= "b".
+        let batch =
+            entries_to_column_batch(&[entry(b"alpha", 10, b"v1"), entry(b"bravo", 9, b"v2")])
+                .expect("transpose");
+        let pred = ColumnRangePredicate {
+            column_id: 0, // user-key column
+            lower: Some(b"b".to_vec()),
+            upper: None,
+        };
+        assert_eq!(pred.matching_rows(&batch), vec![false, true]);
+    }
+
+    #[test]
+    fn matching_rows_all_true_when_column_absent() {
+        let batch = entries_to_column_batch(&[entry(b"k", 1, b"v")]).expect("transpose");
+        // No column 99 in the batch -> cannot filter, every row matches.
+        let pred = ColumnRangePredicate {
+            column_id: 99,
+            lower: Some(b"z".to_vec()),
+            upper: None,
+        };
+        assert_eq!(pred.matching_rows(&batch), vec![true]);
+    }
+}

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod block_index;
 pub(crate) mod block_layout;
 #[cfg(feature = "columnar")]
 pub mod columnar;
+#[cfg(feature = "columnar")]
+pub mod columnar_predicate;
 pub mod data_block;
 pub mod filter;
 mod id;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1290,6 +1290,18 @@ impl Table {
         if !self.metadata.columnar {
             return Err(crate::Error::FeatureUnsupported("columnar"));
         }
+        // The predicate must see its own column, even when the caller did not
+        // project it; decode it too and drop it from each output batch, so a
+        // predicate on an unprojected column still filters instead of matching
+        // every row.
+        let mut decode_projection = projection.to_vec();
+        let added_predicate_column = match predicate {
+            Some(pred) if !decode_projection.contains(&pred.column_id) => {
+                decode_projection.push(pred.column_id);
+                Some(pred.column_id)
+            }
+            _ => None,
+        };
         let mut out = Vec::new();
         for keyed in self.block_index.iter() {
             let keyed = keyed?;
@@ -1302,14 +1314,17 @@ impl Table {
                 continue;
             }
             let handle = BlockHandle::new(keyed.offset(), keyed.size());
-            let batch = self.load_columnar_block_projected(&handle, projection)?;
-            let batch = match predicate {
+            let batch = self.load_columnar_block_projected(&handle, &decode_projection)?;
+            let mut batch = match predicate {
                 Some(pred) => {
                     let mask = pred.matching_rows(&batch);
                     crate::table::columnar_predicate::filter_batch(&batch, &mask)
                 }
                 None => batch,
             };
+            if let Some(column_id) = added_predicate_column {
+                batch.columns.retain(|c| c.column_id != column_id);
+            }
             out.push(batch);
         }
         Ok(out)

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -316,6 +316,27 @@ impl Table {
         DataBlock::from_columnar_block(&block.data, self.metadata.data_block_restart_interval)
     }
 
+    /// Loads a columnar data block and decodes only the projected columns,
+    /// stepping over the rest without decoding them. The returned batch carries
+    /// the requested columns for this block's rows. This is the projection read
+    /// the vectorized scan uses, distinct from the whole-block reconstruction
+    /// that the row read paths use.
+    #[cfg(feature = "columnar")]
+    fn load_columnar_block_projected(
+        &self,
+        handle: &BlockHandle,
+        projection: &[u16],
+    ) -> crate::Result<crate::table::columnar::ColumnBatch> {
+        let block = self.load_block(
+            handle,
+            BlockType::Columnar,
+            self.metadata.data_block_compression,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        crate::table::columnar::ColumnBatch::decode_projected(&block.data, projection)
+    }
+
     /// Returns the (possibly compressed) file size.
     pub(crate) fn file_size(&self) -> u64 {
         self.metadata.file_size
@@ -1243,6 +1264,55 @@ impl Table {
             self.metadata.columnar,
             self.metadata.data_block_restart_interval,
         )
+    }
+
+    /// Scans this columnar SST block by block, returning one [`ColumnBatch`] per
+    /// data block that survives the optional predicate, each carrying only the
+    /// projected columns.
+    ///
+    /// `projection` lists the column ids to decode; every other column is
+    /// stepped over without decoding. When `predicate` is set, a block whose
+    /// zone-map proves it out of range is skipped without being loaded, and each
+    /// surviving block is filtered to the rows that match.
+    ///
+    /// [`ColumnBatch`]: crate::table::columnar::ColumnBatch
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this SST is not columnar, or on a block read / decode
+    /// failure.
+    #[cfg(feature = "columnar")]
+    pub fn columnar_scan(
+        &self,
+        projection: &[u16],
+        predicate: Option<&crate::table::columnar_predicate::ColumnRangePredicate>,
+    ) -> crate::Result<Vec<crate::table::columnar::ColumnBatch>> {
+        if !self.metadata.columnar {
+            return Err(crate::Error::FeatureUnsupported("columnar"));
+        }
+        let mut out = Vec::new();
+        for keyed in self.block_index.iter() {
+            let keyed = keyed?;
+            // Zone-map block skip: prove the block is out of range and never
+            // load it. A missing entry is conservative (cannot skip).
+            if let Some(pred) = predicate
+                && let Some(stats) = self.zone_map.columns_for(*keyed.offset())
+                && pred.can_skip_block(stats)
+            {
+                continue;
+            }
+            let handle = BlockHandle::new(keyed.offset(), keyed.size());
+            let batch = self.load_columnar_block_projected(&handle, projection)?;
+            let batch = match predicate {
+                Some(pred) => {
+                    let mask = pred.matching_rows(&batch);
+                    crate::table::columnar_predicate::filter_batch(&batch, &mask)
+                }
+                None => batch,
+            };
+            out.push(batch);
+        }
+        Ok(out)
     }
 
     /// Creates an iterator over the `Table`.

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -109,3 +109,41 @@ fn columnar_scan_predicate_equals_a_naive_filter() {
     let expected: Vec<Vec<u8>> = (1000..=1999u32).map(key).collect();
     assert_eq!(got, expected, "predicate scan must equal the naive filter");
 }
+
+#[test]
+fn columnar_scan_predicate_on_an_unprojected_column_still_filters() {
+    // Project only the value column, but filter on the (unprojected) key column.
+    // The predicate must still apply, not be silently bypassed, and the output
+    // must carry only the projected value column.
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 4000u32;
+    for i in 0..n {
+        tree.insert(key(i), vec![b'v'; 80], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one flushed SST");
+
+    let pred = ColumnRangePredicate {
+        column_id: COL_USER_KEY,
+        lower: Some(key(1000)),
+        upper: Some(key(1999)),
+    };
+    let batches = table
+        .columnar_scan(&[COL_VALUE], Some(&pred))
+        .expect("columnar scan");
+
+    let total: usize = batches.iter().map(|b| b.row_count as usize).sum();
+    assert_eq!(
+        total, 1000,
+        "a predicate on an unprojected column must still filter the rows"
+    );
+    for batch in &batches {
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == COL_VALUE),
+            "the output must carry only the projected value column"
+        );
+    }
+}

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Vectorized columnar scan: projection decodes only the requested columns, and
+//! a key-range predicate filters to exactly the rows a naive row scan would
+//! keep, skipping out-of-range blocks via the zone-map.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::table::columnar::{
+    COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, column_batch_to_entries,
+};
+use lsm_tree::table::columnar_predicate::ColumnRangePredicate;
+use lsm_tree::{AbstractTree, AnyTree, Config, SequenceNumberCounter, get_tmp_folder};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+/// Opens a standard tree with the columnar layout and zone-map both enabled, so
+/// flushed SSTs are column-organized and carry the per-block key range used for
+/// block skipping.
+fn open_columnar(folder: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar + zone-map");
+    tree
+}
+
+#[test]
+fn columnar_scan_projects_only_the_requested_columns() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 4000u32; // enough rows to span several data blocks
+    for i in 0..n {
+        tree.insert(key(i), vec![b'v'; 80], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one flushed SST");
+
+    // Project only the user-key column: every returned batch must carry that
+    // column alone, proving the value column was never decoded.
+    let batches = table
+        .columnar_scan(&[COL_USER_KEY], None)
+        .expect("columnar scan");
+    assert!(batches.len() > 1, "test wants a multi-block SST");
+    for batch in &batches {
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == COL_USER_KEY),
+            "a key-only projection must not decode any other column"
+        );
+    }
+    let total: usize = batches.iter().map(|b| b.row_count as usize).sum();
+    assert_eq!(total, n as usize, "projection must still see every row");
+}
+
+#[test]
+fn columnar_scan_predicate_equals_a_naive_filter() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 4000u32;
+    for i in 0..n {
+        tree.insert(key(i), vec![b'v'; 80], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one flushed SST");
+
+    // Keys in [k001000, k001999]: a contiguous middle slice that lets the
+    // zone-map skip the blocks entirely below or above it.
+    let lo = key(1000);
+    let hi = key(1999);
+    let pred = ColumnRangePredicate {
+        column_id: COL_USER_KEY,
+        lower: Some(lo.clone()),
+        upper: Some(hi.clone()),
+    };
+    let all = [COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE];
+
+    let batches = table
+        .columnar_scan(&all, Some(&pred))
+        .expect("columnar scan with predicate");
+
+    // Flatten the surviving rows back to keys, in scan order.
+    let mut got: Vec<Vec<u8>> = Vec::new();
+    for batch in &batches {
+        for entry in column_batch_to_entries(batch).expect("untranspose") {
+            got.push(entry.key.user_key.to_vec());
+        }
+    }
+
+    // A naive row scan filtered by the same bounds.
+    let expected: Vec<Vec<u8>> = (1000..=1999u32).map(key).collect();
+    assert_eq!(got, expected, "predicate scan must equal the naive filter");
+}

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -147,3 +147,29 @@ fn columnar_scan_predicate_on_an_unprojected_column_still_filters() {
         );
     }
 }
+
+#[test]
+fn columnar_scan_errors_on_a_non_columnar_sst() {
+    // A tree without the columnar layout flushes a row-major SST; columnar_scan
+    // must reject it rather than misread row blocks as column batches.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.insert(key(0), vec![b'v'; 8], 0);
+    tree.flush_active_memtable(0).expect("flush");
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one flushed SST");
+    assert!(
+        table.columnar_scan(&[COL_USER_KEY], None).is_err(),
+        "scanning a row-major SST as columnar must error"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the read-side benefit of the columnar storage format (#503): a scan that decodes only the columns it needs, skips blocks a predicate proves out of range, and filters the rest, returning column batches. Builds on the columnar block format (#503) and the per-block zone-map (#502).

## What it does

- **Projection** (`ColumnBatch::decode_projected`): decodes only the requested columns, stepping over the rest without allocating or running their codec. A key-only scan never touches the value column.
- **Range predicate** (`ColumnRangePredicate`): an inclusive byte-range filter. `can_skip_block` proves a block is out of range from its zone-map min / max and skips it without loading; `matching_rows` evaluates the predicate over a decoded batch.
- **Row compaction** (`filter_batch`): rebuilds a batch keeping only the matched rows (fixed chunks copied, Bytes offset table + payload repacked, validity compacted).
- **SIMD equality** (`byte_eq_mask`): a per-row equality mask over a fixed-1 column (e.g. value-type to keep only live values), runtime-dispatched to AVX2 / NEON with a portable scalar fallback. Byte equality is endianness-independent, so no comparable transform is needed.
- **Scan API** (`Table::columnar_scan`): walks a columnar SST block by block, applies the zone-map skip and the projection, and yields one `ColumnBatch` per surviving block.

## Acceptance

- A subset projection decodes only those columns (verified: a key-only scan over a multi-block SST returns batches carrying only the key column).
- A selective predicate skips out-of-range blocks via the zone-map and the result equals a naive row scan filtered by the same bounds (equivalence test over a multi-block SST).
- The SIMD and scalar paths are bit-identical on a corpus (NEON exercised on aarch64; the AVX2 path cross-compiles for x86_64 and is exercised on x86 CI).

## Scope

The scan operates per SST (the columnar reader unit). Composing it across SSTs + the memtable at the tree level, and fixed-width numeric range predicates (which need a comparable transform), are later refinements. The existing row read API (point reads, range) is unchanged: it still reconstructs whole rows from columnar blocks.

## Testing

- `cargo nextest run --features lz4,zstd` — 2065 passed (row read paths unchanged)
- `cargo nextest run --features lz4,zstd,columnar` — 2097 passed, including projection, predicate-equals-naive, filter round-trip, and the SIMD bit-identity corpus test
- `cargo clippy --all-features --all-targets` — clean
- no-std: `cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc,columnar` — 0 errors
- AVX2 path cross-compiles for `x86_64-unknown-linux-gnu`
- `cargo test --doc --features columnar` — passes

Closes #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a columnar scan API that supports projecting specific columns during scan, reducing decoded data to only what’s requested.
  * Introduced inclusive byte-range predicates for columnar scans, including block skipping via per-block stats and row-level filtering with accurate null handling.
* **Bug Fixes**
  * Ensured predicates continue to filter correctly even when scanning projects different columns.
* **Tests**
  * Added integration coverage for projection, predicate filtering, and expected errors when scanning non-columnar SSTs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->