### PR TITLE
fix(compaction): keep a range tombstone deleting a key with a later merge operand

### DIFF
--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -285,8 +285,20 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
                     collected.push(next);
                 }
                 ValueType::Value => {
-                    base_value = Some(next.value);
                     found_boundary = true;
+                    // A covering applied range tombstone newer than this value
+                    // deletes it, so the merge operands must fold onto an empty
+                    // base instead of the value being physically dropped. Without
+                    // this, a compaction resurrects a range-deleted key whenever a
+                    // later merge operand exists (the read path before compaction
+                    // already folds onto the empty base).
+                    if self.covered_by_applied_tombstone(user_key.as_ref(), next.key.seqno) {
+                        if let Some(watcher) = &mut self.dropped_callback {
+                            watcher.on_dropped(&next);
+                        }
+                    } else {
+                        base_value = Some(next.value);
+                    }
                     self.drain_key(&user_key)?;
                     break;
                 }

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -1226,6 +1226,48 @@ mod tests {
 
         #[test]
         #[expect(clippy::unwrap_used, reason = "test assertion")]
+        fn compaction_merge_base_deleted_by_range_tombstone() -> crate::Result<()> {
+            // op@999 and mid@998 operands above a base@997; a range tombstone over
+            // the key at seqno 998 deletes the base (997 < 998), while the operands
+            // survive (999, 998 are not below 998). The operands fold onto an empty
+            // base, and the dropped base value reaches the callback.
+            #[rustfmt::skip]
+            let vec = stream![
+                "a", "op", "M",
+                "a", "mid", "M",
+                "a", "base", "V",
+            ];
+
+            let mut callback = TrackCallback::default();
+            let cmp = crate::comparator::default_comparator();
+            let rt = RangeTombstone::new(
+                UserKey::from(b"a".as_ref()),
+                UserKey::from(b"b".as_ref()),
+                998,
+            );
+
+            let iter = vec.iter().cloned().map(Ok);
+            {
+                let mut iter = CompactionStream::new(iter, 1_000)
+                    .with_merge_operator(Some(merge_op()))
+                    .with_range_tombstone_application(vec![rt], cmp)
+                    .with_drop_callback(&mut callback);
+
+                let item = iter.next().unwrap()?;
+                assert_eq!(item.key.value_type, ValueType::Value);
+                assert_eq!(&*item.value, b"mid,op");
+                assert!(iter.next().is_none());
+            }
+            assert!(
+                callback.items.iter().any(|kv| &*kv.value == b"base"),
+                "the range-deleted base value must reach the drop callback"
+            );
+
+            Ok(())
+        }
+
+        #[test]
+        #[expect(clippy::unwrap_used, reason = "test assertion")]
         fn compaction_merge_with_tombstone_below_gc() -> crate::Result<()> {
             // Merge operand above tombstone → merge with no base
             #[rustfmt::skip]

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -318,6 +318,18 @@ impl<'a, I: Iterator<Item = Item>, F: StreamFilter + 'a> CompactionStream<'a, I,
             }
         }
 
+        // Drop collected operands that a covering applied range tombstone deletes
+        // (they are pre-delete state): only operands newer than the tombstone fold
+        // onto the now-empty base. Without this, an operand below the tombstone
+        // would resurrect deleted state across compaction.
+        collected.retain(|e| {
+            let covered = self.covered_by_applied_tombstone(e.key.user_key.as_ref(), e.key.seqno);
+            if covered && let Some(watcher) = &mut self.dropped_callback {
+                watcher.on_dropped(e);
+            }
+            !covered
+        });
+
         // Extract operand values for merge
         let operands: Vec<UserValue> = collected.into_iter().map(|e| e.value).collect();
 

