### PR TITLE
feat: compaction-debt write-backpressure verdict

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,12 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Performance regression check
+    # Two passes in one job: (1) the single-engine db_bench trend (regression
+    # guard + dev/bench dashboard) and (2) the RocksDB head-to-head compare
+    # (public dev/compare overlay dashboard). The name reflects both so it does
+    # not read as a lightweight gate — it is the full public benchmark suite,
+    # and it builds RocksDB from C++ source, so it is minutes, not seconds.
+    name: db_bench trend + RocksDB head-to-head
     # Self-hosted bare-metal runner. Shared GitHub-hosted runners
     # have ±15-20% noise on every db_bench workload — large enough
     # to hide every win below ~20% and produce false-positive
@@ -58,11 +63,15 @@ jobs:
     # self-hosted runners (if added later) without the label
     # won't pick the job up.
     runs-on: [self-hosted, gpu-private-systems]
-    # The db_bench pass is seconds; the compare-rocksdb head-to-head pass
-    # uses a half-second criterion window per scenario (a few minutes for
-    # the whole matrix). The cap mainly bounds the first-run librocksdb-sys
-    # C++ compile and catches a runaway regression early.
-    timeout-minutes: 30
+    # The db_bench pass is seconds and the compare-rocksdb criterion matrix
+    # is a few minutes (half-second window per scenario). The dominant cost is
+    # the first-run / cold-cache librocksdb-sys C++ compile (RocksDB built from
+    # source via bindgen): on a cold rust-cache that alone is 15-25 min, so a
+    # 30 min cap was too tight and the job was cancelled mid-compile, producing
+    # no dashboard at all. 60 min leaves headroom for a cold RocksDB build plus
+    # both bench passes while still catching a genuinely runaway run. A warm
+    # cache finishes in a few minutes well under this.
+    timeout-minutes: 60
     steps:
       # v6 requires runner ≥2.327.1 (node24 runtime) — the self-hosted
       # runner has a current runner agent that satisfies this.

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -196,6 +196,29 @@ pub trait AbstractTree: sealed::Sealed {
         strategy.pending_compaction_bytes(&self.current_version())
     }
 
+    /// Computed write-backpressure verdict from the live L0 table count and the
+    /// strategy's pending-compaction bytes, against the configured
+    /// [`RuntimeConfig::backpressure`](crate::runtime_config::RuntimeConfig)
+    /// thresholds.
+    ///
+    /// Advisory, mirroring [`write_admission`](Self::write_admission): the caller
+    /// consults it and throttles in its own write loop (sleep `suggested_delay`
+    /// at [`Slowdown`](crate::Backpressure::Slowdown), pause at
+    /// [`Stop`](crate::Backpressure::Stop)). The engine never blocks on it,
+    /// because it does not own the compaction that drains the debt — an internal
+    /// stall could deadlock the very thread that would compact.
+    ///
+    /// The strategy is supplied by the caller for the same reason as
+    /// [`compaction_debt`](Self::compaction_debt). Returns
+    /// [`Backpressure::None`](crate::Backpressure::None) by default (no
+    /// thresholds configured).
+    fn write_backpressure(
+        &self,
+        _strategy: &dyn crate::compaction::CompactionStrategy,
+    ) -> crate::Backpressure {
+        crate::Backpressure::None
+    }
+
     /// Storage admission gate: `Ok(())` if a write may proceed, or
     /// [`Error::StorageFull`](crate::Error::StorageFull) if the tree is
     /// over budget and should be treated as read-only.

--- a/src/backpressure.rs
+++ b/src/backpressure.rs
@@ -209,15 +209,22 @@ fn ramp_u64(value: u64, soft: u64, hard: Option<u64>, cap: Duration) -> Duration
     }
 }
 
