### PR TITLE
feat: positional delete-bitmap MVCC for columnar segments

### DIFF
--- a/src/compaction/delete_materialize.rs
+++ b/src/compaction/delete_materialize.rs
@@ -46,12 +46,18 @@ use alloc::vec::Vec;
 /// to match. It un-gates trivially alongside that layer.
 // `pub` (not `pub(crate)`) inside this crate-private module: clippy flags the
 // redundant restriction since the module itself is already crate-scoped.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidHeader`] if the row count exceeds `u32::MAX`:
+/// positions are u32 by the bitmap's design, so a larger segment cannot be
+/// addressed without aliasing earlier rows.
 pub fn build_position_bitmap<'a, I>(
     rows: I,
     tombstones: &[RangeTombstone],
     watermark: SeqNo,
     comparator: &SharedComparator,
-) -> DeleteBitmap
+) -> crate::Result<DeleteBitmap>
 where
     I: IntoIterator<Item = (&'a [u8], SeqNo)>,
 {
@@ -86,13 +92,17 @@ where
         }
         active.expire_until(user_key);
         if active.is_suppressed(seqno) {
-            // Positions are u32 by the bitmap's design; a segment past u32 rows
-            // cannot be addressed, matching `from_columnar_block_masked`.
+            // Positions are u32 by the bitmap's design, matching
+            // `from_columnar_block_masked`.
             bitmap.insert(pos);
         }
-        pos = pos.wrapping_add(1);
+        // Fail loudly rather than wrapping back to 0 (which would mark unrelated
+        // earlier rows): a segment past u32 rows cannot be addressed positionally.
+        pos = pos.checked_add(1).ok_or(crate::Error::InvalidHeader(
+            "delete-bitmap position exceeds u32::MAX",
+        ))?;
     }
-    bitmap
+    Ok(bitmap)
 }
 
 #[cfg(test)]
@@ -106,13 +116,18 @@ mod tests {
 
     /// Collects the marked positions of a build over `rows` as a sorted Vec, so
     /// each test asserts the exact membership set.
+    #[expect(
+        clippy::expect_used,
+        reason = "test inputs are far below the u32::MAX row limit, so the build cannot overflow"
+    )]
     fn marked(
         rows: &[(&[u8], SeqNo)],
         tombstones: &[RangeTombstone],
         watermark: SeqNo,
     ) -> Vec<u32> {
         let cmp = crate::comparator::default_comparator();
-        let bitmap = build_position_bitmap(rows.iter().copied(), tombstones, watermark, &cmp);
+        let bitmap = build_position_bitmap(rows.iter().copied(), tombstones, watermark, &cmp)
+            .expect("position bitmap build");
         let mut out: Vec<u32> = bitmap.iter().collect();
         out.sort_unstable();
         out

--- a/src/compaction/delete_materialize.rs
+++ b/src/compaction/delete_materialize.rs
@@ -105,7 +105,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::UserKey;

--- a/src/compaction/delete_materialize.rs
+++ b/src/compaction/delete_materialize.rs
@@ -45,16 +45,7 @@ use alloc::vec::Vec;
 /// stream, which is currently `std`-gated in the worker, so this module is gated
 /// to match. It un-gates trivially alongside that layer.
 // `pub` (not `pub(crate)`) inside this crate-private module: clippy flags the
-// redundant restriction since the module itself is already crate-scoped. Wired
-// by the merge-on-read delete-application path (a follow-up increment in this
-// change); the dead-code scaffold is removed once that caller lands.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired by the merge-on-read compaction delete-application path"
-    )
-)]
+// redundant restriction since the module itself is already crate-scoped.
 pub fn build_position_bitmap<'a, I>(
     rows: I,
     tombstones: &[RangeTombstone],

