### PR TITLE
docs: external WAL contract and storage invariants reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ compaction rewrites SSTs: no migration step, no format-version bump.
 
 The trade-off: there is no write-ahead log, so we do not offer WAL-style
 millisecond tailing of in-flight updates. For arbitrary historical-seqno queries
-(not just "since X"), pair with `Tree::create_checkpoint`.
+(not just "since X"), pair with `Tree::create_checkpoint`. To layer your own
+durability on top of the engine, see the external-WAL integration contract in
+[docs/external-wal.md](docs/external-wal.md).
 
 ## Limits
 
@@ -187,6 +189,11 @@ See **[docs/tight-space-compaction.md](docs/tight-space-compaction.md)** for the
 opt-in tight-space compaction: how a gated merge on a near-full disk is rewritten
 in key-range slices and reclaimed in place with hole punching, so a compaction
 completes on a disk far smaller than the data it rewrites.
+
+See **[docs/INVARIANTS.md](docs/INVARIANTS.md)** for the engine's load-bearing
+invariants grouped by subsystem (block layout, manifest, compaction,
+snapshot / seqno, range tombstones, recovery / ECC, columnar) — the rule, why it
+holds, and where it is enforced.
 
 ## Support the project
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,203 @@
+# Storage Engine Invariants
+
+The load-bearing invariants the engine enforces, grouped by subsystem. Each entry
+states the **rule**, **why** it holds, and **where** it is enforced (the module or
+test that would break if the invariant were violated), so a reviewer can answer
+"does this change violate invariant X?" without re-deriving the contract.
+
+This is a living reference: when a change adds or alters an invariant, update the
+matching entry (and add one for a new subsystem).
+
+---
+
+## SST block / data layout
+
+- **Keys within a data block are sorted by internal key.** A block iterator and
+  the binary search over restart points both assume ascending order; an unsorted
+  block would silently return wrong seek results. Enforced by the writer emitting
+  entries in sorted order (`src/table/writer`) and verified by the block
+  round-trip tests (`src/table/data_block`).
+
+- **Internal key order is (user_key ascending, seqno descending).** For one user
+  key the newest version (highest seqno) sorts first, so a forward scan meets the
+  visible version before older ones. Enforced in the comparator
+  (`src/value.rs` `InternalKey` ordering; tests `pik_cmp_user_key`,
+  `pik_cmp_seqno`).
+
+- **A block's checksum covers exactly its payload.** The per-block XXH3 (or
+  optional CRC32C) is computed over the block bytes only; parity / per-KV footers
+  sit outside that scope and are sized from the per-SST descriptor, not guessed.
+  A reader that mis-scopes the checksum reports spurious corruption. Enforced in
+  `src/table/block` (header + trailer) and the block-verify walk (`src/verify.rs`).
+
+- **SST block headers omit the `block_flags` byte; self-describing blocks carry
+  it.** `Data` / `Index` / `Filter` / `RangeTombstone` derive parity / footer
+  presence from the per-SST meta descriptor, while `Meta` / `Manifest` /
+  `ManifestFooter` carry an explicit `block_flags` byte (V5 format). The block
+  magic is bumped so a pre-V5 reader rejects V5 blocks at header decode. Enforced
+  in `src/table/block/header.rs` and the format-version gate.
+
+- **A per-block zone map conservatively bounds its block.** The stored
+  `[min, max]` key range and row count cover every key in the block: a query key
+  outside `[min, max]` is provably absent (so a range scan may skip the block),
+  but the bounds never exclude a key that is present — a false skip would lose
+  data. Enforced in `src/table/zone_map.rs` (+ the zone-map round-trip /
+  selectivity tests).
+
+## Filter (AMQ)
+
+- **The filter never produces a false negative.** A `BuRR` membership filter may
+  report a key present when it is absent (a false positive, at rate ≈ 2⁻ʳ), but it
+  must NEVER report a key absent when it is present — a false negative would skip a
+  real key and silently lose data on read. Enforced by the build / probe symmetry
+  in `src/table/filter/ribbon/burr` (every built key reports present; the
+  round-trip tests assert no built key is ever rejected).
+
+## Block cache
+
+- **A cache lookup returns the same bytes a fresh read would.** A cached block /
+  point-read result is keyed by `(block_type, tree, table, offset)`; a hash
+  collision on that key is verified on lookup (the stored user key is compared) and
+  rejected rather than serving a wrong value. A cache hit is therefore
+  indistinguishable from a disk read. Enforced in `src/cache.rs` (the lookup-side
+  key verification) and the cache tests.
+
+## Manifest
+
+- **A manifest version installs atomically.** A new version becomes current only
+  by flipping the current pointer after the new manifest is fully written and
+  synced; a crash mid-write leaves the previous version current. Enforced in
+  `src/manifest.rs` / `src/manifest_blocks` (writer + current-pointer flip).
+
+- **Recovery accepts only a complete prefix.** On open, the manifest is replayed
+  up to the last intact, checksum-valid record; a torn tail (partial final write)
+  is discarded, not half-applied. Enforced by the manifest reader's framing +
+  checksum checks (`src/manifest_blocks/reader.rs`, `footer.rs`).
+
+## Compaction
+
+- **Compaction output preserves every MVCC version visible to a live snapshot.**
+  A merge may physically drop a version only when no open snapshot can observe it;
+  otherwise a snapshot read would change answer across a compaction. Enforced in
+  `src/compaction/worker.rs` (merge + tombstone handling) and the compaction
+  integration tests (`src/compaction/leveled`).
+
+- **A weak tombstone is dropped only below the lowest live snapshot.** Dropping a
+  delete marker that a snapshot still needs would resurrect the deleted key for
+  that snapshot. Enforced in the merge / drop logic
+  (`src/compaction`, `src/range_tombstone_filter.rs`).
+
+- **Sequence numbers are zeroed only at the bottommost level.** Packing a seqno to
+  zero is safe only once no older version and no snapshot below it can exist
+  (bottommost, no live snapshot beneath); doing it higher would collapse distinct
+  versions. Enforced in the bottommost seqno-zeroer (`src/compaction/seqno_zeroer.rs`).
+
+- **L0 compaction is triggered by table (file) count, and pending-compaction debt
+  is measured the same way.** Both the `choose` trigger and `compaction_debt`
+  count tables, not runs, so a multi-table L0 run is not under-counted. Enforced
+  in `src/compaction/leveled` (test `compaction_debt_flags_l0_over_threshold_then_clears`).
+
+## File lifecycle and concurrency
+
+- **A file referenced by a live version or an in-flight reader is never deleted.**
+  Compaction installs the new version and only then drops inputs that no version or
+  open iterator / snapshot still references; an obsolete SST is unlinked after its
+  last reader releases it, never while in use. A premature delete would fault an
+  active read. Enforced by the version ref-counting in `src/version` and the file
+  GC in `src/compaction` / `src/tree`.
+
+- **A directory has at most one writer process.** Opening a tree acquires an
+  exclusive lock on a `LOCK` file; a second open of the same directory fails with
+  `Error::Locked` rather than corrupting shared state through two uncoordinated
+  writers. Enforced in the open path via the `Fs` advisory lock
+  (`Config::with_directory_lock`, default on) and the cross-process lock tests.
+
+## Snapshot / sequence number
+
+- **Sequence numbers are monotonic and caller-assigned.** The engine honors the
+  seqno passed to `insert`; the caller draws them from a monotonic source. A read
+  at snapshot `N` sees only versions with `seqno <= N` — the newest such version
+  of each key. Enforced in the read path (`src/tree`, `src/mvcc_stream.rs`) and the
+  seqno ordering (`src/seqno.rs`, `src/value.rs`).
+
+- **Re-applying a write at its original seqno is idempotent.** The same
+  (key, value, seqno) reproduces the same MVCC version, which is what makes
+  external-WAL replay safe (see [external-wal.md](external-wal.md)).
+
+## Range tombstones
+
+- **A range tombstone covers the half-open interval it encodes, at its seqno.** A
+  point version is shadowed by a covering range tombstone only when the tombstone's
+  seqno is newer than the point's; ordering vs point writes is by seqno, same as
+  point deletes. Enforced in `src/range_tombstone.rs` /
+  `src/range_tombstone_filter.rs` and the range-delete tests.
+
+## Merge operators
+
+- **A merge operand is resolved by folding it over the base value and older
+  operands in seqno order.** A read (or compaction) materializes a key by applying
+  operands oldest-to-newest on top of the base value; a partial fold during
+  compaction must yield the same result as a full fold at read time, so the
+  operator is required to be associative. A non-associative operator would make
+  the answer depend on compaction timing. Enforced in `src/merge.rs` /
+  `src/merge_source.rs` and the merge-operator tests.
+
+## Recovery / ECC
+
+- **ECC verification is three-state: OK, FAIL, or WARN.** A recognized scheme that
+  verifies is OK; a recognized scheme that fails to correct is FAIL; an
+  unrecognized scheme is WARN (soft-fail, recompaction re-stamps) rather than a
+  hard reject. Enforced in `src/verify.rs` / `src/ecc.rs` / `src/secded.rs`.
+
+- **On-read ECC correction is bounded by the scheme.** SEC-DED corrects a single
+  bit per word and detects a double-bit error; Reed-Solomon recovers up to its
+  parity-shard budget. A fault beyond the bound surfaces as a read error, never
+  silent wrong data. Enforced in `src/secded.rs`, `src/ecc.rs`, and the ECC
+  recovery counters (`src/metrics.rs`).
+
+- **ENOSPC during a write leaves an orphan, not corruption.** A write that runs
+  out of space fails before publishing a new version; the partial file is an
+  orphan reclaimed on recovery, and the last durable version is unchanged.
+  Enforced in the write / flush path and recovery (`src/tree`, `src/version/recovery.rs`).
+
+## Encryption at rest
+
+> `encryption` feature.
+
+- **An encrypted block authenticates against its bound AAD.** The AEAD seal binds
+  the block's table id and on-disk header fields as additional authenticated data
+  and protects ciphertext integrity: any tampered byte, or a block substituted from
+  a different table, fails to decrypt rather than yielding altered plaintext.
+  (Same-table relocation is outside the AAD scope by design; cross-tree isolation
+  is provided by key separation, not AAD.) Enforced in `src/encryption/aad.rs`
+  (wire spec [docs/aad-block-format.md](aad-block-format.md) §5.3) and the
+  encryption round-trip / threat-model tests.
+
+## Key-value separation (BlobTree)
+
+- **Every live blob pointer resolves, and GC drops only unreferenced blobs.** With
+  KV separation a large value is written to a blob file and the SST holds an
+  indirection pointer; a read transparently resolves the pointer to the user value,
+  and blob GC reclaims a blob only once no live SST entry references it (tracked via
+  the fragmentation map). A dangling pointer or a prematurely collected blob would
+  lose the value. Enforced in `src/blob_tree` / `src/vlog` (GC in
+  `src/blob_tree/gc.rs`).
+
+## Columnar (PAX) / delete-bitmap
+
+> `columnar` feature.
+
+- **A columnar row's visibility follows the same seqno rule as a row-oriented
+  entry.** Decoding a PAX row group yields the key / seqno / value-type / value
+  sub-columns; a read at snapshot `N` sees a row only if its seqno `<= N`. Enforced
+  in `src/table/columnar.rs`.
+
+- **The positional delete bitmap is applied by row position, MVCC-correctly.** A
+  set bit hides the row at that position for reads at or after the deleting seqno;
+  the original row stays on disk until compaction materializes the deletion.
+  Enforced in `src/table/delete_bitmap.rs`.
+
+- **Sub-column framing is self-describing and bounds-checked.** Each sub-column's
+  offset / length is validated against the block before decode; a truncated or
+  inconsistent frame is rejected, never read past its bound. Enforced in
+  `src/table/columnar.rs` (decode + the columnar round-trip tests).

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -120,9 +120,14 @@ matching entry (and add one for a new subsystem).
   of each key. Enforced in the read path (`src/tree`, `src/mvcc_stream.rs`) and the
   seqno ordering (`src/seqno.rs`, `src/value.rs`).
 