-/// `cap * num / den` in nanoseconds, saturating, with `num < den`.
+/// `cap * num / den` in nanoseconds, exact, with `num < den`.
 fn scale(cap: Duration, num: u64, den: u64) -> Duration {
     if den == 0 {
         return cap;
     }
-    // num < den (stop tier handled before any ramp), so the result nanos are at
-    // most cap's nanos and round-trip back into a Duration. The multiply is on
-    // u128 and saturates, so it cannot overflow.
-    let nanos = cap.as_nanos().saturating_mul(u128::from(num)) / u128::from(den);
+    // Apply the fraction WITHOUT forming `cap_nanos * num` first: for a
+    // near-`Duration::MAX` cap and a wide span that product can exceed u128, and
+    // saturating it would distort the ramp (collapsing it far below the intended
+    // proportion). This mulDiv decomposition is exact and overflow-free given the
+    // `num < den` invariant: the quotient term `(cap_nanos / den) * num` is
+    // <= cap_nanos (since num <= den), and the remainder term's product
+    // `(cap_nanos % den) * num` is < den * num < u128::MAX (both factors < u64::MAX).
+    let cap_nanos = cap.as_nanos();
+    let num = u128::from(num);
+    let den = u128::from(den);
+    let nanos = (cap_nanos / den) * num + ((cap_nanos % den) * num) / den;
     // secs <= cap.as_secs() (which is a u64), so try_from never actually
     // saturates here; the fallback is defensive only.
     let secs = u64::try_from(nanos / 1_000_000_000).unwrap_or(u64::MAX);

--- a/src/backpressure.rs
+++ b/src/backpressure.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Computed write-backpressure verdict.
+//!
+//! The engine is a library: `insert` is synchronous and non-blocking, and flush
+//! plus compaction are driven by the caller, not by an engine-owned thread. So
+//! backpressure is a **verdict the caller consults**, not an internal stall: the
+//! engine would deadlock if it blocked a write on compaction debt draining, since
+//! the blocked thread may be the one that runs compaction. This mirrors the
+//! storage-admission predicate ([`crate::AbstractTree::write_admission`]).
+//!
+//! [`Backpressure`] is computed from two independent signals against
+//! caller-configured thresholds (see the `*_slowdown` / `*_stop` fields on
+//! [`RuntimeConfig`](crate::runtime_config::RuntimeConfig)):
+//!
+//! - **L0 table count** — count-triggered, the same signal the leveled `choose`
+//!   trigger uses; a tall L0 is what spikes read amplification.
+//! - **Pending compaction bytes** — the size-target debt the strategy reports.
+//!
+//! The verdict is the more severe of the two axes. With every threshold unset the
+//! verdict is always [`Backpressure::None`], so the feature is off by default and
+//! the write path is unchanged.
+
+use core::time::Duration;
+
+/// Thresholds that drive the [`Backpressure`] verdict. Every field is opt-in:
+/// `None` disables that axis. With all fields `None` the verdict is always
+/// [`Backpressure::None`].
+///
+/// A `slowdown` threshold without its matching `stop` (or vice versa) is honoured
+/// independently: the axis still produces the tier whose threshold is set.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BackpressureThresholds {
+    /// L0 table count at or above which the verdict is at least
+    /// [`Backpressure::Slowdown`].
+    pub l0_slowdown: Option<usize>,
+    /// L0 table count at or above which the verdict is [`Backpressure::Stop`].
+    pub l0_stop: Option<usize>,
+    /// Pending-compaction bytes at or above which the verdict is at least
+    /// [`Backpressure::Slowdown`].
+    pub bytes_slowdown: Option<u64>,
+    /// Pending-compaction bytes at or above which the verdict is
+    /// [`Backpressure::Stop`].
+    pub bytes_stop: Option<u64>,
+    /// The slowdown delay returned at the stop threshold. The actual
+    /// [`Backpressure::Slowdown`] delay ramps linearly from zero at the slowdown
+    /// threshold to this cap at the stop threshold, so there is no cliff between
+    /// healthy and stopped. `None` (or `Duration::ZERO`) makes a slowdown tier
+    /// report a zero-length delay (advisory tier only).
+    pub max_slowdown: Option<Duration>,
+}
+
+impl BackpressureThresholds {
+    /// All axes disabled: the verdict is always [`Backpressure::None`]. The
+    /// default, and a usable `const` for config construction.
+    pub const OFF: Self = Self {
+        l0_slowdown: None,
+        l0_stop: None,
+        bytes_slowdown: None,
+        bytes_stop: None,
+        max_slowdown: None,
+    };
+
+    /// `true` when no axis is configured, so the verdict is always
+    /// [`Backpressure::None`]. The hot path checks this first to skip the
+    /// version inspection entirely.
+    #[must_use]
+    pub const fn is_off(&self) -> bool {
+        self.l0_slowdown.is_none()
+            && self.l0_stop.is_none()
+            && self.bytes_slowdown.is_none()
+            && self.bytes_stop.is_none()
+    }
+}
+
+/// A computed write-backpressure verdict.
+///
+/// Advisory: the caller honours it in its own write loop (sleep at
+/// [`Slowdown`](Backpressure::Slowdown), pause / shed at
+/// [`Stop`](Backpressure::Stop)). The engine never blocks on it.
+///
+/// # Example
+///
+/// The caller consults the verdict before a write and honours it. Tracking how
+/// long it spent throttled is the caller's own metric (the engine cannot observe
+/// caller-side sleep time):
+///
+/// ```
+/// use core::time::Duration;
+/// use lsm_tree::Backpressure;
+///
+/// /// Returns how long the caller should pause before this write (zero = proceed).
+/// fn honour(verdict: Backpressure) -> Duration {
+///     match verdict {
+///         Backpressure::None => Duration::ZERO,
+///         Backpressure::Slowdown { suggested_delay } => suggested_delay,
+///         // Stop: pause / shed load until a later verdict drops below stop.
+///         Backpressure::Stop => Duration::from_millis(50),
+///     }
+/// }
+///
+/// assert_eq!(honour(Backpressure::None), Duration::ZERO);
+/// assert_eq!(
+///     honour(Backpressure::Slowdown { suggested_delay: Duration::from_micros(200) }),
+///     Duration::from_micros(200),
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backpressure {
+    /// The tree is within its target shape; write at full rate.
+    None,
+    /// The tree is past a slowdown threshold but below stop. The caller should
+    /// delay each write by `suggested_delay` to let compaction catch up. The
+    /// delay grows with the overage (zero at the slowdown threshold, up to the
+    /// configured cap at the stop threshold).
+    Slowdown {
+        /// The recommended per-write delay.
+        suggested_delay: Duration,
+    },
+    /// The tree is at or past a stop threshold. The caller should stop admitting
+    /// writes until a later verdict drops back below stop (the verdict is
+    /// computed, not latched, so it clears as soon as compaction drains).
+    Stop,
+}
+
+impl Backpressure {
+    /// Compute the verdict from the two live signals against `thresholds`.
+    ///
+    /// Pure and allocation-free so it is unit-testable without a tree. The result
+    /// is the more severe of the L0-count and pending-bytes axes; the slowdown
+    /// delay is the larger of the two axes' ramped delays.
+    #[must_use]
+    pub fn compute(
+        l0_table_count: usize,
+        pending_bytes: u64,
+        thresholds: &BackpressureThresholds,
+    ) -> Self {
+        if thresholds.is_off() {
+            return Self::None;
+        }
+
+        // Stop dominates: if either axis is at its stop threshold, stop.
+        let l0_stop = thresholds.l0_stop.is_some_and(|t| l0_table_count >= t);
+        let bytes_stop = thresholds.bytes_stop.is_some_and(|t| pending_bytes >= t);
+        if l0_stop || bytes_stop {
+            return Self::Stop;
+        }
+
+        // Otherwise, the slowdown tier if either axis is past its slowdown
+        // threshold. The delay is the larger ramp across the two axes.
+        let cap = thresholds.max_slowdown.unwrap_or(Duration::ZERO);
+        let mut delay = Duration::ZERO;
+        let mut slowing = false;
+
+        if let Some(soft) = thresholds.l0_slowdown
+            && l0_table_count >= soft
+        {
+            slowing = true;
+            delay = delay.max(ramp_usize(l0_table_count, soft, thresholds.l0_stop, cap));
+        }
+        if let Some(soft) = thresholds.bytes_slowdown
+            && pending_bytes >= soft
+        {
+            slowing = true;
+            delay = delay.max(ramp_u64(pending_bytes, soft, thresholds.bytes_stop, cap));
+        }
+
+        if slowing {
+            Self::Slowdown {
+                suggested_delay: delay,
+            }
+        } else {
+            Self::None
+        }
+    }
+
+    /// `true` for any tier above [`Backpressure::None`].
+    #[must_use]
+    pub const fn is_throttled(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Linear ramp of `value` in `[soft, hard)` onto `[0, cap]`. Without a `hard`
+/// bound the delay sits at `cap` once `value >= soft` (no interval to ramp over).
+fn ramp_usize(value: usize, soft: usize, hard: Option<usize>, cap: Duration) -> Duration {
+    match hard {
+        // hard > soft: linear fraction of the cap. `value` is in `[soft, hard)`
+        // here (stop tier was already handled), so `0 <= num < den`.
+        Some(hard) if hard > soft => {
+            let num = (value - soft) as u64;
+            let den = (hard - soft) as u64;
+            scale(cap, num, den)
+        }
+        _ => cap,
+    }
+}
+
+/// `u64` twin of [`ramp_usize`].
+fn ramp_u64(value: u64, soft: u64, hard: Option<u64>, cap: Duration) -> Duration {
+    match hard {
+        Some(hard) if hard > soft => {
+            let num = value - soft;
+            let den = hard - soft;
+            scale(cap, num, den)
+        }
+        _ => cap,
+    }
+}
+
+/// `cap * num / den` in nanoseconds, saturating, with `num < den`.
+fn scale(cap: Duration, num: u64, den: u64) -> Duration {
+    if den == 0 {
+        return cap;
+    }
+    // num < den (stop tier handled before any ramp), so the result nanos are at
+    // most cap's nanos and round-trip back into a Duration. The multiply is on
+    // u128 and saturates, so it cannot overflow.
+    let nanos = cap.as_nanos().saturating_mul(u128::from(num)) / u128::from(den);
+    // secs <= cap.as_secs() (which is a u64), so try_from never actually
+    // saturates here; the fallback is defensive only.
+    let secs = u64::try_from(nanos / 1_000_000_000).unwrap_or(u64::MAX);
+    // n % 1_000_000_000 is < 1e9 < u32::MAX, so the subsec nanos fit u32.
+    let sub = (nanos % 1_000_000_000) as u32;
+    Duration::new(secs, sub)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backpressure/tests.rs
+++ b/src/backpressure/tests.rs
@@ -149,6 +149,29 @@ fn stop_without_slowdown_threshold_jumps_straight_to_stop() {
 }
 
 #[test]
+fn scale_ramp_stays_proportional_for_huge_cap_and_span() {
+    // Regression: `scale` must apply the fraction without saturating the
+    // numerator first. With a near-`Duration::MAX` cap and a span wide enough
+    // that `cap_nanos * num` overflows `u128`, saturating the product first
+    // collapses the ramp far below its intended proportion. A half ramp must
+    // stay ~half the cap (and never exceed it).
+    let cap = Duration::MAX;
+    let den = u64::MAX;
+    let num = den / 2;
+
+    let got = scale(cap, num, den);
+
+    assert!(got <= cap, "a ramped delay never exceeds the cap");
+    let half_secs = cap.as_secs() / 2;
+    assert!(
+        got.as_secs() >= half_secs - 1,
+        "a half ramp stays proportional (got {}s, expected ~{}s)",
+        got.as_secs(),
+        half_secs,
+    );
+}
+
+#[test]
 fn is_throttled_reflects_tier() {
     assert!(!Backpressure::None.is_throttled());
     assert!(

--- a/src/backpressure/tests.rs
+++ b/src/backpressure/tests.rs
@@ -1,0 +1,161 @@
+use super::*;
+
+fn thresholds() -> BackpressureThresholds {
+    BackpressureThresholds {
+        l0_slowdown: Some(8),
+        l0_stop: Some(16),
+        bytes_slowdown: Some(1_000),
+        bytes_stop: Some(4_000),
+        max_slowdown: Some(Duration::from_millis(10)),
+    }
+}
+
+#[test]
+fn off_thresholds_are_always_none() {
+    let off = BackpressureThresholds::default();
+    assert!(off.is_off());
+    // Even at absurd signal levels, an unconfigured policy never throttles.
+    assert_eq!(
+        Backpressure::compute(1_000_000, u64::MAX, &off),
+        Backpressure::None
+    );
+}
+
+#[test]
+fn below_all_thresholds_is_none() {
+    assert_eq!(
+        Backpressure::compute(0, 0, &thresholds()),
+        Backpressure::None
+    );
+    assert_eq!(
+        Backpressure::compute(7, 999, &thresholds()),
+        Backpressure::None
+    );
+}
+
+#[test]
+fn l0_count_at_slowdown_threshold_yields_zero_delay_slowdown() {
+    // Exactly at the slowdown trigger: throttled, but the ramp delay is zero
+    // (no overage yet), so there is no cliff entering the tier.
+    let v = Backpressure::compute(8, 0, &thresholds());
+    assert_eq!(
+        v,
+        Backpressure::Slowdown {
+            suggested_delay: Duration::ZERO
+        }
+    );
+}
+
+#[test]
+fn l0_count_at_stop_threshold_yields_stop() {
+    assert_eq!(
+        Backpressure::compute(16, 0, &thresholds()),
+        Backpressure::Stop
+    );
+    assert_eq!(
+        Backpressure::compute(100, 0, &thresholds()),
+        Backpressure::Stop
+    );
+}
+
+#[test]
+fn bytes_axis_drives_the_verdict_independently() {
+    // L0 healthy, but pending bytes past slowdown -> Slowdown.
+    assert!(matches!(
+        Backpressure::compute(0, 2_000, &thresholds()),
+        Backpressure::Slowdown { .. }
+    ));
+    // Pending bytes at stop -> Stop regardless of L0.
+    assert_eq!(
+        Backpressure::compute(0, 4_000, &thresholds()),
+        Backpressure::Stop
+    );
+}
+
+#[test]
+fn stop_dominates_slowdown_across_axes() {
+    // L0 only at slowdown, bytes at stop -> Stop wins.
+    assert_eq!(
+        Backpressure::compute(8, 4_000, &thresholds()),
+        Backpressure::Stop
+    );
+}
+
+#[test]
+fn slowdown_delay_grows_monotonically_with_overage() {
+    let t = thresholds();
+    // Walk L0 from soft (8) toward hard (16); the suggested delay must be
+    // non-decreasing and stay below the cap until stop.
+    let mut last = Duration::ZERO;
+    for count in 8..16 {
+        let Backpressure::Slowdown { suggested_delay } = Backpressure::compute(count, 0, &t) else {
+            panic!("expected Slowdown at L0={count}");
+        };
+        assert!(
+            suggested_delay >= last,
+            "delay must not decrease (L0={count})"
+        );
+        assert!(
+            suggested_delay < Duration::from_millis(10),
+            "below cap until stop"
+        );
+        last = suggested_delay;
+    }
+}
+
+#[test]
+fn slowdown_delay_is_max_of_both_axes() {
+    // L0 just past soft (small ramp) but bytes near stop (large ramp): the
+    // larger ramp wins.
+    let t = thresholds();
+    let Backpressure::Slowdown { suggested_delay } = Backpressure::compute(9, 3_900, &t) else {
+        panic!("expected Slowdown");
+    };
+    // bytes ramp at 3900/4000 of the interval [1000,4000] = ~9.67ms, well above
+    // the L0 ramp at 1/8 of [8,16] = ~1.25ms.
+    assert!(suggested_delay > Duration::from_millis(8));
+}
+
+#[test]
+fn slowdown_without_stop_threshold_sits_at_cap() {
+    // Only a slowdown trigger configured (no stop): once past it, the delay is
+    // the cap (no interval to ramp over), and it never escalates to Stop.
+    let t = BackpressureThresholds {
+        l0_slowdown: Some(4),
+        l0_stop: None,
+        bytes_slowdown: None,
+        bytes_stop: None,
+        max_slowdown: Some(Duration::from_millis(5)),
+    };
+    assert_eq!(
+        Backpressure::compute(100, 0, &t),
+        Backpressure::Slowdown {
+            suggested_delay: Duration::from_millis(5)
+        }
+    );
+}
+
+#[test]
+fn stop_without_slowdown_threshold_jumps_straight_to_stop() {
+    let t = BackpressureThresholds {
+        l0_slowdown: None,
+        l0_stop: Some(10),
+        bytes_slowdown: None,
+        bytes_stop: None,
+        max_slowdown: None,
+    };
+    assert_eq!(Backpressure::compute(9, 0, &t), Backpressure::None);
+    assert_eq!(Backpressure::compute(10, 0, &t), Backpressure::Stop);
+}
+
+#[test]
+fn is_throttled_reflects_tier() {
+    assert!(!Backpressure::None.is_throttled());
+    assert!(
+        Backpressure::Slowdown {
+            suggested_delay: Duration::ZERO
+        }
+        .is_throttled()
+    );
+    assert!(Backpressure::Stop.is_throttled());
+}

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -467,6 +467,16 @@ impl AbstractTree for BlobTree {
         self.index.write_admission()
     }
 
+    fn write_backpressure(
+        &self,
+        strategy: &dyn crate::compaction::CompactionStrategy,
+    ) -> crate::Backpressure {
+        // Same delegation as write_admission: the index tree holds the runtime
+        // config and its version is this blob tree's version, so the L0-count
+        // and pending-compaction-bytes signals are computed on the right state.
+        self.index.write_backpressure(strategy)
+    }
+
     #[cfg(feature = "metrics")]
     fn cache_stats(&self) -> crate::CacheStats {
         self.index.cache_stats()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,9 @@ mod abstract_tree;
 pub(crate) mod deletion_pause;
 pub mod heal_hints;
 
+/// Computed write-backpressure verdict (caller-honoured, see [`backpressure`]).
+pub mod backpressure;
+
 // `checkpoint` is `pub(crate)`: it contains internal helpers
 // (`link_or_copy_cross_fs`, `prepare_target`, `run_checkpoint`) used by
 // `Tree::create_checkpoint` and `BlobTree::create_checkpoint`. Exposing
@@ -513,6 +516,8 @@ pub use compression::ZstdDictionary;
 
 #[cfg(feature = "metrics")]
 pub use metrics::{CacheStats, Metrics};
+
+pub use backpressure::{Backpressure, BackpressureThresholds};
 
 #[cfg(feature = "std")]
 #[doc(hidden)]

--- a/src/runtime_config/types.rs
+++ b/src/runtime_config/types.rs
@@ -925,6 +925,17 @@ pub struct RuntimeConfig {
     ///
     /// Toggle takes effect on the next compaction cycle.
     pub tight_space_compaction: bool,
+
+    /// Opt-in write-backpressure thresholds. With every field `None` (default)
+    /// the verdict is always [`crate::Backpressure::None`] and the write path is
+    /// byte-for-byte unchanged. When set,
+    /// [`crate::AbstractTree::write_backpressure`] reports a `Slowdown` / `Stop`
+    /// verdict from the live L0 table count and pending compaction bytes, which
+    /// the caller honours in its own write loop (the engine never blocks
+    /// internally — it does not own the compaction that would drain the debt).
+    /// Live-toggleable: the verdict is computed, not latched, so it clears as
+    /// soon as compaction drains below the thresholds.
+    pub backpressure: crate::backpressure::BackpressureThresholds,
 }
 
 impl Default for RuntimeConfig {
@@ -952,6 +963,7 @@ impl Default for RuntimeConfig {
             storage_admission_check: false,
             storage_limit_bytes: None,
             tight_space_compaction: false,
+            backpressure: crate::backpressure::BackpressureThresholds::OFF,
         }
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -444,6 +444,29 @@ impl AbstractTree for Tree {
         self.compute_write_admission()
     }
 
+    fn write_backpressure(
+        &self,
+        strategy: &dyn crate::compaction::CompactionStrategy,
+    ) -> crate::Backpressure {
+        // Copy the thresholds out (BackpressureThresholds is Copy) so the
+        // arc-swap guard drops immediately; the off check short-circuits before
+        // touching the version, keeping the disabled path free.
+        let thresholds = self.0.runtime_config.load().backpressure;
+        if thresholds.is_off() {
+            return crate::Backpressure::None;
+        }
+        let version = self.current_version();
+        // L0 is the first level; its table (file) count is the count-trigger
+        // signal, matching the leveled `choose` trigger and the L0 term of
+        // `pending_compaction_bytes`.
+        let l0_count = version
+            .iter_levels()
+            .next()
+            .map_or(0, |level| level.table_count());
+        let pending = strategy.pending_compaction_bytes(&version);
+        crate::Backpressure::compute(l0_count, pending, &thresholds)
+    }
+
     fn get_flush_lock(&self) -> FlushGuard<'_> {
         self.flush_lock.lock()
     }

--- a/tests/write_backpressure.rs
+++ b/tests/write_backpressure.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! End-to-end tests for the opt-in computed write-backpressure verdict
+//! ([`AbstractTree::write_backpressure`]): the L0-count signal driving the
+//! Slowdown then Stop tiers, the off-by-default no-op, live re-configuration,
+//! and BlobTree delegation. The pure tier/ramp arithmetic is unit-tested in
+//! `src/backpressure/tests.rs`; here we prove the wiring reads the live version
+//! and the runtime config.
+
+use core::time::Duration;
+use lsm_tree::compaction::Leveled;
+use lsm_tree::{
+    AbstractTree, AnyTree, Backpressure, BackpressureThresholds, Config, KvSeparationOptions,
+    SequenceNumberCounter, get_tmp_folder,
+};
+use std::sync::Arc;
+
+fn open_tree(path: &std::path::Path) -> lsm_tree::Tree {
+    match Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open")
+    {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    }
+}
+
+fn open_blob_tree(path: &std::path::Path) -> lsm_tree::BlobTree {
+    match Config::new(
+        path,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default().separation_threshold(1)))
+    .open()
+    .expect("open")
+    {
+        AnyTree::Blob(t) => t,
+        AnyTree::Standard(_) => panic!("expected Blob tree"),
+    }
+}
+
+/// Flush one non-empty memtable, adding exactly one L0 table (compaction is
+/// caller-driven, so nothing merges L0 underneath us).
+fn add_l0_table(tree: &lsm_tree::Tree, round: u64) {
+    tree.insert(
+        format!("k{round:05}").as_bytes(),
+        b"payload".as_slice(),
+        round,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+}
+
+#[test]
+fn backpressure_off_by_default_is_none() {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    // Build a tall L0 with no thresholds configured: the verdict stays None.
+    for round in 0..6 {
+        add_l0_table(&tree, round);
+    }
+    assert_eq!(
+        tree.write_backpressure(&Leveled::default()),
+        Backpressure::None,
+        "off-by-default must never throttle, regardless of L0 height"
+    );
+}
+
+#[test]
+fn l0_count_drives_slowdown_then_stop() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let strat = Leveled::default();
+
+    // Isolate the L0-count axis (bytes axis unset) for a deterministic test:
+    // each flush adds exactly one L0 table.
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: Some(2),
+            l0_stop: Some(4),
+            bytes_slowdown: None,
+            bytes_stop: None,
+            max_slowdown: Some(Duration::from_millis(5)),
+        };
+    })?;
+
+    // 0 L0 tables: below the slowdown trigger.
+    assert_eq!(tree.write_backpressure(&strat), Backpressure::None);
+
+    // 2 L0 tables: at the slowdown trigger.
+    add_l0_table(&tree, 0);
+    add_l0_table(&tree, 1);
+    assert!(
+        matches!(
+            tree.write_backpressure(&strat),
+            Backpressure::Slowdown { .. }
+        ),
+        "two L0 tables must reach the slowdown tier"
+    );
+
+    // 4 L0 tables: at the stop trigger.
+    add_l0_table(&tree, 2);
+    add_l0_table(&tree, 3);
+    assert_eq!(
+        tree.write_backpressure(&strat),
+        Backpressure::Stop,
+        "four L0 tables must reach the stop tier"
+    );
+    Ok(())
+}
+
+#[test]
+fn thresholds_are_live_toggleable() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let strat = Leveled::default();
+
+    for round in 0..4 {
+        add_l0_table(&tree, round);
+    }
+
+    // Turn the policy on with a low stop trigger: the existing L0 height now
+    // reports Stop (the verdict is computed, not latched).
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: Some(1),
+            l0_stop: Some(2),
+            bytes_slowdown: None,
+            bytes_stop: None,
+            max_slowdown: Some(Duration::from_millis(1)),
+        };
+    })?;
+    assert_eq!(tree.write_backpressure(&strat), Backpressure::Stop);
+
+    // Turn it back off: same L0 height, verdict clears immediately.
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds::OFF;
+    })?;
+    assert_eq!(tree.write_backpressure(&strat), Backpressure::None);
+    Ok(())
+}
+
+#[test]
+fn draining_compaction_clears_the_verdict() -> lsm_tree::Result<()> {
+    // Closed loop: honouring Stop means the caller drains via compaction, which
+    // must clear the verdict (it is computed on the live version, not latched).
+    // Paired with `backpressure_off_by_default_is_none` (which lets L0 grow with
+    // no signal), this proves the verdict is a real, actionable signal.
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let strat = Arc::new(Leveled::default());
+
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: Some(2),
+            l0_stop: Some(4),
+            bytes_slowdown: None,
+            bytes_stop: None,
+            max_slowdown: Some(Duration::from_millis(5)),
+        };
+    })?;
+
+    for round in 0..5 {
+        add_l0_table(&tree, round);
+    }
+    assert_eq!(
+        tree.write_backpressure(&*strat),
+        Backpressure::Stop,
+        "five L0 tables must be at the stop tier before draining"
+    );
+
+    // Honour the signal by draining: a full compaction folds L0 into deeper
+    // levels, dropping the L0 count below the stop trigger.
+    tree.compact(strat.clone(), u64::MAX)?;
+    assert_ne!(
+        tree.write_backpressure(&*strat),
+        Backpressure::Stop,
+        "a draining compaction must clear the Stop verdict"
+    );
+    Ok(())
+}
+
+#[test]
+fn blob_tree_delegates_backpressure_to_index() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let tree = open_blob_tree(folder.path());
+    let strat = Leveled::default();
+
+    // Runtime config lives on the index tree (the blob tree forwards reads /
+    // version through it); the backpressure override delegates there too.
+    tree.index.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: Some(1),
+            l0_stop: Some(2),
+            bytes_slowdown: None,
+            bytes_stop: None,
+            max_slowdown: Some(Duration::from_millis(1)),
+        };
+    })?;
+
+    // Off before any L0 tables.
+    assert_eq!(tree.write_backpressure(&strat), Backpressure::None);
+
+    // Two flushes of the index tree -> stop tier, observed through the blob
+    // tree's delegating override.
+    for round in 0..2u64 {
+        tree.insert(
+            format!("k{round:05}").as_bytes(),
+            b"payload".as_slice(),
+            round,
+        );
+        tree.flush_active_memtable(0).expect("flush");
+    }
+    assert_eq!(tree.write_backpressure(&strat), Backpressure::Stop);
+    Ok(())
+}

