### PR TITLE
perf(filter): prefetch the ribbon coefficient window in the BuRR probe

### DIFF
--- a/src/table/filter/ribbon/burr/filter.rs
+++ b/src/table/filter/ribbon/burr/filter.rs
@@ -171,6 +171,15 @@ impl BurrFilter {
                 standard_equation_from_hash(hash, layer.seed, &layer_params, &mut fingerprint_buf);
             let fingerprint = fingerprint_buf[0];
 
+            let z_words = layer.ribbon.z_raw_words();
+            // Prefetch the [start, start+w) coefficient window before the
+            // threshold check so the hash-random cold miss on z_words[start]
+            // overlaps the is_bumped work. A hint only: the result is unchanged.
+            super::prefetch::prefetch_span(
+                z_words.as_ptr().wrapping_add(equation.start).cast::<u8>(),
+                usize::from(self.params.w) * 8,
+            );
+
             if is_bumped(&equation, &layer.thresholds, self.params.b) {
                 continue;
             }
@@ -178,7 +187,6 @@ impl BurrFilter {
             // GF(2) XOR-reduce. start ∈ [0, m-w] and every set bit offset
             // ∈ [0, w-1], so row_index ∈ [0, m-1] is always in-bounds
             // (proven; no per-row bounds check in the inner loop).
-            let z_words = layer.ribbon.z_raw_words();
             let mut acc: u64 = 0;
             let mut lo = equation.coeff_lo;
             while lo != 0 {
@@ -242,12 +250,19 @@ impl BurrFilter {
             // The first layer that does NOT bump this key is the layer that
             // holds it (the builder kept it at exactly that layer). Same
             // routing as `contains_hash`.
+            let z_words = layer.ribbon.z_raw_words();
+            // Prefetch the [start, start+w) window before the threshold check so
+            // the cold miss on z_words[start] overlaps the is_bumped work.
+            super::prefetch::prefetch_span(
+                z_words.as_ptr().wrapping_add(equation.start).cast::<u8>(),
+                usize::from(self.params.w) * 8,
+            );
+
             if is_bumped(&equation, &layer.thresholds, self.params.b) {
                 continue;
             }
 
             // GF(2) XOR-reduce recovers the stored RHS = the locator.
-            let z_words = layer.ribbon.z_raw_words();
             let mut acc: u64 = 0;
             let mut lo = equation.coeff_lo;
             while lo != 0 {

--- a/src/table/filter/ribbon/burr/mod.rs
+++ b/src/table/filter/ribbon/burr/mod.rs
@@ -76,6 +76,7 @@ pub mod builder;
 pub mod error;
 pub mod filter;
 pub mod params;
+mod prefetch;
 pub(crate) mod threshold;
 pub(crate) mod wire;
 

--- a/src/table/filter/ribbon/burr/prefetch.rs
+++ b/src/table/filter/ribbon/burr/prefetch.rs
@@ -30,8 +30,9 @@
 pub(super) fn prefetch_read(ptr: *const u8) {
     #[cfg(target_arch = "x86_64")]
     {
-        // SAFETY: `_mm_prefetch` is SSE1 (baseline on x86_64) and a pure hint;
-        // the pointer need not be valid and the call cannot fault.
+        // `_mm_prefetch` takes the hint as a const generic in current Rust (not a
+        // runtime argument). SAFETY: it is SSE1 (baseline on x86_64) and a pure
+        // hint; the pointer need not be valid and the call cannot fault.
         unsafe {
             core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(ptr.cast());
         }

--- a/src/table/filter/ribbon/burr/prefetch.rs
+++ b/src/table/filter/ribbon/burr/prefetch.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Read-prefetch hints for the BuRR query hot path.
+//!
+//! Each filter probe XOR-reduces a `[start, start + w)` window of coefficient
+//! words, where `start` is hash-derived (effectively random per probe), so the
+//! first access is a cold cache miss on essentially every check. Prefetching the
+//! window before the preceding threshold work overlaps that miss with useful
+//! computation. Mirrors the random-offset span prefetch RocksDB issues in its
+//! ribbon filter (`util/ribbon_impl.h` `PrefetchSegmentRange`).
+//!
+//! A prefetch is a pure hint: it never faults (even on an invalid address),
+//! never changes the result, and degrades to a no-op on targets without a
+//! prefetch intrinsic, so the filter answer stays bit-identical on every path.
+//! Architecture selection is by `cfg(target_arch)` (the target arch is fixed for
+//! a given binary); it is NOT a runtime-detected ISA feature, so there is no
+//! SIGILL risk: the x86_64 hint is SSE1, baseline on every x86_64 CPU.
+
+// These are bare hardware-hint wrappers on the filter probe hot path: a real
+// call would defeat the purpose, so force inlining.
+#![expect(
+    clippy::inline_always,
+    reason = "bare prefetch-intrinsic wrappers on the probe hot path must inline"
+)]
+
+/// Issues a read-prefetch hint (to all cache levels) for the cache line holding
+/// `ptr`. A no-op on targets without a prefetch intrinsic.
+#[inline(always)]
+pub(super) fn prefetch_read(ptr: *const u8) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SAFETY: `_mm_prefetch` is SSE1 (baseline on x86_64) and a pure hint;
+        // the pointer need not be valid and the call cannot fault.
+        unsafe {
+            core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(ptr.cast());
+        }
+    }
+    #[cfg(all(target_arch = "x86", target_feature = "sse"))]
+    {
+        // SAFETY: same as the x86_64 arm; SSE is compile-time enabled here.
+        unsafe {
+            core::arch::x86::_mm_prefetch::<{ core::arch::x86::_MM_HINT_T0 }>(ptr.cast());
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: `prfm` is a hint; an invalid address does not fault. `readonly`
+        // + `nostack` + `preserves_flags` mark it as a pure memory-touch hint.
+        unsafe {
+            core::arch::asm!(
+                "prfm pldl1keep, [{p}]",
+                p = in(reg) ptr,
+                options(nostack, preserves_flags, readonly),
+            );
+        }
+    }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        all(target_arch = "x86", target_feature = "sse"),
+        target_arch = "aarch64",
+    )))]
+    {
+        let _ = ptr;
+    }
+}
+
+/// Prefetches the `byte_len`-byte span starting at `base`, one hint per 64-byte
+/// cache line, to overlap the cold first-access miss on the hash-random
+/// coefficient window. `base` may be computed with `wrapping_add` past the end
+/// of its allocation: a prefetch of an out-of-range address is harmless.
+#[inline(always)]
+pub(super) fn prefetch_span(base: *const u8, byte_len: usize) {
+    const CACHE_LINE: usize = 64;
+    let mut off = 0;
+    while off < byte_len {
+        prefetch_read(base.wrapping_add(off));
+        off += CACHE_LINE;
+    }
+}

