### PR TITLE
feat(columnar): delete-density rewrite, read-path perf, backpressure + zstd fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,6 +373,12 @@ path = "benches/scan_since.rs"
 required-features = []
 
 [[bench]]
+name = "columnar"
+harness = false
+path = "benches/columnar.rs"
+required-features = ["columnar"]
+
+[[bench]]
 name = "at_insert"
 harness = false
 path = "benches/at_insert.rs"

--- a/benches/columnar.rs
+++ b/benches/columnar.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Columnar (PAX) read-path benchmark matrix: row-major vs columnar, with and
+//! without per-block zone maps. The columnar layout's wins and overhead
+//! boundaries are otherwise unproven on the bench; this exercises them
+//! end-to-end through the public read API, which reconstructs rows from columnar
+//! blocks transparently.
+//!
+//!   - `columnar/full_scan` — iterate every row. Columnar pays the
+//!     transpose-back-to-row cost here, so this is the overhead boundary.
+//!   - `columnar/point_lookup` — random `get`; the layout must not regress the
+//!     point-read path.
+//!
+//! Three layouts per operation: `row` (baseline), `columnar`, and
+//! `columnar+zonemap`.
+
+#![cfg(feature = "columnar")]
+#![expect(
+    clippy::expect_used,
+    reason = "benchmark setup favors concise panic messages"
+)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lsm_tree::runtime_config::RuntimeConfig;
+use lsm_tree::{AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, Tree};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Layout {
+    columnar: bool,
+    zone_map: bool,
+    label: &'static str,
+}
+
+const LAYOUTS: [Layout; 3] = [
+    Layout {
+        columnar: false,
+        zone_map: false,
+        label: "row",
+    },
+    Layout {
+        columnar: true,
+        zone_map: false,
+        label: "columnar",
+    },
+    Layout {
+        columnar: true,
+        zone_map: true,
+        label: "columnar+zonemap",
+    },
+];
+
+/// Build a freshly-flushed single-run tree of `n` entries under `layout`.
+fn build_tree(layout: Layout, n: u64) -> (TempDir, Tree) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut rc = RuntimeConfig::default();
+    rc.columnar = layout.columnar;
+    rc.zone_map = layout.zone_map;
+    let any = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_runtime_config(rc)
+    .open()
+    .expect("open");
+    let tree = match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..n {
+        tree.insert(
+            format!("key{i:08}").as_bytes(),
+            format!("value-{i:08}-payload").as_bytes(),
+            i,
+        );
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    (dir, tree)
+}
+
+/// Run `iters` timed invocations of `op` for Criterion's `iter_custom`, also
+/// recording each op's individual latency and printing P50/P99/P999 to stderr so
+/// a tail regression the aggregate would hide still surfaces.
+fn timed_with_tail<F: FnMut()>(label: &str, iters: u64, mut op: F) -> std::time::Duration {
+    use std::time::Instant;
+    let mut samples = Vec::with_capacity(iters as usize);
+    let started = Instant::now();
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        op();
+        samples.push(t0.elapsed());
+    }
+    let total = started.elapsed();
+    if !samples.is_empty() {
+        samples.sort_unstable();
+        let pct =
+            |per_mille: usize| samples[(samples.len() * per_mille / 1000).min(samples.len() - 1)];
+        eprintln!(
+            "{label}: p50={:?} p99={:?} p999={:?}",
+            pct(500),
+            pct(990),
+            pct(999)
+        );
+    }
+    total
+}
+
+/// Full-row scan: the columnar overhead boundary (rows are transposed back from
+/// columns). Every layout must return the same row count.
+fn bench_full_scan(c: &mut Criterion) {
+    let n = 100_000u64;
+    let mut group = c.benchmark_group("columnar/full_scan");
+    for layout in LAYOUTS {
+        let (_dir, tree) = build_tree(layout, n);
+        let count = tree.iter(SeqNo::MAX, None).count();
+        assert_eq!(
+            count as u64, n,
+            "[{}] full scan must see every row",
+            layout.label
+        );
+
+        group.bench_function(layout.label, |b| {
+            b.iter_custom(|iters| {
+                timed_with_tail(layout.label, iters, || {
+                    let c = tree.iter(SeqNo::MAX, None).count();
+                    std::hint::black_box(c);
+                })
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Point-lookup cost: the layout must not regress `get`. Random-ish key order via
+/// a multiplicative hash, precomputed so the timed loop measures only `get`.
+fn bench_point_lookup(c: &mut Criterion) {
+    let n = 100_000u64;
+    let keys: Vec<Vec<u8>> = (0..n)
+        .map(|i| {
+            let idx = i.wrapping_mul(2_654_435_761) % n;
+            format!("key{idx:08}").into_bytes()
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("columnar/point_lookup");
+    for layout in LAYOUTS {
+        let (_dir, tree) = build_tree(layout, n);
+        group.bench_function(layout.label, |b| {
+            let mut i = 0usize;
+            b.iter_custom(|iters| {
+                timed_with_tail(layout.label, iters, || {
+                    let key = &keys[i % keys.len()];
+                    i = i.wrapping_add(1);
+                    let v = tree.get(key, SeqNo::MAX).expect("get");
+                    std::hint::black_box(v);
+                })
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_full_scan, bench_point_lookup);
+criterion_main!(benches);

--- a/benches/columnar.rs
+++ b/benches/columnar.rs
@@ -85,7 +85,7 @@ fn build_tree(layout: Layout, n: u64) -> (TempDir, Tree) {
 /// a tail regression the aggregate would hide still surfaces.
 fn timed_with_tail<F: FnMut()>(label: &str, iters: u64, mut op: F) -> std::time::Duration {
     use std::time::Instant;
-    let mut samples = Vec::with_capacity(iters as usize);
+    let mut samples = Vec::with_capacity(usize::try_from(iters).unwrap_or(0));
     let started = Instant::now();
     for _ in 0..iters {
         let t0 = Instant::now();

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -152,6 +152,11 @@ pub trait CompactionStrategy: Send + Sync {
     }
 
     /// Decides on what to do based on the current state of the LSM-tree's levels
+    ///
+    /// This is the purely *structural* decision (level shape, run counts, size
+    /// targets); it deliberately does not see the live runtime config. The
+    /// orchestrator layers the runtime-config-driven housekeeping fallback on
+    /// top (the density-based columnar rewrite).
     fn choose(&self, version: &Version, config: &Config, state: &CompactionState) -> Choice;
 
     /// Estimated bytes pending compaction: on-disk data currently sitting above
@@ -166,4 +171,100 @@ pub trait CompactionStrategy: Send + Sync {
     fn pending_compaction_bytes(&self, _version: &Version) -> u64 {
         0
     }
+}
+
+/// Runs a strategy's structural decision and, only when it would otherwise idle,
+/// layers the runtime-config-driven density rewrite on top.
+///
+/// This keeps [`CompactionStrategy::choose`] purely structural (no runtime-config
+/// dependency) while applying the housekeeping fallback uniformly to every
+/// strategy at the orchestration layer, where the live `runtime_config` already
+/// lives. The fallback never preempts real work: it only fires when `choose`
+/// returned [`Choice::DoNothing`], and [`pick_density_rewrite`] self-gates to a
+/// no-op unless a level runs an [`Adaptive`](crate::config::DeleteStrategy::Adaptive)
+/// strategy and holds a dense-enough segment.
+pub(crate) fn choose_with_density_rewrite(
+    strategy: &dyn CompactionStrategy,
+    version: &Version,
+    config: &Config,
+    runtime_config: &crate::runtime_config::RuntimeConfig,
+    state: &CompactionState,
+) -> Choice {
+    let structural = strategy.choose(version, config, state);
+    if matches!(structural, Choice::DoNothing)
+        && let Some(input) = pick_density_rewrite(version, runtime_config, state)
+    {
+        return Choice::Merge(input);
+    }
+    structural
+}
+
+/// Picks a columnar segment whose positional delete-bitmap density has grown
+/// past its level's adaptive purge threshold, for a single-input materializing
+/// rewrite: the masked scan drops the dead rows and the fresh segment carries no
+/// bitmap, reclaiming the merge-on-read mask cost paid on every scan.
+///
+/// Returns the densest eligible candidate, or `None` when no level runs an
+/// [`Adaptive`](crate::config::DeleteStrategy::Adaptive) strategy (a fixed
+/// `CopyOnWrite` never accumulates a bitmap, a fixed `MergeOnRead` never purges)
+/// or no live segment is dense enough. Segments already enrolled in another
+/// compaction (`hidden_set`) are skipped. This self-gating is why the orchestrator
+/// can apply it uniformly after any strategy.
+///
+/// The live `runtime_config` (not the boot snapshot) supplies the per-level
+/// threshold, so an operator's `update_runtime_config` takes effect. The rewrite
+/// targets the candidate's own on-disk size, so the single survivor run stays one
+/// segment.
+pub(crate) fn pick_density_rewrite(
+    version: &Version,
+    runtime_config: &crate::runtime_config::RuntimeConfig,
+    state: &CompactionState,
+) -> Option<Input> {
+    // (density, id, level, file_size) of the densest eligible candidate.
+    let mut best: Option<(u8, TableId, usize, u64)> = None;
+    for (level_idx, level) in version.iter_levels().enumerate() {
+        let crate::config::DeleteStrategy::Adaptive {
+            purge_threshold_percent,
+        } = runtime_config.delete_strategy.get(level_idx)
+        else {
+            continue;
+        };
+        for table in level.iter().flat_map(|run| run.iter()) {
+            if state.hidden_set().is_hidden(table.id()) {
+                continue;
+            }
+            let Some(density) = table.delete_density() else {
+                continue;
+            };
+            if density < purge_threshold_percent {
+                continue;
+            }
+            let take = match best {
+                None => true,
+                Some((best_density, _, _, _)) => density > best_density,
+            };
+            if take {
+                best = Some((density, table.id(), level_idx, table.file_size()));
+            }
+        }
+    }
+
+    let (_, table_id, level_idx, file_size) = best?;
+    let mut table_ids = HashSet::default();
+    table_ids.insert(table_id);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "level index is bounded by level count (<= 7, technically 255)"
+    )]
+    let level = level_idx as u8;
+    Some(Input {
+        table_ids,
+        // In-place single-input rewrite: dest == source level. The masked scan
+        // materializes the survivors; plan_merge_on_read declines a
+        // bitmap-carrying source, so this runs the copy-on-write merge path.
+        dest_level: level,
+        canonical_level: level,
+        // Target the source's own size so the survivor run stays a single segment.
+        target_size: file_size,
+    })
 }

--- a/src/compaction/tiered/mod.rs
+++ b/src/compaction/tiered/mod.rs
@@ -237,6 +237,36 @@ impl CompactionStrategy for Strategy {
         ]
     }
 
+    fn pending_compaction_bytes(&self, version: &Version) -> u64 {
+        // Tiered debt mirrors the space-amplification trigger in `choose`: the
+        // bytes by which total L0 size exceeds the budget
+        // `largest_run * (1 + max_space_amplification_percent / 100)`. This makes
+        // the bytes-axis backpressure (bytes_slowdown / bytes_stop) engage for
+        // size-tiered trees, not only leveled. All runs are counted, including
+        // any already being compacted: the redundancy is on disk until the full
+        // compaction lands. Zero with fewer than two runs (nothing to reclaim).
+        let l0 = version.l0();
+        let mut total: u128 = 0;
+        let mut largest: u128 = 0;
+        let mut run_count = 0usize;
+        for run in l0.iter() {
+            let size: u128 = run.iter().map(|t| u128::from(Table::file_size(t))).sum();
+            total += size;
+            largest = largest.max(size);
+            run_count += 1;
+        }
+        if run_count < 2 || largest == 0 {
+            return 0;
+        }
+        // Same *100-scaled comparison as `choose` (avoids f64 precision loss);
+        // `rhs` saturates so an effectively unbounded threshold yields zero debt.
+        let lhs = total * 100;
+        let rhs = largest.saturating_mul(100 + u128::from(self.max_space_amplification_percent));
+        // saturating_sub: debt floors at zero by definition (none within budget).
+        let debt = lhs.saturating_sub(rhs) / 100;
+        u64::try_from(debt).unwrap_or(u64::MAX)
+    }
+
     fn choose(&self, version: &Version, _: &Config, state: &CompactionState) -> Choice {
         let runs = collect_available_runs(version, state);
 

--- a/src/compaction/tiered/tests.rs
+++ b/src/compaction/tiered/tests.rs
@@ -467,3 +467,32 @@ fn stcs_pending_compaction_bytes_reflects_space_amplification() -> crate::Result
 
     Ok(())
 }
+
+#[test]
+fn stcs_pending_compaction_bytes_is_zero_below_two_runs() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    let strategy = Strategy::default().with_max_space_amplification_percent(0);
+
+    // Empty tree: no runs, nothing to reclaim.
+    assert_eq!(
+        strategy.pending_compaction_bytes(&tree.current_version()),
+        0
+    );
+
+    // A single run cannot be space-amplified against itself, so even a 0% budget
+    // owes nothing.
+    flush_overlapping(&tree, 1, 0)?;
+    assert_eq!(
+        strategy.pending_compaction_bytes(&tree.current_version()),
+        0
+    );
+
+    Ok(())
+}

--- a/src/compaction/tiered/tests.rs
+++ b/src/compaction/tiered/tests.rs
@@ -432,3 +432,38 @@ fn stcs_dissimilar_sizes_break() -> crate::Result<()> {
     assert_eq!(2, tree.table_count());
     Ok(())
 }
+
+#[test]
+fn stcs_pending_compaction_bytes_reflects_space_amplification() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+
+    // 5 similarly-sized overlapping runs: space_amp ~ (5S/S - 1) * 100 = 400%.
+    flush_overlapping(&tree, 5, 0)?;
+    let version = tree.current_version();
+
+    // Past the 200% budget, the size-tiered strategy owes a full compaction, so
+    // it must report non-zero pending bytes for the bytes-axis backpressure to
+    // engage (it returned a flat 0 before, leaving bytes_slowdown/bytes_stop
+    // inert for tiered).
+    let over_budget = Strategy::default().with_max_space_amplification_percent(200);
+    assert!(
+        over_budget.pending_compaction_bytes(&version) > 0,
+        "tiered must report pending bytes when over the space-amplification budget"
+    );
+
+    // A tolerant (effectively unbounded) budget owes nothing.
+    let tolerant = Strategy::default().with_max_space_amplification_percent(u64::MAX);
+    assert_eq!(
+        tolerant.pending_compaction_bytes(&version),
+        0,
+        "no debt when amplification is fully tolerated"
+    );
+
+    Ok(())
+}

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -142,9 +142,15 @@ pub fn do_compaction(opts: &Options) -> crate::Result<CompactionResult> {
         "Consulting compaction strategy {:?}",
         opts.strategy.get_name(),
     );
-    let choice = opts.strategy.choose(
+    // Structural decision plus the runtime-config-driven density-rewrite
+    // fallback (applied here, where the live runtime config lives, so the
+    // structural strategies stay free of it).
+    let runtime_config = opts.runtime_config.load_full();
+    let choice = super::choose_with_density_rewrite(
+        &*opts.strategy,
         &version_history_lock.latest_version().version,
         &opts.config,
+        &runtime_config,
         &compaction_state,
     );
 

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -357,7 +357,9 @@ impl CompressionType {
 
     /// Validate a zstd compression level.
     ///
-    /// Accepts levels in the range 1..=22 and returns an error otherwise.
+    /// Accepts levels in the range `-128..=22` (zstd negative "fast" levels and
+    /// `0` = default included; the on-disk format persists the level in one
+    /// signed byte) and returns an error otherwise.
     #[cfg(zstd_any)]
     fn validate_zstd_level(level: i32) -> crate::Result<()> {
         // zstd accepts negative "fast" levels (down to a very negative minimum)

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -313,9 +313,11 @@ pub enum CompressionType {
     /// Recommended for cold/archival data where compression ratio
     /// matters more than raw speed.
     // NOTE: Uses i32 (not a validated newtype) to match upstream's public API and
-    // the zstd crate's compress(data, level: i32) signature. Validated levels are
-    // produced by CompressionType::zstd() and Decode::decode_from; direct construction
-    // via CompressionType::Zstd(level) must uphold the 1..=22 invariant.
+    // the zstd crate's compress(data, level: i32) signature. zstd accepts negative
+    // "fast" levels and 0 (= default) as well as 1..=22; the on-disk format stores
+    // the level in one signed byte, so the persistable range is -128..=22. Validated
+    // levels are produced by CompressionType::zstd() and Decode::decode_from; direct
+    // construction via CompressionType::Zstd(level) must uphold the -128..=22 invariant.
     #[cfg(zstd_any)]
     Zstd(i32),
 
@@ -358,11 +360,16 @@ impl CompressionType {
     /// Accepts levels in the range 1..=22 and returns an error otherwise.
     #[cfg(zstd_any)]
     fn validate_zstd_level(level: i32) -> crate::Result<()> {
-        if !(1..=22).contains(&level) {
+        // zstd accepts negative "fast" levels (down to a very negative minimum)
+        // plus 0 (= default) and 1..=22. The on-disk format stores the level as a
+        // single signed byte, so the persistable range is `i8::MIN..=22`; a level
+        // below `i8::MIN` is rejected here rather than silently truncated by the
+        // `as i8` cast in `encode_into`.
+        if !(i32::from(i8::MIN)..=22).contains(&level) {
             // NOTE: Uses Error::other (not ErrorKind::InvalidInput) to match
             // upstream's error style and minimize fork divergence.
             return Err(crate::Error::Io(crate::io::Error::other(format!(
-                "invalid zstd compression level {level}, expected 1..=22"
+                "invalid zstd compression level {level}, expected -128..=22"
             ))));
         }
         Ok(())
@@ -375,7 +382,9 @@ impl CompressionType {
     ///
     /// # Errors
     ///
-    /// Returns an error if `level` is outside the valid range `1..=22`.
+    /// Returns an error if `level` is outside the valid range `-128..=22` (zstd
+    /// negative "fast" levels and `0` = default are accepted; the on-disk format
+    /// stores the level in one signed byte).
     #[cfg(zstd_any)]
     pub fn zstd(level: i32) -> crate::Result<Self> {
         Self::validate_zstd_level(level)?;
@@ -390,7 +399,9 @@ impl CompressionType {
     ///
     /// # Errors
     ///
-    /// Returns an error if `level` is outside the valid range `1..=22`.
+    /// Returns an error if `level` is outside the valid range `-128..=22` (zstd
+    /// negative "fast" levels and `0` = default are accepted; the on-disk format
+    /// stores the level in one signed byte).
     #[cfg(zstd_any)]
     pub fn zstd_dict(level: i32, dict_id: u32) -> crate::Result<Self> {
         Self::validate_zstd_level(level)?;
@@ -437,12 +448,12 @@ impl Encode for CompressionType {
                 // Catch invalid levels in debug builds (e.g. direct Zstd(999) construction).
                 // Not a runtime error — encoding must stay infallible for encode_into_vec().
                 debug_assert!(
-                    (1..=22).contains(level),
-                    "zstd level {level} outside valid range 1..=22"
+                    (i32::from(i8::MIN)..=22).contains(level),
+                    "zstd level {level} outside valid range -128..=22"
                 );
                 #[expect(
                     clippy::cast_possible_truncation,
-                    reason = "level range 1..=22 fits i8"
+                    reason = "level range -128..=22 maps exactly to i8"
                 )]
                 writer.write_i8(*level as i8)?;
             }
@@ -451,12 +462,12 @@ impl Encode for CompressionType {
             Self::ZstdDict { level, dict_id } => {
                 writer.write_u8(4)?;
                 debug_assert!(
-                    (1..=22).contains(level),
-                    "zstd level {level} outside valid range 1..=22"
+                    (i32::from(i8::MIN)..=22).contains(level),
+                    "zstd level {level} outside valid range -128..=22"
                 );
                 #[expect(
                     clippy::cast_possible_truncation,
-                    reason = "level range 1..=22 fits i8"
+                    reason = "level range -128..=22 maps exactly to i8"
                 )]
                 writer.write_i8(*level as i8)?;
                 crate::io::WriteBytesExt::write_u32::<crate::io::LittleEndian>(writer, *dict_id)?;

--- a/src/compression/tests.rs
+++ b/src/compression/tests.rs
@@ -47,28 +47,58 @@ mod zstd {
     }
 
     #[test]
-    fn compression_zstd_rejects_invalid_level() {
-        for invalid_level in [0, 23, -1, 200] {
+    fn compression_zstd_rejects_out_of_range_level() {
+        // Above the zstd max (22), or below what one signed byte can persist
+        // (i8::MIN); negative "fast" levels and 0 are valid (see the round-trip
+        // test below).
+        for invalid_level in [23, 100, 200, -129, i32::MIN] {
             let result = CompressionType::zstd(invalid_level);
             assert!(result.is_err(), "level {invalid_level} should be rejected");
         }
     }
 
     #[test]
+    fn compression_zstd_accepts_negative_and_default_levels() {
+        // zstd negative "fast" levels, 0 (= default), and 1..=22 all serialize and
+        // round-trip through the single-signed-byte wire format.
+        for level in [-128, -22, -1, 0, 1, 3, 22] {
+            let original = CompressionType::zstd(level)
+                .unwrap_or_else(|_| panic!("level {level} must be accepted"));
+            let serialized = original.encode_into_vec();
+            let decoded =
+                CompressionType::decode_from(&mut &serialized[..]).expect("decode failed");
+            assert_eq!(original, decoded, "level {level} must round-trip");
+        }
+    }
+
+    #[test]
+    fn compression_roundtrip_zstd_negative_level() {
+        // A negative fast level must produce a valid frame that decompresses back
+        // to the original (the level only affects the compressor's strategy, not
+        // the self-describing frame format).
+        use super::CompressionProvider;
+        let data = b"the quick brown fox jumps over the lazy dog".repeat(64);
+        let compressed = super::ZstdBackend::compress(&data, -22).expect("compress at -22");
+        let back = super::ZstdBackend::decompress(&compressed, data.len()).expect("decompress");
+        assert_eq!(back, data, "a negative-level frame round-trips");
+    }
+
+    #[test]
     fn compression_zstd_decode_rejects_invalid_level() {
-        // Serialize a valid zstd value, then corrupt the level byte
+        // Serialize a valid zstd value, then corrupt the level byte to a value
+        // above the zstd max (the wire is a signed byte, so only 23..=127 are
+        // out of the accepted -128..=22 range).
         let valid = CompressionType::Zstd(3).encode_into_vec();
         assert_eq!(valid.len(), 2);
 
-        // Flip level byte to 0 (out of range 1..=22)
-        let corrupted = vec![valid[0], 0];
-        let result = CompressionType::decode_from(&mut &corrupted[..]);
-        assert!(result.is_err(), "level 0 should be rejected on decode");
-
-        // Flip level byte to 23 (out of range)
-        let corrupted = vec![valid[0], 23];
-        let result = CompressionType::decode_from(&mut &corrupted[..]);
-        assert!(result.is_err(), "level 23 should be rejected on decode");
+        for invalid in [23u8, 100] {
+            let corrupted = vec![valid[0], invalid];
+            let result = CompressionType::decode_from(&mut &corrupted[..]);
+            assert!(
+                result.is_err(),
+                "level {invalid} should be rejected on decode"
+            );
+        }
     }
 
     #[test]
@@ -110,8 +140,10 @@ mod zstd {
     }
 
     #[test]
-    fn compression_zstd_dict_rejects_invalid_level() {
-        for invalid_level in [0, 23, -1, 200] {
+    fn compression_zstd_dict_rejects_out_of_range_level() {
+        // Negative "fast" levels and 0 are valid; only above the zstd max (22) or
+        // below the i8 the wire can persist are rejected.
+        for invalid_level in [23, 100, 200, -129, i32::MIN] {
             let result = CompressionType::zstd_dict(invalid_level, 42);
             assert!(result.is_err(), "level {invalid_level} should be rejected");
         }
@@ -119,17 +151,17 @@ mod zstd {
 
     #[test]
     fn compression_zstd_dict_decode_rejects_invalid_level() {
-        // Serialize a valid ZstdDict, then corrupt the level byte to 0
+        // Serialize a valid ZstdDict, then corrupt the level byte above the max.
         let mut buf = CompressionType::ZstdDict {
             level: 3,
             dict_id: 42,
         }
         .encode_into_vec();
         assert_eq!(buf[0], 4); // tag
-        buf[1] = 0; // corrupt level to 0 (out of range 1..=22)
+        buf[1] = 100; // corrupt level to 100 (above the zstd max of 22)
 
         let result = CompressionType::decode_from(&mut &buf[..]);
-        assert!(result.is_err(), "level 0 should be rejected on decode");
+        assert!(result.is_err(), "level 100 should be rejected on decode");
     }
 
     #[test]

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1235,6 +1235,13 @@ pub fn column_batch_match_entries(
 ) -> Result<Vec<InternalValue>> {
     let (key_col, seqno_col, vt_col, value_cols) = validate_columnar_columns(batch)?;
     let row_count = batch.row_count;
+    if row_count == 0 {
+        // A zero-row block is malformed; fail closed like the scan path rather
+        // than returning an empty match the caller reads as an absent key.
+        return Err(Error::InvalidHeader(
+            "columnar: empty reconstructed data block",
+        ));
+    }
 
     // Lower bound: first row whose key is `>= needle` (keys are block-index
     // sorted: user_key ASC, seqno DESC).

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1216,6 +1216,83 @@ fn bytes_row_slice(data: &Slice, row_count: u32, i: u32) -> Result<Slice> {
     Ok(data.slice(payload_start..payload_end))
 }
 
+/// Reconstructs only the rows whose key equals `needle`, for the columnar
+/// point-read path.
+///
+/// Binary-searches the key column to the first row `>= needle`, then collects the
+/// contiguous `== needle` run as entries (newest-first, matching block order),
+/// skipping rows masked by the positional delete-bitmap. Returns an empty vec
+/// when the key is absent (or every matching row is deleted). The caller
+/// re-encodes this handful of rows into a tiny block and runs the normal
+/// seqno-aware point read, so a columnar point read decodes the block once and
+/// touches one key's rows instead of untransposing and re-encoding the whole
+/// block.
+pub fn column_batch_match_entries(
+    batch: &ColumnBatch,
+    needle: &[u8],
+    comparator: &crate::comparator::SharedComparator,
+    deletes: Option<(&crate::table::delete_bitmap::DeleteBitmap, u32)>,
+) -> Result<Vec<InternalValue>> {
+    let (key_col, seqno_col, vt_col, value_cols) = validate_columnar_columns(batch)?;
+    let row_count = batch.row_count;
+
+    // Lower bound: first row whose key is `>= needle` (keys are block-index
+    // sorted: user_key ASC, seqno DESC).
+    let mut lo = 0u32;
+    let mut hi = row_count;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let k = bytes_column_row(&key_col.data, row_count, mid)?;
+        if comparator.compare(k, needle) == core::cmp::Ordering::Less {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+
+    // Collect the contiguous `== needle` run from `lo`, skipping masked rows.
+    let mut out = Vec::new();
+    let mut row = lo;
+    while row < row_count {
+        let k = bytes_column_row(&key_col.data, row_count, row)?;
+        if comparator.compare(k, needle) != core::cmp::Ordering::Equal {
+            break;
+        }
+        let masked = deletes.is_some_and(|(bitmap, start)| {
+            start
+                .checked_add(row)
+                .is_some_and(|pos| bitmap.contains(pos))
+        });
+        if !masked {
+            // Match the engine's key invariants (non-empty, u16 length).
+            if k.is_empty() || k.len() > u16::MAX as usize {
+                return Err(Error::InvalidHeader(
+                    "columnar: user key is empty or longer than u16::MAX",
+                ));
+            }
+            let seqno = fixed_u64_row(&seqno_col.data, row)?;
+            let vt_byte = vt_col
+                .data
+                .get(row as usize)
+                .copied()
+                .ok_or(Error::InvalidHeader("columnar: value-type row truncated"))?;
+            let value_type = ValueType::try_from(vt_byte)
+                .map_err(|()| Error::InvalidTag(("ValueType", vt_byte)))?;
+            let value = reconstruct_row_value(value_cols, row_count, row)?;
+            out.push(InternalValue {
+                key: InternalKey {
+                    user_key: Slice::from(k),
+                    seqno,
+                    value_type,
+                },
+                value,
+            });
+        }
+        row += 1;
+    }
+    Ok(out)
+}
+
 /// Frames one row's value sub-column cells into a single self-describing value
 /// blob.
 ///

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1104,6 +1104,118 @@ pub fn column_batch_to_entries(batch: &ColumnBatch) -> Result<Vec<InternalValue>
     Ok(out)
 }
 
+/// Consuming, allocation-light counterpart to [`column_batch_to_entries`] for
+/// the scan path.
+///
+/// The key column and a single non-nullable bytes value column are taken as
+/// shared [`Slice`]s, so each row's key / value is a view into one buffer
+/// (zero-copy for the Arc-backed large-value case) instead of a per-row copy.
+/// Any other value layout (fixed-width, multiple sub-columns, or nullable) falls
+/// back to the per-row framing reconstruction.
+pub fn column_batch_into_entries(batch: ColumnBatch) -> Result<Vec<InternalValue>> {
+    // Structural validation (intrinsic columns + framing) before we consume.
+    validate_columnar_columns(&batch)?;
+    let row_count = batch.row_count;
+    let mut cols = batch.columns.into_iter();
+    let key_col = cols
+        .next()
+        .ok_or(Error::InvalidHeader("columnar: missing key column"))?;
+    let seqno_col = cols
+        .next()
+        .ok_or(Error::InvalidHeader("columnar: missing seqno column"))?;
+    let vt_col = cols
+        .next()
+        .ok_or(Error::InvalidHeader("columnar: missing value-type column"))?;
+    let value_cols: Vec<Column> = cols.collect();
+
+    // Shared key buffer: every row's key is a view into it.
+    let key_data = Slice::from(key_col.data);
+
+    // A single non-nullable bytes value column lets every row's value be a view
+    // into one shared buffer; otherwise reconstruct (frame / fixed-width) per row.
+    let single_bytes_value = matches!(
+        value_cols.as_slice(),
+        [c] if c.type_tag == TypeTag::Bytes && c.validity.is_none()
+    );
+    let value_source = if single_bytes_value {
+        let single = value_cols
+            .into_iter()
+            .next()
+            .ok_or(Error::InvalidHeader("columnar: value column vanished"))?;
+        ValueSource::SharedBytes(Slice::from(single.data))
+    } else {
+        ValueSource::Reconstruct(value_cols)
+    };
+
+    let mut out = Vec::with_capacity(row_count as usize);
+    for i in 0..row_count {
+        let user_key = bytes_row_slice(&key_data, row_count, i)?;
+        // Same key invariants as column_batch_to_entries (non-empty, u16 length).
+        if user_key.is_empty() || user_key.len() > u16::MAX as usize {
+            return Err(Error::InvalidHeader(
+                "columnar: user key is empty or longer than u16::MAX",
+            ));
+        }
+        let seqno = fixed_u64_row(&seqno_col.data, i)?;
+        let vt_byte = vt_col
+            .data
+            .get(i as usize)
+            .copied()
+            .ok_or(Error::InvalidHeader("columnar: value-type row truncated"))?;
+        let value_type =
+            ValueType::try_from(vt_byte).map_err(|()| Error::InvalidTag(("ValueType", vt_byte)))?;
+        let value = match &value_source {
+            ValueSource::SharedBytes(data) => bytes_row_slice(data, row_count, i)?,
+            ValueSource::Reconstruct(cols) => reconstruct_row_value(cols, row_count, i)?,
+        };
+        out.push(InternalValue {
+            key: InternalKey {
+                user_key,
+                seqno,
+                value_type,
+            },
+            value,
+        });
+    }
+    Ok(out)
+}
+
+/// Per-row value source for [`column_batch_into_entries`]: a shared bytes buffer
+/// (zero-copy views) or the per-row framing reconstruction.
+enum ValueSource {
+    SharedBytes(Slice),
+    Reconstruct(Vec<Column>),
+}
+
+/// Returns row `i` of a [`TypeTag::Bytes`] column body as a zero-copy [`Slice`]
+/// view into `data` (the column's shared buffer), bounds-checked.
+fn bytes_row_slice(data: &Slice, row_count: u32, i: u32) -> Result<Slice> {
+    let bytes: &[u8] = data.as_ref();
+    let off_bytes = (row_count as usize + 1) * 4;
+    let read_off = |idx: u32| -> Result<usize> {
+        let base = idx as usize * 4;
+        let b = bytes
+            .get(base..base + 4)
+            .ok_or(Error::InvalidHeader("columnar: bytes offset truncated"))?;
+        let arr: [u8; 4] = b
+            .try_into()
+            .map_err(|_| Error::InvalidHeader("columnar: short bytes offset"))?;
+        Ok(u32::from_le_bytes(arr) as usize)
+    };
+    let start = read_off(i)?;
+    let end = read_off(i + 1)?;
+    let payload_start = off_bytes.checked_add(start).ok_or(Error::InvalidHeader(
+        "columnar: bytes payload offset overflow",
+    ))?;
+    let payload_end = off_bytes.checked_add(end).ok_or(Error::InvalidHeader(
+        "columnar: bytes payload offset overflow",
+    ))?;
+    if start > end || payload_end > bytes.len() {
+        return Err(Error::InvalidHeader("columnar: bytes row out of range"));
+    }
+    Ok(data.slice(payload_start..payload_end))
+}
+
 /// Frames one row's value sub-column cells into a single self-describing value
 /// blob.
 ///

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -1258,11 +1258,16 @@ pub fn column_batch_match_entries(
         if comparator.compare(k, needle) != core::cmp::Ordering::Equal {
             break;
         }
-        let masked = deletes.is_some_and(|(bitmap, start)| {
-            start
-                .checked_add(row)
-                .is_some_and(|pos| bitmap.contains(pos))
-        });
+        let masked = if let Some((bitmap, start)) = deletes {
+            // Fail closed on a corrupt block_start_row: an overflowing position
+            // must error like the scan path, never silently expose the row.
+            let pos = start.checked_add(row).ok_or(Error::InvalidHeader(
+                "columnar: row position exceeds u32::MAX",
+            ))?;
+            bitmap.contains(pos)
+        } else {
+            false
+        };
         if !masked {
             // Match the engine's key invariants (non-empty, u16 length).
             if k.is_empty() || k.len() > u16::MAX as usize {

--- a/src/table/columnar/tests.rs
+++ b/src/table/columnar/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
-    column_batch_to_entries, entries_to_column_batch, frame_value_cells,
-    frame_value_cells_nullable, unframe_value_cells, unframe_value_cells_nullable,
-    unframe_value_cells_with_defaults, validate_columnar_ingest_batch,
+    column_batch_into_entries, column_batch_match_entries, column_batch_to_entries,
+    entries_to_column_batch, frame_value_cells, frame_value_cells_nullable, unframe_value_cells,
+    unframe_value_cells_nullable, unframe_value_cells_with_defaults,
+    validate_columnar_ingest_batch,
 };
 use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
 
@@ -845,4 +846,37 @@ fn columnar_decode_rejects_non_zero_bytes_width() {
     // The Bytes column's width byte (must be 0) is at byte 34.
     encoded[34] = 5;
     assert!(ColumnBatch::decode(&encoded).is_err());
+}
+
+#[test]
+fn column_batch_into_entries_rejects_an_empty_key_row() {
+    // A corrupt block can frame an empty key (offset table [0, 0], no payload) —
+    // a byte layout the structural validator accepts. The scan reconstruction
+    // must reject it rather than emit an empty-keyed entry.
+    let mut batch =
+        entries_to_column_batch(&[entry(b"k", 5, ValueType::Value, b"v")]).expect("valid batch");
+    let key_col = batch.columns.get_mut(0).expect("key column");
+    key_col.data = alloc::vec![0u8; 8];
+    let err = column_batch_into_entries(batch).expect_err("empty key must be rejected");
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(m) if m.contains("user key is empty")),
+        "expected an empty-key InvalidHeader, got {err:?}",
+    );
+}
+
+#[test]
+fn column_batch_match_entries_rejects_an_empty_key_row() {
+    // The point-read matcher applies the same non-empty-key invariant as the
+    // scan path: a matched empty key in a corrupt block is an error, not a hit.
+    let mut batch =
+        entries_to_column_batch(&[entry(b"k", 5, ValueType::Value, b"v")]).expect("valid batch");
+    let key_col = batch.columns.get_mut(0).expect("key column");
+    key_col.data = alloc::vec![0u8; 8];
+    let cmp = crate::comparator::default_comparator();
+    let err = column_batch_match_entries(&batch, b"", &cmp, None)
+        .expect_err("matched empty key must be rejected");
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(m) if m.contains("user key is empty")),
+        "expected an empty-key InvalidHeader, got {err:?}",
+    );
 }

--- a/src/table/columnar/tests.rs
+++ b/src/table/columnar/tests.rs
@@ -901,3 +901,19 @@ fn column_batch_match_entries_fails_closed_when_a_delete_mask_position_overflows
         "expected an overflow InvalidHeader, got {err:?}",
     );
 }
+
+#[test]
+fn column_batch_match_entries_rejects_a_zero_row_block() {
+    // A zero-row columnar block is malformed (the writer never emits one). The
+    // point-read matcher must fail closed on it, not return an empty match that
+    // load_columnar_point_block would turn into an absent-key miss, hiding the
+    // on-disk corruption.
+    let batch = entries_to_column_batch(&[]).expect("zero-row batch");
+    let cmp = crate::comparator::default_comparator();
+    let err = column_batch_match_entries(&batch, b"x", &cmp, None)
+        .expect_err("a zero-row block must fail closed");
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(m) if m.contains("empty reconstructed data block")),
+        "expected an empty-block InvalidHeader, got {err:?}",
+    );
+}

--- a/src/table/columnar/tests.rs
+++ b/src/table/columnar/tests.rs
@@ -880,3 +880,24 @@ fn column_batch_match_entries_rejects_an_empty_key_row() {
         "expected an empty-key InvalidHeader, got {err:?}",
     );
 }
+
+#[test]
+fn column_batch_match_entries_fails_closed_when_a_delete_mask_position_overflows() {
+    // Two rows share a key, so both match the needle. With `block_start_row` at
+    // u32::MAX, the second matched row's position (start + 1) overflows u32. A
+    // masked point-read lookup must fail closed (error) like the scan path, never
+    // treat the overflow as "not deleted" and silently expose the row.
+    let batch = entries_to_column_batch(&[
+        entry(b"dup", 5, ValueType::Value, b"v0"),
+        entry(b"dup", 3, ValueType::Value, b"v1"),
+    ])
+    .expect("two-row same-key batch");
+    let bitmap = crate::table::delete_bitmap::DeleteBitmap::new();
+    let cmp = crate::comparator::default_comparator();
+    let err = column_batch_match_entries(&batch, b"dup", &cmp, Some((&bitmap, u32::MAX)))
+        .expect_err("an overflowing delete-mask position must fail closed");
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(m) if m.contains("position exceeds u32::MAX")),
+        "expected an overflow InvalidHeader, got {err:?}",
+    );
+}

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -527,6 +527,29 @@ impl DataBlock {
         Self::encode_entries_to_block(&entries, restart_interval)
     }
 
+    /// Point-read fast path for a columnar block: reconstructs only the rows whose
+    /// key equals `needle` (skipping `deletes`-masked rows) into a tiny row block,
+    /// or `Ok(None)` when the key is absent / wholly deleted. The caller runs the
+    /// normal seqno-aware [`Self::point_read`] on the result. Avoids untransposing
+    /// and re-encoding the whole block per lookup.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn columnar_point_block(
+        block_data: &[u8],
+        needle: &[u8],
+        comparator: &crate::comparator::SharedComparator,
+        restart_interval: u8,
+        deletes: Option<(&crate::table::delete_bitmap::DeleteBitmap, u32)>,
+    ) -> crate::Result<Option<Self>> {
+        let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
+        let entries = crate::table::columnar::column_batch_match_entries(
+            &batch, needle, comparator, deletes,
+        )?;
+        if entries.is_empty() {
+            return Ok(None);
+        }
+        Self::encode_entries_to_block(&entries, restart_interval).map(Some)
+    }
+
     /// As [`Self::from_columnar_block`], but drops rows whose global position is
     /// marked deleted in `deletes`. `block_start_row` is the position of this
     /// block's first row within the segment (block-index order).

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -474,7 +474,9 @@ impl DataBlock {
     #[cfg(feature = "columnar")]
     pub(crate) fn columnar_block_entries(block_data: &[u8]) -> crate::Result<Vec<InternalValue>> {
         let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
-        let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+        // Consuming, zero-copy untranspose: row keys / values are views into the
+        // batch's column buffers rather than per-row copies.
+        let entries = crate::table::columnar::column_batch_into_entries(batch)?;
         // The writer never spills an empty block, so a zero-row columnar block is
         // corrupt; reject it before any consumer with a non-empty precondition.
         if entries.is_empty() {

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -467,21 +467,61 @@ impl DataBlock {
     /// row-major in memory so every existing row read path is reused unchanged.
     /// The caller must have loaded `block` with `BlockType::Columnar` (its AAD /
     /// descriptor), so this is shared by both the random-access and scan paths.
+    /// Decodes a columnar block into its reconstructed row entries (block-index
+    /// order), WITHOUT re-encoding to a row-major block. The scan path iterates
+    /// these directly (no serialize + re-parse round-trip); [`Self::from_columnar_block`]
+    /// re-encodes on top of this for the byte-based point-read path.
     #[cfg(feature = "columnar")]
-    pub(crate) fn from_columnar_block(
-        block_data: &[u8],
-        restart_interval: u8,
-    ) -> crate::Result<Self> {
+    pub(crate) fn columnar_block_entries(block_data: &[u8]) -> crate::Result<Vec<InternalValue>> {
         let batch = crate::table::columnar::ColumnBatch::decode(block_data)?;
         let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
         // The writer never spills an empty block, so a zero-row columnar block is
-        // corrupt; reject it before the row encoder, which has a non-empty
-        // precondition and would otherwise panic.
+        // corrupt; reject it before any consumer with a non-empty precondition.
         if entries.is_empty() {
             return Err(crate::Error::InvalidHeader(
                 "columnar: empty reconstructed data block",
             ));
         }
+        Ok(entries)
+    }
+
+    /// As [`Self::columnar_block_entries`], but drops rows whose global position
+    /// is marked deleted in `deletes`. `block_start_row` is the block's first
+    /// row position (block-index order). Returns `Ok(None)` when every row is
+    /// deleted (the caller skips the block).
+    #[cfg(feature = "columnar")]
+    pub(crate) fn columnar_block_entries_masked(
+        block_data: &[u8],
+        deletes: &crate::table::delete_bitmap::DeleteBitmap,
+        block_start_row: u32,
+    ) -> crate::Result<Option<Vec<InternalValue>>> {
+        let entries = Self::columnar_block_entries(block_data)?;
+        let mut kept = Vec::with_capacity(entries.len());
+        for (index, entry) in entries.into_iter().enumerate() {
+            let offset = u32::try_from(index).map_err(|_| {
+                crate::Error::InvalidHeader("columnar: block row index exceeds u32::MAX")
+            })?;
+            let pos = block_start_row
+                .checked_add(offset)
+                .ok_or(crate::Error::InvalidHeader(
+                    "columnar: row position exceeds u32::MAX",
+                ))?;
+            if !deletes.contains(pos) {
+                kept.push(entry);
+            }
+        }
+        if kept.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(kept))
+    }
+
+    #[cfg(feature = "columnar")]
+    pub(crate) fn from_columnar_block(
+        block_data: &[u8],
+        restart_interval: u8,
+    ) -> crate::Result<Self> {
+        let entries = Self::columnar_block_entries(block_data)?;
         Self::encode_entries_to_block(&entries, restart_interval)
     }
 

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -175,12 +175,14 @@ impl ColumnarBlockIter {
             Bound::Excluded(k) => (k, true),
         };
         let cmp = self.comparator.as_ref();
-        let pos = self.entries[self.lo..self.hi].partition_point(|e| {
-            match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
-                core::cmp::Ordering::Less => true,
-                core::cmp::Ordering::Equal => skip_equal,
-                core::cmp::Ordering::Greater => false,
-            }
+        let pos = self.entries.get(self.lo..self.hi).map_or(0, |window| {
+            window.partition_point(
+                |e| match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => skip_equal,
+                    core::cmp::Ordering::Greater => false,
+                },
+            )
         });
         self.lo += pos;
         self.lo < self.hi
@@ -193,12 +195,14 @@ impl ColumnarBlockIter {
             Bound::Excluded(k) => (k, false),
         };
         let cmp = self.comparator.as_ref();
-        let pos = self.entries[self.lo..self.hi].partition_point(|e| {
-            match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
-                core::cmp::Ordering::Less => true,
-                core::cmp::Ordering::Equal => keep_equal,
-                core::cmp::Ordering::Greater => false,
-            }
+        let pos = self.entries.get(self.lo..self.hi).map_or(0, |window| {
+            window.partition_point(
+                |e| match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
+                    core::cmp::Ordering::Less => true,
+                    core::cmp::Ordering::Equal => keep_equal,
+                    core::cmp::Ordering::Greater => false,
+                },
+            )
         });
         self.hi = self.lo + pos;
         self.lo < self.hi
@@ -211,9 +215,9 @@ impl Iterator for ColumnarBlockIter {
 
     fn next(&mut self) -> Option<InternalValue> {
         if self.lo < self.hi {
-            let item = self.entries[self.lo].clone();
+            let item = self.entries.get(self.lo).cloned();
             self.lo += 1;
-            Some(item)
+            item
         } else {
             None
         }
@@ -225,7 +229,7 @@ impl DoubleEndedIterator for ColumnarBlockIter {
     fn next_back(&mut self) -> Option<InternalValue> {
         if self.lo < self.hi {
             self.hi -= 1;
-            Some(self.entries[self.hi].clone())
+            self.entries.get(self.hi).cloned()
         } else {
             None
         }

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -141,11 +141,167 @@ impl DoubleEndedIterator for OwnedDataBlockIter {
     }
 }
 
-fn create_data_block_reader(
-    block: DataBlock,
+/// In-memory cursor over a columnar block's reconstructed entries. Lets the scan
+/// path iterate a columnar block directly instead of re-encoding it into a
+/// row-major block and re-parsing it. Entries are in block-index order
+/// (`user_key` ASC, `seqno` DESC), so the bound seeks are binary searches; MVCC
+/// version selection happens in the merge layer above, so `seqno` is unused here.
+#[cfg(feature = "columnar")]
+struct ColumnarBlockIter {
+    entries: Vec<InternalValue>,
+    /// Forward cursor: next index to yield. Window is `[lo, hi)`.
+    lo: usize,
+    /// Exclusive back cursor: `next_back` yields `hi - 1`.
+    hi: usize,
     comparator: SharedComparator,
-) -> crate::Result<OwnedDataBlockIter> {
-    OwnedDataBlockIter::try_new(block, |b| b.try_iter(comparator))
+}
+
+#[cfg(feature = "columnar")]
+impl ColumnarBlockIter {
+    fn new(entries: Vec<InternalValue>, comparator: SharedComparator) -> Self {
+        let hi = entries.len();
+        Self {
+            entries,
+            lo: 0,
+            hi,
+            comparator,
+        }
+    }
+
+    /// Narrows `lo` to the first entry at/after the lower bound.
+    fn seek_lower_bound(&mut self, bound: &Bound, _seqno: SeqNo) -> bool {
+        let (key, skip_equal) = match bound {
+            Bound::Included(k) => (k, false),
+            Bound::Excluded(k) => (k, true),
+        };
+        let cmp = self.comparator.as_ref();
+        let pos = self.entries[self.lo..self.hi].partition_point(|e| {
+            match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => skip_equal,
+                core::cmp::Ordering::Greater => false,
+            }
+        });
+        self.lo += pos;
+        self.lo < self.hi
+    }
+
+    /// Narrows `hi` to just past the last entry at/before the upper bound.
+    fn seek_upper_bound(&mut self, bound: &Bound, _seqno: SeqNo) -> bool {
+        let (key, keep_equal) = match bound {
+            Bound::Included(k) => (k, true),
+            Bound::Excluded(k) => (k, false),
+        };
+        let cmp = self.comparator.as_ref();
+        let pos = self.entries[self.lo..self.hi].partition_point(|e| {
+            match cmp.compare(e.key.user_key.as_ref(), key.as_ref()) {
+                core::cmp::Ordering::Less => true,
+                core::cmp::Ordering::Equal => keep_equal,
+                core::cmp::Ordering::Greater => false,
+            }
+        });
+        self.hi = self.lo + pos;
+        self.lo < self.hi
+    }
+}
+
+#[cfg(feature = "columnar")]
+impl Iterator for ColumnarBlockIter {
+    type Item = InternalValue;
+
+    fn next(&mut self) -> Option<InternalValue> {
+        if self.lo < self.hi {
+            let item = self.entries[self.lo].clone();
+            self.lo += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "columnar")]
+impl DoubleEndedIterator for ColumnarBlockIter {
+    fn next_back(&mut self) -> Option<InternalValue> {
+        if self.lo < self.hi {
+            self.hi -= 1;
+            Some(self.entries[self.hi].clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// A loaded data block ready to iterate: a row-major byte block (every row SST,
+/// and the partial-decode fast path) or a columnar block's reconstructed entries
+/// (iterated directly, skipping the re-encode round-trip).
+enum BlockSource {
+    Row(DataBlock),
+    #[cfg(feature = "columnar")]
+    Columnar(Vec<InternalValue>),
+}
+
+/// Iterator over a loaded block, dispatching to the byte-based row reader or the
+/// in-memory columnar reader. Exposes the surface the scan loop drives.
+enum BlockReader {
+    Row(OwnedDataBlockIter),
+    #[cfg(feature = "columnar")]
+    Columnar(ColumnarBlockIter),
+}
+
+impl BlockReader {
+    fn seek_lower_bound(&mut self, bound: &Bound, seqno: SeqNo) -> bool {
+        match self {
+            Self::Row(r) => r.seek_lower_bound(bound, seqno),
+            #[cfg(feature = "columnar")]
+            Self::Columnar(c) => c.seek_lower_bound(bound, seqno),
+        }
+    }
+
+    fn seek_upper_bound(&mut self, bound: &Bound, seqno: SeqNo) -> bool {
+        match self {
+            Self::Row(r) => r.seek_upper_bound(bound, seqno),
+            #[cfg(feature = "columnar")]
+            Self::Columnar(c) => c.seek_upper_bound(bound, seqno),
+        }
+    }
+}
+
+impl Iterator for BlockReader {
+    type Item = InternalValue;
+
+    fn next(&mut self) -> Option<InternalValue> {
+        match self {
+            Self::Row(r) => r.next(),
+            #[cfg(feature = "columnar")]
+            Self::Columnar(c) => c.next(),
+        }
+    }
+}
+
+impl DoubleEndedIterator for BlockReader {
+    fn next_back(&mut self) -> Option<InternalValue> {
+        match self {
+            Self::Row(r) => r.next_back(),
+            #[cfg(feature = "columnar")]
+            Self::Columnar(c) => c.next_back(),
+        }
+    }
+}
+
+fn create_data_block_reader(
+    source: BlockSource,
+    comparator: SharedComparator,
+) -> crate::Result<BlockReader> {
+    match source {
+        BlockSource::Row(block) => Ok(BlockReader::Row(OwnedDataBlockIter::try_new(block, |b| {
+            b.try_iter(comparator)
+        })?)),
+        #[cfg(feature = "columnar")]
+        BlockSource::Columnar(entries) => Ok(BlockReader::Columnar(ColumnarBlockIter::new(
+            entries, comparator,
+        ))),
+    }
 }
 
 /// Per-SST positional delete state for a columnar iterator: the delete-bitmap
@@ -225,10 +381,10 @@ pub struct Iter {
     index_initialized: bool,
 
     lo_offset: BlockOffset,
-    lo_data_block: Option<OwnedDataBlockIter>,
+    lo_data_block: Option<BlockReader>,
 
     hi_offset: BlockOffset,
-    hi_data_block: Option<OwnedDataBlockIter>,
+    hi_data_block: Option<BlockReader>,
 
     range: Bounds,
 
@@ -315,7 +471,7 @@ impl Iter {
     /// Loads, reconstructs (if columnar), and masks a data block by handle.
     /// Returns `Ok(None)` when a columnar block is wholly deleted by the
     /// positional mask, so the caller skips it.
-    fn load_and_resolve(&self, handle: &BlockHandle) -> crate::Result<Option<DataBlock>> {
+    fn load_and_resolve(&self, handle: &BlockHandle) -> crate::Result<Option<BlockSource>> {
         let block_type = if self.columnar {
             crate::table::block::BlockType::Columnar
         } else {
@@ -340,7 +496,6 @@ impl Iter {
         if self.columnar {
             #[cfg(feature = "columnar")]
             {
-                const REENCODE_RESTART_INTERVAL: u8 = 16;
                 // Mask only when the segment has deletes AND this block's start row
                 // is known. The start-row map is built at open from the zone map
                 // (which covers every block), so an unmapped block is unreachable;
@@ -348,20 +503,21 @@ impl Iter {
                 // sharing the no-deletes path rather than defaulting the start to 0
                 // and masking against the wrong physical positions. This matches the
                 // direct-load path (`Table::load_columnar_data_block`).
+                //
+                // The reconstructed entries are iterated directly (no re-encode to
+                // a row-major block + re-parse), so no restart interval is needed.
                 let masked = self.delete_mask.as_ref().and_then(|mask| {
                     mask.block_start_rows
                         .get(&handle.offset().0)
                         .map(|&start| (mask, start))
                 });
                 return match masked {
-                    Some((mask, start)) => DataBlock::from_columnar_block_masked(
-                        &raw.data,
-                        REENCODE_RESTART_INTERVAL,
-                        &mask.bitmap,
-                        start,
-                    ),
-                    None => DataBlock::from_columnar_block(&raw.data, REENCODE_RESTART_INTERVAL)
-                        .map(Some),
+                    Some((mask, start)) => {
+                        DataBlock::columnar_block_entries_masked(&raw.data, &mask.bitmap, start)
+                            .map(|opt| opt.map(BlockSource::Columnar))
+                    }
+                    None => DataBlock::columnar_block_entries(&raw.data)
+                        .map(|entries| Some(BlockSource::Columnar(entries))),
                 };
             }
             #[cfg(not(feature = "columnar"))]
@@ -369,7 +525,7 @@ impl Iter {
                 return Err(crate::Error::FeatureUnsupported("columnar"));
             }
         }
-        DataBlock::from_loaded(raw, self.has_kv_footer).map(Some)
+        DataBlock::from_loaded(raw, self.has_kv_footer).map(|db| Some(BlockSource::Row(db)))
     }
 
     pub fn set_lower_bound(&mut self, bound: Bound) {
@@ -703,7 +859,7 @@ impl Iterator for Iter {
             let partial: Option<DataBlock> = None;
 
             let block = if let Some(db) = partial {
-                db
+                BlockSource::Row(db)
             } else {
                 match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
                     Ok(Some(b)) => b,
@@ -839,7 +995,7 @@ impl DoubleEndedIterator for Iter {
             let partial: Option<DataBlock> = None;
 
             let block = if let Some(db) = partial {
-                db
+                BlockSource::Row(db)
             } else {
                 match self.load_and_resolve(&BlockHandle::new(handle.offset(), handle.size())) {
                     Ok(Some(b)) => b,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -295,6 +295,27 @@ impl Table {
         self.regions.zone_map.is_some()
     }
 
+    /// The fraction of this segment's rows masked by its positional
+    /// delete-bitmap, as a percentage in `0..=100`, or `None` when the segment
+    /// carries no delete-bitmap (nothing masked).
+    ///
+    /// Drives the density-based rewrite policy: a segment whose masked fraction
+    /// has grown past the adaptive purge threshold is worth physically rewriting
+    /// (dropping the masked rows and clearing the bitmap) rather than paying the
+    /// merge-on-read mask cost on every scan.
+    #[must_use]
+    pub fn delete_density(&self) -> Option<u8> {
+        let deleted = self.delete_bitmap().len();
+        if deleted == 0 {
+            return None;
+        }
+        let total = self.metadata.item_count.max(1);
+        // `deleted <= total`, both far below `u64::MAX / 100`, so the percentage
+        // is in `0..=100`; `.min(100)` is belt-and-suspenders for the cast.
+        let percent = (deleted * 100 / total).min(100);
+        Some(u8::try_from(percent).unwrap_or(100))
+    }
+
     fn load_block(
         &self,
         handle: &BlockHandle,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -933,8 +933,15 @@ impl Table {
             let block_handle = block_handle?;
 
             // A columnar block carrying no row for this key (absent / wholly
-            // deleted) returns None here; skip it.
+            // deleted) returns None here; still honor the end-key cutoff before
+            // skipping, so an absent key below this block's end key stops the
+            // scan instead of probing every later candidate block.
             let Some(data_block) = self.load_point_block(block_handle.as_ref(), key)? else {
+                if self.comparator.compare(block_handle.end_key(), key)
+                    == core::cmp::Ordering::Greater
+                {
+                    return Ok(None);
+                }
                 continue;
             };
 
@@ -1065,8 +1072,15 @@ impl Table {
             let block_handle = block_handle?;
 
             // A columnar block carrying no row for this key (absent / wholly
-            // deleted) returns None here; skip it.
+            // deleted) returns None here; still honor the end-key cutoff before
+            // skipping, so an absent key below this block's end key stops the
+            // scan instead of probing every later candidate block.
             let Some(data_block) = self.load_point_block(block_handle.as_ref(), key)? else {
+                if self.comparator.compare(block_handle.end_key(), key)
+                    == core::cmp::Ordering::Greater
+                {
+                    return Ok(None);
+                }
                 continue;
             };
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -407,6 +407,57 @@ impl Table {
         }
     }
 
+    /// Point-read counterpart to [`Self::load_columnar_data_block`]: decodes the
+    /// columnar block once and rebuilds only `needle`'s rows (its MVCC versions,
+    /// minus any masked by the positional delete-bitmap) into a tiny row block, or
+    /// `Ok(None)` when the key is absent / wholly deleted. The caller runs the
+    /// normal seqno-aware point read on the result, so a columnar point read
+    /// touches one key's rows instead of untransposing + re-encoding the whole
+    /// block per lookup.
+    #[cfg(feature = "columnar")]
+    fn load_columnar_point_block(
+        &self,
+        handle: &BlockHandle,
+        needle: &[u8],
+    ) -> crate::Result<Option<DataBlock>> {
+        let block = self.load_block(
+            handle,
+            BlockType::Columnar,
+            self.metadata.data_block_compression,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        let deletes = self
+            .delete_block_starts
+            .as_ref()
+            .and_then(|starts| starts.get(&handle.offset().0))
+            .map(|&start| (self.delete_bitmap.as_ref(), start));
+        DataBlock::columnar_point_block(
+            &block.data,
+            needle,
+            &self.comparator,
+            self.metadata.data_block_restart_interval,
+            deletes,
+        )
+    }
+
+    /// Loads the data block to point-read for `needle`: for a columnar SST the
+    /// key-aware fast path that rebuilds only the matching key's rows; for a row
+    /// SST the whole block. `Ok(None)` means the block carries no row for `needle`
+    /// (columnar: absent / wholly deleted), so the caller moves on.
+    fn load_point_block(
+        &self,
+        handle: &BlockHandle,
+        needle: &[u8],
+    ) -> crate::Result<Option<DataBlock>> {
+        #[cfg(feature = "columnar")]
+        if self.metadata.columnar {
+            return self.load_columnar_point_block(handle, needle);
+        }
+        let _ = needle;
+        self.load_data_block(handle)
+    }
+
     /// Loads a columnar data block and decodes only the projected columns,
     /// stepping over the rest without decoding them. The returned batch carries
     /// the requested columns for this block's rows. This is the projection read
@@ -854,17 +905,20 @@ impl Table {
         // MVCC-correctness argument). A located-block miss falls through to the
         // index walk below.
         if let Some((handle, hint)) = self.locator_block(key_hash)?
-            && let Some(data_block) = self.load_data_block(&handle)?
+            && let Some(data_block) = self.load_point_block(&handle, key)?
         {
+            // A columnar block is narrowed to this key's rows by load_point_block,
+            // so the full-block slot hint does not apply.
+            let is_columnar = cfg!(feature = "columnar") && self.metadata.columnar;
             let found = match hint {
-                Some((slot, is_entry)) => data_block.point_read_value_at_slot(
+                Some((slot, is_entry)) if !is_columnar => data_block.point_read_value_at_slot(
                     slot,
                     is_entry,
                     key,
                     seqno,
                     &self.comparator,
                 )?,
-                None => data_block.point_read_value(key, seqno, &self.comparator)?,
+                _ => data_block.point_read_value(key, seqno, &self.comparator)?,
             };
             if let Some(found) = found {
                 return Ok(Some(found));
@@ -878,8 +932,9 @@ impl Table {
         for block_handle in iter {
             let block_handle = block_handle?;
 
-            // A wholly-deleted columnar block carries no keys; skip it.
-            let Some(data_block) = self.load_data_block(block_handle.as_ref())? else {
+            // A columnar block carrying no row for this key (absent / wholly
+            // deleted) returns None here; skip it.
+            let Some(data_block) = self.load_point_block(block_handle.as_ref(), key)? else {
                 continue;
             };
 
@@ -983,13 +1038,16 @@ impl Table {
         // visible version lives in a later block) safely falls through to the
         // index walk below.
         if let Some((handle, hint)) = self.locator_block(key_hash)?
-            && let Some(data_block) = self.load_data_block(&handle)?
+            && let Some(data_block) = self.load_point_block(&handle, key)?
         {
+            // A columnar block is narrowed to this key's rows by load_point_block,
+            // so the full-block slot hint does not apply.
+            let is_columnar = cfg!(feature = "columnar") && self.metadata.columnar;
             let found = match hint {
-                Some((slot, is_entry)) => {
+                Some((slot, is_entry)) if !is_columnar => {
                     data_block.point_read_at_slot(slot, is_entry, key, seqno, &self.comparator)?
                 }
-                None => data_block.point_read(key, seqno, &self.comparator)?,
+                _ => data_block.point_read(key, seqno, &self.comparator)?,
             };
             if let Some(item) = found {
                 return Ok(Some((item, data_block)));
@@ -1006,8 +1064,9 @@ impl Table {
         for block_handle in iter {
             let block_handle = block_handle?;
 
-            // A wholly-deleted columnar block carries no keys; skip it.
-            let Some(data_block) = self.load_data_block(block_handle.as_ref())? else {
+            // A columnar block carrying no row for this key (absent / wholly
+            // deleted) returns None here; skip it.
+            let Some(data_block) = self.load_point_block(block_handle.as_ref(), key)? else {
                 continue;
             };
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -310,9 +310,9 @@ impl Table {
             return None;
         }
         let total = self.metadata.item_count.max(1);
-        // `deleted <= total`, both far below `u64::MAX / 100`, so the percentage
-        // is in `0..=100`; `.min(100)` is belt-and-suspenders for the cast.
-        let percent = (deleted * 100 / total).min(100);
+        // Widen to u128 so `* 100` cannot overflow regardless of the (already
+        // bounded) inputs; the quotient is clamped to the 0..=100 percentage range.
+        let percent = (u128::from(deleted) * 100 / u128::from(total)).min(100);
         Some(u8::try_from(percent).unwrap_or(100))
     }
 

--- a/tests/columnar_density_rewrite.rs
+++ b/tests/columnar_density_rewrite.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Density-based rewrite of a columnar segment whose delete-bitmap has grown
+//! past the adaptive purge threshold. A segment first relocated with a
+//! sub-threshold bitmap (merge-on-read) becomes over-budget when the operator
+//! lowers the threshold at runtime; an otherwise-idle compaction must then pick
+//! it for a materializing rewrite that physically drops the masked rows and
+//! clears the bitmap, instead of paying the mask cost on every scan forever.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::compaction::Leveled;
+use lsm_tree::config::{DeleteStrategy, DeleteStrategyPolicy};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, SeqNo, SequenceNumberCounter, UserKey, get_tmp_folder,
+};
+use std::sync::Arc;
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn value(i: u32) -> Vec<u8> {
+    format!("value-{i}-payload").into_bytes()
+}
+
+#[test]
+fn density_rewrite_materializes_an_over_threshold_bitmap_segment() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+
+    // Columnar + zone map + Adaptive with a HIGH purge threshold, so the initial
+    // delete relocates into a bitmap (merge-on-read) rather than purging.
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 90,
+        });
+    })
+    .expect("enable columnar adaptive");
+
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Delete the first 50 (25%) at a seqno above every row, in the same memtable.
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+
+    // Materialize the range tombstone into a delete-bitmap via relocation: 25% is
+    // below the 90% threshold, so the segment is relocated carrying the bitmap.
+    tree.major_compact(64 * 1024 * 1024, 5000)
+        .expect("relocate");
+
+    {
+        let version = tree.current_version();
+        let tables: Vec<_> = version.iter_tables().collect();
+        assert_eq!(tables.len(), 1, "one relocated columnar segment");
+        let density = tables[0].delete_density();
+        assert!(
+            matches!(density, Some(p) if (20..=30).contains(&p)),
+            "segment carries a ~25% delete-bitmap, got {density:?}",
+        );
+    }
+
+    // The operator lowers the threshold below the segment's density. The segment
+    // is now over budget, but no structural compaction is due.
+    tree.update_runtime_config(|cfg| {
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 10,
+        });
+    })
+    .expect("lower threshold");
+
+    // An otherwise-idle leveled compaction must pick the dense segment for a
+    // materializing rewrite (the density-rewrite fallback at the orchestrator).
+    tree.compact(Arc::new(Leveled::default()), 5000)
+        .expect("density rewrite");
+
+    // The bitmap is gone (rows physically dropped) and the data still round-trips.
+    let version = tree.current_version();
+    let tables: Vec<_> = version.iter_tables().collect();
+    assert!(
+        tables.iter().all(|t| t.delete_density().is_none()),
+        "density rewrite must clear the delete-bitmap (materialized, not masked)",
+    );
+    assert!(
+        tables.iter().all(|t| t.metadata.columnar),
+        "the rewritten segment stays columnar",
+    );
+    for i in 0..n {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i < 50 {
+            assert!(
+                got.is_none(),
+                "deleted key {i} stays absent after materialization",
+            );
+        } else {
+            assert_eq!(
+                &*got.expect("live key must be present"),
+                value(i).as_slice(),
+                "live key {i} value survives the rewrite",
+            );
+        }
+    }
+}

--- a/tests/columnar_density_rewrite.rs
+++ b/tests/columnar_density_rewrite.rs
@@ -120,3 +120,68 @@ fn density_rewrite_materializes_an_over_threshold_bitmap_segment() {
         }
     }
 }
+
+/// The density rewrite is a no-op when no segment is over its level's threshold,
+/// and when the level does not run an Adaptive strategy at all: an idle
+/// compaction leaves a sub-threshold (and a non-Adaptive) bitmap segment alone.
+#[test]
+fn density_rewrite_skips_sub_threshold_and_non_adaptive() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 90,
+        });
+    })
+    .expect("config");
+
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 5000)
+        .expect("relocate");
+
+    let still_dense = |label: &str| {
+        let version = tree.current_version();
+        let tables: Vec<_> = version.iter_tables().collect();
+        assert_eq!(tables.len(), 1, "{label}: one segment");
+        assert!(
+            tables[0].delete_density().is_some(),
+            "{label}: the segment keeps its delete-bitmap (no rewrite)",
+        );
+    };
+
+    // 25% density is below the 90% Adaptive threshold: an idle compaction must
+    // leave the bitmap in place (the density-rewrite fallback skips it).
+    tree.compact(Arc::new(Leveled::default()), 5000)
+        .expect("idle compaction");
+    still_dense("sub-threshold");
+
+    // A non-Adaptive (merge-on-read) level never purges via the density rewrite,
+    // so the bitmap segment is left alone regardless of how dense it is.
+    tree.update_runtime_config(|cfg| {
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::MergeOnRead);
+    })
+    .expect("switch to merge-on-read");
+    tree.compact(Arc::new(Leveled::default()), 5000)
+        .expect("idle compaction");
+    still_dense("non-adaptive");
+}

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -779,8 +779,9 @@ fn columnar_ingest_range_scan_reconstructs_subcolumns() -> lsm_tree::Result<()> 
         (b"k0", vec![&[1, 0, 0, 0][..], &b"aa"[..]]),
         (b"k1", vec![&[2, 0, 0, 0][..], &b"bbb"[..]]),
     ];
-    let mut scanned = 0usize;
-    for (guard, (exp_key, exp_cells)) in tree.range("k0".."k2", SeqNo::MAX, None).zip(expected) {
+    let mut iter = tree.range("k0".."k2", SeqNo::MAX, None);
+    for (exp_key, exp_cells) in expected {
+        let guard = iter.next().expect("expected reconstructed row");
         let (k, val) = guard.into_inner()?;
         assert_eq!(k.as_ref(), exp_key, "scanned key");
         assert_eq!(
@@ -788,11 +789,10 @@ fn columnar_ingest_range_scan_reconstructs_subcolumns() -> lsm_tree::Result<()> 
             exp_cells,
             "the reconstructed value unframes to the original sub-cells",
         );
-        scanned += 1;
     }
-    assert_eq!(
-        scanned, 2,
-        "both ingested rows are scanned through the Reconstruct path",
+    assert!(
+        iter.next().is_none(),
+        "range scan returned extra rows through the Reconstruct path",
     );
     Ok(())
 }

--- a/tests/columnar_ingest.rs
+++ b/tests/columnar_ingest.rs
@@ -14,7 +14,7 @@ use lsm_tree::table::columnar::{
     unframe_value_cells_nullable,
 };
 use lsm_tree::{
-    AbstractTree, AnyTree, Config, InternalValue, SeqNo, SequenceNumberCounter, ValueType,
+    AbstractTree, AnyTree, Config, Guard, InternalValue, SeqNo, SequenceNumberCounter, ValueType,
     get_tmp_folder,
 };
 use test_log::test;
@@ -745,5 +745,54 @@ fn columnar_scan_spans_segments_with_evolving_schema() -> lsm_tree::Result<()> {
             "the shared column 3 is present in every segment",
         );
     }
+    Ok(())
+}
+
+/// A range scan over a multi-sub-column segment reconstructs each row's value
+/// through the framing (Reconstruct) path rather than the single-bytes
+/// zero-copy fast path: the scan re-frames the two value sub-columns into the
+/// opaque per-row value, which unframes back to the original sub-cells.
+#[test]
+fn columnar_ingest_range_scan_reconstructs_subcolumns() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+
+    let mut ingest = any.ingestion()?;
+    ingest.write_columnar_batch(&two_subcolumn_batch())?;
+    ingest.finish()?;
+
+    let tags = [TypeTag::Fixed(4), TypeTag::Bytes];
+    let expected: [(&[u8], Vec<&[u8]>); 2] = [
+        (b"k0", vec![&[1, 0, 0, 0][..], &b"aa"[..]]),
+        (b"k1", vec![&[2, 0, 0, 0][..], &b"bbb"[..]]),
+    ];
+    let mut scanned = 0usize;
+    for (guard, (exp_key, exp_cells)) in tree.range("k0".."k2", SeqNo::MAX, None).zip(expected) {
+        let (k, val) = guard.into_inner()?;
+        assert_eq!(k.as_ref(), exp_key, "scanned key");
+        assert_eq!(
+            unframe_value_cells(val.as_ref(), &tags)?,
+            exp_cells,
+            "the reconstructed value unframes to the original sub-cells",
+        );
+        scanned += 1;
+    }
+    assert_eq!(
+        scanned, 2,
+        "both ingested rows are scanned through the Reconstruct path",
+    );
     Ok(())
 }

--- a/tests/columnar_read_paths.rs
+++ b/tests/columnar_read_paths.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Columnar read-path coverage: reverse iteration, bounded ranges, masked
+//! (deleted) scans, and point reads (present / absent / deleted). These exercise
+//! the entries-backed columnar scan iterator (`next_back`, the bound seeks) and
+//! the single-key columnar point-read fast path, which a plain forward full scan
+//! does not.
+
+#![cfg(feature = "columnar")]
+
+use lsm_tree::config::{BlockSizePolicy, DeleteStrategy, DeleteStrategyPolicy};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, Guard, SeqNo, SequenceNumberCounter, Tree, UserKey,
+    get_tmp_folder,
+};
+use test_log::test;
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+
+fn value(i: u32) -> Vec<u8> {
+    format!("value-{i:06}-payload").into_bytes()
+}
+
+fn open_columnar(folder: &std::path::Path) -> Tree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+    tree
+}
+
+/// Reverse iteration over a columnar segment yields the same rows as forward,
+/// reversed — exercising the columnar iterator's `next_back`.
+#[test]
+fn columnar_reverse_scan_matches_forward() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let collect = |rev: bool| -> Vec<(Vec<u8>, Vec<u8>)> {
+        let iter = tree.range(key(0)..key(1_000_000), SeqNo::MAX, None);
+        let mut v: Vec<(Vec<u8>, Vec<u8>)> = if rev {
+            iter.rev()
+                .map(|g| {
+                    let (k, val) = g.into_inner().expect("guard");
+                    (k.to_vec(), val.to_vec())
+                })
+                .collect()
+        } else {
+            iter.map(|g| {
+                let (k, val) = g.into_inner().expect("guard");
+                (k.to_vec(), val.to_vec())
+            })
+            .collect()
+        };
+        if rev {
+            v.reverse();
+        }
+        v
+    };
+
+    let forward = collect(false);
+    let reversed = collect(true);
+    assert_eq!(forward.len(), n as usize);
+    assert_eq!(forward, reversed, "reverse scan must mirror forward scan");
+}
+
+/// Bounded ranges over a columnar segment respect inclusive / exclusive bounds —
+/// exercising the columnar iterator's lower / upper bound seeks.
+#[test]
+fn columnar_bounded_range_respects_bounds() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    // Half-open [50, 150): 100 rows.
+    let half_open = tree.range(key(50)..key(150), SeqNo::MAX, None).count();
+    assert_eq!(half_open, 100, "[50, 150) spans 100 rows");
+
+    // Inclusive [50, 150]: 101 rows.
+    let inclusive = tree.range(key(50)..=key(150), SeqNo::MAX, None).count();
+    assert_eq!(inclusive, 101, "[50, 150] spans 101 rows");
+
+    // The first and last keys of the half-open range are exactly as expected.
+    let mut iter = tree.range(key(50)..key(150), SeqNo::MAX, None);
+    let first = iter.next().expect("first").into_inner().expect("guard").0;
+    assert_eq!(&*first, key(50).as_slice());
+    let last = iter
+        .next_back()
+        .expect("last")
+        .into_inner()
+        .expect("guard")
+        .0;
+    assert_eq!(&*last, key(149).as_slice());
+}
+
+/// Point reads on a columnar segment: present key returns its value, absent key
+/// returns `None` (the columnar point-read fast path's empty result).
+#[test]
+fn columnar_point_read_present_and_absent() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 100u32;
+    for i in (0..n).step_by(2) {
+        // Only even keys exist.
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    for i in 0..n {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i % 2 == 0 {
+            assert_eq!(
+                &*got.expect("even key present"),
+                value(i).as_slice(),
+                "even key {i}",
+            );
+        } else {
+            assert!(got.is_none(), "odd key {i} is absent");
+        }
+    }
+    // A key past the end of the keyspace is absent too.
+    assert!(tree.get(key(10_000), SeqNo::MAX).expect("get").is_none());
+}
+
+/// A columnar segment carrying a materialized delete-bitmap: deleted rows are
+/// hidden on both the masked scan and the masked point-read paths.
+#[test]
+fn columnar_masked_scan_and_point_read_hide_deletes() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::MergeOnRead);
+    })
+    .expect("enable columnar merge-on-read");
+
+    let n = 200u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Range-delete the first 50 keys above all of them, then materialize into a
+    // delete-bitmap via relocation.
+    tree.remove_range(
+        UserKey::from(&key(0)[..]),
+        UserKey::from(&key(50)[..]),
+        1000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 5000)
+        .expect("relocate");
+
+    // Masked scan: deleted rows are skipped, survivors remain.
+    let scanned = tree.range(key(0)..key(1_000_000), SeqNo::MAX, None).count();
+    assert_eq!(
+        scanned,
+        (n - 50) as usize,
+        "deleted rows are masked from the scan"
+    );
+
+    // Masked point reads: deleted keys read as absent, survivors return values.
+    for i in 0..n {
+        let got = tree.get(key(i), SeqNo::MAX).expect("get");
+        if i < 50 {
+            assert!(got.is_none(), "deleted key {i} reads as absent");
+        } else {
+            assert_eq!(
+                &*got.expect("live key"),
+                value(i).as_slice(),
+                "live key {i}"
+            );
+        }
+    }
+}
+
+/// A columnar segment whose delete-bitmap masks whole interior blocks: small
+/// data blocks make the segment span many blocks, and a large contiguous delete
+/// leaves entire interior blocks fully dead. The masked scan reconstructs each
+/// fully-dead block to "nothing" and skips it, yielding only the head and tail
+/// survivors (not just per-row masking within a single block).
+#[test]
+fn columnar_masked_scan_skips_a_wholly_deleted_block() {
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    // Small data blocks so the segment spans many blocks for a few hundred rows.
+    .data_block_size_policy(BlockSizePolicy::all(1_024))
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 90,
+        });
+    })
+    .expect("enable columnar adaptive");
+
+    let n = 300u32;
+    for i in 0..n {
+        tree.insert(key(i), value(i), u64::from(i));
+    }
+    // Delete a large contiguous middle range above every row. 60% < 90%, so the
+    // relocation keeps the bitmap; the deleted span covers whole interior blocks.
+    tree.remove_range(
+        UserKey::from(&key(60)[..]),
+        UserKey::from(&key(240)[..]),
+        10_000,
+    );
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 100_000)
+        .expect("relocate");
+
+    {
+        let version = tree.current_version();
+        let tables: Vec<_> = version.iter_tables().collect();
+        assert!(
+            tables.iter().any(|t| t.delete_density().is_some()),
+            "relocation must keep the sub-threshold delete-bitmap",
+        );
+    }
+
+    let survivors: Vec<u32> = tree
+        .range(key(0)..key(1_000_000), SeqNo::MAX, None)
+        .map(|g| {
+            let (k, _) = g.into_inner().expect("guard");
+            let s = std::str::from_utf8(&k).expect("utf8 key");
+            s.trim_start_matches('k').parse::<u32>().expect("key index")
+        })
+        .collect();
+    let expected: Vec<u32> = (0..60).chain(240..n).collect();
+    assert_eq!(
+        survivors, expected,
+        "only the head and tail survive; fully-dead interior blocks are skipped",
+    );
+}


### PR DESCRIPTION
## Summary

Columnar delete-bitmap density rewrite and a public columnar benchmark matrix
(the headline of #551), plus the columnar read-path performance work and two
correctness fixes surfaced along the way.

## Delete-density rewrite (#551 Part A)

A columnar segment relocated with a sub-threshold delete-bitmap (merge-on-read)
was never re-evaluated, so once its masked fraction crossed the adaptive purge
threshold (e.g. after an operator lowered it at runtime) it paid the
merge-on-read mask cost on every scan forever, with nothing scheduling the
physical rewrite.

The orchestrator now layers a density-rewrite fallback on top of the structural
strategy: when a strategy returns `DoNothing`, the densest segment whose
delete-bitmap fraction is at or above its level's `Adaptive` purge threshold is
scheduled for a single-input materializing rewrite (the masked scan drops the
dead rows; the fresh segment carries no bitmap). It self-gates to a no-op unless
a level runs `Adaptive` and holds a dense-enough live segment, applies uniformly
to every strategy without preempting real work, and reads the live runtime
config so a threshold change takes effect. `CompactionStrategy::choose` stays
purely structural.

## Columnar benchmark matrix (#551 Part B)

`benches/columnar.rs`: row vs columnar vs columnar+zonemap, across full scan and
point lookup, through the public read API, printing P50/P99/P999. It proved the
read-path gaps the rest of this PR closes.

## Columnar read-path performance

Driven by the new benchmark:

- **Scan: iterate columnar blocks directly** instead of decode -> untranspose ->
  re-encode row block -> re-parse. A new entries-backed seekable block iterator
  reads the reconstructed rows directly (bound seeks are binary searches over the
  sorted entries; MVCC version selection stays in the merge layer).
- **Scan: zero-copy untranspose.** The key column and a single non-nullable bytes
  value column are taken as shared slices, so a value larger than the inline
  threshold becomes a zero-copy view instead of a per-row allocation.
- **Point read: no whole-block re-encode.** A columnar point read decoded and
  re-encoded the entire block per lookup just to binary-search it. It now decodes
  the block once and rebuilds only the matching key's MVCC versions (binary-search
  the key column, skip masked rows) into a tiny block, then runs the normal
  seqno-aware point read. The retrieval-ribbon locator still resolves the block in
  O(1).

Measured (100k entries, no compression):

| Op | Columnar vs row-major before | after |
|----|------------------------------|-------|
| `full_scan` | ~1.67x | ~1.0x (parity) |
| `point_lookup` | ~10x | ~2.3x |

## Fixes found along the way

- **`fix(tiered)`: space-amplification debt as pending compaction bytes.** The
  size-tiered strategy returned a flat `0` from `pending_compaction_bytes`, so the
  bytes-axis write backpressure (`bytes_slowdown` / `bytes_stop`) was inert for
  tiered trees even when space amplification ran away. It now reports the bytes by
  which total L0 size exceeds its space-amplification budget. (Audit verdict: the
  L0-count axis and resume were already correct for every strategy; this was the
  one bytes-axis gap.)
- **`fix(compression)`: accept zstd negative and default levels.** The level was
  restricted to `1..=22`, and serializing a directly-constructed `Zstd(level)`
  below 1 hit a `debug_assert` panic. zstd accepts negative "fast" levels and `0`
  (= default), and our backend maps them through, so the range is now `-128..=22`
  (the on-disk format stores the level in one signed byte). Verified a negative
  level round-trips end to end.

## Testing

- Full suite: 2258 passed; columnar / point-read / MVCC suites green.
- Regression tests: tiered space-amp pending bytes; columnar density rewrite
  (a 25% segment materialized after the threshold drops to 10%); zstd negative
  level round-trip.
- `clippy --all-features --all-targets` clean; no-std check 0; doctests pass;
  `cargo doc` clean; benches compile and run.

Closes #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Criterion benchmark (`columnar` feature) for full scans and point lookups.
  * Improved columnar read paths with direct in-memory iteration and key-based point reads, including correct handling of positional deletes.
  * Added density-aware compaction fallback and exposed delete-density calculation; tiered compaction now accounts for pending “debt” for backpressure.
* **Bug Fixes**
  * Expanded accepted Zstd compression levels to the full `-128..=22` signed-byte range (including negative “fast” levels).
* **Tests**
  * Added/updated unit and integration coverage for columnar read/write edge cases, density-rewrite behavior, and compression validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->