--- a/tests/write_backpressure.rs
+++ b/tests/write_backpressure.rs
@@ -2,11 +2,11 @@
 // Copyright (c) 2026-present, Structured World Foundation
 
 //! End-to-end tests for the opt-in computed write-backpressure verdict
-//! ([`AbstractTree::write_backpressure`]): the L0-count signal driving the
-//! Slowdown then Stop tiers, the off-by-default no-op, live re-configuration,
-//! and BlobTree delegation. The pure tier/ramp arithmetic is unit-tested in
-//! `src/backpressure/tests.rs`; here we prove the wiring reads the live version
-//! and the runtime config.
+//! ([`AbstractTree::write_backpressure`]): the L0-count and pending-compaction-
+//! bytes signals driving the Slowdown then Stop tiers, the off-by-default no-op,
+//! live re-configuration, and BlobTree delegation. The pure tier/ramp arithmetic
+//! is unit-tested in `src/backpressure/tests.rs`; here we prove the wiring reads
+//! the live version and the runtime config.
 
 use core::time::Duration;
 use lsm_tree::compaction::Leveled;
@@ -181,6 +181,58 @@ fn draining_compaction_clears_the_verdict() -> lsm_tree::Result<()> {
         tree.write_backpressure(&*strat),
         Backpressure::Stop,
         "a draining compaction must clear the Stop verdict"
+    );
+    Ok(())
+}
+
+#[test]
+fn bytes_axis_drives_verdict_with_l0_axis_off() -> lsm_tree::Result<()> {
+    // Prove the wiring forwards `strategy.pending_compaction_bytes(&version)`
+    // into the verdict, independent of the L0-count axis. Leveled counts L0's
+    // whole size as pending once L0 reaches its file threshold (default 4), so
+    // four flushed tables give a non-zero pending-bytes signal.
+    let folder = get_tmp_folder();
+    let tree = open_tree(folder.path());
+    let strat = Leveled::default();
+
+    for round in 0..4 {
+        add_l0_table(&tree, round);
+    }
+
+    // L0-count axis OFF; only the bytes axis armed. Non-zero pending bytes are
+    // past the slowdown trigger (1), with the stop trigger out of reach.
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: None,
+            l0_stop: None,
+            bytes_slowdown: Some(1),
+            bytes_stop: Some(u64::MAX),
+            max_slowdown: Some(Duration::from_millis(5)),
+        };
+    })?;
+    assert!(
+        matches!(
+            tree.write_backpressure(&strat),
+            Backpressure::Slowdown { .. }
+        ),
+        "non-zero pending compaction bytes must throttle via the bytes axis alone"
+    );
+
+    // Lower the stop trigger so the same pending bytes now reach Stop: the bytes
+    // axis drives both tiers, not just slowdown.
+    tree.update_runtime_config(|c| {
+        c.backpressure = BackpressureThresholds {
+            l0_slowdown: None,
+            l0_stop: None,
+            bytes_slowdown: Some(1),
+            bytes_stop: Some(1),
+            max_slowdown: Some(Duration::from_millis(5)),
+        };
+    })?;
+    assert_eq!(
+        tree.write_backpressure(&strat),
+        Backpressure::Stop,
+        "pending bytes at/above the stop trigger reach the stop tier via the bytes axis"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds an opt-in, caller-honoured write-backpressure signal. `write_backpressure()` computes a `Backpressure` verdict (`None` / `Slowdown { suggested_delay }` / `Stop`) from the live L0 table count and the strategy's pending-compaction bytes against configurable `RuntimeConfig` thresholds, mirroring the storage-admission predicate (#484).

Closes #547.

## Design (computed signal, not internal blocking)

The engine is a library: `insert` is synchronous and non-blocking, and flush + compaction are caller-driven. So backpressure is a verdict the caller consults and honours in its own write loop (sleep at `Slowdown`, pause / shed at `Stop`); the engine never blocks internally on debt draining, which would deadlock the very thread that runs compaction. With every threshold unset (default) the verdict is always `None` and the write path is byte-for-byte unchanged.

The `Slowdown` delay ramps linearly from zero at the slowdown threshold to a configured cap at the stop threshold (no cliff). Thresholds are live-toggleable; the verdict is computed, not latched. `BlobTree` delegates to its index tree.

Observability of time-spent-throttled is caller-owned (documented): the engine is pull-model and cannot observe caller-side sleep, so the caller advances its own metric.

## Changes

- `src/backpressure.rs` (+ tests): `Backpressure` enum + `BackpressureThresholds` + pure `compute()`.
- `src/runtime_config/types.rs`: `backpressure` field, default OFF.
- `src/abstract_tree.rs`: `write_backpressure(&dyn CompactionStrategy)` trait method (default `None`).
- `src/tree/mod.rs`, `src/blob_tree/mod.rs`: overrides (Tree computes; BlobTree delegates).
- `tests/write_backpressure.rs`: 5 integration tests.
- `.github/workflows/benchmark.yml`: raise the bench timeout 30m -> 60m and rename the job to reflect it is the full public bench suite (cold librocksdb-sys compile was being cancelled at 30m).

## Testing

11 unit + 5 integration (L0 -> Slowdown -> Stop, off-by-default no-op, live-toggle, BlobTree delegation, drain-clears-verdict closed loop) + 1 doctest. Gate: clippy `--all-features --all-targets` clean, no_std check 0/0, nextest lz4,zstd 2126 + columnar 2210, doctests 66.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added computed write backpressure for trees using live runtime thresholds based on L0 buildup and pending compaction bytes (with slowdown delays and stop behavior).
  * Exposed new backpressure API via the main library interface, and applied the same behavior to blob-backed trees through delegation.

* **Bug Fixes**
  * Improved benchmark workflow reliability by clarifying benchmark labeling and increasing the job timeout to better accommodate cold-cache builds and both benchmark passes.

* **Tests**
  * Added unit and end-to-end coverage validating verdict tiers, monotonic delay behavior, live threshold updates, and blob-tree delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->