### PR TITLE
docs: README quick start, comparison table, and discoverability metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,15 +44,16 @@ path = "src/lib.rs"
 [features]
 # `std` is the canonical platform feature. Default-on so every existing
 # downstream consumer keeps the current build profile (file I/O, threads,
-# `std::sync` primitives, system clock). Turning it OFF puts the crate
-# into no-std + alloc mode — currently in progress: only foundational
-# modules compile without `std`, the rest still imports `std::*` directly
-# and is gated to migrate incrementally. The `cargo check
-# --no-default-features --features alloc` CI job tracks migration progress
-# (expected to fail until each module is ported). New code added to this
-# crate MUST be no-std-friendly: prefer `core::*` / `alloc::*`, gate
-# std-only primitives behind `#[cfg(feature = "std")]`, and pick external
-# crates that support no-std.
+# `std::sync` primitives, system clock). Turning it OFF selects no-std +
+# alloc mode: the engine modules (read / write / compaction / recovery over
+# the injected `Fs`) compile without `std`; only the std default trait impls
+# (the system filesystem, the io_uring backend, the system clock) stay behind
+# `#[cfg(feature = "std")]`. The `cargo check --no-default-features --features
+# alloc` CI job builds this on the bare-metal `thumbv7em-none-eabihf` target
+# (no std at all), so any leaked `std::*` import fails the build. New code MUST
+# stay no-std-friendly: prefer `core::*` / `alloc::*`, gate std-only primitives
+# behind `#[cfg(feature = "std")]`, and pick external crates that support
+# no-std.
 default = ["std", "parallel"]
 std = [
     "dep:arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/structured-world/coordinode-lsm-tree"
 homepage = "https://github.com/structured-world/coordinode-lsm-tree"
 documentation = "https://docs.rs/coordinode-lsm-tree"
 keywords = ["lsm-tree", "storage", "database", "embedded", "key-value"]
-categories = ["data-structures", "database-implementations", "filesystem", "compression"]
+categories = ["data-structures", "database-implementations", "no-std", "compression"]
 
 [package.metadata.docs.rs]
 # Build the docs.rs page with every feature enabled so the rendered

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 
 ## Quick start
 
+```sh
+cargo add coordinode-lsm-tree@5.7
+```
+
+or add it to `Cargo.toml` directly:
+
 ```toml
 [dependencies]
 coordinode-lsm-tree = "5.7"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,35 @@ LSM-tree storage engine in Rust. Embedded library; provides keyed point reads, p
 
 On-disk format version **V5**. V5 introduces a wire-format break for filter blocks (BuRR replaces Bloom); V3 and V4 databases are not readable by this version and vice versa. Versioning is single-monotonic: every breaking format change bumps to the next version with explicit migration notes.
 
+## Quick start
+
+```toml
+[dependencies]
+coordinode-lsm-tree = "5.7"
+```
+
+```rust
+use lsm_tree::{AbstractTree, Config, SeqNo, SequenceNumberCounter};
+
+let dir = tempfile::tempdir()?;
+let seqno = SequenceNumberCounter::default();
+
+// Two counters: one hands out write sequence numbers, the other tracks the
+// persisted watermark. The default build adds no compression or encryption
+// (see the feature-flag table below to opt in).
+let tree = Config::new(dir.path(), seqno.clone(), SequenceNumberCounter::default()).open()?;
+
+tree.insert("key", "value", seqno.next());
+
+// Read at the latest visible snapshot. MVCC: pass any past SeqNo to read as-of.
+let value = tree.get("key", SeqNo::MAX)?;
+assert_eq!(value.as_deref(), Some(b"value".as_ref()));
+
+// No write-ahead log by design: call flush when you need durability (or layer
+// your own WAL, see docs/external-wal.md).
+tree.flush_active_memtable(0)?;
+```
+
 ## Features
 
 ### Read path
@@ -81,6 +110,56 @@ On-disk format version **V5**. V5 introduces a wire-format break for filter bloc
 - Pluggable `Fs` trait: back the engine on the standard filesystem, on `io_uring`, on an in-memory `MemFs`, or on a custom implementation.
 - Pluggable `CompressionProvider` for third-party codecs.
 
+## Comparison
+
+A factual capability matrix, not a benchmark: pick by the capabilities your
+workload needs; for throughput / latency see [Benchmarks](#benchmarks).
+
+| | coordinode-lsm-tree | RocksDB | sled | redb |
+|---|---|---|---|---|
+| Implementation | pure Rust | C++ (FFI bindings) | pure Rust | pure Rust |
+| Data structure | LSM-tree | LSM-tree | log-structured | B+tree (copy-on-write) |
+| MVCC snapshot reads | ✅ (read at any `SeqNo`) | ✅ (snapshots) | ✅ (transactions) | ✅ (read transactions) |
+| `no_std` + `alloc` | ✅ | no | no | no |
+| Encryption at rest | ✅ built-in (AES-256-GCM) | wrapper / plugin | no | no |
+| Per-block ECC + self-heal | ✅ | no | no | no |
+| Columnar (PAX) blocks | ✅ | no | no | no |
+| CDC surviving compaction | ✅ (data-block grain) | WAL tail only | no | no |
+| Built-in durability / WAL | external (caller-owned) | ✅ | ✅ | ✅ |
+| Pluggable FS / `io_uring` | ✅ | no | no | no |
+
+RocksDB is the closest peer in data model and feature breadth, but it is a C++
+library reached over FFI; this engine targets the same LSM capabilities in pure
+Rust: no C/C++ toolchain, `no_std`-capable, no FFI audit surface. sled and redb
+are pure-Rust but different shapes: sled is log-structured and pre-1.0; redb is a
+read-optimised B+tree. [Fjall](https://github.com/fjall-rs/fjall) is a
+higher-level key-value store built on `fjall-rs/lsm-tree`, the engine this crate
+was forked from, so Fjall and this crate are siblings over a shared ancestor
+(see [Credits](#credits)).
+
+## When to use
+
+Reach for this engine when you want:
+
+- a **write-optimised** embedded store (LSM beats a B+tree on write-heavy and
+  ingest workloads);
+- **pure Rust, no C/C++ toolchain** (cross-compilation, `no_std` targets,
+  reproducible builds, no FFI to audit);
+- **integrity / compliance** built in: checksums end to end, optional encryption
+  at rest and per-block ECC with on-read self-healing;
+- **change-data-capture** that survives compaction (`scan_since_seqno`);
+- to **own durability** yourself (supply your own WAL, or accept flush-on-demand).
+
+Look elsewhere when you need:
+
+- **millisecond tailing** of in-flight, not-yet-flushed writes: there is no
+  built-in WAL (pair with [docs/external-wal.md](docs/external-wal.md), or use a
+  WAL-backed engine);
+- a **read-mostly tiny dataset** where a B+tree (redb / LMDB) has lower read
+  amplification;
+- a **batteries-included database server** with a query language: this is a
+  storage engine, not a database.
+
 ## Incremental scan / CDC
 
 `Tree::scan_since_seqno(target)` streams every change committed at or after a
@@ -128,7 +207,7 @@ All optional. The default build (`std` + `parallel`) is the minimal core: no com
 | Flag | Pulls in | Enable when |
 |---|---|---|
 | `lz4` | [`lz4_flex`](https://github.com/PSeitz/lz4_flex) | Block compression wanted, decompression latency matters more than ratio. |
-| `zstd` | [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust, no FFI) | Block compression wanted, ratio matters more than absolute decompression speed. Supports `CompressionType::Zstd` and dictionary-mode `CompressionType::ZstdDict`. Decompression is ~2-3.5× slower than C reference. |
+| `zstd` | [`structured-zstd`](https://github.com/structured-world/structured-zstd) (pure-Rust, no FFI) | Block compression wanted, ratio matters more than raw decode speed (zstd trades some decode latency vs `lz4` for a better ratio). Supports `CompressionType::Zstd` and dictionary-mode `CompressionType::ZstdDict`. The pure-Rust decode is competitive with the C reference (libzstd) on the engine's small (4-64 KiB) read-path blocks (see [Benchmarks](#benchmarks)). |
 | `columnar` | (pure code, `alloc` only) | Columnar PAX SST block layout: each row-group stores its key / seqno / value-type / value sub-columns contiguously, for column-projection pushdown, vectorized predicate scans, per-column zstd dictionaries, and positional delete-bitmap MVCC. Enable for analytical or wide-row scans where reading a subset of columns dominates. |
 | `encryption` | `aes-gcm`, `rand_chacha` | AES-256-GCM block encryption at rest. Keys are caller-managed. |
 | `page_ecc` | [`reed-solomon-simd`](https://github.com/AndersTrier/reed-solomon-simd) | Per-block error-correcting parity (Reed-Solomon shards or per-word SEC-DED) after each on-disk block, with on-read self-healing, three-state verification, and a patrol scrub. Enable for latent-bit-rot protection on long-lived cold data. |

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ coordinode-lsm-tree = "5.7"
 ```rust
 use lsm_tree::{AbstractTree, Config, SeqNo, SequenceNumberCounter};
 
-let dir = tempfile::tempdir()?;
 let seqno = SequenceNumberCounter::default();
 
-// Two counters: one hands out write sequence numbers, the other tracks the
-// persisted watermark. The default build adds no compression or encryption
-// (see the feature-flag table below to opt in).
-let tree = Config::new(dir.path(), seqno.clone(), SequenceNumberCounter::default()).open()?;
+// Point the engine at a directory on disk. Two counters: one hands out write
+// sequence numbers, the other tracks the persisted watermark. The default build
+// adds no compression or encryption (see the feature-flag table below to opt in).
+let tree = Config::new("my_db", seqno.clone(), SequenceNumberCounter::default()).open()?;
 
 tree.insert("key", "value", seqno.next());
 


### PR DESCRIPTION
## Summary

Polishes the public-facing surface (README + crate metadata) now that the roadmap is feature-complete. Improves first-touch conversion and search discoverability without marketing claims.

## Changes

- **README Quick Start** — `cargo add` (pinned to `5.7`, the release this lands in) plus a minimal open / insert / get / flush example mirroring the crate-level `//!` docs.
- **Comparison + When-to-use** — a factual capability matrix vs RocksDB / sled / redb (implementation, structure, MVCC, `no_std`, encryption at rest, ECC, columnar, CDC, WAL) and an honest when-to-use / when-not section.
- **Corrected the zstd decode claim** — the old "~2-3.5x slower than C reference" predated the SIMD-kernel + decoder-context-reuse work. Fresh same-run benchmark (i9): cold zstd-22 `point_read` ours 885µs vs RocksDB 911µs at 1k, and 182.7ms vs 183.4ms at 70k — a tie/slight edge, so the line now states the decode is **competitive with the C reference (libzstd)** and links the benchmarks.
- **crates.io category** `filesystem` -> `no-std` (this is a database, not a filesystem tool; `no_std` is the unique differentiator in this field).

Repo metadata (description, homepage -> docs.rs, topics) was updated out-of-tree.

## Testing

Docs / metadata only; no code change. `cargo metadata` parses; README has no em-dash and no internal-reference leaks; the version pin is forward-looking to the 5.7.0 release this merges into.

Closes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a **Quick start** guide with a minimal Rust example for creating/opening a directory-backed tree, using `SeqNo::MAX`, and flushing for durability, with an explicit note that there is **no built-in WAL** and durability is **caller-managed**.
  * Added a **Comparison** section vs RocksDB, sled, and redb, plus **when-to-use** guidance and limitations around tailing in-flight updates.
  * Updated **`zstd`** feature documentation to highlight **compression ratio vs decode speed** and **dictionary-mode** support.
* **Chores**
  * Updated crate metadata by removing the `filesystem` category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->