### PR TITLE
feat(columnar): accumulate ingest batches into one rowgroup

### DIFF
--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -459,15 +459,25 @@ impl ColumnBatch {
             a.validate(old_rows)?;
             b.validate(other.row_count)?;
         }
-        for (a, b) in self.columns.iter_mut().zip(&other.columns) {
+        // Encode every merged column into temporaries first; only after all
+        // succeed do we mutate `self`. A fallible encode mid-loop would otherwise
+        // leave the batch half-appended (some columns longer) while `row_count`
+        // stays unchanged, corrupting the pending rowgroup.
+        let mut merged: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::with_capacity(self.columns.len());
+        for (a, b) in self.columns.iter().zip(&other.columns) {
             let new_validity = combine_validity(
                 a.validity.as_deref(),
                 old_rows,
                 b.validity.as_deref(),
                 other.row_count,
             )?;
-            match a.type_tag {
-                TypeTag::Fixed(_) => a.data.extend_from_slice(&b.data),
+            let new_data = match a.type_tag {
+                TypeTag::Fixed(_) => {
+                    let mut data = Vec::with_capacity(a.data.len() + b.data.len());
+                    data.extend_from_slice(&a.data);
+                    data.extend_from_slice(&b.data);
+                    data
+                }
                 TypeTag::Bytes => {
                     let mut cells: Vec<&[u8]> = Vec::with_capacity(combined_rows as usize);
                     for i in 0..old_rows {
@@ -476,12 +486,14 @@ impl ColumnBatch {
                     for j in 0..other.row_count {
                         cells.push(bytes_column_row(&b.data, other.row_count, j)?);
                     }
-                    let encoded = encode_bytes_column(&cells)?;
-                    drop(cells); // end the borrow of `a.data` before replacing it
-                    a.data = encoded;
+                    encode_bytes_column(&cells)?
                 }
-            }
-            a.validity = new_validity;
+            };
+            merged.push((new_data, new_validity));
+        }
+        for (col, (data, validity)) in self.columns.iter_mut().zip(merged) {
+            col.data = data;
+            col.validity = validity;
         }
         self.row_count = combined_rows;
         Ok(())
@@ -1000,7 +1012,12 @@ pub fn validate_columnar_ingest_batch(
     batch: &ColumnBatch,
     comparator: &crate::SharedComparator,
 ) -> Result<()> {
-    let (key_col, seqno_col, _vt_col, _value_cols) = validate_columnar_columns(batch)?;
+    let (key_col, seqno_col, vt_col, _value_cols) = validate_columnar_columns(batch)?;
+    // Reject a malformed value-type tag on submit rather than letting it surface
+    // only at flush-time decode (`column_batch_to_entries`).
+    for &vt_byte in &vt_col.data {
+        ValueType::try_from(vt_byte).map_err(|()| Error::InvalidTag(("ValueType", vt_byte)))?;
+    }
     for i in 0..batch.row_count {
         if fixed_u64_row(&seqno_col.data, i)? != 0 {
             return Err(Error::FeatureUnsupported(

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -411,11 +411,17 @@ impl ColumnBatch {
                 .all(|(a, b)| a.column_id == b.column_id && a.type_tag == b.type_tag)
     }
 
-    /// Total size of the column data, used to decide when an accumulated
-    /// rowgroup has reached the target block size.
+    /// Total size of the column bytes (data plus any validity bitmap), used to
+    /// decide when an accumulated rowgroup has reached the target block size. The
+    /// validity bitmap is `ceil(row_count / 8)` bytes per nullable column, so
+    /// omitting it would let a nullable-heavy rowgroup overrun the target before
+    /// the flush threshold trips.
     #[must_use]
     pub(crate) fn data_size(&self) -> usize {
-        self.columns.iter().map(|c| c.data.len()).sum()
+        self.columns
+            .iter()
+            .map(|c| c.data.len() + c.validity.as_ref().map_or(0, Vec::len))
+            .sum()
     }
 
     /// Appends `other`'s rows after this batch's, in place, so a sequence of
@@ -915,7 +921,14 @@ fn reconstruct_row_value(value_cols: &[Column], row_count: u32, row: u32) -> Res
     Ok(Slice::from(frame_value_cells(&cells)?))
 }
 
-pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>> {
+/// Validates the intrinsic + value column layout and per-column framing of a
+/// columnar batch, returning the destructured columns. Shared by
+/// [`column_batch_to_entries`] (which then decodes every row) and
+/// [`validate_columnar_ingest_batch`] (which checks the ingest contract without
+/// decoding), so the structural checks cannot diverge between the two paths.
+fn validate_columnar_columns(
+    batch: &ColumnBatch,
+) -> Result<(&Column, &Column, &Column, &[Column])> {
     let [key_col, seqno_col, vt_col, value_cols @ ..] = batch.columns.as_slice() else {
         return Err(Error::InvalidHeader(
             "columnar: batch missing the intrinsic columns",
@@ -938,9 +951,9 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
         ));
     }
     // The three intrinsic fields are never null. Running `validate` also bounds
-    // `row_count` against the fixed-width column lengths before the allocation
-    // below, so a malformed batch claiming a huge row count is rejected instead
-    // of reserving for billions of rows.
+    // `row_count` against the fixed-width column lengths, so a malformed batch
+    // claiming a huge row count is rejected instead of reserving for billions of
+    // rows.
     for col in [key_col, seqno_col, vt_col] {
         if col.validity.is_some() {
             return Err(Error::InvalidHeader(
@@ -965,6 +978,58 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
         seen_value_column_ids.push(col.column_id);
         col.validate(batch.row_count)?;
     }
+    Ok((key_col, seqno_col, vt_col, value_cols))
+}
+
+/// Validates a columnar batch against the ingest contract without decoding every
+/// row into an [`InternalValue`].
+///
+/// The column layout / framing must be valid, every row's seqno `0` (the
+/// ingestion assigns the sequence number), and keys strictly increasing within
+/// the batch. The full decode runs once at flush on the accumulated rowgroup, so
+/// this lets the ingestion reject a bad batch eagerly without deserialising every
+/// submitted row twice. Cross-batch ordering is the caller's responsibility (it
+/// tracks the last key written).
+///
+/// # Errors
+///
+/// Returns an error if the layout / framing is invalid, a row carries a non-zero
+/// seqno, or the keys are empty / oversized / not strictly increasing within the
+/// batch.
+pub fn validate_columnar_ingest_batch(
+    batch: &ColumnBatch,
+    comparator: &crate::SharedComparator,
+) -> Result<()> {
+    let (key_col, seqno_col, _vt_col, _value_cols) = validate_columnar_columns(batch)?;
+    for i in 0..batch.row_count {
+        if fixed_u64_row(&seqno_col.data, i)? != 0 {
+            return Err(Error::FeatureUnsupported(
+                "columnar batch ingest requires every row seqno to be 0 (the ingestion assigns the sequence number)",
+            ));
+        }
+    }
+    let mut prev: Option<&[u8]> = None;
+    for i in 0..batch.row_count {
+        let key = bytes_column_row(&key_col.data, batch.row_count, i)?;
+        if key.is_empty() || key.len() > u16::MAX as usize {
+            return Err(Error::InvalidHeader(
+                "columnar: user key is empty or longer than u16::MAX",
+            ));
+        }
+        if let Some(p) = prev
+            && comparator.compare(p, key) != core::cmp::Ordering::Less
+        {
+            return Err(Error::InvalidHeader(
+                "columnar batch ingest requires strictly increasing keys",
+            ));
+        }
+        prev = Some(key);
+    }
+    Ok(())
+}
+
+pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>> {
+    let (key_col, seqno_col, vt_col, value_cols) = validate_columnar_columns(batch)?;
     let mut out = Vec::with_capacity(batch.row_count as usize);
     for i in 0..batch.row_count {
         let user_key = bytes_column_row(&key_col.data, batch.row_count, i)?;

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -371,6 +371,116 @@ impl ColumnBatch {
         bytes_column_row(&key_col.data, self.row_count, 0).map(Some)
     }
 
+    /// Returns the last row's user key, or `None` for an empty batch. Like
+    /// [`Self::first_user_key`] but for the final row, so the ingest path can
+    /// carry the ordering boundary forward after accumulating a batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the first column is not the non-null user-key column
+    /// or its row framing is malformed.
+    pub(crate) fn last_user_key(&self) -> Result<Option<&[u8]>> {
+        let Some(last) = self.row_count.checked_sub(1) else {
+            return Ok(None);
+        };
+        let key_col = self
+            .columns
+            .first()
+            .filter(|c| c.column_id == COL_USER_KEY)
+            .ok_or(Error::InvalidHeader(
+                "columnar: first column is not the user-key column",
+            ))?;
+        if key_col.type_tag != TypeTag::Bytes || key_col.validity.is_some() {
+            return Err(Error::InvalidHeader(
+                "columnar: first column is not the non-null user-key column",
+            ));
+        }
+        key_col.validate(self.row_count)?;
+        bytes_column_row(&key_col.data, self.row_count, last).map(Some)
+    }
+
+    /// Whether `other` has the same column layout (each column's id and type, in
+    /// order) as this batch, so the two can be appended into one rowgroup.
+    #[must_use]
+    pub(crate) fn same_layout(&self, other: &Self) -> bool {
+        self.columns.len() == other.columns.len()
+            && self
+                .columns
+                .iter()
+                .zip(&other.columns)
+                .all(|(a, b)| a.column_id == b.column_id && a.type_tag == b.type_tag)
+    }
+
+    /// Total size of the column data, used to decide when an accumulated
+    /// rowgroup has reached the target block size.
+    #[must_use]
+    pub(crate) fn data_size(&self) -> usize {
+        self.columns.iter().map(|c| c.data.len()).sum()
+    }
+
+    /// Appends `other`'s rows after this batch's, in place, so a sequence of
+    /// small ingest batches can accumulate into one rowgroup before a block is
+    /// written. The two batches must share the same columns (id + type) in the
+    /// same order; a `Fixed` column concatenates verbatim, a `Bytes` column
+    /// re-frames the merged cells, and a validity bitmap is combined across both
+    /// (a `None` bitmap on either side counts that side's rows as present).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the column counts or layouts differ, the combined row
+    /// count exceeds `u32::MAX`, or either batch's columns are malformed for
+    /// their own row count.
+    pub(crate) fn append(&mut self, other: &Self) -> Result<()> {
+        if self.columns.len() != other.columns.len() {
+            return Err(Error::InvalidHeader(
+                "columnar: append column-count mismatch",
+            ));
+        }
+        let old_rows = self.row_count;
+        let combined_rows = old_rows
+            .checked_add(other.row_count)
+            .ok_or(Error::InvalidHeader(
+                "columnar: appended row count exceeds u32",
+            ))?;
+        // Validate the layout and framing of both batches before mutating, so an
+        // invalid append leaves this batch unchanged.
+        for (a, b) in self.columns.iter().zip(&other.columns) {
+            if a.column_id != b.column_id || a.type_tag != b.type_tag {
+                return Err(Error::InvalidHeader(
+                    "columnar: append column layout mismatch",
+                ));
+            }
+            a.validate(old_rows)?;
+            b.validate(other.row_count)?;
+        }
+        for (a, b) in self.columns.iter_mut().zip(&other.columns) {
+            let new_validity = combine_validity(
+                a.validity.as_deref(),
+                old_rows,
+                b.validity.as_deref(),
+                other.row_count,
+            )?;
+            match a.type_tag {
+                TypeTag::Fixed(_) => a.data.extend_from_slice(&b.data),
+                TypeTag::Bytes => {
+                    let mut cells: Vec<&[u8]> = Vec::with_capacity(combined_rows as usize);
+                    for i in 0..old_rows {
+                        cells.push(bytes_column_row(&a.data, old_rows, i)?);
+                    }
+                    for j in 0..other.row_count {
+                        cells.push(bytes_column_row(&b.data, other.row_count, j)?);
+                    }
+                    let encoded = encode_bytes_column(&cells)?;
+                    drop(cells); // end the borrow of `a.data` before replacing it
+                    a.data = encoded;
+                }
+            }
+            a.validity = new_validity;
+        }
+        self.row_count = combined_rows;
+        Ok(())
+    }
+
     /// Encodes the batch into a columnar block payload using `codec` for every
     /// column. The returned bytes are the block payload (without the surrounding
     /// block header / checksum, which the writer adds).
@@ -628,6 +738,67 @@ fn bytes_column_row(data: &[u8], row_count: u32, i: u32) -> Result<&[u8]> {
     payload
         .get(start..end)
         .ok_or(Error::InvalidHeader("columnar: bytes row out of range"))
+}
+
+/// Encodes variable-width cells as a [`TypeTag::Bytes`] column body: a
+/// `(len + 1)`-entry little-endian `u32` offset array followed by the
+/// concatenated payload.
+fn encode_bytes_column(cells: &[&[u8]]) -> Result<Vec<u8>> {
+    let mut offsets = Vec::with_capacity((cells.len() + 1) * 4);
+    let mut acc = 0u32;
+    offsets.extend_from_slice(&acc.to_le_bytes());
+    for c in cells {
+        let len = u32::try_from(c.len())
+            .map_err(|_| Error::InvalidHeader("columnar: bytes cell exceeds u32"))?;
+        acc = acc
+            .checked_add(len)
+            .ok_or(Error::InvalidHeader("columnar: bytes payload exceeds u32"))?;
+        offsets.extend_from_slice(&acc.to_le_bytes());
+    }
+    let mut out = offsets;
+    out.reserve(acc as usize);
+    for c in cells {
+        out.extend_from_slice(c);
+    }
+    Ok(out)
+}
+
+/// Whether row `row`'s presence bit is set in a validity bitmap (set = valid).
+fn validity_bit(bitmap: &[u8], row: u32) -> bool {
+    bitmap
+        .get((row / 8) as usize)
+        .is_some_and(|b| (b >> (row % 8)) & 1 == 1)
+}
+
+/// Combines two columns' validity bitmaps for an append: the result spans
+/// `a_rows + b_rows` rows, treating a `None` bitmap as all-present. Returns
+/// `None` only when both inputs are `None` (the appended column stays non-null).
+fn combine_validity(
+    a: Option<&[u8]>,
+    a_rows: u32,
+    b: Option<&[u8]>,
+    b_rows: u32,
+) -> Result<Option<Vec<u8>>> {
+    if a.is_none() && b.is_none() {
+        return Ok(None);
+    }
+    let total = a_rows.checked_add(b_rows).ok_or(Error::InvalidHeader(
+        "columnar: combined row count exceeds u32",
+    ))?;
+    let mut out = alloc::vec![0u8; validity_len(total)];
+    for idx in 0..total {
+        let present = if idx < a_rows {
+            a.is_none_or(|v| validity_bit(v, idx))
+        } else {
+            // idx >= a_rows here, so the subtraction does not underflow and
+            // idx - a_rows < b_rows.
+            b.is_none_or(|v| validity_bit(v, idx - a_rows))
+        };
+        if present && let Some(byte) = out.get_mut((idx / 8) as usize) {
+            *byte |= 1u8 << (idx % 8);
+        }
+    }
+    Ok(Some(out))
 }
 
 /// Reads row `i` of a `Fixed(8)` column body as a little-endian `u64`.
@@ -1738,6 +1909,89 @@ mod tests {
             vec![None],
             "the null bytes row reconstructs as absent, not as an empty cell",
         );
+    }
+
+    #[test]
+    fn append_concatenates_fixed_bytes_and_nullable_columns() {
+        // Build a two-row consumer batch with a fixed-4 (id 3), a bytes (id 4),
+        // and a nullable fixed-2 (id 5) value sub-column.
+        let build = |keys: [&[u8]; 2],
+                     fixed: [u32; 2],
+                     bytes: [&[u8]; 2],
+                     nf2: [Option<[u8; 2]>; 2]|
+         -> ColumnBatch {
+            let mut batch = entries_to_column_batch(&[
+                InternalValue::from_components(keys[0], b"x", 0, ValueType::Value),
+                InternalValue::from_components(keys[1], b"x", 0, ValueType::Value),
+            ])
+            .expect("transpose");
+            batch.columns.pop();
+            batch.columns.push(Column {
+                column_id: 3,
+                type_tag: TypeTag::Fixed(4),
+                validity: None,
+                data: fixed.iter().flat_map(|v| v.to_le_bytes()).collect(),
+            });
+            let mut bytes_data = Vec::new();
+            let mut acc = 0u32;
+            bytes_data.extend_from_slice(&acc.to_le_bytes());
+            for c in bytes {
+                acc += u32::try_from(c.len()).expect("bytes cell length fits u32");
+                bytes_data.extend_from_slice(&acc.to_le_bytes());
+            }
+            for c in bytes {
+                bytes_data.extend_from_slice(c);
+            }
+            batch.columns.push(Column {
+                column_id: 4,
+                type_tag: TypeTag::Bytes,
+                validity: None,
+                data: bytes_data,
+            });
+            let mut nf2_data = Vec::new();
+            let mut nf2_valid = 0u8;
+            for (i, v) in nf2.iter().enumerate() {
+                nf2_data.extend_from_slice(&v.unwrap_or([0, 0]));
+                if v.is_some() {
+                    nf2_valid |= 1 << i;
+                }
+            }
+            batch.columns.push(Column {
+                column_id: 5,
+                type_tag: TypeTag::Fixed(2),
+                validity: Some(alloc::vec![nf2_valid]),
+                data: nf2_data,
+            });
+            batch
+        };
+
+        let mut a = build([b"k0", b"k1"], [1, 2], [b"a", b"bb"], [Some([9, 9]), None]);
+        let b = build(
+            [b"k2", b"k3"],
+            [3, 4],
+            [b"ccc", b"dddd"],
+            [Some([7, 7]), None],
+        );
+        a.append(&b).expect("append");
+        assert_eq!(a.row_count, 4);
+
+        let entries = column_batch_to_entries(&a).expect("untranspose combined");
+        let tags = [TypeTag::Fixed(4), TypeTag::Bytes, TypeTag::Fixed(2)];
+        let check = |entry: &InternalValue,
+                     key: &[u8],
+                     fixed: [u8; 4],
+                     bytes: &[u8],
+                     nf2: Option<[u8; 2]>| {
+            assert_eq!(entry.key.user_key.as_ref(), key);
+            let cells = unframe_value_cells_nullable(entry.value.as_ref(), &tags).expect("unframe");
+            assert_eq!(cells[0], Some(&fixed[..]));
+            assert_eq!(cells[1], Some(bytes));
+            assert_eq!(cells[2], nf2.as_ref().map(|n| &n[..]));
+        };
+        check(&entries[0], b"k0", [1, 0, 0, 0], b"a", Some([9, 9]));
+        check(&entries[1], b"k1", [2, 0, 0, 0], b"bb", None);
+        check(&entries[2], b"k2", [3, 0, 0, 0], b"ccc", Some([7, 7]));
+        check(&entries[3], b"k3", [4, 0, 0, 0], b"dddd", None);
     }
 
     fn sample_batch() -> ColumnBatch {

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1380,7 +1380,7 @@ mod tests {
         COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
         column_batch_to_entries, entries_to_column_batch, frame_value_cells,
         frame_value_cells_nullable, unframe_value_cells, unframe_value_cells_nullable,
-        unframe_value_cells_with_defaults,
+        unframe_value_cells_with_defaults, validate_columnar_ingest_batch,
     };
     use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
 
@@ -1890,6 +1890,20 @@ mod tests {
         assert!(
             column_batch_to_entries(&duplicate).is_err(),
             "duplicate value sub-column ids must be rejected",
+        );
+    }
+
+    #[test]
+    fn validate_ingest_rejects_an_invalid_value_type() {
+        // The eager ingest validation must reject a malformed value-type byte on
+        // the submitting call, not defer it to the flush-time decode.
+        let mut batch =
+            entries_to_column_batch(&[entry(b"k0", 0, ValueType::Value, b"v")]).expect("transpose");
+        batch.columns[2].data[0] = 99; // not a valid ValueType tag
+        assert!(
+            validate_columnar_ingest_batch(&batch, &crate::comparator::default_comparator())
+                .is_err(),
+            "an invalid value-type tag must be rejected during eager validation",
         );
     }
 

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -736,6 +736,18 @@ impl MultiWriter {
         self.writer.write_columnar_batch(batch, &comparator)
     }
 
+    /// Validates a columnar batch against the ingest contract without writing,
+    /// so the ingestion can reject a malformed batch eagerly while block emission
+    /// stays deferred. Forwards to the inner writer's validation.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn validate_columnar_batch(
+        &self,
+        batch: &crate::table::columnar::ColumnBatch,
+    ) -> crate::Result<()> {
+        let comparator = self.comparator.clone();
+        self.writer.validate_columnar_batch(batch, &comparator)
+    }
+
     /// Finishes the last table, making sure all data is written durably
     ///
     /// Returns the metadata of created tables

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1155,6 +1155,51 @@ impl Writer {
     /// Returns an error if the batch shape is malformed, the layout is not
     /// columnar, the keys are not strictly increasing, a row carries a non-zero
     /// seqno, or the block write fails.
+    /// Validates a columnar batch against the ingest contract without writing
+    /// anything: the layout must be columnar, the batch shape valid, every per-row
+    /// seqno `0`, and the keys strictly increasing within the batch. This lets the
+    /// ingestion reject a bad batch eagerly even though the block emission is
+    /// deferred (batches accumulate into one rowgroup). Cross-batch / cross-block
+    /// ordering is the caller's responsibility (it tracks the last key); the check
+    /// here starts fresh, so it is independent of any not-yet-flushed rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the layout is not columnar, the batch shape is
+    /// malformed, a row carries a non-zero seqno, or the keys are not strictly
+    /// increasing within the batch.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn validate_columnar_batch(
+        &self,
+        batch: &crate::table::columnar::ColumnBatch,
+        comparator: &crate::SharedComparator,
+    ) -> crate::Result<()> {
+        if !self.use_columnar {
+            return Err(crate::Error::FeatureUnsupported(
+                "columnar batch ingest requires the columnar layout",
+            ));
+        }
+        let entries = crate::table::columnar::column_batch_to_entries(batch)?;
+        if entries.iter().any(|e| e.key.seqno != 0) {
+            return Err(crate::Error::FeatureUnsupported(
+                "columnar batch ingest requires every row seqno to be 0 (the ingestion assigns the sequence number)",
+            ));
+        }
+        let mut prev: Option<&crate::UserKey> = None;
+        for e in &entries {
+            if let Some(p) = prev
+                && comparator.compare(p.as_ref(), e.key.user_key.as_ref())
+                    != core::cmp::Ordering::Less
+            {
+                return Err(crate::Error::InvalidHeader(
+                    "columnar batch ingest requires strictly increasing keys",
+                ));
+            }
+            prev = Some(&e.key.user_key);
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "columnar")]
     pub(crate) fn write_columnar_batch(
         &mut self,

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -1138,23 +1138,6 @@ impl Writer {
         )
     }
 
-    /// Writes a consumer-provided [`ColumnBatch`](crate::table::columnar::ColumnBatch)
-    /// as a single columnar block, storing its value sub-columns directly instead
-    /// of re-transposing the intrinsic value. The batch must carry the three
-    /// intrinsic columns plus one or more value sub-columns; the columnar layout
-    /// must be enabled. Keys must be strictly increasing by `comparator` (within
-    /// the batch and across successive batches / row writes on this writer), and
-    /// every per-row seqno must be `0` (the ingestion assigns one sequence
-    /// number). Each call appends one block.
-    ///
-    /// Returns the batch's last user key (or `None` for an empty batch) so a
-    /// caller can track the ingest ordering across batches.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the batch shape is malformed, the layout is not
-    /// columnar, the keys are not strictly increasing, a row carries a non-zero
-    /// seqno, or the block write fails.
     /// Validates a columnar batch against the ingest contract without writing
     /// anything: the layout must be columnar, the batch shape valid, every per-row
     /// seqno `0`, and the keys strictly increasing within the batch. This lets the
@@ -1179,27 +1162,31 @@ impl Writer {
                 "columnar batch ingest requires the columnar layout",
             ));
         }
-        let entries = crate::table::columnar::column_batch_to_entries(batch)?;
-        if entries.iter().any(|e| e.key.seqno != 0) {
-            return Err(crate::Error::FeatureUnsupported(
-                "columnar batch ingest requires every row seqno to be 0 (the ingestion assigns the sequence number)",
-            ));
-        }
-        let mut prev: Option<&crate::UserKey> = None;
-        for e in &entries {
-            if let Some(p) = prev
-                && comparator.compare(p.as_ref(), e.key.user_key.as_ref())
-                    != core::cmp::Ordering::Less
-            {
-                return Err(crate::Error::InvalidHeader(
-                    "columnar batch ingest requires strictly increasing keys",
-                ));
-            }
-            prev = Some(&e.key.user_key);
-        }
-        Ok(())
+        // Validate the layout, framing, seqno-zero, and intra-batch key order
+        // without decoding every row into an `InternalValue`: the batch is
+        // re-validated and fully decoded once at flush (on the accumulated
+        // rowgroup), so an eager full decode here would deserialise every
+        // submitted row twice.
+        crate::table::columnar::validate_columnar_ingest_batch(batch, comparator)
     }
 
+    /// Writes a consumer-provided [`ColumnBatch`](crate::table::columnar::ColumnBatch)
+    /// as a single columnar block, storing its value sub-columns directly instead
+    /// of re-transposing the intrinsic value. The batch must carry the three
+    /// intrinsic columns plus one or more value sub-columns; the columnar layout
+    /// must be enabled. Keys must be strictly increasing by `comparator` (within
+    /// the batch and across successive batches / row writes on this writer), and
+    /// every per-row seqno must be `0` (the ingestion assigns one sequence
+    /// number). Each call appends one block.
+    ///
+    /// Returns the batch's last user key (or `None` for an empty batch) so a
+    /// caller can track the ingest ordering across batches.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the batch shape is malformed, the layout is not
+    /// columnar, the keys are not strictly increasing, a row carries a non-zero
+    /// seqno, or the block write fails.
     #[cfg(feature = "columnar")]
     pub(crate) fn write_columnar_batch(
         &mut self,

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -30,6 +30,11 @@ pub struct Ingestion<'a> {
     pub(crate) writer: MultiWriter,
     seqno: SeqNo,
     last_key: Option<UserKey>,
+    /// Successive columnar batches with the same layout accumulate here into one
+    /// rowgroup, flushed to a block once they reach the target data-block size or
+    /// the layout changes, so many small ingest batches become few large blocks.
+    #[cfg(feature = "columnar")]
+    pending_columnar: Option<crate::table::columnar::ColumnBatch>,
 }
 
 impl<'a> Ingestion<'a> {
@@ -165,6 +170,8 @@ impl<'a> Ingestion<'a> {
             writer,
             seqno: 0,
             last_key: None,
+            #[cfg(feature = "columnar")]
+            pending_columnar: None,
         })
     }
 
@@ -320,11 +327,51 @@ impl<'a> Ingestion<'a> {
                 "columnar batch ingest: first key must follow the last written key",
             ));
         }
+        // Validate the batch eagerly (layout, shape, seqno, within-batch order) so
+        // a malformed batch is rejected on the call that submits it, even though
+        // the block emission is deferred by the accumulation below.
+        self.writer.validate_columnar_batch(batch)?;
+        // Accumulate into the pending rowgroup. A batch with the same column
+        // layout extends the current rowgroup; a different layout (or none yet)
+        // flushes what is pending and starts a fresh rowgroup. The block is
+        // emitted lazily, once the rowgroup reaches the target data-block size
+        // (below) or at `finish`, so a stream of small batches becomes a few
+        // large columnar blocks instead of one block per call.
+        match &mut self.pending_columnar {
+            Some(pending) if pending.same_layout(batch) => pending.append(batch)?,
+            _ => {
+                self.flush_pending_columnar()?;
+                self.pending_columnar = Some(batch.clone());
+            }
+        }
         // Carry the batch's last key forward: it both records the ordering
         // boundary for any later write and signals `finish` that data was
         // written (it installs nothing when `last_key` is `None`).
-        if let Some(last) = self.writer.write_columnar_batch(batch)? {
-            self.last_key = Some(last);
+        if let Some(last) = batch.last_user_key()? {
+            self.last_key = Some(crate::UserKey::from(last));
+        }
+        let target = self
+            .tree
+            .config
+            .data_block_size_policy
+            .get(INITIAL_CANONICAL_LEVEL) as usize;
+        if self
+            .pending_columnar
+            .as_ref()
+            .is_some_and(|p| p.data_size() >= target)
+        {
+            self.flush_pending_columnar()?;
+        }
+        Ok(())
+    }
+
+    /// Writes the accumulated columnar rowgroup as one block, if any is pending.
+    /// The inner writer reports the last key it wrote, but the ingestion already
+    /// tracks `last_key` per accepted batch, so the return value is discarded.
+    #[cfg(feature = "columnar")]
+    fn flush_pending_columnar(&mut self) -> crate::Result<()> {
+        if let Some(batch) = self.pending_columnar.take() {
+            self.writer.write_columnar_batch(&batch)?;
         }
         Ok(())
     }
@@ -335,13 +382,19 @@ impl<'a> Ingestion<'a> {
     ///
     /// Will return `Err` if an IO error occurs.
     #[allow(clippy::significant_drop_tightening)]
-    pub fn finish(self) -> crate::Result<()> {
+    #[cfg_attr(not(feature = "columnar"), allow(unused_mut))]
+    pub fn finish(mut self) -> crate::Result<()> {
         use crate::{AbstractTree, Table};
 
         if self.last_key.is_none() {
             log::trace!("No data written to Ingestion, returning early");
             return Ok(());
         }
+
+        // Emit the final accumulated columnar rowgroup (if any) before the
+        // writer is finalized below.
+        #[cfg(feature = "columnar")]
+        self.flush_pending_columnar()?;
 
         // CRITICAL SECTION: Atomic flush + seqno allocation + registration
         //

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -371,7 +371,12 @@ impl<'a> Ingestion<'a> {
     #[cfg(feature = "columnar")]
     fn flush_pending_columnar(&mut self) -> crate::Result<()> {
         if let Some(batch) = self.pending_columnar.take() {
-            self.writer.write_columnar_batch(&batch)?;
+            // Restore the pending rowgroup if the write fails, so the buffered
+            // rows are not silently dropped from ingestion state.
+            if let Err(e) = self.writer.write_columnar_batch(&batch) {
+                self.pending_columnar = Some(batch);
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -519,6 +519,54 @@ fn columnar_ingest_flushes_the_rowgroup_on_a_layout_change() -> lsm_tree::Result
 }
 
 #[test]
+fn columnar_ingest_rotates_the_rowgroup_at_the_size_threshold() -> lsm_tree::Result<()> {
+    // The third flush trigger: a same-layout stream whose accumulated size crosses
+    // the target data-block size flushes mid-ingest, so a large stream produces
+    // more than one block even though every batch shares the layout (unlike the
+    // small-batch merge, which stays one block).
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    // Each row carries a 4 KiB bytes value, so a handful of same-layout batches
+    // far exceed the target data-block size and the rowgroup rotates before
+    // finish.
+    let big = vec![b'x'; 4096];
+    let mut ingest = any.ingestion()?;
+    for key in [b"k0".as_slice(), b"k1", b"k2", b"k3"] {
+        ingest.write_columnar_batch(&fixed_bytes_batch(&[(key, 1, &big)]))?;
+    }
+    ingest.finish()?;
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one ingested SST");
+    let batches = table.columnar_scan(&[3, 4], None)?;
+    assert!(
+        batches.len() >= 2,
+        "size-threshold rotation splits a large same-layout stream into multiple blocks (got {})",
+        batches.len(),
+    );
+    assert_eq!(
+        batches.iter().map(|b| b.row_count).sum::<u32>(),
+        4,
+        "every row is present across the rotated blocks",
+    );
+    for k in [b"k0".as_slice(), b"k1", b"k2", b"k3"] {
+        assert!(any.get(k, SeqNo::MAX)?.is_some(), "every key is readable");
+    }
+    Ok(())
+}
+
+#[test]
 fn columnar_ingest_round_trips_a_nullable_value_subcolumn() -> lsm_tree::Result<()> {
     // A value sub-column may be absent for some rows (a sparse field). Ingest a
     // batch whose fixed-4 sub-column is null for the second row, then read both

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -367,6 +367,157 @@ fn columnar_ingest_rejected_on_a_blob_tree() -> lsm_tree::Result<()> {
     Ok(())
 }
 
+/// Builds a same-layout batch (value = a fixed-4 sub-column id 3 and a bytes
+/// sub-column id 4) for the given rows, used to exercise rowgroup accumulation.
+fn fixed_bytes_batch(rows: &[(&[u8], u32, &[u8])]) -> ColumnBatch {
+    let entries: Vec<_> = rows
+        .iter()
+        .map(|(k, _, _)| {
+            InternalValue::from_components(k.to_vec(), b"x".to_vec(), 0, ValueType::Value)
+        })
+        .collect();
+    let mut batch = entries_to_column_batch(&entries).expect("transpose");
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: rows.iter().flat_map(|(_, f, _)| f.to_le_bytes()).collect(),
+    });
+    let mut bytes_data = Vec::new();
+    let mut acc = 0u32;
+    bytes_data.extend_from_slice(&acc.to_le_bytes());
+    for (_, _, b) in rows {
+        acc += u32::try_from(b.len()).unwrap();
+        bytes_data.extend_from_slice(&acc.to_le_bytes());
+    }
+    for (_, _, b) in rows {
+        bytes_data.extend_from_slice(b);
+    }
+    batch.columns.push(Column {
+        column_id: 4,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data: bytes_data,
+    });
+    batch
+}
+
+/// Builds a batch whose value is a single fixed-4 sub-column (id 3) for the given
+/// rows: a different layout from [`fixed_bytes_batch`], so the two cannot merge.
+fn fixed_only_batch(rows: &[(&[u8], u32)]) -> ColumnBatch {
+    let entries: Vec<_> = rows
+        .iter()
+        .map(|(k, _)| {
+            InternalValue::from_components(k.to_vec(), b"x".to_vec(), 0, ValueType::Value)
+        })
+        .collect();
+    let mut batch = entries_to_column_batch(&entries).expect("transpose");
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: rows.iter().flat_map(|(_, f)| f.to_le_bytes()).collect(),
+    });
+    batch
+}
+
+#[test]
+fn columnar_ingest_merges_small_batches_into_one_rowgroup() -> lsm_tree::Result<()> {
+    // Three small same-layout batches accumulate into one rowgroup, written as a
+    // single columnar block (not one block per batch), and every row reads back.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    ingest.write_columnar_batch(&fixed_bytes_batch(&[(b"k0", 1, b"a"), (b"k1", 2, b"bb")]))?;
+    ingest.write_columnar_batch(&fixed_bytes_batch(&[
+        (b"k2", 3, b"ccc"),
+        (b"k3", 4, b"dddd"),
+    ]))?;
+    ingest.write_columnar_batch(&fixed_bytes_batch(&[(b"k4", 5, b"e"), (b"k5", 6, b"ff")]))?;
+    ingest.finish()?;
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one ingested SST");
+    let batches = table.columnar_scan(&[3, 4], None)?;
+    assert_eq!(
+        batches.len(),
+        1,
+        "three small same-layout batches merge into a single rowgroup block",
+    );
+    assert_eq!(
+        batches.iter().map(|b| b.row_count).sum::<u32>(),
+        6,
+        "the merged rowgroup holds every row",
+    );
+
+    // Spot-check the first and last rows reconstruct to their sub-cells.
+    let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+    let v0 = any.get(b"k0", SeqNo::MAX)?.expect("k0");
+    assert_eq!(
+        unframe_value_cells(v0.as_ref(), &tags)?,
+        vec![&1u32.to_le_bytes()[..], &b"a"[..]],
+    );
+    let v5 = any.get(b"k5", SeqNo::MAX)?.expect("k5");
+    assert_eq!(
+        unframe_value_cells(v5.as_ref(), &tags)?,
+        vec![&6u32.to_le_bytes()[..], &b"ff"[..]],
+    );
+    Ok(())
+}
+
+#[test]
+fn columnar_ingest_flushes_the_rowgroup_on_a_layout_change() -> lsm_tree::Result<()> {
+    // A batch with a different column layout cannot extend the pending rowgroup,
+    // so it flushes what is buffered and starts a new block. Both blocks carry
+    // sub-column 3, so a projection over it sees two batches (two blocks).
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| cfg.columnar = true)
+        .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    ingest.write_columnar_batch(&fixed_only_batch(&[(b"k0", 1), (b"k1", 2)]))?;
+    ingest.write_columnar_batch(&fixed_bytes_batch(&[
+        (b"k2", 3, b"ccc"),
+        (b"k3", 4, b"dddd"),
+    ]))?;
+    ingest.finish()?;
+
+    let version = tree.current_version();
+    let table = version.iter_tables().next().expect("one ingested SST");
+    let batches = table.columnar_scan(&[3], None)?;
+    assert_eq!(
+        batches.len(),
+        2,
+        "a layout change flushes the pending rowgroup into its own block",
+    );
+    for k in [b"k0".as_slice(), b"k1", b"k2", b"k3"] {
+        assert!(any.get(k, SeqNo::MAX)?.is_some(), "every key is readable");
+    }
+    Ok(())
+}
+
 #[test]
 fn columnar_ingest_round_trips_a_nullable_value_subcolumn() -> lsm_tree::Result<()> {
     // A value sub-column may be absent for some rows (a sparse field). Ingest a


### PR DESCRIPTION
## Summary

Builds on #532 (which builds on #522) to accumulate consumer columnar ingest batches into larger rowgroups. The base of this PR is the #532 branch (stacked); it should be retargeted to `main` once #532 / #522 merge.

Previously each `write_columnar_batch` call emitted its own columnar block, so a stream of small batches produced many tiny blocks (poor compression, more block-index entries, more per-block overhead on scan). Now successive batches with the same column layout accumulate into one rowgroup, written as a single block.

## What it adds

- **`ColumnBatch::append`**: concatenates another batch's rows in place: fixed columns extend verbatim, bytes columns re-frame with rebased offsets, and validity bitmaps are combined (a `None` bitmap counts that side's rows as present). Helpers `same_layout`, `data_size`, and `last_user_key` support the accumulation.
- **Ingestion accumulation**: the ingestion buffers a pending rowgroup and flushes it as one block when it reaches the target data-block size, when a batch's layout differs from the pending one, or at `finish`.
- **Eager validation**: a batch is still validated when it is submitted (layout is columnar, shape valid, every per-row seqno `0`, keys strictly increasing within the batch), so a malformed batch is rejected on the call that submits it even though block emission is deferred. Cross-batch ordering is enforced by the ingestion's last-key guard.

## Testing

- Unit: `ColumnBatch::append` over fixed + bytes + nullable columns reconstructs every row (through `column_batch_to_entries`).
- Integration: three small same-layout batches merge into a single rowgroup block (projection sees one block, all rows readable); a layout change flushes the pending rowgroup into its own block (projection sees two blocks, all keys readable); the existing eager-rejection tests (non-columnar layout, non-zero seqno, unsorted keys) still reject on submit.
- Full gate: clippy `--all-features --all-targets` clean, no-std (`thumbv7em` + `alloc`) errcount 0, nextest (columnar 2182 + lz4,zstd 2104), doctests 63.

Closes #534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Columnar batches with matching layouts are now appended and merged into single rowgroups, with support for correctly reconstructing row-boundary user keys across fixed and variable-width data.
  * Added eager columnar ingestion validation before writing: checks feature support, batch framing/layout consistency, rejects non-zero seqnos, enforces strictly increasing user keys, and validates value-type tags.
  * Ingestion now accumulates pending columnar data and flushes/rotates rowgroups when layout changes or when the configured size threshold is reached.
* **Tests**
  * Added end-to-end coverage for rowgroup merging, flushing on layout changes, and rotation at size thresholds, plus eager rejection of invalid value-type tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->