-- **Re-applying a write at its original seqno is idempotent.** The same
-  (key, value, seqno) reproduces the same MVCC version, which is what makes
-  external-WAL replay safe (see [external-wal.md](external-wal.md)).
+- **Re-applying a put / delete at its original seqno is idempotent; a merge
+  operand is NOT.** For a put or delete, the same (key, value, seqno) reproduces
+  the same MVCC version (an overwrite), which is what makes external-WAL replay
+  safe. A merge operand re-applied on top of its already-persisted self is folded
+  a second time by merge resolution (see [Merge operators](#merge-operators)
+  below), so a counter would double-count. External-WAL replay must therefore
+  apply each record exactly once, strictly above the durable watermark, never
+  relying on over-replay being harmless (see [external-wal.md](external-wal.md)).
 
 ## Range tombstones
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -40,7 +40,7 @@ matching entry (and add one for a new subsystem).
 - **A per-block zone map conservatively bounds its block.** The stored
   `[min, max]` key range and row count cover every key in the block: a query key
   outside `[min, max]` is provably absent (so a range scan may skip the block),
-  but the bounds never exclude a key that is present — a false skip would lose
+  but the bounds never exclude a key that is present: a false skip would lose
   data. Enforced in `src/table/zone_map.rs` (+ the zone-map round-trip /
   selectivity tests).
 
@@ -48,19 +48,21 @@ matching entry (and add one for a new subsystem).
 
 - **The filter never produces a false negative.** A `BuRR` membership filter may
   report a key present when it is absent (a false positive, at rate ≈ 2⁻ʳ), but it
-  must NEVER report a key absent when it is present — a false negative would skip a
+  must NEVER report a key absent when it is present: a false negative would skip a
   real key and silently lose data on read. Enforced by the build / probe symmetry
   in `src/table/filter/ribbon/burr` (every built key reports present; the
   round-trip tests assert no built key is ever rejected).
 
 ## Block cache
 
-- **A cache lookup returns the same bytes a fresh read would.** A cached block /
-  point-read result is keyed by `(block_type, tree, table, offset)`; a hash
-  collision on that key is verified on lookup (the stored user key is compared) and
-  rejected rather than serving a wrong value. A cache hit is therefore
-  indistinguishable from a disk read. Enforced in `src/cache.rs` (the lookup-side
-  key verification) and the cache tests.
+- **A cache lookup returns the same bytes a fresh read would.** The block cache is
+  keyed by `(block_type, tree, table, offset)`, an exact physical address, so a
+  hit returns precisely that block, indistinguishable from a disk read (no key
+  comparison is needed because the offset is exact, not hashed). The separate
+  point-read (row) cache is keyed by a key *hash* (the same hash the bloom filter
+  uses), so on a hit it compares the stored `user_key` against the lookup key and
+  rejects a hash collision rather than serving a wrong value. Enforced in
+  `src/cache.rs` (`get_block` / `get_row`) and the cache tests.
 
 ## Manifest
 
@@ -87,10 +89,15 @@ matching entry (and add one for a new subsystem).
   that snapshot. Enforced in the merge / drop logic
   (`src/compaction`, `src/range_tombstone_filter.rs`).
 
-- **Sequence numbers are zeroed only at the bottommost level.** Packing a seqno to
-  zero is safe only once no older version and no snapshot below it can exist
-  (bottommost, no live snapshot beneath); doing it higher would collapse distinct
-  versions. Enforced in the bottommost seqno-zeroer (`src/compaction/seqno_zeroer.rs`).
+- **Sequence numbers are zeroed only at the bottommost level, and only when no
+  range tombstone covers the key.** Packing a seqno to zero is safe only at the
+  bottommost level with no live snapshot beneath. It additionally requires that no
+  range tombstone anywhere in the version covers the key: range tombstones are
+  applied by seqno comparison (`RT@r` suppresses `K@s` iff it covers `K` and
+  `s < r`), so zeroing `K@s` to `K@0` would let any covering tombstone with
+  `r > 0` wrongly suppress it, even one older than the original entry. Tombstones
+  are gathered from every level, not just this compaction's inputs. Enforced in the
+  bottommost seqno-zeroer (`src/compaction/seqno_zeroer.rs`).
 
 - **L0 compaction is triggered by table (file) count, and pending-compaction debt
   is measured the same way.** Both the `choose` trigger and `compaction_debt`
@@ -116,8 +123,10 @@ matching entry (and add one for a new subsystem).
 
 - **Sequence numbers are monotonic and caller-assigned.** The engine honors the
   seqno passed to `insert`; the caller draws them from a monotonic source. A read
-  at snapshot `N` sees only versions with `seqno <= N` — the newest such version
-  of each key. Enforced in the read path (`src/tree`, `src/mvcc_stream.rs`) and the
+  at read-seqno `R` sees only versions with `seqno < R` (the read seqno is an
+  exclusive upper bound); the newest such version of each key. The visible
+  watermark is published as the last applied seqno + 1, so a write at seqno `s` is
+  visible at read seqno `s + 1`. Enforced in the read path (`src/tree`, `src/mvcc_stream.rs`) and the
   seqno ordering (`src/seqno.rs`, `src/value.rs`).
 
 - **Re-applying a put / delete at its original seqno is idempotent; a merge
@@ -199,7 +208,7 @@ matching entry (and add one for a new subsystem).
 
 - **The positional delete bitmap is a pure membership set; MVCC correctness is
   established when it is built, not at read time.** The bitmap carries no per-row
-  seqno — a set bit unconditionally hides the row at that position for every reader
+  seqno: a set bit unconditionally hides the row at that position for every reader
   of the segment. The MVCC reconciliation happens at materialization time: a row's
   bit is set only once its deleting tombstone is visible to every live snapshot
   (its seqno below the compaction threshold), so a still-visible older version is

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -84,10 +84,13 @@ matching entry (and add one for a new subsystem).
   `src/compaction/worker.rs` (merge + tombstone handling) and the compaction
   integration tests (`src/compaction/leveled`).
 
-- **A weak tombstone is dropped only below the lowest live snapshot.** Dropping a
-  delete marker that a snapshot still needs would resurrect the deleted key for
-  that snapshot. Enforced in the merge / drop logic
-  (`src/compaction`, `src/range_tombstone_filter.rs`).
+- **A weak tombstone is dropped below the lowest live snapshot, or when it
+  collapses with its matching value.** Dropping a delete marker that a snapshot
+  still needs would resurrect the deleted key for that snapshot. Beyond the
+  snapshot-watermark rule, the compaction stream also drops a weak tombstone when
+  the next entry for the same key is a `Value` (single-delete semantics: the weak
+  delete annihilates exactly that one put). Enforced in the merge / drop logic
+  (`src/compaction/stream.rs`, `src/range_tombstone_filter.rs`).
 
 - **Sequence numbers are zeroed only at the bottommost level, and only when no
   range tombstone covers the key.** Packing a seqno to zero is safe only at the

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -203,8 +203,10 @@ matching entry (and add one for a new subsystem).
 
 - **A columnar row's visibility follows the same seqno rule as a row-oriented
   entry.** Decoding a PAX row group yields the key / seqno / value-type / value
-  sub-columns; a read at snapshot `N` sees a row only if its seqno `<= N`. Enforced
-  in `src/table/columnar.rs`.
+  sub-columns; a read at read-seqno `R` sees a row only if its seqno `< R` (the
+  same exclusive upper bound as the row-oriented path; see
+  [Snapshot / sequence number](#snapshot--sequence-number)). Enforced in
+  `src/table/columnar.rs`.
 
 - **The positional delete bitmap is a pure membership set; MVCC correctness is
   established when it is built, not at read time.** The bitmap carries no per-row

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -197,10 +197,13 @@ matching entry (and add one for a new subsystem).
   sub-columns; a read at snapshot `N` sees a row only if its seqno `<= N`. Enforced
   in `src/table/columnar.rs`.
 
-- **The positional delete bitmap is applied by row position, MVCC-correctly.** A
-  set bit hides the row at that position for reads at or after the deleting seqno;
-  the original row stays on disk until compaction materializes the deletion.
-  Enforced in `src/table/delete_bitmap.rs`.
+- **The positional delete bitmap is a pure membership set; MVCC correctness is
+  established when it is built, not at read time.** The bitmap carries no per-row
+  seqno — a set bit unconditionally hides the row at that position for every reader
+  of the segment. The MVCC reconciliation happens at materialization time: a row's
+  bit is set only once its deleting tombstone is visible to every live snapshot
+  (its seqno below the compaction threshold), so a still-visible older version is
+  never masked. Enforced in `src/table/delete_bitmap.rs`.
 
 - **Sub-column framing is self-describing and bounds-checked.** Each sub-column's
   offset / length is validated against the block before decode; a truncated or

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -9,8 +9,9 @@ your own WAL before applying it and replay the tail on restart.
 This document specifies the contract for building that external WAL on top of the
 existing public API. No engine callbacks are required (see
 [Why no hook API](#why-no-hook-api)); the contract is expressed entirely through
-the write methods (`insert`, `remove`, `remove_range`, `merge`, and `WriteBatch`),
-`flush_active_memtable`, `get_highest_persisted_seqno`, and recover-on-open.
+the write methods (`insert`, `remove`, `remove_weak`, `remove_range`, `merge`, and
+`WriteBatch`), `flush_active_memtable`, `get_highest_persisted_seqno`, and
+recover-on-open.
 
 ## The sequence number is the durability cursor
 
@@ -23,9 +24,10 @@ fn insert<K: Into<UserKey>, V: Into<UserValue>>(&self, key: K, value: V, seqno: 
 The engine does not assign seqnos; the caller does, typically by drawing
 monotonically increasing values from a [`SequenceNumberCounter`]. Because the
 seqno is an input, it is the single cursor that ties your WAL records to engine
-state: a WAL record and the `insert` it produces share one seqno, and recovery is
-expressed as "replay every WAL record with a seqno above what the engine already
-persisted".
+state: a WAL record and the write it produces share one seqno, and recovery is
+expressed as "replay every WAL record with a seqno above your trim watermark `W`"
+(the gap-free applied-and-persisted prefix defined in section 3, not the raw
+persisted maximum).
 
 MVCC visibility follows the seqno: a read at read-seqno `R` sees the newest version
 of each key with `seqno < R`: the read seqno is an *exclusive* upper bound. The

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -1,0 +1,114 @@
+# External Write-Ahead Log Integration
+
+This engine has **no internal write-ahead log**: a write lands in the active
+memtable and becomes durable only when that memtable is flushed to an SST. A
+crash between a write and the next flush loses every unflushed write. Durability
+is therefore the caller's responsibility — if you need it, you log each write to
+your own WAL before applying it and replay the tail on restart.
+
+This document specifies the contract for building that external WAL on top of the
+existing public API. No engine callbacks are required (see
+[Why no hook API](#why-no-hook-api)); the contract is expressed entirely through
+`insert`, `flush_active_memtable`, `get_highest_persisted_seqno`, and
+recover-on-open.
+
+## The sequence number is the durability cursor
+
+Every write carries a caller-supplied sequence number:
+
+```rust,ignore
+fn insert<K: Into<UserKey>, V: Into<UserValue>>(&self, key: K, value: V, seqno: SeqNo) -> (u64, u64);
+```
+
+The engine does not assign seqnos — the caller does, typically by drawing
+monotonically increasing values from a [`SequenceNumberCounter`]. Because the
+seqno is an input, it is the single cursor that ties your WAL records to engine
+state: a WAL record and the `insert` it produces share one seqno, and recovery is
+expressed as "replay every WAL record with a seqno above what the engine already
+persisted".
+
+MVCC visibility follows the seqno: a read at snapshot `N` sees the newest version
+of each key with `seqno <= N` (see [INVARIANTS.md](INVARIANTS.md), Snapshot /
+seqno). Re-applying a record with its original seqno reproduces the exact same
+version, which is what makes replay idempotent.
+
+## 1. Log before apply
+
+For each write (or batch):
+
+1. Draw the seqno(s) the write will carry (`SequenceNumberCounter::next`, or your
+   own monotonic source).
+2. Append the record — keys, values, and the seqno — to your WAL and make it
+   durable (`fsync`, or your log's equivalent).
+3. Only then call `insert(key, value, seqno)` (or a `WriteBatch` at that seqno).
+
+The ordering is what guarantees recoverability: if the process dies after step 2
+but before or during step 3, the record is in your WAL and replay re-applies it.
+If it dies before step 2, the write never happened from the caller's point of
+view, so there is nothing to lose. Never apply before logging — a write that
+reaches the memtable but not the WAL is unrecoverable after a crash that drops the
+memtable.
+
+## 2. Durability points — when a seqno is safe to trim
+
+A write is durable once the memtable holding it has been flushed:
+
+```rust,ignore
+fn flush_active_memtable(&self, eviction_seqno: SeqNo) -> crate::Result<()>;
+```
+
+When this returns `Ok`, the active memtable has been written and synced as an SST,
+so every seqno it contained is now on disk and survives a crash. To learn the
+watermark, query:
+
+```rust,ignore
+fn get_highest_persisted_seqno(&self) -> Option<SeqNo>;
+```
+
+This returns the highest seqno present in the persisted SSTs (`None` for an empty
+tree). After a flush, **every WAL record with `seqno <= get_highest_persisted_seqno()`
+is redundant and may be trimmed** — its data is recoverable from the SSTs without
+the WAL.
+
+`create_checkpoint` gives the same guarantee for a point-in-time copy: the
+checkpoint directory contains every SST live at the call, so its contents are
+durable up to the persisted watermark at that moment; it does not flush the active
+memtable, so unflushed writes are not in the checkpoint.
+
+Note `get_highest_persisted_seqno` is the *persisted* watermark, distinct from
+`get_highest_seqno` (the max over memtable + SSTs, including not-yet-durable
+writes). Trim against the persisted one only.
+
+## 3. Recovery replay
+
+On `Config::open` the engine recovers its state from the persisted SSTs alone (it
+has no log of its own to replay). After open:
+
+1. Read the durable watermark: `let durable = tree.get_highest_persisted_seqno();`
+   (`None` ⇒ empty tree ⇒ replay everything).
+2. Replay your WAL from `durable + 1` forward, re-applying each record with
+   `insert(key, value, seqno)` at its original seqno.
+3. Records at or below `durable` may be skipped (already persisted) or replayed
+   harmlessly — re-applying a record with its original seqno reproduces the same
+   MVCC version, so replay is idempotent and a conservative "replay from a little
+   earlier" is always safe.
+
+Idempotence is the safety net for the crash window in step 1 of
+[Log before apply](#1-log-before-apply): a record that was logged, applied, but
+not yet flushed is replayed on restart and produces a byte-identical version, so
+double-apply is a no-op rather than a corruption.
+
+## Why no hook API
+
+A thin observability hook surface (`before_write_batch`, `after_flush`,
+`after_checkpoint`) was considered and is **not** provided: the existing API
+already expresses the full contract. The seqno is a caller input, so the caller
+already knows every seqno it applied without a callback; `flush_active_memtable` /
+`create_checkpoint` return `Ok` exactly when their durability guarantee holds; and
+`get_highest_persisted_seqno` reports the watermark to trim against. Adding
+callbacks would duplicate information the caller already has and couple the engine
+to a notification lifecycle it does not need. If a future requirement cannot be
+expressed through this surface, a hook trait can be added then — document-first
+until proven necessary.
+
+[`SequenceNumberCounter`]: https://docs.rs/coordinode-lsm-tree/latest/lsm_tree/struct.SequenceNumberCounter.html

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -66,9 +66,14 @@ fn get_highest_persisted_seqno(&self) -> Option<SeqNo>;
 ```
 
 This returns the highest seqno present in the persisted SSTs (`None` for an empty
-tree). After a flush, **every WAL record with `seqno <= get_highest_persisted_seqno()`
-is redundant and may be trimmed** — its data is recoverable from the SSTs without
-the WAL.
+tree) — the *maximum*, not a contiguity guarantee. When writes are applied in
+strict seqno order (the single-writer log-before-apply pattern above guarantees
+this), that maximum *is* a contiguous prefix: **every WAL record with
+`seqno <= get_highest_persisted_seqno()` is on disk and may be trimmed**. If you
+apply writes out of seqno order (concurrent appliers can flush a higher seqno
+while a lower one is still pending), the maximum is NOT contiguous — a delayed
+lower seqno may be absent from every SST — so trim only against a contiguous
+applied-and-persisted prefix you track yourself, never against the raw maximum.
 
 `create_checkpoint` gives the same guarantee for a point-in-time copy: it flushes
 the active memtable first, then hard-links every resulting SST into the checkpoint
@@ -87,17 +92,19 @@ has no log of its own to replay). After open:
 
 1. Read the durable watermark: `let durable = tree.get_highest_persisted_seqno();`
    (`None` ⇒ empty tree ⇒ replay everything).
-2. Replay your WAL from `durable + 1` forward, re-applying each record with
-   `insert(key, value, seqno)` at its original seqno.
-3. Records at or below `durable` may be skipped (already persisted) or replayed
-   harmlessly — re-applying a record with its original seqno reproduces the same
-   MVCC version, so replay is idempotent and a conservative "replay from a little
-   earlier" is always safe.
+2. Replay your WAL **strictly from `durable + 1`** forward, re-applying each record
+   with `insert(key, value, seqno)` at its original seqno.
+3. Do NOT re-apply records at or below `durable`. For put / delete that would be
+   harmless (re-applying at the original seqno reproduces the same MVCC version, an
+   overwrite), but a **merge operand** re-applied on top of its already-persisted
+   self is folded twice by merge resolution — a counter would double-count. The
+   strict `> durable` boundary is correct for every record type, so use it
+   unconditionally rather than relying on over-replay being idempotent.
 
-Idempotence is the safety net for the crash window in step 1 of
-[Log before apply](#1-log-before-apply): a record that was logged, applied, but
-not yet flushed is replayed on restart and produces a byte-identical version, so
-double-apply is a no-op rather than a corruption.
+The strict boundary still covers the crash window in step 1 of
+[Log before apply](#1-log-before-apply): a record that was logged and applied but
+not yet flushed is, by definition, absent from the SSTs, so its seqno is above
+`durable` and step 2 replays it exactly once.
 
 ## Why no hook API
 

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -43,13 +43,22 @@ twice), so replay must apply each record exactly once (see
 For each write (or batch):
 
 1. Draw the seqno(s) the write will carry (`SequenceNumberCounter::next`, or your
-   own monotonic source).
+   own monotonic source). A `WriteBatch` shares a single seqno across all its
+   entries.
 2. Append the record (keys, values, and the seqno) to your WAL and make it
    durable (`fsync`, or your log's equivalent).
-3. Only then call the original write API at that seqno (`insert` for a put,
+3. Only then call the matching write API at that seqno: `insert` for a put,
    `remove` for a point delete, `remove_weak` for a weak/single delete,
    `remove_range` for a range tombstone, `merge` for a merge operand, or a
-   `WriteBatch`). Apply the same operation that was logged, not always `insert`.
+   `WriteBatch`. Use the admission-gated `try_*` variant (`try_insert`,
+   `try_merge`, ...) if you want over-budget writes refused up front. Apply the
+   same operation that was logged, never collapsing to `insert`.
+4. If the write API returns an error (an admission rejection, or `apply_batch`
+   rejecting a malformed batch), the record was NOT applied: keep it in the WAL,
+   do not advance your applied-and-persisted watermark, and retry or surface the
+   failure. On success, publish your visible watermark so reads observe the write,
+   e.g. `visible_seqno.fetch_max(seqno + 1)` (the exclusive read bound from the
+   durability-cursor section).
 
 The ordering is what guarantees recoverability: if the process dies after step 2
 but before or during step 3, the record is in your WAL and replay re-applies it.
@@ -129,7 +138,7 @@ has no log of its own to replay). After open:
 The strict boundary still covers the crash window in step 1 of
 [Log before apply](#1-log-before-apply): a record that was logged and applied but
 not yet flushed is, by definition, absent from the SSTs, so its seqno is above
-`durable` and step 2 replays it exactly once.
+your trim watermark `W` and the replay step covers it exactly once.
 
 ## Why no hook API
 

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -70,10 +70,11 @@ tree). After a flush, **every WAL record with `seqno <= get_highest_persisted_se
 is redundant and may be trimmed** — its data is recoverable from the SSTs without
 the WAL.
 
-`create_checkpoint` gives the same guarantee for a point-in-time copy: the
-checkpoint directory contains every SST live at the call, so its contents are
-durable up to the persisted watermark at that moment; it does not flush the active
-memtable, so unflushed writes are not in the checkpoint.
+`create_checkpoint` gives the same guarantee for a point-in-time copy: it flushes
+the active memtable first, then hard-links every resulting SST into the checkpoint
+directory, so the checkpoint contains every write that had reached the active
+memtable at the call (the persisted watermark advances to cover the flushed
+writes).
 
 Note `get_highest_persisted_seqno` is the *persisted* watermark, distinct from
 `get_highest_seqno` (the max over memtable + SSTs, including not-yet-durable

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -29,8 +29,10 @@ persisted".
 
 MVCC visibility follows the seqno: a read at snapshot `N` sees the newest version
 of each key with `seqno <= N` (see [INVARIANTS.md](INVARIANTS.md), Snapshot /
-seqno). Re-applying a record with its original seqno reproduces the same
-version, which is what makes replay idempotent.
+seqno). Re-applying a put or delete at its original seqno reproduces the same
+version (an overwrite); a merge operand is the exception — re-applying folds it
+twice — so replay must apply each record exactly once (see
+[Recovery replay](#3-recovery-replay)).
 
 ## 1. Log before apply
 
@@ -92,8 +94,11 @@ has no log of its own to replay). After open:
 
 1. Read the durable watermark: `let durable = tree.get_highest_persisted_seqno();`
    (`None` ⇒ empty tree ⇒ replay everything).
-2. Replay your WAL **strictly from `durable + 1`** forward, re-applying each record
-   with `insert(key, value, seqno)` at its original seqno.
+2. Replay every WAL record with **`seqno > durable`** (a strict lower bound — phrase
+   it as `> durable`, not a literal `durable + 1`, which would overflow at the top
+   of the seqno range), re-applying each with its **original operation** and seqno:
+   a logged put via `insert`, a delete via `remove`, a merge via `merge`. Never
+   collapse every record to `insert` — that loses deletes and merge semantics.
 3. Do NOT re-apply records at or below `durable`. For put / delete that would be
    harmless (re-applying at the original seqno reproduces the same MVCC version, an
    overwrite), but a **merge operand** re-applied on top of its already-persisted

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -29,7 +29,7 @@ persisted".
 
 MVCC visibility follows the seqno: a read at snapshot `N` sees the newest version
 of each key with `seqno <= N` (see [INVARIANTS.md](INVARIANTS.md), Snapshot /
-seqno). Re-applying a record with its original seqno reproduces the exact same
+seqno). Re-applying a record with its original seqno reproduces the same
 version, which is what makes replay idempotent.
 
 ## 1. Log before apply

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -3,7 +3,7 @@
 This engine has **no internal write-ahead log**: a write lands in the active
 memtable and becomes durable only when that memtable is flushed to an SST. A
 crash between a write and the next flush loses every unflushed write. Durability
-is therefore the caller's responsibility — if you need it, you log each write to
+is therefore the caller's responsibility: if you need it, you log each write to
 your own WAL before applying it and replay the tail on restart.
 
 This document specifies the contract for building that external WAL on top of the
@@ -20,18 +20,20 @@ Every write carries a caller-supplied sequence number:
 fn insert<K: Into<UserKey>, V: Into<UserValue>>(&self, key: K, value: V, seqno: SeqNo) -> (u64, u64);
 ```
 
-The engine does not assign seqnos — the caller does, typically by drawing
+The engine does not assign seqnos; the caller does, typically by drawing
 monotonically increasing values from a [`SequenceNumberCounter`]. Because the
 seqno is an input, it is the single cursor that ties your WAL records to engine
 state: a WAL record and the `insert` it produces share one seqno, and recovery is
 expressed as "replay every WAL record with a seqno above what the engine already
 persisted".
 
-MVCC visibility follows the seqno: a read at snapshot `N` sees the newest version
-of each key with `seqno <= N` (see [INVARIANTS.md](INVARIANTS.md), Snapshot /
-seqno). Re-applying a put or delete at its original seqno reproduces the same
-version (an overwrite); a merge operand is the exception — re-applying folds it
-twice — so replay must apply each record exactly once (see
+MVCC visibility follows the seqno: a read at read-seqno `R` sees the newest version
+of each key with `seqno < R`: the read seqno is an *exclusive* upper bound. The
+visible watermark is published as the last applied seqno + 1, so a write at seqno
+`s` becomes visible once the watermark reaches `s + 1` (see
+[INVARIANTS.md](INVARIANTS.md), Snapshot / seqno). Re-applying a put or delete at its original seqno reproduces the same
+version (an overwrite); a merge operand is the exception (re-applying folds it
+twice), so replay must apply each record exactly once (see
 [Recovery replay](#3-recovery-replay)).
 
 ## 1. Log before apply
@@ -40,18 +42,18 @@ For each write (or batch):
 
 1. Draw the seqno(s) the write will carry (`SequenceNumberCounter::next`, or your
    own monotonic source).
-2. Append the record — keys, values, and the seqno — to your WAL and make it
+2. Append the record (keys, values, and the seqno) to your WAL and make it
    durable (`fsync`, or your log's equivalent).
 3. Only then call `insert(key, value, seqno)` (or a `WriteBatch` at that seqno).
 
 The ordering is what guarantees recoverability: if the process dies after step 2
 but before or during step 3, the record is in your WAL and replay re-applies it.
 If it dies before step 2, the write never happened from the caller's point of
-view, so there is nothing to lose. Never apply before logging — a write that
+view, so there is nothing to lose. Never apply before logging: a write that
 reaches the memtable but not the WAL is unrecoverable after a crash that drops the
 memtable.
 
-## 2. Durability points — when a seqno is safe to trim
+## 2. Durability points: when a seqno is safe to trim
 
 A write is durable once the memtable holding it has been flushed:
 
@@ -68,13 +70,13 @@ fn get_highest_persisted_seqno(&self) -> Option<SeqNo>;
 ```
 
 This returns the highest seqno present in the persisted SSTs (`None` for an empty
-tree) — the *maximum*, not a contiguity guarantee. When writes are applied in
+tree): the *maximum*, not a contiguity guarantee. When writes are applied in
 strict seqno order (the single-writer log-before-apply pattern above guarantees
 this), that maximum *is* a contiguous prefix: **every WAL record with
 `seqno <= get_highest_persisted_seqno()` is on disk and may be trimmed**. If you
 apply writes out of seqno order (concurrent appliers can flush a higher seqno
-while a lower one is still pending), the maximum is NOT contiguous — a delayed
-lower seqno may be absent from every SST — so trim only against a contiguous
+while a lower one is still pending), the maximum is NOT contiguous (a delayed
+lower seqno may be absent from every SST), so trim only against a contiguous
 applied-and-persisted prefix you track yourself, never against the raw maximum.
 
 `create_checkpoint` gives the same guarantee for a point-in-time copy: it flushes
@@ -94,15 +96,17 @@ has no log of its own to replay). After open:
 
 1. Read the durable watermark: `let durable = tree.get_highest_persisted_seqno();`
    (`None` ⇒ empty tree ⇒ replay everything).
-2. Replay every WAL record with **`seqno > durable`** (a strict lower bound — phrase
+2. Replay every WAL record with **`seqno > durable`** (a strict lower bound; phrase
    it as `> durable`, not a literal `durable + 1`, which would overflow at the top
    of the seqno range), re-applying each with its **original operation** and seqno:
-   a logged put via `insert`, a delete via `remove`, a merge via `merge`. Never
-   collapse every record to `insert` — that loses deletes and merge semantics.
+   the same call it was logged for (`insert` for a put, `remove` for a point
+   delete, `remove_range` for a range tombstone, `merge` for a merge operand, or
+   the original `WriteBatch` for a batch). Never collapse every record to `insert`,
+   which loses deletes, range tombstones, and merge semantics.
 3. Do NOT re-apply records at or below `durable`. For put / delete that would be
    harmless (re-applying at the original seqno reproduces the same MVCC version, an
    overwrite), but a **merge operand** re-applied on top of its already-persisted
-   self is folded twice by merge resolution — a counter would double-count. The
+   self is folded twice by merge resolution, so a counter would double-count. The
    strict `> durable` boundary is correct for every record type, so use it
    unconditionally rather than relying on over-replay being idempotent.
 
@@ -121,7 +125,7 @@ already knows every seqno it applied without a callback; `flush_active_memtable`
 `get_highest_persisted_seqno` reports the watermark to trim against. Adding
 callbacks would duplicate information the caller already has and couple the engine
 to a notification lifecycle it does not need. If a future requirement cannot be
-expressed through this surface, a hook trait can be added then — document-first
+expressed through this surface, a hook trait can be added then; document-first
 until proven necessary.
 
 [`SequenceNumberCounter`]: https://docs.rs/coordinode-lsm-tree/latest/lsm_tree/struct.SequenceNumberCounter.html

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -9,8 +9,8 @@ your own WAL before applying it and replay the tail on restart.
 This document specifies the contract for building that external WAL on top of the
 existing public API. No engine callbacks are required (see
 [Why no hook API](#why-no-hook-api)); the contract is expressed entirely through
-`insert`, `flush_active_memtable`, `get_highest_persisted_seqno`, and
-recover-on-open.
+the write methods (`insert`, `remove`, `remove_range`, `merge`, and `WriteBatch`),
+`flush_active_memtable`, `get_highest_persisted_seqno`, and recover-on-open.
 
 ## The sequence number is the durability cursor
 
@@ -70,14 +70,18 @@ fn get_highest_persisted_seqno(&self) -> Option<SeqNo>;
 ```
 
 This returns the highest seqno present in the persisted SSTs (`None` for an empty
-tree): the *maximum*, not a contiguity guarantee. When writes are applied in
-strict seqno order (the single-writer log-before-apply pattern above guarantees
-this), that maximum *is* a contiguous prefix: **every WAL record with
-`seqno <= get_highest_persisted_seqno()` is on disk and may be trimmed**. If you
-apply writes out of seqno order (concurrent appliers can flush a higher seqno
-while a lower one is still pending), the maximum is NOT contiguous (a delayed
-lower seqno may be absent from every SST), so trim only against a contiguous
-applied-and-persisted prefix you track yourself, never against the raw maximum.
+tree): the *maximum*, not a contiguity guarantee. A record is trimmable only once
+it has both been **applied** (its `insert` / `remove` / `merge` / ... returned)
+AND **persisted**. A record fsynced to your WAL but not yet applied (a crash
+between the log write and the apply) is absent from every SST and must stay in the
+WAL for replay, even if a later seqno was applied and flushed past it. So trim only
+a gap-free prefix of applied-and-persisted records: when you apply in strict seqno
+order and every record up to some seqno has been applied,
+`get_highest_persisted_seqno()` is that contiguous watermark and records with
+`seqno <= it` may be trimmed. If applies can be reordered or skipped (concurrent
+appliers, or a failed apply that leaves a gap), the maximum is NOT contiguous, so
+track the applied-and-persisted prefix yourself and never trim against the raw
+maximum.
 
 `create_checkpoint` gives the same guarantee for a point-in-time copy: it flushes
 the active memtable first, then hard-links every resulting SST into the checkpoint

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -44,7 +44,10 @@ For each write (or batch):
    own monotonic source).
 2. Append the record (keys, values, and the seqno) to your WAL and make it
    durable (`fsync`, or your log's equivalent).
-3. Only then call `insert(key, value, seqno)` (or a `WriteBatch` at that seqno).
+3. Only then call the original write API at that seqno (`insert` for a put,
+   `remove` for a point delete, `remove_weak` for a weak/single delete,
+   `remove_range` for a range tombstone, `merge` for a merge operand, or a
+   `WriteBatch`). Apply the same operation that was logged, not always `insert`.
 
 The ordering is what guarantees recoverability: if the process dies after step 2
 but before or during step 3, the record is in your WAL and replay re-applies it.
@@ -98,21 +101,28 @@ writes). Trim against the persisted one only.
 On `Config::open` the engine recovers its state from the persisted SSTs alone (it
 has no log of its own to replay). After open:
 
-1. Read the durable watermark: `let durable = tree.get_highest_persisted_seqno();`
-   (`None` ⇒ empty tree ⇒ replay everything).
-2. Replay every WAL record with **`seqno > durable`** (a strict lower bound; phrase
-   it as `> durable`, not a literal `durable + 1`, which would overflow at the top
-   of the seqno range), re-applying each with its **original operation** and seqno:
-   the same call it was logged for (`insert` for a put, `remove` for a point
-   delete, `remove_range` for a range tombstone, `merge` for a merge operand, or
-   the original `WriteBatch` for a batch). Never collapse every record to `insert`,
-   which loses deletes, range tombstones, and merge semantics.
-3. Do NOT re-apply records at or below `durable`. For put / delete that would be
-   harmless (re-applying at the original seqno reproduces the same MVCC version, an
+1. Recover from your **trim watermark `W`**, not the raw persisted maximum. `W` is
+   the gap-free applied-and-persisted prefix you trimmed to (section 2); replay
+   every WAL record that survived the trim, i.e. `seqno > W`. With strict gap-free
+   in-order apply `W == get_highest_persisted_seqno()`, but if you retained a lower
+   record across a gap (a logged-but-unapplied seqno below a flushed higher one) it
+   is still in the WAL and MUST be replayed, so never use the raw maximum as the
+   boundary, which would skip it. (Phrase the bound as `> W`, not a literal
+   `W + 1`, which would overflow at the top of the seqno range.)
+2. Replay each surviving record with its **original operation** and seqno: the
+   same call it was logged for (`insert` for a put, `remove` for a point delete,
+   `remove_weak` for a weak/single delete, `remove_range` for a range tombstone,
+   `merge` for a merge operand, or the original `WriteBatch` for a batch). Never
+   collapse every record to `insert`, which loses deletes, range tombstones, and
+   merge semantics.
+3. Do NOT re-apply records at or below `W`. For put / delete that would be harmless
+   (re-applying at the original seqno reproduces the same MVCC version, an
    overwrite), but a **merge operand** re-applied on top of its already-persisted
    self is folded twice by merge resolution, so a counter would double-count. The
-   strict `> durable` boundary is correct for every record type, so use it
-   unconditionally rather than relying on over-replay being idempotent.
+   strict `> W` boundary is correct for every record type, so use it
+   unconditionally rather than relying on over-replay being idempotent. For
+   merge-bearing workloads, apply gap-free so that `W` equals the persisted maximum
+   and no already-persisted operand can sit above `W` to be replayed.
 
 The strict boundary still covers the crash window in step 1 of
 [Log before apply](#1-log-before-apply): a record that was logged and applied but


### PR DESCRIPTION
## Summary

Two documentation references for the storage engine. Docs-only (no code change).

Closes #520, closes #518.

## docs/external-wal.md (#520)

The contract for building durability on top of the WAL-less engine:

- **Log before apply** — the seqno is a caller input to `insert`, so it is the cursor that ties WAL records to engine state; log + sync the record, then apply.
- **Durability points** — `flush_active_memtable` returning `Ok` makes every seqno in the flushed memtable durable; `get_highest_persisted_seqno` is the watermark to trim the WAL against (distinct from `get_highest_seqno`); `create_checkpoint` for point-in-time copies.
- **Recovery replay** — on open the engine recovers from SSTs alone; replay the WAL from `get_highest_persisted_seqno() + 1`, idempotent because re-applying a record at its original seqno reproduces the same MVCC version.
- Resolves the open question: the existing public API expresses the full contract, so no engine hook trait is added (documented why).

## docs/INVARIANTS.md (#518)

The engine's load-bearing invariants, each as **rule + why + where enforced** (module / test), so a reviewer can check "does this change violate invariant X?" without re-deriving the contract. Grouped by subsystem: SST block layout + zone map, filter (AMQ no-false-negative), block cache coherence, manifest, compaction, file lifecycle & concurrency, snapshot / seqno, range tombstones, merge operators, recovery / ECC, encryption-at-rest AAD binding, key-value separation (BlobTree), columnar / delete-bitmap.

The set goes beyond the originally enumerated subsystems: the filter no-false-negative property, block-cache coherence, the file-reference lifecycle + single-writer directory lock, the AAD position binding, and the blob-pointer / GC invariant are all load-bearing correctness contracts that were previously only implicit in code.

## README

Both docs linked from the README (external-wal.md from the no-WAL trade-off section; INVARIANTS.md alongside the data-integrity / tight-space references).

## Testing

Docs-only: pure Markdown, no `///` rustdoc touched and no `include_str!`, so there is no build, lint, or doctest impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an external write-ahead log guide describing the required log-before-apply workflow, durability timing, checkpoint flush behavior, and recovery replay/trim boundaries (including special merge replay handling).
  * Introduced a living “storage engine invariants” reference with subsystem-grouped correctness rules covering data layout, filters, caching, compaction/MVCC, recovery/ECC, encryption authenticity, lifecycle, and snapshot/seqno semantics.
  * Updated the README to link to the new external-WAL and invariants references for clearer checkpointing and data integrity guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->