### PR TITLE
docs(columnar): consumer sub-column schema evolution conventions

### DIFF
--- a/src/byteview/builder.rs
+++ b/src/byteview/builder.rs
@@ -1,6 +1,6 @@
 use super::ByteView;
 
-/// A builder for a [`ByteView`] that allows mutation before freezing it.
+/// A builder for a `ByteView` that allows mutation before freezing it.
 pub struct Builder(ByteView);
 
 impl Builder {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1546,7 +1546,7 @@ impl Config {
     /// [`EncryptionProvider`].
     ///
     /// The caller is responsible for key management and rotation.
-    /// See [`crate::Aes256GcmProvider`] (behind the `encryption` feature)
+    /// See `crate::Aes256GcmProvider` (behind the `encryption` feature)
     /// for a ready-to-use AES-256-GCM implementation.
     ///
     /// **Important constraints:**

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! This module defines the [`EncryptionProvider`] trait for pluggable
 //! block-level encryption and, behind the `encryption` feature, ships a
-//! ready-to-use [`Aes256GcmProvider`] implementation.
+//! ready-to-use `Aes256GcmProvider` implementation.
 //!
 //! ## Pipeline order
 //!
@@ -47,7 +47,7 @@
 //! omit those features, which would break the links.)
 //!
 //! Still pending in a follow-up: replacing the legacy
-//! [`Aes256GcmProvider`] Block I/O code path below with the
+//! `Aes256GcmProvider` Block I/O code path below with the
 //! `encrypt_block` / `decrypt_block` entry points at every
 //! `Block::write_into` / `Block::from_reader` site.
 
@@ -129,7 +129,7 @@ pub trait EncryptionProvider:
     /// capability when an encryption provider is configured (see
     /// `Config::open`) and rejects an unsupported provider up front rather than
     /// failing mid-I/O. Defaults to `false`; AAD-capable providers (e.g.
-    /// [`Aes256GcmProvider`]) override it to `true`.
+    /// `Aes256GcmProvider`) override it to `true`.
     #[must_use]
     fn supports_aad_block_path(&self) -> bool {
         false
@@ -183,7 +183,7 @@ pub trait EncryptionProvider:
     ///
     /// The default returns [`crate::Error::Encrypt`]: a provider that cannot bind
     /// AAD must not serve the block path. AAD-capable providers (e.g.
-    /// [`Aes256GcmProvider`]) override this.
+    /// `Aes256GcmProvider`) override this.
     fn encrypt_block_aad(
         &self,
         _plaintext: &[u8],

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -738,9 +738,9 @@ impl Iterator for DataBlockEntryIter {
 ///
 /// **Zstd-dictionary blocks: not supported.** This facade calls
 /// [`crate::table::Block::from_file`] with no
-/// [`crate::compression::ZstdDictionary`] attached (it has no way to
+/// `crate::compression::ZstdDictionary` attached (it has no way to
 /// fetch one without a live `Tree`), so blocks compressed with
-/// [`crate::CompressionType::ZstdDict`] fail with
+/// `crate::CompressionType::ZstdDict` fail with
 /// [`crate::Error::ZstdDictMismatch`] even though they are otherwise
 /// valid. Inspect such SSTs through the owning `Tree` instead.
 ///

--- a/src/pinnable_slice.rs
+++ b/src/pinnable_slice.rs
@@ -37,7 +37,7 @@ pub enum PinnableSlice {
     ///
     /// The [`Block`] keeps the decompressed data alive via refcounted
     /// `Slice` / `ByteView`. `value` is a sub-slice created via
-    /// [`Slice::slice`], sharing the same backing allocation.
+    /// `Slice::slice`, sharing the same backing allocation.
     Pinned {
         /// Keeps the decompressed block buffer alive via refcount.
         _block: Block,

--- a/src/table/block/transform.rs
+++ b/src/table/block/transform.rs
@@ -202,7 +202,7 @@ impl EccParams {
 /// Codec configuration for the compression step of a block payload.
 ///
 /// Fields are private; the only way to construct a value is via
-/// [`Self::new`] (non-dict codecs) or [`Self::with_dict`]
+/// [`Self::new`] (non-dict codecs) or `Self::with_dict`
 /// (dict-required codec, takes the dictionary handle directly). Two
 /// invariants the previous open-fields shape relied on are now
 /// enforced by the constructors:
@@ -215,7 +215,7 @@ impl EccParams {
 /// 2. `kind == ZstdDict` is unreachable without an attached
 ///    dictionary: the `new()` constructor refuses `ZstdDict` (returns
 ///    [`crate::Error::FeatureUnsupported`], forcing callers through
-///    [`Self::with_dict`]), and `with_dict` takes the dictionary by
+///    `Self::with_dict`), and `with_dict` takes the dictionary by
 ///    reference and derives `dict_id` from `dict.id()` itself. There
 ///    is therefore no construction path that yields a `ZstdDict`
 ///    context without a matching dict. The runtime `ZstdDictMismatch`

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -32,6 +32,31 @@
 //! let bytes = batch.encode(CodecId::Plain).unwrap();
 //! assert_eq!(ColumnBatch::decode(&bytes).unwrap(), batch);
 //! ```
+//!
+//! # Schema evolution
+//!
+//! The format is schema-free: each column self-describes its `column_id`,
+//! [`TypeTag`], and [`CodecId`], so segments written at different times may
+//! carry different column sets and still read back through one projection. Three
+//! consumer-facing conventions make that safe as a value sub-column schema
+//! evolves:
+//!
+//! - **Column-id stability.** A `column_id` is a stable field identifier: it
+//!   denotes the same logical field, with the same interpretation, in every
+//!   segment. A consumer must not repurpose an id for a different field across
+//!   schema versions, otherwise a projection for it would mean different things
+//!   in old and new segments. Retire an id rather than reusing it.
+//! - **Schema version.** The engine attaches no version to a batch. A consumer
+//!   that needs to tell schema versions apart tags them itself, e.g. with a
+//!   reserved `column_id` carrying a version number, which keeps the engine
+//!   schema-free.
+//! - **Projection over a missing column.** [`ColumnBatch::decode_projected`]
+//!   (and the table-level columnar scan built on it) returns only the projected
+//!   columns actually present in a block. Projecting a `column_id` absent from a
+//!   segment is not an error: that segment's batches simply omit the column and
+//!   the consumer applies its own default or treats it as null, while a newer
+//!   segment that carries the column returns it. Mixed old/new segments thus
+//!   coexist with no migration step.
 
 use crate::{Error, Result, Slice, ValueType, key::InternalKey, value::InternalValue};
 use alloc::vec::Vec;

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -7,7 +7,7 @@
 //! It drives two pushdowns:
 //!
 //! - **Block skip** ([`ColumnRangePredicate::can_skip_block`]): compare the
-//!   predicate bounds against the per-block zone-map ([`ColumnStats`]) min / max
+//!   predicate bounds against the per-block zone-map (`ColumnStats`) min / max
 //!   (#502). A block whose column range is disjoint from the predicate cannot
 //!   contain a matching row, so it is skipped without ever decoding it.
 //! - **Row filter** ([`ColumnRangePredicate::matching_rows`]): evaluate the

--- a/src/table/delete_bitmap.rs
+++ b/src/table/delete_bitmap.rs
@@ -14,8 +14,8 @@
 //!
 //! Rows are grouped into fixed [`CHUNK_ROWS`]-row chunks (a bulk delete of a
 //! whole chunk is therefore O(1), not O(rows)). Each non-empty chunk is stored
-//! either as a sorted [`Container::Sparse`] array of in-chunk offsets, or, once
-//! it holds more than [`SPARSE_MAX`] rows, as a [`Container::Dense`] bitset.
+//! either as a sorted `Container::Sparse` array of in-chunk offsets, or, once
+//! it holds more than `SPARSE_MAX` rows, as a `Container::Dense` bitset.
 //! This mirrors a Roaring bitmap's array/bitset containers but at a fixed
 //! 2048-row granularity tuned to the columnar block size. Empty chunks are not
 //! stored.

--- a/src/time.rs
+++ b/src/time.rs
@@ -91,9 +91,9 @@ pub fn unix_timestamp() -> Duration {
 /// Monotonic instant used for elapsed-time logging on the compaction / flush
 /// paths.
 ///
-/// Under `std` this is a re-export of [`std::time::Instant`]. Under `no_std`
+/// Under `std` this is a re-export of `std::time::Instant`. Under `no_std`
 /// there is no ambient monotonic clock, so this is a zero-sized stub whose
-/// [`elapsed`](Instant::elapsed) always reports [`core::time::Duration::ZERO`]
+/// `elapsed` always reports `core::time::Duration::ZERO`
 /// — the timing logs degrade to `0ns` rather than failing to compile.
 // no-std: wire a caller-provided monotonic Clock hook (mirroring the
 // `unix_timestamp` wall-clock hook) if real elapsed timing is needed.

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -627,3 +627,123 @@ fn columnar_ingest_round_trips_a_nullable_value_subcolumn() -> lsm_tree::Result<
     );
     Ok(())
 }
+
+/// Like [`two_subcolumn_batch`] but for keys `k2`/`k3` and with a third value
+/// sub-column (id 5), modelling a newer schema version that added a field.
+fn three_subcolumn_batch() -> ColumnBatch {
+    let mut batch = entries_to_column_batch(&[
+        InternalValue::from_components(b"k2", b"ignored", 0, ValueType::Value),
+        InternalValue::from_components(b"k3", b"ignored", 0, ValueType::Value),
+    ])
+    .expect("transpose");
+    batch.columns.pop();
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![3, 0, 0, 0, 4, 0, 0, 0], // row 0 = 3, row 1 = 4
+    });
+    let mut bytes_data = Vec::new();
+    for off in [0u32, 2, 5] {
+        bytes_data.extend_from_slice(&off.to_le_bytes());
+    }
+    bytes_data.extend_from_slice(b"ccddd"); // row 0 = "cc", row 1 = "ddd"
+    batch.columns.push(Column {
+        column_id: 4,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data: bytes_data,
+    });
+    batch.columns.push(Column {
+        column_id: 5,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data: vec![5, 0, 0, 0, 6, 0, 0, 0], // the new field: row 0 = 5, row 1 = 6
+    });
+    batch
+}
+
+/// Schema-evolution read contract: two segments written at different schema
+/// versions coexist. The first carries value sub-columns {3, 4}; the second adds
+/// a new sub-column 5. A projection for column 5 across both segments returns it
+/// from the new-schema segment and omits it gracefully (no error) from the
+/// old-schema one, while the shared column 3 is satisfied by both. The storage
+/// layer is schema-free, so no migration is needed to read mixed old/new data.
+#[test]
+fn columnar_scan_spans_segments_with_evolving_schema() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+
+    // Two ingestions, two segments: old schema {3,4} then new schema {3,4,5}.
+    {
+        let mut ingest = any.ingestion()?;
+        ingest.write_columnar_batch(&two_subcolumn_batch())?;
+        ingest.finish()?;
+    }
+    {
+        let mut ingest = any.ingestion()?;
+        ingest.write_columnar_batch(&three_subcolumn_batch())?;
+        ingest.finish()?;
+    }
+
+    let version = tree.current_version();
+    let tables: Vec<_> = version.iter_tables().collect();
+    assert_eq!(tables.len(), 2, "one segment per ingestion");
+
+    // Project the new column 5 across both segments. Exactly one carries it; the
+    // other returns batches without it (graceful omission, not an error).
+    let mut with_col5 = 0;
+    let mut without_col5 = 0;
+    let mut col5_data = Vec::new();
+    for table in &tables {
+        let batches = table.columnar_scan(&[5], None)?;
+        let present = batches
+            .iter()
+            .any(|b| b.columns.iter().any(|c| c.column_id == 5));
+        if present {
+            with_col5 += 1;
+            for b in &batches {
+                for c in b.columns.iter().filter(|c| c.column_id == 5) {
+                    col5_data.extend_from_slice(&c.data);
+                }
+            }
+        } else {
+            without_col5 += 1;
+        }
+    }
+    assert_eq!(with_col5, 1, "only the new-schema segment carries column 5");
+    assert_eq!(
+        without_col5, 1,
+        "the old-schema segment omits column 5 gracefully",
+    );
+    assert_eq!(
+        col5_data,
+        vec![5, 0, 0, 0, 6, 0, 0, 0],
+        "the new sub-column's bytes are the ingested values verbatim",
+    );
+
+    // The shared sub-column 3 is satisfied by BOTH segments.
+    for table in &tables {
+        let batches = table.columnar_scan(&[3], None)?;
+        assert!(
+            batches
+                .iter()
+                .any(|b| b.columns.iter().any(|c| c.column_id == 3)),
+            "the shared column 3 is present in every segment",
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Documents the consumer-facing contract for evolving a value sub-column schema over time, and adds a test for the mixed old/new read path. With consumer value sub-columns, different segments can carry different column sets as a schema evolves; the storage layer is already schema-free (each block self-describes its columns by `column_id` + type tag), so what was missing is the contract and its verification.

## Changes

- **Schema-evolution doc section** in the columnar module docs covering:
  - **column-id stability** (a `column_id` is a stable field identifier, never repurposed across schema versions),
  - **schema-version tagging is consumer-owned** (e.g. a reserved column), keeping the engine schema-free,
  - **projection over a missing column** is not an error: a segment without the column returns batches that omit it (the consumer applies a default / treats it as null), while a newer segment that carries it returns it. Mixed old/new segments coexist with no migration step.
- **Mixed-schema integration test** (`columnar_scan_spans_segments_with_evolving_schema`): ingests two segments with different value sub-column sets ({3,4} then {3,4,5}) and scans the new column across both, asserting it is returned from the segment that carries it and gracefully omitted from the one that does not, while a shared column is satisfied by both.
- **Doc-link cleanup**: the columnar predicate and delete-bitmap module docs linked to `pub(crate)` items (zone-map stats, bitmap container variants, sparse threshold). rustdoc cannot resolve a public-doc link to a private item, so it warned. These internal types stay private and are now referenced as code spans. `cargo doc --all-features` builds with zero warnings.

## Testing

Full gate: clippy `--all-features --all-targets` clean, no-std (`thumbv7em` + `alloc`) errcount 0, `cargo doc --all-features` zero warnings, nextest (lz4,zstd 2105 + columnar 2189), doctests 63.

Closes #533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified columnar schema-evolution guidance: schema-free format expectations, stable column IDs, consumer-managed schema versioning, and projection behavior when projected columns are missing.

* **Tests**
  * Added end-to-end schema-evolution coverage for columnar ingestion and scanning across segments, including validating omission of missing projected columns and consistent presence of shared columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->