### PR TITLE
feat(columnar): tree-level projected columnar scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 # Default features carry the runtime-dispatched SIMD decode kernels (avx2/bmi2/
 # neon/sve/...); `default-features = false` would silently drop them and leave
 # the sequence decoder on the scalar path, measurably slower on cold point reads.
-structured-zstd = { version = "0.0.45", optional = true, features = ["lsm"] }
+structured-zstd = { version = "0.0.48", optional = true, features = ["lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is
@@ -211,24 +211,17 @@ xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 # pulled in behind the `crc32c` feature — the default `Xxh3_64` algorithm
 # needs only `xxhash-rust`.
 crc32c = { version = "0.6", optional = true }
-# Exact pin on a prerelease — RC API can churn between releases, so locking
-# the exact version is intentional. The 0.11 surface we depend on:
+# The 0.11 surface we depend on:
 #   - aes_gcm::aead::{AeadInOut, Generate, Nonce, Tag}
 #   - AeadInOut::{encrypt_inout_detached, decrypt_inout_detached}
 #   - Nonce::generate_from_rng (via Generate)
 #   - Nonce::try_from / Tag::try_from
 # rand_core re-exported via aes-gcm's `rand_core` feature so `aead::rand_core`
 # exposes the rand_core 0.10 trait family (no version-skew).
-# TODO: bump to stable aes-gcm 0.11.0 once released — at that point this pin
-# becomes a normal "^0.11" caret requirement and the API list above can be
-# treated as the public 0.11 surface, not a prerelease snapshot.
-aes-gcm = { version = "=0.11.0-rc.4", optional = true, features = ["aes", "rand_core"] }
-# Exact pin on the matching prerelease — chacha20poly1305 0.11.0-rc.3 lines
-# up with aes-gcm 0.11.0-rc.3 on the shared `aead` 0.6 surface, so both
-# suites can share the same AeadInOut / Nonce / Tag types in the
-# AEAD-dispatch module. Bumps in lockstep with aes-gcm when the stable
-# 0.11.0 lands.
-chacha20poly1305 = { version = "=0.11.0-rc.3", optional = true, features = ["rand_core"] }
+aes-gcm = { version = "0.11.0", optional = true, features = ["aes", "rand_core"] }
+# Matches aes-gcm 0.11.0 on the shared `aead` 0.6 surface, so both suites
+# share the same AeadInOut / Nonce / Tag types in the AEAD-dispatch module.
+chacha20poly1305 = { version = "0.11.0", optional = true, features = ["rand_core"] }
 rand_chacha = { version = "0.10", optional = true }
 # Pure-Rust Reed-Solomon erasure coding, SIMD-accelerated on x86_64 / aarch64.
 # Used by the optional `page_ecc` feature for per-block parity. Apache-2.0 /

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,8 @@ lz4_flex = { version = "0.13.0", optional = true, default-features = false }
 # Default features carry the runtime-dispatched SIMD decode kernels (avx2/bmi2/
 # neon/sve/...); `default-features = false` would silently drop them and leave
 # the sequence decoder on the scalar path, measurably slower on cold point reads.
+# 0.0.48 is the published crates.io release; it fixes a dictionary match
+# binary-tree encoder panic present in 0.0.46/0.0.47 on high (BT-strategy) levels.
 structured-zstd = { version = "0.0.48", optional = true, features = ["lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -163,4 +163,74 @@ impl AnyTree {
             Self::Blob(b) => Ok(AnyIngestion::Blob(BlobIngestion::new(b)?)),
         }
     }
+
+    /// Runs a projected columnar scan across the tree.
+    ///
+    /// Delegates to [`Tree::columnar_scan`](crate::Tree::columnar_scan) on a
+    /// standard tree: iterates the columnar segments intersecting `range` and
+    /// visible at `seqno`, applies each segment's positional delete-bitmap and the
+    /// optional `predicate`, and yields projected
+    /// [`ColumnBatch`](crate::table::columnar::ColumnBatch)es in key order,
+    /// merging overlapping segments newest-seqno-wins. See
+    /// [`Tree::columnar_scan`](crate::Tree::columnar_scan) for the full contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tree is a blob tree (columnar scan does not support
+    /// KV separation), if a visible non-columnar segment overlaps `range`, or —
+    /// lazily, while iterating — on a block read / decode failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lsm_tree::table::columnar::{Column, TypeTag, entries_to_column_batch};
+    /// use lsm_tree::{AnyTree, Config, InternalValue, SeqNo, ValueType};
+    ///
+    /// let folder = tempfile::tempdir()?;
+    /// let any = Config::new(folder, Default::default(), Default::default()).open()?;
+    /// if let AnyTree::Standard(tree) = &any {
+    ///     tree.update_runtime_config(|cfg| cfg.columnar = true)?;
+    /// }
+    ///
+    /// // Ingest one row whose value is a single fixed-4 sub-column (id 3).
+    /// let mut batch = entries_to_column_batch(&[InternalValue::from_components(
+    ///     b"k0".to_vec(),
+    ///     b"x".to_vec(),
+    ///     0,
+    ///     ValueType::Value,
+    /// )])?;
+    /// batch.columns.pop();
+    /// batch.columns.push(Column {
+    ///     column_id: 3,
+    ///     type_tag: TypeTag::Fixed(4),
+    ///     validity: None,
+    ///     data: vec![1, 0, 0, 0],
+    /// });
+    /// let mut ingestion = any.ingestion()?;
+    /// ingestion.write_columnar_batch(&batch)?;
+    /// ingestion.finish()?;
+    ///
+    /// // Scan projecting only sub-column 3 across the whole tree.
+    /// let mut rows = 0;
+    /// for batch in any.columnar_scan(&[3], None, SeqNo::MAX, ..)? {
+    ///     rows += batch?.row_count;
+    /// }
+    /// assert_eq!(rows, 1);
+    /// # Ok::<(), lsm_tree::Error>(())
+    /// ```
+    #[cfg(feature = "columnar")]
+    pub fn columnar_scan<R: core::ops::RangeBounds<crate::UserKey>>(
+        &self,
+        projection: &[u16],
+        predicate: Option<&crate::table::columnar_predicate::ColumnRangePredicate>,
+        seqno: crate::SeqNo,
+        range: R,
+    ) -> crate::Result<crate::tree::columnar_scan::ColumnarScan> {
+        match self {
+            Self::Standard(t) => t.columnar_scan(projection, predicate, seqno, range),
+            Self::Blob(_) => Err(crate::Error::FeatureUnsupported(
+                "columnar scan is not supported for blob trees",
+            )),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,9 @@ pub use {
     vlog::BlobFile,
 };
 
+#[cfg(feature = "columnar")]
+pub use tree::columnar_scan::ColumnarScan;
+
 #[cfg(zstd_any)]
 pub use compression::ZstdDictionary;
 

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -761,7 +761,7 @@ fn build_bytes_column<'a>(rows: impl Iterator<Item = &'a [u8]>) -> Result<Vec<u8
 
 /// Reads row `i` of a [`TypeTag::Bytes`] column body (offset table + payload),
 /// bounds-checked.
-fn bytes_column_row(data: &[u8], row_count: u32, i: u32) -> Result<&[u8]> {
+pub(crate) fn bytes_column_row(data: &[u8], row_count: u32, i: u32) -> Result<&[u8]> {
     let off_bytes = (row_count as usize + 1) * 4;
     let read_off = |idx: u32| -> Result<usize> {
         let base = idx as usize * 4;
@@ -845,7 +845,7 @@ fn combine_validity(
 }
 
 /// Reads row `i` of a `Fixed(8)` column body as a little-endian `u64`.
-fn fixed_u64_row(data: &[u8], i: u32) -> Result<u64> {
+pub(crate) fn fixed_u64_row(data: &[u8], i: u32) -> Result<u64> {
     let base = i as usize * 8;
     let b = data
         .get(base..base + 8)

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -208,6 +208,98 @@ fn compact_validity(bits: &[u8], mask: &[bool], kept: usize) -> Vec<u8> {
     out
 }
 
+/// Builds a new batch from `batch`'s rows selected (and reordered) by `indices`.
+///
+/// Like [`filter_batch`] but driven by an explicit row-index list rather than a
+/// per-row bool mask, so it can both *drop* and *reorder* rows. The tree-level
+/// merge path (`Tree::columnar_scan` over an overlapping segment group) uses it
+/// to gather the surviving rows of a group in key order after a stable sort +
+/// newest-wins dedup. An out-of-range index contributes an empty (`Bytes`) or
+/// zero-filled (`Fixed`) cell rather than panicking, so a malformed index can
+/// never desync a column's framing from the output row count.
+#[must_use]
+pub(crate) fn take_rows(batch: &ColumnBatch, indices: &[u32]) -> ColumnBatch {
+    let rows = batch.row_count as usize;
+    let columns = batch
+        .columns
+        .iter()
+        .map(|c| take_column(c, rows, indices))
+        .collect();
+    // `indices.len()` is the output row count; it fits u32 because every index
+    // addresses a row of a single block, whose count is itself a u32.
+    let row_count = u32::try_from(indices.len()).unwrap_or(u32::MAX);
+    ColumnBatch { row_count, columns }
+}
+
+/// Gathers one column to the rows listed in `indices` (in that order),
+/// rebuilding its framing (fixed chunks copied, `Bytes` offset table + payload
+/// repacked) and its validity bitmap. Sibling of [`filter_column`] for the
+/// index-driven [`take_rows`] gather.
+fn take_column(col: &Column, rows: usize, indices: &[u32]) -> Column {
+    let data = match col.type_tag {
+        TypeTag::Fixed(width) => {
+            let width = width as usize;
+            let mut out = Vec::with_capacity(indices.len() * width);
+            for &i in indices {
+                let i = i as usize;
+                if let Some(start) = i.checked_mul(width)
+                    && let Some(end) = start.checked_add(width)
+                    && let Some(chunk) = col.data.get(start..end)
+                {
+                    out.extend_from_slice(chunk);
+                } else {
+                    // Out-of-range index: zero-fill one cell so the fixed framing
+                    // stays `row_count * width` bytes long.
+                    out.resize(out.len() + width, 0);
+                }
+            }
+            out
+        }
+        TypeTag::Bytes => {
+            let mut offsets = Vec::with_capacity((indices.len() + 1) * 4);
+            let mut payload = Vec::new();
+            let mut acc: u32 = 0;
+            offsets.extend_from_slice(&acc.to_le_bytes());
+            for &i in indices {
+                // A missing cell degrades to empty (one offset still written), so
+                // the offset table stays in lockstep with the output row count.
+                let value = bytes_row(&col.data, rows, i as usize).unwrap_or(&[]);
+                payload.extend_from_slice(value);
+                let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+                acc = acc.saturating_add(len);
+                offsets.extend_from_slice(&acc.to_le_bytes());
+            }
+            offsets.extend_from_slice(&payload);
+            offsets
+        }
+    };
+    let validity = col
+        .validity
+        .as_ref()
+        .map(|bits| take_validity(bits, indices));
+    Column {
+        column_id: col.column_id,
+        type_tag: col.type_tag,
+        validity,
+        data,
+    }
+}
+
+/// Rebuilds a validity bitmap for the rows listed in `indices`, preserving each
+/// gathered row's null bit in output order. Index-driven counterpart of
+/// [`compact_validity`].
+fn take_validity(bits: &[u8], indices: &[u32]) -> Vec<u8> {
+    let mut out = alloc::vec![0u8; indices.len().div_ceil(8)];
+    for (o, &i) in indices.iter().enumerate() {
+        let i = i as usize;
+        let valid = bits.get(i / 8).is_some_and(|b| b & (1u8 << (i % 8)) != 0);
+        if valid && let Some(byte) = out.get_mut(o / 8) {
+            *byte |= 1u8 << (o % 8);
+        }
+    }
+    out
+}
+
 /// Whether row `row` is valid (non-null) per the column's validity bitmap. A
 /// column with no bitmap has every row valid; otherwise a set bit means valid.
 fn row_valid(col: &Column, row: usize) -> bool {

--- a/src/table/iter.rs
+++ b/src/table/iter.rs
@@ -18,6 +18,10 @@ use crate::{
     },
 };
 use alloc::sync::Arc;
+// `Vec` is not in the `no_std` prelude; the columnar block iterator below needs
+// it explicitly (under `std` this just re-imports the prelude type).
+#[cfg(feature = "columnar")]
+use alloc::vec::Vec;
 
 use crate::path::PathBuf;
 use self_cell::self_cell;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -129,6 +129,21 @@ impl core::fmt::Debug for Table {
     }
 }
 
+/// How an SST's rows are visible at a query snapshot, returned by
+/// [`Table::seqno_visibility`]. Drives whether the tree-level columnar scan can
+/// stream a segment verbatim ([`All`](Self::All)) or must apply a per-row seqno
+/// mask ([`Partial`](Self::Partial)); [`None`](Self::None) segments are dropped.
+#[cfg(feature = "columnar")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SeqnoVisibility {
+    /// No row is visible at the snapshot (the SST postdates it).
+    None,
+    /// Every row is visible (the SST entirely predates the snapshot).
+    All,
+    /// The snapshot straddles the SST's seqno range; visibility is per-row.
+    Partial,
+}
+
 /// Result of a bloom filter check.
 enum BloomResult {
     /// Bloom says key is definitely absent — skip point read.
@@ -184,6 +199,34 @@ impl Table {
     #[must_use]
     pub fn global_seqno(&self) -> SeqNo {
         self.0.global_seqno
+    }
+
+    /// Classifies how this SST's rows are visible at query snapshot `seqno`,
+    /// using the same exclusive MVCC rule as [`Self::point_read`]: a row is
+    /// visible iff its effective seqno (`local + global_seqno`) is `< seqno`.
+    ///
+    /// Bulk-ingested columnar SSTs carry a uniform per-row seqno (every local
+    /// seqno is `0`, sharing one `global_seqno`), so they classify as wholly
+    /// [`All`](SeqnoVisibility::All) or wholly [`None`](SeqnoVisibility::None);
+    /// only a flush-produced multi-seqno SST whose seqno range straddles the
+    /// snapshot is [`Partial`](SeqnoVisibility::Partial), which the tree-level
+    /// columnar scan resolves with a per-row seqno mask.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn seqno_visibility(&self, seqno: SeqNo) -> SeqnoVisibility {
+        // Translate the query snapshot into this table's local seqno space; a
+        // snapshot below the base predates every row.
+        let Some(local_threshold) = seqno.checked_sub(self.global_seqno()) else {
+            return SeqnoVisibility::None;
+        };
+        // seqnos are (min, max) local; visible rows satisfy `local < threshold`.
+        if self.metadata.seqnos.0 >= local_threshold {
+            return SeqnoVisibility::None;
+        }
+        if self.metadata.seqnos.1 < local_threshold {
+            SeqnoVisibility::All
+        } else {
+            SeqnoVisibility::Partial
+        }
     }
 
     pub fn referenced_blob_bytes(&self) -> crate::Result<u64> {

--- a/src/tree/columnar_scan.rs
+++ b/src/tree/columnar_scan.rs
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024-present, fjall-rs
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Tree-level projected columnar scan.
+//!
+//! Lifts the per-SST [`Table::columnar_scan`](crate::Table::columnar_scan) to the
+//! whole tree: a consumer holding a [`Tree`] (or an
+//! [`AnyTree`](crate::AnyTree)) can run a projected, predicate-pushed columnar
+//! scan across every columnar segment intersecting a key range and visible at an
+//! MVCC snapshot, without reimplementing segment selection, snapshot visibility,
+//! delete-masking, or cross-segment ordering.
+//!
+//! # Strategy (overlap-aware merge)
+//!
+//! A row's effective sequence number is `local_seqno + global_seqno`. Bulk
+//! ingested segments carry a *uniform per-segment* seqno (every local seqno is
+//! `0`, one `global_seqno` per table), so their visibility is segment-granular;
+//! flush-produced segments carry per-row seqnos, so a snapshot can straddle them.
+//! The visible columnar segments overlapping the range are grouped by key-range
+//! overlap:
+//!
+//! - A **singleton** group (a segment whose key range overlaps no other) whose
+//!   rows are all visible streams its
+//!   [`Table::columnar_scan`](crate::Table::columnar_scan) batches verbatim —
+//!   zero-copy column-skip, no key decode, no row gather. A singleton the
+//!   snapshot straddles gets a per-row seqno mask first.
+//! - An **overlapping** group is row-merged: the projection is augmented with the
+//!   intrinsic key + seqno columns, each segment's rows are visibility-masked and
+//!   tagged with their effective seqno, the union is sorted by `(key asc,
+//!   effective seqno desc)`, and the first (newest) row of each key is kept. The
+//!   expensive key/seqno decode + gather is paid only where segments overlap.
+//!
+//! Groups are emitted in ascending key order, so the scan yields projected
+//! [`ColumnBatch`]es in global key order. This mirrors how `InfluxDB` `IOx`
+//! inserts its deduplication operator only over overlapping files and engineers
+//! compaction to keep files non-overlapping: as multi-segment columnar compaction
+//! reduces overlap, more of the scan takes the zero-cost singleton path.
+//!
+//! Deletes are expressed through each segment's positional delete-bitmap (applied
+//! inside [`Table::columnar_scan`](crate::Table::columnar_scan)); this scan does
+//! not interpret value-type tombstone rows. Memtable rows are not consulted —
+//! columnar data lives only in segments — and a visible non-columnar segment
+//! overlapping the range is rejected (a mixed-mode tree is unsupported here).
+
+use core::ops::{Bound, RangeBounds};
+
+use alloc::{vec, vec::Vec};
+
+use crate::comparator::UserComparator;
+use crate::table::SeqnoVisibility;
+use crate::table::columnar::{
+    COL_SEQNO, COL_USER_KEY, ColumnBatch, TypeTag, bytes_column_row, fixed_u64_row,
+};
+use crate::table::columnar_predicate::{ColumnRangePredicate, filter_batch, take_rows};
+use crate::{Error, SeqNo, Table, Tree, UserKey};
+
+/// A visible columnar segment selected for the scan, with its cached key range,
+/// sequence base, and snapshot-visibility class.
+struct Segment {
+    table: Table,
+    min: UserKey,
+    max: UserKey,
+    /// The segment's `global_seqno` base; a row's effective seqno is
+    /// `local + global`.
+    global: SeqNo,
+    /// Whether every row is visible at the snapshot, or visibility is per-row.
+    visibility: SeqnoVisibility,
+}
+
+/// One key-disjoint group of segments: either a single segment (streamed
+/// verbatim) or several whose key ranges transitively overlap (row-merged).
+struct Group {
+    segments: Vec<Segment>,
+    /// Running maximum key of the group's span, used while grouping.
+    max: UserKey,
+}
+
+impl Tree {
+    /// Runs a projected columnar scan across the whole tree.
+    ///
+    /// Iterates the columnar segments intersecting `range` and visible at
+    /// `seqno`, applies each segment's positional delete-bitmap and the optional
+    /// `predicate` (zone-map block-skip + row filter), and yields projected
+    /// [`ColumnBatch`]es in ascending key order. Overlapping segments are merged
+    /// with newest-`seqno`-wins semantics so an overwritten key is returned once
+    /// (its newest version); disjoint segments stream without merge overhead.
+    ///
+    /// `projection` lists the column ids to decode (value sub-column ids, plus
+    /// optionally the intrinsic [`COL_USER_KEY`] / seqno / value-type columns);
+    /// every other column is stepped over without decoding. Each yielded batch
+    /// carries exactly the projected columns.
+    ///
+    /// This reads only segments; memtable rows are not consulted (columnar data
+    /// is written directly to segments via
+    /// [`write_columnar_batch`](crate::AnyIngestion::write_columnar_batch)).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a visible non-columnar segment overlaps `range` (a
+    /// mixed-mode tree is unsupported here), or — lazily, while iterating — on a
+    /// block read / decode failure or a layout mismatch between segments of an
+    /// overlapping group.
+    pub fn columnar_scan<R: RangeBounds<UserKey>>(
+        &self,
+        projection: &[u16],
+        predicate: Option<&ColumnRangePredicate>,
+        seqno: SeqNo,
+        range: R,
+    ) -> crate::Result<ColumnarScan> {
+        let comparator = self.config.comparator.clone();
+
+        // Owned bounds keep the returned iterator free of borrows from `range`.
+        let lo = clone_bound(range.start_bound());
+        let hi = clone_bound(range.end_bound());
+        let bounds_ref = (bound_as_ref(&lo), bound_as_ref(&hi));
+
+        let super_version = self.version_history.read().get_version_for_snapshot(seqno);
+
+        let mut segments: Vec<Segment> = Vec::new();
+        for table in super_version.version.iter_tables() {
+            if !table.check_key_range_overlap_cmp(&bounds_ref, comparator.as_ref()) {
+                continue;
+            }
+            // Snapshot visibility (exclusive MVCC). `None` segments postdate the
+            // snapshot and are dropped before the columnar check, so an invisible
+            // non-columnar segment never trips the mixed-mode error.
+            let visibility = table.seqno_visibility(seqno);
+            if visibility == SeqnoVisibility::None {
+                continue;
+            }
+            if !table.metadata.columnar {
+                return Err(Error::FeatureUnsupported(
+                    "columnar_scan: a non-columnar segment overlaps the range (mixed-mode tree)",
+                ));
+            }
+            let key_range = &table.metadata.key_range;
+            segments.push(Segment {
+                min: key_range.min().clone(),
+                max: key_range.max().clone(),
+                global: table.global_seqno(),
+                visibility,
+                table: table.clone(),
+            });
+        }
+
+        let groups = group_by_overlap(segments, comparator.as_ref());
+
+        Ok(ColumnarScan {
+            groups: groups.into_iter().collect(),
+            buffered: Vec::new().into(),
+            projection: projection.to_vec(),
+            predicate: predicate.cloned(),
+            comparator,
+            seqno,
+        })
+    }
+}
+
+/// Partitions `segments` into key-disjoint overlap groups, ordered by ascending
+/// minimum key. Segments are sorted by their minimum key, then greedily extended
+/// into the current group while the next segment's minimum key is `<=` the
+/// group's running maximum (an inclusive-range overlap). The result preserves
+/// global key order across groups: group `i`'s span lies entirely below group
+/// `i + 1`'s.
+fn group_by_overlap(mut segments: Vec<Segment>, cmp: &dyn UserComparator) -> Vec<Group> {
+    use core::cmp::Ordering;
+
+    segments.sort_by(|a, b| cmp.compare(a.min.as_ref(), b.min.as_ref()));
+
+    let mut groups: Vec<Group> = Vec::new();
+    for seg in segments {
+        match groups.last_mut() {
+            Some(g) if cmp.compare(seg.min.as_ref(), g.max.as_ref()) != Ordering::Greater => {
+                if cmp.compare(seg.max.as_ref(), g.max.as_ref()) == Ordering::Greater {
+                    g.max = seg.max.clone();
+                }
+                g.segments.push(seg);
+            }
+            _ => groups.push(Group {
+                max: seg.max.clone(),
+                segments: vec![seg],
+            }),
+        }
+    }
+    groups
+}
+
+/// Iterator over a tree-level projected columnar scan.
+///
+/// Yields projected [`ColumnBatch`]es in ascending key order. Created by
+/// [`Tree::columnar_scan`] (and surfaced through
+/// [`AnyTree::columnar_scan`](crate::AnyTree::columnar_scan)). Each overlap group
+/// is processed lazily on demand, so at most one group's output is buffered at a
+/// time.
+pub struct ColumnarScan {
+    groups: alloc::collections::VecDeque<Group>,
+    buffered: alloc::collections::VecDeque<ColumnBatch>,
+    projection: Vec<u16>,
+    predicate: Option<ColumnRangePredicate>,
+    comparator: alloc::sync::Arc<dyn UserComparator>,
+    /// The query snapshot, used for per-row seqno visibility masking.
+    seqno: SeqNo,
+}
+
+impl ColumnarScan {
+    /// Processes one overlap group into its projected, key-ordered output
+    /// batches. A singleton group streams its segment's batches (masking by seqno
+    /// only when the snapshot straddles the segment); an overlapping group is
+    /// row-merged with newest-effective-seqno-wins dedup.
+    fn process_group(&self, group: &Group) -> crate::Result<Vec<ColumnBatch>> {
+        if let [seg] = group.segments.as_slice() {
+            return self.process_singleton(seg);
+        }
+        self.merge_group(group)
+    }
+
+    /// Singleton group: no cross-segment merge. When every row is visible the
+    /// per-SST projected scan streams verbatim (zero-copy column-skip); when the
+    /// snapshot straddles the segment, a per-row seqno mask is applied.
+    fn process_singleton(&self, seg: &Segment) -> crate::Result<Vec<ColumnBatch>> {
+        if seg.visibility == SeqnoVisibility::All {
+            let mut out = seg
+                .table
+                .columnar_scan(&self.projection, self.predicate.as_ref())?;
+            out.retain(|b| b.row_count > 0);
+            return Ok(out);
+        }
+
+        // Partial visibility: decode the seqno column too, drop rows whose
+        // effective seqno is not visible, then strip the seqno column if the
+        // caller did not project it.
+        let seqno_projected = self.projection.contains(&COL_SEQNO);
+        let mut augmented = self.projection.clone();
+        if !seqno_projected {
+            augmented.push(COL_SEQNO);
+        }
+        // Visible iff `local < threshold` (the snapshot in this segment's local
+        // seqno space); `Partial` guarantees the subtraction is in range.
+        let threshold = self.seqno.saturating_sub(seg.global);
+
+        let mut out = Vec::new();
+        for batch in seg
+            .table
+            .columnar_scan(&augmented, self.predicate.as_ref())?
+        {
+            if batch.row_count == 0 {
+                continue;
+            }
+            let mask = seqno_visibility_mask(&batch, threshold)?;
+            let mut visible = filter_batch(&batch, &mask);
+            if !seqno_projected {
+                visible.columns.retain(|c| c.column_id != COL_SEQNO);
+            }
+            if visible.row_count > 0 {
+                out.push(visible);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Row-merges an overlapping segment group: over the union of the segments'
+    /// visible projected rows, keep the newest version of each key (highest
+    /// effective seqno), gathered in key order.
+    fn merge_group(&self, group: &Group) -> crate::Result<Vec<ColumnBatch>> {
+        // The merge needs each row's key and effective seqno, so decode the
+        // intrinsic key + seqno columns even when the caller did not project them
+        // (dropped again at the end).
+        let key_projected = self.projection.contains(&COL_USER_KEY);
+        let seqno_projected = self.projection.contains(&COL_SEQNO);
+        let mut augmented = self.projection.clone();
+        if !key_projected {
+            augmented.push(COL_USER_KEY);
+        }
+        if !seqno_projected {
+            augmented.push(COL_SEQNO);
+        }
+
+        // Concatenate every segment's visible rows into one batch, tracking each
+        // surviving row's effective seqno (`local + global`) in lockstep so the
+        // dedup can compare versions across segments with different bases.
+        let mut combined: Option<ColumnBatch> = None;
+        let mut effective: Vec<SeqNo> = Vec::new();
+        for seg in &group.segments {
+            let threshold = self.seqno.saturating_sub(seg.global);
+            for batch in seg
+                .table
+                .columnar_scan(&augmented, self.predicate.as_ref())?
+            {
+                if batch.row_count == 0 {
+                    continue;
+                }
+                let seqno_col = batch
+                    .columns
+                    .iter()
+                    .find(|c| c.column_id == COL_SEQNO)
+                    .ok_or(Error::InvalidHeader(
+                        "columnar_scan: merged group missing the seqno column",
+                    ))?;
+                let mut mask = Vec::with_capacity(batch.row_count as usize);
+                for row in 0..batch.row_count {
+                    let local = fixed_u64_row(&seqno_col.data, row)?;
+                    let visible = seg.visibility == SeqnoVisibility::All || local < threshold;
+                    mask.push(visible);
+                    if visible {
+                        // Translate to the global coordinate for cross-segment
+                        // comparison; a visible row cannot overflow (its effective
+                        // seqno is `< snapshot <= SeqNo::MAX`).
+                        let eff = local.checked_add(seg.global).ok_or(Error::InvalidHeader(
+                            "columnar_scan: effective seqno overflow",
+                        ))?;
+                        effective.push(eff);
+                    }
+                }
+                let visible = filter_batch(&batch, &mask);
+                if visible.row_count == 0 {
+                    continue;
+                }
+                match &mut combined {
+                    Some(acc) => acc.append(&visible)?,
+                    None => combined = Some(visible),
+                }
+            }
+        }
+        let Some(combined) = combined else {
+            return Ok(Vec::new());
+        };
+
+        // Extract every row's key once (fallible framing read), then sort indices
+        // by (key asc, effective seqno desc) and keep the first per key.
+        let key_col = combined
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .ok_or(Error::InvalidHeader(
+                "columnar_scan: merged group missing the key column",
+            ))?;
+        if key_col.type_tag != TypeTag::Bytes {
+            return Err(Error::InvalidHeader(
+                "columnar_scan: key column is not a bytes column",
+            ));
+        }
+        let rows = combined.row_count;
+        debug_assert_eq!(rows as usize, effective.len(), "seqno tracked per row");
+        let mut keys: Vec<&[u8]> = Vec::with_capacity(rows as usize);
+        for i in 0..rows {
+            keys.push(bytes_column_row(&key_col.data, rows, i)?);
+        }
+
+        // Indices are always in range (`0..rows`, and `keys` / `effective` both
+        // have `rows` entries), so the `get` defaults below are never taken; they
+        // only satisfy the no-panic-indexing lint.
+        let key_at = |i: u32| keys.get(i as usize).copied().unwrap_or(&[]);
+        let eff_at = |i: u32| effective.get(i as usize).copied().unwrap_or(0);
+        let cmp = self.comparator.as_ref();
+        let mut order: Vec<u32> = (0..rows).collect();
+        order.sort_by(|&a, &b| {
+            cmp.compare(key_at(a), key_at(b))
+                .then_with(|| eff_at(b).cmp(&eff_at(a)))
+        });
+
+        // Keep the first index of each distinct key (highest effective seqno);
+        // drop the shadowed older duplicates.
+        let mut kept: Vec<u32> = Vec::with_capacity(order.len());
+        let mut prev: Option<&[u8]> = None;
+        for &i in &order {
+            let key = key_at(i);
+            if let Some(p) = prev
+                && cmp.compare(p, key) == core::cmp::Ordering::Equal
+            {
+                continue;
+            }
+            prev = Some(key);
+            kept.push(i);
+        }
+
+        let mut merged = take_rows(&combined, &kept);
+        // Match the singleton contract: yield exactly the projected columns.
+        if !key_projected {
+            merged.columns.retain(|c| c.column_id != COL_USER_KEY);
+        }
+        if !seqno_projected {
+            merged.columns.retain(|c| c.column_id != COL_SEQNO);
+        }
+        if merged.row_count == 0 {
+            return Ok(Vec::new());
+        }
+        Ok(vec![merged])
+    }
+}
+
+/// Builds a per-row keep mask for `batch` marking rows whose seqno is visible at
+/// `local_threshold` (a row is visible iff its local seqno is `< threshold`).
+/// The batch must carry the [`COL_SEQNO`] column.
+fn seqno_visibility_mask(batch: &ColumnBatch, local_threshold: SeqNo) -> crate::Result<Vec<bool>> {
+    let seqno_col = batch
+        .columns
+        .iter()
+        .find(|c| c.column_id == COL_SEQNO)
+        .ok_or(Error::InvalidHeader(
+            "columnar_scan: partial-visibility batch missing the seqno column",
+        ))?;
+    let mut mask = Vec::with_capacity(batch.row_count as usize);
+    for row in 0..batch.row_count {
+        mask.push(fixed_u64_row(&seqno_col.data, row)? < local_threshold);
+    }
+    Ok(mask)
+}
+
+impl Iterator for ColumnarScan {
+    type Item = crate::Result<ColumnBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(batch) = self.buffered.pop_front() {
+                return Some(Ok(batch));
+            }
+            let group = self.groups.pop_front()?;
+            match self.process_group(&group) {
+                Ok(batches) => self.buffered.extend(batches),
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+}
+
+/// Clones a borrowed key bound into an owned one.
+fn clone_bound(bound: Bound<&UserKey>) -> Bound<UserKey> {
+    match bound {
+        Bound::Included(k) => Bound::Included(k.clone()),
+        Bound::Excluded(k) => Bound::Excluded(k.clone()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+/// Borrows an owned key bound as a byte-slice bound for key-range overlap checks.
+fn bound_as_ref(bound: &Bound<UserKey>) -> Bound<&[u8]> {
+    match bound {
+        Bound::Included(k) => Bound::Included(k.as_ref()),
+        Bound::Excluded(k) => Bound::Excluded(k.as_ref()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}

--- a/src/tree/columnar_scan.rs
+++ b/src/tree/columnar_scan.rs
@@ -86,6 +86,12 @@ impl Tree {
     /// with newest-`seqno`-wins semantics so an overwritten key is returned once
     /// (its newest version); disjoint segments stream without merge overhead.
     ///
+    /// `range` bounds the result at row granularity: a segment that only
+    /// partially overlaps `range` contributes only the rows whose keys fall
+    /// inside it (the inclusive / exclusive sense of each bound is honored). A
+    /// fully unbounded range keeps the zero-copy fast path for an all-visible
+    /// segment.
+    ///
     /// `projection` lists the column ids to decode (value sub-column ids, plus
     /// optionally the intrinsic [`COL_USER_KEY`] / seqno / value-type columns);
     /// every other column is stepped over without decoding. Each yielded batch
@@ -153,6 +159,8 @@ impl Tree {
             predicate: predicate.cloned(),
             comparator,
             seqno,
+            lo,
+            hi,
         })
     }
 }
@@ -201,6 +209,11 @@ pub struct ColumnarScan {
     comparator: alloc::sync::Arc<dyn UserComparator>,
     /// The query snapshot, used for per-row seqno visibility masking.
     seqno: SeqNo,
+    /// The requested key range. Applied as a per-row filter (not just segment
+    /// selection): a segment that only partially overlaps the range must still
+    /// drop the rows that fall outside it.
+    lo: Bound<UserKey>,
+    hi: Bound<UserKey>,
 }
 
 impl ColumnarScan {
@@ -215,11 +228,20 @@ impl ColumnarScan {
         self.merge_group(group)
     }
 
-    /// Singleton group: no cross-segment merge. When every row is visible the
-    /// per-SST projected scan streams verbatim (zero-copy column-skip); when the
-    /// snapshot straddles the segment, a per-row seqno mask is applied.
+    /// Whether the requested key range is fully unbounded, so no per-row range
+    /// filtering is needed (the segment's every row is in range).
+    fn range_is_full(&self) -> bool {
+        matches!(self.lo, Bound::Unbounded) && matches!(self.hi, Bound::Unbounded)
+    }
+
+    /// Singleton group: no cross-segment merge. When every row is visible and the
+    /// range is unbounded, the per-SST projected scan streams verbatim (zero-copy
+    /// column-skip). Otherwise a per-row mask drops rows that are seqno-invisible
+    /// (when the snapshot straddles the segment) or outside the requested range
+    /// (when the segment only partially overlaps it).
     fn process_singleton(&self, seg: &Segment) -> crate::Result<Vec<ColumnBatch>> {
-        if seg.visibility == SeqnoVisibility::All {
+        let range_filter = !self.range_is_full();
+        if seg.visibility == SeqnoVisibility::All && !range_filter {
             let mut out = seg
                 .table
                 .columnar_scan(&self.projection, self.predicate.as_ref())?;
@@ -227,17 +249,23 @@ impl ColumnarScan {
             return Ok(out);
         }
 
-        // Partial visibility: decode the seqno column too, drop rows whose
-        // effective seqno is not visible, then strip the seqno column if the
-        // caller did not project it.
+        // Decode the columns the mask needs even when the caller did not project
+        // them (dropped again at the end): the seqno column for partial-visibility
+        // masking, the key column for range filtering.
+        let partial = seg.visibility == SeqnoVisibility::Partial;
         let seqno_projected = self.projection.contains(&COL_SEQNO);
+        let key_projected = self.projection.contains(&COL_USER_KEY);
         let mut augmented = self.projection.clone();
-        if !seqno_projected {
+        if partial && !seqno_projected {
             augmented.push(COL_SEQNO);
+        }
+        if range_filter && !key_projected {
+            augmented.push(COL_USER_KEY);
         }
         // Visible iff `local < threshold` (the snapshot in this segment's local
         // seqno space); `Partial` guarantees the subtraction is in range.
         let threshold = self.seqno.saturating_sub(seg.global);
+        let cmp = self.comparator.as_ref();
 
         let mut out = Vec::new();
         for batch in seg
@@ -247,10 +275,57 @@ impl ColumnarScan {
             if batch.row_count == 0 {
                 continue;
             }
-            let mask = seqno_visibility_mask(&batch, threshold)?;
+            let seqno_col = if partial {
+                Some(
+                    batch
+                        .columns
+                        .iter()
+                        .find(|c| c.column_id == COL_SEQNO)
+                        .ok_or(Error::InvalidHeader(
+                            "columnar_scan: partial-visibility batch missing the seqno column",
+                        ))?,
+                )
+            } else {
+                None
+            };
+            let key_col = if range_filter {
+                Some(
+                    batch
+                        .columns
+                        .iter()
+                        .find(|c| c.column_id == COL_USER_KEY)
+                        .ok_or(Error::InvalidHeader(
+                            "columnar_scan: range-filtered batch missing the key column",
+                        ))?,
+                )
+            } else {
+                None
+            };
+
+            let mut mask = Vec::with_capacity(batch.row_count as usize);
+            for row in 0..batch.row_count {
+                let seqno_ok = match seqno_col {
+                    Some(seqno_col) => fixed_u64_row(&seqno_col.data, row)? < threshold,
+                    None => true,
+                };
+                // Evaluate the range bound only when the row survived the seqno
+                // gate (short-circuit), so a row's key is decoded only if needed.
+                let keep = if !seqno_ok {
+                    false
+                } else if let Some(key_col) = key_col {
+                    let key = bytes_column_row(&key_col.data, batch.row_count, row)?;
+                    key_in_bounds(key, &self.lo, &self.hi, cmp)
+                } else {
+                    true
+                };
+                mask.push(keep);
+            }
             let mut visible = filter_batch(&batch, &mask);
-            if !seqno_projected {
+            if partial && !seqno_projected {
                 visible.columns.retain(|c| c.column_id != COL_SEQNO);
+            }
+            if range_filter && !key_projected {
+                visible.columns.retain(|c| c.column_id != COL_USER_KEY);
             }
             if visible.row_count > 0 {
                 out.push(visible);
@@ -360,7 +435,9 @@ impl ColumnarScan {
         });
 
         // Keep the first index of each distinct key (highest effective seqno);
-        // drop the shadowed older duplicates.
+        // drop the shadowed older duplicates and any key outside the requested
+        // range (a segment may only partially overlap it).
+        let range_filter = !self.range_is_full();
         let mut kept: Vec<u32> = Vec::with_capacity(order.len());
         let mut prev: Option<&[u8]> = None;
         for &i in &order {
@@ -371,6 +448,9 @@ impl ColumnarScan {
                 continue;
             }
             prev = Some(key);
+            if range_filter && !key_in_bounds(key, &self.lo, &self.hi, cmp) {
+                continue;
+            }
             kept.push(i);
         }
 
@@ -389,22 +469,27 @@ impl ColumnarScan {
     }
 }
 
-/// Builds a per-row keep mask for `batch` marking rows whose seqno is visible at
-/// `local_threshold` (a row is visible iff its local seqno is `< threshold`).
-/// The batch must carry the [`COL_SEQNO`] column.
-fn seqno_visibility_mask(batch: &ColumnBatch, local_threshold: SeqNo) -> crate::Result<Vec<bool>> {
-    let seqno_col = batch
-        .columns
-        .iter()
-        .find(|c| c.column_id == COL_SEQNO)
-        .ok_or(Error::InvalidHeader(
-            "columnar_scan: partial-visibility batch missing the seqno column",
-        ))?;
-    let mut mask = Vec::with_capacity(batch.row_count as usize);
-    for row in 0..batch.row_count {
-        mask.push(fixed_u64_row(&seqno_col.data, row)? < local_threshold);
-    }
-    Ok(mask)
+/// Whether `key` lies within the requested `[lo, hi]` key bounds, per the tree
+/// comparator. An unbounded side never excludes; the inclusive / exclusive sense
+/// of each bound matches the `RangeBounds` the caller passed.
+fn key_in_bounds(
+    key: &[u8],
+    lo: &Bound<UserKey>,
+    hi: &Bound<UserKey>,
+    cmp: &dyn UserComparator,
+) -> bool {
+    use core::cmp::Ordering;
+    let above_lo = match lo {
+        Bound::Unbounded => true,
+        Bound::Included(k) => cmp.compare(key, k.as_ref()) != Ordering::Less,
+        Bound::Excluded(k) => cmp.compare(key, k.as_ref()) == Ordering::Greater,
+    };
+    let below_hi = match hi {
+        Bound::Unbounded => true,
+        Bound::Included(k) => cmp.compare(key, k.as_ref()) != Ordering::Greater,
+        Bound::Excluded(k) => cmp.compare(key, k.as_ref()) == Ordering::Less,
+    };
+    above_lo && below_hi
 }
 
 impl Iterator for ColumnarScan {

--- a/src/tree/columnar_scan.rs
+++ b/src/tree/columnar_scan.rs
@@ -350,6 +350,15 @@ impl ColumnarScan {
         if !seqno_projected {
             augmented.push(COL_SEQNO);
         }
+        // The predicate is applied AFTER newest-version dedup (below), so its
+        // column must be decoded here even when the caller did not project it.
+        let predicate_col = self.predicate.as_ref().map(|p| p.column_id);
+        let predicate_col_projected = predicate_col.is_some_and(|c| self.projection.contains(&c));
+        if let Some(pc) = predicate_col
+            && !augmented.contains(&pc)
+        {
+            augmented.push(pc);
+        }
 
         // Concatenate every segment's visible rows into one batch, tracking each
         // surviving row's effective seqno (`local + global`) in lockstep so the
@@ -358,10 +367,12 @@ impl ColumnarScan {
         let mut effective: Vec<SeqNo> = Vec::new();
         for seg in &group.segments {
             let threshold = self.seqno.saturating_sub(seg.global);
-            for batch in seg
-                .table
-                .columnar_scan(&augmented, self.predicate.as_ref())?
-            {
+            // No predicate here: in an overlap group the predicate must run after
+            // newest-version dedup, so every version (including a newest one that
+            // fails the predicate but shadows an older matching version) has to be
+            // collected first. Predicate-driven zone-map block-skip is likewise
+            // unsafe here for the same reason, so it is also dropped.
+            for batch in seg.table.columnar_scan(&augmented, None)? {
                 if batch.row_count == 0 {
                     continue;
                 }
@@ -455,12 +466,27 @@ impl ColumnarScan {
         }
 
         let mut merged = take_rows(&combined, &kept);
+
+        // Apply the row predicate AFTER newest-version dedup: each surviving row is
+        // now the newest visible version of its key, so a key whose newest version
+        // fails the predicate is correctly dropped instead of falling back to an
+        // older matching version.
+        if let Some(pred) = self.predicate.as_ref() {
+            let mask = pred.matching_rows(&merged);
+            merged = filter_batch(&merged, &mask);
+        }
+
         // Match the singleton contract: yield exactly the projected columns.
         if !key_projected {
             merged.columns.retain(|c| c.column_id != COL_USER_KEY);
         }
         if !seqno_projected {
             merged.columns.retain(|c| c.column_id != COL_SEQNO);
+        }
+        if let Some(pc) = predicate_col
+            && !predicate_col_projected
+        {
+            merged.columns.retain(|c| c.column_id != pc);
         }
         if merged.row_count == 0 {
             return Ok(Vec::new());

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
+#[cfg(feature = "columnar")]
+pub mod columnar_scan;
 pub mod ingest;
 pub mod inner;
 pub mod sealed;

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -777,3 +777,88 @@ fn tree_columnar_scan_blob_tree_unsupported() {
         "columnar scan over a blob tree must be rejected"
     );
 }
+
+/// Collects `(key, sub-column-3)` pairs from a bounded-range tree scan, asserting
+/// each batch carries exactly the key + value-3 columns.
+fn scan_range_pairs<R: std::ops::RangeBounds<UserKey>>(
+    tree: &lsm_tree::Tree,
+    range: R,
+) -> Vec<(Vec<u8>, u32)> {
+    let mut out = Vec::new();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY, 3], None, SeqNo::MAX, range)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        let key_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .expect("key column");
+        let val_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == 3)
+            .expect("value column");
+        let rows = batch.row_count as usize;
+        let off = |i: usize| {
+            let b: [u8; 4] = key_col.data[i * 4..i * 4 + 4].try_into().unwrap();
+            u32::from_le_bytes(b) as usize
+        };
+        let payload = &key_col.data[(rows + 1) * 4..];
+        for i in 0..rows {
+            let k = payload[off(i)..off(i + 1)].to_vec();
+            let a = u32::from_le_bytes(val_col.data[i * 4..i * 4 + 4].try_into().unwrap());
+            out.push((k, a));
+        }
+    }
+    out
+}
+
+#[test]
+fn tree_columnar_scan_filters_rows_to_the_requested_range() {
+    // A bounded range that PARTIALLY overlaps a single segment must return only
+    // the in-range rows — not the whole segment (the range is a row filter, not
+    // just a segment selector).
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[
+        (key(0), 0),
+        (key(1), 1),
+        (key(2), 2),
+        (key(3), 3),
+        (key(4), 4),
+    ]);
+    let tree = standard(&any);
+
+    // [k1, k4): exclusive upper → k1, k2, k3.
+    let got = scan_range_pairs(tree, UserKey::from(&key(1)[..])..UserKey::from(&key(4)[..]));
+    assert_eq!(
+        got,
+        vec![(key(1), 1), (key(2), 2), (key(3), 3)],
+        "only rows inside the requested range are returned",
+    );
+
+    // Inclusive upper [k1, k3] → k1, k2, k3.
+    let got = scan_range_pairs(tree, UserKey::from(&key(1)[..])..=UserKey::from(&key(3)[..]));
+    assert_eq!(got, vec![(key(1), 1), (key(2), 2), (key(3), 3)]);
+}
+
+#[test]
+fn tree_columnar_scan_overlap_merge_filters_rows_to_the_range() {
+    // The overlap-merge path must also enforce the row-level range: a bounded scan
+    // over two overlapping segments returns only in-range keys.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 0), (key(2), 2), (key(4), 4)]);
+    ingest_segment(&any, &[(key(1), 1), (key(3), 3), (key(5), 5)]); // overlaps → merge
+
+    let tree = standard(&any);
+    // [k2, k4]: inclusive → k2, k3, k4.
+    let got = scan_range_pairs(tree, UserKey::from(&key(2)[..])..=UserKey::from(&key(4)[..]));
+    assert_eq!(
+        got,
+        vec![(key(2), 2), (key(3), 3), (key(4), 4)],
+        "the merge path drops rows outside the requested range",
+    );
+}

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -917,7 +917,9 @@ fn tree_columnar_scan_merge_preserves_a_nullable_sub_column() {
         }
     }
     let col3 = col3.expect("value sub-column present");
-    let validity = col3.validity.expect("nullable column keeps its validity bitmap");
+    let validity = col3
+        .validity
+        .expect("nullable column keeps its validity bitmap");
     let is_valid = |row: usize| validity[row / 8] & (1 << (row % 8)) != 0;
     // Key order: row0=k0 (valid), row1=k1 (valid), row2=k2 (NULL).
     assert!(is_valid(0), "k0 is non-null");

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -924,3 +924,75 @@ fn tree_columnar_scan_merge_preserves_a_nullable_sub_column() {
     assert!(is_valid(1), "k1 is non-null");
     assert!(!is_valid(2), "k2's null survives the merge gather");
 }
+
+/// Ingests a single-key segment whose value is one variable-width (Bytes) sub-
+/// column (id 3), so a value-column predicate can actually row-filter it.
+fn ingest_bytes_value(any: &AnyTree, k: &[u8], value: &[u8]) {
+    let mut batch = entries_to_column_batch(&[InternalValue::from_components(
+        k.to_vec(),
+        b"x".to_vec(),
+        0,
+        ValueType::Value,
+    )])
+    .expect("transpose");
+    batch.columns.pop();
+    // One-row Bytes column: (row + 1) u32 offset table [0, len] then the payload.
+    let mut data = Vec::new();
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.extend_from_slice(&(value.len() as u32).to_le_bytes());
+    data.extend_from_slice(value);
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Bytes,
+        validity: None,
+        data,
+    });
+    let mut ingest = any.ingestion().expect("ingestion");
+    ingest.write_columnar_batch(&batch).expect("write");
+    ingest.finish().expect("finish");
+}
+
+#[test]
+fn tree_columnar_scan_applies_predicate_after_newest_version_wins() {
+    // MVCC + predicate ordering in the overlap-merge path: when a key's NEWEST
+    // visible version does NOT match the predicate but an older version does, the
+    // key must be OMITTED (the newest version shadows the older) — not returned as
+    // the stale matching older row.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_bytes_value(&any, &key(1), b"aaa"); // older: matches predicate
+    ingest_bytes_value(&any, &key(1), b"zzz"); // newer, same key: does NOT match
+
+    let pred = ColumnRangePredicate {
+        column_id: 3,
+        lower: Some(b"aaa".to_vec()),
+        upper: Some(b"aaa".to_vec()),
+    };
+    let tree = standard(&any);
+    let mut keys: Vec<Vec<u8>> = Vec::new();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY, 3], Some(&pred), SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        let key_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .expect("key column");
+        let rows = batch.row_count as usize;
+        let off = |i: usize| {
+            let b: [u8; 4] = key_col.data[i * 4..i * 4 + 4].try_into().unwrap();
+            u32::from_le_bytes(b) as usize
+        };
+        let payload = &key_col.data[(rows + 1) * 4..];
+        for i in 0..rows {
+            keys.push(payload[off(i)..off(i + 1)].to_vec());
+        }
+    }
+    assert!(
+        keys.is_empty(),
+        "k1's newest version (zzz) fails the predicate, so k1 is omitted, not \
+         returned as the stale older matching version; got {keys:?}",
+    );
+}

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -822,13 +822,16 @@ fn tree_columnar_scan_filters_rows_to_the_requested_range() {
     // just a segment selector).
     let folder = get_tmp_folder();
     let any = open_columnar_any(folder.path());
-    ingest_segment(&any, &[
-        (key(0), 0),
-        (key(1), 1),
-        (key(2), 2),
-        (key(3), 3),
-        (key(4), 4),
-    ]);
+    ingest_segment(
+        &any,
+        &[
+            (key(0), 0),
+            (key(1), 1),
+            (key(2), 2),
+            (key(3), 3),
+            (key(4), 4),
+        ],
+    );
     let tree = standard(&any);
 
     // [k1, k4): exclusive upper → k1, k2, k3.
@@ -840,7 +843,10 @@ fn tree_columnar_scan_filters_rows_to_the_requested_range() {
     );
 
     // Inclusive upper [k1, k3] → k1, k2, k3.
-    let got = scan_range_pairs(tree, UserKey::from(&key(1)[..])..=UserKey::from(&key(3)[..]));
+    let got = scan_range_pairs(
+        tree,
+        UserKey::from(&key(1)[..])..=UserKey::from(&key(3)[..]),
+    );
     assert_eq!(got, vec![(key(1), 1), (key(2), 2), (key(3), 3)]);
 }
 
@@ -855,7 +861,10 @@ fn tree_columnar_scan_overlap_merge_filters_rows_to_the_range() {
 
     let tree = standard(&any);
     // [k2, k4]: inclusive → k2, k3, k4.
-    let got = scan_range_pairs(tree, UserKey::from(&key(2)[..])..=UserKey::from(&key(4)[..]));
+    let got = scan_range_pairs(
+        tree,
+        UserKey::from(&key(2)[..])..=UserKey::from(&key(4)[..]),
+    );
     assert_eq!(
         got,
         vec![(key(2), 2), (key(3), 3), (key(4), 4)],

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -7,15 +7,124 @@
 
 #![cfg(feature = "columnar")]
 
+use lsm_tree::config::{DeleteStrategy, DeleteStrategyPolicy};
 use lsm_tree::table::columnar::{
-    COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, column_batch_to_entries,
+    COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, Column, ColumnBatch, TypeTag,
+    column_batch_to_entries, entries_to_column_batch,
 };
 use lsm_tree::table::columnar_predicate::ColumnRangePredicate;
-use lsm_tree::{AbstractTree, AnyTree, Config, SequenceNumberCounter, get_tmp_folder};
+use lsm_tree::{
+    AbstractTree, AnyTree, Config, Error, InternalValue, SeqNo, SequenceNumberCounter, UserKey,
+    ValueType, get_tmp_folder,
+};
 use test_log::test;
 
 fn key(i: u32) -> Vec<u8> {
     format!("k{i:06}").into_bytes()
+}
+
+/// Builds a consumer columnar batch whose value is one fixed-4 sub-column
+/// (id 3, holding `a` little-endian). Per-row seqnos are 0, so the ingestion
+/// assigns the atomic global sequence number. `rows` must be sorted by key.
+fn subcol_batch(rows: &[(Vec<u8>, u32)]) -> ColumnBatch {
+    let entries: Vec<InternalValue> = rows
+        .iter()
+        .map(|(k, _)| InternalValue::from_components(k.clone(), b"ignored", 0, ValueType::Value))
+        .collect();
+    let mut batch = entries_to_column_batch(&entries).expect("transpose");
+    // Replace the single opaque value column with one fixed-4 sub-column (id 3).
+    batch.columns.pop();
+    let mut data = Vec::with_capacity(rows.len() * 4);
+    for (_, a) in rows {
+        data.extend_from_slice(&a.to_le_bytes());
+    }
+    batch.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        validity: None,
+        data,
+    });
+    batch
+}
+
+/// Opens a columnar standard tree and ingests `rows` as one new SST, returning
+/// the tree (wrapped in [`AnyTree`]). Each call creates a separate segment with
+/// its own `global_seqno`.
+fn ingest_segment(any: &AnyTree, rows: &[(Vec<u8>, u32)]) {
+    let mut ingest = any.ingestion().expect("ingestion");
+    ingest
+        .write_columnar_batch(&subcol_batch(rows))
+        .expect("write batch");
+    ingest.finish().expect("finish");
+}
+
+/// Opens an empty columnar tree (columnar + zone-map enabled).
+fn open_columnar_any(folder: &std::path::Path) -> AnyTree {
+    let any = Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar + zone-map");
+    any
+}
+
+/// Flattens a tree-level columnar scan into `(key, sub-column-3 value)` pairs in
+/// yield order, asserting every batch carries exactly `expect_columns`.
+fn scan_to_pairs(
+    tree: &lsm_tree::Tree,
+    projection: &[u16],
+    predicate: Option<&ColumnRangePredicate>,
+    seqno: SeqNo,
+    expect_columns: &[u16],
+) -> Vec<(Vec<u8>, u32)> {
+    let mut out = Vec::new();
+    for batch in tree
+        .columnar_scan(projection, predicate, seqno, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        let mut ids: Vec<u16> = batch.columns.iter().map(|c| c.column_id).collect();
+        ids.sort_unstable();
+        let mut want = expect_columns.to_vec();
+        want.sort_unstable();
+        assert_eq!(
+            ids, want,
+            "each batch carries exactly the projected columns"
+        );
+        let key_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .expect("key column projected for this assertion");
+        let val_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == 3)
+            .expect("value sub-column projected for this assertion");
+        // The key column is a Bytes column: rebuild its (row+1) offset table view.
+        let rows = batch.row_count as usize;
+        let off = |i: usize| {
+            let b: [u8; 4] = key_col.data[i * 4..i * 4 + 4].try_into().unwrap();
+            u32::from_le_bytes(b) as usize
+        };
+        let payload = &key_col.data[(rows + 1) * 4..];
+        for i in 0..rows {
+            let k = payload[off(i)..off(i + 1)].to_vec();
+            let a = u32::from_le_bytes(val_col.data[i * 4..i * 4 + 4].try_into().unwrap());
+            out.push((k, a));
+        }
+    }
+    out
 }
 
 /// Opens a standard tree with the columnar layout and zone-map both enabled, so
@@ -171,5 +280,500 @@ fn columnar_scan_errors_on_a_non_columnar_sst() {
     assert!(
         table.columnar_scan(&[COL_USER_KEY], None).is_err(),
         "scanning a row-major SST as columnar must error"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tree-level projected columnar scan (#566): lifts the per-SST scan across the
+// whole tree, owning segment selection, MVCC visibility, delete-masking, and
+// cross-segment ordering / newest-wins merge.
+// ---------------------------------------------------------------------------
+
+fn standard(any: &AnyTree) -> &lsm_tree::Tree {
+    match any {
+        AnyTree::Standard(t) => t,
+        AnyTree::Blob(_) => panic!("expected standard tree"),
+    }
+}
+
+#[test]
+fn tree_columnar_scan_streams_disjoint_segments_in_key_order() {
+    // Two ingested segments with disjoint key ranges (the append-only common
+    // case) stream verbatim and concatenate in global key order.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 10), (key(1), 11)]);
+    ingest_segment(&any, &[(key(2), 12), (key(3), 13)]);
+
+    let got = scan_to_pairs(
+        standard(&any),
+        &[COL_USER_KEY, 3],
+        None,
+        SeqNo::MAX,
+        &[COL_USER_KEY, 3],
+    );
+    let expected: Vec<(Vec<u8>, u32)> =
+        vec![(key(0), 10), (key(1), 11), (key(2), 12), (key(3), 13)];
+    assert_eq!(
+        got, expected,
+        "disjoint segments yield every row in key order"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_overlapping_segments_keep_newest() {
+    // The same key is written in an older then a newer segment (an overwrite).
+    // The scan must return one row per key — the newest version — not duplicates.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 100), (key(1), 101), (key(2), 102)]);
+    // Newer segment overwrites k1, adds k3; overlaps the first segment's range.
+    ingest_segment(&any, &[(key(1), 201), (key(3), 203)]);
+
+    let got = scan_to_pairs(
+        standard(&any),
+        &[COL_USER_KEY, 3],
+        None,
+        SeqNo::MAX,
+        &[COL_USER_KEY, 3],
+    );
+    let expected: Vec<(Vec<u8>, u32)> = vec![
+        (key(0), 100),
+        (key(1), 201), // newest wins over 101
+        (key(2), 102),
+        (key(3), 203),
+    ];
+    assert_eq!(
+        got, expected,
+        "overlapping segments merge newest-seqno-wins, no duplicate keys"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_projection_decodes_only_requested_columns() {
+    // Projecting only sub-column 3 across multiple segments yields batches that
+    // carry that column alone — the intrinsic value / key columns are not decoded.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 10), (key(1), 11)]);
+    ingest_segment(&any, &[(key(2), 12)]);
+
+    let tree = standard(&any);
+    let mut rows = 0u32;
+    for batch in tree
+        .columnar_scan(&[3], None, SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == 3),
+            "a sub-column-3 projection must not decode any other column"
+        );
+        rows += batch.row_count;
+    }
+    assert_eq!(rows, 3, "projection still sees every row across segments");
+}
+
+#[test]
+fn tree_columnar_scan_predicate_filters_across_segments() {
+    // A key-range predicate prunes rows across two disjoint segments, leaving the
+    // contiguous middle slice.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 0), (key(1), 1), (key(2), 2)]);
+    ingest_segment(&any, &[(key(3), 3), (key(4), 4), (key(5), 5)]);
+
+    let pred = ColumnRangePredicate {
+        column_id: COL_USER_KEY,
+        lower: Some(key(1)),
+        upper: Some(key(4)),
+    };
+    let got = scan_to_pairs(
+        standard(&any),
+        &[COL_USER_KEY, 3],
+        Some(&pred),
+        SeqNo::MAX,
+        &[COL_USER_KEY, 3],
+    );
+    let expected: Vec<(Vec<u8>, u32)> = vec![(key(1), 1), (key(2), 2), (key(3), 3), (key(4), 4)];
+    assert_eq!(got, expected, "predicate filters rows across segments");
+}
+
+#[test]
+fn tree_columnar_scan_snapshot_excludes_newer_segment() {
+    // MVCC visibility is segment-granular for uniform-seqno ingested segments: a
+    // snapshot at the newer segment's base sees the older segment only.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 10), (key(1), 11)]);
+    ingest_segment(&any, &[(key(2), 12), (key(3), 13)]);
+
+    let tree = standard(&any);
+    let version = tree.current_version();
+    let mut bases: Vec<SeqNo> = version.iter_tables().map(|t| t.global_seqno()).collect();
+    bases.sort_unstable();
+    let (older, newer) = (bases[0], bases[1]);
+    assert!(older < newer, "two ingestions get increasing seqno bases");
+
+    // Snapshot == newer base: the newer segment (base == snapshot) is excluded by
+    // the exclusive rule; the older segment (base < snapshot) is visible.
+    let got = scan_to_pairs(tree, &[COL_USER_KEY, 3], None, newer, &[COL_USER_KEY, 3]);
+    assert_eq!(
+        got,
+        vec![(key(0), 10), (key(1), 11)],
+        "a snapshot at the newer base sees only the older segment"
+    );
+
+    // A snapshot at or below the oldest base sees nothing.
+    assert!(
+        tree.columnar_scan(&[COL_USER_KEY, 3], None, older, ..)
+            .expect("scan")
+            .next()
+            .is_none(),
+        "a snapshot at the oldest base sees no segment"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_full_row_reconstruction_unaffected() {
+    // The row path (get) still reconstructs whole rows after the same data is
+    // scanned column-wise — columnar_scan does not perturb full-row reads.
+    use lsm_tree::table::columnar::unframe_value_cells;
+
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 7), (key(1), 8)]);
+
+    // Column scan sees the sub-column values.
+    let got = scan_to_pairs(
+        standard(&any),
+        &[COL_USER_KEY, 3],
+        None,
+        SeqNo::MAX,
+        &[COL_USER_KEY, 3],
+    );
+    assert_eq!(got, vec![(key(0), 7), (key(1), 8)]);
+
+    // Full-row get reconstructs each row's framed value (one fixed-4 sub-column).
+    let tags = [TypeTag::Fixed(4)];
+    let v0 = any.get(key(0), SeqNo::MAX).expect("get").expect("k0");
+    assert_eq!(
+        unframe_value_cells(v0.as_ref(), &tags).expect("unframe"),
+        vec![&7u32.to_le_bytes()[..]],
+    );
+    let v1 = any.get(key(1), SeqNo::MAX).expect("get").expect("k1");
+    assert_eq!(
+        unframe_value_cells(v1.as_ref(), &tags).expect("unframe"),
+        vec![&8u32.to_le_bytes()[..]],
+    );
+}
+
+#[test]
+fn tree_columnar_scan_drops_internal_columns_when_unprojected() {
+    // When the caller does not project the key column, the overlap-merge path
+    // still decodes it internally but must drop it from the output, leaving
+    // exactly the projected value sub-column.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 100), (key(1), 101)]);
+    ingest_segment(&any, &[(key(1), 201)]); // overlap forces the merge path
+
+    let tree = standard(&any);
+    let mut values: Vec<u32> = Vec::new();
+    for batch in tree
+        .columnar_scan(&[3], None, SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == 3),
+            "merge output must carry only the projected value column"
+        );
+        let col = &batch.columns[0];
+        for i in 0..batch.row_count as usize {
+            values.push(u32::from_le_bytes(
+                col.data[i * 4..i * 4 + 4].try_into().unwrap(),
+            ));
+        }
+    }
+    assert_eq!(
+        values,
+        vec![100, 201],
+        "merge keeps newest, drops key column"
+    );
+}
+
+/// Flattens a tree-level columnar scan projecting only the key column into keys.
+fn scan_keys(tree: &lsm_tree::Tree, seqno: SeqNo) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY], None, seqno, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == COL_USER_KEY),
+            "key-only projection drops the internally-decoded seqno column"
+        );
+        let key_col = &batch.columns[0];
+        let rows = batch.row_count as usize;
+        let off = |i: usize| {
+            let b: [u8; 4] = key_col.data[i * 4..i * 4 + 4].try_into().unwrap();
+            u32::from_le_bytes(b) as usize
+        };
+        let payload = &key_col.data[(rows + 1) * 4..];
+        for i in 0..rows {
+            out.push(payload[off(i)..off(i + 1)].to_vec());
+        }
+    }
+    out
+}
+
+#[test]
+fn tree_columnar_scan_masks_per_row_seqno_when_snapshot_straddles_segment() {
+    // A flush-produced columnar segment carries per-row seqnos, so a snapshot can
+    // straddle it. The scan must drop rows whose seqno is not visible (the
+    // partial-visibility path), not return the whole segment.
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    tree.insert(key(0), b"a".to_vec(), 1);
+    tree.insert(key(1), b"b".to_vec(), 2);
+    tree.insert(key(2), b"c".to_vec(), 3);
+    tree.flush_active_memtable(0).expect("flush");
+
+    // Snapshot 2: only rows with seqno < 2 are visible (k0 @ seqno 1).
+    assert_eq!(
+        scan_keys(&tree, 2),
+        vec![key(0)],
+        "partial visibility keeps only rows below the snapshot"
+    );
+    // Snapshot MAX: every row is visible.
+    assert_eq!(scan_keys(&tree, SeqNo::MAX), vec![key(0), key(1), key(2)]);
+}
+
+#[test]
+fn tree_columnar_scan_applies_delete_bitmap_masking() {
+    // A columnar segment carrying a positional delete-bitmap (built by relocating
+    // a range tombstone under the Adaptive merge-on-read strategy) must have its
+    // deleted rows masked out by the tree-level scan.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+        // High purge threshold: the delete relocates into a bitmap (masked),
+        // not a physical purge, so the segment carries a delete-bitmap.
+        cfg.delete_strategy = DeleteStrategyPolicy::all(DeleteStrategy::Adaptive {
+            purge_threshold_percent: 90,
+        });
+    })
+    .expect("enable columnar adaptive");
+
+    for i in 0..10u32 {
+        tree.insert(key(i), vec![b'v'; 16], u64::from(i) + 1);
+    }
+    tree.remove_range(UserKey::from(&key(0)[..]), UserKey::from(&key(4)[..]), 1000);
+    tree.flush_active_memtable(0).expect("flush");
+    tree.major_compact(64 * 1024 * 1024, 5000)
+        .expect("relocate");
+
+    {
+        let version = tree.current_version();
+        let tables: Vec<_> = version.iter_tables().collect();
+        assert_eq!(tables.len(), 1, "one relocated segment");
+        assert!(
+            tables[0].delete_density().is_some(),
+            "segment must carry a delete-bitmap for this test to be meaningful",
+        );
+    }
+
+    // Scan the whole tree: the deleted keys [0,4) must be masked out.
+    let got = scan_keys(tree, SeqNo::MAX);
+    let expected: Vec<Vec<u8>> = (4..10u32).map(key).collect();
+    assert_eq!(
+        got, expected,
+        "tree-level scan masks the segment's positional deletes"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_errors_on_mixed_mode_tree() {
+    // If a non-columnar segment overlaps the range (a mixed-mode tree), the scan
+    // must reject the request rather than silently skip that segment's data.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("open");
+    let AnyTree::Standard(tree) = &any else {
+        panic!("expected standard tree");
+    };
+
+    // A row-major segment (columnar disabled) overlapping the scan range.
+    tree.insert(key(0), vec![b'v'; 8], 0);
+    tree.flush_active_memtable(0).expect("flush row segment");
+    tree.update_runtime_config(|cfg| {
+        cfg.columnar = true;
+        cfg.zone_map = true;
+    })
+    .expect("enable columnar");
+    ingest_segment(&any, &[(key(1), 11)]);
+
+    assert!(
+        matches!(
+            tree.columnar_scan(&[3], None, SeqNo::MAX, ..),
+            Err(Error::FeatureUnsupported(_))
+        ),
+        "a non-columnar segment overlapping the range must be rejected"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_empty_when_range_misses_every_segment() {
+    // An empty tree, and a range below all data, both yield no batches.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+
+    assert!(
+        standard(&any)
+            .columnar_scan(&[3], None, SeqNo::MAX, ..)
+            .expect("scan")
+            .next()
+            .is_none(),
+        "an empty tree yields no batches"
+    );
+
+    ingest_segment(&any, &[(key(5), 50), (key(6), 60)]);
+    let upper = key(2);
+    let got: Vec<_> = standard(&any)
+        .columnar_scan(
+            &[COL_USER_KEY, 3],
+            None,
+            SeqNo::MAX,
+            ..UserKey::from(&upper[..]),
+        )
+        .expect("scan")
+        .collect();
+    assert!(
+        got.is_empty(),
+        "a range that misses every segment yields no batches"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_predicate_on_unprojected_column_still_filters() {
+    // Filter on the key column but project only the value sub-column: the
+    // predicate must still apply across segments, and the output carries only the
+    // projected column.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+    ingest_segment(&any, &[(key(0), 0), (key(1), 1), (key(2), 2)]);
+    ingest_segment(&any, &[(key(3), 3), (key(4), 4)]);
+
+    let pred = ColumnRangePredicate {
+        column_id: COL_USER_KEY,
+        lower: Some(key(1)),
+        upper: Some(key(3)),
+    };
+    let tree = standard(&any);
+    let mut rows = 0u32;
+    for batch in tree
+        .columnar_scan(&[3], Some(&pred), SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        assert!(
+            batch.columns.iter().all(|c| c.column_id == 3),
+            "output carries only the projected value column"
+        );
+        rows += batch.row_count;
+    }
+    assert_eq!(
+        rows, 3,
+        "predicate on the unprojected key column still filters"
+    );
+}
+
+// EXPLAIN ANALYZE at a consumer reads per-scan block-decode counts by diffing
+// the standard `metrics` block-load counters around the scan: the columnar scan
+// participates in that accounting, and zone-map-skipped blocks are never loaded,
+// so the delta is exactly the blocks decoded (pushdown effectiveness). No
+// columnar-specific stats API is needed.
+#[cfg(feature = "metrics")]
+#[test]
+fn tree_columnar_scan_block_decode_count_drops_with_predicate() {
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    let n = 4000u32; // spans several data blocks
+    for i in 0..n {
+        tree.insert(key(i), vec![b'v'; 80], 0);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+
+    let metrics = tree.metrics();
+
+    // Full scan: count the data blocks decoded.
+    let before = metrics.data_block_load_count();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY], None, SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        batch.expect("batch");
+    }
+    let full = metrics.data_block_load_count() - before;
+
+    // Narrow predicate: the zone-map prunes the blocks outside [k001000, k001099],
+    // so strictly fewer data blocks are decoded.
+    let pred = ColumnRangePredicate {
+        column_id: COL_USER_KEY,
+        lower: Some(key(1000)),
+        upper: Some(key(1099)),
+    };
+    let before = metrics.data_block_load_count();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY], Some(&pred), SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        batch.expect("batch");
+    }
+    let pruned = metrics.data_block_load_count() - before;
+
+    assert!(full > 1, "test wants a multi-block segment, got {full}");
+    assert!(
+        pruned < full,
+        "zone-map predicate must skip blocks (decoded {pruned} with predicate vs {full} without)"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_blob_tree_unsupported() {
+    // Columnar scan is a standard-tree feature; a blob tree must reject it.
+    let folder = get_tmp_folder();
+    let any = Config::new(
+        folder.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(Default::default()))
+    .open()
+    .expect("open blob tree");
+    assert!(
+        matches!(
+            any.columnar_scan(&[3], None, SeqNo::MAX, ..),
+            Err(lsm_tree::Error::FeatureUnsupported(_))
+        ),
+        "columnar scan over a blob tree must be rejected"
     );
 }

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -871,3 +871,56 @@ fn tree_columnar_scan_overlap_merge_filters_rows_to_the_range() {
         "the merge path drops rows outside the requested range",
     );
 }
+
+#[test]
+fn tree_columnar_scan_merge_preserves_a_nullable_sub_column() {
+    // The overlap-merge gather (`take_rows`) must carry a nullable value
+    // sub-column's validity bitmap through. Build two overlapping segments where
+    // one row's value is null, force the merge path, and assert the null survives
+    // in the recovered column.
+    let folder = get_tmp_folder();
+    let any = open_columnar_any(folder.path());
+
+    // Segment A: k0 (valid), k2 (NULL) — a nullable fixed-4 sub-column (id 3).
+    let mut batch_a = entries_to_column_batch(&[
+        InternalValue::from_components(key(0), b"x".to_vec(), 0, ValueType::Value),
+        InternalValue::from_components(key(2), b"x".to_vec(), 0, ValueType::Value),
+    ])
+    .expect("transpose");
+    batch_a.columns.pop();
+    batch_a.columns.push(Column {
+        column_id: 3,
+        type_tag: TypeTag::Fixed(4),
+        // LSB-first: row 0 valid (bit set), row 1 (k2) null (bit clear) → 0b01.
+        validity: Some(vec![0b0000_0001]),
+        data: vec![10, 0, 0, 0, 0, 0, 0, 0],
+    });
+    {
+        let mut ingest = any.ingestion().expect("ingestion");
+        ingest.write_columnar_batch(&batch_a).expect("write A");
+        ingest.finish().expect("finish A");
+    }
+    // Segment B: k1 — overlaps A's [k0, k2] range, forcing the merge path.
+    ingest_segment(&any, &[(key(1), 11)]);
+
+    let tree = standard(&any);
+    let mut col3: Option<Column> = None;
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY, 3], None, SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        // Output is one merged batch in key order: k0, k1, k2.
+        if let Some(c) = batch.columns.into_iter().find(|c| c.column_id == 3) {
+            assert!(col3.is_none(), "merge yields a single batch here");
+            col3 = Some(c);
+        }
+    }
+    let col3 = col3.expect("value sub-column present");
+    let validity = col3.validity.expect("nullable column keeps its validity bitmap");
+    let is_valid = |row: usize| validity[row / 8] & (1 << (row % 8)) != 0;
+    // Key order: row0=k0 (valid), row1=k1 (valid), row2=k2 (NULL).
+    assert!(is_valid(0), "k0 is non-null");
+    assert!(is_valid(1), "k1 is non-null");
+    assert!(!is_valid(2), "k2's null survives the merge gather");
+}


### PR DESCRIPTION
## Summary

Lifts the per-SST `Table::columnar_scan` to the whole tree via `Tree::columnar_scan` (surfaced through `AnyTree::columnar_scan`). A consumer holding a tree can now run a **projected, predicate-pushed columnar scan across every columnar segment** intersecting a key range and visible at an MVCC snapshot, yielding `ColumnBatch`es in key order — without reimplementing segment selection, snapshot visibility, delete-masking, or cross-segment ordering.

```rust
let scan = tree.columnar_scan(&[col_a, col_b], Some(&predicate), seqno, lo..hi)?;
for batch in scan { /* projected ColumnBatch in key order */ }
```

## Design — overlap-aware merge (InfluxDB IOx model)

Visible columnar segments are grouped by key-range overlap:

- **Singleton + all-visible** → streams its per-SST scan **verbatim** (zero-copy column-skip, no key/seqno decode, no row gather).
- **Overlapping group** → row-merged: keep the newest version of each key by **effective seqno**, gathered in key order.

The expensive key/seqno decode + gather is paid **only where segments actually overlap** — the disjoint append-only (TIMESERIES) case stays zero-cost. As multi-segment columnar compaction reduces overlap, more of the scan takes the fast path, mirroring how IOx inserts its dedup operator only over overlapping files.

MVCC visibility via `Table::seqno_visibility`: segment-granular for uniform-seqno ingested segments, per-row masked when a snapshot straddles a flush-produced multi-seqno segment.

**EXPLAIN ANALYZE** needs no new API: the columnar scan feeds the standard `metrics` block-load counters, and zone-map-skipped blocks are never loaded, so a consumer reads per-scan decode counts by diffing `data_block_load_count` around the scan.

## Also in this PR

- **Dependency updates** (`build(deps)`): `structured-zstd` 0.0.45 → 0.0.48 (0.0.46/0.0.47 had a dict match-BT encoder panic on BT-strategy levels; 0.0.48 fixes it), `aes-gcm` / `chacha20poly1305` RC → stable `0.11.0`.
- Fix a latent no_std break: the columnar block iterator in `table/iter` used `Vec` without importing it, so `--no-default-features --features columnar` failed to build.

## Testing

- 14 tree-level integration tests: disjoint streaming, overlapping newest-wins, snapshot visibility, per-row seqno mask, projection column-skip, predicate across segments + on an unprojected column, delete-bitmap masking, mixed-mode rejection, empty range, internal-column drop, block-decode-count drops with a pruning predicate (via `metrics`), blob-tree rejection.
- Full suite `cargo nextest run --all-features`: **2506 passed, 0 failed**.
- `cargo clippy --all-features --all-targets`: clean. `cargo doc` (+ all-features): 0 warnings. Doc tests: pass. `no_std` `--features alloc` and `--features columnar`: both build clean.

Closes #566

https://claude.ai/code/session_01VuBftVDYEigwgvYEe1G6fK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature-gated, projected columnar scans with snapshot-aware visibility, key-range filtering, and overlap-aware newest-wins merging across visible segments.
  * Publicly exposed the `ColumnarScan` iterator (when the columnar feature is enabled).
* **Bug Fixes**
  * Improved row gathering/merge behavior, preserving ordering, nullability, delete-bitmap masking, and correct intrinsic filtering; rejects unsupported scan layouts (mixed-mode/blob trees).
* **Tests**
  * Expanded coverage for projected scans, predicates, MVCC visibility, deduplication, key-range handling, and zone-map pruning.
* **Chores**
  * Updated optional and encryption dependency version pins to stable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->