### PR TITLE
test(external-wal): reference implementation and end-to-end recipe test

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ The trade-off: there is no write-ahead log, so we do not offer WAL-style
 millisecond tailing of in-flight updates. For arbitrary historical-seqno queries
 (not just "since X"), pair with `Tree::create_checkpoint`. To layer your own
 durability on top of the engine, see the external-WAL integration contract in
-[docs/external-wal.md](docs/external-wal.md).
+[docs/external-wal.md](docs/external-wal.md) and its runnable worked example
+(`cargo run --example external_wal`).
 
 ## Limits
 

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -140,6 +140,32 @@ The strict boundary still covers the crash window in step 1 of
 not yet flushed is, by definition, absent from the SSTs, so its seqno is above
 your trim watermark `W` and the replay step covers it exactly once.
 
+## Executable companion
+
+This recipe is not only specified here; it is executed and self-verified in the
+repository, so a future engine change that violated the contract would break a
+test rather than silently diverge from the prose:
+
+- **Reference WAL** —
+  [`tests/external_wal/reference_wal.rs`](../tests/external_wal/reference_wal.rs)
+  is a minimal append-only WAL: append + `fsync`, trim through a watermark, and
+  replay the survivors in order. It is illustrative (a `std`-only test/dev
+  surface, not the `no_std` production path), and is the worked example the spec
+  refers to.
+- **Worked example** —
+  [`examples/external_wal.rs`](../examples/external_wal.rs) runs the full recipe
+  (log-before-apply, flush, trim to `W`, crash, reopen, replay above `W`) and
+  asserts the recovered state. Run it with `cargo run --example external_wal`.
+- **Integration test** — [`tests/external_wal.rs`](../tests/external_wal.rs)
+  drives the recipe across every write kind through a crash and asserts the
+  recovered state is byte-for-byte a non-crashed run's. Its contract guards
+  prove a wrong recovery is *detectably* wrong: collapsing ops to `insert`,
+  re-applying a merge at or below `W`, or replaying from the raw persisted
+  maximum instead of `W` each make the recovery diverge.
+
+Keep this spec and that proof in sync: a change to the contract should update
+both.
+
 ## Why no hook API
 
 A thin observability hook surface (`before_write_batch`, `after_flush`,

--- a/docs/external-wal.md
+++ b/docs/external-wal.md
@@ -146,17 +146,17 @@ This recipe is not only specified here; it is executed and self-verified in the
 repository, so a future engine change that violated the contract would break a
 test rather than silently diverge from the prose:
 
-- **Reference WAL** —
+- **Reference WAL:**
   [`tests/external_wal/reference_wal.rs`](../tests/external_wal/reference_wal.rs)
   is a minimal append-only WAL: append + `fsync`, trim through a watermark, and
   replay the survivors in order. It is illustrative (a `std`-only test/dev
   surface, not the `no_std` production path), and is the worked example the spec
   refers to.
-- **Worked example** —
+- **Worked example:**
   [`examples/external_wal.rs`](../examples/external_wal.rs) runs the full recipe
   (log-before-apply, flush, trim to `W`, crash, reopen, replay above `W`) and
   asserts the recovered state. Run it with `cargo run --example external_wal`.
-- **Integration test** — [`tests/external_wal.rs`](../tests/external_wal.rs)
+- **Integration test:** [`tests/external_wal.rs`](../tests/external_wal.rs)
   drives the recipe across every write kind through a crash and asserts the
   recovered state is byte-for-byte a non-crashed run's. Its contract guards
   prove a wrong recovery is *detectably* wrong: collapsing ops to `insert`,

--- a/examples/external_wal.rs
+++ b/examples/external_wal.rs
@@ -3,7 +3,8 @@
 
 //! Worked example for the external-WAL recipe (`docs/external-wal.md`): the
 //! engine has no internal WAL, so durability is the caller's job. This program
-//! logs each write to an [append-only reference WAL](#) **before** applying it,
+//! logs each write to an append-only reference WAL (`reference_wal`) **before**
+//! applying it,
 //! flushes to make a prefix durable, trims the WAL to that watermark, simulates
 //! a crash (drop the tree, keeping the SST directory + WAL), reopens, and
 //! replays the surviving tail strictly above the watermark.

--- a/examples/external_wal.rs
+++ b/examples/external_wal.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Worked example for the external-WAL recipe (`docs/external-wal.md`): the
+//! engine has no internal WAL, so durability is the caller's job. This program
+//! logs each write to an [append-only reference WAL](#) **before** applying it,
+//! flushes to make a prefix durable, trims the WAL to that watermark, simulates
+//! a crash (drop the tree, keeping the SST directory + WAL), reopens, and
+//! replays the surviving tail strictly above the watermark.
+//!
+//! Run it with `cargo run --example external_wal`. It reuses the same reference
+//! WAL the integration test in `tests/external_wal.rs` exercises, so the spec,
+//! the example, and the test stay in lock-step.
+
+#[path = "../tests/external_wal/reference_wal.rs"]
+mod reference_wal;
+
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, MAX_SEQNO, MergeOperator, SequenceNumberCounter, UserValue,
+};
+use reference_wal::{ReferenceWal, WalOp, WalRecord};
+use std::path::Path;
+use std::sync::Arc;
+
+/// `counter` merge operator: base + sum of i64 little-endian operands.
+struct CounterMerge;
+
+impl MergeOperator for CounterMerge {
+    fn merge(
+        &self,
+        _key: &[u8],
+        base: Option<&[u8]>,
+        operands: &[&[u8]],
+    ) -> lsm_tree::Result<UserValue> {
+        let mut n: i64 = base.map_or(0, |b| i64::from_le_bytes(b.try_into().expect("8 bytes")));
+        for op in operands {
+            n += i64::from_le_bytes((*op).try_into().expect("8 bytes"));
+        }
+        Ok(n.to_le_bytes().to_vec().into())
+    }
+}
+
+fn open(folder: &Path) -> AnyTree {
+    Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_merge_operator(Some(Arc::new(CounterMerge)))
+    .open()
+    .expect("open tree")
+}
+
+/// Applies one logged record at its seqno with its original operation.
+fn apply(tree: &AnyTree, record: &WalRecord) {
+    match &record.op {
+        WalOp::Insert { key, value } => {
+            tree.insert(key.as_slice(), value.as_slice(), record.seqno);
+        }
+        WalOp::Remove { key } => {
+            tree.remove(key.as_slice(), record.seqno);
+        }
+        WalOp::Merge { key, value } => {
+            tree.merge(key.as_slice(), value.as_slice(), record.seqno);
+        }
+        // The integration test covers remove_weak / remove_range / batch too; the
+        // example keeps to the three commonest kinds for readability.
+        other => unreachable!("example workload uses only insert/remove/merge, got {other:?}"),
+    }
+}
+
+fn main() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let wal_path = dir.path().join("external.wal");
+
+    // --- Live operation: log before apply, flush, trim to the watermark. ---
+    {
+        let tree = open(dir.path());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+
+        // A small durable prefix (seqnos 0..=1), applied in strict order.
+        for record in [
+            WalRecord {
+                seqno: 0,
+                op: WalOp::Insert {
+                    key: b"user:1".to_vec(),
+                    value: b"alice".to_vec(),
+                },
+            },
+            WalRecord {
+                seqno: 1,
+                op: WalOp::Merge {
+                    key: b"logins".to_vec(),
+                    value: 1i64.to_le_bytes().to_vec(),
+                },
+            },
+        ] {
+            wal.append(&record)?; // 1. log + fsync ...
+            apply(&tree, &record); // 2. ... then apply
+        }
+
+        tree.flush_active_memtable(0)?; // 3. make the prefix durable
+        let w = tree.get_highest_persisted_seqno().expect("flushed");
+        println!("flushed; durable watermark W = {w}");
+        wal.trim_through(w)?; // 4. the prefix is on disk; drop it from the WAL
+
+        // Writes above W live only in the active memtable — lost on a crash.
+        for record in [
+            WalRecord {
+                seqno: 2,
+                op: WalOp::Merge {
+                    key: b"logins".to_vec(),
+                    value: 1i64.to_le_bytes().to_vec(),
+                },
+            },
+            WalRecord {
+                seqno: 3,
+                op: WalOp::Remove {
+                    key: b"user:1".to_vec(),
+                },
+            },
+        ] {
+            wal.append(&record)?;
+            apply(&tree, &record);
+        }
+
+        // --- Crash: drop the tree (the memtable with seqnos 2..=3 is gone). ---
+        drop(tree);
+        println!("crashed (dropped the tree); SST dir + WAL survive on disk");
+    }
+
+    // --- Recovery: reopen (recovers seqnos 0..=1 from SSTs), replay above W. ---
+    let tree = open(dir.path());
+    let wal = ReferenceWal::open(&wal_path)?;
+    for record in wal.records()? {
+        apply(&tree, &record); // every surviving record is above W by construction
+    }
+
+    let logins = tree
+        .get("logins", MAX_SEQNO)?
+        .map(|v| i64::from_le_bytes((*v).try_into().expect("8 bytes")));
+    let user1 = tree.get("user:1", MAX_SEQNO)?;
+    println!("recovered: logins = {logins:?}, user:1 = {user1:?}");
+
+    assert_eq!(
+        logins,
+        Some(2),
+        "two merge operands folded across the crash"
+    );
+    assert_eq!(user1, None, "the replayed remove survived the crash");
+    println!("recovery reproduced the pre-crash state exactly");
+    Ok(())
+}

