### PR TITLE
feat(salvage): recover encrypted and dictionary-compressed SSTs

### DIFF
--- a/src/repair.rs
+++ b/src/repair.rs
@@ -174,13 +174,20 @@ fn try_salvage_table(
     // preserves the corrupt bytes for the operator to inspect.
     let quarantined = quarantine_file(&**fs, table_base_folder, table_path, file_name)?;
 
-    // Salvage under the tree's configured comparator so the rewritten SST opens
-    // and orders consistently with the rest of the tree on reopen.
-    let report = crate::salvage::salvage_sst_with_comparator(
+    // Salvage under the tree's configured comparator + crypto/dictionary context
+    // so the rewritten SST opens, orders, and decrypts / decompresses consistently
+    // with the rest of the tree on reopen (the reopen below uses the same
+    // `config.encryption` / `config.zstd_dictionary`).
+    let report = crate::salvage::salvage_with_context(
         &quarantined,
         table_path.to_path_buf(),
         fs,
         &config.comparator,
+        &crate::salvage::SalvageOptions {
+            encryption: config.encryption.clone(),
+            #[cfg(zstd_any)]
+            zstd_dictionary: config.zstd_dictionary.clone(),
+        },
     )?;
     if report.salvaged_path.is_none() {
         return Ok(None);

--- a/src/salvage.rs
+++ b/src/salvage.rs
@@ -16,9 +16,33 @@
 //! the corruption is not propagated into the recovered copy.
 
 use crate::UserKey;
+use crate::encryption::EncryptionProvider;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use std::path::PathBuf;
+
+/// The recovery + write context salvage needs to recover an SST that is
+/// encrypted and/or zstd-dictionary compressed.
+///
+/// Block salvage opens the source and rewrites the recovered copy through the
+/// normal table path, so both ends need the same crypto / dictionary context as
+/// the live tree: without the [`EncryptionProvider`] an encrypted source cannot
+/// be decrypted to read its blocks (and the rewritten copy would be plaintext,
+/// inconsistent with an encrypted reopen); without the dictionary a
+/// dictionary-compressed source cannot be decompressed (and the copy could not
+/// be re-compressed to match). [`crate::repair`] fills this from the tree's
+/// `Config`; [`salvage_sst`] defaults it to empty (a plain, unencrypted source).
+#[derive(Clone, Default)]
+pub struct SalvageOptions {
+    /// Encryption provider matching the source's at-rest encryption, or `None`
+    /// for an unencrypted source.
+    pub encryption: Option<Arc<dyn EncryptionProvider>>,
+    /// zstd dictionary matching the source's dictionary compression, or `None`
+    /// when the source uses no dictionary.
+    #[cfg(zstd_any)]
+    pub zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+}
 
 /// Why a block could not be salvaged and had to be dropped.
 #[derive(Debug, Clone)]
@@ -167,22 +191,51 @@ pub fn salvage_sst(
     dest: std::path::PathBuf,
     fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
 ) -> crate::Result<SalvageReport> {
-    salvage_sst_with_comparator(source, dest, fs, &crate::comparator::default_comparator())
+    salvage_sst_with_options(source, dest, fs, &SalvageOptions::default())
 }
 
-/// Salvages `source` into `dest` under a caller-supplied `comparator`.
+/// Salvages `source` into `dest` with an explicit recovery + write context.
 ///
-/// [`crate::repair`] calls this with the tree's configured comparator so the
-/// rewritten SST opens and orders consistently with the rest of the tree; the
-/// public [`salvage_sst`] wraps it with the default lexicographic comparator.
-pub(crate) fn salvage_sst_with_comparator(
+/// Use this over [`salvage_sst`] to salvage an SST that is encrypted and/or
+/// zstd-dictionary compressed: supply the matching [`EncryptionProvider`] and
+/// dictionary in `options` so the source can be decrypted / decompressed to read
+/// its blocks and the recovered copy is written under the same context. Opens and
+/// rewrites under the default lexicographic comparator; [`crate::repair`] uses the
+/// tree's configured comparator instead via the crate-internal path.
+///
+/// # Errors
+///
+/// As [`salvage_sst`]; additionally fails to open the source when `options` does
+/// not carry the encryption / dictionary context the source was written with.
+pub fn salvage_sst_with_options(
+    source: &std::path::Path,
+    dest: std::path::PathBuf,
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    options: &SalvageOptions,
+) -> crate::Result<SalvageReport> {
+    salvage_with_context(
+        source,
+        dest,
+        fs,
+        &crate::comparator::default_comparator(),
+        options,
+    )
+}
+
+/// Salvages `source` into `dest` under a caller-supplied `comparator` and
+/// recovery context.
+///
+/// [`crate::repair`] calls this with the tree's configured comparator and the
+/// `Config`'s encryption provider + zstd dictionary, so the rewritten SST opens,
+/// orders, and decrypts / decompresses consistently with the rest of the tree;
+/// the public entry points wrap it with the default lexicographic comparator.
+pub(crate) fn salvage_with_context(
     source: &std::path::Path,
     dest: std::path::PathBuf,
     fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
     comparator: &crate::comparator::SharedComparator,
+    options: &SalvageOptions,
 ) -> crate::Result<SalvageReport> {
-    use alloc::sync::Arc;
-
     // Digest the source through the injected `Fs`, not `std::fs`: salvage runs
     // over MemFs / fault-injected / routed backends (repair passes its own `fs`),
     // where a direct `std::fs` read would miss the file or hash the wrong bytes.
@@ -203,9 +256,11 @@ pub(crate) fn salvage_sst_with_comparator(
         Arc::clone(fs),
         false,
         false,
-        None,
+        // Decrypt / decompress the source with the caller's context: without it an
+        // encrypted or dictionary-compressed source cannot be read at all.
+        options.encryption.clone(),
         #[cfg(zstd_any)]
-        None,
+        options.zstd_dictionary.clone(),
         comparator.clone(),
         #[cfg(feature = "metrics")]
         metrics,
@@ -217,17 +272,23 @@ pub(crate) fn salvage_sst_with_comparator(
     // Fail closed on range tombstones: the positional walk re-emits only point
     // entries, so salvaging an SST that carries range tombstones would drop them
     // and let lower-level keys they cover reappear after repair (a merge-semantics
-    // violation). Reject until the writer path can re-emit them, the same way
-    // encrypted / dictionary SSTs fall back to quarantine.
+    // violation). Reject until the writer path can re-emit them.
     if !table.range_tombstones().is_empty() {
         return Err(crate::Error::FeatureUnsupported(
             "salvage of an SST with range tombstones",
         ));
     }
 
+    // The recovered copy is written under the SAME context as the source: its
+    // compression + ECC layout, plus the caller's encryption provider and zstd
+    // dictionary, so an encrypted / dictionary source salvages into a copy that
+    // reopens under the live tree's `Config` instead of a plaintext mismatch.
     let writer = crate::table::Writer::new(dest.clone(), table.id(), 0, Arc::clone(fs))?
         .use_data_block_compression(table.metadata.data_block_compression)
-        .use_ecc(table.metadata.ecc_params);
+        .use_ecc(table.metadata.ecc_params)
+        .use_encryption(options.encryption.clone());
+    #[cfg(zstd_any)]
+    let writer = writer.use_zstd_dictionary(options.zstd_dictionary.clone());
 
     let walk = match salvage_blocks(&table, writer, comparator) {
         Ok(walk) => walk,

--- a/src/salvage/tests.rs
+++ b/src/salvage/tests.rs
@@ -1,4 +1,4 @@
-use super::{DropReason, salvage_sst};
+use super::{DropReason, SalvageOptions, salvage_sst, salvage_sst_with_options};
 use crate::comparator::default_comparator;
 use crate::fs::{Fs, StdFs};
 use crate::table::{Table, Writer};
@@ -610,6 +610,224 @@ fn salvage_sst_reads_and_writes_through_the_injected_fs() -> crate::Result<()> {
         reopen_item_count(dest, &fs)?,
         u64::from(n),
         "the salvaged SST reopens through the same in-memory backend",
+    );
+    Ok(())
+}
+
+// --- Forwarded recovery context: encrypted + dictionary-compressed sources ---
+
+/// Reads the second data block's on-disk offset from a context-aware reopen of
+/// `source`, then flips a byte just past that block's header so its checksum /
+/// AEAD tag fails on load while every other block stays intact.
+fn corrupt_second_data_block(
+    source: &std::path::Path,
+    fs: &Arc<dyn Fs>,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+    #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+) -> crate::Result<()> {
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, source)?);
+    let table = Table::recover(
+        source.to_path_buf(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(fs),
+        false,
+        false,
+        encryption,
+        #[cfg(zstd_any)]
+        zstd_dictionary,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    let offsets: alloc::vec::Vec<u64> = table
+        .data_block_handles()
+        .filter_map(Result::ok)
+        .map(|kh| *kh.as_ref().offset())
+        .collect();
+    let Some(&second) = offsets.get(1) else {
+        panic!("source SST must have at least two data blocks, got {offsets:?}");
+    };
+    let flip = usize::try_from(second).unwrap_or(0) + 16;
+    let mut bytes = std::fs::read(source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(source, &bytes)?;
+    Ok(())
+}
+
+/// An encrypted source: salvage cannot open it without the provider (the gap this
+/// closes), but with the provider in `SalvageOptions` it block-salvages like a
+/// plain SST and the recovered copy reopens under the same encryption.
+#[cfg(feature = "encryption")]
+#[test]
+fn salvage_recovers_an_encrypted_sst_with_the_provider() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let enc: Arc<dyn crate::encryption::EncryptionProvider> =
+        Arc::new(crate::encryption::Aes256GcmProvider::new(&[0x42; 32]));
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_encryption(Some(Arc::clone(&enc)));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source encrypted SST is non-empty"
+    );
+
+    corrupt_second_data_block(
+        &source,
+        &fs,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    // Without the provider, the encrypted source cannot even be opened.
+    assert!(
+        salvage_sst(&source, dest.clone(), &fs).is_err(),
+        "an encrypted SST must not salvage without the provider",
+    );
+
+    // With the provider, it block-salvages: the corrupt block is dropped, the
+    // rest recovered, and the copy is written encrypted.
+    let options = SalvageOptions {
+        encryption: Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        zstd_dictionary: None,
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block drops: {report:?}"
+    );
+    assert!(
+        report.entries_salvaged > 0 && report.entries_salvaged < u64::from(n),
+        "a partial key range is recovered, got {} of {n}",
+        report.entries_salvaged,
+    );
+
+    // The salvaged copy reopens UNDER ENCRYPTION (a plaintext copy would fail the
+    // encrypted reopen) and holds exactly the recovered entries.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &dest)?);
+    let reopened = Table::recover(
+        dest,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(&fs),
+        false,
+        false,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    assert_eq!(
+        reopened.metadata.item_count, report.entries_salvaged,
+        "the encrypted salvaged copy reopens with exactly the recovered entries",
+    );
+    Ok(())
+}
+
+/// A zstd-dictionary-compressed source: salvage cannot decompress it without the
+/// dictionary, but with the dictionary in `SalvageOptions` it block-salvages and
+/// the recovered copy reopens under the same dictionary.
+#[cfg(zstd_any)]
+#[test]
+fn salvage_recovers_a_dictionary_sst_with_the_dictionary() -> crate::Result<()> {
+    use crate::CompressionType;
+    use crate::compression::ZstdDictionary;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A small training corpus so the dictionary has content to match against.
+    let samples: alloc::vec::Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
+    let dict = Arc::new(ZstdDictionary::new(&samples));
+    let compression = CompressionType::ZstdDict {
+        level: 3,
+        dict_id: dict.id(),
+    };
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_data_block_compression(compression)
+        .use_zstd_dictionary(Some(Arc::clone(&dict)));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source dictionary SST is non-empty"
+    );
+
+    corrupt_second_data_block(&source, &fs, None, Some(Arc::clone(&dict)))?;
+
+    // Without the dictionary, the source's blocks cannot be decompressed.
+    assert!(
+        salvage_sst(&source, dest.clone(), &fs).is_err(),
+        "a dictionary SST must not salvage without the dictionary",
+    );
+
+    let options = SalvageOptions {
+        encryption: None,
+        zstd_dictionary: Some(Arc::clone(&dict)),
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block drops: {report:?}"
+    );
+    assert!(
+        report.entries_salvaged > 0 && report.entries_salvaged < u64::from(n),
+        "a partial key range is recovered, got {} of {n}",
+        report.entries_salvaged,
+    );
+
+    // The salvaged copy reopens UNDER THE DICTIONARY with the recovered entries.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &dest)?);
+    let reopened = Table::recover(
+        dest,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(&fs),
+        false,
+        false,
+        None,
+        Some(Arc::clone(&dict)),
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    assert_eq!(
+        reopened.metadata.item_count, report.entries_salvaged,
+        "the dictionary salvaged copy reopens with exactly the recovered entries",
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

First slice of #568 (salvage/autoheal faithful recovery): make block salvage work for **encrypted** and **zstd-dictionary-compressed** SSTs.

Block salvage opened the source and rewrote the recovered copy with **no** encryption / dictionary context — `recover_inner(.., None, None, ..)` and a plain `Writer`. So an encrypted or dictionary SST could not be salvaged at all: the source couldn't be decrypted / decompressed to read its blocks, and the rewritten copy wouldn't match an encrypted / dictionary reopen. During repair this was **doubly broken** — `try_salvage_table` reopened the salvaged copy with `config.encryption` / `config.zstd_dictionary` while salvage had written it plaintext / dictionary-less.

## Change

- Add `SalvageOptions { encryption, zstd_dictionary }` and a public `salvage_sst_with_options`; the internal `salvage_with_context` forwards the provider + dictionary into **both** the source open (`recover_inner`) and the destination `Writer` (`use_encryption` / `use_zstd_dictionary`).
- `repair::try_salvage_table` passes the tree's `config.encryption` / `config.zstd_dictionary` (already held for the reopen), so a damaged encrypted / dictionary table is now **block-salvaged** instead of quarantined whole-file.
- `salvage_sst` keeps its simple signature (empty context) — fully back-compatible.

## Testing

- New unit tests: an encrypted SST and a dictionary SST each (a) fail to salvage without the context, and (b) block-salvage a corrupt block **with** it, the recovered copy reopening under the same encryption / dictionary.
- `cargo nextest run --all-features`: **2494 passed, 0 failed**. clippy `--all-features --all-targets`: clean. `cargo doc` (+all-features): 0 warnings. doctests: pass. no-std `--features alloc`: clean.

## Scope

Part of #568. Independent of the other slices (columnar-native re-emit, writer-config mirroring, fast copy-through/autoheal, vlog blob salvage) — those land separately.

https://claude.ai/code/session_01VuBftVDYEigwgvYEe1G6fK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Salvage now preserves the original recovery context for affected SST files, including encryption and supported compression dictionaries.
  * Added an option-based salvage flow that lets recovery succeed for protected or dictionary-compressed files when the matching context is available.

* **Bug Fixes**
  * Fixed recovery of corrupted SST files that previously could not be salvaged without the original encryption or dictionary settings.
  * Improved handling so recovered files reopen correctly and retain the expected item count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->