### PR TITLE
feat(columnar): consumer value sub-columns via columnar ingest

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,10 +58,11 @@ jobs:
     # self-hosted runners (if added later) without the label
     # won't pick the job up.
     runs-on: [self-hosted, gpu-private-systems]
-    # 60 (was 30): absorbs the compare-rocksdb head-to-head pass added
-    # below (bounded criterion settings, but the zstd22/10k write points
-    # are seconds each) plus the first-run librocksdb-sys C++ compile.
-    timeout-minutes: 60
+    # The db_bench pass is seconds; the compare-rocksdb head-to-head pass
+    # uses a half-second criterion window per scenario (a few minutes for
+    # the whole matrix). The cap mainly bounds the first-run librocksdb-sys
+    # C++ compile and catches a runaway regression early.
+    timeout-minutes: 30
     steps:
       # v6 requires runner ≥2.327.1 (node24 runtime) — the self-hosted
       # runner has a current runner agent that satisfies this.
@@ -145,11 +146,14 @@ jobs:
       # is a ratio measured on one host in one run, it stays meaningful
       # even if this runner's CPU changes between runs.
       #
-      # Bounded criterion settings keep the heavy zstd22/10k write points
-      # from dominating the timeout: a small sample count with a short
-      # measurement window still yields a stable median for the dashboard
-      # without the default 100-sample sweep (which on a multi-second-per
-      # -iteration point would run for many minutes each).
+      # Bounded criterion settings keep the harness fast: this is a
+      # ratio comparison (both engines in one process per scenario), so a
+      # short warm-up + measurement window per scenario still yields a
+      # stable median while keeping the whole matrix (5 workloads x sizes x
+      # engines) well under the timeout. The default 100-sample, multi-second
+      # sweep ran for ~60 min across the matrix and timed out, producing no
+      # dashboard at all; a half-second window per scenario brings it to a
+      # few minutes.
       #
       # Runner requirement: librocksdb-sys builds from source via bindgen,
       # so the host must have a C/C++ toolchain + libclang. On Linux
@@ -187,7 +191,7 @@ jobs:
         run: |
           cd tools/compare-rocksdb
           cargo bench --bench compare -- \
-            --sample-size 10 --warm-up-time 1 --measurement-time 5
+            --sample-size 10 --warm-up-time 0.5 --measurement-time 0.5
 
       # Publish the criterion HTML report tree (per-group overlay charts)
       # to gh-pages under dev/compare, alongside the db_bench dashboard at

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -79,17 +79,19 @@ impl AnyIngestion<'_> {
     /// columnar block, stored directly without re-transposing the value.
     ///
     /// The batch carries the three intrinsic columns (`[key, seqno, value-type]`)
-    /// plus one or more value sub-columns; its keys must be sorted and order
-    /// after any previously written data. The per-row seqnos are typically `0`:
-    /// [`finish`](Self::finish) assigns the atomic global sequence number. The
-    /// columnar layout must be enabled (`columnar` in the runtime config) on a
-    /// standard tree; a row-mode or blob tree rejects the batch.
+    /// plus one or more value sub-columns. Its keys must be strictly increasing
+    /// (by the tree comparator) within the batch and after any previously written
+    /// data, and every per-row seqno must be `0`: [`finish`](Self::finish) assigns
+    /// the atomic global sequence number. The columnar layout must be enabled
+    /// (`columnar` in the runtime config) on a standard tree; a row-mode or blob
+    /// tree rejects the batch.
     ///
     /// # Errors
     ///
-    /// Returns an error if the batch shape is invalid, the layout is not
-    /// columnar, a block write fails, or the tree is a blob tree (columnar
-    /// ingest does not support KV separation).
+    /// Returns an error if the batch shape is invalid, the keys are not strictly
+    /// increasing, any row carries a non-zero seqno, the layout is not columnar,
+    /// a block write fails, or the tree is a blob tree (columnar ingest does not
+    /// support KV separation).
     ///
     /// # Examples
     ///

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -75,6 +75,27 @@ impl AnyIngestion<'_> {
         }
     }
 
+    /// Writes a consumer-provided columnar batch (its value sub-columns) as one
+    /// columnar block. See [`Ingestion::write_columnar_batch`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the batch shape is invalid, the layout is not
+    /// columnar, a block write fails, or the tree is a blob tree (columnar
+    /// ingest does not support KV separation).
+    #[cfg(feature = "columnar")]
+    pub fn write_columnar_batch(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+    ) -> crate::Result<()> {
+        match self {
+            Self::Standard(i) => i.write_columnar_batch(batch),
+            Self::Blob(_) => Err(crate::Error::FeatureUnsupported(
+                "columnar batch ingest is not supported for blob trees",
+            )),
+        }
+    }
+
     /// Finalizes ingestion and registers created tables (and blob files if present).
     ///
     /// # Errors

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -76,13 +76,53 @@ impl AnyIngestion<'_> {
     }
 
     /// Writes a consumer-provided columnar batch (its value sub-columns) as one
-    /// columnar block. See [`Ingestion::write_columnar_batch`].
+    /// columnar block, stored directly without re-transposing the value.
+    ///
+    /// The batch carries the three intrinsic columns (`[key, seqno, value-type]`)
+    /// plus one or more value sub-columns; its keys must be sorted and order
+    /// after any previously written data. The per-row seqnos are typically `0`:
+    /// [`finish`](Self::finish) assigns the atomic global sequence number. The
+    /// columnar layout must be enabled (`columnar` in the runtime config) on a
+    /// standard tree; a row-mode or blob tree rejects the batch.
     ///
     /// # Errors
     ///
     /// Returns an error if the batch shape is invalid, the layout is not
     /// columnar, a block write fails, or the tree is a blob tree (columnar
     /// ingest does not support KV separation).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lsm_tree::table::columnar::{Column, TypeTag, entries_to_column_batch};
