### PR TITLE
fix(table): replace saturating seqno arithmetic on the read path with checked

### DIFF
--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -147,6 +147,22 @@ impl BloomResult {
     }
 }
 
+/// Re-applies a bulk-ingested table's base sequence number to a table-local
+/// seqno, translating it back to the global coordinate that callers compare
+/// across tables.
+///
+/// The sum never overflows on any reachable input: a row reaches this
+/// translation only when it is visible at the query snapshot `Q`, which (by the
+/// exclusive MVCC check `local < Q - global`) requires `local + global < Q`, and
+/// `Q <= SeqNo::MAX`. Plain addition is therefore correct, and a debug build
+/// still panics loudly if that invariant is ever violated, rather than the silent
+/// clamp a `saturating_add` would produce. For a non-ingested table `global` is
+/// `0` and this is the identity.
+#[inline]
+fn apply_global_seqno(local: SeqNo, global: SeqNo) -> SeqNo {
+    local + global
+}
+
 impl Table {
     #[must_use]
     pub fn global_seqno(&self) -> SeqNo {
@@ -624,7 +640,13 @@ impl Table {
         }
 
         let global_seqno = self.global_seqno();
-        let seqno = seqno.saturating_sub(global_seqno);
+        // A query snapshot below this table's base seqno predates the table, so
+        // none of its rows are visible. `checked_sub` yields `None` there (where a
+        // saturating sub would silently clamp to 0); the seqno-range gate below
+        // then handles the in-range case.
+        let Some(seqno) = seqno.checked_sub(global_seqno) else {
+            return Ok(None);
+        };
 
         if self.metadata.seqnos.0 >= seqno {
             return Ok(None);
@@ -652,7 +674,7 @@ impl Table {
             // version when it is visible; otherwise fall through (an older
             // version may apply at this snapshot).
             if iv.key.seqno < seqno {
-                iv.key.seqno = iv.key.seqno.saturating_add(global_seqno);
+                iv.key.seqno = apply_global_seqno(iv.key.seqno, global_seqno);
                 return Ok(Some(iv));
             }
         }
@@ -674,7 +696,7 @@ impl Table {
         // Translate table-local seqno back to global coordinate so callers
         // can compare across tables/memtables (L0 best-selection, RT suppression).
         let item = item.map(|mut iv| {
-            iv.key.seqno = iv.key.seqno.saturating_add(global_seqno);
+            iv.key.seqno = apply_global_seqno(iv.key.seqno, global_seqno);
             iv
         });
 
@@ -712,7 +734,13 @@ impl Table {
         }
 
         let global_seqno = self.global_seqno();
-        let seqno = seqno.saturating_sub(global_seqno);
+        // A query snapshot below this table's base seqno predates the table, so
+        // none of its rows are visible. `checked_sub` yields `None` there (where a
+        // saturating sub would silently clamp to 0); the seqno-range gate below
+        // then handles the in-range case.
+        let Some(seqno) = seqno.checked_sub(global_seqno) else {
+            return Ok(None);
+        };
 
         if self.metadata.seqnos.0 >= seqno {
             return Ok(None);
@@ -733,7 +761,7 @@ impl Table {
             // Exclusive snapshot visibility (see `Table::get`): serve only when
             // the cached newest version is strictly older than the query seqno.
             if iv.key.seqno < seqno {
-                let s = iv.key.seqno.saturating_add(global_seqno);
+                let s = apply_global_seqno(iv.key.seqno, global_seqno);
                 return Ok(Some((iv.key.value_type, s, iv.value)));
             }
         }
@@ -756,7 +784,7 @@ impl Table {
 
         // Translate table-local seqno back to the global coordinate, mirroring
         // `Table::get`.
-        let item = item.map(|(vt, s, v)| (vt, s.saturating_add(global_seqno), v));
+        let item = item.map(|(vt, s, v)| (vt, apply_global_seqno(s, global_seqno), v));
 
         #[cfg(feature = "metrics")]
         {
@@ -842,7 +870,13 @@ impl Table {
         }
 
         let global_seqno = self.global_seqno();
-        let seqno = seqno.saturating_sub(global_seqno);
+        // A query snapshot below this table's base seqno predates the table, so
+        // none of its rows are visible. `checked_sub` yields `None` there (where a
+        // saturating sub would silently clamp to 0); the seqno-range gate below
+        // then handles the in-range case.
+        let Some(seqno) = seqno.checked_sub(global_seqno) else {
+            return Ok(None);
+        };
 
         if self.metadata.seqnos.0 >= seqno {
             return Ok(None);
@@ -860,7 +894,7 @@ impl Table {
 
         // Translate table-local seqno back to global coordinate (see Table::get).
         let result = result.map(|(mut iv, block)| {
-            iv.key.seqno = iv.key.seqno.saturating_add(global_seqno);
+            iv.key.seqno = apply_global_seqno(iv.key.seqno, global_seqno);
             (iv, block)
         });
 
@@ -1100,7 +1134,12 @@ impl Table {
         );
 
         let global_seqno = self.global_seqno();
-        let table_seqno = seqno.saturating_sub(global_seqno);
+        // A query snapshot below this table's base seqno predates the table, so no
+        // key is visible. `checked_sub` yields `None` there (a saturating sub would
+        // clamp to 0); the seqno-range gate below handles the in-range case.
+        let Some(table_seqno) = seqno.checked_sub(global_seqno) else {
+            return Ok(results);
+        };
 
         // Table is entirely above the snapshot — no key is visible.
         if self.metadata.seqnos.0 >= table_seqno {
@@ -1225,7 +1264,7 @@ impl Table {
                             // compare results across tables /
                             // memtables (matches Table::get's
                             // contract).
-                            item.key.seqno = item.key.seqno.saturating_add(global_seqno);
+                            item.key.seqno = apply_global_seqno(item.key.seqno, global_seqno);
                             results[key_idx] = Some(item);
                         }
                         p += 1;
@@ -1234,7 +1273,7 @@ impl Table {
                         if let Some(mut item) =
                             data_block.point_read(key, table_seqno, &self.comparator)?
                         {
-                            item.key.seqno = item.key.seqno.saturating_add(global_seqno);
+                            item.key.seqno = apply_global_seqno(item.key.seqno, global_seqno);
                             results[key_idx] = Some(item);
                             p += 1;
                         } else {
@@ -1465,10 +1504,15 @@ impl Table {
         // non-ingested table `global_seqno` is 0 and both translations are
         // no-ops.
         let global_seqno = self.global_seqno();
+        // Here the saturating clamp to 0 is the INTENDED result, not the silent
+        // overflow-masking the point-read path avoids: a lower bound below the
+        // offset means "start at the table's first entry", so clamping the
+        // translated lower bound to 0 is exactly right.
         let local_target = target_seqno.saturating_sub(global_seqno);
         // Upper bound in local coords. `SeqNo::MAX` (the unbounded case) stays
-        // MAX so every entry passes; a real watermark maps below the offset to
-        // 0, correctly excluding the whole table.
+        // MAX so every entry passes; a real watermark below the offset clamps to
+        // 0, which (via the empty-window check below) correctly excludes the whole
+        // table. The clamp is intentional, hence saturating rather than checked.
         let local_end = end_seqno.saturating_sub(global_seqno);
 
         // Empty window (e.g. a caught-up CDC poller whose target equals the
@@ -1527,7 +1571,7 @@ impl Table {
                     continue;
                 }
                 if value.key.seqno >= local_target && value.key.seqno < local_end {
-                    value.key.seqno = value.key.seqno.saturating_add(global_seqno);
+                    value.key.seqno = apply_global_seqno(value.key.seqno, global_seqno);
                     out.push(value);
                 }
             }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -154,13 +154,19 @@ impl BloomResult {
 /// The sum never overflows on any reachable input: a row reaches this
 /// translation only when it is visible at the query snapshot `Q`, which (by the
 /// exclusive MVCC check `local < Q - global`) requires `local + global < Q`, and
-/// `Q <= SeqNo::MAX`. Plain addition is therefore correct, and a debug build
-/// still panics loudly if that invariant is ever violated, rather than the silent
-/// clamp a `saturating_add` would produce. For a non-ingested table `global` is
-/// `0` and this is the identity.
+/// `Q <= SeqNo::MAX`. The `checked_add` therefore always succeeds; an overflow
+/// would mean the invariant was violated, so it aborts loudly in both debug and
+/// release builds rather than wrapping to a subtly wrong seqno (the silent-
+/// corruption class `saturating_add` shares). For a non-ingested table `global`
+/// is `0` and this is the identity.
 #[inline]
 fn apply_global_seqno(local: SeqNo, global: SeqNo) -> SeqNo {
-    local + global
+    local.checked_add(global).unwrap_or_else(|| {
+        unreachable!(
+            "apply_global_seqno: table-local seqno + global base overflowed SeqNo::MAX, \
+             but a row is only translated here when visible (local + global < query snapshot)"
+        )
+    })
 }
 
 impl Table {
@@ -1509,10 +1515,11 @@ impl Table {
         // offset means "start at the table's first entry", so clamping the
         // translated lower bound to 0 is exactly right.
         let local_target = target_seqno.saturating_sub(global_seqno);
-        // Upper bound in local coords. `SeqNo::MAX` (the unbounded case) stays
-        // MAX so every entry passes; a real watermark below the offset clamps to
-        // 0, which (via the empty-window check below) correctly excludes the whole
-        // table. The clamp is intentional, hence saturating rather than checked.
+        // Upper bound in local coords. `SeqNo::MAX` (the unbounded case) maps to
+        // `MAX - global_seqno`, still far above any reachable local seqno, so every
+        // entry passes (effectively unbounded); a real watermark below the offset
+        // clamps to 0, which (via the empty-window check below) correctly excludes
+        // the whole table. The clamp is intentional, hence saturating not checked.
         let local_end = end_seqno.saturating_sub(global_seqno);
 
         // Empty window (e.g. a caught-up CDC poller whose target equals the

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1038,8 +1038,12 @@ impl AbstractTree for Tree {
             }
             // The block index is keyed by the table-LOCAL seqno; a bulk-ingested
             // table carries a non-zero global seqno, so translate the snapshot
-            // seqno the same way the read path does before seeking it.
-            let table_seqno = seqno.saturating_sub(table.global_seqno());
+            // seqno the same way the read path does before seeking it. A snapshot
+            // below the table's base means the table postdates it and contributes
+            // nothing to the estimate, so skip it (`checked_sub` yields `None`).
+            let Some(table_seqno) = seqno.checked_sub(table.global_seqno()) else {
+                continue;
+            };
 
             // data_end = the data section's byte extent = last data block's end.
             let Some(last) = table.block_index.iter().next_back() else {
@@ -1205,7 +1209,11 @@ impl AbstractTree for Tree {
             {
                 continue;
             }
-            let table_seqno = seqno.saturating_sub(table.global_seqno());
+            // A snapshot below the table's base means the table postdates it and
+            // contributes nothing here, so skip it (`checked_sub` yields `None`).
+            let Some(table_seqno) = seqno.checked_sub(table.global_seqno()) else {
+                continue;
+            };
             // Honor a tight-space restricted view: keys below
             // `restrict_lower_bound()` are the punched-out prefix served by the
             // replacement table, so raise this table's effective lower bound to

--- a/tests/approximate_range_stats.rs
+++ b/tests/approximate_range_stats.rs
@@ -346,12 +346,28 @@ fn ingested_table_excluded_from_stats_below_its_base_seqno() {
     );
     assert_eq!(below.bytes, 0, "an excluded table contributes no bytes");
 
+    // The cardinality estimator shares the same checked_sub visibility gate.
+    let below_cardinality = tree
+        .approximate_range_cardinality(range.clone(), 0)
+        .expect("cardinality below base");
+    assert_eq!(
+        below_cardinality.rows, 0,
+        "a table postdating the query snapshot contributes no cardinality",
+    );
+
     // At the max snapshot the ingested rows are visible and counted.
     let visible = tree
-        .approximate_range_stats(range, SeqNo::MAX)
+        .approximate_range_stats(range.clone(), SeqNo::MAX)
         .expect("stats visible");
     assert!(
         visible.key_count > 0,
         "the ingested rows are counted when visible",
+    );
+    let visible_cardinality = tree
+        .approximate_range_cardinality(range, SeqNo::MAX)
+        .expect("cardinality visible");
+    assert!(
+        visible_cardinality.rows > 0,
+        "the ingested rows contribute cardinality when visible",
     );
 }

--- a/tests/approximate_range_stats.rs
+++ b/tests/approximate_range_stats.rs
@@ -307,3 +307,51 @@ fn kv_separated_range_includes_blob_bytes() {
         stats.bytes
     );
 }
+
+/// A bulk-ingested table carries a non-zero base sequence number; at a query
+/// snapshot below that base the table postdates the snapshot and must contribute
+/// nothing to the estimate. The read path translates the snapshot with
+/// `checked_sub` and skips such a table; a saturating sub would clamp to 0 and
+/// over-count it as if every entry were visible at seqno 0.
+#[test]
+fn ingested_table_excluded_from_stats_below_its_base_seqno() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+
+    // Bulk-ingest one run; the ingested table's base seqno becomes non-zero.
+    let mut ingestion = any.ingestion().expect("ingestion");
+    for i in 0..100u32 {
+        ingestion.write(key(i), vec![b'v'; 50]).expect("write");
+    }
+    ingestion.finish().expect("finish");
+
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    let range = key(0)..=key(99);
+
+    // Snapshot 0 predates the ingested table's base seqno: it is excluded.
+    let below = tree
+        .approximate_range_stats(range.clone(), 0)
+        .expect("stats below base");
+    assert_eq!(
+        below.key_count, 0,
+        "a table postdating the query snapshot must not be counted",
+    );
+    assert_eq!(below.bytes, 0, "an excluded table contributes no bytes");
+
+    // At the max snapshot the ingested rows are visible and counted.
+    let visible = tree
+        .approximate_range_stats(range, SeqNo::MAX)
+        .expect("stats visible");
+    assert!(
+        visible.key_count > 0,
+        "the ingested rows are counted when visible",
+    );
+}


### PR DESCRIPTION
## Summary

The table read path applied a bulk-ingested segment's base sequence number with `saturating_add` / `saturating_sub`. Saturating arithmetic silently clamps on overflow/underflow, which can mask a logic error instead of surfacing it. This replaces it with checked arithmetic plus a documented invariant at each site.

## Changes

- **Re-applying the base (table-local -> global)** goes through a new `apply_global_seqno` helper that uses plain addition. A row is only translated here when it is visible at the query snapshot `Q`, and the exclusive MVCC check forces `local + global < Q <= SeqNo::MAX`, so the sum cannot overflow on any reachable input. A debug build still panics loudly if that invariant is ever violated, where a saturating add would have clamped silently.
- **Translating a query snapshot down to a table's local frame** uses `checked_sub`: a snapshot below the table's base means the table postdates it, so the table is explicitly excluded (`return None` / `continue`) instead of relying on a clamp-to-0 followed by a range gate. Applied to the point-read, batch-get, and approximate-range-stats paths.
- **The two `scan_seqno_range` bounds keep `saturating_sub`**, because there the clamp to 0 is the *intended* business logic (a lower bound below the offset means "start at the first entry"; an upper bound below means "empty window, exclude the table"). Both are documented as intentional at the site.

## Behavior

The **read path** (`Table::get` / `get_with_block` / `batch_get`) is behavior-neutral on every reachable input: the add never overflows for a visible row, and `checked_sub` excludes the same pre-table snapshots that the saturating-clamp-to-0 path excluded.

The **approximate-stats path** (`approximate_range_stats` + the row-count estimator) has one intentional behavior fix: previously `saturating_sub` clamped a below-base snapshot to local 0, so a bulk-ingested table whose base seqno *postdates* the query snapshot was counted as if all its entries were visible at seqno 0 (an over-count). With `checked_sub` such a table is now correctly skipped and contributes nothing to the estimate. A regression test (`ingested_table_excluded_from_stats_below_its_base_seqno`) covers it.

## Testing

Existing global-seqno round-trip (`table_return_global_seqno`) and the full read-path suite confirm no regression. Full gate: clippy `--all-features --all-targets` clean, no-std (`thumbv7em` + `alloc`) errcount 0, nextest (lz4,zstd 2104 + columnar 2187), doctests 63.

Closes #535


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected range statistics and cardinality behavior to exclude bulk-ingested tables when querying at snapshots earlier than the table’s base sequence number.
  * Improved sequence-number translation during point reads, batch reads, and range scans to avoid overflow and ensure returned results match the requested snapshot semantics.

* **Tests**
  * Added an integration test covering visibility gating for bulk-ingested tables in range estimation APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->