--- a/src/compaction/delete_materialize.rs
+++ b/src/compaction/delete_materialize.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Merge-on-read delete materialization for columnar segments.
+//!
+//! Builds the positional [`DeleteBitmap`] for a columnar segment from the range
+//! tombstones that cover its rows below the compaction watermark, reusing the
+//! same monotonic active-set sweep as the compaction stream's
+//! `covered_by_applied_tombstone`. The bitmap is a pure membership set: a
+//! position is marked iff its entry is deleted for every live snapshot (some
+//! active tombstone strictly below the watermark outranks the entry's seqno).
+//! Deletes at or above the watermark stay as ordinary tombstones in higher
+//! levels until a later compaction, exactly as the copy-on-write drop path
+//! treats them.
+
+use crate::{
+    SeqNo, active_tombstone_set::ActiveTombstoneSet, comparator::SharedComparator,
+    range_tombstone::RangeTombstone, table::delete_bitmap::DeleteBitmap,
+};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// Builds a positional delete-bitmap for a columnar segment.
+///
+/// `rows` yields each entry's `(user_key, seqno)` in the segment's physical
+/// position order — block-index order, every stored version a distinct
+/// position. This is the SAME numbering the writer assigns when it transposes
+/// the entries and the read mask checks via
+/// [`DataBlock::from_columnar_block_masked`](crate::table::data_block::DataBlock),
+/// so a marked position drops the exact entry the merge-on-read compaction
+/// resolved as deleted.
+///
+/// `tombstones` is the whole-version range-tombstone set; only those strictly
+/// below `watermark` (visible to the oldest live snapshot) materialize. A
+/// position is marked iff an active below-watermark tombstone outranks its
+/// entry's seqno (`entry_seqno < tombstone_seqno`), matching the stream's
+/// `covered_by_applied_tombstone`.
+///
+/// Entries must arrive in non-decreasing `user_key` order (guaranteed by the
+/// segment layout: keys ascend, versions of one key descend by seqno), so the
+/// active set is swept monotonically in one pass.
+///
+/// The body is `core` + `alloc` only (active-set sweep over `RangeTombstone`s):
+/// it rides on the same range-tombstone-application machinery as the compaction
+/// stream, which is currently `std`-gated in the worker, so this module is gated
+/// to match. It un-gates trivially alongside that layer.
+// `pub` (not `pub(crate)`) inside this crate-private module: clippy flags the
+// redundant restriction since the module itself is already crate-scoped. Wired
+// by the merge-on-read delete-application path (a follow-up increment in this
+// change); the dead-code scaffold is removed once that caller lands.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired by the merge-on-read compaction delete-application path"
+    )
+)]
+pub fn build_position_bitmap<'a, I>(
+    rows: I,
+    tombstones: &[RangeTombstone],
+    watermark: SeqNo,
+    comparator: &SharedComparator,
+) -> DeleteBitmap
+where
+    I: IntoIterator<Item = (&'a [u8], SeqNo)>,
+{
+    // Only strictly-below-watermark tombstones materialize (PITR/MVCC safety):
+    // one at or above the watermark might not be in effect for a snapshot
+    // between the entry's seqno and the tombstone's, so its covered entries are
+    // preserved as ordinary rows + a higher-level tombstone. Mirrors
+    // `CompactionStream::with_range_tombstone_application`.
+    let mut applicable: Vec<&RangeTombstone> = tombstones
+        .iter()
+        .filter(|rt| rt.visible_at(watermark))
+        .collect();
+    applicable.sort_by(|a, b| a.cmp_with_comparator(b, comparator.as_ref()));
+
+    let mut bitmap = DeleteBitmap::new();
+    let mut active = ActiveTombstoneSet::new_with_comparator(comparator.clone());
+    let mut rt_idx = 0usize;
+    let mut pos: u32 = 0;
+
+    for (user_key, seqno) in rows {
+        // Activate every applicable tombstone whose start <= user_key; rows are
+        // key-ordered, so the index only advances (monotonic sweep).
+        while let Some(rt) = applicable.get(rt_idx) {
+            if comparator.compare(&rt.start, user_key) == core::cmp::Ordering::Greater {
+                break;
+            }
+            // cutoff = MAX: every applicable (already below-watermark) tombstone
+            // activates; `is_suppressed` then marks the entry iff some active
+            // tombstone outranks its seqno. Mirrors the stream's sweep.
+            active.activate(rt, SeqNo::MAX);
+            rt_idx += 1;
+        }
+        active.expire_until(user_key);
+        if active.is_suppressed(seqno) {
+            // Positions are u32 by the bitmap's design; a segment past u32 rows
+            // cannot be addressed, matching `from_columnar_block_masked`.
+            bitmap.insert(pos);
+        }
+        pos = pos.wrapping_add(1);
+    }
+    bitmap
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::UserKey;
+
+    fn rt(start: &[u8], end: &[u8], seqno: SeqNo) -> RangeTombstone {
+        RangeTombstone::new(UserKey::from(start), UserKey::from(end), seqno)
+    }
+
+    /// Collects the marked positions of a build over `rows` as a sorted Vec, so
+    /// each test asserts the exact membership set.
+    fn marked(
+        rows: &[(&[u8], SeqNo)],
+        tombstones: &[RangeTombstone],
+        watermark: SeqNo,
+    ) -> Vec<u32> {
+        let cmp = crate::comparator::default_comparator();
+        let bitmap = build_position_bitmap(rows.iter().copied(), tombstones, watermark, &cmp);
+        let mut out: Vec<u32> = bitmap.iter().collect();
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn no_tombstones_marks_nothing() {
+        let rows: &[(&[u8], SeqNo)] = &[(b"a", 5), (b"b", 5), (b"c", 5)];
+        assert!(marked(rows, &[], 100).is_empty());
+    }
+
+    #[test]
+    fn below_watermark_tombstone_marks_covered_half_open_range() {
+        // [b, d) @10, watermark 20: b, c are covered (10 > entry seqno 5); a is
+        // before the range, d is the exclusive end, e is after.
+        let rows: &[(&[u8], SeqNo)] = &[(b"a", 5), (b"b", 5), (b"c", 5), (b"d", 5), (b"e", 5)];
+        assert_eq!(marked(rows, &[rt(b"b", b"d", 10)], 20), vec![1, 2]);
+    }
+
+    #[test]
+    fn at_or_above_watermark_tombstone_marks_nothing() {
+        // Tombstone seqno == watermark is invisible to the oldest live snapshot
+        // (which reads AT the watermark), so it must not materialize.
+        let rows: &[(&[u8], SeqNo)] = &[(b"b", 5), (b"c", 5)];
+        assert!(marked(rows, &[rt(b"a", b"z", 20)], 20).is_empty());
+        // Strictly above: also not materialized.
+        assert!(marked(rows, &[rt(b"a", b"z", 25)], 20).is_empty());
+    }
+
+    #[test]
+    fn entry_newer_than_tombstone_survives() {
+        // Entry seqno 15 >= tombstone seqno 10: the delete does not outrank it,
+        // so the row is not marked even though the key is in range.
+        let rows: &[(&[u8], SeqNo)] = &[(b"b", 15)];
+        assert!(marked(rows, &[rt(b"a", b"z", 10)], 100).is_empty());
+    }
+
+    #[test]
+    fn per_version_positions_marked_independently() {
+        // One key with two versions: b@15 survives the @10 delete, b@5 is
+        // dropped. Position numbering counts every version, so only position 1
+        // (b@5) is marked.
+        let rows: &[(&[u8], SeqNo)] = &[(b"b", 15), (b"b", 5)];
+        assert_eq!(marked(rows, &[rt(b"a", b"z", 10)], 100), vec![1]);
+    }
+
+    #[test]
+    fn overlapping_tombstones_take_the_highest_seqno() {
+        // [a, z)@8 and [c, e)@12 overlap on c, d. An entry at seqno 10 is
+        // outranked only where the @12 tombstone is active (c, d); under @8
+        // alone (b, e..) it survives.
+        let rows: &[(&[u8], SeqNo)] = &[(b"b", 10), (b"c", 10), (b"d", 10), (b"e", 10)];
+        let tombstones = [rt(b"a", b"z", 8), rt(b"c", b"e", 12)];
+        assert_eq!(marked(rows, &tombstones, 100), vec![1, 2]);
+    }
+}

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -143,6 +143,11 @@ pub(super) fn prepare_table_writer(
         .use_seqno_in_index(rc.seqno_in_index)
         .use_zone_map(rc.zone_map)
         .use_columnar(rc.columnar)
+        // Per-level delete strategy: under copy-on-write the output SSTs persist
+        // no delete-bitmap (deleted rows are dropped); merge-on-read / adaptive
+        // keep a populated bitmap. Read off the live snapshot so a policy change
+        // migrates segments at the next compaction.
+        .delete_strategy(rc.delete_strategy.get(dst_lvl))
         .use_disable_cow_on_sst(rc.disable_cow_on_sst_files)
         .use_bloom_policy({
             use crate::config::FilterPolicyEntry::{Bloom, None};

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -267,6 +267,23 @@ impl ProducedOutput {
             blob_file.mark_as_deleted();
         }
     }
+
+    /// Builds the output for a merge-on-read relocation: the `created` segment
+    /// (the source's blocks reused verbatim plus a delete-bitmap) replaces the
+    /// `deleted` source segment, with no blob files and no fragmentation. Lets
+    /// the relocation path reuse [`install_merge`]'s atomic version edit instead
+    /// of hand-rolling one.
+    #[cfg(feature = "std")]
+    pub(super) fn for_relocation(created: Table, deleted: Table) -> Self {
+        Self {
+            created_tables: vec![created],
+            created_blob_files: Vec::new(),
+            rewritten_blob_files_to_drop: Vec::new(),
+            tables_to_delete: vec![deleted],
+            blob_frag_map: FragmentationMap::default(),
+            consumed_through: crate::HashMap::default(),
+        }
+    }
 }
 
 // TODO: find a better name

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -7,6 +7,8 @@
 pub(crate) mod fifo;
 pub(crate) mod leveled;
 // pub(crate) mod maintenance;
+#[cfg(feature = "std")]
+pub(crate) mod delete_materialize;
 pub(crate) mod drop_range;
 pub mod filter;
 mod flavour;

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1555,6 +1555,11 @@ fn plan_merge_on_read(
         || source.metadata.ecc_params.is_some()
         || source.metadata.ecc_unrecognized
         || source.zone_map.is_empty()
+        // A source that already carries a delete bitmap reads through the mask,
+        // so `scan()` below yields the surviving rows under renumbered ordinals
+        // that no longer line up with the verbatim-copied physical blocks. Relocating
+        // it would alias the wrong rows; fall back to copy-on-write instead.
+        || !source.delete_bitmap().is_empty()
     {
         return Ok(None);
     }
@@ -1570,7 +1575,7 @@ fn plan_merge_on_read(
         input_range_tombstones,
         opts.mvcc_gc_watermark,
         &opts.config.comparator,
-    );
+    )?;
     if bitmap.is_empty() {
         return Ok(None);
     }
@@ -1609,8 +1614,15 @@ fn run_merge_on_read_relocation(
     let (folder, level_fs) = opts.config.tables_folder_for_level(payload.dest_level);
     let new_path = folder.join(new_id.to_string());
 
-    let checksum =
-        source.relocate_columnar_with_deletes(&new_path, new_id, bitmap, opts.config.sync_mode)?;
+    // Write the relocated SST through the DESTINATION level's filesystem (the
+    // same one that recovers and installs it below), not the source table's.
+    let checksum = source.relocate_columnar_with_deletes(
+        &new_path,
+        &*level_fs,
+        new_id,
+        bitmap,
+        opts.config.sync_mode,
+    )?;
 
     let relocated = Table::recover(
         new_path,

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1566,12 +1566,19 @@ fn plan_merge_on_read(
 
     // Positional bitmap from the segment's own below-watermark range tombstones,
     // over every stored version in block-index order (scan order = the writer's
-    // position numbering = the read mask's expectation).
-    let entries = source.scan()?.collect::<crate::Result<Vec<_>>>()?;
+    // position numbering = the read mask's expectation). Keep only the key and
+    // seqno per row, dropping each scanned value so planning does not retain a
+    // whole segment's values in memory.
+    let keys = source
+        .scan()?
+        .map(|entry| {
+            let entry = entry?;
+            Ok((entry.key.user_key, entry.key.seqno))
+        })
+        .collect::<crate::Result<Vec<_>>>()?;
     let bitmap = super::delete_materialize::build_position_bitmap(
-        entries
-            .iter()
-            .map(|e| (e.key.user_key.as_ref(), e.key.seqno)),
+        keys.iter()
+            .map(|(user_key, seqno)| (user_key.as_ref(), *seqno)),
         input_range_tombstones,
         opts.mvcc_gc_watermark,
         &opts.config.comparator,

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -1523,6 +1523,149 @@ fn hidden_guard<T>(
     })
 }
 
+/// Decides whether the merge reduces to a merge-on-read relocation and, if so,
+/// returns the positional delete-bitmap to materialize.
+///
+/// The conservative, provably-safe trigger: a SINGLE input segment that is
+/// columnar, relocatable (non-encrypted, non-ECC, carries a zone map), under a
+/// bitmap-writing strategy, whose own below-watermark range tombstones delete at
+/// least one row. A single input means no foreign live keys can be lost and no
+/// foreign point tombstone can be missed. The bitmap is built over the segment's
+/// own scan (every version in block-index = position order) so it matches the
+/// read mask. `None` falls through to the normal copy-on-write merge, including
+/// the adaptive purge once the deleted fraction crosses the threshold.
+#[cfg(feature = "std")]
+fn plan_merge_on_read(
+    opts: &Options,
+    payload: &CompactionPayload,
+    tables: &[Table],
+    input_range_tombstones: &[crate::range_tombstone::RangeTombstone],
+) -> crate::Result<Option<(Table, crate::table::delete_bitmap::DeleteBitmap)>> {
+    let dst_lvl: usize = payload.canonical_level.into();
+    let strategy = opts.runtime_config.load_full().delete_strategy.get(dst_lvl);
+    if !strategy.writes_bitmap() {
+        return Ok(None);
+    }
+    // Single relocatable columnar segment only; anything else is copy-on-write.
+    let [source] = tables else {
+        return Ok(None);
+    };
+    if !source.metadata.columnar
+        || source.encryption.is_some()
+        || source.metadata.ecc_params.is_some()
+        || source.metadata.ecc_unrecognized
+        || source.zone_map.is_empty()
+    {
+        return Ok(None);
+    }
+
+    // Positional bitmap from the segment's own below-watermark range tombstones,
+    // over every stored version in block-index order (scan order = the writer's
+    // position numbering = the read mask's expectation).
+    let entries = source.scan()?.collect::<crate::Result<Vec<_>>>()?;
+    let bitmap = super::delete_materialize::build_position_bitmap(
+        entries
+            .iter()
+            .map(|e| (e.key.user_key.as_ref(), e.key.seqno)),
+        input_range_tombstones,
+        opts.mvcc_gc_watermark,
+        &opts.config.comparator,
+    );
+    if bitmap.is_empty() {
+        return Ok(None);
+    }
+
+    // Adaptive: once the deleted fraction crosses the threshold, purge instead
+    // (fall through to the copy-on-write merge, which drops the rows and clears
+    // the bitmap).
+    if let crate::config::DeleteStrategy::Adaptive {
+        purge_threshold_percent,
+    } = strategy
+    {
+        let item_count = source.metadata.item_count.max(1);
+        // `bitmap.len() <= item_count`, both far below `u64::MAX / 100`.
+        let deleted_percent = bitmap.len() * 100 / item_count;
+        if deleted_percent >= u64::from(purge_threshold_percent) {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some((source.clone(), bitmap)))
+}
+
+/// Relocates `source` into a new segment that reuses its data blocks verbatim
+/// plus `bitmap`, then installs the version edit replacing `source`. The caller
+/// has already released the version read lock (the install takes the write lock).
+#[cfg(feature = "std")]
+fn run_merge_on_read_relocation(
+    compaction_state: &mut CompactionGuard<'_>,
+    opts: &Options,
+    payload: &CompactionPayload,
+    source: &Table,
+    bitmap: &crate::table::delete_bitmap::DeleteBitmap,
+) -> crate::Result<CompactionResult> {
+    let dst_lvl: usize = payload.canonical_level.into();
+    let new_id = opts.table_id_generator.next();
+    let (folder, level_fs) = opts.config.tables_folder_for_level(payload.dest_level);
+    let new_path = folder.join(new_id.to_string());
+
+    let checksum =
+        source.relocate_columnar_with_deletes(&new_path, new_id, bitmap, opts.config.sync_mode)?;
+
+    let relocated = Table::recover(
+        new_path,
+        checksum,
+        0,
+        opts.tree_id,
+        new_id,
+        opts.config.cache.clone(),
+        opts.config.descriptor_table.clone(),
+        level_fs,
+        opts.config.filter_block_pinning_policy.get(dst_lvl),
+        opts.config.index_block_pinning_policy.get(dst_lvl),
+        opts.config.encryption.clone(),
+        #[cfg(zstd_any)]
+        opts.config.zstd_dictionary.clone(),
+        opts.config.comparator.clone(),
+        #[cfg(feature = "metrics")]
+        opts.metrics.clone(),
+    )?;
+
+    compaction_state
+        .hidden_set_mut()
+        .hide(payload.table_ids.iter().copied());
+
+    let produced = super::flavour::ProducedOutput::for_relocation(relocated, source.clone());
+    let result = (|| -> crate::Result<usize> {
+        let mut version_history_lock = opts.version_history.write();
+        let tables_out = super::flavour::install_merge(
+            &mut version_history_lock,
+            opts,
+            payload,
+            vec![produced],
+        )?;
+        version_history_lock.maintenance(
+            &opts.config.path,
+            opts.mvcc_gc_watermark,
+            &*opts.config.fs,
+        )?;
+        drop(version_history_lock);
+        Ok(tables_out)
+    })();
+
+    compaction_state
+        .hidden_set_mut()
+        .show(payload.table_ids.iter().copied());
+
+    let tables_out = result?;
+    Ok(CompactionResult {
+        action: CompactionAction::Merged,
+        dest_level: Some(payload.dest_level),
+        tables_in: 1,
+        tables_out,
+    })
+}
+
 #[expect(clippy::too_many_lines)]
 fn merge_tables(
     mut compaction_state: CompactionGuard<'_>,
@@ -1575,6 +1718,28 @@ fn merge_tables(
         .collect();
     input_range_tombstones.sort();
     input_range_tombstones.dedup();
+
+    // Merge-on-read fast path: a lone columnar segment whose own range
+    // tombstones (below the watermark) delete some of its rows is relocated (its
+    // data blocks reused verbatim plus a positional delete-bitmap) instead of
+    // being re-transposed. Detection is read-only, so it runs under the held
+    // read lock; on a hit the lock is released before the relocation installs
+    // its own version edit. Multi-input merges and any non-relocatable segment
+    // fall through to the normal copy-on-write merge below.
+    #[cfg(feature = "std")]
+    if let Some((source, bitmap)) =
+        plan_merge_on_read(opts, payload, &tables, &input_range_tombstones)?
+    {
+        drop(current_super_version);
+        drop(version_history_lock);
+        return run_merge_on_read_relocation(
+            &mut compaction_state,
+            opts,
+            payload,
+            &source,
+            &bitmap,
+        );
+    }
 
     // ---- Parallel sub-compaction (std only) ----
     // A non-relocating compaction can be split into disjoint key ranges that

--- a/src/config/delete_strategy.rs
+++ b/src/config/delete_strategy.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Row-level delete strategy for columnar segments.
+//!
+//! A columnar segment can apply a delete either by rewriting itself
+//! ([`DeleteStrategy::CopyOnWrite`]) or by recording the deleted row positions
+//! in a delete-bitmap overlay and deferring the rewrite
+//! ([`DeleteStrategy::MergeOnRead`]). [`DeleteStrategy::Adaptive`] starts
+//! merge-on-read and purges to a rewrite once too large a fraction of the
+//! segment is deleted. The choice is a per-level policy (see
+//! [`DeleteStrategyPolicy`]) so read-heavy lower levels can favour copy-on-write
+//! while write-heavy upper levels favour merge-on-read.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// How a columnar segment applies row-level deletes.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum DeleteStrategy {
+    /// Rewrite the segment at compaction, physically dropping deleted rows and
+    /// writing no delete-bitmap. Read-fast (no mask) at the cost of rewriting
+    /// the whole segment per delete batch. Best for read-heavy segments.
+    CopyOnWrite,
+    /// Record deleted rows in the positional delete-bitmap and reuse the
+    /// existing columnar blocks, deferring the rewrite. Cheap deletes, masked at
+    /// read. Best for write-heavy segments.
+    MergeOnRead,
+    /// Merge-on-read until the deleted fraction exceeds `purge_threshold_percent`,
+    /// then purge: rewrite the segment, drop deleted rows, and clear the bitmap.
+    /// Balances write and read amplification automatically.
+    Adaptive {
+        /// Deleted-row fraction, in percent (`0..=100`), past which a compaction
+        /// purges the segment back to copy-on-write. Bounds read amplification.
+        purge_threshold_percent: u8,
+    },
+}
+
+impl DeleteStrategy {
+    /// The default adaptive strategy: merge-on-read, purging once more than 5% of
+    /// the segment's rows are deleted (matching the lakehouse auto-purge default).
+    #[must_use]
+    pub const fn default_adaptive() -> Self {
+        Self::Adaptive {
+            purge_threshold_percent: 5,
+        }
+    }
+
+    /// Whether this strategy records deletes in a bitmap (merge-on-read) rather
+    /// than rewriting the segment immediately (copy-on-write).
+    #[must_use]
+    pub const fn writes_bitmap(self) -> bool {
+        matches!(self, Self::MergeOnRead | Self::Adaptive { .. })
+    }
+}
+
+impl Default for DeleteStrategy {
+    fn default() -> Self {
+        Self::default_adaptive()
+    }
+}
+
+/// Per-level [`DeleteStrategy`], mirroring the compression / locator policies.
+///
+/// Index `level` selects that level's strategy, and a level past the end reuses
+/// the last entry (so a single-entry policy applies everywhere).
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DeleteStrategyPolicy(Vec<DeleteStrategy>);
+
+impl core::ops::Deref for DeleteStrategyPolicy {
+    type Target = [DeleteStrategy];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DeleteStrategyPolicy {
+    /// The strategy for `level`, clamping to the last entry for levels past the
+    /// end of the policy. Empty policies fall back to [`DeleteStrategy::default`].
+    #[must_use]
+    pub fn get(&self, level: usize) -> DeleteStrategy {
+        self.0
+            .get(level)
+            .copied()
+            .unwrap_or_else(|| self.0.last().copied().unwrap_or_default())
+    }
+
+    /// Uses the same strategy in every level.
+    #[must_use]
+    pub fn all(strategy: DeleteStrategy) -> Self {
+        Self(vec![strategy])
+    }
+
+    /// Constructs a custom per-level policy.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is empty or contains more than 255 elements.
+    #[must_use]
+    pub fn new(policy: impl Into<Vec<DeleteStrategy>>) -> Self {
+        let policy = policy.into();
+        assert!(
+            !policy.is_empty(),
+            "delete strategy policy may not be empty"
+        );
+        assert!(policy.len() <= 255, "delete strategy policy is too large");
+        Self(policy)
+    }
+}
+
+impl Default for DeleteStrategyPolicy {
+    /// Adaptive (5% purge threshold) in every level.
+    fn default() -> Self {
+        Self::all(DeleteStrategy::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_adaptive_five_percent() {
+        assert_eq!(
+            DeleteStrategy::default(),
+            DeleteStrategy::Adaptive {
+                purge_threshold_percent: 5
+            }
+        );
+    }
+
+    #[test]
+    fn writes_bitmap_only_for_mor_and_adaptive() {
+        assert!(!DeleteStrategy::CopyOnWrite.writes_bitmap());
+        assert!(DeleteStrategy::MergeOnRead.writes_bitmap());
+        assert!(DeleteStrategy::default_adaptive().writes_bitmap());
+    }
+
+    #[test]
+    fn policy_get_clamps_to_last_level() {
+        let policy =
+            DeleteStrategyPolicy::new([DeleteStrategy::MergeOnRead, DeleteStrategy::CopyOnWrite]);
+        assert_eq!(policy.get(0), DeleteStrategy::MergeOnRead);
+        assert_eq!(policy.get(1), DeleteStrategy::CopyOnWrite);
+        // Levels past the end reuse the last entry (read-heavy bottom).
+        assert_eq!(policy.get(2), DeleteStrategy::CopyOnWrite);
+        assert_eq!(policy.get(99), DeleteStrategy::CopyOnWrite);
+    }
+
+    #[test]
+    fn all_applies_everywhere() {
+        let policy = DeleteStrategyPolicy::all(DeleteStrategy::MergeOnRead);
+        assert_eq!(policy.get(0), DeleteStrategy::MergeOnRead);
+        assert_eq!(policy.get(7), DeleteStrategy::MergeOnRead);
+    }
+
+    #[test]
+    #[should_panic(expected = "may not be empty")]
+    fn new_rejects_empty_policy() {
+        let _ = DeleteStrategyPolicy::new(Vec::new());
+    }
+}

--- a/src/config/delete_strategy.rs
+++ b/src/config/delete_strategy.rs
@@ -52,6 +52,19 @@ impl DeleteStrategy {
     pub const fn writes_bitmap(self) -> bool {
         matches!(self, Self::MergeOnRead | Self::Adaptive { .. })
     }
+
+    /// Whether an [`Adaptive`](Self::Adaptive) threshold is within its documented
+    /// `0..=100` range. A threshold above 100 can never be reached (deleted
+    /// percent caps at 100), so the segment would never purge.
+    #[must_use]
+    const fn has_valid_threshold(self) -> bool {
+        match self {
+            Self::Adaptive {
+                purge_threshold_percent,
+            } => purge_threshold_percent <= 100,
+            Self::CopyOnWrite | Self::MergeOnRead => true,
+        }
+    }
 }
 
 impl Default for DeleteStrategy {
@@ -87,8 +100,17 @@ impl DeleteStrategyPolicy {
     }
 
     /// Uses the same strategy in every level.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an [`Adaptive`](DeleteStrategy::Adaptive) purge threshold is
+    /// above 100 (outside its documented `0..=100` range).
     #[must_use]
     pub fn all(strategy: DeleteStrategy) -> Self {
+        assert!(
+            strategy.has_valid_threshold(),
+            "adaptive purge threshold must be in 0..=100"
+        );
         Self(vec![strategy])
     }
 
@@ -96,7 +118,8 @@ impl DeleteStrategyPolicy {
     ///
     /// # Panics
     ///
-    /// Panics if the policy is empty or contains more than 255 elements.
+    /// Panics if the policy is empty, contains more than 255 elements, or any
+    /// [`Adaptive`](DeleteStrategy::Adaptive) purge threshold is above 100.
     #[must_use]
     pub fn new(policy: impl Into<Vec<DeleteStrategy>>) -> Self {
         let policy = policy.into();
@@ -105,6 +128,13 @@ impl DeleteStrategyPolicy {
             "delete strategy policy may not be empty"
         );
         assert!(policy.len() <= 255, "delete strategy policy is too large");
+        assert!(
+            policy
+                .iter()
+                .copied()
+                .all(DeleteStrategy::has_valid_threshold),
+            "adaptive purge threshold must be in 0..=100"
+        );
         Self(policy)
     }
 }
@@ -159,5 +189,38 @@ mod tests {
     #[should_panic(expected = "may not be empty")]
     fn new_rejects_empty_policy() {
         let _ = DeleteStrategyPolicy::new(Vec::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "adaptive purge threshold must be in 0..=100")]
+    fn all_rejects_threshold_above_100() {
+        let _ = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 101,
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "adaptive purge threshold must be in 0..=100")]
+    fn new_rejects_threshold_above_100() {
+        let _ = DeleteStrategyPolicy::new([
+            DeleteStrategy::MergeOnRead,
+            DeleteStrategy::Adaptive {
+                purge_threshold_percent: 200,
+            },
+        ]);
+    }
+
+    #[test]
+    fn threshold_100_is_accepted() {
+        // The documented upper bound is inclusive.
+        let policy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 100,
+        });
+        assert_eq!(
+            policy.get(0),
+            DeleteStrategy::Adaptive {
+                purge_threshold_percent: 100
+            }
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@
 
 mod block_size;
 mod compression;
+mod delete_strategy;
 mod filter;
 mod hash_ratio;
 mod locator;
@@ -12,6 +13,7 @@ mod restart_interval;
 
 pub use block_size::BlockSizePolicy;
 pub use compression::CompressionPolicy;
+pub use delete_strategy::{DeleteStrategy, DeleteStrategyPolicy};
 pub use filter::{BloomConstructionPolicy, FilterPolicy, FilterPolicyEntry};
 pub use hash_ratio::HashRatioPolicy;
 pub use locator::{LocatorPolicy, LocatorPolicyEntry, LocatorPrecision};

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -827,6 +827,15 @@ pub struct RuntimeConfig {
     /// both row and columnar SSTs at once.
     pub columnar: bool,
 
+    /// Per-level row-level delete strategy for columnar segments: copy-on-write
+    /// (rewrite and drop deleted rows), merge-on-read (record deletes in the
+    /// positional delete-bitmap and defer the rewrite), or adaptive (merge-on-read
+    /// until a purge threshold). Read-heavy lower levels can favour copy-on-write
+    /// while write-heavy upper levels favour merge-on-read; changing the policy
+    /// migrates segments at the next compaction. Default: adaptive (5% purge
+    /// threshold) in every level.
+    pub delete_strategy: crate::config::DeleteStrategyPolicy,
+
     /// Index-size threshold (bytes) at or below which an SST's block index
     /// is written single-level; above it the index spills to a two-level
     /// (partitioned) layout. A single-level index is one block reached by a
@@ -936,6 +945,7 @@ impl Default for RuntimeConfig {
             seqno_in_index: false,
             zone_map: false,
             columnar: false,
+            delete_strategy: crate::config::DeleteStrategyPolicy::default(),
             index_partition_spill_threshold: crate::table::writer::DEFAULT_SPILL_THRESHOLD,
             disable_cow_on_sst_files: true,
             use_reflink_for_checkpoint: true,

--- a/src/table/block/type.rs
+++ b/src/table/block/type.rs
@@ -69,6 +69,13 @@ pub enum BlockType {
     /// framework that fills these blocks is built only with the `columnar`
     /// feature.
     Columnar,
+    /// Optional per-table positional delete-bitmap section: marks, by row
+    /// position, which rows of the table's columnar segment are deleted. A pure
+    /// membership set (MVCC reconciled at materialization via the compaction
+    /// watermark), applied as a mask at scan time. Kept parallel to the data
+    /// (like [`Self::ZoneMap`]) so a read without deletes pays nothing. Absent
+    /// unless the segment has materialized deletes.
+    DeleteBitmap,
 }
 
 // Wire tags are renumbered contiguously `0..=6` for V5. The previous
@@ -94,6 +101,7 @@ impl From<BlockType> for u8 {
             BlockType::SeqnoBounds => 9,
             BlockType::ZoneMap => 10,
             BlockType::Columnar => 11,
+            BlockType::DeleteBitmap => 12,
         }
     }
 }
@@ -115,6 +123,7 @@ impl TryFrom<u8> for BlockType {
             9 => Ok(Self::SeqnoBounds),
             10 => Ok(Self::ZoneMap),
             11 => Ok(Self::Columnar),
+            12 => Ok(Self::DeleteBitmap),
             _ => Err(crate::Error::InvalidTag(("BlockType", value))),
         }
     }
@@ -145,6 +154,7 @@ mod tests {
             (9, BlockType::SeqnoBounds),
             (10, BlockType::ZoneMap),
             (11, BlockType::Columnar),
+            (12, BlockType::DeleteBitmap),
         ] {
             assert_eq!(
                 u8::from(variant),
@@ -163,9 +173,9 @@ mod tests {
     fn block_type_rejects_unknown_wire_tag() {
         // Forward-incompatibility guard: a tag this build doesn't know
         // (newer writer, older reader) must surface as a typed error,
-        // not a silent coercion to a known variant. 12 is the first
+        // not a silent coercion to a known variant. 13 is the first
         // unused tag past the contiguous range.
-        assert!(BlockType::try_from(12).is_err());
+        assert!(BlockType::try_from(13).is_err());
         assert!(BlockType::try_from(255).is_err());
     }
 }

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -502,24 +502,35 @@ impl DataBlock {
         block_start_row: u32,
     ) -> crate::Result<Option<Self>> {
         let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
-        let mut entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+        let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
         if entries.is_empty() {
             return Err(crate::Error::InvalidHeader(
                 "columnar: empty reconstructed data block",
             ));
         }
-        // Positions are `block_start_row + index`; the bitmap is u32-positional,
-        // and a segment past u32 rows cannot be addressed by it.
-        let mut pos = block_start_row;
-        entries.retain(|_| {
-            let keep = !deletes.contains(pos);
-            pos = pos.wrapping_add(1);
-            keep
-        });
-        if entries.is_empty() {
+        // Each row's position is `block_start_row + index`. The bitmap is
+        // u32-positional and `build_position_bitmap` rejects segments past
+        // u32::MAX rows at write time, but a corrupt zone-map `block_start_row`
+        // could still push the sum over, so fail explicitly rather than wrapping
+        // back to 0 (which would mask the wrong rows).
+        let mut kept = Vec::with_capacity(entries.len());
+        for (index, entry) in entries.into_iter().enumerate() {
+            let offset = u32::try_from(index).map_err(|_| {
+                crate::Error::InvalidHeader("columnar: block row index exceeds u32::MAX")
+            })?;
+            let pos = block_start_row
+                .checked_add(offset)
+                .ok_or(crate::Error::InvalidHeader(
+                    "columnar: row position exceeds u32::MAX",
+                ))?;
+            if !deletes.contains(pos) {
+                kept.push(entry);
+            }
+        }
+        if kept.is_empty() {
             return Ok(None);
         }
-        Self::encode_entries_to_block(&entries, restart_interval).map(Some)
+        Self::encode_entries_to_block(&kept, restart_interval).map(Some)
     }
 
     /// Re-encodes reconstructed columnar `entries` into a row-major data block.

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -482,8 +482,62 @@ impl DataBlock {
                 "columnar: empty reconstructed data block",
             ));
         }
+        Self::encode_entries_to_block(&entries, restart_interval)
+    }
+
+    /// As [`Self::from_columnar_block`], but drops rows whose global position is
+    /// marked deleted in `deletes`. `block_start_row` is the position of this
+    /// block's first row within the segment (block-index order).
+    ///
+    /// Returns `Ok(None)` when every row in the block is deleted: the row encoder
+    /// has a non-empty precondition, so a fully-deleted block is reported as
+    /// "nothing to yield" and the caller skips it.
+    // Reconstruction-side masking primitive; the iterator wires it to the
+    // delete-bitmap + per-block start position in a follow-up change.
+    #[cfg(feature = "columnar")]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "wired into the iterator delete-masking path in a follow-up change"
+        )
+    )]
+    pub(crate) fn from_columnar_block_masked(
+        block_data: &[u8],
+        restart_interval: u8,
+        deletes: &crate::table::delete_bitmap::DeleteBitmap,
+        block_start_row: u32,
+    ) -> crate::Result<Option<Self>> {
+        let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
+        let mut entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+        if entries.is_empty() {
+            return Err(crate::Error::InvalidHeader(
+                "columnar: empty reconstructed data block",
+            ));
+        }
+        // Positions are `block_start_row + index`; the bitmap is u32-positional,
+        // and a segment past u32 rows cannot be addressed by it.
+        let mut pos = block_start_row;
+        entries.retain(|_| {
+            let keep = !deletes.contains(pos);
+            pos = pos.wrapping_add(1);
+            keep
+        });
+        if entries.is_empty() {
+            return Ok(None);
+        }
+        Self::encode_entries_to_block(&entries, restart_interval).map(Some)
+    }
+
+    /// Re-encodes reconstructed columnar `entries` into a row-major data block.
+    /// In-memory, so a fixed restart interval yields a correct iterable block.
+    #[cfg(feature = "columnar")]
+    fn encode_entries_to_block(
+        entries: &[InternalValue],
+        restart_interval: u8,
+    ) -> crate::Result<Self> {
         let mut buf = Vec::new();
-        Self::encode_into(&mut buf, &entries, restart_interval, 0.0)?;
+        Self::encode_into(&mut buf, entries, restart_interval, 0.0)?;
         let len = u32::try_from(buf.len())
             .map_err(|_| crate::Error::InvalidHeader("columnar: re-encoded block exceeds u32"))?;
         let header = crate::table::block::Header {
@@ -2495,5 +2549,86 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[cfg(feature = "columnar")]
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn from_columnar_block_masked_drops_deleted_positions() {
+        use crate::table::columnar::{CodecId, entries_to_column_batch};
+        use crate::table::delete_bitmap::DeleteBitmap;
+
+        // A 4-row block (in-block positions 0..4): keys a, b, c, d.
+        let entries = [
+            InternalValue::from_components(Slice::from(b"a".as_slice()), Slice::from([]), 1, Value),
+            InternalValue::from_components(Slice::from(b"b".as_slice()), Slice::from([]), 1, Value),
+            InternalValue::from_components(Slice::from(b"c".as_slice()), Slice::from([]), 1, Value),
+            InternalValue::from_components(Slice::from(b"d".as_slice()), Slice::from([]), 1, Value),
+        ];
+        let data = entries_to_column_batch(&entries)
+            .unwrap()
+            .encode(CodecId::Plain)
+            .unwrap();
+
+        // The block starts at global row 10, so delete global positions 10 (a)
+        // and 12 (c); b and d must survive.
+        let mut dv = DeleteBitmap::new();
+        dv.insert(10);
+        dv.insert(12);
+        let block = DataBlock::from_columnar_block_masked(&data, 16, &dv, 10)
+            .unwrap()
+            .expect("not all rows deleted");
+
+        assert_eq!(block.len(), 2);
+        assert!(
+            block
+                .point_read(b"a", SeqNo::MAX, &default_comparator())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            block
+                .point_read(b"b", SeqNo::MAX, &default_comparator())
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            block
+                .point_read(b"c", SeqNo::MAX, &default_comparator())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            block
+                .point_read(b"d", SeqNo::MAX, &default_comparator())
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[cfg(feature = "columnar")]
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn from_columnar_block_masked_returns_none_when_all_deleted() {
+        use crate::table::columnar::{CodecId, entries_to_column_batch};
+        use crate::table::delete_bitmap::DeleteBitmap;
+
+        let entries = [
+            InternalValue::from_components(Slice::from(b"a".as_slice()), Slice::from([]), 1, Value),
+            InternalValue::from_components(Slice::from(b"b".as_slice()), Slice::from([]), 1, Value),
+        ];
+        let data = entries_to_column_batch(&entries)
+            .unwrap()
+            .encode(CodecId::Plain)
+            .unwrap();
+
+        let mut dv = DeleteBitmap::new();
+        dv.insert(0);
+        dv.insert(1);
+        assert!(
+            DataBlock::from_columnar_block_masked(&data, 16, &dv, 0)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -492,16 +492,9 @@ impl DataBlock {
     /// Returns `Ok(None)` when every row in the block is deleted: the row encoder
     /// has a non-empty precondition, so a fully-deleted block is reported as
     /// "nothing to yield" and the caller skips it.
-    // Reconstruction-side masking primitive; the iterator wires it to the
-    // delete-bitmap + per-block start position in a follow-up change.
+    // Reconstruction-side masking primitive used by the iterator's columnar
+    // delete-masking path (see `Iter::load_and_resolve`).
     #[cfg(feature = "columnar")]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "wired into the iterator delete-masking path in a follow-up change"
-        )
-    )]
     pub(crate) fn from_columnar_block_masked(
         block_data: &[u8],
         restart_interval: u8,

--- a/src/table/delete_bitmap.rs
+++ b/src/table/delete_bitmap.rs
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Positional delete-bitmap for columnar segments.
+//!
+//! A [`DeleteBitmap`] marks, by row position, which rows of a columnar segment
+//! are deleted. It is a pure membership set: MVCC reconciliation happens at
+//! materialization time (a row is added only once its deleting tombstone is
+//! visible to every live snapshot, i.e. its seqno is below the compaction
+//! watermark), so the read path is a plain `contains` check with no per-row
+//! seqno to interpret.
+//!
+//! # Layout
+//!
+//! Rows are grouped into fixed [`CHUNK_ROWS`]-row chunks (a bulk delete of a
+//! whole chunk is therefore O(1), not O(rows)). Each non-empty chunk is stored
+//! either as a sorted [`Container::Sparse`] array of in-chunk offsets, or, once
+//! it holds more than [`SPARSE_MAX`] rows, as a [`Container::Dense`] bitset.
+//! This mirrors a Roaring bitmap's array/bitset containers but at a fixed
+//! 2048-row granularity tuned to the columnar block size. Empty chunks are not
+//! stored.
+//!
+//! # no-std
+//!
+//! Build, query, union, and the serialized [`DeleteBitmap::encode`] /
+//! [`DeleteBitmap::decode`] round-trip are all `core` + `alloc` only, so an
+//! embedded or WASM reader can apply deletes without `std`.
+//!
+//! # Examples
+//!
+//! ```
+//! use lsm_tree::table::delete_bitmap::DeleteBitmap;
+//!
+//! let mut dv = DeleteBitmap::new();
+//! dv.insert(5);
+//! dv.insert(5000);
+//! assert!(dv.contains(5));
+//! assert!(!dv.contains(6));
+//!
+//! let bytes = dv.encode();
+//! let decoded = DeleteBitmap::decode(&bytes).unwrap();
+//! assert_eq!(decoded, dv);
+//! ```
+
+use crate::{Error, Result};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+/// Rows per chunk. A bulk delete spanning a full chunk costs O(1) bitmap work.
+pub const CHUNK_ROWS: u32 = 2048;
+
+/// 64-bit words in a dense chunk bitset (`CHUNK_ROWS / 64`).
+const WORDS_PER_CHUNK: usize = (CHUNK_ROWS as usize) / 64;
+
+/// Sparse-to-dense break-even: a dense chunk is `WORDS_PER_CHUNK * 8` bytes; a
+/// sparse `u16` offset is 2 bytes, so beyond this many rows the dense bitset is
+/// the smaller (and faster) representation.
+const SPARSE_MAX: usize = WORDS_PER_CHUNK * 4;
+
+const KIND_SPARSE: u8 = 0;
+const KIND_DENSE: u8 = 1;
+
+/// Splits a row position into its `(chunk index, in-chunk offset)`. The offset
+/// is `row % CHUNK_ROWS`, which the compiler proves fits `u16`.
+fn split(row: u32) -> (u32, u16) {
+    (row / CHUNK_ROWS, (row % CHUNK_ROWS) as u16)
+}
+
+/// One chunk's in-chunk row offsets, in the representation that is currently
+/// smaller for its cardinality.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Container {
+    /// Sorted, deduplicated in-chunk offsets in `0..CHUNK_ROWS`.
+    Sparse(Vec<u16>),
+    /// Dense `CHUNK_ROWS`-bit bitset, word `w` bit `b` = row `w * 64 + b`.
+    Dense(Box<[u64; WORDS_PER_CHUNK]>),
+}
+
+impl Container {
+    fn contains(&self, off: u16) -> bool {
+        match self {
+            Self::Sparse(offs) => offs.binary_search(&off).is_ok(),
+            Self::Dense(words) => {
+                let (w, b) = (off as usize / 64, off as usize % 64);
+                words.get(w).is_some_and(|word| word & (1u64 << b) != 0)
+            }
+        }
+    }
+
+    /// Inserts `off`; returns `true` if it was newly added.
+    fn insert(&mut self, off: u16) -> bool {
+        match self {
+            Self::Sparse(offs) => match offs.binary_search(&off) {
+                Ok(_) => false,
+                Err(pos) => {
+                    offs.insert(pos, off);
+                    if offs.len() > SPARSE_MAX {
+                        *self = Self::densify(offs);
+                    }
+                    true
+                }
+            },
+            Self::Dense(words) => {
+                let (w, b) = (off as usize / 64, off as usize % 64);
+                let mask = 1u64 << b;
+                // off < CHUNK_ROWS is a caller invariant, so the word exists; the
+                // bounds-checked access keeps the read path panic-free regardless.
+                let Some(word) = words.get_mut(w) else {
+                    return false;
+                };
+                let was = *word & mask != 0;
+                *word |= mask;
+                !was
+            }
+        }
+    }
+
+    fn densify(offs: &[u16]) -> Self {
+        let mut words = Box::new([0u64; WORDS_PER_CHUNK]);
+        for &off in offs {
+            if let Some(word) = words.get_mut(off as usize / 64) {
+                *word |= 1u64 << (off as usize % 64);
+            }
+        }
+        Self::Dense(words)
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "a chunk holds at most CHUNK_ROWS (2048) distinct offsets, well within u32"
+    )]
+    fn cardinality(&self) -> u32 {
+        match self {
+            Self::Sparse(offs) => offs.len() as u32,
+            Self::Dense(words) => words.iter().map(|w| w.count_ones()).sum(),
+        }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "w < 32 and b < 64, so w*64 + b < 2048 fits u16"
+    )]
+    fn for_each<F: FnMut(u16)>(&self, mut f: F) {
+        match self {
+            Self::Sparse(offs) => offs.iter().for_each(|&o| f(o)),
+            Self::Dense(words) => {
+                for (w, &word) in words.iter().enumerate() {
+                    let mut bits = word;
+                    while bits != 0 {
+                        let b = bits.trailing_zeros() as usize;
+                        // w < 32 and b < 64, so w*64 + b < 2048 fits in u16.
+                        f((w * 64 + b) as u16);
+                        bits &= bits - 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A positional delete set over the rows of one columnar segment.
+///
+/// See the [module documentation](self) for the layout and MVCC semantics.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DeleteBitmap {
+    /// Non-empty chunks, kept sorted by chunk index for `contains` lookups.
+    chunks: Vec<(u32, Container)>,
+}
+
+impl DeleteBitmap {
+    /// Creates an empty delete set (no rows deleted).
+    #[must_use]
+    pub fn new() -> Self {
+        Self { chunks: Vec::new() }
+    }
+
+    /// Returns `true` if no rows are marked deleted.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.chunks.is_empty()
+    }
+
+    /// Returns the number of deleted rows.
+    #[must_use]
+    pub fn len(&self) -> u64 {
+        self.chunks
+            .iter()
+            .map(|(_, c)| u64::from(c.cardinality()))
+            .sum()
+    }
+
+    /// Marks row `row` deleted. Returns `true` if it was not already deleted.
+    pub fn insert(&mut self, row: u32) -> bool {
+        let (chunk, off) = split(row);
+        match self.chunks.binary_search_by_key(&chunk, |(c, _)| *c) {
+            Ok(pos) => self.chunks.get_mut(pos).is_some_and(|(_, c)| c.insert(off)),
+            Err(pos) => {
+                self.chunks
+                    .insert(pos, (chunk, Container::Sparse(alloc::vec![off])));
+                true
+            }
+        }
+    }
+
+    /// Returns `true` if row `row` is marked deleted.
+    #[must_use]
+    pub fn contains(&self, row: u32) -> bool {
+        let (chunk, off) = split(row);
+        match self.chunks.binary_search_by_key(&chunk, |(c, _)| *c) {
+            Ok(pos) => self.chunks.get(pos).is_some_and(|(_, c)| c.contains(off)),
+            Err(_) => false,
+        }
+    }
+
+    /// Returns `true` if any row in chunk `chunk_index` is deleted. Lets a scan
+    /// skip an entire untouched block in O(log chunks) without per-row checks.
+    #[must_use]
+    pub fn chunk_has_deletes(&self, chunk_index: u32) -> bool {
+        self.chunks
+            .binary_search_by_key(&chunk_index, |(c, _)| *c)
+            .is_ok()
+    }
+
+    /// Unions `other` into `self` (merge-on-write: the result marks a row
+    /// deleted iff either side did).
+    pub fn union(&mut self, other: &Self) {
+        for (chunk, container) in &other.chunks {
+            match self.chunks.binary_search_by_key(chunk, |(c, _)| *c) {
+                Ok(pos) => {
+                    if let Some((_, dst)) = self.chunks.get_mut(pos) {
+                        container.for_each(|off| {
+                            dst.insert(off);
+                        });
+                    }
+                }
+                Err(pos) => self.chunks.insert(pos, (*chunk, container.clone())),
+            }
+        }
+    }
+
+    /// Iterates the deleted row positions in ascending order.
+    pub fn iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.chunks.iter().flat_map(|(chunk, container)| {
+            let base = chunk * CHUNK_ROWS;
+            let mut rows = Vec::with_capacity(container.cardinality() as usize);
+            container.for_each(|off| rows.push(base + u32::from(off)));
+            rows.into_iter()
+        })
+    }
+
+    /// Serializes to the portable on-disk form (`core` + `alloc` decodable).
+    ///
+    /// Layout: `u32` non-empty-chunk count, then per chunk `u32` index, `u8`
+    /// kind, and the container payload (sparse: `u16` count + offsets; dense:
+    /// [`WORDS_PER_CHUNK`] little-endian `u64` words).
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "chunk count <= row_count/2048 fits u32; a chunk holds <= 2048 offsets, fitting u16"
+    )]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(self.chunks.len() as u32).to_le_bytes());
+        for (chunk, container) in &self.chunks {
+            out.extend_from_slice(&chunk.to_le_bytes());
+            match container {
+                Container::Sparse(offs) => {
+                    out.push(KIND_SPARSE);
+                    out.extend_from_slice(&(offs.len() as u16).to_le_bytes());
+                    for &off in offs {
+                        out.extend_from_slice(&off.to_le_bytes());
+                    }
+                }
+                Container::Dense(words) => {
+                    out.push(KIND_DENSE);
+                    for &word in words.iter() {
+                        out.extend_from_slice(&word.to_le_bytes());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Decodes a buffer produced by [`DeleteBitmap::encode`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidHeader`] on a truncated buffer, an unknown
+    /// container kind, an out-of-range offset, or chunk indices that are not
+    /// strictly ascending.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        let mut cur = Cursor::new(bytes);
+        let chunk_count = cur.u32()?;
+        let mut chunks = Vec::with_capacity(chunk_count as usize);
+        let mut last_chunk: Option<u32> = None;
+        for _ in 0..chunk_count {
+            let chunk = cur.u32()?;
+            if last_chunk.is_some_and(|p| chunk <= p) {
+                return Err(Error::InvalidHeader(
+                    "delete_bitmap: chunk indices not strictly ascending",
+                ));
+            }
+            last_chunk = Some(chunk);
+            let container = match cur.u8()? {
+                KIND_SPARSE => {
+                    let count = cur.u16()? as usize;
+                    let mut offs = Vec::with_capacity(count);
+                    let mut last: Option<u16> = None;
+                    for _ in 0..count {
+                        let off = cur.u16()?;
+                        if u32::from(off) >= CHUNK_ROWS {
+                            return Err(Error::InvalidHeader(
+                                "delete_bitmap: sparse offset out of range",
+                            ));
+                        }
+                        if last.is_some_and(|p| off <= p) {
+                            return Err(Error::InvalidHeader(
+                                "delete_bitmap: sparse offsets not strictly ascending",
+                            ));
+                        }
+                        last = Some(off);
+                        offs.push(off);
+                    }
+                    Container::Sparse(offs)
+                }
+                KIND_DENSE => {
+                    let mut words = Box::new([0u64; WORDS_PER_CHUNK]);
+                    for word in words.iter_mut() {
+                        *word = cur.u64()?;
+                    }
+                    Container::Dense(words)
+                }
+                _ => {
+                    return Err(Error::InvalidHeader(
+                        "delete_bitmap: unknown container kind",
+                    ));
+                }
+            };
+            chunks.push((chunk, container));
+        }
+        Ok(Self { chunks })
+    }
+}
+
+/// Little-endian cursor over a byte buffer with bounds-checked reads.
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take<const N: usize>(&mut self) -> Result<[u8; N]> {
+        let end = self
+            .pos
+            .checked_add(N)
+            .ok_or(Error::InvalidHeader("delete_bitmap: length overflow"))?;
+        let arr = self
+            .buf
+            .get(self.pos..end)
+            .and_then(|s| <[u8; N]>::try_from(s).ok())
+            .ok_or(Error::InvalidHeader("delete_bitmap: truncated buffer"))?;
+        self.pos = end;
+        Ok(arr)
+    }
+
+    fn u8(&mut self) -> Result<u8> {
+        let [b] = self.take()?;
+        Ok(b)
+    }
+
+    fn u16(&mut self) -> Result<u16> {
+        Ok(u16::from_le_bytes(self.take()?))
+    }
+
+    fn u32(&mut self) -> Result<u32> {
+        Ok(u32::from_le_bytes(self.take()?))
+    }
+
+    fn u64(&mut self) -> Result<u64> {
+        Ok(u64::from_le_bytes(self.take()?))
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::cast_possible_truncation,
+    reason = "test assertions over fixed in-test buffers"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_contains_across_chunks() {
+        let mut dv = DeleteBitmap::new();
+        assert!(dv.is_empty());
+        assert!(dv.insert(0));
+        assert!(dv.insert(CHUNK_ROWS - 1)); // last row of chunk 0
+        assert!(dv.insert(CHUNK_ROWS)); // first row of chunk 1
+        assert!(dv.insert(100_000));
+        assert!(!dv.insert(0)); // already present
+
+        assert!(dv.contains(0));
+        assert!(dv.contains(CHUNK_ROWS - 1));
+        assert!(dv.contains(CHUNK_ROWS));
+        assert!(dv.contains(100_000));
+        assert!(!dv.contains(1));
+        assert!(!dv.contains(CHUNK_ROWS + 1));
+        assert_eq!(dv.len(), 4);
+        assert!(!dv.is_empty());
+    }
+
+    #[test]
+    fn sparse_promotes_to_dense_and_stays_correct() {
+        let mut dv = DeleteBitmap::new();
+        // Fill one chunk past the sparse-to-dense threshold with even rows.
+        let n = (SPARSE_MAX as u32 + 50).min(CHUNK_ROWS / 2);
+        for i in 0..n {
+            assert!(dv.insert(i * 2));
+        }
+        assert_eq!(dv.len(), u64::from(n));
+        for i in 0..n {
+            assert!(dv.contains(i * 2), "even row {} missing", i * 2);
+            assert!(!dv.contains(i * 2 + 1), "odd row {} present", i * 2 + 1);
+        }
+    }
+
+    #[test]
+    fn chunk_has_deletes_enables_block_skip() {
+        let mut dv = DeleteBitmap::new();
+        dv.insert(3 * CHUNK_ROWS + 7);
+        assert!(!dv.chunk_has_deletes(0));
+        assert!(!dv.chunk_has_deletes(2));
+        assert!(dv.chunk_has_deletes(3));
+        assert!(!dv.chunk_has_deletes(4));
+    }
+
+    #[test]
+    fn union_is_set_union() {
+        let mut a = DeleteBitmap::new();
+        a.insert(1);
+        a.insert(CHUNK_ROWS + 1);
+        let mut b = DeleteBitmap::new();
+        b.insert(1); // overlap
+        b.insert(2);
+        b.insert(5 * CHUNK_ROWS); // new chunk
+        a.union(&b);
+
+        for row in [1, 2, CHUNK_ROWS + 1, 5 * CHUNK_ROWS] {
+            assert!(a.contains(row), "row {row} missing after union");
+        }
+        assert_eq!(a.len(), 4);
+    }
+
+    #[test]
+    fn iter_yields_ascending_rows() {
+        let mut dv = DeleteBitmap::new();
+        let rows = [9_u32, 1, CHUNK_ROWS + 3, 2, CHUNK_ROWS];
+        for &r in &rows {
+            dv.insert(r);
+        }
+        let got: Vec<u32> = dv.iter().collect();
+        assert_eq!(got, [1, 2, 9, CHUNK_ROWS, CHUNK_ROWS + 3]);
+    }
+
+    #[test]
+    fn encode_decode_round_trip_sparse_and_dense() {
+        let mut dv = DeleteBitmap::new();
+        // Sparse chunk.
+        dv.insert(5);
+        dv.insert(900);
+        // Dense chunk (cross the threshold).
+        for i in 0..=(SPARSE_MAX as u32) {
+            dv.insert(CHUNK_ROWS + i);
+        }
+        let bytes = dv.encode();
+        let decoded = DeleteBitmap::decode(&bytes).unwrap();
+        assert_eq!(decoded, dv);
+    }
+
+    #[test]
+    fn decode_empty_round_trips() {
+        let dv = DeleteBitmap::new();
+        let decoded = DeleteBitmap::decode(&dv.encode()).unwrap();
+        assert!(decoded.is_empty());
+        assert_eq!(decoded, dv);
+    }
+
+    #[test]
+    fn decode_truncated_buffer_errors() {
+        let mut dv = DeleteBitmap::new();
+        dv.insert(7);
+        let bytes = dv.encode();
+        assert!(DeleteBitmap::decode(&bytes[..bytes.len() - 1]).is_err());
+        assert!(DeleteBitmap::decode(&[]).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_unknown_kind() {
+        // 1 chunk, index 0, kind 99.
+        let bytes = [1, 0, 0, 0, 0, 0, 0, 0, 99];
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_out_of_range_offset() {
+        // 1 chunk, index 0, sparse, count 1, offset = CHUNK_ROWS (out of range).
+        let mut bytes = alloc::vec![1, 0, 0, 0, 0, 0, 0, 0, KIND_SPARSE, 1, 0];
+        bytes.extend_from_slice(&(CHUNK_ROWS as u16).to_le_bytes());
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_non_ascending_chunks() {
+        // 2 chunks both index 0 (not strictly ascending).
+        let bytes = [
+            2,
+            0,
+            0,
+            0, // count
+            0,
+            0,
+            0,
+            0,
+            KIND_SPARSE,
+            0,
+            0, // chunk 0, empty sparse
+            0,
+            0,
+            0,
+            0,
+            KIND_SPARSE,
+            0,
+            0, // chunk 0 again
+        ];
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+}

--- a/src/table/delete_bitmap.rs
+++ b/src/table/delete_bitmap.rs
@@ -291,11 +291,27 @@ impl DeleteBitmap {
     /// strictly ascending.
     pub fn decode(bytes: &[u8]) -> Result<Self> {
         let mut cur = Cursor::new(bytes);
-        let chunk_count = cur.u32()?;
-        let mut chunks = Vec::with_capacity(chunk_count as usize);
+        let chunk_count = usize::try_from(cur.u32()?)
+            .map_err(|_| Error::InvalidHeader("delete_bitmap: chunk count does not fit usize"))?;
+        // Bound the preallocation by the smallest a chunk can be (index u32 +
+        // kind u8 + sparse count u16 = 7 bytes), so a corrupt header cannot
+        // request a huge `Vec` before the loop fails on a truncated buffer.
+        if chunk_count > cur.remaining_len() / 7 {
+            return Err(Error::InvalidHeader(
+                "delete_bitmap: chunk count exceeds encoded payload",
+            ));
+        }
+        let mut chunks = Vec::with_capacity(chunk_count);
         let mut last_chunk: Option<u32> = None;
         for _ in 0..chunk_count {
             let chunk = cur.u32()?;
+            // The chunk's base row is `chunk * CHUNK_ROWS`; reject an index whose
+            // base would overflow the u32 position space the mask addresses.
+            if chunk > u32::MAX / CHUNK_ROWS {
+                return Err(Error::InvalidHeader(
+                    "delete_bitmap: chunk index out of row-position range",
+                ));
+            }
             if last_chunk.is_some_and(|p| chunk <= p) {
                 return Err(Error::InvalidHeader(
                     "delete_bitmap: chunk indices not strictly ascending",
@@ -305,6 +321,11 @@ impl DeleteBitmap {
             let container = match cur.u8()? {
                 KIND_SPARSE => {
                     let count = cur.u16()? as usize;
+                    if count == 0 || count > CHUNK_ROWS as usize {
+                        return Err(Error::InvalidHeader(
+                            "delete_bitmap: sparse count out of range",
+                        ));
+                    }
                     let mut offs = Vec::with_capacity(count);
                     let mut last: Option<u16> = None;
                     for _ in 0..count {
@@ -337,7 +358,17 @@ impl DeleteBitmap {
                     ));
                 }
             };
+            // `encode` never emits an empty container; an empty one is malformed.
+            if container.cardinality() == 0 {
+                return Err(Error::InvalidHeader("delete_bitmap: empty container"));
+            }
             chunks.push((chunk, container));
+        }
+        // The section must decode exactly, with nothing left over.
+        if cur.remaining_len() != 0 {
+            return Err(Error::InvalidHeader(
+                "delete_bitmap: trailing bytes after chunks",
+            ));
         }
         Ok(Self { chunks })
     }
@@ -352,6 +383,13 @@ struct Cursor<'a> {
 impl<'a> Cursor<'a> {
     fn new(buf: &'a [u8]) -> Self {
         Self { buf, pos: 0 }
+    }
+
+    /// Bytes not yet consumed. `pos` never exceeds `buf.len()` (every read goes
+    /// through bounds-checked `take`), so the floor at 0 only guards against a
+    /// future bug rather than a reachable underflow.
+    fn remaining_len(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
     }
 
     fn take<const N: usize>(&mut self) -> Result<[u8; N]> {
@@ -553,27 +591,69 @@ mod tests {
 
     #[test]
     fn decode_rejects_non_ascending_chunks() {
-        // 2 chunks both index 0 (not strictly ascending).
+        // 2 chunks both index 0 (not strictly ascending). Each is a non-empty
+        // sparse chunk (count 1, offset 0) so the count check passes and the
+        // ascending check is the one that fires.
         let bytes = [
             2,
             0,
             0,
-            0, // count
+            0, // chunk_count = 2
             0,
             0,
             0,
             0,
             KIND_SPARSE,
+            1,
             0,
-            0, // chunk 0, empty sparse
+            0,
+            0, // chunk 0: count 1, offset 0
             0,
             0,
             0,
             0,
             KIND_SPARSE,
+            1,
+            0,
             0,
             0, // chunk 0 again
         ];
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_chunk_count_exceeding_payload() {
+        // chunk_count claims a huge number of chunks but the buffer holds none,
+        // so the header is rejected before any large allocation.
+        let bytes = u32::MAX.to_le_bytes();
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_empty_sparse_container() {
+        // 1 chunk, index 0, sparse, count 0 (an empty container `encode` never
+        // emits).
+        let bytes = [1, 0, 0, 0, 0, 0, 0, 0, KIND_SPARSE, 0, 0];
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_chunk_index_out_of_range() {
+        // 1 chunk whose index * CHUNK_ROWS would overflow the u32 position space.
+        let mut bytes = alloc::vec![1, 0, 0, 0];
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // chunk index = u32::MAX
+        bytes.extend_from_slice(&[KIND_SPARSE, 1, 0, 0, 0]);
+        assert!(DeleteBitmap::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_trailing_bytes() {
+        // A valid encoding with one extra byte appended must fail (the section
+        // decodes exactly).
+        let mut dv = DeleteBitmap::new();
+        dv.insert(7);
+        let mut bytes = dv.encode();
+        bytes.push(0);
         assert!(DeleteBitmap::decode(&bytes).is_err());
     }
 }

--- a/src/table/delete_bitmap.rs
+++ b/src/table/delete_bitmap.rs
@@ -442,6 +442,41 @@ mod tests {
     }
 
     #[test]
+    fn full_chunk_bulk_delete_is_dense_and_compact() {
+        // A bulk delete of a whole chunk is O(1) bitmap work: the chunk collapses
+        // to a single dense bitset (O(1) space, not O(rows) sparse offsets) and is
+        // skipped / queried in O(1).
+        let mut dv = DeleteBitmap::new();
+        for off in 0..CHUNK_ROWS {
+            dv.insert(CHUNK_ROWS + off);
+        }
+        assert_eq!(
+            dv.len(),
+            u64::from(CHUNK_ROWS),
+            "every row of the chunk marked"
+        );
+        assert!(dv.chunk_has_deletes(1), "the full chunk reports deletes");
+        assert!(
+            !dv.chunk_has_deletes(0),
+            "an untouched neighbour skips in O(1)"
+        );
+        assert!(!dv.chunk_has_deletes(2));
+        // Boundary rows present; their neighbours in adjacent chunks are not.
+        assert!(dv.contains(CHUNK_ROWS));
+        assert!(dv.contains(2 * CHUNK_ROWS - 1));
+        assert!(!dv.contains(CHUNK_ROWS - 1));
+        assert!(!dv.contains(2 * CHUNK_ROWS));
+        // Dense storage: a full chunk encodes to one bounded bitset, far below the
+        // ~2 bytes/row a sparse array of CHUNK_ROWS offsets would need.
+        let encoded = dv.encode();
+        assert!(
+            encoded.len() < CHUNK_ROWS as usize,
+            "a full chunk must store densely (O(1) space), got {} bytes for {CHUNK_ROWS} rows",
+            encoded.len(),
+        );
+    }
+
+    #[test]
     fn union_is_set_union() {
         let mut a = DeleteBitmap::new();
         a.insert(1);

--- a/src/table/delete_bitmap.rs
+++ b/src/table/delete_bitmap.rs
@@ -434,6 +434,18 @@ impl<'a> Cursor<'a> {
 mod tests {
     use super::*;
 
+    /// Asserts that decoding `bytes` fails with exactly the expected
+    /// `InvalidHeader` message, proving the intended validation path fired rather
+    /// than some other error a generic `is_err()` would also accept.
+    fn assert_decode_rejects(bytes: &[u8], expected: &str) {
+        match DeleteBitmap::decode(bytes) {
+            Err(Error::InvalidHeader(msg)) => {
+                assert_eq!(msg, expected, "decode failed on the wrong validation path");
+            }
+            other => panic!("expected InvalidHeader({expected:?}), got {other:?}"),
+        }
+    }
+
     #[test]
     fn insert_and_contains_across_chunks() {
         let mut dv = DeleteBitmap::new();
@@ -576,9 +588,10 @@ mod tests {
 
     #[test]
     fn decode_rejects_unknown_kind() {
-        // 1 chunk, index 0, kind 99.
-        let bytes = [1, 0, 0, 0, 0, 0, 0, 0, 99];
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        // 1 chunk, index 0, kind 99. Pad to the minimum per-chunk length so the
+        // payload-size guard passes and the unknown-kind check is what fires.
+        let bytes = [1, 0, 0, 0, 0, 0, 0, 0, 99, 0, 0];
+        assert_decode_rejects(&bytes, "delete_bitmap: unknown container kind");
     }
 
     #[test]
@@ -586,7 +599,7 @@ mod tests {
         // 1 chunk, index 0, sparse, count 1, offset = CHUNK_ROWS (out of range).
         let mut bytes = alloc::vec![1, 0, 0, 0, 0, 0, 0, 0, KIND_SPARSE, 1, 0];
         bytes.extend_from_slice(&(CHUNK_ROWS as u16).to_le_bytes());
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(&bytes, "delete_bitmap: sparse offset out of range");
     }
 
     #[test]
@@ -618,7 +631,10 @@ mod tests {
             0,
             0, // chunk 0 again
         ];
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(
+            &bytes,
+            "delete_bitmap: chunk indices not strictly ascending",
+        );
     }
 
     #[test]
@@ -626,7 +642,7 @@ mod tests {
         // chunk_count claims a huge number of chunks but the buffer holds none,
         // so the header is rejected before any large allocation.
         let bytes = u32::MAX.to_le_bytes();
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(&bytes, "delete_bitmap: chunk count exceeds encoded payload");
     }
 
     #[test]
@@ -634,7 +650,7 @@ mod tests {
         // 1 chunk, index 0, sparse, count 0 (an empty container `encode` never
         // emits).
         let bytes = [1, 0, 0, 0, 0, 0, 0, 0, KIND_SPARSE, 0, 0];
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(&bytes, "delete_bitmap: sparse count out of range");
     }
 
     #[test]
@@ -643,7 +659,10 @@ mod tests {
         let mut bytes = alloc::vec![1, 0, 0, 0];
         bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // chunk index = u32::MAX
         bytes.extend_from_slice(&[KIND_SPARSE, 1, 0, 0, 0]);
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(
+            &bytes,
+            "delete_bitmap: chunk index out of row-position range",
+        );
     }
 
     #[test]
@@ -654,6 +673,6 @@ mod tests {
         dv.insert(7);
         let mut bytes = dv.encode();
         bytes.push(0);
-        assert!(DeleteBitmap::decode(&bytes).is_err());
+        assert_decode_rejects(&bytes, "delete_bitmap: trailing bytes after chunks");
     }
 }

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -148,6 +148,11 @@ pub struct Inner {
     /// range-cardinality estimate and the block-skip scan path.
     pub(crate) zone_map: crate::table::zone_map::ZoneMap,
 
+    /// Per-segment positional delete-bitmap, loaded on open from the optional
+    /// `delete_bitmap` section. Empty when the segment has no materialized
+    /// deletes, so a scan applies no mask. Read by the columnar scan path.
+    pub(crate) delete_bitmap: crate::table::delete_bitmap::DeleteBitmap,
+
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy
     /// enabled; lets a point read resolve a key to its data block in O(1),

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -150,8 +150,15 @@ pub struct Inner {
 
     /// Per-segment positional delete-bitmap, loaded on open from the optional
     /// `delete_bitmap` section. Empty when the segment has no materialized
-    /// deletes, so a scan applies no mask. Read by the columnar scan path.
-    pub(crate) delete_bitmap: crate::table::delete_bitmap::DeleteBitmap,
+    /// deletes, so a read applies no mask. `Arc` so a reader can hold it cheaply.
+    pub(crate) delete_bitmap: alloc::sync::Arc<crate::table::delete_bitmap::DeleteBitmap>,
+
+    /// Each data block's first global row position (file offset -> start row, in
+    /// block-index = writer order), built on open from the zone map when the
+    /// delete-bitmap is non-empty. `None` when there are no deletes. Lets the
+    /// read paths resolve a block's start position in O(1) for positional
+    /// masking, instead of recomputing the cumulative row counts per read.
+    pub(crate) delete_block_starts: Option<alloc::sync::Arc<crate::HashMap<u64, u32>>>,
 
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -327,26 +327,25 @@ impl Iter {
             #[cfg(feature = "columnar")]
             {
                 const REENCODE_RESTART_INTERVAL: u8 = 16;
-                return match &self.delete_mask {
-                    Some(mask) => {
-                        // A masked segment maps every data block (the start-row map
-                        // is built at open from the zone map, which covers every
-                        // block). A missing offset is an invariant violation, not a
-                        // "starts at row 0" default: defaulting to 0 would mask the
-                        // block against the wrong physical positions. Surface it
-                        // (matching the direct-load path) rather than mis-masking.
-                        let Some(&start) = mask.block_start_rows.get(&handle.offset().0) else {
-                            return Err(crate::Error::InvalidHeader(
-                                "delete mask: data block offset missing from the start-row map",
-                            ));
-                        };
-                        DataBlock::from_columnar_block_masked(
-                            &raw.data,
-                            REENCODE_RESTART_INTERVAL,
-                            &mask.bitmap,
-                            start,
-                        )
-                    }
+                // Mask only when the segment has deletes AND this block's start row
+                // is known. The start-row map is built at open from the zone map
+                // (which covers every block), so an unmapped block is unreachable;
+                // it falls through to reconstructing the whole block (no mask),
+                // sharing the no-deletes path rather than defaulting the start to 0
+                // and masking against the wrong physical positions. This matches the
+                // direct-load path (`Table::load_columnar_data_block`).
+                let masked = self.delete_mask.as_ref().and_then(|mask| {
+                    mask.block_start_rows
+                        .get(&handle.offset().0)
+                        .map(|&start| (mask, start))
+                });
+                return match masked {
+                    Some((mask, start)) => DataBlock::from_columnar_block_masked(
+                        &raw.data,
+                        REENCODE_RESTART_INTERVAL,
+                        &mask.bitmap,
+                        start,
+                    ),
                     None => DataBlock::from_columnar_block(&raw.data, REENCODE_RESTART_INTERVAL)
                         .map(Some),
                 };

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -148,6 +148,14 @@ fn create_data_block_reader(
     OwnedDataBlockIter::try_new(block, |b| b.try_iter(comparator))
 }
 
+/// Per-SST positional delete state for a columnar iterator: the delete-bitmap
+/// plus each data block's first global row position (block-index order), so a
+/// reconstructed block can drop its deleted rows by position.
+pub struct DeleteMask {
+    pub(crate) bitmap: crate::table::delete_bitmap::DeleteBitmap,
+    pub(crate) block_start_rows: crate::HashMap<u64, u32>,
+}
+
 #[expect(
     clippy::struct_excessive_bools,
     reason = "each bool is an independent per-SST read-path flag (kv footer, columnar, init, poisoned), not a state enum"
@@ -195,6 +203,11 @@ pub struct Iter {
     /// read as `BlockType::Columnar` and reconstructed into a row block.
     columnar: bool,
 
+    /// Positional delete mask for a columnar SST with materialized deletes;
+    /// `None` when the segment has no deletes. Applied during block
+    /// reconstruction so deleted rows never reach the reader.
+    delete_mask: Option<DeleteMask>,
+
     index_initialized: bool,
 
     lo_offset: BlockOffset,
@@ -232,6 +245,7 @@ impl Iter {
         heal_hints: Option<Arc<crate::heal_hints::HealHints>>,
         has_kv_footer: bool,
         columnar: bool,
+        delete_mask: Option<DeleteMask>,
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
         #[cfg(feature = "zstd")] block_layout: crate::table::block_layout::BlockLayoutMap,
@@ -253,6 +267,7 @@ impl Iter {
             heal_hints,
             has_kv_footer,
             columnar,
+            delete_mask,
             #[cfg(zstd_any)]
             zstd_dictionary,
             comparator,
@@ -283,7 +298,10 @@ impl Iter {
     /// into a row-major block; a row SST's block is loaded directly. The
     /// reconstructed block is in-memory, so a fixed restart interval yields a
     /// correct, iterable block regardless of the SST's recorded value.
-    fn load_and_resolve(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+    /// Loads, reconstructs (if columnar), and masks a data block by handle.
+    /// Returns `Ok(None)` when a columnar block is wholly deleted by the
+    /// positional mask, so the caller skips it.
+    fn load_and_resolve(&self, handle: &BlockHandle) -> crate::Result<Option<DataBlock>> {
         let block_type = if self.columnar {
             crate::table::block::BlockType::Columnar
         } else {
@@ -309,14 +327,32 @@ impl Iter {
             #[cfg(feature = "columnar")]
             {
                 const REENCODE_RESTART_INTERVAL: u8 = 16;
-                return DataBlock::from_columnar_block(&raw.data, REENCODE_RESTART_INTERVAL);
+                return match &self.delete_mask {
+                    Some(mask) => {
+                        // The block-index order is the writer's row order, so the
+                        // block's first global row position comes from the map.
+                        let start = mask
+                            .block_start_rows
+                            .get(&handle.offset().0)
+                            .copied()
+                            .unwrap_or(0);
+                        DataBlock::from_columnar_block_masked(
+                            &raw.data,
+                            REENCODE_RESTART_INTERVAL,
+                            &mask.bitmap,
+                            start,
+                        )
+                    }
+                    None => DataBlock::from_columnar_block(&raw.data, REENCODE_RESTART_INTERVAL)
+                        .map(Some),
+                };
             }
             #[cfg(not(feature = "columnar"))]
             {
                 return Err(crate::Error::FeatureUnsupported("columnar"));
             }
         }
-        DataBlock::from_loaded(raw, self.has_kv_footer)
+        DataBlock::from_loaded(raw, self.has_kv_footer).map(Some)
     }
 
     pub fn set_lower_bound(&mut self, bound: Bound) {
@@ -636,9 +672,15 @@ impl Iterator for Iter {
             // upper bound, decode only the covering prefix. Falls back to a full
             // load (which checks the block cache) otherwise.
             #[cfg(feature = "zstd")]
-            let partial = match self.try_partial_block(&handle) {
-                Ok(p) => p,
-                Err(e) => return self.poison(e),
+            let partial = if self.delete_mask.is_some() {
+                // Positional masking needs the whole block; skip the partial-decode
+                // fast path so deleted rows are dropped during reconstruction.
+                None
+            } else {
+                match self.try_partial_block(&handle) {
+                    Ok(p) => p,
+                    Err(e) => return self.poison(e),
+                }
             };
             #[cfg(not(feature = "zstd"))]
             let partial: Option<DataBlock> = None;
@@ -647,7 +689,9 @@ impl Iterator for Iter {
                 db
             } else {
                 match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
-                    Ok(b) => b,
+                    Ok(Some(b)) => b,
+                    // The block was wholly deleted by the mask; skip to the next.
+                    Ok(None) => continue,
                     Err(e) => return self.poison(e),
                 }
             };
@@ -764,9 +808,15 @@ impl DoubleEndedIterator for Iter {
             // upper bound, decode only the covering prefix. Falls back to a full
             // load (which checks the block cache) otherwise.
             #[cfg(feature = "zstd")]
-            let partial = match self.try_partial_block(&handle) {
-                Ok(p) => p,
-                Err(e) => return self.poison(e),
+            let partial = if self.delete_mask.is_some() {
+                // Positional masking needs the whole block; skip the partial-decode
+                // fast path so deleted rows are dropped during reconstruction.
+                None
+            } else {
+                match self.try_partial_block(&handle) {
+                    Ok(p) => p,
+                    Err(e) => return self.poison(e),
+                }
             };
             #[cfg(not(feature = "zstd"))]
             let partial: Option<DataBlock> = None;
@@ -775,7 +825,9 @@ impl DoubleEndedIterator for Iter {
                 db
             } else {
                 match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
-                    Ok(b) => b,
+                    Ok(Some(b)) => b,
+                    // The block was wholly deleted by the mask; skip to the next.
+                    Ok(None) => continue,
                     Err(e) => return self.poison(e),
                 }
             };

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -329,13 +329,17 @@ impl Iter {
                 const REENCODE_RESTART_INTERVAL: u8 = 16;
                 return match &self.delete_mask {
                     Some(mask) => {
-                        // The block-index order is the writer's row order, so the
-                        // block's first global row position comes from the map.
-                        let start = mask
-                            .block_start_rows
-                            .get(&handle.offset().0)
-                            .copied()
-                            .unwrap_or(0);
+                        // A masked segment maps every data block (the start-row map
+                        // is built at open from the zone map, which covers every
+                        // block). A missing offset is an invariant violation, not a
+                        // "starts at row 0" default: defaulting to 0 would mask the
+                        // block against the wrong physical positions. Surface it
+                        // (matching the direct-load path) rather than mis-masking.
+                        let Some(&start) = mask.block_start_rows.get(&handle.offset().0) else {
+                            return Err(crate::Error::InvalidHeader(
+                                "delete mask: data block offset missing from the start-row map",
+                            ));
+                        };
                         DataBlock::from_columnar_block_masked(
                             &raw.data,
                             REENCODE_RESTART_INTERVAL,

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -152,8 +152,8 @@ fn create_data_block_reader(
 /// plus each data block's first global row position (block-index order), so a
 /// reconstructed block can drop its deleted rows by position.
 pub struct DeleteMask {
-    pub(crate) bitmap: crate::table::delete_bitmap::DeleteBitmap,
-    pub(crate) block_start_rows: crate::HashMap<u64, u32>,
+    pub(crate) bitmap: Arc<crate::table::delete_bitmap::DeleteBitmap>,
+    pub(crate) block_start_rows: Arc<crate::HashMap<u64, u32>>,
 }
 
 #[expect(

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -286,7 +286,10 @@ impl Table {
         )
     }
 
-    fn load_data_block(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+    /// Loads (and, for columnar SSTs, reconstructs + delete-masks) a data block.
+    /// Returns `Ok(None)` when a columnar block is wholly deleted by the
+    /// positional mask, so the caller treats it as carrying no keys.
+    fn load_data_block(&self, handle: &BlockHandle) -> crate::Result<Option<DataBlock>> {
         // Columnar SSTs store each data block as a PAX `ColumnBatch`; reconstruct
         // the row entries on load so every row read path works unchanged.
         #[cfg(feature = "columnar")]
@@ -306,6 +309,7 @@ impl Table {
             self.zstd_dictionary.as_deref(),
         )
         .and_then(|block| DataBlock::from_loaded(block, has_kv_footer))
+        .map(Some)
     }
 
     /// Loads a columnar data block and reconstructs it as a row-major
@@ -313,8 +317,11 @@ impl Table {
     /// re-encode them row-major in memory so the existing point-read / iterator
     /// machinery is reused verbatim. The native column-projection read path
     /// (decode only the referenced columns) is a later optimization.
+    ///
+    /// Returns `Ok(None)` when the positional delete-bitmap deletes every row of
+    /// the block, so the caller treats it as carrying no keys.
     #[cfg(feature = "columnar")]
-    fn load_columnar_data_block(&self, handle: &BlockHandle) -> crate::Result<DataBlock> {
+    fn load_columnar_data_block(&self, handle: &BlockHandle) -> crate::Result<Option<DataBlock>> {
         let block = self.load_block(
             handle,
             BlockType::Columnar,
@@ -322,7 +329,23 @@ impl Table {
             #[cfg(zstd_any)]
             self.zstd_dictionary.as_deref(),
         )?;
-        DataBlock::from_columnar_block(&block.data, self.metadata.data_block_restart_interval)
+        let restart = self.metadata.data_block_restart_interval;
+        match self
+            .delete_block_starts
+            .as_ref()
+            .and_then(|starts| starts.get(&handle.offset().0))
+        {
+            // The segment has materialized deletes and this block has a recorded
+            // start position: drop the deleted rows during reconstruction.
+            Some(&start) => DataBlock::from_columnar_block_masked(
+                &block.data,
+                restart,
+                &self.delete_bitmap,
+                start,
+            ),
+            // No deletes (or, unreachably, an unmapped block): reconstruct whole.
+            None => DataBlock::from_columnar_block(&block.data, restart).map(Some),
+        }
     }
 
     /// Loads a columnar data block and decodes only the projected columns,
@@ -752,8 +775,9 @@ impl Table {
         // Fast path: retrieval-ribbon locator (see `point_read_inner` for the
         // MVCC-correctness argument). A located-block miss falls through to the
         // index walk below.
-        if let Some((handle, hint)) = self.locator_block(key_hash)? {
-            let data_block = self.load_data_block(&handle)?;
+        if let Some((handle, hint)) = self.locator_block(key_hash)?
+            && let Some(data_block) = self.load_data_block(&handle)?
+        {
             let found = match hint {
                 Some((slot, is_entry)) => data_block.point_read_value_at_slot(
                     slot,
@@ -776,7 +800,10 @@ impl Table {
         for block_handle in iter {
             let block_handle = block_handle?;
 
-            let data_block = self.load_data_block(block_handle.as_ref())?;
+            // A wholly-deleted columnar block carries no keys; skip it.
+            let Some(data_block) = self.load_data_block(block_handle.as_ref())? else {
+                continue;
+            };
 
             if let Some(found) = data_block.point_read_value(key, seqno, &self.comparator)? {
                 return Ok(Some(found));
@@ -871,8 +898,9 @@ impl Table {
         // hit returns the correct MVCC answer and a miss (absent key, or the
         // visible version lives in a later block) safely falls through to the
         // index walk below.
-        if let Some((handle, hint)) = self.locator_block(key_hash)? {
-            let data_block = self.load_data_block(&handle)?;
+        if let Some((handle, hint)) = self.locator_block(key_hash)?
+            && let Some(data_block) = self.load_data_block(&handle)?
+        {
             let found = match hint {
                 Some((slot, is_entry)) => {
                     data_block.point_read_at_slot(slot, is_entry, key, seqno, &self.comparator)?
@@ -894,7 +922,10 @@ impl Table {
         for block_handle in iter {
             let block_handle = block_handle?;
 
-            let data_block = self.load_data_block(block_handle.as_ref())?;
+            // A wholly-deleted columnar block carries no keys; skip it.
+            let Some(data_block) = self.load_data_block(block_handle.as_ref())? else {
+                continue;
+            };
 
             if let Some(item) = data_block.point_read(key, seqno, &self.comparator)? {
                 return Ok(Some((item, data_block)));
@@ -1149,7 +1180,10 @@ impl Table {
                 continue;
             }
 
-            let data_block = self.load_data_block(block_handle.as_ref())?;
+            // A wholly-deleted columnar block carries no keys; skip it.
+            let Some(data_block) = self.load_data_block(block_handle.as_ref())? else {
+                continue;
+            };
 
             // Drain passing keys that fall inside [..end_key].
             //
@@ -1470,7 +1504,10 @@ impl Table {
                 continue;
             }
 
-            let block = self.load_data_block(handle.as_ref())?;
+            // A wholly-deleted columnar block carries no keys; skip it.
+            let Some(block) = self.load_data_block(handle.as_ref())? else {
+                continue;
+            };
             let data = &block.inner.data;
             for item in block.iter(self.comparator.clone()) {
                 let mut value = item.materialize(data);

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1507,6 +1507,35 @@ impl Table {
         self.range_iter(range)
     }
 
+    /// Builds the positional delete mask for a columnar iterator: clones the
+    /// delete-bitmap and maps each data block's file offset to its first global
+    /// row position (block-index = writer row order). `None` when the segment has
+    /// no deletes, so a delete-free table pays nothing. Per-block row counts come
+    /// from the zone map, which a delete-bitmap SST always carries (enforced on
+    /// open).
+    fn build_delete_mask(&self) -> Option<iter::DeleteMask> {
+        if self.delete_bitmap.is_empty() {
+            return None;
+        }
+        let mut block_start_rows = crate::HashMap::default();
+        let mut start: u32 = 0;
+        for keyed in self.block_index.iter() {
+            let Ok(keyed) = keyed else { return None };
+            let offset = keyed.offset().0;
+            block_start_rows.insert(offset, start);
+            let row_count = self
+                .zone_map
+                .columns_for(offset)
+                .and_then(|stats| stats.first())
+                .map_or(0, |col| col.row_count);
+            start = start.wrapping_add(row_count);
+        }
+        Some(iter::DeleteMask {
+            bitmap: self.delete_bitmap.clone(),
+            block_start_rows,
+        })
+    }
+
     /// Like [`Self::range`] but returns the concrete [`iter::Iter`] reader.
     ///
     /// The seekable range pipeline holds the concrete type so it can re-position
@@ -1527,6 +1556,7 @@ impl Table {
             self.heal_hints.get().cloned(),
             self.metadata.kv_checksum_algo.is_some(),
             self.metadata.columnar,
+            self.build_delete_mask(),
             #[cfg(zstd_any)]
             self.zstd_dictionary.clone(),
             self.comparator.clone(),
@@ -2230,6 +2260,16 @@ impl Table {
         } else {
             crate::table::delete_bitmap::DeleteBitmap::default()
         };
+
+        // A delete-bitmap is positional; masking it on the read path needs each
+        // block's row count, which comes from the zone map. The writer co-writes
+        // both, so a bitmap without a zone map is a malformed SST (masking would
+        // resolve every block to position 0 and corrupt visibility).
+        if !delete_bitmap.is_empty() && zone_map.is_empty() {
+            return Err(crate::Error::InvalidHeader(
+                "delete-bitmap SST is missing its zone map",
+            ));
+        }
 
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -332,20 +332,26 @@ impl Table {
             self.zstd_dictionary.as_deref(),
         )?;
         let restart = self.metadata.data_block_restart_interval;
-        match self
-            .delete_block_starts
-            .as_ref()
-            .and_then(|starts| starts.get(&handle.offset().0))
-        {
-            // The segment has materialized deletes and this block has a recorded
-            // start position: drop the deleted rows during reconstruction.
-            Some(&start) => DataBlock::from_columnar_block_masked(
-                &block.data,
-                restart,
-                &self.delete_bitmap,
-                start,
-            ),
-            // No deletes (or, unreachably, an unmapped block): reconstruct whole.
+        match self.delete_block_starts.as_ref() {
+            // The segment has materialized deletes: every data block has a
+            // recorded start position (the map is built at open from the zone map,
+            // which covers every block). Drop the deleted rows during
+            // reconstruction; a missing offset is an invariant violation (it would
+            // otherwise silently mask the wrong positions), so surface it.
+            Some(starts) => {
+                let Some(&start) = starts.get(&handle.offset().0) else {
+                    return Err(crate::Error::InvalidHeader(
+                        "delete mask: data block offset missing from the start-row map",
+                    ));
+                };
+                DataBlock::from_columnar_block_masked(
+                    &block.data,
+                    restart,
+                    &self.delete_bitmap,
+                    start,
+                )
+            }
+            // No materialized deletes: reconstruct the whole block.
             None => DataBlock::from_columnar_block(&block.data, restart).map(Some),
         }
     }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod locator;
 pub(crate) mod meta;
 pub(crate) mod multi_writer;
 pub(crate) mod regions;
+#[cfg(feature = "std")]
+mod relocate;
 mod scanner;
 pub(crate) mod seqno_bounds;
 pub mod util;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1311,6 +1311,11 @@ impl Table {
             }
             _ => None,
         };
+        // Positional deletes are masked at scan time. The block index yields
+        // blocks in key (= write) order, the same order the writer assigned row
+        // positions, so `row_base` is each block's first global row position.
+        let has_deletes = !self.delete_bitmap.is_empty();
+        let mut row_base: u32 = 0;
         let mut out = Vec::new();
         for keyed in self.block_index.iter() {
             let keyed = keyed?;
@@ -1320,17 +1325,37 @@ impl Table {
                 && let Some(stats) = self.zone_map.columns_for(*keyed.offset())
                 && pred.can_skip_block(stats)
             {
+                // Advance the position cursor by the skipped block's row count
+                // (from its zone-map stats) so later blocks still map to the
+                // right delete positions. Skipped rows are predicate-excluded, so
+                // whether they are deleted does not affect the output.
+                if has_deletes && let Some(first) = stats.first() {
+                    row_base = row_base.wrapping_add(first.row_count);
+                }
                 continue;
             }
             let handle = BlockHandle::new(keyed.offset(), keyed.size());
             let batch = self.load_columnar_block_projected(&handle, &decode_projection)?;
-            let mut batch = match predicate {
-                Some(pred) => {
-                    let mask = pred.matching_rows(&batch);
-                    crate::table::columnar_predicate::filter_batch(&batch, &mask)
+            let row_count = batch.row_count;
+            let mut batch = if predicate.is_some() || has_deletes {
+                let mut keep = match predicate {
+                    Some(pred) => pred.matching_rows(&batch),
+                    None => alloc::vec![true; row_count as usize],
+                };
+                if has_deletes {
+                    let mut pos = row_base;
+                    for k in &mut keep {
+                        if self.delete_bitmap.contains(pos) {
+                            *k = false;
+                        }
+                        pos = pos.wrapping_add(1);
+                    }
                 }
-                None => batch,
+                crate::table::columnar_predicate::filter_batch(&batch, &keep)
+            } else {
+                batch
             };
+            row_base = row_base.wrapping_add(row_count);
             if let Some(column_id) = added_predicate_column {
                 batch.columns.retain(|c| c.column_id != column_id);
             }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -253,6 +253,14 @@ impl Table {
         self.metadata.id
     }
 
+    /// This segment's positional delete-bitmap (rows deleted by position),
+    /// loaded on open. Empty when the segment has no materialized deletes, in
+    /// which case a scan applies no mask.
+    #[must_use]
+    pub fn delete_bitmap(&self) -> &crate::table::delete_bitmap::DeleteBitmap {
+        &self.delete_bitmap
+    }
+
     fn load_block(
         &self,
         handle: &BlockHandle,
@@ -2159,6 +2167,45 @@ impl Table {
             crate::table::zone_map::ZoneMap::default()
         };
 
+        // Load the optional positional delete-bitmap section. Unlike the zone
+        // map (a skip optimization that degrades safely to empty), the delete
+        // bitmap is correctness data: silently dropping an unreadable one would
+        // resurrect deleted rows. The block already carries checksum / ECC /
+        // AEAD, so if it still cannot be decoded the error is propagated and
+        // table recovery fails rather than returning deleted data.
+        let delete_bitmap = if let Some(db_handle) = regions.delete_bitmap {
+            let block = Block::from_file(
+                file_handle.as_ref(),
+                db_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: metadata.id,
+                    block_type: BlockType::DeleteBitmap,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::DeleteBitmap {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            crate::table::delete_bitmap::DeleteBitmap::decode(&block.data)?
+        } else {
+            crate::table::delete_bitmap::DeleteBitmap::default()
+        };
+
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
@@ -2264,6 +2311,7 @@ impl Table {
                 block_layout,
                 seqno_bounds,
                 zone_map,
+                delete_bitmap,
                 locator_index,
                 encryption,
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -332,26 +332,24 @@ impl Table {
             self.zstd_dictionary.as_deref(),
         )?;
         let restart = self.metadata.data_block_restart_interval;
-        match self.delete_block_starts.as_ref() {
-            // The segment has materialized deletes: every data block has a
-            // recorded start position (the map is built at open from the zone map,
-            // which covers every block). Drop the deleted rows during
-            // reconstruction; a missing offset is an invariant violation (it would
-            // otherwise silently mask the wrong positions), so surface it.
-            Some(starts) => {
-                let Some(&start) = starts.get(&handle.offset().0) else {
-                    return Err(crate::Error::InvalidHeader(
-                        "delete mask: data block offset missing from the start-row map",
-                    ));
-                };
-                DataBlock::from_columnar_block_masked(
-                    &block.data,
-                    restart,
-                    &self.delete_bitmap,
-                    start,
-                )
-            }
-            // No materialized deletes: reconstruct the whole block.
+        match self
+            .delete_block_starts
+            .as_ref()
+            .and_then(|starts| starts.get(&handle.offset().0))
+        {
+            // The segment has materialized deletes and this block has a recorded
+            // start position: drop the deleted rows during reconstruction. The
+            // start-row map is built at open from the zone map (every block), so
+            // an unmapped block is unreachable; it falls through to the whole-block
+            // reconstruction below rather than masking against the wrong positions.
+            Some(&start) => DataBlock::from_columnar_block_masked(
+                &block.data,
+                restart,
+                &self.delete_bitmap,
+                start,
+            ),
+            // No materialized deletes (or, unreachably, an unmapped block):
+            // reconstruct the whole block.
             None => DataBlock::from_columnar_block(&block.data, restart).map(Some),
         }
     }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -258,7 +258,7 @@ impl Table {
     /// which case a scan applies no mask.
     #[must_use]
     pub fn delete_bitmap(&self) -> &crate::table::delete_bitmap::DeleteBitmap {
-        &self.delete_bitmap
+        self.delete_bitmap.as_ref()
     }
 
     fn load_block(
@@ -1507,29 +1507,13 @@ impl Table {
         self.range_iter(range)
     }
 
-    /// Builds the positional delete mask for a columnar iterator: clones the
-    /// delete-bitmap and maps each data block's file offset to its first global
-    /// row position (block-index = writer row order). `None` when the segment has
-    /// no deletes, so a delete-free table pays nothing. Per-block row counts come
-    /// from the zone map, which a delete-bitmap SST always carries (enforced on
-    /// open).
+    /// Builds the positional delete mask for a columnar iterator from the
+    /// on-open cache: the delete-bitmap plus each block's first global row
+    /// position. `None` when the segment has no deletes, so a delete-free table
+    /// pays nothing. Cheap (two `Arc` clones); the cumulative row counts were
+    /// computed once on open.
     fn build_delete_mask(&self) -> Option<iter::DeleteMask> {
-        if self.delete_bitmap.is_empty() {
-            return None;
-        }
-        let mut block_start_rows = crate::HashMap::default();
-        let mut start: u32 = 0;
-        for keyed in self.block_index.iter() {
-            let Ok(keyed) = keyed else { return None };
-            let offset = keyed.offset().0;
-            block_start_rows.insert(offset, start);
-            let row_count = self
-                .zone_map
-                .columns_for(offset)
-                .and_then(|stats| stats.first())
-                .map_or(0, |col| col.row_count);
-            start = start.wrapping_add(row_count);
-        }
+        let block_start_rows = self.delete_block_starts.clone()?;
         Some(iter::DeleteMask {
             bitmap: self.delete_bitmap.clone(),
             block_start_rows,
@@ -2271,6 +2255,28 @@ impl Table {
             ));
         }
 
+        // Cache each data block's first global row position (file offset -> start
+        // row) once on open, so positional delete masking is O(1) per block on
+        // every read instead of recomputing cumulative row counts. Empty when the
+        // segment has no deletes.
+        let delete_block_starts = if delete_bitmap.is_empty() {
+            None
+        } else {
+            let mut map = crate::HashMap::default();
+            let mut start: u32 = 0;
+            for keyed in block_index.iter() {
+                let keyed = keyed?;
+                map.insert(keyed.offset().0, start);
+                let row_count = zone_map
+                    .columns_for(keyed.offset().0)
+                    .and_then(|stats| stats.first())
+                    .map_or(0, |col| col.row_count);
+                start = start.wrapping_add(row_count);
+            }
+            Some(alloc::sync::Arc::new(map))
+        };
+        let delete_bitmap = alloc::sync::Arc::new(delete_bitmap);
+
         // Load the optional retrieval-ribbon locator section and pair it with an
         // ordinal → data-block-handle map (the index yields handles in key/write
         // order, which is the writer's block_id ordering). Only when the section
@@ -2377,6 +2383,7 @@ impl Table {
                 seqno_bounds,
                 zone_map,
                 delete_bitmap,
+                delete_block_starts,
                 locator_index,
                 encryption,
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -10,6 +10,7 @@ pub mod columnar;
 #[cfg(feature = "columnar")]
 pub mod columnar_predicate;
 pub mod data_block;
+pub mod delete_bitmap;
 pub mod filter;
 mod id;
 mod index_block;

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -119,6 +119,11 @@ pub struct MultiWriter {
     /// flush / compaction uniformly writes columnar (or row-major) data blocks.
     use_columnar: bool,
 
+    /// Delete strategy applied to every successor [`Writer`], preserved across
+    /// rotation. Under copy-on-write the writers persist no delete-bitmap; under
+    /// merge-on-read / adaptive a populated bitmap is written.
+    delete_strategy: crate::config::DeleteStrategy,
+
     /// When `true`, each output SST has per-file copy-on-write cleared at
     /// creation (Btrfs `FS_NOCOW_FL`) so write-once SSTs avoid the
     /// copy-on-write fragmentation penalty. Preserved across rotations so every successor
@@ -200,6 +205,7 @@ impl MultiWriter {
             use_seqno_in_index: false,
             use_zone_map: false,
             use_columnar: false,
+            delete_strategy: crate::config::DeleteStrategy::default(),
             disable_cow_on_sst: false,
             locator_entry: crate::config::LocatorPolicyEntry::None,
 
@@ -573,6 +579,14 @@ impl MultiWriter {
         self
     }
 
+    /// Sets the delete strategy for this and every rotated successor writer.
+    #[must_use]
+    pub fn delete_strategy(mut self, strategy: crate::config::DeleteStrategy) -> Self {
+        self.delete_strategy = strategy;
+        self.writer = self.writer.delete_strategy(strategy);
+        self
+    }
+
     /// Wires the resolved retrieval-ribbon locator policy entry through to the
     /// inner [`Writer`] and preserves it across rotations, so every successor
     /// table in the run emits its own per-SST locator section (or none, when
@@ -639,6 +653,7 @@ impl MultiWriter {
         new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
         new_writer = new_writer.use_zone_map(self.use_zone_map);
         new_writer = new_writer.use_columnar(self.use_columnar);
+        new_writer = new_writer.delete_strategy(self.delete_strategy);
         new_writer = new_writer.use_disable_cow(self.disable_cow_on_sst);
         new_writer = new_writer.use_locator(self.locator_entry);
 

--- a/src/table/regions.rs
+++ b/src/table/regions.rs
@@ -98,6 +98,11 @@ pub struct ParsedRegions {
     /// per-column `(min, max, null_count, row_count)` stats for predicate-based
     /// block-skip, kept parallel to the index so point reads pay nothing for it.
     pub zone_map: Option<BlockHandle>,
+    /// Optional positional delete-bitmap section (the `delete_bitmap` section).
+    /// Present only when the segment has materialized deletes; marks deleted
+    /// rows by position, applied as a mask at scan time. Absent otherwise, so a
+    /// segment without deletes pays nothing.
+    pub delete_bitmap: Option<BlockHandle>,
     pub linked_blob_files: Option<BlockHandle>,
     pub metadata: BlockHandle,
     /// Mid-file backup of the meta block. Writer order:
@@ -155,6 +160,10 @@ impl ParsedRegions {
                 .transpose()?,
             zone_map: toc
                 .section(b"zone_map")
+                .map(toc_entry_to_handle)
+                .transpose()?,
+            delete_bitmap: toc
+                .section(b"delete_bitmap")
                 .map(toc_entry_to_handle)
                 .transpose()?,
             linked_blob_files: toc

--- a/src/table/relocate.rs
+++ b/src/table/relocate.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Merge-on-read segment relocation: rewrite a columnar SST into a new file that
+//! reuses every data block verbatim and carries a positional delete-bitmap,
+//! deferring the expensive re-transpose that copy-on-write pays.
+//!
+//! Because merge-on-read keeps all rows (deleted ones are masked by the bitmap,
+//! not dropped), the output segment is byte-identical to the source except for a
+//! new table id and an added `delete_bitmap` section. So this copies the data /
+//! index / filter / zone-map / seqno-bounds sections (and the torn-write
+//! defenses) verbatim, re-encodes only the two `meta` blocks with the new id,
+//! and appends the bitmap. The data section stays first, so the block-index /
+//! zone-map / seqno-bounds absolute offsets stay valid; every other section is
+//! addressed through the table of contents.
+
+use super::Table;
+use super::block::decoder::ParsedItem;
+use super::block::{Block, BlockIdentity, BlockTransform, BlockType};
+use super::data_block::DataBlock;
+use super::delete_bitmap::DeleteBitmap;
+use crate::checksum::ChecksummedWriter;
+use crate::fs::{FsFile, FsOpenOptions, SyncMode};
+use crate::io::BufWriter;
+use crate::path::Path;
+use crate::{Checksum, InternalValue, TableId, UserValue};
+use alloc::vec::Vec;
+
+/// Largest chunk read+written when copying a section verbatim, so a multi-MiB
+/// data section never has to be buffered whole.
+const COPY_CHUNK: usize = 256 * 1024;
+
+impl Table {
+    /// Writes a new SST at `new_path` that reuses this columnar segment's data
+    /// blocks verbatim, re-points the on-disk table id to `new_table_id`, and
+    /// adds `delete_bitmap` as a positional row mask. Returns the new file's
+    /// checksum (for [`Table::recover`]); the caller installs and recovers it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::FeatureUnsupported`] when the segment cannot be
+    /// relocated by verbatim block reuse: an encrypted segment (the AEAD binds
+    /// the table id, so a re-pointed copy fails verification), a segment carrying
+    /// Page ECC (the re-encoded meta would need the parity layout), a row-major
+    /// segment, or one without a zone map (the positional mask needs the
+    /// per-block row counts the zone map carries). The caller falls back to a
+    /// copy-on-write rewrite in those cases.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired by the merge-on-read compaction path")
+    )]
+    pub(crate) fn relocate_columnar_with_deletes(
+        &self,
+        new_path: &Path,
+        new_table_id: TableId,
+        delete_bitmap: &DeleteBitmap,
+        sync_mode: SyncMode,
+    ) -> crate::Result<Checksum> {
+        // Verbatim block reuse is sound only for a non-encrypted, non-ECC
+        // columnar segment that already carries a zone map (the bitmap's
+        // positional mask resolves each block's start row from the zone-map row
+        // counts, and the open-time invariant rejects a bitmap without one).
+        if self.encryption.is_some()
+            || self.metadata.ecc_params.is_some()
+            || self.metadata.ecc_unrecognized
+            || !self.metadata.columnar
+            || self.zone_map.is_empty()
+        {
+            return Err(crate::Error::FeatureUnsupported(
+                "merge-on-read block reuse needs a non-encrypted, non-ECC columnar segment with a zone map",
+            ));
+        }
+
+        let mut src = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let reader = crate::sfa::Reader::from_reader(&mut src)?;
+
+        // Re-encode the meta KV block with the new id. The block is loaded TAIL
+        // (`meta`) since MID and TAIL carry identical content; the same patched
+        // payload is written to both sections below.
+        let meta_payload = self.repoint_meta_block(&*src, new_table_id)?;
+
+        let out = self
+            .fs
+            .open(new_path, &FsOpenOptions::new().write(true).create_new(true))?;
+        let out = BufWriter::with_capacity(u16::MAX.into(), out);
+        let out = ChecksummedWriter::new(out);
+        let mut writer = crate::sfa::Writer::from_writer(out);
+
+        let meta_identity = BlockIdentity {
+            table_id: new_table_id,
+            block_type: BlockType::Meta,
+            dict_id: 0,
+            window_log: 0,
+        };
+        for entry in reader.toc().iter() {
+            let name = entry.name();
+            writer.start(name)?;
+            if name == b"meta_mid" || name == b"meta" {
+                // Re-encoded copy (new id), not the source bytes. Non-encrypted
+                // segment, so the two copies are byte-identical (no nonce).
+                Block::write_into(
+                    &mut writer,
+                    &meta_payload,
+                    meta_identity,
+                    &BlockTransform::PLAIN,
+                )?;
+            } else {
+                copy_section(&*src, &mut writer, entry.pos(), entry.len())?;
+            }
+        }
+
+        // Inject the positional delete-bitmap. Its position is free (addressed by
+        // name through the table of contents); appended after the copied
+        // sections. Same uncompressed envelope as the other meta sections.
+        writer.start(b"delete_bitmap")?;
+        let encoded = delete_bitmap.encode();
+        Block::write_into(
+            &mut writer,
+            &encoded,
+            BlockIdentity {
+                table_id: new_table_id,
+                block_type: BlockType::DeleteBitmap,
+                dict_id: 0,
+                window_log: 0,
+            },
+            &BlockTransform::PLAIN,
+        )?;
+
+        let mut checksummed = writer.into_inner()?;
+        let checksum = checksummed.checksum();
+        let file = checksummed.inner_mut().get_mut();
+        FsFile::sync_all_with(&**file, sync_mode)?;
+        #[expect(
+            clippy::expect_used,
+            reason = "an SST path always has a parent directory (the table folder)"
+        )]
+        crate::file::fsync_directory(
+            new_path.parent().expect("table file has a parent folder"),
+            &*self.fs,
+            sync_mode,
+        )?;
+        Ok(checksum)
+    }
+
+    /// Loads this segment's meta KV block, replaces the `table_id` entry's value
+    /// with `new_table_id`, and re-encodes the payload (uncompressed, ready for a
+    /// [`BlockType::Meta`] write). Every other meta field is preserved byte-exact,
+    /// so fields the parsed view does not expose still round-trip.
+    fn repoint_meta_block(
+        &self,
+        src: &dyn FsFile,
+        new_table_id: TableId,
+    ) -> crate::Result<Vec<u8>> {
+        // Non-encrypted precondition (checked by the caller): PLAIN transform.
+        let block = Block::from_file(
+            src,
+            self.regions.metadata,
+            BlockIdentity {
+                table_id: self.metadata.id,
+                block_type: BlockType::Meta,
+                dict_id: 0,
+                window_log: 0,
+            },
+            &BlockTransform::PLAIN,
+        )?;
+        let block = DataBlock::new(block);
+        // Meta keys are lexicographic, so the default comparator orders them.
+        let cmp = crate::comparator::default_comparator();
+        let mut entries: Vec<InternalValue> = block
+            .iter(cmp)
+            .map(|item| item.materialize(block.as_slice()))
+            .collect();
+
+        let mut patched = false;
+        for entry in &mut entries {
+            if entry.key.user_key.as_ref() == b"table_id" {
+                entry.value = UserValue::from(&new_table_id.to_le_bytes()[..]);
+                patched = true;
+            }
+        }
+        if !patched {
+            return Err(crate::Error::InvalidHeader(
+                "relocate: meta block missing table_id",
+            ));
+        }
+
+        // Same encode parameters the writer uses for the meta block
+        // (restart interval 1, no hashing). The reader point-reads by key, so the
+        // restart interval need not match the source; keeping it identical avoids
+        // surprises.
+        let mut payload = Vec::new();
+        DataBlock::encode_into(&mut payload, &entries, 1, 0.0)?;
+        Ok(payload)
+    }
+}
+
+/// Copies `len` bytes from `src` at absolute offset `pos` into `writer`,
+/// in bounded chunks so a large data section is never buffered whole.
+fn copy_section<W: crate::io::Write>(
+    src: &dyn FsFile,
+    writer: &mut W,
+    pos: u64,
+    len: u64,
+) -> crate::Result<()> {
+    let mut offset = pos;
+    let end = pos + len;
+    while offset < end {
+        // `end - offset` is bounded by the section length (a u64 file size);
+        // the `min` caps each read at COPY_CHUNK, so the cast cannot truncate.
+        #[expect(clippy::cast_possible_truncation, reason = "capped at COPY_CHUNK")]
+        let want = (end - offset).min(COPY_CHUNK as u64) as usize;
+        let bytes = crate::file::read_exact(src, offset, want)?;
+        writer.write_all(&bytes)?;
+        offset += want as u64;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::cache::Cache;
+    use crate::descriptor_table::DescriptorTable;
+    use crate::fs::StdFs;
+    use crate::table::Writer;
+    use crate::{SeqNo, hash::hash64};
+    use alloc::sync::Arc;
+    use test_log::test;
+
+    #[cfg(feature = "metrics")]
+    use crate::metrics::Metrics;
+
+    fn recover_at(file: &Path, checksum: Checksum, table_id: TableId) -> crate::Result<Table> {
+        #[cfg(feature = "metrics")]
+        let metrics = Arc::new(Metrics::default());
+        Table::recover(
+            file.to_path_buf(),
+            checksum,
+            0,
+            0,
+            table_id,
+            Arc::new(Cache::with_capacity_bytes(1_000_000)),
+            Some(Arc::new(DescriptorTable::new(10))),
+            Arc::new(StdFs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            metrics,
+        )
+    }
+
+    #[cfg(feature = "columnar")]
+    #[test]
+    fn relocate_reuses_blocks_and_masks_deleted_rows() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let src_path = dir.path().join("src");
+        let out_path = dir.path().join("out");
+
+        let n = 96u32;
+        // Positions follow write (= key) order.
+        let deleted = [4u32, 7, 40, 95];
+
+        // Source: a columnar segment with a zone map and NO deletes.
+        let mut writer = Writer::new(src_path.clone(), 0, 0, Arc::new(StdFs))?
+            .use_columnar(true)
+            .use_zone_map(true);
+        for i in 0..n {
+            let key = format!("k{i:04}").into_bytes();
+            writer.write(InternalValue::from_components(
+                key,
+                b"val",
+                1,
+                crate::ValueType::Value,
+            ))?;
+        }
+        let (_, src_checksum) = writer.finish()?.expect("source table written");
+        let source = recover_at(&src_path, src_checksum, 0)?;
+
+        // Relocate into a new segment (id 1) carrying the bitmap.
+        let mut bitmap = DeleteBitmap::new();
+        for &row in &deleted {
+            bitmap.insert(row);
+        }
+        let out_checksum =
+            source.relocate_columnar_with_deletes(&out_path, 1, &bitmap, SyncMode::Normal)?;
+
+        let relocated = recover_at(&out_path, out_checksum, 1)?;
+
+        // (i) format flags + id preserved; (ii) deleted rows masked, live found.
+        assert_eq!(relocated.metadata.id, 1, "meta carries the new table id");
+        assert!(relocated.metadata.columnar, "columnar flag preserved");
+        for i in 0..n {
+            let key = format!("k{i:04}").into_bytes();
+            let got = relocated.get(&key, SeqNo::MAX, hash64(&key))?;
+            if deleted.contains(&i) {
+                assert!(
+                    got.is_none(),
+                    "deleted row {i} must read absent after relocate"
+                );
+            } else {
+                let got = got.expect("live row must survive relocate");
+                assert_eq!(&*got.value, b"val", "live value preserved verbatim");
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn relocate_rejects_row_major_segment() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let src_path = dir.path().join("src");
+
+        // Row-major (no columnar): block reuse must refuse and let the caller CoW.
+        let mut writer = Writer::new(src_path.clone(), 0, 0, Arc::new(StdFs))?.use_zone_map(true);
+        writer.write(InternalValue::from_components(
+            b"a",
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+        let (_, checksum) = writer.finish()?.expect("table written");
+        let source = recover_at(&src_path, checksum, 0)?;
+
+        let out_path = dir.path().join("out");
+        let mut bitmap = DeleteBitmap::new();
+        bitmap.insert(0);
+        let err = source
+            .relocate_columnar_with_deletes(&out_path, 1, &bitmap, SyncMode::Normal)
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::FeatureUnsupported(_)),
+            "row-major segment must be rejected, got {err:?}",
+        );
+        Ok(())
+    }
+}

--- a/src/table/relocate.rs
+++ b/src/table/relocate.rs
@@ -48,6 +48,7 @@ impl Table {
     pub(crate) fn relocate_columnar_with_deletes(
         &self,
         new_path: &Path,
+        out_fs: &dyn crate::fs::Fs,
         new_table_id: TableId,
         delete_bitmap: &DeleteBitmap,
         sync_mode: SyncMode,
@@ -67,6 +68,9 @@ impl Table {
             ));
         }
 
+        // Read the source through ITS filesystem; write the output through the
+        // destination level's `out_fs` (the same one that recovers and installs
+        // the relocated table), so level routing stays consistent.
         let mut src = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
         let reader = crate::sfa::Reader::from_reader(&mut src)?;
 
@@ -75,67 +79,76 @@ impl Table {
         // payload is written to both sections below.
         let meta_payload = self.repoint_meta_block(&*src, new_table_id)?;
 
-        let out = self
-            .fs
-            .open(new_path, &FsOpenOptions::new().write(true).create_new(true))?;
-        let out = BufWriter::with_capacity(u16::MAX.into(), out);
-        let out = ChecksummedWriter::new(out);
-        let mut writer = crate::sfa::Writer::from_writer(out);
+        let out = out_fs.open(new_path, &FsOpenOptions::new().write(true).create_new(true))?;
 
-        let meta_identity = BlockIdentity {
-            table_id: new_table_id,
-            block_type: BlockType::Meta,
-            dict_id: 0,
-            window_log: 0,
-        };
-        for entry in reader.toc().iter() {
-            let name = entry.name();
-            writer.start(name)?;
-            if name == b"meta_mid" || name == b"meta" {
-                // Re-encoded copy (new id), not the source bytes. Non-encrypted
-                // segment, so the two copies are byte-identical (no nonce).
-                Block::write_into(
-                    &mut writer,
-                    &meta_payload,
-                    meta_identity,
-                    &BlockTransform::PLAIN,
-                )?;
-            } else {
-                copy_section(&*src, &mut writer, entry.pos(), entry.len())?;
-            }
-        }
+        // Once the output file exists, any later failure (section copy, bitmap
+        // write, sync, directory fsync) must not leave a partial, uninstalled SST
+        // behind. Best-effort remove it before propagating the error.
+        let result = (|| -> crate::Result<Checksum> {
+            let out = BufWriter::with_capacity(u16::MAX.into(), out);
+            let out = ChecksummedWriter::new(out);
+            let mut writer = crate::sfa::Writer::from_writer(out);
 
-        // Inject the positional delete-bitmap. Its position is free (addressed by
-        // name through the table of contents); appended after the copied
-        // sections. Same uncompressed envelope as the other meta sections.
-        writer.start(b"delete_bitmap")?;
-        let encoded = delete_bitmap.encode();
-        Block::write_into(
-            &mut writer,
-            &encoded,
-            BlockIdentity {
+            let meta_identity = BlockIdentity {
                 table_id: new_table_id,
-                block_type: BlockType::DeleteBitmap,
+                block_type: BlockType::Meta,
                 dict_id: 0,
                 window_log: 0,
-            },
-            &BlockTransform::PLAIN,
-        )?;
+            };
+            for entry in reader.toc().iter() {
+                let name = entry.name();
+                writer.start(name)?;
+                if name == b"meta_mid" || name == b"meta" {
+                    // Re-encoded copy (new id), not the source bytes. Non-encrypted
+                    // segment, so the two copies are byte-identical (no nonce).
+                    Block::write_into(
+                        &mut writer,
+                        &meta_payload,
+                        meta_identity,
+                        &BlockTransform::PLAIN,
+                    )?;
+                } else {
+                    copy_section(&*src, &mut writer, entry.pos(), entry.len())?;
+                }
+            }
 
-        let mut checksummed = writer.into_inner()?;
-        let checksum = checksummed.checksum();
-        let file = checksummed.inner_mut().get_mut();
-        FsFile::sync_all_with(&**file, sync_mode)?;
-        #[expect(
-            clippy::expect_used,
-            reason = "an SST path always has a parent directory (the table folder)"
-        )]
-        crate::file::fsync_directory(
-            new_path.parent().expect("table file has a parent folder"),
-            &*self.fs,
-            sync_mode,
-        )?;
-        Ok(checksum)
+            // Inject the positional delete-bitmap. Its position is free (addressed
+            // by name through the table of contents); appended after the copied
+            // sections. Same uncompressed envelope as the other meta sections.
+            writer.start(b"delete_bitmap")?;
+            let encoded = delete_bitmap.encode();
+            Block::write_into(
+                &mut writer,
+                &encoded,
+                BlockIdentity {
+                    table_id: new_table_id,
+                    block_type: BlockType::DeleteBitmap,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &BlockTransform::PLAIN,
+            )?;
+
+            let mut checksummed = writer.into_inner()?;
+            let checksum = checksummed.checksum();
+            let file = checksummed.inner_mut().get_mut();
+            FsFile::sync_all_with(&**file, sync_mode)?;
+            #[expect(
+                clippy::expect_used,
+                reason = "an SST path always has a parent directory (the table folder)"
+            )]
+            crate::file::fsync_directory(
+                new_path.parent().expect("table file has a parent folder"),
+                out_fs,
+                sync_mode,
+            )?;
+            Ok(checksum)
+        })();
+
+        if result.is_err() {
+            let _ = out_fs.remove_file(new_path);
+        }
+        result
     }
 
     /// Loads this segment's meta KV block, replaces the `table_id` entry's value
@@ -213,13 +226,18 @@ fn copy_section<W: crate::io::Write>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "tests intentionally unwrap setup failures to keep assertions focused"
+)]
 mod tests {
     use super::*;
     use crate::cache::Cache;
     use crate::descriptor_table::DescriptorTable;
     use crate::fs::StdFs;
     use crate::table::Writer;
+    #[cfg(feature = "columnar")]
     use crate::{SeqNo, hash::hash64};
     use alloc::sync::Arc;
     use test_log::test;
@@ -282,8 +300,13 @@ mod tests {
         for &row in &deleted {
             bitmap.insert(row);
         }
-        let out_checksum =
-            source.relocate_columnar_with_deletes(&out_path, 1, &bitmap, SyncMode::Normal)?;
+        let out_checksum = source.relocate_columnar_with_deletes(
+            &out_path,
+            &StdFs,
+            1,
+            &bitmap,
+            SyncMode::Normal,
+        )?;
 
         let relocated = recover_at(&out_path, out_checksum, 1)?;
 
@@ -326,7 +349,7 @@ mod tests {
         let mut bitmap = DeleteBitmap::new();
         bitmap.insert(0);
         let err = source
-            .relocate_columnar_with_deletes(&out_path, 1, &bitmap, SyncMode::Normal)
+            .relocate_columnar_with_deletes(&out_path, &StdFs, 1, &bitmap, SyncMode::Normal)
             .unwrap_err();
         assert!(
             matches!(err, crate::Error::FeatureUnsupported(_)),

--- a/src/table/relocate.rs
+++ b/src/table/relocate.rs
@@ -45,10 +45,6 @@ impl Table {
     /// segment, or one without a zone map (the positional mask needs the
     /// per-block row counts the zone map carries). The caller falls back to a
     /// copy-on-write rewrite in those cases.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired by the merge-on-read compaction path")
-    )]
     pub(crate) fn relocate_columnar_with_deletes(
         &self,
         new_path: &Path,

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3871,3 +3871,45 @@ fn delete_bitmap_masks_rows_in_range_scan() -> crate::Result<()> {
     );
     Ok(())
 }
+
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_bitmap_masks_deleted_key_in_point_read() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let n = 64u32;
+    // Row positions follow write (= key) order: keys k0003 / k0010 / k0050.
+    let deleted = [3u32, 10, 50];
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0..n {
+        let key = format!("k{i:04}").into_bytes();
+        writer.write(crate::InternalValue::from_components(
+            key,
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    for &row in &deleted {
+        writer.delete_bitmap_mut().insert(row);
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+
+    // A deleted key reads as absent; a live key is still found.
+    for i in 0..n {
+        let key = format!("k{i:04}").into_bytes();
+        let got = table.get(&key, SeqNo::MAX, hash64(&key))?;
+        if deleted.contains(&i) {
+            assert!(got.is_none(), "deleted key {i} must read as absent");
+        } else {
+            assert!(got.is_some(), "live key {i} must be found");
+        }
+    }
+    Ok(())
+}

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3772,10 +3772,8 @@ fn delete_bitmap_masks_rows_in_columnar_scan() -> crate::Result<()> {
     let (_, checksum) = writer.finish()?.expect("table written");
 
     let table = recover_test_table(&file, checksum)?;
-    let batches = table.columnar_scan(
-        &[COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE],
-        None,
-    )?;
+    let batches =
+        table.columnar_scan(&[COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE], None)?;
 
     let mut got: Vec<Vec<u8>> = Vec::new();
     for batch in &batches {
@@ -3792,5 +3790,34 @@ fn delete_bitmap_masks_rows_in_columnar_scan() -> crate::Result<()> {
         got, expected,
         "deleted row positions must be masked out of the columnar scan"
     );
+    Ok(())
+}
+
+#[test]
+fn copy_on_write_strategy_suppresses_the_delete_bitmap_section() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .delete_strategy(crate::config::DeleteStrategy::CopyOnWrite);
+    for key in [b"a".as_ref(), b"b", b"c"] {
+        writer.write(crate::InternalValue::from_components(
+            key,
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    // Mark a row deleted; copy-on-write drops rows instead of masking, so it must
+    // not persist a bitmap section even though a position was marked.
+    writer.delete_bitmap_mut().insert(1);
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    assert!(
+        table.regions.delete_bitmap.is_none(),
+        "copy-on-write must not persist a delete-bitmap section"
+    );
+    assert!(table.delete_bitmap().is_empty());
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3741,3 +3741,56 @@ fn delete_bitmap_section_absent_when_no_deletes() -> crate::Result<()> {
     assert!(table.delete_bitmap().is_empty());
     Ok(())
 }
+
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_bitmap_masks_rows_in_columnar_scan() -> crate::Result<()> {
+    use crate::table::columnar::{
+        COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, column_batch_to_entries,
+    };
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let n = 64u32;
+    // Row positions follow write (= key) order: these are keys k0003/k0010/k0050.
+    let deleted = [3u32, 10, 50];
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_columnar(true);
+    for i in 0..n {
+        let key = format!("k{i:04}").into_bytes();
+        writer.write(crate::InternalValue::from_components(
+            key,
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    for &row in &deleted {
+        writer.delete_bitmap_mut().insert(row);
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    let batches = table.columnar_scan(
+        &[COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE],
+        None,
+    )?;
+
+    let mut got: Vec<Vec<u8>> = Vec::new();
+    for batch in &batches {
+        for entry in column_batch_to_entries(batch)? {
+            got.push(entry.key.user_key.to_vec());
+        }
+    }
+
+    let expected: Vec<Vec<u8>> = (0..n)
+        .filter(|i| !deleted.contains(i))
+        .map(|i| format!("k{i:04}").into_bytes())
+        .collect();
+    assert_eq!(
+        got, expected,
+        "deleted row positions must be masked out of the columnar scan"
+    );
+    Ok(())
+}

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3688,7 +3688,9 @@ fn delete_bitmap_section_round_trips() -> crate::Result<()> {
     // Row positions follow write order: rows 0, 2, 5 are keys a, c, f.
     let deleted_rows = [0u32, 2, 5];
 
-    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    // A delete-bitmap SST must carry a zone map (per-block row counts power the
+    // positional masking; recovery enforces this).
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_zone_map(true);
     for key in keys {
         writer.write(crate::InternalValue::from_components(
             key,
@@ -3756,7 +3758,9 @@ fn delete_bitmap_masks_rows_in_columnar_scan() -> crate::Result<()> {
     // Row positions follow write (= key) order: these are keys k0003/k0010/k0050.
     let deleted = [3u32, 10, 50];
 
-    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_columnar(true);
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
     for i in 0..n {
         let key = format!("k{i:04}").into_bytes();
         writer.write(crate::InternalValue::from_components(
@@ -3819,5 +3823,51 @@ fn copy_on_write_strategy_suppresses_the_delete_bitmap_section() -> crate::Resul
         "copy-on-write must not persist a delete-bitmap section"
     );
     assert!(table.delete_bitmap().is_empty());
+    Ok(())
+}
+
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_bitmap_masks_rows_in_range_scan() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let n = 64u32;
+    // Row positions follow write (= key) order: keys k0003 / k0010 / k0050.
+    let deleted = [3u32, 10, 50];
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0..n {
+        let key = format!("k{i:04}").into_bytes();
+        writer.write(crate::InternalValue::from_components(
+            key,
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    for &row in &deleted {
+        writer.delete_bitmap_mut().insert(row);
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    // A full forward range scan goes through the columnar reconstruction +
+    // positional mask; deleted positions must never be yielded.
+    let got: Vec<Vec<u8>> = table
+        .range_iter(..)
+        .map(|r| r.map(|kv| kv.key.user_key.to_vec()))
+        .collect::<crate::Result<Vec<_>>>()?;
+
+    let expected: Vec<Vec<u8>> = (0..n)
+        .filter(|i| !deleted.contains(i))
+        .map(|i| format!("k{i:04}").into_bytes())
+        .collect();
+    assert_eq!(
+        got, expected,
+        "deleted row positions must be masked out of the range scan"
+    );
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3654,3 +3654,90 @@ fn zone_map_absent_without_policy() -> crate::Result<()> {
         None::<fn(Writer) -> Writer>,
     )
 }
+
+/// Helper: recover a freshly written table from `file` with default test config.
+fn recover_test_table(file: &std::path::Path, checksum: Checksum) -> crate::Result<Table> {
+    #[cfg(feature = "metrics")]
+    let metrics = Arc::new(Metrics::default());
+    Table::recover(
+        file.to_path_buf(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(1_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::new(StdFs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        metrics,
+    )
+}
+
+#[test]
+fn delete_bitmap_section_round_trips() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let keys: [&[u8]; 8] = [b"a", b"b", b"c", b"d", b"e", b"f", b"g", b"h"];
+    // Row positions follow write order: rows 0, 2, 5 are keys a, c, f.
+    let deleted_rows = [0u32, 2, 5];
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    for key in keys {
+        writer.write(crate::InternalValue::from_components(
+            key,
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    for &row in &deleted_rows {
+        writer.delete_bitmap_mut().insert(row);
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    assert!(
+        table.regions.delete_bitmap.is_some(),
+        "delete-bitmap section must be present when rows are deleted"
+    );
+    let dv = table.delete_bitmap();
+    assert_eq!(dv.len(), deleted_rows.len() as u64);
+    for row in 0..8u32 {
+        assert_eq!(
+            dv.contains(row),
+            deleted_rows.contains(&row),
+            "row {row} membership mismatch after reopen"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn delete_bitmap_section_absent_when_no_deletes() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    writer.write(crate::InternalValue::from_components(
+        b"a",
+        b"v",
+        1,
+        crate::ValueType::Value,
+    ))?;
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    assert!(
+        table.regions.delete_bitmap.is_none(),
+        "no delete-bitmap section when the segment has no deletes"
+    );
+    assert!(table.delete_bitmap().is_empty());
+    Ok(())
+}

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -114,7 +114,8 @@ pub fn load_block(
             | BlockType::BlockLayout
             | BlockType::Locator
             | BlockType::SeqnoBounds
-            | BlockType::ZoneMap => {}
+            | BlockType::ZoneMap
+            | BlockType::DeleteBitmap => {}
         }
 
         return Ok(block);
@@ -209,7 +210,8 @@ pub fn load_block(
         | BlockType::BlockLayout
         | BlockType::Locator
         | BlockType::SeqnoBounds
-        | BlockType::ZoneMap => {}
+        | BlockType::ZoneMap
+        | BlockType::DeleteBitmap => {}
     }
 
     // ECC recovered this block's payload from parity. The bytes returned below

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -163,6 +163,12 @@ pub struct Writer {
     /// by default (section absent, zero extra bytes).
     delete_bitmap: crate::table::delete_bitmap::DeleteBitmap,
 
+    /// This segment's delete strategy (the per-SST resolution of the level
+    /// policy). Under copy-on-write the bitmap is not persisted (deleted rows are
+    /// dropped instead); under merge-on-read / adaptive a non-empty bitmap is
+    /// written. Default: adaptive (writes the bitmap).
+    delete_strategy: crate::config::DeleteStrategy,
+
     /// Resolved retrieval-ribbon locator settings for this table, or `None`
     /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
     /// `Some` makes the writer accumulate a per-key locator and emit the
@@ -332,6 +338,7 @@ impl Writer {
             seqno_bounds_section: Vec::new(),
             zone_map_section: Vec::new(),
             delete_bitmap: crate::table::delete_bitmap::DeleteBitmap::new(),
+            delete_strategy: crate::config::DeleteStrategy::default(),
 
             locator: None,
             locators: Vec::new(),
@@ -701,6 +708,18 @@ impl Writer {
     /// the optional `delete_bitmap` SST section.
     pub fn delete_bitmap_mut(&mut self) -> &mut crate::table::delete_bitmap::DeleteBitmap {
         &mut self.delete_bitmap
+    }
+
+    /// Sets this segment's delete strategy (the per-SST resolution of the level
+    /// policy). Under [`DeleteStrategy::CopyOnWrite`] the delete-bitmap is not
+    /// persisted even if rows were marked, since copy-on-write drops deleted rows
+    /// rather than masking them. Default: adaptive.
+    ///
+    /// [`DeleteStrategy::CopyOnWrite`]: crate::config::DeleteStrategy::CopyOnWrite
+    #[must_use]
+    pub fn delete_strategy(mut self, strategy: crate::config::DeleteStrategy) -> Self {
+        self.delete_strategy = strategy;
+        self
     }
 
     /// Enables column-organized data blocks (see [`Self::use_columnar`] field).
@@ -1475,9 +1494,10 @@ impl Writer {
         }
 
         // Write the optional positional delete-bitmap section (only when the
-        // segment has materialized deletes). Applied as a row mask at scan time;
+        // segment has materialized deletes AND the strategy keeps a bitmap;
+        // copy-on-write drops rows instead). Applied as a row mask at scan time;
         // absent otherwise, so a read without deletes pays nothing.
-        if !self.delete_bitmap.is_empty() {
+        if !self.delete_bitmap.is_empty() && self.delete_strategy.writes_bitmap() {
             self.file_writer.start("delete_bitmap")?;
             self.block_buffer.clear();
             self.block_buffer

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -158,6 +158,11 @@ pub struct Writer {
     /// `use_zone_map` is off (section absent, zero extra bytes).
     zone_map_section: Vec<(BlockOffset, Vec<crate::table::zone_map::ColumnStats>)>,
 
+    /// Positional delete-bitmap accumulated for this segment, serialized into
+    /// the optional `delete_bitmap` SST section at finish when non-empty. Empty
+    /// by default (section absent, zero extra bytes).
+    delete_bitmap: crate::table::delete_bitmap::DeleteBitmap,
+
     /// Resolved retrieval-ribbon locator settings for this table, or `None`
     /// (default) when the level's [`crate::config::LocatorPolicy`] is disabled.
     /// `Some` makes the writer accumulate a per-key locator and emit the
@@ -326,6 +331,7 @@ impl Writer {
             block_layouts: Vec::new(),
             seqno_bounds_section: Vec::new(),
             zone_map_section: Vec::new(),
+            delete_bitmap: crate::table::delete_bitmap::DeleteBitmap::new(),
 
             locator: None,
             locators: Vec::new(),
@@ -687,6 +693,14 @@ impl Writer {
         self.assert_not_started("use_zone_map");
         self.use_zone_map = zone_map;
         self
+    }
+
+    /// Mutable access to this segment's positional delete-bitmap, so a caller
+    /// (e.g. compaction materialization) can mark rows deleted by position
+    /// before [`finish`](Self::finish). A non-empty bitmap is serialized into
+    /// the optional `delete_bitmap` SST section.
+    pub fn delete_bitmap_mut(&mut self) -> &mut crate::table::delete_bitmap::DeleteBitmap {
+        &mut self.delete_bitmap
     }
 
     /// Enables column-organized data blocks (see [`Self::use_columnar`] field).
@@ -1443,6 +1457,37 @@ impl Writer {
                 crate::table::block::BlockIdentity {
                     table_id: self.table_id,
                     block_type: crate::table::block::BlockType::ZoneMap,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.ecc {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+        }
+
+        // Write the optional positional delete-bitmap section (only when the
+        // segment has materialized deletes). Applied as a row mask at scan time;
+        // absent otherwise, so a read without deletes pays nothing.
+        if !self.delete_bitmap.is_empty() {
+            self.file_writer.start("delete_bitmap")?;
+            self.block_buffer.clear();
+            self.block_buffer
+                .extend_from_slice(&self.delete_bitmap.encode());
+            Block::write_into(
+                &mut self.file_writer,
+                &self.block_buffer,
+                crate::table::block::BlockIdentity {
+                    table_id: self.table_id,
+                    block_type: crate::table::block::BlockType::DeleteBitmap,
                     dict_id: 0,
                     window_log: 0,
                 },

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1498,6 +1498,15 @@ impl Writer {
         // copy-on-write drops rows instead). Applied as a row mask at scan time;
         // absent otherwise, so a read without deletes pays nothing.
         if !self.delete_bitmap.is_empty() && self.delete_strategy.writes_bitmap() {
+            // Co-write invariant: the positional mask resolves each block's start
+            // row from the zone map, and recovery rejects a delete-bitmap SST that
+            // lacks one. Fail here at the write site (a clear misconfiguration)
+            // rather than letting the SST be written and then fail to open.
+            if self.zone_map_section.is_empty() {
+                return Err(crate::Error::InvalidHeader(
+                    "delete-bitmap requires the zone map (use_zone_map(true))",
+                ));
+            }
             self.file_writer.start("delete_bitmap")?;
             self.block_buffer.clear();
             self.block_buffer
@@ -2159,6 +2168,33 @@ mod tests {
     use super::*;
     use crate::fs::StdFs;
     use test_log::test;
+
+    #[test]
+    fn finish_rejects_a_delete_bitmap_without_a_zone_map() -> crate::Result<()> {
+        // The positional mask resolves each block's start row from the zone map,
+        // so a segment that marks deletes must also carry one. The writer must
+        // reject the misconfiguration at finish() rather than emit an SST that
+        // then fails to open.
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("1");
+        let mut writer = Writer::new(path, 1, 0, Arc::new(StdFs))?;
+        writer.write(InternalValue::from_components(
+            b"a",
+            b"v",
+            1,
+            ValueType::Value,
+        ))?;
+        // Mark a delete, but never enable the zone map.
+        writer.delete_bitmap_mut().insert(0);
+        match writer.finish() {
+            Ok(_) => panic!("must reject a delete-bitmap without a zone map"),
+            Err(err) => assert!(
+                matches!(err, crate::Error::InvalidHeader(_)),
+                "expected an InvalidHeader error, got {err:?}",
+            ),
+        }
+        Ok(())
+    }
 
     #[test]
     fn table_writer_count() -> crate::Result<()> {

--- a/tests/merge_on_read_relocation.rs
+++ b/tests/merge_on_read_relocation.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end merge-on-read relocation: a lone columnar segment whose own range
+//! tombstones delete some rows is compacted by reusing its data blocks verbatim
+//! and recording the deleted row positions in a delete-bitmap, instead of
+//! re-transposing and dropping the rows. The deleted rows read as absent, the
+//! survivors keep their values, and the segment carries a non-empty bitmap (the
+//! proof that block reuse, not copy-on-write, happened).
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::config::{DeleteStrategy, DeleteStrategyPolicy};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, UserKey, get_tmp_folder,
+};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn value(i: u32) -> Vec<u8> {
+    format!("value-{i}-payload").into_bytes()
+}
+
+fn open_merge_on_read(folder: &std::path::Path) -> lsm_tree::Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::MergeOnRead);
+    })
+    .expect("enable merge-on-read columnar");
+    tree
+}
+
+#[test]
+fn merge_on_read_relocates_a_single_columnar_segment() {
+    let folder = get_tmp_folder();
+    let tree = open_merge_on_read(folder.path());
+
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Range-delete the first 50 keys at a seqno above all of them, in the same
+    // memtable, so the flushed segment carries both the data and its own range
+    // tombstone.
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+
+    // One columnar segment with a below-watermark range tombstone. A major
+    // compaction with a watermark above the tombstone materializes the deletes.
+    tree.major_compact(64 * 1024 * 1024, 5000).expect("compact");
+
+    // Deleted rows read as absent; survivors keep their exact values.
+    for i in 0..n {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i < 50 {
+            assert!(got.is_none(), "deleted key {i} must read as absent");
+        } else {
+            assert_eq!(
+                &*got.expect("live key must be present"),
+                value(i).as_slice(),
+                "live key {i} value",
+            );
+        }
+    }
+
+    // Merge-on-read proof: the segment carries a non-empty delete-bitmap (rows
+    // reused and masked, not dropped) and stays columnar.
+    let version = tree.current_version();
+    let tables: Vec<_> = version.iter_tables().collect();
+    assert!(
+        tables.iter().any(|t| !t.delete_bitmap().is_empty()),
+        "a delete-bitmap must have been materialized (merge-on-read), not dropped (copy-on-write)",
+    );
+    assert!(
+        tables.iter().all(|t| t.metadata.columnar),
+        "the relocated segment stays columnar",
+    );
+}

--- a/tests/merge_on_read_visibility.rs
+++ b/tests/merge_on_read_visibility.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! MVCC visibility of merge-on-read deletes, end to end, across read paths and
+//! strategies:
+//!
+//! - a below-watermark delete materialized into the bitmap is hidden on the
+//!   point AND range paths (and the segment carries the bitmap, proving block
+//!   reuse rather than a re-transpose drop);
+//! - an above-watermark delete is NOT materialized (the bitmap stays empty) and
+//!   keeps the normal seqno-aware visibility: the row is visible to a snapshot
+//!   below the delete seqno and hidden at or above it;
+//! - the adaptive strategy purges (copy-on-write, no bitmap) once the deleted
+//!   fraction crosses the threshold.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::config::{DeleteStrategy, DeleteStrategyPolicy};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, Guard, SeqNo, SequenceNumberCounter, UserKey, get_tmp_folder,
+};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn value(i: u32) -> Vec<u8> {
+    format!("value-{i}-payload").into_bytes()
+}
+
+fn open_with(folder: &std::path::Path, strategy: DeleteStrategy) -> lsm_tree::Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(strategy);
+    })
+    .expect("configure columnar delete strategy");
+    tree
+}
+
+fn bitmap_materialized(tree: &lsm_tree::Tree) -> bool {
+    let version = tree.current_version();
+    version.iter_tables().any(|t| !t.delete_bitmap().is_empty())
+}
+
+#[test]
+fn merge_on_read_delete_is_hidden_on_point_and_range_paths() {
+    let folder = get_tmp_folder();
+    let tree = open_with(folder.path(), DeleteStrategy::MergeOnRead);
+
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Below-watermark range delete of the first 50 keys.
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 5000).expect("compact");
+
+    assert!(
+        bitmap_materialized(&tree),
+        "merge-on-read must materialize a delete-bitmap (block reuse)",
+    );
+
+    // Point path: deleted absent, survivors keep their values.
+    for i in 0..n {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i < 50 {
+            assert!(got.is_none(), "point: deleted key {i} must be absent");
+        } else {
+            assert_eq!(
+                &*got.expect("present"),
+                value(i).as_slice(),
+                "point: key {i}"
+            );
+        }
+    }
+
+    // Range path: the deleted keys never appear; every survivor does, once, with
+    // its exact value.
+    let mut seen = Vec::new();
+    for guard in tree.range(key(0)..key(999_999), SeqNo::MAX, None) {
+        let (k, v) = guard.into_inner().expect("range item");
+        seen.push(k.clone());
+        let i: u32 = std::str::from_utf8(&k).unwrap()[1..].parse().unwrap();
+        assert!(i >= 50, "range: deleted key index {i} must not be yielded");
+        assert_eq!(&*v, value(i).as_slice(), "range: value for key {i}");
+    }
+    assert_eq!(
+        seen.len(),
+        (n - 50) as usize,
+        "range yields exactly the survivors"
+    );
+}
+
+#[test]
+fn above_watermark_delete_keeps_seqno_visibility_and_no_bitmap() {
+    let folder = get_tmp_folder();
+    let tree = open_with(folder.path(), DeleteStrategy::MergeOnRead);
+
+    for i in 0..100u32 {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Delete at seqno 1000, compacted with a watermark (500) BELOW it: the delete
+    // is not visible to every live snapshot, so it must NOT materialize.
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 500).expect("compact");
+
+    assert!(
+        !bitmap_materialized(&tree),
+        "an above-watermark delete must not be materialized into a bitmap",
+    );
+
+    // Seqno-aware visibility through the retained range tombstone: visible to a
+    // snapshot below the delete seqno, hidden at or above it.
+    for i in 0..50u32 {
+        assert!(
+            tree.get(key(i), 999).expect("get@999").is_some(),
+            "key {i} must be visible to a snapshot (999) below the delete seqno",
+        );
+        assert!(
+            tree.get(key(i), 1500).expect("get@1500").is_none(),
+            "key {i} must be hidden at a snapshot (1500) above the delete seqno",
+        );
+    }
+    // Survivors are always visible.
+    for i in 50..100u32 {
+        assert!(tree.get(key(i), SeqNo::MAX).expect("get").is_some());
+    }
+}
+
+#[test]
+fn adaptive_purges_to_copy_on_write_over_threshold() {
+    let folder = get_tmp_folder();
+    // 5% purge threshold; a 50% delete is far above it, so the next compaction
+    // purges (copy-on-write: drop the rows, write no bitmap).
+    let tree = open_with(
+        folder.path(),
+        DeleteStrategy::Adaptive {
+            purge_threshold_percent: 5,
+        },
+    );
+
+    for i in 0..100u32 {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 5000).expect("compact");
+
+    assert!(
+        !bitmap_materialized(&tree),
+        "over the adaptive threshold the deletes are purged copy-on-write, no bitmap",
+    );
+    for i in 0..100u32 {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i < 50 {
+            assert!(got.is_none(), "purged key {i} must be absent");
+        } else {
+            assert!(got.is_some(), "survivor {i} must be present");
+        }
+    }
+}

--- a/tests/merge_on_read_visibility.rs
+++ b/tests/merge_on_read_visibility.rs
@@ -93,11 +93,11 @@ fn merge_on_read_delete_is_hidden_on_point_and_range_paths() {
 
     // Range path: the deleted keys never appear; every survivor does, once, with
     // its exact value.
-    let mut seen = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
     for guard in tree.range(key(0)..key(999_999), SeqNo::MAX, None) {
         let (k, v) = guard.into_inner().expect("range item");
-        seen.push(k.clone());
         let i: u32 = std::str::from_utf8(&k).unwrap()[1..].parse().unwrap();
+        assert!(seen.insert(i), "range: duplicate key index {i} yielded");
         assert!(i >= 50, "range: deleted key index {i} must not be yielded");
         assert_eq!(&*v, value(i).as_slice(), "range: value for key {i}");
     }
@@ -106,6 +106,9 @@ fn merge_on_read_delete_is_hidden_on_point_and_range_paths() {
         (n - 50) as usize,
         "range yields exactly the survivors"
     );
+    for i in 50..n {
+        assert!(seen.contains(&i), "range: missing survivor key index {i}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Positional delete-bitmap MVCC for columnar segments: immutable columnar SSTs gain row-level deletes/updates without rewriting the whole segment per change, reconciled to the native seqno MVCC and applied as a row mask at read time, with a configurable choice between rewriting eagerly (copy-on-write) and reusing the blocks (merge-on-read).

## What landed

- **In-tree `DeleteBitmap`** — chunked, roaring-inspired positional bitmap (2048-row chunks, sparse array promoting to a dense bitset). `core` + `alloc` on both build and read, so an embedded / WASM reader applies deletes without `std`. Encode/decode round-trip; a bulk delete of a whole chunk is O(1) space.
- **`delete_bitmap` SST section** — a parallel named section in the columnar SST (sibling to `seqno_bounds` / `zone_map`), same per-block checksum / ECC / AEAD. An unreadable section fails recovery rather than degrading to empty (dropping it would resurrect deleted rows).
- **Read masking on every path** — vectorized columnar scan, the key-based point read, and the range iterator all apply the positional mask; a block whose rows are all deleted is skipped. A segment with no deletes carries no bitmap and pays nothing.
- **`DeleteStrategy` config** — per-level policy + global default + per-SST override + the `delete_strategy` runtime knob. `CopyOnWrite` | `MergeOnRead` | `Adaptive { purge_threshold_percent }` (default adaptive at 5%).
- **Merge-on-read materialization at compaction** — when a merge reduces to a single columnar segment whose own below-watermark range tombstones delete some of its rows, the segment is relocated: its data / index / filter / zone-map / seqno-bounds sections are copied verbatim, only the meta block is re-pointed to the new table id, and the delete-bitmap is added. This reuses the blocks instead of re-transposing them (no bloom rehash, no index rebuild). Detection is read-only under the version read lock; the relocation installs its own version edit.
- **Adaptive purge** — once the deleted fraction crosses the threshold, the plan declines and the copy-on-write merge drops the rows and writes no bitmap, bounding read amplification.

## Tests

Bitmap unit tests (sparse/dense, chunk skip, encode/decode, O(1) bulk chunk); table-level masking on the scan / range / point paths; end-to-end MVCC visibility (`tests/merge_on_read_visibility.rs`): a below-watermark delete is hidden on the point and range paths with the bitmap materialized; an above-watermark delete is not materialized and keeps seqno-aware visibility (visible below the delete seqno, hidden at or above it); the adaptive strategy purges copy-on-write over the threshold; plus `tests/merge_on_read_relocation.rs` for the relocation path.

Full gate green: `clippy --all-features --all-targets`, `no-std-check` errcount 0, `nextest` on `lz4,zstd` and `lz4,zstd,columnar`, doctests.

## Conservative v1 scope (follow-ups)

These keep the first cut provably safe; each is a tracked optimization, not a correctness gap:

- **Single-input trigger only.** Merge-on-read fires when the merge reduces to one relocatable columnar segment with its own covering tombstones. A single input means no foreign live key can be lost and no foreign point tombstone can be missed. Multi-input merges fall through to the existing copy-on-write path. Broadening to the multi-input delete-only case needs explicit surviving-tombstone preservation.
- **Tombstones kept verbatim.** The relocated segment keeps its range tombstones, so the bitmap is redundant with them (safe: a later copy-on-write re-compaction re-applies the still-present tombstones, no resurrection) but they are not yet garbage-collected. Consuming them so the bitmap is the sole record needs the compaction scan to apply the mask first.
- **Per-row marking.** Building the bitmap marks each covered position individually; a whole-chunk bulk-mark (O(1)) is not yet wired into the materialization (the dense storage is already O(1)).

> The on-disk format is pre-stable: there are no external consumers, so old data is not supported across format changes (regenerate instead).

Closes #507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-level row-delete strategies for columnar segments: copy-on-write, merge-on-read, and adaptive purge.
  * Introduced positional delete bitmaps for columnar SSTs, enabling both point-read and scan-time masking of deleted rows.
  * Enabled merge-on-read relocation during compactions to reuse materialized delete information when possible.
* **Bug Fixes**
  * Columnar reads now correctly omit blocks that are entirely deleted.
* **Tests**
  * Added integration and recovery/masking coverage for delete-bitmap persistence and MVCC visibility across strategies (including adaptive behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->