+    /// use lsm_tree::{AnyTree, Config, InternalValue, ValueType};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let any = Config::new(folder, Default::default(), Default::default()).open()?;
+    /// if let AnyTree::Standard(tree) = &any {
+    ///     tree.update_runtime_config(|cfg| cfg.columnar = true)?;
+    /// }
+    ///
+    /// // One row whose value is a single fixed-4 sub-column (id 3).
+    /// let mut batch = entries_to_column_batch(&[InternalValue::from_components(
+    ///     b"k0".to_vec(),
+    ///     b"x".to_vec(),
+    ///     0,
+    ///     ValueType::Value,
+    /// )])?;
+    /// batch.columns.pop();
+    /// batch.columns.push(Column {
+    ///     column_id: 3,
+    ///     type_tag: TypeTag::Fixed(4),
+    ///     validity: None,
+    ///     data: vec![1, 0, 0, 0],
+    /// });
+    ///
+    /// let mut ingestion = any.ingestion()?;
+    /// ingestion.write_columnar_batch(&batch)?;
+    /// ingestion.finish()?;
+    /// # Ok::<(), lsm_tree::Error>(())
+    /// ```
     #[cfg(feature = "columnar")]
     pub fn write_columnar_batch(
         &mut self,

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -666,34 +666,84 @@ pub fn entries_to_column_batch(entries: &[InternalValue]) -> Result<ColumnBatch>
 /// Returns an error if the batch does not carry exactly the four intrinsic
 /// columns in order with the expected type tags, or if a row is truncated or
 /// carries an unknown value type.
+/// Returns row `row`'s `width`-byte cell from a fixed-width column's data.
+fn fixed_column_row(data: &[u8], width: u8, row: u32) -> Result<&[u8]> {
+    let w = width as usize;
+    let start = (row as usize).checked_mul(w).ok_or(Error::InvalidHeader(
+        "columnar: fixed column offset overflow",
+    ))?;
+    let end = start.checked_add(w).ok_or(Error::InvalidHeader(
+        "columnar: fixed column offset overflow",
+    ))?;
+    data.get(start..end)
+        .ok_or(Error::InvalidHeader("columnar: fixed column row truncated"))
+}
+
+/// Returns row `row`'s cell bytes from `col`, dispatching on the column's type.
+fn column_cell(col: &Column, row_count: u32, row: u32) -> Result<&[u8]> {
+    match col.type_tag {
+        TypeTag::Fixed(width) => fixed_column_row(&col.data, width, row),
+        TypeTag::Bytes => bytes_column_row(&col.data, row_count, row),
+    }
+}
+
+/// Reconstructs a row's value from its value sub-columns. A single sub-column
+/// yields the cell verbatim (the intrinsic opaque value, or a degenerate
+/// one-column consumer value); two or more are joined by [`frame_value_cells`]
+/// into one self-describing blob the consumer reverses with
+/// [`unframe_value_cells`].
+fn reconstruct_row_value(value_cols: &[Column], row_count: u32, row: u32) -> Result<Slice> {
+    if let [single] = value_cols {
+        return Ok(Slice::from(column_cell(single, row_count, row)?));
+    }
+    let mut cells = Vec::with_capacity(value_cols.len());
+    for col in value_cols {
+        cells.push((col.type_tag, column_cell(col, row_count, row)?));
+    }
+    Ok(Slice::from(frame_value_cells(&cells)?))
+}
+
 pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>> {
-    let [key_col, seqno_col, vt_col, value_col] = batch.columns.as_slice() else {
+    let [key_col, seqno_col, vt_col, value_cols @ ..] = batch.columns.as_slice() else {
         return Err(Error::InvalidHeader(
-            "columnar: expected four intrinsic columns",
+            "columnar: batch missing the intrinsic columns",
         ));
     };
+    if value_cols.is_empty() {
+        return Err(Error::InvalidHeader(
+            "columnar: batch carries no value column",
+        ));
+    }
     if key_col.column_id != COL_USER_KEY
         || key_col.type_tag != TypeTag::Bytes
         || seqno_col.column_id != COL_SEQNO
         || seqno_col.type_tag != TypeTag::Fixed(8)
         || vt_col.column_id != COL_VALUE_TYPE
         || vt_col.type_tag != TypeTag::Fixed(1)
-        || value_col.column_id != COL_VALUE
-        || value_col.type_tag != TypeTag::Bytes
     {
         return Err(Error::InvalidHeader(
             "columnar: unexpected intrinsic column layout",
         ));
     }
-    // Intrinsic fields are never null, and a hand-built `ColumnBatch` must clear
-    // the same framing checks a decoded one does. Running `validate` here also
-    // bounds `row_count` against the fixed-width column lengths before the
-    // allocation below, so a malformed batch claiming a huge row count is
-    // rejected instead of reserving for billions of rows.
-    for col in [key_col, seqno_col, vt_col, value_col] {
+    // The three intrinsic fields are never null. Running `validate` also bounds
+    // `row_count` against the fixed-width column lengths before the allocation
+    // below, so a malformed batch claiming a huge row count is rejected instead
+    // of reserving for billions of rows.
+    for col in [key_col, seqno_col, vt_col] {
         if col.validity.is_some() {
             return Err(Error::InvalidHeader(
                 "columnar: intrinsic columns must not be nullable",
+            ));
+        }
+        col.validate(batch.row_count)?;
+    }
+    // Value sub-columns are consumer-defined (id / type / count). Nullable value
+    // sub-columns are a later slice, so reject a validity bitmap for now; the
+    // per-column `validate` bounds each against `row_count` like the intrinsics.
+    for col in value_cols {
+        if col.validity.is_some() {
+            return Err(Error::InvalidHeader(
+                "columnar: nullable value sub-columns are not supported yet",
             ));
         }
         col.validate(batch.row_count)?;
@@ -717,14 +767,14 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
             .ok_or(Error::InvalidHeader("columnar: value-type row truncated"))?;
         let value_type =
             ValueType::try_from(vt_byte).map_err(|()| Error::InvalidTag(("ValueType", vt_byte)))?;
-        let value = bytes_column_row(&value_col.data, batch.row_count, i)?;
+        let value = reconstruct_row_value(value_cols, batch.row_count, i)?;
         out.push(InternalValue {
             key: InternalKey {
                 user_key: Slice::from(user_key),
                 seqno,
                 value_type,
             },
-            value: Slice::from(value),
+            value,
         });
     }
     Ok(out)
@@ -1127,6 +1177,53 @@ mod tests {
             ],
         };
         assert!(column_batch_to_entries(&bad).is_err());
+    }
+
+    #[test]
+    fn untranspose_frames_multiple_value_subcolumns() {
+        // A consumer batch: the three intrinsic columns plus two value
+        // sub-columns (a fixed-4 and a variable-width bytes). Each row's
+        // reconstructed value is the framed concat of its two sub-cells, which
+        // unframe_value_cells reverses.
+        let mut batch = entries_to_column_batch(&[
+            entry(b"k0", 1, ValueType::Value, b"ignored"),
+            entry(b"k1", 2, ValueType::Value, b"ignored"),
+        ])
+        .expect("transpose");
+        // Replace the single opaque value column with two value sub-columns.
+        batch.columns.pop();
+        batch.columns.push(Column {
+            column_id: 3,
+            type_tag: TypeTag::Fixed(4),
+            validity: None,
+            data: vec![1, 0, 0, 0, 2, 0, 0, 0], // row 0 = 1, row 1 = 2
+        });
+        let mut bytes_data = Vec::new();
+        for off in [0u32, 2, 5] {
+            bytes_data.extend_from_slice(&off.to_le_bytes());
+        }
+        bytes_data.extend_from_slice(b"aabbb"); // row 0 = "aa", row 1 = "bbb"
+        batch.columns.push(Column {
+            column_id: 4,
+            type_tag: TypeTag::Bytes,
+            validity: None,
+            data: bytes_data,
+        });
+
+        let entries = column_batch_to_entries(&batch).expect("untranspose");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key.user_key.as_ref(), b"k0");
+        assert_eq!(entries[1].key.seqno, 2);
+
+        let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+        assert_eq!(
+            unframe_value_cells(entries[0].value.as_ref(), &tags).expect("unframe 0"),
+            vec![&[1, 0, 0, 0][..], &b"aa"[..]],
+        );
+        assert_eq!(
+            unframe_value_cells(entries[1].value.as_ref(), &tags).expect("unframe 1"),
+            vec![&[2, 0, 0, 0][..], &b"bbb"[..]],
+        );
     }
 
     fn sample_batch() -> ColumnBatch {

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -730,14 +730,175 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
     Ok(out)
 }
 
+/// Frames one row's value sub-column cells into a single self-describing value
+/// blob.
+///
+/// This is the form the row read paths (point / range / merge-on-read) return for
+/// a row whose value the consumer split into sub-columns (the read-path model:
+/// reconstruct from sub-columns on read, no opaque copy).
+///
+/// A fixed-width cell is stored verbatim: its width is recoverable from the
+/// column's [`TypeTag`], so a fixed sub-column (e.g. a vector dimension) carries
+/// no per-cell framing overhead. A variable-width ([`TypeTag::Bytes`]) cell is
+/// length-prefixed (`u32` little-endian). The consumer recovers the sub-columns
+/// with [`unframe_value_cells`], replaying the value sub-columns' type tags; the
+/// engine never interprets the cell bytes.
+///
+/// # Errors
+///
+/// Returns an error if a variable-width cell is longer than `u32::MAX` (a cell is
+/// block-bounded to at most a few MiB, so this is a structural impossibility, not
+/// an expected case).
+///
+/// # Examples
+///
+/// ```
+/// use lsm_tree::table::columnar::{frame_value_cells, unframe_value_cells, TypeTag};
+///
+/// let tags = [TypeTag::Fixed(4), TypeTag::Bytes, TypeTag::Fixed(2)];
+/// let blob = frame_value_cells(&[
+///     (TypeTag::Fixed(4), &[1, 2, 3, 4][..]),
+///     (TypeTag::Bytes, b"hello"),
+///     (TypeTag::Fixed(2), &[9, 9][..]),
+/// ])
+/// .unwrap();
+/// let cells = unframe_value_cells(&blob, &tags).unwrap();
+/// assert_eq!(cells, vec![&[1, 2, 3, 4][..], b"hello", &[9, 9][..]]);
+/// ```
+pub fn frame_value_cells(cells: &[(TypeTag, &[u8])]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    for (tag, cell) in cells {
+        match tag {
+            // Width recoverable from the tag: append verbatim, no length prefix.
+            TypeTag::Fixed(_) => out.extend_from_slice(cell),
+            TypeTag::Bytes => {
+                let len = u32::try_from(cell.len()).map_err(|_| {
+                    Error::InvalidHeader("columnar: framed value sub-cell exceeds u32")
+                })?;
+                out.extend_from_slice(&len.to_le_bytes());
+                out.extend_from_slice(cell);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Splits a value blob produced by [`frame_value_cells`] back into its sub-column
+/// cells.
+///
+/// Given the value sub-columns' [`TypeTag`]s in column order; the returned slices
+/// borrow from `blob`. Inverse of [`frame_value_cells`].
+///
+/// # Errors
+///
+/// Returns an error if the blob is truncated relative to `type_tags` (a fixed
+/// cell or a length-prefixed cell runs past the end), or if bytes remain after
+/// the last cell (the blob and the tag list disagree).
+pub fn unframe_value_cells<'a>(blob: &'a [u8], type_tags: &[TypeTag]) -> Result<Vec<&'a [u8]>> {
+    let mut out = Vec::with_capacity(type_tags.len());
+    let mut pos = 0usize;
+    for tag in type_tags {
+        match tag {
+            TypeTag::Fixed(width) => {
+                let end = pos
+                    .checked_add(*width as usize)
+                    .ok_or(Error::InvalidHeader("columnar: framed value overflow"))?;
+                let cell = blob.get(pos..end).ok_or(Error::InvalidHeader(
+                    "columnar: framed value truncated (fixed)",
+                ))?;
+                out.push(cell);
+                pos = end;
+            }
+            TypeTag::Bytes => {
+                let len_end = pos
+                    .checked_add(4)
+                    .ok_or(Error::InvalidHeader("columnar: framed value overflow"))?;
+                let len_bytes = blob.get(pos..len_end).ok_or(Error::InvalidHeader(
+                    "columnar: framed value truncated (length)",
+                ))?;
+                let len = u32::from_le_bytes(
+                    <[u8; 4]>::try_from(len_bytes)
+                        .map_err(|_| Error::InvalidHeader("columnar: framed value length"))?,
+                ) as usize;
+                let end = len_end
+                    .checked_add(len)
+                    .ok_or(Error::InvalidHeader("columnar: framed value overflow"))?;
+                let cell = blob.get(len_end..end).ok_or(Error::InvalidHeader(
+                    "columnar: framed value truncated (bytes)",
+                ))?;
+                out.push(cell);
+                pos = end;
+            }
+        }
+    }
+    if pos != blob.len() {
+        return Err(Error::InvalidHeader(
+            "columnar: framed value has trailing bytes",
+        ));
+    }
+    Ok(out)
+}
+
 #[expect(clippy::expect_used, clippy::indexing_slicing, reason = "test code")]
 #[cfg(test)]
 mod tests {
     use super::{
         COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
-        column_batch_to_entries, entries_to_column_batch,
+        column_batch_to_entries, entries_to_column_batch, frame_value_cells, unframe_value_cells,
     };
     use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
+
+    #[test]
+    fn fixed_only_value_framing_has_no_overhead_and_round_trips() {
+        // Fixed-width cells are stored verbatim (width recoverable from the tag),
+        // so the framed blob is the bare concatenation: zero per-cell overhead.
+        let tags = [TypeTag::Fixed(4), TypeTag::Fixed(4)];
+        let blob = frame_value_cells(&[
+            (TypeTag::Fixed(4), &[1, 0, 0, 0][..]),
+            (TypeTag::Fixed(4), &[2, 0, 0, 0][..]),
+        ])
+        .expect("frame");
+        assert_eq!(blob, vec![1, 0, 0, 0, 2, 0, 0, 0], "no length prefixes");
+        let cells = unframe_value_cells(&blob, &tags).expect("unframe");
+        assert_eq!(cells, vec![&[1, 0, 0, 0][..], &[2, 0, 0, 0][..]]);
+    }
+
+    #[test]
+    fn mixed_value_framing_round_trips() {
+        let tags = [TypeTag::Bytes, TypeTag::Fixed(1), TypeTag::Bytes];
+        let blob = frame_value_cells(&[
+            (TypeTag::Bytes, b"abc"),
+            (TypeTag::Fixed(1), &[7][..]),
+            (TypeTag::Bytes, b""),
+        ])
+        .expect("frame");
+        let cells = unframe_value_cells(&blob, &tags).expect("unframe");
+        assert_eq!(cells, vec![&b"abc"[..], &[7][..], &b""[..]]);
+    }
+
+    #[test]
+    fn empty_value_framing_round_trips() {
+        let blob = frame_value_cells(&[]).expect("frame");
+        assert!(blob.is_empty());
+        assert!(unframe_value_cells(&blob, &[]).expect("unframe").is_empty());
+    }
+
+    #[test]
+    fn unframe_rejects_truncated_blob() {
+        // A fixed(4) tag over a 2-byte blob is truncated.
+        assert!(unframe_value_cells(&[1, 2], &[TypeTag::Fixed(4)]).is_err());
+        // A bytes tag whose declared length runs past the end.
+        let mut blob = 8u32.to_le_bytes().to_vec();
+        blob.extend_from_slice(b"abc"); // 3 bytes present, length claims 8
+        assert!(unframe_value_cells(&blob, &[TypeTag::Bytes]).is_err());
+    }
+
+    #[test]
+    fn unframe_rejects_trailing_bytes() {
+        // One fixed(2) cell, but the blob carries an extra byte the tags do not
+        // cover: the blob and the tag list disagree.
+        assert!(unframe_value_cells(&[1, 2, 3], &[TypeTag::Fixed(2)]).is_err());
+    }
 
     fn entry(user_key: &[u8], seqno: u64, value_type: ValueType, value: &[u8]) -> InternalValue {
         InternalValue {

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -340,6 +340,28 @@ impl Column {
 }
 
 impl ColumnBatch {
+    /// The first row's user key, or `None` for an empty batch. Reads only the
+    /// intrinsic key column, so the ingest ordering guard can check a batch
+    /// against the previously written key without decoding the whole batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the first column is not the intrinsic user-key column
+    /// or its row framing is malformed.
+    pub(crate) fn first_user_key(&self) -> Result<Option<&[u8]>> {
+        if self.row_count == 0 {
+            return Ok(None);
+        }
+        let key_col = self
+            .columns
+            .first()
+            .filter(|c| c.column_id == COL_USER_KEY)
+            .ok_or(Error::InvalidHeader(
+                "columnar: first column is not the user-key column",
+            ))?;
+        bytes_column_row(&key_col.data, self.row_count, 0).map(Some)
+    }
+
     /// Encodes the batch into a columnar block payload using `codec` for every
     /// column. The returned bytes are the block payload (without the surrounding
     /// block header / checksum, which the writer adds).

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -768,10 +768,20 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
         }
         col.validate(batch.row_count)?;
     }
-    // Value sub-columns are consumer-defined (id / type / count). Nullable value
-    // sub-columns are a later slice, so reject a validity bitmap for now; the
-    // per-column `validate` bounds each against `row_count` like the intrinsics.
+    // Value sub-columns are consumer-defined (id / type / count). Their ids must
+    // be unique and must not overlap the intrinsic columns (`< COL_VALUE`), since
+    // projection later selects columns by id and a collision would make the
+    // result ambiguous. Nullable value sub-columns are a later slice, so reject a
+    // validity bitmap for now; the per-column `validate` bounds each against
+    // `row_count` like the intrinsics.
+    let mut seen_value_column_ids = Vec::with_capacity(value_cols.len());
     for col in value_cols {
+        if col.column_id < COL_VALUE || seen_value_column_ids.contains(&col.column_id) {
+            return Err(Error::InvalidHeader(
+                "columnar: value sub-column ids must be unique and must not overlap intrinsic columns",
+            ));
+        }
+        seen_value_column_ids.push(col.column_id);
         if col.validity.is_some() {
             return Err(Error::InvalidHeader(
                 "columnar: nullable value sub-columns are not supported yet",

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -359,6 +359,15 @@ impl ColumnBatch {
             .ok_or(Error::InvalidHeader(
                 "columnar: first column is not the user-key column",
             ))?;
+        // This runs before the full `column_batch_to_entries` validation, so
+        // confirm the intrinsic key column's shape (non-null `Bytes`, correctly
+        // framed for `row_count`) before the low-level offset read.
+        if key_col.type_tag != TypeTag::Bytes || key_col.validity.is_some() {
+            return Err(Error::InvalidHeader(
+                "columnar: first column is not the non-null user-key column",
+            ));
+        }
+        key_col.validate(self.row_count)?;
         bytes_column_row(&key_col.data, self.row_count, 0).map(Some)
     }
 
@@ -842,7 +851,16 @@ pub fn frame_value_cells(cells: &[(TypeTag, &[u8])]) -> Result<Vec<u8>> {
     for (tag, cell) in cells {
         match tag {
             // Width recoverable from the tag: append verbatim, no length prefix.
-            TypeTag::Fixed(_) => out.extend_from_slice(cell),
+            // The cell length must equal the tag width, or the blob would not
+            // un-frame with the same tags (and would shift later cells).
+            TypeTag::Fixed(width) => {
+                if cell.len() != usize::from(*width) {
+                    return Err(Error::InvalidHeader(
+                        "columnar: fixed value sub-cell length does not match its type tag",
+                    ));
+                }
+                out.extend_from_slice(cell);
+            }
             TypeTag::Bytes => {
                 let len = u32::try_from(cell.len()).map_err(|_| {
                     Error::InvalidHeader("columnar: framed value sub-cell exceeds u32")
@@ -970,6 +988,60 @@ mod tests {
         // One fixed(2) cell, but the blob carries an extra byte the tags do not
         // cover: the blob and the tag list disagree.
         assert!(unframe_value_cells(&[1, 2, 3], &[TypeTag::Fixed(2)]).is_err());
+    }
+
+    #[test]
+    fn frame_rejects_fixed_cell_length_mismatch() {
+        // A fixed(4) tag with a 3-byte cell would misframe (and shift later cells),
+        // so framing rejects it.
+        assert!(frame_value_cells(&[(TypeTag::Fixed(4), &[1, 2, 3][..])]).is_err());
+    }
+
+    #[test]
+    fn first_user_key_rejects_a_non_key_first_column() {
+        // A first column that is not the non-null bytes user-key column is
+        // rejected before any low-level offset read.
+        let fixed_first = ColumnBatch {
+            row_count: 1,
+            columns: alloc::vec![Column {
+                column_id: COL_USER_KEY,
+                type_tag: TypeTag::Fixed(4),
+                validity: None,
+                data: alloc::vec![0, 0, 0, 0],
+            }],
+        };
+        assert!(fixed_first.first_user_key().is_err());
+
+        let missing = ColumnBatch {
+            row_count: 1,
+            columns: alloc::vec![Column {
+                column_id: 99,
+                type_tag: TypeTag::Bytes,
+                validity: None,
+                data: alloc::vec![0, 0, 0, 0, 0, 0, 0, 0],
+            }],
+        };
+        assert!(missing.first_user_key().is_err());
+    }
+
+    #[test]
+    fn first_user_key_returns_the_first_row_key() {
+        // A two-row key column: the first key is read without decoding the batch.
+        let mut data = Vec::new();
+        for off in [0u32, 2, 5] {
+            data.extend_from_slice(&off.to_le_bytes());
+        }
+        data.extend_from_slice(b"k0k11");
+        let batch = ColumnBatch {
+            row_count: 2,
+            columns: alloc::vec![Column {
+                column_id: COL_USER_KEY,
+                type_tag: TypeTag::Bytes,
+                validity: None,
+                data,
+            }],
+        };
+        assert_eq!(batch.first_user_key().expect("first key"), Some(&b"k0"[..]));
     }
 
     fn entry(user_key: &[u8], seqno: u64, value_type: ValueType, value: &[u8]) -> InternalValue {

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1320,6 +1320,53 @@ mod tests {
         );
     }
 
+    #[test]
+    fn untranspose_rejects_value_subcolumn_id_collisions() {
+        // Projection selects value sub-columns by id, so a value sub-column that
+        // reuses an intrinsic id (0/1/2) or duplicates another value id would make
+        // projected results ambiguous. The untranspose must reject both.
+        let make = |value_cols: Vec<Column>| -> ColumnBatch {
+            let mut batch =
+                entries_to_column_batch(&[entry(b"k0", 1, ValueType::Value, b"ignored")])
+                    .expect("transpose");
+            batch.columns.pop(); // drop the single opaque value column
+            batch.columns.extend(value_cols);
+            batch
+        };
+
+        // A value sub-column reusing COL_USER_KEY (0).
+        let collide_intrinsic = make(vec![Column {
+            column_id: COL_USER_KEY,
+            type_tag: TypeTag::Fixed(4),
+            validity: None,
+            data: vec![0, 0, 0, 0],
+        }]);
+        assert!(
+            column_batch_to_entries(&collide_intrinsic).is_err(),
+            "a value sub-column reusing an intrinsic id must be rejected",
+        );
+
+        // Two value sub-columns sharing id 5.
+        let duplicate = make(vec![
+            Column {
+                column_id: 5,
+                type_tag: TypeTag::Fixed(4),
+                validity: None,
+                data: vec![0, 0, 0, 0],
+            },
+            Column {
+                column_id: 5,
+                type_tag: TypeTag::Fixed(4),
+                validity: None,
+                data: vec![1, 0, 0, 0],
+            },
+        ]);
+        assert!(
+            column_batch_to_entries(&duplicate).is_err(),
+            "duplicate value sub-column ids must be rejected",
+        );
+    }
+
     fn sample_batch() -> ColumnBatch {
         // 3 rows: a fixed u32 column (row 1 null) and a variable-width Bytes
         // column (all valid). Bytes data = offset array [0,2,2,5] + payload.

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -732,7 +732,8 @@ impl MultiWriter {
         if self.writer.output_size_hint() >= self.target_size {
             self.rotate()?;
         }
-        self.writer.write_columnar_batch(batch)
+        let comparator = self.comparator.clone();
+        self.writer.write_columnar_batch(batch, &comparator)
     }
 
     /// Finishes the last table, making sure all data is written durably

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -720,6 +720,21 @@ impl MultiWriter {
         Ok(())
     }
 
+    /// Writes a consumer-provided columnar batch as one columnar block, rotating
+    /// to a fresh table first if the current one has reached the target size (a
+    /// batch is a block boundary, mirroring the new-key rotation in
+    /// [`Self::write`]). Forwards to the inner writer's columnar-ingest path.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn write_columnar_batch(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+    ) -> crate::Result<Option<crate::UserKey>> {
+        if self.writer.output_size_hint() >= self.target_size {
+            self.rotate()?;
+        }
+        self.writer.write_columnar_batch(batch)
+    }
+
     /// Finishes the last table, making sure all data is written durably
     ///
     /// Returns the metadata of created tables

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -4139,6 +4139,15 @@ fn write_columnar_batch_accounts_tombstones_seqno_bounds_and_restart_locator() -
     // is_tombstone covers Tombstone + WeakTombstone; weak count is just the latter.
     assert_eq!(table.metadata.tombstone_count, 2, "two tombstone-kind rows");
     assert_eq!(table.metadata.weak_tombstone_count, 1, "one weak tombstone");
+    // The seqno-bounds section is written and loaded: every ingested row carries
+    // seqno 0, so the recovered bounds are exactly (0, 0). This proves the
+    // use_seqno_in_index path ran rather than relying on the point read alone
+    // (which can succeed through the normal index path regardless).
+    assert_eq!(
+        table.metadata.seqnos,
+        (0, 0),
+        "columnar ingest writes local seqno bounds of (0, 0)",
+    );
     assert!(
         table.get(b"k0", SeqNo::MAX, hash64(b"k0"))?.is_some(),
         "the live row reads back",
@@ -4192,6 +4201,13 @@ fn write_columnar_batch_on_an_empty_batch_writes_no_block() -> crate::Result<()>
             .write_columnar_batch(&empty, &crate::comparator::default_comparator())?
             .is_none(),
         "an empty batch yields no last key",
+    );
+    // Finishing must also produce no SST: a None last key alone does not prove
+    // the "writes no block" contract (a buggy writer could emit a table yet
+    // still return None).
+    assert!(
+        writer.finish()?.is_none(),
+        "an empty batch must not produce an SST",
     );
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3657,6 +3657,14 @@ fn zone_map_absent_without_policy() -> crate::Result<()> {
 
 /// Helper: recover a freshly written table from `file` with default test config.
 fn recover_test_table(file: &std::path::Path, checksum: Checksum) -> crate::Result<Table> {
+    recover_test_table_with_id(file, checksum, 0)
+}
+
+fn recover_test_table_with_id(
+    file: &std::path::Path,
+    checksum: Checksum,
+    table_id: TableId,
+) -> crate::Result<Table> {
     #[cfg(feature = "metrics")]
     let metrics = Arc::new(Metrics::default());
     Table::recover(
@@ -3664,7 +3672,7 @@ fn recover_test_table(file: &std::path::Path, checksum: Checksum) -> crate::Resu
         checksum,
         0,
         0,
-        0,
+        table_id,
         Arc::new(Cache::with_capacity_bytes(1_000_000)),
         Some(Arc::new(DescriptorTable::new(10))),
         Arc::new(StdFs),
@@ -3973,5 +3981,117 @@ fn write_columnar_batch_stores_value_subcolumns_and_round_trips() -> crate::Resu
         unframe_value_cells(v1.value.as_ref(), &tags)?,
         vec![&[2, 0, 0, 0][..], &b"bbb"[..]],
     );
+    Ok(())
+}
+
+/// A positional delete-bitmap masks whole rows of a value-sub-column segment in
+/// both the point and the projection read paths: the mask is value-agnostic, so
+/// deleting by position hides each row's intrinsic key and every sub-column
+/// while survivors keep their reconstructed sub-cells and projected bytes.
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_bitmap_masks_value_subcolumns_in_point_and_projection_reads() -> crate::Result<()> {
+    use crate::fs::SyncMode;
+    use crate::table::columnar::{Column, TypeTag, entries_to_column_batch, unframe_value_cells};
+    use crate::table::delete_bitmap::DeleteBitmap;
+
+    let dir = tempdir()?;
+    let src = dir.path().join("src");
+    let out = dir.path().join("out");
+
+    // Five rows; the value is split into a fixed-4 (col 3) and a bytes (col 4)
+    // sub-column. fixed values 10,20,30,40,50; bytes "a","bb","ccc","dddd","eeeee".
+    let fixed: [u32; 5] = [10, 20, 30, 40, 50];
+    let payloads: [&[u8]; 5] = [b"a", b"bb", b"ccc", b"dddd", b"eeeee"];
+    let mut batch = entries_to_column_batch(
+        &(0..5u32)
+            .map(|i| {
+                crate::InternalValue::from_components(
+                    format!("k{i}").into_bytes(),
+                    b"x",
+                    1,
+                    crate::ValueType::Value,
+                )
+            })
+            .collect::<Vec<_>>(),
+    )?;
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: fixed.iter().flat_map(|v| v.to_le_bytes()).collect(),
+    });
+    let mut bytes_data = Vec::new();
+    let mut acc = 0u32;
+    bytes_data.extend_from_slice(&acc.to_le_bytes());
+    for p in payloads {
+        acc += u32::try_from(p.len()).unwrap();
+        bytes_data.extend_from_slice(&acc.to_le_bytes());
+    }
+    for p in payloads {
+        bytes_data.extend_from_slice(p);
+    }
+    batch.columns.push(Column {
+        column_id: 4,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data: bytes_data,
+    });
+
+    let mut writer = Writer::new(src.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    writer.write_columnar_batch(&batch)?;
+    let (_, checksum) = writer.finish()?.expect("source written");
+    let source = recover_test_table(&src, checksum)?;
+
+    // Mask rows 1 and 3 by position (value-agnostic) and relocate.
+    let mut bitmap = DeleteBitmap::new();
+    bitmap.insert(1);
+    bitmap.insert(3);
+    let out_checksum =
+        source.relocate_columnar_with_deletes(&out, &StdFs, 1, &bitmap, SyncMode::Normal)?;
+    let relocated = recover_test_table_with_id(&out, out_checksum, 1)?;
+
+    // Point path: masked rows read absent; survivors reconstruct their sub-cells.
+    let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+    for i in 0..5u32 {
+        let key = format!("k{i}").into_bytes();
+        let got = relocated.get(&key, SeqNo::MAX, hash64(&key))?;
+        if i == 1 || i == 3 {
+            assert!(got.is_none(), "masked row {i} must read absent");
+        } else {
+            let v = got.expect("survivor present");
+            assert_eq!(
+                unframe_value_cells(v.value.as_ref(), &tags)?,
+                vec![&fixed[i as usize].to_le_bytes()[..], payloads[i as usize]],
+                "survivor {i} sub-cells",
+            );
+        }
+    }
+
+    // Projection path: a scan over sub-column 3 yields the survivors only, with
+    // their fixed bytes; the masked rows never appear.
+    let batches = relocated.columnar_scan(&[3], None)?;
+    let mut col3 = Vec::new();
+    let mut rows = 0u32;
+    for b in &batches {
+        assert!(
+            b.columns.iter().all(|c| c.column_id == 3),
+            "projection decodes only sub-column 3",
+        );
+        rows += b.row_count;
+        for c in b.columns.iter().filter(|c| c.column_id == 3) {
+            col3.extend_from_slice(&c.data);
+        }
+    }
+    assert_eq!(rows, 3, "two of five rows masked out of the projection");
+    let want: Vec<u8> = [10u32, 30, 50]
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+    assert_eq!(col3, want, "projected fixed bytes are the survivors");
+
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3932,9 +3932,10 @@ fn write_columnar_batch_stores_value_subcolumns_and_round_trips() -> crate::Resu
 
     // A consumer batch: the intrinsic columns for two sorted keys, with the
     // single value column replaced by two value sub-columns (a fixed-4 + a bytes).
+    // Per-row seqnos are 0 (the ingest contract; the table assigns the seqno).
     let mut batch = entries_to_column_batch(&[
-        crate::InternalValue::from_components(b"k0", b"ignored", 1, crate::ValueType::Value),
-        crate::InternalValue::from_components(b"k1", b"ignored", 2, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"k0", b"ignored", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"k1", b"ignored", 0, crate::ValueType::Value),
     ])?;
     batch.columns.pop();
     batch.columns.push(Column {
@@ -3958,7 +3959,7 @@ fn write_columnar_batch_stores_value_subcolumns_and_round_trips() -> crate::Resu
     let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
         .use_columnar(true)
         .use_zone_map(true);
-    writer.write_columnar_batch(&batch)?;
+    writer.write_columnar_batch(&batch, &crate::comparator::default_comparator())?;
     let (_, checksum) = writer.finish()?.expect("table written");
 
     let table = recover_test_table(&file, checksum)?;
@@ -4009,7 +4010,7 @@ fn delete_bitmap_masks_value_subcolumns_in_point_and_projection_reads() -> crate
                 crate::InternalValue::from_components(
                     format!("k{i}").into_bytes(),
                     b"x",
-                    1,
+                    0, // ingest contract: per-row seqno is 0
                     crate::ValueType::Value,
                 )
             })
@@ -4042,7 +4043,7 @@ fn delete_bitmap_masks_value_subcolumns_in_point_and_projection_reads() -> crate
     let mut writer = Writer::new(src.clone(), 0, 0, Arc::new(StdFs))?
         .use_columnar(true)
         .use_zone_map(true);
-    writer.write_columnar_batch(&batch)?;
+    writer.write_columnar_batch(&batch, &crate::comparator::default_comparator())?;
     let (_, checksum) = writer.finish()?.expect("source written");
     let source = recover_test_table(&src, checksum)?;
 

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -3913,3 +3913,65 @@ fn delete_bitmap_masks_deleted_key_in_point_read() -> crate::Result<()> {
     }
     Ok(())
 }
+
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_batch_stores_value_subcolumns_and_round_trips() -> crate::Result<()> {
+    use crate::table::columnar::{Column, TypeTag, entries_to_column_batch, unframe_value_cells};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    // A consumer batch: the intrinsic columns for two sorted keys, with the
+    // single value column replaced by two value sub-columns (a fixed-4 + a bytes).
+    let mut batch = entries_to_column_batch(&[
+        crate::InternalValue::from_components(b"k0", b"ignored", 1, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"k1", b"ignored", 2, crate::ValueType::Value),
+    ])?;
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![1, 0, 0, 0, 2, 0, 0, 0],
+    });
+    let mut bytes_data = Vec::new();
+    for off in [0u32, 2, 5] {
+        bytes_data.extend_from_slice(&off.to_le_bytes());
+    }
+    bytes_data.extend_from_slice(b"aabbb");
+    batch.columns.push(Column {
+        column_id: 4,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data: bytes_data,
+    });
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    writer.write_columnar_batch(&batch)?;
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    assert!(table.metadata.columnar, "segment must be columnar");
+
+    // Point reads reconstruct the framed value, which unframes to the original
+    // sub-cells.
+    let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+    let v0 = table
+        .get(b"k0", SeqNo::MAX, hash64(b"k0"))?
+        .expect("k0 present");
+    assert_eq!(
+        unframe_value_cells(v0.value.as_ref(), &tags)?,
+        vec![&[1, 0, 0, 0][..], &b"aa"[..]],
+    );
+    let v1 = table
+        .get(b"k1", SeqNo::MAX, hash64(b"k1"))?
+        .expect("k1 present");
+    assert_eq!(
+        unframe_value_cells(v1.value.as_ref(), &tags)?,
+        vec![&[2, 0, 0, 0][..], &b"bbb"[..]],
+    );
+    Ok(())
+}

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -4096,3 +4096,102 @@ fn delete_bitmap_masks_value_subcolumns_in_point_and_projection_reads() -> crate
 
     Ok(())
 }
+
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_batch_accounts_tombstones_seqno_bounds_and_restart_locator() -> crate::Result<()>
+{
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::table::columnar::{Column, TypeTag, entries_to_column_batch};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("t");
+    // Distinct keys with mixed value types plus one fixed value sub-column,
+    // written with seqno-in-index and restart-precision locator enabled so the
+    // tombstone / weak-tombstone accounting, the seqno-bounds, and the
+    // restart-precision locator branches all run.
+    let mut batch = entries_to_column_batch(&[
+        crate::InternalValue::from_components(b"k0", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"k1", b"", 0, crate::ValueType::Tombstone),
+        crate::InternalValue::from_components(b"k2", b"", 0, crate::ValueType::WeakTombstone),
+    ])?;
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(2),
+        validity: None,
+        data: vec![1, 1, 2, 2, 3, 3],
+    });
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_seqno_in_index(true)
+        .use_locator(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        });
+    writer.write_columnar_batch(&batch, &crate::comparator::default_comparator())?;
+    let (_, checksum) = writer.finish()?.expect("table written");
+    let table = recover_test_table(&file, checksum)?;
+
+    // is_tombstone covers Tombstone + WeakTombstone; weak count is just the latter.
+    assert_eq!(table.metadata.tombstone_count, 2, "two tombstone-kind rows");
+    assert_eq!(table.metadata.weak_tombstone_count, 1, "one weak tombstone");
+    assert!(
+        table.get(b"k0", SeqNo::MAX, hash64(b"k0"))?.is_some(),
+        "the live row reads back",
+    );
+    Ok(())
+}
+
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_batch_on_an_empty_batch_writes_no_block() -> crate::Result<()> {
+    use crate::table::columnar::{Column, TypeTag};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("t");
+    // An empty batch (zero rows) carrying the intrinsic columns plus a value
+    // sub-column writes no block and returns no last key.
+    let empty = crate::table::columnar::ColumnBatch {
+        row_count: 0,
+        columns: vec![
+            Column {
+                column_id: 0,
+                type_tag: TypeTag::Bytes,
+                validity: None,
+                data: 0u32.to_le_bytes().to_vec(),
+            },
+            Column {
+                column_id: 1,
+                type_tag: TypeTag::Fixed(8),
+                validity: None,
+                data: Vec::new(),
+            },
+            Column {
+                column_id: 2,
+                type_tag: TypeTag::Fixed(1),
+                validity: None,
+                data: Vec::new(),
+            },
+            Column {
+                column_id: 3,
+                type_tag: TypeTag::Fixed(4),
+                validity: None,
+                data: Vec::new(),
+            },
+        ],
+    };
+    let mut writer = Writer::new(file, 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    assert!(
+        writer
+            .write_columnar_batch(&empty, &crate::comparator::default_comparator())?
+            .is_none(),
+        "an empty batch yields no last key",
+    );
+    Ok(())
+}

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1073,6 +1073,33 @@ impl Writer {
         zone_block_min: Option<crate::UserKey>,
     ) -> crate::Result<()> {
         let batch = crate::table::columnar::entries_to_column_batch(&self.chunk)?;
+        self.encode_columnar_batch_block(
+            &batch,
+            last_key,
+            last_seqno,
+            seqno_bounds,
+            item_count,
+            zone_block_min,
+        )?;
+        self.chunk.clear();
+        self.chunk_size = 0;
+        Ok(())
+    }
+
+    /// Encodes a `ColumnBatch` as a columnar (PAX) block and registers it like a
+    /// data block (index handle, seqno bounds, zone-map key range). Shared by the
+    /// intrinsic transpose spill ([`Self::spill_columnar_block`]) and the
+    /// consumer columnar-ingest path ([`Self::write_columnar_batch`]).
+    #[cfg(feature = "columnar")]
+    fn encode_columnar_batch_block(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+        last_key: crate::UserKey,
+        last_seqno: crate::SeqNo,
+        seqno_bounds: Option<(u64, u64)>,
+        item_count: usize,
+        zone_block_min: Option<crate::UserKey>,
+    ) -> crate::Result<()> {
         let payload = batch.encode(crate::table::columnar::CodecId::Plain)?;
         let transform = {
             let t = crate::table::block::BlockTransform::from_parts(
@@ -1108,10 +1135,104 @@ impl Writer {
             seqno_bounds,
             item_count,
             zone_block_min,
-        )?;
-        self.chunk.clear();
-        self.chunk_size = 0;
-        Ok(())
+        )
+    }
+
+    /// Writes a consumer-provided [`ColumnBatch`](crate::table::columnar::ColumnBatch)
+    /// as a single columnar block, storing its value sub-columns directly instead
+    /// of re-transposing the intrinsic value. The batch must carry the three
+    /// intrinsic columns plus one or more value sub-columns, with keys in
+    /// non-decreasing order (the writer's sorted-input contract); the columnar
+    /// layout must be enabled. Each call appends one block, so callers feed
+    /// successive batches in key order.
+    ///
+    /// # Errors
+    ///
+    /// Propagates batch validation errors (malformed intrinsic layout, framing,
+    /// or key/value invariants) and any block write error.
+    #[cfg(feature = "columnar")]
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "wired by the columnar ingest path (a follow-up slice)"
+        )
+    )]
+    pub(crate) fn write_columnar_batch(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+    ) -> crate::Result<()> {
+        debug_assert!(
+            self.use_columnar,
+            "write_columnar_batch requires use_columnar(true)"
+        );
+        debug_assert!(
+            self.locator.is_none(),
+            "columnar ingest does not record retrieval-ribbon locators yet"
+        );
+        // Validate the batch shape and obtain per-row keys / seqnos / value-types.
+        // The framed values feed the shape accounting; the block stores the
+        // consumer's sub-columns (not a re-transpose).
+        let entries = crate::table::columnar::column_batch_to_entries(batch)?;
+        let Some(last) = entries.last() else {
+            return Ok(()); // empty batch: no block
+        };
+        let last_key = last.key.user_key.clone();
+        let last_seqno = last.key.seqno;
+        let item_count = entries.len();
+        let seqno_bounds = self.use_seqno_in_index.then(|| {
+            entries.iter().fold((u64::MAX, u64::MIN), |(mn, mx), e| {
+                (mn.min(e.key.seqno), mx.max(e.key.seqno))
+            })
+        });
+        let zone_block_min = self
+            .use_zone_map
+            .then(|| entries.first().map(|e| e.key.user_key.clone()))
+            .flatten();
+
+        // Per-row shape / seqno / key accounting, mirroring `write()` minus the
+        // chunk push and the locator (the direct columnar block uses neither).
+        for e in &entries {
+            let user_key = &e.key.user_key;
+            self.meta.sum_user_key_bytes += user_key.len() as u64;
+            self.meta.sum_value_bytes += e.value.len() as u64;
+            if e.is_tombstone() {
+                self.meta.tombstone_count += 1;
+            }
+            if e.key.value_type == ValueType::WeakTombstone {
+                self.meta.weak_tombstone_count += 1;
+            }
+            if e.key.value_type == ValueType::Value
+                && let Some((prev_key, prev_type)) = &self.previous_item
+                && prev_type == &ValueType::WeakTombstone
+                && prev_key.as_ref() == user_key.as_ref()
+            {
+                self.meta.weak_tombstone_reclaimable_count += 1;
+            }
+            if Some(user_key) != self.current_key.as_ref() {
+                self.meta.key_count += 1;
+                self.current_key = Some(user_key.clone());
+                if self.bloom_policy.is_active() {
+                    self.filter_writer.register_key(user_key)?;
+                }
+            }
+            if self.meta.first_key.is_none() {
+                self.meta.first_key = Some(user_key.clone());
+            }
+            self.previous_item = Some((user_key.clone(), e.key.value_type));
+            self.meta.lowest_seqno = self.meta.lowest_seqno.min(e.key.seqno);
+            self.meta.highest_seqno = self.meta.highest_seqno.max(e.key.seqno);
+            self.meta.highest_kv_seqno = self.meta.highest_kv_seqno.max(e.key.seqno);
+        }
+
+        self.encode_columnar_batch_block(
+            batch,
+            last_key,
+            last_seqno,
+            seqno_bounds,
+            item_count,
+            zone_block_min,
+        )
     }
 
     /// Encodes `chunk` into `buf`, returning the `block_flags` bits the transform

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1146,36 +1146,32 @@ impl Writer {
     /// layout must be enabled. Each call appends one block, so callers feed
     /// successive batches in key order.
     ///
+    /// Returns the batch's last user key (or `None` for an empty batch) so a
+    /// caller can track the ingest ordering across batches.
+    ///
     /// # Errors
     ///
     /// Propagates batch validation errors (malformed intrinsic layout, framing,
     /// or key/value invariants) and any block write error.
     #[cfg(feature = "columnar")]
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "wired by the columnar ingest path (a follow-up slice)"
-        )
-    )]
     pub(crate) fn write_columnar_batch(
         &mut self,
         batch: &crate::table::columnar::ColumnBatch,
-    ) -> crate::Result<()> {
-        debug_assert!(
-            self.use_columnar,
-            "write_columnar_batch requires use_columnar(true)"
-        );
-        debug_assert!(
-            self.locator.is_none(),
-            "columnar ingest does not record retrieval-ribbon locators yet"
-        );
+    ) -> crate::Result<Option<crate::UserKey>> {
+        // A columnar batch only makes sense (and only reads back correctly) when
+        // the table is marked columnar; reject a row-mode writer rather than
+        // writing a columnar block under a row descriptor.
+        if !self.use_columnar {
+            return Err(crate::Error::FeatureUnsupported(
+                "columnar batch ingest requires the columnar layout",
+            ));
+        }
         // Validate the batch shape and obtain per-row keys / seqnos / value-types.
         // The framed values feed the shape accounting; the block stores the
         // consumer's sub-columns (not a re-transpose).
         let entries = crate::table::columnar::column_batch_to_entries(batch)?;
         let Some(last) = entries.last() else {
-            return Ok(()); // empty batch: no block
+            return Ok(None); // empty batch: no block
         };
         let last_key = last.key.user_key.clone();
         let last_seqno = last.key.seqno;
@@ -1191,8 +1187,10 @@ impl Writer {
             .flatten();
 
         // Per-row shape / seqno / key accounting, mirroring `write()` minus the
-        // chunk push and the locator (the direct columnar block uses neither).
-        for e in &entries {
+        // chunk push (the direct columnar block holds all rows already). The
+        // locator records each new key's position within this single block, the
+        // same as the flush path does for a transposed columnar block.
+        for (row, e) in entries.iter().enumerate() {
             let user_key = &e.key.user_key;
             self.meta.sum_user_key_bytes += user_key.len() as u64;
             self.meta.sum_value_bytes += e.value.len() as u64;
@@ -1215,6 +1213,23 @@ impl Writer {
                 if self.bloom_policy.is_active() {
                     self.filter_writer.register_key(user_key)?;
                 }
+                if let Some(spec) = self.locator {
+                    // `row` is this key's item index within the forming columnar
+                    // block; `locator_block_id` is the block's ordinal.
+                    let pos = row as u64;
+                    let slot = match spec.precision {
+                        crate::config::LocatorPrecision::Block => 0,
+                        crate::config::LocatorPrecision::Restart => {
+                            pos / u64::from(self.data_block_restart_interval)
+                        }
+                        crate::config::LocatorPrecision::Entry => pos,
+                    };
+                    self.locators.push((
+                        crate::hash::hash64(user_key),
+                        self.locator_block_id,
+                        slot,
+                    ));
+                }
             }
             if self.meta.first_key.is_none() {
                 self.meta.first_key = Some(user_key.clone());
@@ -1227,12 +1242,19 @@ impl Writer {
 
         self.encode_columnar_batch_block(
             batch,
-            last_key,
+            last_key.clone(),
             last_seqno,
             seqno_bounds,
             item_count,
             zone_block_min,
-        )
+        )?;
+        // This block's keys were recorded with the current locator ordinal;
+        // advance it so a following batch's keys belong to the next block (the
+        // chunk-based path does this in `spill_block`).
+        if self.locator.is_some() {
+            self.locator_block_id += 1;
+        }
+        Ok(Some(last_key))
     }
 
     /// Encodes `chunk` into `buf`, returning the `block_flags` bits the transform

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1210,6 +1210,13 @@ impl Writer {
             .then(|| entries.first().map(|e| e.key.user_key.clone()))
             .flatten();
 
+        // Flush any row chunk buffered by prior `write()` calls before this
+        // direct block, so its block (and locator ordinal) is registered first
+        // and the sorted block / index order is preserved. The validation above
+        // ran first, so an invalid batch never forces a spill. A no-op when the
+        // chunk is empty (the columnar-only ingest path).
+        self.spill_block()?;
+
         // Per-row shape / seqno / key accounting, mirroring `write()` minus the
         // chunk push (the direct columnar block holds all rows already). The
         // locator records each new key's position within this single block, the

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1141,22 +1141,25 @@ impl Writer {
     /// Writes a consumer-provided [`ColumnBatch`](crate::table::columnar::ColumnBatch)
     /// as a single columnar block, storing its value sub-columns directly instead
     /// of re-transposing the intrinsic value. The batch must carry the three
-    /// intrinsic columns plus one or more value sub-columns, with keys in
-    /// non-decreasing order (the writer's sorted-input contract); the columnar
-    /// layout must be enabled. Each call appends one block, so callers feed
-    /// successive batches in key order.
+    /// intrinsic columns plus one or more value sub-columns; the columnar layout
+    /// must be enabled. Keys must be strictly increasing by `comparator` (within
+    /// the batch and across successive batches / row writes on this writer), and
+    /// every per-row seqno must be `0` (the ingestion assigns one sequence
+    /// number). Each call appends one block.
     ///
     /// Returns the batch's last user key (or `None` for an empty batch) so a
     /// caller can track the ingest ordering across batches.
     ///
     /// # Errors
     ///
-    /// Propagates batch validation errors (malformed intrinsic layout, framing,
-    /// or key/value invariants) and any block write error.
+    /// Returns an error if the batch shape is malformed, the layout is not
+    /// columnar, the keys are not strictly increasing, a row carries a non-zero
+    /// seqno, or the block write fails.
     #[cfg(feature = "columnar")]
     pub(crate) fn write_columnar_batch(
         &mut self,
         batch: &crate::table::columnar::ColumnBatch,
+        comparator: &crate::SharedComparator,
     ) -> crate::Result<Option<crate::UserKey>> {
         // A columnar batch only makes sense (and only reads back correctly) when
         // the table is marked columnar; reject a row-mode writer rather than
@@ -1173,6 +1176,27 @@ impl Writer {
         let Some(last) = entries.last() else {
             return Ok(None); // empty batch: no block
         };
+
+        // Ingest contract. Unsorted keys would corrupt the sorted block index /
+        // zone map; a non-zero seqno would read back shifted by the table's
+        // assigned sequence number. Reject both before writing anything.
+        if entries.iter().any(|e| e.key.seqno != 0) {
+            return Err(crate::Error::FeatureUnsupported(
+                "columnar batch ingest requires every row seqno to be 0 (the ingestion assigns the sequence number)",
+            ));
+        }
+        let mut prev = self.current_key.as_ref();
+        for e in &entries {
+            if let Some(p) = prev
+                && comparator.compare(p.as_ref(), e.key.user_key.as_ref())
+                    != core::cmp::Ordering::Less
+            {
+                return Err(crate::Error::InvalidHeader(
+                    "columnar batch ingest requires strictly increasing keys",
+                ));
+            }
+            prev = Some(&e.key.user_key);
+        }
         let last_key = last.key.user_key.clone();
         let last_seqno = last.key.seqno;
         let item_count = entries.len();

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -145,6 +145,10 @@ impl<'a> Ingestion<'a> {
 
         writer = writer.use_seqno_in_index(rc.seqno_in_index);
         writer = writer.use_zone_map(rc.zone_map);
+        // Match the flush writer: when the columnar layout is enabled, ingested
+        // tables are columnar too (a row ingest is transposed at spill, a
+        // columnar batch is stored directly via `write_columnar_batch`).
+        writer = writer.use_columnar(rc.columnar);
         writer = writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
         writer = writer.use_locator(tree.config.locator_policy.get(INITIAL_CANONICAL_LEVEL));
@@ -274,6 +278,39 @@ impl<'a> Ingestion<'a> {
         // Remember the last user key to validate the next call's ordering
         self.last_key = Some(key);
 
+        Ok(())
+    }
+
+    /// Writes a consumer-provided columnar batch (its value sub-columns) as one
+    /// columnar block.
+    ///
+    /// The batch carries the three intrinsic columns ([key, seqno, value-type])
+    /// plus one or more value sub-columns; its keys must be sorted and order
+    /// after any previously written data (the ingestion's sorted-input
+    /// contract). The per-row seqnos are typically `0`: the ingestion assigns
+    /// the atomic global sequence number at [`finish`](Self::finish), shared by
+    /// every ingested table.
+    ///
+    /// Requires the columnar layout (enable `columnar` in the runtime config
+    /// before opening the ingestion); a row-mode ingestion rejects the batch. An
+    /// ingestion is either row-oriented (via [`write`](Self::write)) or
+    /// columnar, not both.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the batch shape is invalid, the layout is not
+    /// columnar, or a block write fails.
+    #[cfg(feature = "columnar")]
+    pub fn write_columnar_batch(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+    ) -> crate::Result<()> {
+        // Carry the batch's last key forward: it both records the ordering
+        // boundary for any later write and signals `finish` that data was
+        // written (it installs nothing when `last_key` is `None`).
+        if let Some(last) = self.writer.write_columnar_batch(batch)? {
+            self.last_key = Some(last);
+        }
         Ok(())
     }
 

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -285,11 +285,11 @@ impl<'a> Ingestion<'a> {
     /// columnar block.
     ///
     /// The batch carries the three intrinsic columns ([key, seqno, value-type])
-    /// plus one or more value sub-columns; its keys must be sorted and order
-    /// after any previously written data (the ingestion's sorted-input
-    /// contract). The per-row seqnos are typically `0`: the ingestion assigns
-    /// the atomic global sequence number at [`finish`](Self::finish), shared by
-    /// every ingested table.
+    /// plus one or more value sub-columns. Its keys must be strictly increasing
+    /// (by the tree comparator) within the batch and after any previously written
+    /// data, and every per-row seqno must be `0`: the ingestion assigns the atomic
+    /// global sequence number at [`finish`](Self::finish), shared by every
+    /// ingested table.
     ///
     /// Requires the columnar layout (enable `columnar` in the runtime config
     /// before opening the ingestion); a row-mode ingestion rejects the batch. An
@@ -298,8 +298,9 @@ impl<'a> Ingestion<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the batch shape is invalid, the layout is not
-    /// columnar, or a block write fails.
+    /// Returns an error if the batch shape is invalid, the keys are not strictly
+    /// increasing, any row carries a non-zero seqno, the layout is not columnar,
+    /// or a block write fails.
     #[cfg(feature = "columnar")]
     pub fn write_columnar_batch(
         &mut self,

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -306,6 +306,20 @@ impl<'a> Ingestion<'a> {
         &mut self,
         batch: &crate::table::columnar::ColumnBatch,
     ) -> crate::Result<()> {
+        // Cross-call ordering guard, like the row write methods: the batch's
+        // first key must strictly follow the last key written through this
+        // ingestion. The inner writer also rejects unsorted keys, but its running
+        // key resets on table rotation, so this `last_key` check (which persists
+        // across rotations) is what catches a batch that interleaves out of order
+        // with a previous write or batch.
+        if let Some(prev) = &self.last_key
+            && let Some(first) = batch.first_user_key()?
+            && self.tree.config.comparator.compare(prev, first) != Ordering::Less
+        {
+            return Err(crate::Error::InvalidHeader(
+                "columnar batch ingest: first key must follow the last written key",
+            ));
+        }
         // Carry the batch's last key forward: it both records the ordering
         // boundary for any later write and signals `finish` that data was
         // written (it installs nothing when `last_key` is `None`).

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -317,3 +317,25 @@ fn columnar_ingest_after_a_row_write_keeps_block_order() -> lsm_tree::Result<()>
     );
     Ok(())
 }
+
+#[test]
+fn columnar_ingest_rejected_on_a_blob_tree() -> lsm_tree::Result<()> {
+    // KV-separated (blob) trees do not support columnar batch ingest.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(Default::default()))
+    .open()?;
+
+    let mut ingest = any.ingestion()?;
+    assert!(
+        ingest
+            .write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 0))
+            .is_err(),
+        "columnar ingest is not supported on a blob tree",
+    );
+    Ok(())
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -103,7 +103,10 @@ fn columnar_ingest_rejected_without_columnar_layout() -> lsm_tree::Result<()> {
     let batch = two_subcolumn_batch();
     let mut ingest = any.ingestion()?;
     assert!(
-        ingest.write_columnar_batch(&batch).is_err(),
+        matches!(
+            ingest.write_columnar_batch(&batch),
+            Err(lsm_tree::Error::FeatureUnsupported(_))
+        ),
         "columnar ingest must be rejected when the layout is not columnar",
     );
     Ok(())
@@ -222,7 +225,10 @@ fn columnar_ingest_rejects_unsorted_keys() -> lsm_tree::Result<()> {
 
     let mut ingest = any.ingestion()?;
     assert!(
-        ingest.write_columnar_batch(&batch).is_err(),
+        matches!(
+            ingest.write_columnar_batch(&batch),
+            Err(lsm_tree::Error::InvalidHeader(_))
+        ),
         "descending keys must be rejected",
     );
     Ok(())
@@ -247,9 +253,10 @@ fn columnar_ingest_rejects_nonzero_seqno() -> lsm_tree::Result<()> {
 
     let mut ingest = any.ingestion()?;
     assert!(
-        ingest
-            .write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 5))
-            .is_err(),
+        matches!(
+            ingest.write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 5)),
+            Err(lsm_tree::Error::FeatureUnsupported(_))
+        ),
         "a non-zero row seqno must be rejected",
     );
     Ok(())
@@ -276,9 +283,10 @@ fn columnar_ingest_rejects_batch_out_of_order_with_a_prior_write() -> lsm_tree::
     let mut ingest = any.ingestion()?;
     ingest.write(b"z".to_vec(), b"v".to_vec())?;
     assert!(
-        ingest
-            .write_columnar_batch(&one_fixed_subcolumn_batch(b"a", 0))
-            .is_err(),
+        matches!(
+            ingest.write_columnar_batch(&one_fixed_subcolumn_batch(b"a", 0)),
+            Err(lsm_tree::Error::InvalidHeader(_))
+        ),
         "a batch whose first key precedes a prior write must be rejected",
     );
     Ok(())
@@ -332,9 +340,10 @@ fn columnar_ingest_rejected_on_a_blob_tree() -> lsm_tree::Result<()> {
 
     let mut ingest = any.ingestion()?;
     assert!(
-        ingest
-            .write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 0))
-            .is_err(),
+        matches!(
+            ingest.write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 0)),
+            Err(lsm_tree::Error::FeatureUnsupported(_))
+        ),
         "columnar ingest is not supported on a blob tree",
     );
     Ok(())

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end columnar ingest: a consumer hands the ingestion a pre-transposed
+//! `ColumnBatch` whose value is split into typed sub-columns. The batch is
+//! stored as a columnar block (sub-columns kept, not re-transposed), and point
+//! reads reconstruct each row's value, which unframes back to the original
+//! sub-cells.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::table::columnar::{
+    Column, ColumnBatch, TypeTag, entries_to_column_batch, unframe_value_cells,
+};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, InternalValue, SeqNo, SequenceNumberCounter, ValueType,
+    get_tmp_folder,
+};
+use test_log::test;
+
+/// Builds a consumer batch for two sorted keys whose value is two sub-columns:
+/// a fixed-4 column and a variable-width bytes column. Per-row seqnos are 0, so
+/// the ingestion assigns the atomic global sequence number.
+fn two_subcolumn_batch() -> ColumnBatch {
+    let mut batch = entries_to_column_batch(&[
+        InternalValue::from_components(b"k0", b"ignored", 0, ValueType::Value),
+        InternalValue::from_components(b"k1", b"ignored", 0, ValueType::Value),
+    ])
+    .expect("transpose");
+    // Drop the single opaque value column; add two value sub-columns.
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![1, 0, 0, 0, 2, 0, 0, 0], // row 0 = 1, row 1 = 2
+    });
+    let mut bytes_data = Vec::new();
+    for off in [0u32, 2, 5] {
+        bytes_data.extend_from_slice(&off.to_le_bytes());
+    }
+    bytes_data.extend_from_slice(b"aabbb"); // row 0 = "aa", row 1 = "bbb"
+    batch.columns.push(Column {
+        column_id: 4,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data: bytes_data,
+    });
+    batch
+}
+
+#[test]
+fn columnar_ingest_round_trips_value_subcolumns() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // Columnar ingest requires the columnar layout; enable it on the inner tree.
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+
+    let batch = two_subcolumn_batch();
+    let mut ingest = any.ingestion()?;
+    ingest.write_columnar_batch(&batch)?;
+    ingest.finish()?;
+
+    let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+    let v0 = any.get(b"k0", SeqNo::MAX)?.expect("k0 present");
+    assert_eq!(
+        unframe_value_cells(v0.as_ref(), &tags)?,
+        vec![&[1, 0, 0, 0][..], &b"aa"[..]],
+    );
+    let v1 = any.get(b"k1", SeqNo::MAX)?.expect("k1 present");
+    assert_eq!(
+        unframe_value_cells(v1.as_ref(), &tags)?,
+        vec![&[2, 0, 0, 0][..], &b"bbb"[..]],
+    );
+    Ok(())
+}
+
+#[test]
+fn columnar_ingest_rejected_without_columnar_layout() -> lsm_tree::Result<()> {
+    // A row-mode tree (columnar disabled) must refuse a columnar batch rather
+    // than write a columnar block under a row descriptor.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    let batch = two_subcolumn_batch();
+    let mut ingest = any.ingestion()?;
+    assert!(
+        ingest.write_columnar_batch(&batch).is_err(),
+        "columnar ingest must be rejected when the layout is not columnar",
+    );
+    Ok(())
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -283,3 +283,37 @@ fn columnar_ingest_rejects_batch_out_of_order_with_a_prior_write() -> lsm_tree::
     );
     Ok(())
 }
+
+#[test]
+fn columnar_ingest_after_a_row_write_keeps_block_order() -> lsm_tree::Result<()> {
+    // A row write buffers a chunk; a following (in-order) columnar batch must not
+    // register its block before that buffered chunk is spilled, or the sorted
+    // block index is left out of order and the row-written key is lost.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    ingest.write(b"a".to_vec(), b"va".to_vec())?;
+    ingest.write_columnar_batch(&one_fixed_subcolumn_batch(b"b", 0))?;
+    ingest.finish()?;
+
+    assert!(
+        any.get(b"a", SeqNo::MAX)?.is_some(),
+        "the row-written key must survive the following columnar batch",
+    );
+    assert!(
+        any.get(b"b", SeqNo::MAX)?.is_some(),
+        "the columnar-batch key must be present",
+    );
+    Ok(())
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -163,14 +163,31 @@ fn columnar_ingest_projects_individual_value_subcolumns() -> lsm_tree::Result<()
         "fixed-4 sub-column bytes"
     );
 
-    // Project only the bytes sub-column (id 4): again decoded in isolation.
+    // Project only the bytes sub-column (id 4): again decoded in isolation, and
+    // its payload is the two ingested values verbatim (asserting the id alone
+    // would also pass for an empty or wrong-row column).
     let batches = table.columnar_scan(&[4], None)?;
+    let mut col4_data = Vec::new();
+    let mut rows = 0u32;
     for b in &batches {
         assert!(
             b.columns.iter().all(|c| c.column_id == 4),
             "a sub-column-4 projection must not decode any other column",
         );
+        rows += b.row_count;
+        for col in b.columns.iter().filter(|c| c.column_id == 4) {
+            col4_data.extend_from_slice(&col.data);
+        }
     }
+    assert_eq!(rows, 2, "projection still sees every row");
+    // The bytes column body: (row_count + 1) little-endian u32 offsets [0, 2, 5]
+    // followed by the concatenated payload "aabbb" (row 0 = "aa", row 1 = "bbb").
+    let mut want_col4 = Vec::new();
+    for off in [0u32, 2, 5] {
+        want_col4.extend_from_slice(&off.to_le_bytes());
+    }
+    want_col4.extend_from_slice(b"aabbb");
+    assert_eq!(col4_data, want_col4, "projected bytes sub-column payload");
     Ok(())
 }
 

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -170,3 +170,87 @@ fn columnar_ingest_projects_individual_value_subcolumns() -> lsm_tree::Result<()
     }
     Ok(())
 }
+
+/// One row whose value is a single fixed-4 sub-column (id 3), the smallest batch
+/// that still exercises the ingest contract checks.
+fn one_fixed_subcolumn_batch(key: &[u8], seqno: u64) -> ColumnBatch {
+    let mut batch = entries_to_column_batch(&[InternalValue::from_components(
+        key.to_vec(),
+        b"x".to_vec(),
+        seqno,
+        ValueType::Value,
+    )])
+    .expect("transpose");
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![0, 0, 0, 0],
+    });
+    batch
+}
+
+#[test]
+fn columnar_ingest_rejects_unsorted_keys() -> lsm_tree::Result<()> {
+    // Two rows in descending key order: the ingest must reject them rather than
+    // write a block whose sorted index would be corrupt.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut batch = entries_to_column_batch(&[
+        InternalValue::from_components(b"k1".to_vec(), b"x".to_vec(), 0, ValueType::Value),
+        InternalValue::from_components(b"k0".to_vec(), b"x".to_vec(), 0, ValueType::Value),
+    ])?;
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![0, 0, 0, 0, 0, 0, 0, 0],
+    });
+
+    let mut ingest = any.ingestion()?;
+    assert!(
+        ingest.write_columnar_batch(&batch).is_err(),
+        "descending keys must be rejected",
+    );
+    Ok(())
+}
+
+#[test]
+fn columnar_ingest_rejects_nonzero_seqno() -> lsm_tree::Result<()> {
+    // A non-zero per-row seqno would read back shifted by the table's assigned
+    // sequence number, so the ingest must reject it.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    assert!(
+        ingest
+            .write_columnar_batch(&one_fixed_subcolumn_batch(b"k0", 5))
+            .is_err(),
+        "a non-zero row seqno must be rejected",
+    );
+    Ok(())
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -254,3 +254,32 @@ fn columnar_ingest_rejects_nonzero_seqno() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn columnar_ingest_rejects_batch_out_of_order_with_a_prior_write() -> lsm_tree::Result<()> {
+    // A columnar batch whose first key precedes a key already written through the
+    // same ingestion must be rejected, not silently produce an unsorted run (this
+    // cross-call guard holds even across writer table rotations).
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    ingest.write(b"z".to_vec(), b"v".to_vec())?;
+    assert!(
+        ingest
+            .write_columnar_batch(&one_fixed_subcolumn_batch(b"a", 0))
+            .is_err(),
+        "a batch whose first key precedes a prior write must be rejected",
+    );
+    Ok(())
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -108,3 +108,65 @@ fn columnar_ingest_rejected_without_columnar_layout() -> lsm_tree::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn columnar_ingest_projects_individual_value_subcolumns() -> lsm_tree::Result<()> {
+    // A projection scan over a consumer-ingested segment decodes only the
+    // requested value sub-column, never the others or the intrinsic value.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+
+    {
+        let mut ingest = any.ingestion()?;
+        ingest.write_columnar_batch(&two_subcolumn_batch())?;
+        ingest.finish()?;
+    }
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one ingested SST");
+
+    // Project only the fixed-4 sub-column (id 3): every batch carries it alone,
+    // and its bytes are the two ingested values verbatim.
+    let batches = table.columnar_scan(&[3], None)?;
+    let mut col3_data = Vec::new();
+    let mut rows = 0u32;
+    for b in &batches {
+        assert!(
+            b.columns.iter().all(|c| c.column_id == 3),
+            "a sub-column-3 projection must not decode any other column",
+        );
+        rows += b.row_count;
+        for col in b.columns.iter().filter(|c| c.column_id == 3) {
+            col3_data.extend_from_slice(&col.data);
+        }
+    }
+    assert_eq!(rows, 2, "projection still sees every row");
+    assert_eq!(
+        col3_data,
+        vec![1, 0, 0, 0, 2, 0, 0, 0],
+        "fixed-4 sub-column bytes"
+    );
+
+    // Project only the bytes sub-column (id 4): again decoded in isolation.
+    let batches = table.columnar_scan(&[4], None)?;
+    for b in &batches {
+        assert!(
+            b.columns.iter().all(|c| c.column_id == 4),
+            "a sub-column-4 projection must not decode any other column",
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Lets a consumer split a value into typed sub-columns and ingest a pre-transposed `ColumnBatch` directly, so analytical scans project individual sub-columns without decoding the whole value. The engine stays value-agnostic: it stores the sub-columns verbatim and reconstructs a row's value through a self-describing framing, never interpreting cell bytes.

## What it adds

- **Reversible value framing** (`frame_value_cells` / `unframe_value_cells`): a row's value sub-cells join into one self-describing blob (fixed-width cells verbatim, variable-width length-prefixed) that the consumer reverses by type tag. Fixed sub-columns carry no per-cell overhead.
- **Row reconstruction**: the columnar untranspose now accepts the three intrinsic columns plus one or more value sub-columns; a single value column round-trips byte-for-byte, two or more are framed. All existing corruption guards are preserved.
- **Writer + ingest path**: `Writer::write_columnar_batch` stores a consumer batch as one columnar block (keeping the sub-columns), wired through `MultiWriter` up to the public `tree.ingestion()?.write_columnar_batch(...).finish()`. The ingestion enables the columnar layout when the runtime config asks for it; a row-mode or blob tree rejects the batch.
- **Projection + MVCC composition**: the vectorized `columnar_scan(projection, predicate)` projects individual sub-columns, and the positional delete-bitmap masks sub-column rows in both point and projection reads (the mask is value-agnostic).

## v1 constraints

One batch is one block, keys must be sorted, value sub-columns are non-nullable, and per-row seqnos are `0` (the ingestion assigns the atomic global sequence number). Nullable value sub-columns and custom-comparator sorted-input validation are follow-ups.

## Testing

- Unit: framing round-trip plus edge cases, N-sub-column untranspose, decode guards.
- Integration (`tests/columnar_ingest.rs`): ingest round-trip through the public API, layout-required rejection, per-sub-column projection.
- Composition: the delete-bitmap masks value sub-columns in point and projection reads.
- Full gate: clippy `--all-features --all-targets`, no-std (`thumbv7em` + `alloc`) errcount 0, nextest (columnar 2163 + lz4,zstd 2104), doctests 61.

Closes #522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added feature-gated columnar batch ingest for pre-transposed batches, including validation of intrinsic/value sub-column layout, strict key ordering, and proper behavior for empty batches.
  * Added utilities for framing/unframing multi-sub-column values to support correct reconstruction and projection/scans.
* **Bug Fixes**
  * Improved columnar batch encoding/recovery to correctly account for tombstones/weak-tombstones, deletes masking, and seqno bounds.
* **Tests**
  * Expanded end-to-end columnar ingest tests covering round-trips, projections, ordering/seqno rejection, and unsupported configurations.
* **Chores**
  * Reduced benchmark workflow timeout and shortened benchmark timing windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->