--- a/examples/external_wal.rs
+++ b/examples/external_wal.rs
@@ -104,7 +104,7 @@ fn main() -> lsm_tree::Result<()> {
         println!("flushed; durable watermark W = {w}");
         wal.trim_through(w)?; // 4. the prefix is on disk; drop it from the WAL
 
-        // Writes above W live only in the active memtable — lost on a crash.
+        // Writes above W live only in the active memtable, lost on a crash.
         for record in [
             WalRecord {
                 seqno: 2,

--- a/tests/compat_matrix.rs
+++ b/tests/compat_matrix.rs
@@ -154,6 +154,12 @@ fn build_config(dir: &std::path::Path, cell: Cell) -> Config {
     )
     .data_block_compression_policy(CompressionPolicy::all(compression_type(cell.comp)));
 
+    // `cfg` is reassigned only inside the `encryption` / `page_ecc` feature
+    // blocks below, so the binding needs `mut` only when one of them is enabled.
+    #[cfg_attr(
+        not(any(feature = "encryption", feature = "page_ecc")),
+        expect(unused_mut, reason = "mut is used only under encryption / page_ecc")
+    )]
     let mut cfg = if cell.blob {
         // threshold 1 forces every value down the blob path so the KV-sep axis
         // is actually exercised (the values here are small).

--- a/tests/external_wal.rs
+++ b/tests/external_wal.rs
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Executable proof of the external-WAL recipe specified in
+//! `docs/external-wal.md`: drive the documented contract end-to-end through a
+//! crash and recovery, and assert the recovered state is byte-for-byte what a
+//! non-crashed run produced. The contract-guard tests additionally prove that a
+//! deliberately wrong recovery (collapsing ops to `insert`, re-applying a merge
+//! at or below the watermark, or replaying from the raw persisted maximum
+//! instead of the gap-free watermark) is *detectably* wrong.
+
+#![cfg(feature = "std")]
+
+#[path = "external_wal/reference_wal.rs"]
+mod reference_wal;
+
+// `Guard` (the re-exported `IterGuard` trait) is required for `into_inner()` on
+// scan results.
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, Guard, MAX_SEQNO, MergeOperator, SequenceNumberCounter,
+    UserValue, WriteBatch,
+};
+use reference_wal::{BatchEntry, ReferenceWal, WalOp, WalRecord};
+use std::path::Path;
+use std::sync::Arc;
+
+/// Counter merge operator: base + sum of i64 little-endian operands. Re-applying
+/// an operand folds it twice, which is exactly the footgun the strict `> W`
+/// replay boundary exists to prevent.
+struct CounterMerge;
+
+impl MergeOperator for CounterMerge {
+    fn merge(
+        &self,
+        _key: &[u8],
+        base_value: Option<&[u8]>,
+        operands: &[&[u8]],
+    ) -> lsm_tree::Result<UserValue> {
+        let mut counter: i64 = match base_value {
+            Some(bytes) if bytes.len() == 8 => {
+                i64::from_le_bytes(bytes.try_into().expect("checked length"))
+            }
+            Some(_) => return Err(lsm_tree::Error::MergeOperator),
+            None => 0,
+        };
+        for operand in operands {
+            if operand.len() != 8 {
+                return Err(lsm_tree::Error::MergeOperator);
+            }
+            counter += i64::from_le_bytes((*operand).try_into().expect("checked length"));
+        }
+        Ok(counter.to_le_bytes().to_vec().into())
+    }
+}
+
+/// Opens (or reopens) a tree at `folder` with the counter merge operator. The
+/// SAME operator must be configured on reopen, or merge resolution on read would
+/// fail.
+fn open_tree(folder: &Path) -> AnyTree {
+    Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_merge_operator(Some(Arc::new(CounterMerge)))
+    .open()
+    .expect("open tree")
+}
+
+/// Applies one logged record at its original seqno with its original operation,
+/// never collapsing to `insert`. This is the "apply" half of log-before-apply
+/// and the whole of replay.
+fn apply(tree: &AnyTree, record: &WalRecord) -> lsm_tree::Result<()> {
+    let seqno = record.seqno;
+    match &record.op {
+        WalOp::Insert { key, value } => {
+            tree.insert(key.as_slice(), value.as_slice(), seqno);
+        }
+        WalOp::Remove { key } => {
+            tree.remove(key.as_slice(), seqno);
+        }
+        WalOp::RemoveWeak { key } => {
+            tree.remove_weak(key.as_slice(), seqno);
+        }
+        WalOp::RemoveRange { start, end } => {
+            tree.remove_range(start.as_slice(), end.as_slice(), seqno);
+        }
+        WalOp::Merge { key, value } => {
+            tree.merge(key.as_slice(), value.as_slice(), seqno);
+        }
+        WalOp::Batch { entries } => {
+            let mut batch = WriteBatch::new();
+            for entry in entries {
+                match entry {
+                    BatchEntry::Insert { key, value } => {
+                        batch.insert(key.as_slice(), value.as_slice())
+                    }
+                    BatchEntry::Remove { key } => batch.remove(key.as_slice()),
+                    BatchEntry::RemoveWeak { key } => batch.remove_weak(key.as_slice()),
+                    BatchEntry::Merge { key, value } => {
+                        batch.merge(key.as_slice(), value.as_slice())
+                    }
+                }
+            }
+            tree.apply_batch(batch, seqno)?;
+        }
+    }
+    Ok(())
+}
+
+/// The full visible state at `MAX_SEQNO` as sorted `(key, value)` pairs — the
+/// byte-identity fingerprint two runs must agree on.
+fn snapshot(tree: &AnyTree) -> Vec<(Vec<u8>, Vec<u8>)> {
+    tree.iter(MAX_SEQNO, None)
+        .map(|guard| {
+            let (key, value) = guard.into_inner().expect("scan entry");
+            (key.to_vec(), value.to_vec())
+        })
+        .collect()
+}
+
+/// A deterministic workload exercising every logged write kind: `insert`,
+/// `remove`, `remove_weak`, `remove_range`, `merge`, and a `WriteBatch` (which
+/// itself mixes insert / remove_weak / merge). Seqnos `0..=FLUSH_AFTER` are
+/// flushed (durable) before the crash; `> FLUSH_AFTER` live only in the lost
+/// memtable and must be recovered from the WAL.
+const FLUSH_AFTER: u64 = 6;
+
+fn workload() -> Vec<WalRecord> {
+    let i64op = |n: i64| n.to_le_bytes().to_vec();
+    vec![
+        WalRecord {
+            seqno: 0,
+            op: WalOp::Insert {
+                key: b"apple".to_vec(),
+                value: b"red".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 1,
+            op: WalOp::Insert {
+                key: b"banana".to_vec(),
+                value: b"yellow".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 2,
+            op: WalOp::Merge {
+                key: b"counter".to_vec(),
+                value: i64op(5),
+            },
+        },
+        WalRecord {
+            seqno: 3,
+            op: WalOp::Insert {
+                key: b"cherry".to_vec(),
+                value: b"dark".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 4,
+            op: WalOp::Batch {
+                entries: vec![
+                    BatchEntry::Insert {
+                        key: b"date".to_vec(),
+                        value: b"brown".to_vec(),
+                    },
+                    BatchEntry::RemoveWeak {
+                        key: b"banana".to_vec(),
+                    },
+                    BatchEntry::Merge {
+                        key: b"counter".to_vec(),
+                        value: i64op(3),
+                    },
+                ],
+            },
+        },
+        WalRecord {
+            seqno: 5,
+            op: WalOp::Remove {
+                key: b"apple".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 6,
+            op: WalOp::RemoveRange {
+                start: b"cherry".to_vec(),
+                end: b"date".to_vec(),
+            },
+        },
+        // ---- flush boundary: W = 6 ----
+        WalRecord {
+            seqno: 7,
+            op: WalOp::Insert {
+                key: b"elderberry".to_vec(),
+                value: b"purple".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 8,
+            op: WalOp::Merge {
+                key: b"counter".to_vec(),
+                value: i64op(2),
+            },
+        },
+        WalRecord {
+            seqno: 9,
+            op: WalOp::Insert {
+                key: b"fig".to_vec(),
+                value: b"green".to_vec(),
+            },
+        },
+        WalRecord {
+            seqno: 10,
+            op: WalOp::Remove {
+                key: b"elderberry".to_vec(),
+            },
+        },
+    ]
+}
+
+/// The reference WAL preserves every op kind across a round-trip and `trim_through`
+/// drops exactly the records at or below the watermark.
+#[test]
+fn reference_wal_round_trips_and_trims_below_the_watermark() -> std::io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("round_trip.wal");
+
+    let records = workload();
+    let mut wal = ReferenceWal::create(&path)?;
+    for record in &records {
+        wal.append(record)?;
+    }
+    assert_eq!(
+        wal.records()?,
+        records,
+        "round-trip preserves every op kind and seqno",
+    );
+
+    wal.trim_through(FLUSH_AFTER)?;
+    let kept = wal.records()?;
+    assert!(
+        kept.iter().all(|r| r.seqno > FLUSH_AFTER),
+        "trim drops every record at or below W: {kept:?}",
+    );
+    assert_eq!(
+        kept,
+        records
+            .iter()
+            .filter(|r| r.seqno > FLUSH_AFTER)
+            .cloned()
+            .collect::<Vec<_>>(),
+        "trim keeps the above-W suffix verbatim",
+    );
+    Ok(())
+}
+
+/// The headline contract test: run the documented recipe end-to-end through a
+/// crash (drop the tree, keep the SST dir + WAL) and assert the recovered state
+/// is byte-for-byte what a non-crashed run produced, for every write kind.
+#[test]
+fn external_wal_recipe_survives_crash_and_recovers_identical_state() -> lsm_tree::Result<()> {
+    let work = workload();
+
+    // Reference: a single no-crash run of the whole workload.
+    let ref_dir = tempfile::tempdir()?;
+    let reference = {
+        let tree = open_tree(ref_dir.path());
+        for record in &work {
+            apply(&tree, record)?;
+        }
+        snapshot(&tree)
+    };
+
+    // Recipe run: log-before-apply, flush, trim to W, more writes, then crash.
+    let dir = tempfile::tempdir()?;
+    let wal_path = dir.path().join("external.wal");
+    {
+        let tree = open_tree(dir.path());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+
+        // Phase 1 — durable prefix: apply in strict seqno order through the flush.
+        for record in work.iter().filter(|r| r.seqno <= FLUSH_AFTER) {
+            wal.append(record)?; // log ...
+            apply(&tree, record)?; // ... before apply
+        }
+        tree.flush_active_memtable(0)?;
+        let w = tree
+            .get_highest_persisted_seqno()
+            .expect("flushed tree has a persisted watermark");
+        assert_eq!(
+            w, FLUSH_AFTER,
+            "gap-free in-order apply: W == persisted maximum"
+        );
+        wal.trim_through(w)?; // the prefix is durable; drop it from the WAL
+
+        // Phase 2 — post-flush writes that live only in the active memtable.
+        for record in work.iter().filter(|r| r.seqno > FLUSH_AFTER) {
+            wal.append(record)?;
+            apply(&tree, record)?;
+        }
+
+        // Crash: drop the tree, losing the unflushed memtable. The SST directory
+        // and the WAL persist on disk.
+        drop(tree);
+    }
+
+    // Recovery: reopen (recovers from SSTs up to W) and replay strictly above W.
+    let recovered = {
+        let tree = open_tree(dir.path());
+        let wal = ReferenceWal::open(&wal_path)?;
+        for record in wal.records()? {
+            assert!(
+                record.seqno > FLUSH_AFTER,
+                "the trimmed WAL holds only records above W",
+            );
+            apply(&tree, &record)?;
+        }
+        snapshot(&tree)
+    };
+
+    assert_eq!(
+        recovered, reference,
+        "recovered state is byte-for-byte the non-crashed run's state",
+    );
+    Ok(())
+}

--- a/tests/external_wal.rs
+++ b/tests/external_wal.rs
@@ -16,6 +16,7 @@ mod reference_wal;
 
 // `Guard` (the re-exported `IterGuard` trait) is required for `into_inner()` on
 // scan results.
+use lsm_tree::fs::{CrashFs, Fs, MemFs};
 use lsm_tree::{
     AbstractTree, AnyTree, Config, Guard, MAX_SEQNO, MergeOperator, SequenceNumberCounter,
     UserValue, WriteBatch,
@@ -67,6 +68,20 @@ fn open_tree(folder: &Path) -> AnyTree {
     .expect("open tree")
 }
 
+/// Opens (or reopens) a tree at `folder` on an injected filesystem, with the
+/// counter merge operator. Used by the `CrashFs` power-loss variant.
+fn open_tree_on(folder: &Path, fs: Arc<dyn Fs>) -> AnyTree {
+    Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_merge_operator(Some(Arc::new(CounterMerge)))
+    .with_shared_fs(fs)
+    .open()
+    .expect("open tree")
+}
+
 /// Applies one logged record at its original seqno with its original operation,
 /// never collapsing to `insert`. This is the "apply" half of log-before-apply
 /// and the whole of replay.
@@ -108,7 +123,7 @@ fn apply(tree: &AnyTree, record: &WalRecord) -> lsm_tree::Result<()> {
     Ok(())
 }
 
-/// The full visible state at `MAX_SEQNO` as sorted `(key, value)` pairs — the
+/// The full visible state at `MAX_SEQNO` as sorted `(key, value)` pairs: the
 /// byte-identity fingerprint two runs must agree on.
 fn snapshot(tree: &AnyTree) -> Vec<(Vec<u8>, Vec<u8>)> {
     tree.iter(MAX_SEQNO, None)
@@ -279,7 +294,7 @@ fn external_wal_recipe_survives_crash_and_recovers_identical_state() -> lsm_tree
         let tree = open_tree(dir.path());
         let mut wal = ReferenceWal::create(&wal_path)?;
 
-        // Phase 1 — durable prefix: apply in strict seqno order through the flush.
+        // Phase 1, durable prefix: apply in strict seqno order through the flush.
         for record in work.iter().filter(|r| r.seqno <= FLUSH_AFTER) {
             wal.append(record)?; // log ...
             apply(&tree, record)?; // ... before apply
@@ -294,7 +309,7 @@ fn external_wal_recipe_survives_crash_and_recovers_identical_state() -> lsm_tree
         );
         wal.trim_through(w)?; // the prefix is durable; drop it from the WAL
 
-        // Phase 2 — post-flush writes that live only in the active memtable.
+        // Phase 2, post-flush writes that live only in the active memtable.
         for record in work.iter().filter(|r| r.seqno > FLUSH_AFTER) {
             wal.append(record)?;
             apply(&tree, record)?;
@@ -338,7 +353,7 @@ fn counter_of(tree: &AnyTree) -> Option<i64> {
         .map(|v| i64::from_le_bytes((*v).try_into().expect("8-byte counter")))
 }
 
-/// Contract guard — the **original operation** must be replayed, never collapsed
+/// Contract guard:the **original operation** must be replayed, never collapsed
 /// to `insert`. A `remove` recovered as an `insert` resurrects the key, so a
 /// collapsing recovery is detectably wrong.
 #[test]
@@ -396,13 +411,13 @@ fn collapsing_a_remove_to_insert_is_detectably_wrong() -> lsm_tree::Result<()> {
     };
     assert!(
         has_key(&wrong, b"k"),
-        "collapsing the remove to an insert resurrects k — detectably wrong",
+        "collapsing the remove to an insert resurrects k, detectably wrong",
     );
     assert_ne!(correct, wrong, "the two recoveries must diverge");
     Ok(())
 }
 
-/// Contract guard — a merge operand at or below the watermark `W` is already
+/// Contract guard:a merge operand at or below the watermark `W` is already
 /// folded into the persisted SSTs; re-applying it on recovery folds it twice.
 /// The strict `> W` boundary prevents this; replaying every record double-counts.
 #[test]
@@ -471,13 +486,13 @@ fn re_applying_a_merge_at_or_below_the_watermark_double_counts() -> lsm_tree::Re
     assert_eq!(
         wrong,
         Some(18),
-        "re-applying the at-or-below-W operands double-counts — detectably wrong",
+        "re-applying the at-or-below-W operands double-counts, detectably wrong",
     );
     assert_ne!(correct, wrong);
     Ok(())
 }
 
-/// Contract guard — replay must use the gap-free watermark `W`, not the raw
+/// Contract guard:replay must use the gap-free watermark `W`, not the raw
 /// persisted maximum. A record that was logged but not applied (a crash between
 /// the log write and the apply) sits below a higher applied-and-flushed seqno;
 /// `W` stays below the gap, so `> W` replays it, while `> raw_maximum` skips it
@@ -537,7 +552,7 @@ fn replaying_from_the_raw_maximum_skips_a_logged_but_unapplied_gap() -> lsm_tree
     let records = ReferenceWal::open(&wal_path)?.records()?;
 
     // Correct replay (> W = 0): re-applies the gap (1) and re-applies b (2,
-    // already persisted — a harmless overwrite). "gap" is recovered.
+    // already persisted, a harmless overwrite). "gap" is recovered.
     let correct = {
         let tree = open_tree(dir.path());
         for record in records.iter().filter(|r| r.seqno > 0) {
@@ -560,8 +575,77 @@ fn replaying_from_the_raw_maximum_skips_a_logged_but_unapplied_gap() -> lsm_tree
     };
     assert!(
         !has_key(&wrong, b"gap"),
-        "replaying from the raw maximum loses the gap record — detectably wrong",
+        "replaying from the raw maximum loses the gap record, detectably wrong",
     );
     assert_ne!(correct, wrong);
+    Ok(())
+}
+
+/// The recipe recovers through the fault-injection harness: the engine runs on a
+/// `CrashFs` over an in-memory disk whose `crash()` drops every unsynced write (a
+/// stronger crash than a clean drop). The reference WAL stays on the caller's
+/// real disk, unaffected by the engine's power loss, and replay above `W`
+/// reconstructs the lost tail.
+#[test]
+fn external_wal_recipe_recovers_through_the_crash_fs_harness() -> lsm_tree::Result<()> {
+    let work = workload();
+
+    // Reference: a single no-crash run on the default filesystem.
+    let ref_dir = tempfile::tempdir()?;
+    let reference = {
+        let tree = open_tree(ref_dir.path());
+        for record in &work {
+            apply(&tree, record)?;
+        }
+        snapshot(&tree)
+    };
+
+    let db_dir = tempfile::tempdir()?; // engine storage path (keys into MemFs)
+    let wal_dir = tempfile::tempdir()?; // the caller's WAL, on the real disk
+    let wal_path = wal_dir.path().join("external.wal");
+
+    // An in-memory disk under a crash-injecting wrapper. `mem` is held so the
+    // post-crash state survives the tree teardown for the reopen.
+    let mem = MemFs::new();
+    let crash = Arc::new(CrashFs::from_shared(Arc::new(mem.clone())));
+    {
+        let tree = open_tree_on(db_dir.path(), crash.clone());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+
+        for record in work.iter().filter(|r| r.seqno <= FLUSH_AFTER) {
+            wal.append(record)?;
+            apply(&tree, record)?;
+        }
+        tree.flush_active_memtable(0)?;
+        let w = tree
+            .get_highest_persisted_seqno()
+            .expect("flushed tree has a persisted watermark");
+        wal.trim_through(w)?;
+        for record in work.iter().filter(|r| r.seqno > FLUSH_AFTER) {
+            wal.append(record)?;
+            apply(&tree, record)?;
+        }
+
+        // Power loss: drop every unsynced engine write, then tear the tree down.
+        // The flushed SSTs were synced, so they survive; the unflushed memtable
+        // (seqnos above W) does not.
+        crash.crash();
+        drop(tree);
+    }
+
+    // Recover on the surviving in-memory disk and replay strictly above W.
+    let recovered = {
+        let tree = open_tree_on(db_dir.path(), Arc::new(mem.clone()));
+        let wal = ReferenceWal::open(&wal_path)?;
+        for record in wal.records()? {
+            apply(&tree, &record)?;
+        }
+        snapshot(&tree)
+    };
+
+    assert_eq!(
+        recovered, reference,
+        "recovery through the crash harness reproduces the non-crashed state",
+    );
     Ok(())
 }

--- a/tests/external_wal.rs
+++ b/tests/external_wal.rs
@@ -325,3 +325,243 @@ fn external_wal_recipe_survives_crash_and_recovers_identical_state() -> lsm_tree
     );
     Ok(())
 }
+
+/// Whether the visible state contains `key`.
+fn has_key(state: &[(Vec<u8>, Vec<u8>)], key: &[u8]) -> bool {
+    state.iter().any(|(k, _)| k.as_slice() == key)
+}
+
+/// The counter value folded by [`CounterMerge`], if the key is present.
+fn counter_of(tree: &AnyTree) -> Option<i64> {
+    tree.get("counter", MAX_SEQNO)
+        .expect("counter read")
+        .map(|v| i64::from_le_bytes((*v).try_into().expect("8-byte counter")))
+}
+
+/// Contract guard — the **original operation** must be replayed, never collapsed
+/// to `insert`. A `remove` recovered as an `insert` resurrects the key, so a
+/// collapsing recovery is detectably wrong.
+#[test]
+fn collapsing_a_remove_to_insert_is_detectably_wrong() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let wal_path = dir.path().join("external.wal");
+
+    // insert "k" (durable), then remove "k" above the watermark.
+    {
+        let tree = open_tree(dir.path());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+        let insert = WalRecord {
+            seqno: 0,
+            op: WalOp::Insert {
+                key: b"k".to_vec(),
+                value: b"v".to_vec(),
+            },
+        };
+        wal.append(&insert)?;
+        apply(&tree, &insert)?;
+        tree.flush_active_memtable(0)?;
+        let w = tree.get_highest_persisted_seqno().expect("flushed");
+        wal.trim_through(w)?;
+        let remove = WalRecord {
+            seqno: 1,
+            op: WalOp::Remove { key: b"k".to_vec() },
+        };
+        wal.append(&remove)?;
+        apply(&tree, &remove)?;
+        drop(tree);
+    }
+    let records = ReferenceWal::open(&wal_path)?.records()?;
+
+    // Correct replay: the original `remove` wins, "k" is absent.
+    let correct = {
+        let tree = open_tree(dir.path());
+        for record in &records {
+            apply(&tree, record)?;
+        }
+        snapshot(&tree)
+    };
+    assert!(!has_key(&correct, b"k"), "the replayed remove deletes k");
+
+    // Wrong replay: collapse the surviving record to an insert of its key.
+    let wrong = {
+        let tree = open_tree(dir.path());
+        for record in &records {
+            if let WalOp::Remove { key } = &record.op {
+                tree.insert(key.as_slice(), b"resurrected".as_slice(), record.seqno);
+            } else {
+                apply(&tree, record)?;
+            }
+        }
+        snapshot(&tree)
+    };
+    assert!(
+        has_key(&wrong, b"k"),
+        "collapsing the remove to an insert resurrects k — detectably wrong",
+    );
+    assert_ne!(correct, wrong, "the two recoveries must diverge");
+    Ok(())
+}
+
+/// Contract guard — a merge operand at or below the watermark `W` is already
+/// folded into the persisted SSTs; re-applying it on recovery folds it twice.
+/// The strict `> W` boundary prevents this; replaying every record double-counts.
+#[test]
+fn re_applying_a_merge_at_or_below_the_watermark_double_counts() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let wal_path = dir.path().join("external.wal");
+    let i64op = |n: i64| n.to_le_bytes().to_vec();
+
+    // merge +5, +3 (durable: counter persists as 8), then +2 above the watermark.
+    // NOTE: the WAL is deliberately NOT trimmed here, so the persisted operands
+    // are still present for a wrong replay to re-fold.
+    let w;
+    {
+        let tree = open_tree(dir.path());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+        for (seqno, delta) in [(0u64, 5i64), (1, 3)] {
+            let rec = WalRecord {
+                seqno,
+                op: WalOp::Merge {
+                    key: b"counter".to_vec(),
+                    value: i64op(delta),
+                },
+            };
+            wal.append(&rec)?;
+            apply(&tree, &rec)?;
+        }
+        tree.flush_active_memtable(0)?;
+        w = tree.get_highest_persisted_seqno().expect("flushed");
+        assert_eq!(w, 1, "both operands persisted, gap-free");
+        let above = WalRecord {
+            seqno: 2,
+            op: WalOp::Merge {
+                key: b"counter".to_vec(),
+                value: i64op(2),
+            },
+        };
+        wal.append(&above)?;
+        apply(&tree, &above)?;
+        drop(tree);
+    }
+    let records = ReferenceWal::open(&wal_path)?.records()?;
+
+    // Correct replay: only the operand above W (+2) is re-applied: 8 + 2 = 10.
+    let correct = {
+        let tree = open_tree(dir.path());
+        for record in records.iter().filter(|r| r.seqno > w) {
+            apply(&tree, record)?;
+        }
+        counter_of(&tree)
+    };
+    assert_eq!(
+        correct,
+        Some(10),
+        "strict > W replay yields the true counter"
+    );
+
+    // Wrong replay: re-apply every record, re-folding the persisted +5 and +3:
+    // 8 + 5 + 3 + 2 = 18.
+    let wrong = {
+        let tree = open_tree(dir.path());
+        for record in &records {
+            apply(&tree, record)?;
+        }
+        counter_of(&tree)
+    };
+    assert_eq!(
+        wrong,
+        Some(18),
+        "re-applying the at-or-below-W operands double-counts — detectably wrong",
+    );
+    assert_ne!(correct, wrong);
+    Ok(())
+}
+
+/// Contract guard — replay must use the gap-free watermark `W`, not the raw
+/// persisted maximum. A record that was logged but not applied (a crash between
+/// the log write and the apply) sits below a higher applied-and-flushed seqno;
+/// `W` stays below the gap, so `> W` replays it, while `> raw_maximum` skips it
+/// and loses the write.
+#[test]
+fn replaying_from_the_raw_maximum_skips_a_logged_but_unapplied_gap() -> lsm_tree::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let wal_path = dir.path().join("external.wal");
+
+    // Apply + flush seqno 0 ("a"). Then log seqno 1 ("gap") WITHOUT applying it
+    // (the crash window between log-before-apply's step 2 and step 3). Then
+    // log + apply + flush seqno 2 ("b"). The applied-and-persisted prefix is 0
+    // (the gap at 1 is unapplied), so W = 0 while the raw persisted maximum = 2.
+    {
+        let tree = open_tree(dir.path());
+        let mut wal = ReferenceWal::create(&wal_path)?;
+
+        let a = WalRecord {
+            seqno: 0,
+            op: WalOp::Insert {
+                key: b"a".to_vec(),
+                value: b"0".to_vec(),
+            },
+        };
+        wal.append(&a)?;
+        apply(&tree, &a)?;
+        tree.flush_active_memtable(0)?;
+
+        // Logged, fsynced, but the process "dies" before applying it.
+        let gap = WalRecord {
+            seqno: 1,
+            op: WalOp::Insert {
+                key: b"gap".to_vec(),
+                value: b"1".to_vec(),
+            },
+        };
+        wal.append(&gap)?;
+        // (no apply)
+
+        let b = WalRecord {
+            seqno: 2,
+            op: WalOp::Insert {
+                key: b"b".to_vec(),
+                value: b"2".to_vec(),
+            },
+        };
+        wal.append(&b)?;
+        apply(&tree, &b)?;
+        tree.flush_active_memtable(0)?;
+
+        let raw_max = tree.get_highest_persisted_seqno().expect("flushed");
+        assert_eq!(raw_max, 2, "the raw persisted maximum jumps past the gap");
+        // The caller's gap-free applied-and-persisted watermark is 0, NOT 2.
+        wal.trim_through(0)?; // keeps seqnos 1 and 2
+        drop(tree);
+    }
+    let records = ReferenceWal::open(&wal_path)?.records()?;
+
+    // Correct replay (> W = 0): re-applies the gap (1) and re-applies b (2,
+    // already persisted — a harmless overwrite). "gap" is recovered.
+    let correct = {
+        let tree = open_tree(dir.path());
+        for record in records.iter().filter(|r| r.seqno > 0) {
+            apply(&tree, record)?;
+        }
+        snapshot(&tree)
+    };
+    assert!(
+        has_key(&correct, b"gap"),
+        "the logged-but-unapplied gap is recovered"
+    );
+
+    // Wrong replay (> raw maximum = 2): skips the gap at seqno 1 entirely.
+    let wrong = {
+        let tree = open_tree(dir.path());
+        for record in records.iter().filter(|r| r.seqno > 2) {
+            apply(&tree, record)?;
+        }
+        snapshot(&tree)
+    };
+    assert!(
+        !has_key(&wrong, b"gap"),
+        "replaying from the raw maximum loses the gap record — detectably wrong",
+    );
+    assert_ne!(correct, wrong);
+    Ok(())
+}

--- a/tests/external_wal/reference_wal.rs
+++ b/tests/external_wal/reference_wal.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Minimal append-only reference WAL — the worked example for the external-WAL
+//! recipe in `docs/external-wal.md`.
+//!
+//! This is **illustrative, not a production WAL**: it is `std`-only (a test/dev
+//! surface, never the `no_std` production path), single-threaded, and rewrites
+//! the whole file on trim. It exists to make the documented recipe executable
+//! and self-verifying, not to be fast or crash-hardened in its own right.
+//!
+//! The contract it embodies (see `docs/external-wal.md`):
+//!
+//! - A record stores the **original operation** plus the **caller-assigned
+//!   seqno** it was applied at. Recovery replays the original op, never
+//!   collapsing everything to `insert`.
+//! - [`append`](ReferenceWal::append) fsyncs before returning, so a record that
+//!   survives a crash is exactly one whose `append` had returned (log-before-apply).
+//! - [`trim_through`](ReferenceWal::trim_through) drops every record with
+//!   `seqno <= W`, where `W` is the caller's gap-free applied-and-persisted
+//!   watermark. Records above `W` (incl. a logged-but-unapplied gap below a
+//!   flushed higher seqno) are retained for replay.
+//! - [`records`](ReferenceWal::records) reads the survivors back in append order
+//!   so recovery can replay each one exactly once, strictly above `W`.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+/// A single entry inside a logged [`WalOp::Batch`]. A batch shares one seqno
+/// across all its entries, so entries carry no seqno of their own. Range
+/// tombstones are not batchable, mirroring [`crate::WriteBatch`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchEntry {
+    Insert { key: Vec<u8>, value: Vec<u8> },
+    Remove { key: Vec<u8> },
+    RemoveWeak { key: Vec<u8> },
+    Merge { key: Vec<u8>, value: Vec<u8> },
+}
+
+/// The original write operation a record was logged for. Replay applies the
+/// matching engine call (`insert` / `remove` / `remove_weak` / `remove_range` /
+/// `merge` / `apply_batch`), never collapsing to `insert`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WalOp {
+    Insert { key: Vec<u8>, value: Vec<u8> },
+    Remove { key: Vec<u8> },
+    RemoveWeak { key: Vec<u8> },
+    RemoveRange { start: Vec<u8>, end: Vec<u8> },
+    Merge { key: Vec<u8>, value: Vec<u8> },
+    Batch { entries: Vec<BatchEntry> },
+}
+
+/// One logged write: the caller-assigned seqno plus the original operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalRecord {
+    pub seqno: u64,
+    pub op: WalOp,
+}
+
+/// An append-only file WAL. Each [`append`](Self::append) encodes one
+/// [`WalRecord`] and fsyncs before returning.
+pub struct ReferenceWal {
+    path: PathBuf,
+    file: File,
+}
+
+impl ReferenceWal {
+    /// Creates a fresh, empty WAL at `path` (truncating any existing file).
+    pub fn create(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)?;
+        file.sync_all()?;
+        Ok(Self { path, file })
+    }
+
+    /// Reopens an existing WAL for replay + further appends after a crash. The
+    /// file is opened for append so recovery can keep logging once it resumes.
+    pub fn open(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        let file = OpenOptions::new().read(true).append(true).open(&path)?;
+        Ok(Self { path, file })
+    }
+
+    /// Appends one record and fsyncs. On return the record is durable, so it is
+    /// safe to apply the matching engine write (log-before-apply).
+    pub fn append(&mut self, record: &WalRecord) -> io::Result<()> {
+        let mut buf = Vec::new();
+        encode_record(record, &mut buf);
+        // Frame: [u32 payload length][payload]. The length prefix lets the
+        // reader recover the record boundary without a delimiter scan.
+        let len = u32::try_from(buf.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "WAL record too large"))?;
+        self.file.write_all(&len.to_le_bytes())?;
+        self.file.write_all(&buf)?;
+        self.file.sync_all()?;
+        Ok(())
+    }
+
+    /// Reads every surviving record back in append order.
+    pub fn records(&self) -> io::Result<Vec<WalRecord>> {
+        let mut file = File::open(&self.path)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        decode_records(&bytes)
+    }
+
+    /// Drops every record with `seqno <= w`, keeping the rest in order. `w` is
+    /// the caller's gap-free applied-and-persisted watermark: records at or
+    /// below it are durable in the engine's SSTs and never need replay, while
+    /// records above it (including a logged-but-unapplied seqno that sits below
+    /// a flushed higher one) are retained.
+    ///
+    /// Rewrites the whole file for simplicity — a production WAL would rotate
+    /// segments instead.
+    pub fn trim_through(&mut self, w: u64) -> io::Result<()> {
+        let kept: Vec<WalRecord> = self
+            .records()?
+            .into_iter()
+            .filter(|r| r.seqno > w)
+            .collect();
+
+        let tmp = self.path.with_extension("wal.tmp");
+        {
+            let mut out = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp)?;
+            for record in &kept {
+                let mut buf = Vec::new();
+                encode_record(record, &mut buf);
+                let len = u32::try_from(buf.len()).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "WAL record too large")
+                })?;
+                out.write_all(&len.to_le_bytes())?;
+                out.write_all(&buf)?;
+            }
+            out.sync_all()?;
+        }
+        std::fs::rename(&tmp, &self.path)?;
+        // Reopen the live handle on the rewritten file so later appends land
+        // after the retained records rather than at the stale offset.
+        self.file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .open(&self.path)?;
+        self.file.sync_all()?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoding: length-prefixed, dependency-free. Each byte string is `[u32 len][bytes]`.
+// ---------------------------------------------------------------------------
+
+const TAG_INSERT: u8 = 0;
+const TAG_REMOVE: u8 = 1;
+const TAG_REMOVE_WEAK: u8 = 2;
+const TAG_REMOVE_RANGE: u8 = 3;
+const TAG_MERGE: u8 = 4;
+const TAG_BATCH: u8 = 5;
+
+const BATCH_INSERT: u8 = 0;
+const BATCH_REMOVE: u8 = 1;
+const BATCH_REMOVE_WEAK: u8 = 2;
+const BATCH_MERGE: u8 = 3;
+
+fn put_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    let len = u32::try_from(bytes.len()).expect("test key/value fits in u32");
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn encode_record(record: &WalRecord, out: &mut Vec<u8>) {
+    out.extend_from_slice(&record.seqno.to_le_bytes());
+    match &record.op {
+        WalOp::Insert { key, value } => {
+            out.push(TAG_INSERT);
+            put_bytes(out, key);
+            put_bytes(out, value);
+        }
+        WalOp::Remove { key } => {
+            out.push(TAG_REMOVE);
+            put_bytes(out, key);
+        }
+        WalOp::RemoveWeak { key } => {
+            out.push(TAG_REMOVE_WEAK);
+            put_bytes(out, key);
+        }
+        WalOp::RemoveRange { start, end } => {
+            out.push(TAG_REMOVE_RANGE);
+            put_bytes(out, start);
+            put_bytes(out, end);
+        }
+        WalOp::Merge { key, value } => {
+            out.push(TAG_MERGE);
+            put_bytes(out, key);
+            put_bytes(out, value);
+        }
+        WalOp::Batch { entries } => {
+            out.push(TAG_BATCH);
+            let count = u32::try_from(entries.len()).expect("test batch fits in u32");
+            out.extend_from_slice(&count.to_le_bytes());
+            for entry in entries {
+                match entry {
+                    BatchEntry::Insert { key, value } => {
+                        out.push(BATCH_INSERT);
+                        put_bytes(out, key);
+                        put_bytes(out, value);
+                    }
+                    BatchEntry::Remove { key } => {
+                        out.push(BATCH_REMOVE);
+                        put_bytes(out, key);
+                    }
+                    BatchEntry::RemoveWeak { key } => {
+                        out.push(BATCH_REMOVE_WEAK);
+                        put_bytes(out, key);
+                    }
+                    BatchEntry::Merge { key, value } => {
+                        out.push(BATCH_MERGE);
+                        put_bytes(out, key);
+                        put_bytes(out, value);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// A cursor over the raw WAL bytes. Returns `None` from any read once the buffer
+/// is exhausted, so a torn tail record (a crash mid-append before fsync, or a
+/// truncated frame) is dropped rather than panicking — matching how a real WAL
+/// discards a partial trailing record on recovery.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let slice = self.bytes.get(self.pos..end)?;
+        self.pos = end;
+        Some(slice)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        let raw: [u8; 4] = self.take(4)?.try_into().ok()?;
+        Some(u32::from_le_bytes(raw))
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        let raw: [u8; 8] = self.take(8)?.try_into().ok()?;
+        Some(u64::from_le_bytes(raw))
+    }
+
+    fn bytes(&mut self) -> Option<Vec<u8>> {
+        let len = self.u32()? as usize;
+        Some(self.take(len)?.to_vec())
+    }
+}
+
+fn decode_batch_entries(cur: &mut Cursor) -> Option<Vec<BatchEntry>> {
+    let count = cur.u32()? as usize;
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let tag = *cur.take(1)?.first()?;
+        let entry = match tag {
+            BATCH_INSERT => BatchEntry::Insert {
+                key: cur.bytes()?,
+                value: cur.bytes()?,
+            },
+            BATCH_REMOVE => BatchEntry::Remove { key: cur.bytes()? },
+            BATCH_REMOVE_WEAK => BatchEntry::RemoveWeak { key: cur.bytes()? },
+            BATCH_MERGE => BatchEntry::Merge {
+                key: cur.bytes()?,
+                value: cur.bytes()?,
+            },
+            _ => return None,
+        };
+        entries.push(entry);
+    }
+    Some(entries)
+}
+
+fn decode_one(payload: &[u8]) -> Option<WalRecord> {
+    let mut cur = Cursor {
+        bytes: payload,
+        pos: 0,
+    };
+    let seqno = cur.u64()?;
+    let tag = *cur.take(1)?.first()?;
+    let op = match tag {
+        TAG_INSERT => WalOp::Insert {
+            key: cur.bytes()?,
+            value: cur.bytes()?,
+        },
+        TAG_REMOVE => WalOp::Remove { key: cur.bytes()? },
+        TAG_REMOVE_WEAK => WalOp::RemoveWeak { key: cur.bytes()? },
+        TAG_REMOVE_RANGE => WalOp::RemoveRange {
+            start: cur.bytes()?,
+            end: cur.bytes()?,
+        },
+        TAG_MERGE => WalOp::Merge {
+            key: cur.bytes()?,
+            value: cur.bytes()?,
+        },
+        TAG_BATCH => WalOp::Batch {
+            entries: decode_batch_entries(&mut cur)?,
+        },
+        _ => return None,
+    };
+    Some(WalRecord { seqno, op })
+}
+
+fn decode_records(bytes: &[u8]) -> io::Result<Vec<WalRecord>> {
+    let mut frame = Cursor { bytes, pos: 0 };
+    let mut out = Vec::new();
+    // Stop at the first short/torn frame: a crash between framing the length and
+    // fsyncing the payload leaves a partial tail that must be discarded, not
+    // decoded. Every fully-fsynced record precedes it, so this is lossless for
+    // the recipe (which only relies on records whose `append` had returned).
+    while let Some(len) = frame.u32() {
+        let Some(payload) = frame.take(len as usize) else {
+            break;
+        };
+        let Some(record) = decode_one(payload) else {
+            break;
+        };
+        out.push(record);
+    }
+    Ok(out)
+}

--- a/tests/external_wal/reference_wal.rs
+++ b/tests/external_wal/reference_wal.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026-present, Structured World Foundation
 
-//! Minimal append-only reference WAL — the worked example for the external-WAL
+//! Minimal append-only reference WAL: the worked example for the external-WAL
 //! recipe in `docs/external-wal.md`.
 //!
 //! This is **illustrative, not a production WAL**: it is `std`-only (a test/dev
@@ -115,7 +115,7 @@ impl ReferenceWal {
     /// records above it (including a logged-but-unapplied seqno that sits below
     /// a flushed higher one) are retained.
     ///
-    /// Rewrites the whole file for simplicity — a production WAL would rotate
+    /// Rewrites the whole file for simplicity; a production WAL would rotate
     /// segments instead.
     pub fn trim_through(&mut self, w: u64) -> io::Result<()> {
         let kept: Vec<WalRecord> = self
@@ -234,7 +234,7 @@ fn encode_record(record: &WalRecord, out: &mut Vec<u8>) {
 
 /// A cursor over the raw WAL bytes. Returns `None` from any read once the buffer
 /// is exhausted, so a torn tail record (a crash mid-append before fsync, or a
-/// truncated frame) is dropped rather than panicking — matching how a real WAL
+/// truncated frame) is dropped rather than panicking, matching how a real WAL
 /// discards a partial trailing record on recovery.
 struct Cursor<'a> {
     bytes: &'a [u8],


### PR DESCRIPTION
## Summary

Makes the external-WAL contract in `docs/external-wal.md` executable and self-verifying, so a future engine change that violated it would break a test rather than silently diverge from the prose.

- **Reference WAL** (`tests/external_wal/reference_wal.rs`): a minimal append-only WAL (append + fsync, trim through a watermark, replay the survivors). std-only test/dev surface, dependency-free encoding, torn-tail tolerant.
- **End-to-end recipe test** (`tests/external_wal.rs`): drives the documented recipe across every write kind (insert / remove / remove_weak / remove_range / merge / `WriteBatch`) through a crash and recovery (log-before-apply, flush, trim to the gap-free watermark `W`, crash, reopen, replay strictly above `W`), asserting the recovered state is byte-for-byte a non-crashed run's. A second variant runs the engine on the `CrashFs` fault-injection harness (power-loss over an in-memory disk).
- **Contract guards**: three tests prove a deliberately wrong recovery is detectably wrong: collapsing ops to `insert`, re-applying a merge at or below `W`, and replaying from the raw persisted maximum instead of `W`.
- **Worked example** (`examples/external_wal.rs`): runnable via `cargo run --example external_wal`, reuses the same reference WAL.
- **Docs**: `docs/external-wal.md` gains an "Executable companion" section; the README durability note points at the example.

## Testing

- 6 new integration tests, all pass.
- `cargo run --example external_wal` recovers the pre-crash state exactly.
- Full suite green (2292 tests); `clippy --all-features`, no-std check, and `cargo doc` clean.

Closes #552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable external WAL worked example demonstrating durability handled by the caller.
  * Added an accompanying reference WAL implementation used for replay and trimming.

* **Tests**
  * Added end-to-end external WAL recovery tests covering crash/reopen and mixed write operations.
  * Added guard tests that fail if recovery collapses or replays records incorrectly.

* **Documentation**
  * Expanded the external WAL documentation with a runnable recipe and an “Executable companion” section pointing to the example and verification coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->