### PR TITLE
refactor: coherent storage-statistics surface with compaction-debt and cache snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 - Block-based tables with optional compression (none / LZ4 / Zstd) and prefix truncation.
 - Per-table data block size policy and per-table compression policy.
 - Optional **zstd dictionary compression**, trained per-table or per-column for small (4-64 KiB) blocks and blob files.
+- Optional **columnar PAX block layout** (`columnar` feature): per-row-group column-major storage of key / seqno / value-type / value sub-columns, for column-projection pushdown, vectorized predicate scans, per-column dictionaries, and positional delete-bitmap MVCC.
 - Optional **block-level encryption at rest**: AES-256-GCM, key supplied by caller.
+- Optional **per-block error-correcting parity** (`page_ecc` feature): Reed-Solomon shards or per-word SEC-DED after each block, with on-read self-healing, three-state verification, and a patrol scrub for latent bit-rot.
 - Optional per-table block hash indexes for faster point lookups [[3]](#footnotes).
 - Optional partitioned block index & filters for better cache efficiency [[1]](#footnotes).
 - Per-level filter/index block pinning configuration.
@@ -64,9 +66,17 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
   during the checkpoint (deletions are deferred), and the resulting
   directory opens as an independent tree.
 
+### Introspection
+
+- Storage footprint and entry shape (`storage_stats`): used / capacity / available bytes, item & table counts, average on-disk entry size, reclaimable-bytes estimate, and a coarse storage status.
+- Per-level and per-segment size / entry / access stats (`level_segment_stats`) for tiering and placement decisions.
+- Approximate range size (`approximate_range_stats`) and cardinality + selectivity (`approximate_range_cardinality`) for query planning, estimated from block-index offsets and per-block zone maps without reading data blocks.
+- Compaction-debt estimate (`compaction_debt`): pending-compaction bytes above each level's target, a scheduler / tiering signal.
+
 ### Internals
 
 - 100% stable Rust, MSRV 1.92.
+- `no_std` + `alloc` support: the core engine (read / write / compaction / recovery over the injected `Fs`) compiles without `std`; std-only conveniences (threaded fan-out, system clock, the std filesystem backend) stay behind the `std` feature.
 - No FFI: zstd via [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust), LZ4 via `lz4_flex`, AES via `aes-gcm`.
 - Pluggable `Fs` trait: back the engine on the standard filesystem, on `io_uring`, on an in-memory `MemFs`, or on a custom implementation.
 - Pluggable `CompressionProvider` for third-party codecs.
@@ -110,15 +120,20 @@ millisecond tailing of in-flight updates. For arbitrary historical-seqno queries
 
 ## Feature flags
 
-All optional, all off by default. The default build is the minimal core (no compression, no encryption, std filesystem). Every flag below is gated because it pulls in extra dependencies or runtime overhead.
+All optional. The default build (`std` + `parallel`) is the minimal core: no compression, no encryption, std filesystem, with the built-in parallel-compression executor. Every capability flag below is gated because it pulls in extra dependencies or runtime overhead. Turning `std` off (with `alloc`) selects the `no_std` build (see the platform note in `Cargo.toml`).
 
 | Flag | Pulls in | Enable when |
 |---|---|---|
 | `lz4` | [`lz4_flex`](https://github.com/PSeitz/lz4_flex) | Block compression wanted, decompression latency matters more than ratio. |
 | `zstd` | [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust, no FFI) | Block compression wanted, ratio matters more than absolute decompression speed. Supports `CompressionType::Zstd` and dictionary-mode `CompressionType::ZstdDict`. Decompression is ~2-3.5× slower than C reference. |
+| `columnar` | (pure code, `alloc` only) | Columnar PAX SST block layout: each row-group stores its key / seqno / value-type / value sub-columns contiguously, for column-projection pushdown, vectorized predicate scans, per-column zstd dictionaries, and positional delete-bitmap MVCC. Enable for analytical or wide-row scans where reading a subset of columns dominates. |
 | `encryption` | `aes-gcm`, `rand_chacha` | AES-256-GCM block encryption at rest. Keys are caller-managed. |
+| `page_ecc` | [`reed-solomon-simd`](https://github.com/AndersTrier/reed-solomon-simd) | Per-block error-correcting parity (Reed-Solomon shards or per-word SEC-DED) after each on-disk block, with on-read self-healing, three-state verification, and a patrol scrub. Enable for latent-bit-rot protection on long-lived cold data. |
+| `crc32c` | [`crc32c`](https://github.com/zowens/crc32c) | Selects the hardware-accelerated CRC32C block checksum (`ChecksumType::Crc32c`) over the default XXH3. Enable when interop or CPU profile favours CRC32C. |
 | `io-uring` (linux only) | [`io-uring`](https://github.com/tokio-rs/io-uring) | I/O-bound workload on a modern Linux kernel: adds an `io_uring` `Fs` backend. |
+| `io-uring-raw` (linux only) | [`syscalls`](https://github.com/jasonwhite/syscalls) | Pure-Rust `no_std` io_uring `Fs` backend on raw Linux syscalls (no libc), for embedded or sandboxed Linux targets without `std`. |
 | `bytes_1` | [`bytes`](https://github.com/tokio-rs/bytes) | Consumer already speaks `bytes::Bytes` (tokio/hyper/tonic stack) and wants zero-copy interop with engine slices. |
+| `parallel` (default-on) | [`rayon`](https://github.com/rayon-rs/rayon) | Built-in rayon-backed parallel block-compression executor. `std`-only; the `CompactionSpawner` trait lets a caller inject a custom executor without this flag. |
 | `metrics` | (none) | Production observability or profiling. Compiles in atomic counters around block I/O, filter probes, compaction, and cache hit rates (`tree.metrics()`). Small but non-zero hot-path cost. |
 | `ribbon-serde` | `serde` | Snapshotting the internal `RibbonFilterRepr` for debugging or out-of-band transport. Not used by the on-disk format. |
 

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -181,6 +181,21 @@ pub trait AbstractTree: sealed::Sealed {
         crate::storage_stats::compute_level_segment_stats(&self.current_version())
     }
 
+    /// Estimated bytes pending compaction under `strategy`: on-disk data above
+    /// its level's target that must eventually be rewritten downward (a `RocksDB`
+    /// `estimate-pending-compaction-bytes` analog), a compaction-debt signal for a
+    /// scheduler / tiering consumer.
+    ///
+    /// The strategy is supplied by the caller because the engine does not own a
+    /// configured compaction strategy (it is injected per compaction run); a
+    /// `&dyn` keeps this object-safe. Returns `0` for strategies without a
+    /// size-target notion of debt (FIFO, drop-range), or when the tree is at or
+    /// below its target shape. See
+    /// [`CompactionStrategy::pending_compaction_bytes`](crate::compaction::CompactionStrategy::pending_compaction_bytes).
+    fn compaction_debt(&self, strategy: &dyn crate::compaction::CompactionStrategy) -> u64 {
+        strategy.pending_compaction_bytes(&self.current_version())
+    }
+
     /// Storage admission gate: `Ok(())` if a write may proceed, or
     /// [`Error::StorageFull`](crate::Error::StorageFull) if the tree is
     /// over budget and should be treated as read-only.

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -609,6 +609,17 @@ pub trait AbstractTree: sealed::Sealed {
     #[cfg(feature = "metrics")]
     fn metrics(&self) -> &Arc<crate::Metrics>;
 
+    /// A point-in-time [`CacheStats`](crate::CacheStats) snapshot of block-cache
+    /// effectiveness (cumulative hit / miss counts and rate) and occupancy
+    /// (current size against capacity).
+    ///
+    /// The stable, owned observability view over the block cache, so a consumer
+    /// can read cache health without holding the mutable
+    /// [`metrics`](Self::metrics) handle. Counts are cumulative since process
+    /// start; derive a rate over an interval from the delta between two polls.
+    #[cfg(feature = "metrics")]
+    fn cache_stats(&self) -> crate::CacheStats;
+
     /// Acquires the flush lock which is required to call [`Tree::flush`].
     fn get_flush_lock(&self) -> FlushGuard<'_>;
 

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -468,6 +468,11 @@ impl AbstractTree for BlobTree {
     }
 
     #[cfg(feature = "metrics")]
+    fn cache_stats(&self) -> crate::CacheStats {
+        self.index.cache_stats()
+    }
+
+    #[cfg(feature = "metrics")]
     fn metrics(&self) -> &Arc<crate::Metrics> {
         self.index.metrics()
     }

--- a/src/compaction/leveled/mod.rs
+++ b/src/compaction/leveled/mod.rs
@@ -479,8 +479,10 @@ impl CompactionStrategy for Strategy {
             // overflow u64 — plain addition.
             if idx == 0 {
                 // L0 is count-triggered: once it reaches the L0 file threshold its
-                // whole size is pending a merge into L1.
-                if level.iter().count() >= usize::from(self.l0_threshold) {
+                // whole size is pending a merge into L1. Use the table (file)
+                // count, matching the `choose` trigger; `iter().count()` would
+                // count runs, undercounting a multi-table L0 run.
+                if level.table_count() >= usize::from(self.l0_threshold) {
                     debt += level.size();
                 }
             } else if let Some(&target) = targets.get(idx) {

--- a/src/compaction/leveled/mod.rs
+++ b/src/compaction/leveled/mod.rs
@@ -468,6 +468,30 @@ impl CompactionStrategy for Strategy {
         ]
     }
 
+    fn pending_compaction_bytes(&self, version: &Version) -> u64 {
+        // Read-only snapshot: an empty compaction state (nothing hidden) so the
+        // targets reflect the full current footprint; no level shift.
+        let targets = self.compute_level_targets(version, 0, &CompactionState::default());
+        let mut debt = 0u64;
+        for (idx, level) in version.iter_levels().enumerate() {
+            // Each term is at most one level's on-disk size, so the running sum is
+            // bounded by the tree's total footprint (disk capacity) and cannot
+            // overflow u64 — plain addition.
+            if idx == 0 {
+                // L0 is count-triggered: once it reaches the L0 file threshold its
+                // whole size is pending a merge into L1.
+                if level.iter().count() >= usize::from(self.l0_threshold) {
+                    debt += level.size();
+                }
+            } else if let Some(&target) = targets.get(idx) {
+                // max(0, size - target): the bytes above this level's target are
+                // the work that must be rewritten downward.
+                debt += level.size().saturating_sub(target);
+            }
+        }
+        debt
+    }
+
     #[expect(clippy::too_many_lines)]
     fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice {
         // Tie the invariant to the caller-supplied `Config::level_count`

--- a/src/compaction/leveled/test.rs
+++ b/src/compaction/leveled/test.rs
@@ -184,6 +184,41 @@ fn leveled_l0_reached_limit() -> crate::Result<()> {
 }
 
 #[test]
+fn compaction_debt_flags_l0_over_threshold_then_clears() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let strategy = Arc::new(Strategy::default());
+
+    // Empty tree: no level is above target, so nothing is pending.
+    assert_eq!(tree.compaction_debt(&*strategy), 0);
+
+    // Four overlapping L0 runs reach the default L0 threshold (4): the whole of
+    // L0 is pending a merge into L1, so the debt estimate is non-zero.
+    for i in 0..4u8 {
+        tree.insert("a", "v", 0);
+        tree.insert([b'k', i].as_slice(), "v", 0);
+        tree.insert("z", "v", 0);
+        tree.flush_active_memtable(0)?;
+    }
+    assert!(
+        tree.compaction_debt(&*strategy) > 0,
+        "L0 at the file threshold should report pending compaction debt",
+    );
+
+    // After compaction the runs collapse into a single L1 table below target,
+    // clearing the debt.
+    tree.compact(strategy, 0)?;
+    assert_eq!(tree.compaction_debt(&*Arc::new(Strategy::default())), 0);
+
+    Ok(())
+}
+
+#[test]
 fn leveled_l0_reached_limit_disjoint() -> crate::Result<()> {
     let dir = tempfile::tempdir()?;
     let tree = Config::new(

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -153,4 +153,17 @@ pub trait CompactionStrategy: Send + Sync {
 
     /// Decides on what to do based on the current state of the LSM-tree's levels
     fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice;
+
+    /// Estimated bytes pending compaction: on-disk data currently sitting above
+    /// its level's target size that must eventually be rewritten downward (a
+    /// `RocksDB` `estimate-pending-compaction-bytes` analog). A scheduler /
+    /// tiering consumer reads it as a compaction-debt signal; `0` means the tree
+    /// is at or below its target shape.
+    ///
+    /// The default is `0` for strategies without a size-target notion of debt
+    /// (FIFO, drop-range, major one-shot); the leveled strategy overrides it with
+    /// the per-level overflow sum.
+    fn pending_compaction_bytes(&self, _version: &Version) -> u64 {
+        0
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,7 +511,7 @@ pub use {
 pub use compression::ZstdDictionary;
 
 #[cfg(feature = "metrics")]
-pub use metrics::Metrics;
+pub use metrics::{CacheStats, Metrics};
 
 #[cfg(feature = "std")]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,8 @@ pub mod scrub;
 
 pub mod storage_stats;
 pub use storage_stats::{
-    ApproximateRangeStats, LevelStats, RangeCardinality, SegmentStats, StorageStats, StorageStatus,
+    ApproximateRangeStats, LevelStats, RangeCardinality, SegmentStats, StorageStatistics,
+    StorageStats, StorageStatus,
 };
 
 mod version;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -118,10 +118,20 @@ impl Metrics {
     /// the caller-supplied live cache `size_bytes` / `capacity_bytes` (the block
     /// cache owns its occupancy, [`Metrics`] owns the hit / miss tallies).
     pub fn cache_stats(&self, size_bytes: u64, capacity_bytes: u64) -> CacheStats {
+        // Read the counters once so hits / misses / hit_rate are a single
+        // consistent snapshot (block_cache_hit_rate would re-read the atomics).
+        let hits = self.block_load_cached_count() as u64;
+        let misses = self.block_load_io_count() as u64;
+        let total = hits + misses;
+        let hit_rate = if total == 0 {
+            1.0
+        } else {
+            hits as f64 / total as f64
+        };
         CacheStats {
-            hits: self.block_load_cached_count() as u64,
-            misses: self.block_load_io_count() as u64,
-            hit_rate: self.block_cache_hit_rate(),
+            hits,
+            misses,
+            hit_rate,
             size_bytes,
             capacity_bytes,
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -93,8 +93,10 @@ pub struct Metrics {
 /// stable owned value instead of reaching into the mutable `&Arc<Metrics>`.
 /// Counts are cumulative since process start (they reset on restart, like all of
 /// [`Metrics`]); derive a rate over an interval from the delta between two polls.
+// No `PartialEq`: `hit_rate` is an `f64`, so equality would inherit float
+// comparison semantics. Compare the integer fields explicitly instead.
 #[must_use]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct CacheStats {
     /// Cumulative block reads served from the block cache (all block types).
     pub hits: u64,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -86,11 +86,47 @@ pub struct Metrics {
     pub(crate) ecc_shard_recovered: AtomicUsize,
 }
 
+/// A point-in-time snapshot of block-cache effectiveness and occupancy.
+///
+/// Derived from [`Metrics`] (the cumulative hit / miss counters) plus the live
+/// block cache's current size and capacity, so an observability consumer gets a
+/// stable owned value instead of reaching into the mutable `&Arc<Metrics>`.
+/// Counts are cumulative since process start (they reset on restart, like all of
+/// [`Metrics`]); derive a rate over an interval from the delta between two polls.
+#[must_use]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct CacheStats {
+    /// Cumulative block reads served from the block cache (all block types).
+    pub hits: u64,
+    /// Cumulative block reads that missed the cache and hit disk (all block types).
+    pub misses: u64,
+    /// Hit rate in `0.0..=1.0` (`hits / (hits + misses)`); `1.0` when no block
+    /// has been loaded yet (nothing has missed).
+    pub hit_rate: f64,
+    /// Current weighted bytes resident in the block cache.
+    pub size_bytes: u64,
+    /// Configured maximum bytes the block cache may hold.
+    pub capacity_bytes: u64,
+}
+
 #[expect(
     clippy::cast_precision_loss,
     reason = "metrics can accept precision loss"
 )]
 impl Metrics {
+    /// Builds a [`CacheStats`] snapshot from the cumulative cache counters and
+    /// the caller-supplied live cache `size_bytes` / `capacity_bytes` (the block
+    /// cache owns its occupancy, [`Metrics`] owns the hit / miss tallies).
+    pub fn cache_stats(&self, size_bytes: u64, capacity_bytes: u64) -> CacheStats {
+        CacheStats {
+            hits: self.block_load_cached_count() as u64,
+            misses: self.block_load_io_count() as u64,
+            hit_rate: self.block_cache_hit_rate(),
+            size_bytes,
+            capacity_bytes,
+        }
+    }
+
     /// Returns the cache hit rate for file descriptors in percent (0.0 - 1.0).
     pub fn table_file_cache_hit_rate(&self) -> f64 {
         let uncached = self.table_file_opened_uncached.load(Relaxed) as f64;

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -214,6 +214,143 @@ pub struct RangeCardinality {
     pub selectivity: f64,
 }
 
+/// Grouped, object-safe read-only storage-statistics surface.
+///
+/// A coherent view over a tree's non-query statistics: on-disk footprint
+/// ([`storage_stats`](Self::storage_stats)), per-level / per-segment sizing
+/// ([`level_segment_stats`](Self::level_segment_stats)), compaction debt
+/// ([`compaction_debt`](Self::compaction_debt)), and block-cache health
+/// ([`cache_stats`](Self::cache_stats)). A planner / tiering / capacity consumer
+/// bounds on `T: StorageStatistics` (or `&dyn StorageStatistics`) and a test can
+/// supply a mock. Every [`AbstractTree`](crate::AbstractTree) implements it — it
+/// is a super-trait of `AbstractTree`.
+///
+/// The per-query range estimators
+/// ([`approximate_range_stats`](crate::AbstractTree::approximate_range_stats),
+/// [`approximate_range_cardinality`](crate::AbstractTree::approximate_range_cardinality))
+/// are generic over the range type and so not object-safe; they stay on
+/// [`AbstractTree`](crate::AbstractTree) rather than joining this trait.
+pub trait StorageStatistics {
+    /// On-disk footprint and average entry shape: used / capacity / available
+    /// bytes, item & table counts, average entry size, reclaimable-bytes
+    /// estimate, and a coarse [`StorageStatus`]. See
+    /// [`StorageStats::estimated_remaining_entries`] for a budget projection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lsm_tree::Error as TreeError;
+    /// use lsm_tree::{AbstractTree, Config, StorageStatistics};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let tree = Config::new(&folder, Default::default(), Default::default()).open()?;
+    /// for i in 0..100u32 {
+    ///     tree.insert(format!("k{i:04}"), "v", 0);
+    /// }
+    /// tree.flush_active_memtable(0)?;
+    ///
+    /// // Both traits are in scope, so disambiguate the shared method name.
+    /// let stats = StorageStatistics::storage_stats(&tree)?;
+    /// assert_eq!(stats.item_count, 100);
+    /// // Roughly how many more average-shaped entries fit in another 1 MiB.
+    /// let _headroom = stats.estimated_remaining_entries(1024 * 1024);
+    /// #
+    /// # Ok::<(), TreeError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a live file's size cannot be stat-ed.
+    fn storage_stats(&self) -> crate::Result<StorageStats>;
+
+    /// Per-LSM-level and per-segment size + entry-count stats, for tiering and
+    /// erasure-coding placement decisions (which level / segment is large enough
+    /// to demote, EC-encode, or migrate).
+    ///
+    /// Cheap: derived from the live version's metadata plus one file-size stat
+    /// per segment (no data-block scan). The per-level totals reconcile with
+    /// [`storage_stats`](Self::storage_stats): summed across levels they equal
+    /// the SST portion of [`StorageStats::used_bytes`] and
+    /// [`StorageStats::item_count`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lsm_tree::Error as TreeError;
+    /// use lsm_tree::{AbstractTree, Config, StorageStatistics};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let tree = Config::new(&folder, Default::default(), Default::default()).open()?;
+    /// for i in 0..100u32 {
+    ///     tree.insert(format!("k{i:04}"), "v", 0);
+    /// }
+    /// tree.flush_active_memtable(0)?;
+    ///
+    /// // Both traits are in scope, so disambiguate the shared method names.
+    /// let levels = StorageStatistics::level_segment_stats(&tree)?;
+    /// let total: u64 = levels.iter().map(|l| l.item_count).sum();
+    /// assert_eq!(total, StorageStatistics::storage_stats(&tree)?.item_count);
+    /// #
+    /// # Ok::<(), TreeError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a segment's file size cannot be stat-ed.
+    fn level_segment_stats(&self) -> crate::Result<Vec<LevelStats>>;
+
+    /// Estimated bytes pending compaction under `strategy`: on-disk data above
+    /// its level's target that must eventually be rewritten downward (a `RocksDB`
+    /// `estimate-pending-compaction-bytes` analog), a compaction-debt signal for a
+    /// scheduler / tiering consumer.
+    ///
+    /// The strategy is a caller argument because the engine does not own a
+    /// configured compaction strategy (it is injected per compaction run); a
+    /// `&dyn` keeps this object-safe. Returns `0` for strategies without a
+    /// size-target notion of debt (FIFO, drop-range), or when the tree is at or
+    /// below its target shape. See
+    /// [`CompactionStrategy::pending_compaction_bytes`](crate::compaction::CompactionStrategy::pending_compaction_bytes).
+    fn compaction_debt(&self, strategy: &dyn crate::compaction::CompactionStrategy) -> u64;
+
+    /// A point-in-time [`CacheStats`](crate::CacheStats) snapshot of block-cache
+    /// effectiveness (cumulative hit / miss counts and rate) and occupancy
+    /// (current size against capacity).
+    ///
+    /// The stable, owned observability view over the block cache, so a consumer
+    /// reads cache health without holding the mutable
+    /// [`metrics`](crate::AbstractTree::metrics) handle. Counts are cumulative
+    /// since process start; derive a rate over an interval from the delta between
+    /// two polls.
+    #[cfg(feature = "metrics")]
+    fn cache_stats(&self) -> crate::CacheStats;
+}
+
+/// Every [`AbstractTree`](crate::AbstractTree) is a [`StorageStatistics`] by
+/// delegating to its own inherent stats methods, so a `Tree` / `BlobTree` can be
+/// used directly as `&dyn StorageStatistics`. The logic lives once on
+/// `AbstractTree`; this is a thin object-safe re-exposure for the grouped /
+/// mockable surface (a test mock implements `StorageStatistics` directly without
+/// being an `AbstractTree`). When both traits are in scope, disambiguate a bare
+/// `tree.storage_stats()` with `StorageStatistics::storage_stats(&tree)`.
+impl<T: crate::AbstractTree + ?Sized> StorageStatistics for T {
+    fn storage_stats(&self) -> crate::Result<StorageStats> {
+        crate::AbstractTree::storage_stats(self)
+    }
+
+    fn level_segment_stats(&self) -> crate::Result<Vec<LevelStats>> {
+        crate::AbstractTree::level_segment_stats(self)
+    }
+
+    fn compaction_debt(&self, strategy: &dyn crate::compaction::CompactionStrategy) -> u64 {
+        crate::AbstractTree::compaction_debt(self, strategy)
+    }
+
+    #[cfg(feature = "metrics")]
+    fn cache_stats(&self) -> crate::CacheStats {
+        crate::AbstractTree::cache_stats(self)
+    }
+}
+
 impl StorageStats {
     /// Approximately how many more average-shaped entries fit in `budget_bytes`,
     /// using [`Self::avg_entry_on_disk_bytes`].

--- a/src/storage_stats.rs
+++ b/src/storage_stats.rs
@@ -222,8 +222,8 @@ pub struct RangeCardinality {
 /// ([`compaction_debt`](Self::compaction_debt)), and block-cache health
 /// ([`cache_stats`](Self::cache_stats)). A planner / tiering / capacity consumer
 /// bounds on `T: StorageStatistics` (or `&dyn StorageStatistics`) and a test can
-/// supply a mock. Every [`AbstractTree`](crate::AbstractTree) implements it — it
-/// is a super-trait of `AbstractTree`.
+/// supply a mock. Every [`AbstractTree`](crate::AbstractTree) implements it via a
+/// blanket impl (`impl<T: AbstractTree + ?Sized> StorageStatistics for T`).
 ///
 /// The per-query range estimators
 /// ([`approximate_range_stats`](crate::AbstractTree::approximate_range_stats),

--- a/src/storage_stats/tests.rs
+++ b/src/storage_stats/tests.rs
@@ -64,3 +64,41 @@ fn compute_on_empty_version_maps_compaction_flag_to_status() {
     let idle = compute_storage_stats(&version, false, true).unwrap();
     assert_eq!(idle.status, StorageStatus::Healthy);
 }
+
+#[test]
+fn storage_statistics_is_object_safe_via_mock() -> crate::Result<()> {
+    // A non-tree mock implements the trait, proving it is object-safe and usable
+    // for planner / tiering tests without a real engine behind it.
+    struct MockStats;
+    impl StorageStatistics for MockStats {
+        fn storage_stats(&self) -> crate::Result<StorageStats> {
+            Ok(stats_with_avg(6))
+        }
+        fn level_segment_stats(&self) -> crate::Result<Vec<LevelStats>> {
+            Ok(Vec::new())
+        }
+        fn compaction_debt(&self, _strategy: &dyn crate::compaction::CompactionStrategy) -> u64 {
+            123
+        }
+        #[cfg(feature = "metrics")]
+        fn cache_stats(&self) -> crate::CacheStats {
+            crate::CacheStats {
+                hits: 9,
+                misses: 1,
+                hit_rate: 0.9,
+                size_bytes: 10,
+                capacity_bytes: 100,
+            }
+        }
+    }
+
+    let mock = MockStats;
+    let stats: &dyn StorageStatistics = &mock;
+    assert_eq!(stats.storage_stats()?.avg_entry_on_disk_bytes, 6);
+    assert!(stats.level_segment_stats()?.is_empty());
+    let strategy = crate::compaction::leveled::Strategy::default();
+    assert_eq!(stats.compaction_debt(&strategy), 123);
+    #[cfg(feature = "metrics")]
+    assert_eq!(stats.cache_stats().hits, 9);
+    Ok(())
+}

--- a/src/storage_stats/tests.rs
+++ b/src/storage_stats/tests.rs
@@ -102,3 +102,34 @@ fn storage_statistics_is_object_safe_via_mock() -> crate::Result<()> {
     assert_eq!(stats.cache_stats().hits, 9);
     Ok(())
 }
+
+#[test]
+fn storage_statistics_blanket_impl_over_real_tree() -> crate::Result<()> {
+    // Drive the blanket `impl<T: AbstractTree> StorageStatistics for T` over a
+    // real tree (the mock above bypasses it), and a non-leveled strategy through
+    // the trait-default `pending_compaction_bytes` of 0.
+    use crate::{AbstractTree, Config, SequenceNumberCounter, StorageStatistics};
+
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in 0..50u32 {
+        tree.insert(format!("k{i:04}"), "v", 0);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let s: &dyn StorageStatistics = &tree;
+    assert_eq!(s.storage_stats()?.item_count, 50);
+    let level_items: u64 = s.level_segment_stats()?.iter().map(|l| l.item_count).sum();
+    assert_eq!(level_items, 50);
+    // FIFO has no size-target debt notion, so the trait default 0 applies.
+    let fifo = crate::compaction::fifo::Strategy::new(u64::MAX, None);
+    assert_eq!(s.compaction_debt(&fifo), 0);
+    #[cfg(feature = "metrics")]
+    assert!(s.cache_stats().capacity_bytes > 0);
+    Ok(())
+}

--- a/src/tree/cache_stats_tests.rs
+++ b/src/tree/cache_stats_tests.rs
@@ -53,3 +53,32 @@ fn cache_stats_reports_capacity_and_counts_after_reads() -> crate::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn cache_stats_works_for_kv_separated_tree() -> crate::Result<()> {
+    // A KV-separated (blob) tree dispatches cache_stats to BlobTree, which
+    // delegates to its index tree. Large values land in blob files.
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?;
+    for i in 0..50u32 {
+        tree.insert(format!("k{i:04}"), vec![0u8; 4096], 0);
+    }
+    tree.flush_active_memtable(0)?;
+    for i in 0..50u32 {
+        assert!(tree.get(format!("k{i:04}"), MAX_SEQNO)?.is_some());
+    }
+
+    let cs = tree.cache_stats();
+    assert!(cs.capacity_bytes > 0, "the block cache has a capacity");
+    assert!(
+        cs.size_bytes <= cs.capacity_bytes,
+        "resident size stays within capacity",
+    );
+    Ok(())
+}

--- a/src/tree/cache_stats_tests.rs
+++ b/src/tree/cache_stats_tests.rs
@@ -1,0 +1,55 @@
+use crate::{AbstractTree, Config, MAX_SEQNO, SequenceNumberCounter};
+use test_log::test;
+
+#[test]
+fn cache_stats_reports_capacity_and_counts_after_reads() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // Empty cache: a configured capacity, but nothing loaded yet.
+    let before = tree.cache_stats();
+    assert!(
+        before.capacity_bytes > 0,
+        "the default block cache has a capacity",
+    );
+    assert_eq!(
+        before.hits + before.misses,
+        0,
+        "no block has been loaded yet",
+    );
+    assert!(
+        (before.hit_rate - 1.0).abs() < f64::EPSILON,
+        "no miss yet, so the rate is 1.0",
+    );
+
+    // Flush an SST and read every key back so data / index / filter blocks flow
+    // through the cache.
+    for i in 0..200u32 {
+        tree.insert(format!("k{i:04}"), "v", 0);
+    }
+    tree.flush_active_memtable(0)?;
+    for i in 0..200u32 {
+        assert!(tree.get(format!("k{i:04}"), MAX_SEQNO)?.is_some());
+    }
+
+    let after = tree.cache_stats();
+    assert!(
+        after.hits + after.misses > 0,
+        "reads should have loaded blocks through the cache",
+    );
+    assert!(
+        after.size_bytes <= after.capacity_bytes,
+        "resident size stays within capacity",
+    );
+    assert_eq!(
+        after.capacity_bytes, before.capacity_bytes,
+        "capacity is stable across reads",
+    );
+
+    Ok(())
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -453,6 +453,12 @@ impl AbstractTree for Tree {
         &self.0.metrics
     }
 
+    #[cfg(feature = "metrics")]
+    fn cache_stats(&self) -> crate::CacheStats {
+        let cache = &self.0.config.cache;
+        self.metrics().cache_stats(cache.size(), cache.capacity())
+    }
+
     fn version_free_list_len(&self) -> usize {
         self.version_history.read().free_list_len()
     }
@@ -3785,3 +3791,6 @@ fn effective_lower_bound<'a>(
 
 #[cfg(test)]
 mod cardinality_tests;
+
+#[cfg(all(test, feature = "metrics"))]
+mod cache_stats_tests;


### PR DESCRIPTION
## Summary

Groups the scattered read-only storage statistics into a coherent, object-safe surface and adds the two missing signals a planner / tiering / capacity consumer needs. Closes #521.

## Changes

### Two new metrics (the capability gain)
- **`compaction_debt`** — estimated pending-compaction bytes (a `RocksDB` `estimate-pending-compaction-bytes` analog). Added as `CompactionStrategy::pending_compaction_bytes(version)` (default `0`; the leveled strategy sums each level's bytes above its target plus L0 once it reaches the file threshold) and surfaced as `AbstractTree::compaction_debt(strategy)`. The strategy is a caller argument because the engine does not own a configured compaction strategy (it is injected per compaction run); a `&dyn` keeps it object-safe.
- **`CacheStats`** — an owned block-cache snapshot (hits, misses, hit rate, current size, capacity) built by `Metrics::cache_stats(...)`, surfaced as `AbstractTree::cache_stats()` (metrics feature). Replaces handing out the mutable `&Arc<Metrics>` for cache observability.

### Grouping trait
- **`StorageStatistics`** — an object-safe trait collecting the non-query stats (`storage_stats`, `level_segment_stats`, `compaction_debt`, `cache_stats`). A consumer can bound on `&dyn StorageStatistics` and a test can supply a mock. It is exposed through a blanket impl over `AbstractTree` (the logic stays on `AbstractTree`, so its `enum_dispatch` surface is undisturbed and no doctests move). The generic range estimators (`approximate_range_stats` / `approximate_range_cardinality`) are not object-safe and stay on `AbstractTree`.

### Docs
- README: feature-flag table now lists `columnar`, `page_ecc`, `crc32c`, `io-uring-raw`, and the default-on `parallel`; added Features bullets for the columnar PAX layout and per-block ECC, a new Introspection section, and a `no_std` note.

## Testing

Full gate green: clippy `--all-features --all-targets` clean, `no_std` check (`thumbv7em` + `alloc`) zero errors / warnings, nextest (lz4,zstd 2109 + columnar 2193), doctests 65. Three regression tests in separate files: compaction debt over a known leveled version, the cache-stats snapshot after reads, and a mock proving `StorageStatistics` is object-safe.

Closes #521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded “Storage & encoding” options (optional columnar PAX layout, AES-256-GCM at-rest encryption, and per-block ECC with self-healing/patrol scrubbing).
  * Added an Introspection section for new runtime statistics and clarified `std`/`no_std` + feature flags (including new gated capabilities).

* **New Features**
  * Added `CacheStats` (hit rate + cache occupancy) and `cache_stats` reporting when metrics are enabled.
  * Added “compaction debt” estimates to quantify pending leveled compaction work.
  * Introduced a new `StorageStatistics` interface consolidating key storage metrics.

* **Tests**
  * Added coverage for compaction debt behavior and cache statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->