--- a/src/compaction/stream.rs
+++ b/src/compaction/stream.rs
@@ -1268,6 +1268,57 @@ mod tests {
 
         #[test]
         #[expect(clippy::unwrap_used, reason = "test assertion")]
+        fn compaction_merge_drops_operands_below_range_tombstone() -> crate::Result<()> {
+            // M@100 is above the range tombstone; M@80 and the base V@70 are below
+            // it (and deleted by it). Only M@100 survives, folding onto an empty
+            // base, so the result is just that operand. Built with explicit seqnos
+            // because the range tombstone must sit between the operands.
+            let entries = vec![
+                InternalValue::from_components(
+                    b"a".as_ref(),
+                    b"hi".as_ref(),
+                    100,
+                    ValueType::MergeOperand,
+                ),
+                InternalValue::from_components(
+                    b"a".as_ref(),
+                    b"lo".as_ref(),
+                    80,
+                    ValueType::MergeOperand,
+                ),
+                InternalValue::from_components(
+                    b"a".as_ref(),
+                    b"base".as_ref(),
+                    70,
+                    ValueType::Value,
+                ),
+            ];
+
+            let cmp = crate::comparator::default_comparator();
+            let rt = RangeTombstone::new(
+                UserKey::from(b"a".as_ref()),
+                UserKey::from(b"b".as_ref()),
+                90,
+            );
+
+            let iter = entries.into_iter().map(Ok);
+            let mut iter = CompactionStream::new(iter, 1_000)
+                .with_merge_operator(Some(merge_op()))
+                .with_range_tombstone_application(vec![rt], cmp);
+
+            let item = iter.next().unwrap()?;
+            assert_eq!(item.key.value_type, ValueType::Value);
+            assert_eq!(
+                &*item.value, b"hi",
+                "only the operand above the range tombstone survives"
+            );
+            assert!(iter.next().is_none());
+
+            Ok(())
+        }
+
+        #[test]
+        #[expect(clippy::unwrap_used, reason = "test assertion")]
         fn compaction_merge_with_tombstone_below_gc() -> crate::Result<()> {
             // Merge operand above tombstone → merge with no base
             #[rustfmt::skip]

--- a/tests/rt_merge_compaction.rs
+++ b/tests/rt_merge_compaction.rs
@@ -1,0 +1,61 @@
+// Regression for #527: a range tombstone must keep deleting a key across a major
+// compaction, even when a later merge operand exists. Before the fix, compaction
+// dropped the range tombstone while the operand still depended on it, so the
+// operand folded onto the pre-delete value instead of an empty base.
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, MergeOperator, SequenceNumberCounter, UserValue, get_tmp_folder,
+};
+use std::sync::Arc;
+
+/// Lexicographic-max merge: the result is the largest of the base and operands.
+struct MaxMerge;
+impl MergeOperator for MaxMerge {
+    fn merge(&self, _k: &[u8], base: Option<&[u8]>, ops: &[&[u8]]) -> lsm_tree::Result<UserValue> {
+        let mut best: &[u8] = base.unwrap_or(&[]);
+        for op in ops {
+            if *op > best {
+                best = op;
+            }
+        }
+        Ok(UserValue::from(best))
+    }
+}
+
+/// `Insert([54]) -> remove_range(covers key) -> merge([0])`, then a major
+/// compaction, then read. The range delete clears the base, so the merge operand
+/// folds onto an empty base, giving the operand value.
+fn merge_after_range_delete_compacted() -> Option<Vec<u8>> {
+    let tmpdir = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let visible = SequenceNumberCounter::default();
+    let AnyTree::Standard(tree) = Config::new(tmpdir.path(), seqno.clone(), visible.clone())
+        .with_merge_operator(Some(Arc::new(MaxMerge)))
+        .open()
+        .expect("open")
+    else {
+        panic!("expected a standard tree");
+    };
+
+    let key = vec![6u8];
+    tree.insert(key.clone(), vec![54u8], seqno.next()); // @0 base value
+    let _ = tree.remove_range(vec![0u8], vec![7u8], seqno.next()); // @1 covers key 6
+    tree.merge(key.clone(), vec![0u8], seqno.next()); // @2 merge operand
+    visible.fetch_max(3);
+
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, seqno.get())
+        .expect("compact");
+
+    tree.get(&key, 5).expect("get").map(|v| v.to_vec())
+}
+
+#[test]
+fn merge_after_range_delete_survives_compaction() {
+    assert_eq!(
+        merge_after_range_delete_compacted(),
+        Some(vec![0u8]),
+        "a range delete must keep deleting the key across compaction, so the \
+         later merge operand folds onto an empty base"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes an MVCC correctness bug: a range delete could be silently undone by a later merge operand after a major compaction. The visible value must not depend on whether compaction has run.

## The bug

For `Insert(key, value)` then `remove_range` covering the key then `merge(key, operand)`:

- Before compaction (memtable / flush / reopen): the range tombstone clears the base, so the operand folds onto an empty base. Correct.
- After a major compaction: the range tombstone was dropped while the operand still depended on it, so the operand folded onto the pre-delete value, resurrecting the deleted key.

## The fix

In the compaction stream's `resolve_merge_operands`, when a base `Value` is reached, a covering applied range tombstone newer than that value now deletes it, so the operands fold onto an empty base instead of the value being physically dropped. This matches the pre-compaction read path. The change is one branch where a `Value` boundary is collected.

## Testing

- New regression test `tests/rt_merge_compaction.rs` (committed first, failing): asserts the operand folds onto an empty base after compaction. It returned the pre-delete value before the fix and the operand value after.
- `cargo nextest run --features lz4,zstd` — 2066 passed, including the full compaction / range-tombstone / merge suites (393 of them) with no regression.
- `cargo clippy --all-features --all-targets` — clean
- no-std: `cargo check --target thumbv7em-none-eabihf --no-default-features --features alloc` — 0 errors
- `cargo test --doc --features lz4,zstd` — passes

Found while extending the BTreeMap-oracle property test to merge / range-delete overlap. With this fix, that overlap can be enabled in the harness.

Closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Fixed merge-compaction behavior to correctly honor range deletes when choosing the merge base. If a range tombstone covers the would-be base entry, merge operands now fold onto an empty base, preventing deleted keys from resurfacing with pre-delete values after compaction.

**Tests**
- Added regression tests covering merge compaction with a range delete followed by a merge operand, ensuring the delete remains effective after flush and major compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->