--- a/src/table/filter/ribbon/burr/wire.rs
+++ b/src/table/filter/ribbon/burr/wire.rs
@@ -496,6 +496,15 @@ fn walk_first_layer(bytes: &[u8], hash: u64, expected_type: u8) -> crate::Result
             standard_equation_from_hash(hash, seed, &layer_params, &mut fingerprint_buf);
         let fingerprint = fingerprint_buf[0];
 
+        // Prefetch the [start, start+w) coefficient window (w u64 rows = w*8
+        // bytes) before the threshold check so the hash-random cold miss on the
+        // first band row overlaps the is_bumped work. Hint only; clamped to `z`.
+        let win_start = equation.start * 8;
+        super::prefetch::prefetch_span(
+            z.as_ptr().wrapping_add(win_start),
+            (usize::from(w) * 8).min(z.len().saturating_sub(win_start)),
+        );
+
         if is_bumped(&equation, thresholds, b) {
             continue;
         }
@@ -614,6 +623,16 @@ pub(crate) fn contains_hash(decoded: &DecodedFilter<'_>, hash: u64) -> bool {
             standard_equation_from_hash(hash, layer.seed, &layer_params, &mut fingerprint_buf);
         let fingerprint = fingerprint_buf[0];
 
+        // Prefetch the [start, start+w) coefficient window (w u64 rows = w*8
+        // bytes) before the threshold check so the hash-random cold miss on the
+        // first band row overlaps the is_bumped work. Hint only; clamped to `z`.
+        let z = layer.z_bytes;
+        let win_start = equation.start * 8;
+        super::prefetch::prefetch_span(
+            z.as_ptr().wrapping_add(win_start),
+            (usize::from(decoded.w) * 8).min(z.len().saturating_sub(win_start)),
+        );
+
         if is_bumped(&equation, layer.thresholds, decoded.b) {
             continue;
         }
@@ -626,7 +645,6 @@ pub(crate) fn contains_hash(decoded: &DecodedFilter<'_>, hash: u64) -> bool {
         // → u64 per matched row inline (no per-call allocation, vs
         // pre-decoding into Vec<u64> which would happen on every
         // FilterBlock construction during the LSM read path).
-        let z = layer.z_bytes;
         let mut acc: u64 = 0;
         let mut lo = equation.coeff_lo;
         while lo != 0 {


### PR DESCRIPTION
## Summary

Prefetch the ribbon coefficient window in the BuRR filter query hot path, mirroring the random-offset span prefetch RocksDB issues in its ribbon filter. Closes #540.

## Change

Each filter probe XOR-reduces a `[start, start+w)` window of coefficient words, where `start` is hash-derived (effectively random per probe), so the first access is a cold cache miss on essentially every point-read filter check. The probe sits on the point-read hot path (one per SST lookup, ahead of the data-block read), so the miss is paid before any useful work.

This prefetches the window (one hint per 64-byte cache line) right after the equation is computed and before the threshold check, so the miss overlaps the `is_bumped` work. Applied to all four reduce sites: the in-memory `contains_hash` / `recover_value` and the two wire-format probe paths that the LSM read path actually exercises (the issue cited only the in-memory path, but the point-read bench runs the wire path).

The prefetch is a pure hint: it never faults, never changes the result, and degrades to a no-op on targets without a prefetch intrinsic. Architecture is selected by `cfg(target_arch)` (x86_64 `_mm_prefetch` / aarch64 `prfm` / no-op); the x86_64 hint is baseline SSE1, so there is no runtime-feature gating or SIGILL risk.

## Testing

Full gate green: clippy `--all-features --all-targets` clean, `no_std` check (`thumbv7em` + `alloc`) zero errors / warnings, nextest (lz4,zstd 2110 + columnar 2194), doctests 65. Filter answers are bit-identical across the change (the 140 BuRR / ribbon round-trip tests pass unchanged).

## Bench gate

This is a speculative micro-optimization, so it ships **only if it wins**: the `point_read` benchmark on the pinned bench host must show an improvement above run-to-run noise, with a flamegraph / perf-stat confirming the coefficient-window access is a cache-miss hotspot that the prefetch reduces. If no measurable win is found, the negative result is recorded and this PR is closed rather than merging an unmeasurable hint.

Closes #540


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized filter query performance for membership checking and value recovery by improving internal data access patterns.
* **Performance**
  * Added cache-prefetch hints for coefficient/window reads in the hot probing paths to reduce latency during repeated queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->