### PR TITLE
feat(salvage): total recovery for SSTs and blob files with in-place ECC autoheal

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -49,6 +49,27 @@ slow-timeout = { period = "30s", terminate-after = 4 }
 filter = "test(partial_decode_) | test(lazy_block) | test(ecc_heal_scheduled) | test(block_layout_section_roundtrips_for_large_zstd) | test(compatibility_matrix_round_trips)"
 slow-timeout = { period = "30s", terminate-after = 4 }
 
+# Wall-clock concurrency stress: 4 writers + 2 readers contend on one
+# encrypted tree for a fixed 2-second window, then exact-equality
+# assertions run over the committed tally. The test's correctness envelope
+# assumes its threads actually get CPU / disk / fds during that window;
+# co-scheduled with the rest of the suite it can starve and flake on
+# resource pressure that has nothing to do with encryption. Claim every
+# scheduler slot so it runs ALONE — the assertions stay at full strength
+# (a real engine race still fires solo), only cross-test contention is
+# removed. Mirrored in the ci profile below.
+[[profile.default.overrides]]
+filter = "test(concurrent_encrypted_no_corruption)"
+threads-required = "num-cpus"
+
+# The single-byte-bitrot heal fuzzer runs for a fixed ~45s wall-clock budget
+# (`#[ignore]`d, so it only runs under `--run-ignored`), well past the 10s
+# ceiling by design. Give it a generous window so a slower runner's corpus
+# build does not push it into a spurious termination.
+[[profile.default.overrides]]
+filter = "test(fuzz_heal_bitrot)"
+slow-timeout = { period = "90s", terminate-after = 2 }
+
 # CI profile: retries for flaky tests, JUnit XML output, longer timeouts.
 [profile.ci]
 retries = 2
@@ -65,3 +86,16 @@ store-failure-output = true
 [[profile.ci.overrides]]
 filter = "test(prop_)"
 slow-timeout = { period = "120s", terminate-after = 4 }
+
+# See the default-profile override of the same filter: the wall-clock
+# stress test claims the whole scheduler so cross-test contention cannot
+# starve its 2-second window.
+[[profile.ci.overrides]]
+filter = "test(concurrent_encrypted_no_corruption)"
+threads-required = "num-cpus"
+
+# The bitrot heal fuzzer's fixed ~45s budget (see the default-profile note); a
+# generous timeout keeps it from a spurious termination on a slow CI runner.
+[[profile.ci.overrides]]
+filter = "test(fuzz_heal_bitrot)"
+slow-timeout = { period = "90s", terminate-after = 2 }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,7 @@ jobs:
       # token leakage where actions/upload-artifact captures the
       # whole working tree, including the .git/config that the
       # default checkout populated with GITHUB_TOKEN).
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -104,7 +104,7 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' &&
            github.event.pull_request.head.repo.full_name == github.repository)
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,7 @@ jobs:
       # token leakage where actions/upload-artifact captures the
       # whole working tree, including the .git/config that the
       # default checkout populated with GITHUB_TOKEN).
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete stale release-plz branches
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        uses: actions/github-script@v9
         with:
           script: |
             const branches = await github.paginate(

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -210,7 +210,7 @@ jobs:
         if: needs.changes.outputs.code == 'false'
         run: |
           echo "::notice::No code paths changed — skipping format + clippy. Required-check name still emitted as success."
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         if: needs.changes.outputs.code != 'false'
         with:
           persist-credentials: false
@@ -283,7 +283,7 @@ jobs:
         if: needs.changes.outputs.code != 'false' && needs.lint.result != 'success'
         run: |
           echo "::notice::Lint failed (result=${{ needs.lint.result }}) — skipping test work to avoid duplicate noise on an already-failed PR. Required-check name still emitted; fix the lint failure to unblock real test runs."
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         with:
           persist-credentials: false
@@ -327,6 +327,54 @@ jobs:
         working-directory: tools/sst-dump
         run: cargo nextest run
 
+  fuzz-heal:
+    # Reproducible single-byte-bitrot fuzzer over the SST read / heal path:
+    # flips one bit in a corpus of SSTs (varied block size, per-KV checksum,
+    # columnar, compression, encryption, Page-ECC) for a fixed ~45s budget and
+    # asserts the read path never panics and never returns a wrong value (a
+    # flipped block heals via ECC or fails its checksum, never silent corruption).
+    # `#[ignore]`d, so it is excluded from the normal `test` job and run here with
+    # `--run-ignored=only`. Ubuntu-only (the invariant is platform-independent);
+    # not a required check.
+    needs: [changes, lint]
+    if: ${{ needs.changes.outputs.code != 'false' && needs.lint.result == 'success' }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          prefix-key: ubuntu-cargo
+      - uses: taiki-e/install-action@1ef5c5f58e85d25baaaa1704478fdd6c2921f2b5  # nextest
+      - name: Run bitrot heal fuzzer
+        # Pin the reproducer directory explicitly so the test's dump location does
+        # not depend on the process working directory (robust if the crate ever
+        # moves into a workspace subdirectory). The dump step reads the same path.
+        env:
+          FUZZ_HEAL_REPRO_DIR: ${{ github.workspace }}
+        # `--retries 0` overrides the ci profile's retries: the fuzzer dumps the
+        # EXACT failing SST, and a retry (on a non-deterministic corpus) would
+        # either overwrite that dump or mask a real failure that does not replay.
+        run: cargo nextest run --profile ci --all-features --run-ignored=only --retries 0 -E 'test(fuzz_heal_bitrot)'
+      - name: Dump reproducer on failure
+        if: failure()
+        # The corpus is not byte-deterministic (encrypted / timestamped SSTs), so
+        # the seed alone cannot replay a failure in those. The test writes the
+        # EXACT failing SST to `fuzz_heal_repro.sst`; surface it (base64) in the
+        # log so the case reproduces directly, no artifact upload needed.
+        env:
+          FUZZ_HEAL_REPRO_DIR: ${{ github.workspace }}
+        run: |
+          echo "=== fuzz_heal_repro.txt ==="
+          cat "$FUZZ_HEAL_REPRO_DIR/fuzz_heal_repro.txt" 2>/dev/null || echo "(no repro txt)"
+          echo "=== fuzz_heal_repro.sst (base64) ==="
+          base64 "$FUZZ_HEAL_REPRO_DIR/fuzz_heal_repro.sst" 2>/dev/null || echo "(no repro sst)"
+
   no-std-check:
     # Gates the `#![no_std]` + alloc engine path. The engine modules compile
     # unconditionally; only the std default trait implementations (the system
@@ -346,7 +394,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -429,7 +477,7 @@ jobs:
         target: ${{ fromJSON(needs['cross-matrix'].outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -447,7 +495,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly

--- a/.github/workflows/coordinode-ci.yml
+++ b/.github/workflows/coordinode-ci.yml
@@ -210,7 +210,7 @@ jobs:
         if: needs.changes.outputs.code == 'false'
         run: |
           echo "::notice::No code paths changed — skipping format + clippy. Required-check name still emitted as success."
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         if: needs.changes.outputs.code != 'false'
         with:
           persist-credentials: false
@@ -283,7 +283,7 @@ jobs:
         if: needs.changes.outputs.code != 'false' && needs.lint.result != 'success'
         run: |
           echo "::notice::Lint failed (result=${{ needs.lint.result }}) — skipping test work to avoid duplicate noise on an already-failed PR. Required-check name still emitted; fix the lint failure to unblock real test runs."
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         if: needs.changes.outputs.code != 'false' && needs.lint.result == 'success'
         with:
           persist-credentials: false
@@ -341,7 +341,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -394,7 +394,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -477,7 +477,7 @@ jobs:
         target: ${{ fromJSON(needs['cross-matrix'].outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -495,7 +495,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly

--- a/.github/workflows/coordinode-release.yml
+++ b/.github/workflows/coordinode-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate token (SW Release Bot)
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
@@ -23,7 +23,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # persist-credentials: false — release-plz reads the token via

--- a/.github/workflows/coordinode-release.yml
+++ b/.github/workflows/coordinode-release.yml
@@ -23,7 +23,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           # persist-credentials: false — release-plz reads the token via
@@ -44,7 +44,7 @@ jobs:
 
       # Step 1: Create or update release PR (version bump + changelog)
       - name: Create release PR
-        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7  # v0.5.130
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131
         with:
           command: release-pr
           config: .release-plz.toml
@@ -54,7 +54,7 @@ jobs:
       # Step 2: If version in Cargo.toml > latest tag, create GitHub Release + tag
       # This triggers release.yml → cargo publish via OIDC
       - name: Create GitHub Release
-        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7  # v0.5.130
+        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9  # v0.5.131
         with:
           command: release
           config: .release-plz.toml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@v7
         with:
           # gh CLI authenticates via the GH_TOKEN env var on the merge
           # step; no git config credentials are needed here.
@@ -23,14 +23,14 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Generate App Token
         id: app-token
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # gh CLI authenticates via the GH_TOKEN env var on the merge
           # step; no git config credentials are needed here.

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label issue by title prefix
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        uses: actions/github-script@v9
         with:
           script: |
             const title = context.payload.issue.title.toLowerCase();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # cargo publish authenticates via OIDC against crates.io
           # (rust-lang/crates-io-auth-action below); no git config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@v7
         with:
           # cargo publish authenticates via OIDC against crates.io
           # (rust-lang/crates-io-auth-action below); no git config

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ mutants*
 profile.json
 fuzz*/**/out*
 
+# The bitrot heal fuzzer dumps the exact failing SST here on a failure so the
+# case reproduces; a runtime artifact, never committed.
+fuzz_heal_repro.*
+
 old
 .claude/
 .forge/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,13 +161,25 @@ spin = { version = "0.12", default-features = false, features = ["mutex", "spin_
 # userspace fast-path, concurrent readers); `spin::RwLock` is the no_std lock.
 hashbrown = { version = "0.17", default-features = false, features = ["default-hasher"] }
 parking_lot = { version = "0.12", optional = true }
-lz4_flex = { version = "0.13.0", optional = true, default-features = false }
-# Default features carry the runtime-dispatched SIMD decode kernels (avx2/bmi2/
-# neon/sve/...); `default-features = false` would silently drop them and leave
-# the sequence decoder on the scalar path, measurably slower on cold point reads.
-# 0.0.48 is the published crates.io release; it fixes a dictionary match
-# binary-tree encoder panic present in 0.0.46/0.0.47 on high (BT-strategy) levels.
-structured-zstd = { version = "0.0.48", optional = true, features = ["lsm"] }
+# LZ4 block codec for hot-path blocks. `default-features = false` drops the
+# `std` and `frame` defaults (we use only the block API and stay no_std-capable
+# via `alloc`), but the malformed-input safety flags are NOT dropped: verify and
+# salvage decompress SST bytes that may be DAMAGED, so keep `checked-decode`
+# (decompression bounds checks) plus the `safe-decode` / `safe-encode` pure-safe
+# paths — disabling them would risk UB on adversarial/corrupt input.
+lz4_flex = { version = "0.14.0", optional = true, default-features = false, features = [
+    "alloc",
+    "checked-decode",
+    "safe-decode",
+    "safe-encode",
+] }
+# structured-zstd default features carry the runtime-dispatched SIMD decode
+# kernels (avx2/bmi2/neon/sve/...); `default-features = false` would silently
+# drop them and leave the sequence decoder on the scalar path, measurably slower
+# on cold point reads. 0.0.49 is the published crates.io release; it carries the
+# dictionary match binary-tree encoder panic fix (introduced in 0.0.48, absent
+# in 0.0.46/0.0.47 on high BT-strategy levels) plus encoder decode/parse perf.
+structured-zstd = { version = "0.0.49", optional = true, features = ["lsm"] }
 # `once_cell::race::OnceBox` — the no-std + alloc one-shot primitive.
 # We pick it over `std::sync::OnceLock` (which has both `set` and the
 # stabilised `get_or_try_init` on our 1.92 MSRV) because OnceLock is

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LSM-tree storage engine in Rust. Embedded library; provides keyed point reads, p
 
 ## Status
 
-On-disk format version **V5**. V5 introduces a wire-format break for filter blocks (BuRR replaces Bloom); V3 and V4 databases are not readable by this version and vice versa. Versioning is single-monotonic: every breaking format change bumps to the next version with explicit migration notes.
+On-disk format version **V5** — the ONLY supported format. The engine carries no legacy decode paths, no backward-compat variations, and no in-place upgrade: a pre-V5 database fails to open with `InvalidVersion`. Versioning is single-monotonic: every breaking format change bumps to the next version with explicit migration notes. Conversion of pre-V5 databases is planned as standalone migration tooling, kept strictly outside the live engine.
 
 ## Quick start
 

--- a/docs/data-integrity.md
+++ b/docs/data-integrity.md
@@ -255,8 +255,31 @@ inspection, or rollback to a known-good point.
   fully-valid file, quarantine the corrupt ones, and report the key range each
   dropped, so one bad block costs only its own keys instead of the whole file. A
   columnar segment with a damaged sidecar degrades conservatively: a torn
-  sub-column drops just its block, and a corrupt delete-bitmap reads as "all rows
-  live, pending recompaction" rather than failing the open.
+  sub-column drops just its block. A delete-bearing segment whose positional
+  delete bitmap cannot be applied (unreadable bitmap, or a bitmap whose
+  positioning zone map is unreadable) fails the salvage closed by default —
+  recovering "all rows live" would resurrect deleted rows — unless explicitly
+  opted in (`SalvageOptions::allow_delete_resurrection`, `sst-dump salvage
+  --allow-delete-resurrection`).
+- **`salvage::salvage_blob_file(src, dest, &fs, id, &comparator) -> crate::Result<BlobSalvageReport>`**:
+  record-granular salvage of one blob (vlog) file. The `comparator` must be the
+  SAME `SharedComparator` the source tree was written with (pass the tree's
+  configured comparator, or `comparator::default_comparator()` for the default
+  lexicographic ordering): the salvage walk orders and validates recovered
+  records under it, so a mismatched comparator would mis-order the output. When a frame fails checksum,
+  header-CRC, or structural validation, the record stream re-syncs to the next
+  frame magic WHEN one is found in-bounds; if none is (for example a CRC-vouched
+  frame end overruns the data section), the scan terminates. Either way the
+  resync magic (and every frame chained after it) has an unproven boundary (it
+  may be nested in the damaged frame's user bytes), so the walk **drops the
+  entire tail past the first resync / termination** (fail closed): the
+  conservative loss is as much as everything after the first damaged record, not
+  just that one record, because a fabricated chain of checksum-valid frames is
+  indistinguishable from genuine ones and re-emitting it would forge records.
+  Only records BEFORE the first resync are recovered. The salvaged file is written COMPACTED, so it is **not a drop-in
+  replacement** while SST entries hold `ValueHandle::offset` values into the
+  source: re-target them through `BlobSalvageReport::offset_remap` first (a
+  source offset absent from the map is a lost record).
 - **`Config::repair_with_salvage(true)`** (also `tools/sst-dump repair
   --salvage`): the manifest rebuild above, but an SST that fails verification is
   block-salvaged in place instead of being left out, and

--- a/docs/manifest-recovery.md
+++ b/docs/manifest-recovery.md
@@ -1,0 +1,235 @@
+# Manifest recovery
+
+When a database is opened without a usable manifest (it was lost, truncated, or
+never committed) the engine rebuilds one by scanning the on-disk SST files under
+`tables/`. Recovery is **total**: it always produces a valid, openable tree. It
+never stops at a state that an operator must repair by hand, and re-running it is
+deterministic, so the same bytes yield the same tree every time.
+
+Some on-disk states are genuinely ambiguous. A tight-space-punched SST whose
+restriction bound was lost can no longer prove exactly where its live data
+begins; a delete bitmap whose content hash does not match could mask the wrong
+rows. At every such point recovery neither guesses silently nor gives up. It
+makes a deterministic choice governed by a single policy: whether to keep data
+that would otherwise be **resurrected**, i.e. made visible again after the
+tombstone or restriction that hid it was lost, or to drop it. That policy is the
+`allow_resurrection` flag; it defaults to *drop* (never resurrect), and it is the
+only knob a recovery ever exposes. It is set through
+`Config::repair_with_resurrection(salvage, allow_resurrection)` (the plain
+`repair` and `repair_with_salvage` entry points default it to *drop*), and it
+forwards to `SalvageOptions::allow_delete_resurrection` for the delete-mask
+decision, so one flag governs both the restriction prefix and the delete mask.
+
+## Invariants
+
+These hold at every branch of the algorithm below.
+
+- **Totality.** Recovery always yields a valid, openable tree. There is no
+  dead-end and no "recovered but unusable, fix it manually" outcome.
+- **One policy knob.** The sole tunable is `allow_resurrection`: keep
+  possibly-superseded or possibly-deleted data, or drop it. Default is drop.
+- **Intact live data is never discarded to avoid ambiguous data.** A restricted
+  SST is a dead prefix followed by a live suffix; the live suffix is always
+  recovered, and only the ambiguous prefix is subject to the flag. The table is
+  *restricted*, not set aside whole.
+- **Determinism.** The same bytes and the same flag always produce the same
+  result. A re-run makes no new keep-or-drop decisions.
+- **Exclusion only for the genuinely unrecoverable.** A file is set aside only
+  when it carries no recoverable live data whose loss the flag could have
+  prevented: a name that is not a table id, a redundant duplicate of a table
+  already recovered, or a file so damaged that not one block decodes. Excluding
+  it still leaves a valid tree.
+- **Transient versus persistent I/O.** A transient fault (`Interrupted`,
+  `WouldBlock`) propagates so the caller can retry; it is never laundered into a
+  keep-or-drop verdict. Persistent failures classify deterministically.
+
+## Algorithm
+
+```mermaid
+flowchart TD
+    START([Rebuild manifest from tables/]) --> LOOP{{For each file}}
+    LOOP -->|name is not a table id| QNAME[Set aside: foreign file]
+    LOOP -->|table id| DUP{Id already recovered?}
+    DUP -->|yes| KEEPBEST[Keep the better copy;<br/>drop the redundant one]
+    DUP -->|no| OPEN[Open + recover]
+
+    OPEN -->|transient I/O| PROP1[Propagate for retry]
+    OPEN -->|no block decodes| DROP1[Exclude: unrecoverable]
+    OPEN -->|opened| R0
+
+    R0{Restriction bound} -->|transient sidecar read| PROP2[Propagate for retry]
+    R0 -->|sidecar valid| REXACT[Bound = exact sidecar bound;<br/>no prefix probe]
+    R0 -->|no trustworthy sidecar| RNB{Prefix punched?}
+
+    RNB -->|no| RHEALTHY[Healthy table: unrestricted]
+    RNB -->|yes| RDER{allow_resurrection?}
+    RDER -->|no| RPAT{Zeroed blocks form<br/>a clean prefix?}
+    RPAT -->|yes| RCONS[Bound = first readable block's end;<br/>drop the straddling block]
+    RPAT -->|no| RIRR[Set aside, marked resurrectable:<br/>punch failures made the bound unknowable]
+    RDER -->|yes| RGREEDY[Bound = first readable block<br/>past the last hole;<br/>keep the readable region]
+
+    REXACT --> REOPEN[Reopen restricted;<br/>live suffix always kept]
+    RCONS --> REOPEN
+    RGREEDY --> REOPEN
+    RHEALTHY --> V0
+    REOPEN --> V0
+
+    V0{Verify data blocks} -->|all clean| MASK0
+    V0 -->|transient| PROP3[Propagate for retry]
+    V0 -->|some corrupt| VSALV
+    OPEN -->|recovery fails,<br/>blocks salvageable| VSALV
+    VSALV[Salvage: recover readable blocks;<br/>drop the corrupt ones] --> VRES[Re-restrict the output to the bound;<br/>from the restricted view or the sidecar;<br/>fail-closed unless resurrection is on]
+    VRES --> MASK0
+
+    MASK0{Delete bitmap} -->|absent or authenticated| RECORD[Record into the manifest]
+    MASK0 -->|content unauthenticated| MTR{transient?}
+    MTR -->|yes| PROP4[Propagate for retry]
+    MTR -->|no| MFLAG{allow_resurrection?}
+    MFLAG -->|yes| MRES[Drop the mask: all rows live]
+    MFLAG -->|no| MDROP[Exclude: visibility unrecoverable]
+    MRES --> RECORD
+    RECORD --> LOOP
+```
+
+## Restriction resolution
+
+A tight-space compaction reclaims a consumed key-range prefix of an SST in place
+with a hole punch, leaving the block-aligned prefix reading as zeros; the
+surviving view is *restricted* to keys at or above a bound. The exact bound is a
+key, recorded in a small `.restrict-bound` sidecar beside the SST. Recovery's job
+is to reconstruct that restricted view even when the sidecar is not trustworthy.
+
+A valid sidecar always denotes a *committed* restriction (see *A sidecar proves a
+committed restriction* below). Two cases arise.
+
+**The sidecar is valid.** Its bound is honored directly, without reading the
+prefix below it. Whether the punch has run makes no difference: if the prefix is
+already punched, the reopened view digests only the live suffix; if it is not
+(the crash window between the durable commit and the punch, or a punch deferred
+by a live reader), the installed output already covers the dropped prefix, so
+honoring resurrects nothing and the punch's absence costs only unreclaimed
+space, not correctness. Probing the dead prefix would add nothing, since both
+probe outcomes honor the same bound; worse, a persistently unreadable sector in
+an already-dead block would spuriously discard the exact bound.
+
+**There is no trustworthy sidecar but the SST is punched.** The bound is not
+known exactly; whether the punch geometry can stand in for it depends on the
+punch *pattern*. When the zeroed blocks form a *clean prefix* (every zeroed
+block precedes every readable one, the pattern of a fully successful reclaim),
+the live data begins at the first readable block. Because the bound is a key and
+the punch is block-aligned, that block may *straddle* the bound, holding both
+superseded keys below it and live keys at or above it. With resurrection
+disabled, recovery restricts to that block's end key, dropping the straddling
+block: this can lose up to one block of live suffix, but it never resurrects a
+superseded key, which is exactly the trade the flag governs.
+
+An *irregular* pattern — a readable block below a zeroed one — is positive
+evidence the reclaim did not finish: the top-down pass punched its
+higher-offset blocks and then hit a failure (or a crash) before reaching the
+lower ones. Any readable block may then equally be an intact-but-consumed
+block the pass never reached, so no geometry bound can separate consumed data
+from live: anchoring anywhere either resurrects superseded rows or discards
+live ones. With resurrection disabled such a table
+is *set aside* (its bound is genuinely unrecoverable); enabling resurrection
+keeps the whole readable region past the last hole, accepting the re-exposure
+by contract. The reclaim itself punches top-down and stops at the first
+failure, so any failure (or crash mid-reclaim) leaves intact blocks strictly
+below the zeroed ones — always the detectable irregular pattern, never
+intact-but-consumed blocks masquerading as a live suffix above a clean prefix.
+The only invisible case left is a reclaim whose very first punch failed: it
+leaves no hole at all, indistinguishable from an unpunched table by
+construction (no scheme can detect zero evidence), and the committed slice
+output shadows that unrestricted survivor until a later compaction rewrites
+it.
+
+**Flag-dependent set-asides stay reclaimable — the knob is two-way.** Every
+set-aside whose *only* cause is the disabled resurrection flag (an irregular
+punch, or a punched sidecar-less source whose whole-file recovery also failed)
+is written with a `.resurrectable` marker beside it in the quarantine
+directory. A later repair run *with* resurrection first returns every marked
+file to the tables folder and then recovers it through the normal scan, so
+switching the flag never requires a manual file move in either direction.
+Unmarked quarantine content — duplicates, corrupt files, bulk-ingest rejects,
+salvage byproducts — is never reclaimed: those exclusions do not depend on the
+flag.
+
+Whenever a bound is known or derivable, the table is recovered restricted; its
+live suffix is never thrown away to avoid the ambiguous prefix. This holds even
+when the live suffix is *itself* corrupt (a rare double failure): recovery
+salvages the suffix's readable blocks, drops the corrupt ones, then reopens the
+result restricted to the bound and re-records its sidecar, so a later
+manifest-loss repair honors it. The readable part of the suffix survives; only
+the corrupt blocks are lost, and nothing below the bound is resurrected. Only
+the irregular-punch state above — where no live suffix can even be delimited —
+sets a table aside, and the resurrection flag still recovers its readable
+region.
+
+**Salvage always re-restricts, on every path that reaches it.** Salvage rewrites
+its source as a fresh, *unpunched* table that re-emits the straddling block's
+sub-bound rows, so its output must be re-restricted to the bound or those rows
+resurrect. This is a single step every salvage funnels through, whether salvage
+was reached because block verification failed (the restriction is read from the
+already-restricted view) or because whole-file recovery failed before producing a
+table at all (the restriction is read straight from the `.restrict-bound`
+sidecar). With resurrection disabled both re-impose the bound; with it enabled
+both keep the whole readable region and clear the sidecar, since the unpunched
+replacement would otherwise be wrongly restricted on a later repair.
+
+**A sidecar proves a committed restriction.** Recovery honors a valid sidecar
+even when the punch has not (yet) zeroed the prefix, so a sidecar that outlived an
+*uncommitted* restriction would silently drop live keys. Tight-space compaction
+rules that state out by ordering: the sidecar is written *strictly after* the
+slice's version install commits, so its mere existence proves the restriction is
+durable. An aborted slice crashes or returns before the install and so never
+reaches the sidecar write — there is no uncommitted sidecar to leave behind, and
+no rollback that must retract one. Only two on-disk states remain, both safe: a
+sidecar present means the restriction is committed, so honoring its bound drops
+only prefix the installed output already covers; and a slice that committed but
+crashed before writing its sidecar leaves an unpunched input with no sidecar,
+which recovers unrestricted while the committed output shadows the redundant
+prefix by sequence number. That shadowing is total because a tight-space slice
+output is a **superset** of its consumed inputs — the slice merge runs without
+bottommost GC (no tombstone drop, no seqno zeroing), so the output retains every
+record, including a tombstone whose deleted key also lived in this survivor's
+prefix but whose tombstone-bearing sibling was fully consumed. Ordinary last-level
+GC would have dropped that tombstone and re-exposed the key; retaining it keeps
+the unrestricted survivor's prefix fully shadowed, so nothing resurrects. Space is
+reclaimed by the hole punch, and a later normal compaction does the deferred GC.
+
+## Delete-mask resolution
+
+A columnar SST records positional deletions in a delete bitmap, and the meta
+block binds the bitmap's content hash. During recovery there is no whole-file
+digest to cross-check, so the bitmap must authenticate against that recorded
+hash before it is applied; an equal-cardinality but forged substitution would
+otherwise mask the wrong rows.
+
+An unauthenticated bitmap (forged, corrupt, or degraded) cannot be applied
+faithfully: applying it masks the wrong rows, and ignoring it resurrects the
+deleted ones. With resurrection disabled, the table's correct visibility is
+unrecoverable, so it is excluded, and the flag recovers it by accepting
+resurrection. A transient fault while checking the mask propagates for retry
+rather than being read as an unauthenticated bitmap.
+
+The same reasoning covers a corrupt catalogue that could *conceal* a deletion
+section rather than corrupt a present one: its visibility is equally
+unrecoverable, so by default it is excluded and the flag recovers it by accepting
+resurrection. The flag governs policy, not mechanism: enabling resurrection
+opens the door, but recovery can only walk through it where salvage can actually
+re-emit the table. Salvage cannot re-emit a range-tombstone table, so such a
+table is excluded whatever the flag; the delete-bitmap path, which salvage can
+re-emit, is where the flag has observable effect. An exclusion forced by
+salvage's mechanical limits is still a valid tree that opens with no manual step,
+not a dead-end.
+
+## What recovery must never do
+
+- **Throw away a whole table to avoid an ambiguous fragment.** A restricted
+  SST's live suffix is always recovered; only the ambiguous prefix is dropped.
+- **End at "recovered but broken, repair by hand".** There is no manual-repair
+  step; the flag is the only decision, and both of its settings yield a valid
+  tree.
+- **Silently resurrect.** With the flag at its default, no lost tombstone or lost
+  restriction ever brings deleted or superseded data back.
+- **Turn a retryable fault into a permanent verdict.** Transient I/O propagates;
+  it never becomes a keep-or-drop decision.

--- a/docs/manifest-recovery.md
+++ b/docs/manifest-recovery.md
@@ -196,6 +196,37 @@ GC would have dropped that tombstone and re-exposed the key; retaining it keeps
 the unrestricted survivor's prefix fully shadowed, so nothing resurrects. Space is
 reclaimed by the hole punch, and a later normal compaction does the deferred GC.
 
+## Blob frontier resolution
+
+A tight-space blob defragmentation punches the consumed prefix of a stale blob
+file, `[data_start, frontier)`, and records the frontier in the manifest's
+blob-restrictions section — its only durable copy (blob files carry no
+sidecar). When the manifest is lost, recovery re-derives the frontier from the
+punch geometry itself. Unlike an SST's bound — a *key*, which the block-aligned
+punch cannot reproduce, hence the sidecar — the blob frontier is a *byte
+offset at a frame boundary*, so the geometry recovers it exactly: the punch
+zeroes precisely `[data_start, frontier)` and the first live frame's magic
+sits at the frontier.
+
+Anchoring is structural, never length-based. A zeroed run counts only when a
+valid frame decodes at its end, so a zero-filled value payload inside the live
+suffix (stepped over by frame framing) can never move the frontier. A
+partially completed punch — intact-but-consumed frames between holes — is
+walked hole by hole, and the frontier is the end of the last anchored run.
+Non-zero bytes that fail to decode end the walk at the last anchored frontier:
+content corruption is not punch geometry and surfaces exactly as it would on
+an unpunched file. A file whose first data byte is non-zero recovers with
+frontier `0` (whole file) at zero extra read cost; this also covers the
+committed-but-unpunched crash window, whose redundant prefix is superseded by
+the relocated copies and reclaimed later — the same safe fallback as an SST
+slice that committed without its sidecar.
+
+The recovered file's digest covers the live region, `[frontier, end)`, and the
+rebuilt snapshot re-persists the restriction from the recovered frontier, so a
+later relocation resumes exactly where the punch stopped. No resurrection
+question arises: blob bytes are reachable only through value handles, so a
+frontier recovered too low exposes nothing.
+
 ## Delete-mask resolution
 
 A columnar SST records positional deletions in a delete bitmap, and the meta

--- a/docs/tight-space-compaction.md
+++ b/docs/tight-space-compaction.md
@@ -41,8 +41,15 @@ slice `[lower, boundary)`:
    fsync it.
 2. **Install** one atomic, durable version edit that adds the output and either
    restricts each input that extends past the boundary to `[boundary, hi)` or
-   drops an input the slice fully consumed.
-3. **Punch** the consumed data blocks of each restricted input (the bytes below
+   drops an input the slice fully consumed. This edit is the slice's commit
+   point: nothing before it is durable, everything after it is.
+3. **Mark** each restricted input's exact bound in a small sibling
+   `.restrict-bound` sidecar, written *strictly after* the install commits. The
+   sidecar is the only record of the exact bound that survives a lost manifest,
+   so a later rebuild from `tables/` can reconstruct the restricted view. Writing
+   it after the commit makes its existence prove the restriction is committed
+   (see *Crash safety*).
+4. **Punch** the consumed data blocks of each restricted input (the bytes below
    the boundary), reclaiming their space while leaving the file in place for the
    restricted view that still serves the suffix.
 
@@ -58,12 +65,42 @@ The final slice merges the remainder and removes the inputs outright.
 ## Crash safety
 
 Each slice is one durable version edit, so a crash mid-rewrite is always
-recoverable: the manifest carries each input's persisted key-range restriction,
-and recovery rebuilds the restricted view. A crash before a slice's edit leaves
-an orphan output (swept on recovery) and an intact input; a crash after it leaves
-the restriction recorded, so the punched prefix is already routed to the
-installed output. Reopening a partially-rewritten tree yields a consistent state
-with every key readable, and a later compaction continues the work.
+recoverable, and recovery works from either of two sources.
+
+**Manifest intact.** The version edit carries each input's persisted key-range
+restriction, so normal recovery rebuilds the restricted view directly. A crash
+before a slice's edit leaves an orphan output (swept on recovery) and an intact
+input; a crash after it leaves the restriction recorded, so the consumed prefix
+is already routed to the installed output.
+
+**Manifest lost.** When the manifest is gone, recovery rebuilds it from the SST
+files under `tables/` and cannot consult any commit state, so it needs an on-disk
+record of each restriction. That is the `.restrict-bound` sidecar, and the order
+in step 3 is what makes it trustworthy: because the sidecar is written *strictly
+after* the version install commits, **a sidecar on disk proves its restriction is
+committed.** An aborted or crashed slice can never leave an uncommitted sidecar
+behind, so there is no rollback that must chase one down. The two remaining crash
+windows are both safe:
+
+- *Committed, sidecar written, not yet punched.* Recovery honors the bound (the
+  installed output covers the dropped prefix); the punch is pure reclaim and its
+  absence loses nothing.
+- *Committed, crash before the sidecar is written.* No sidecar and an unpunched
+  input, so recovery keeps the whole input unrestricted. This is safe because a
+  slice output is a **superset** of its consumed inputs: tight-space slices run
+  their merges *without bottommost GC* (no tombstone drop, no seqno zeroing, no
+  range-tombstone application), even when the destination is the last level. So
+  the committed output shadows the unrestricted input's prefix by sequence number
+  for every key — including keys whose tombstone lived in a *different*,
+  fully-consumed input, which ordinary last-level GC would have dropped along with
+  the rows it covered. Nothing is resurrected and nothing is lost; only the
+  redundant prefix waits for a later compaction to reclaim it. No punch was armed
+  in this window (the punch follows the sidecar write), so this slice reclaims
+  nothing from that input; a later compaction reclaims it.
+
+Either way, reopening a partially-rewritten tree yields a consistent state with
+every key readable, and a later compaction continues the work. The recovery rules
+are specified in `docs/manifest-recovery.md`.
 
 ## KV-separated trees
 
@@ -111,6 +148,11 @@ file).
   intended trade-off for an emergency, opt-in path.
 - **Correctness**: identical to an ordinary merge. Every key is preserved, the
   latest version wins, and the result round-trips through a reopen.
+- **GC is deferred, not performed here.** Slice merges run without bottommost GC
+  (tombstones and superseded versions are retained) so every output is a superset
+  that stays crash-safe under manifest repair (see *Crash safety*). Tight-space
+  reclaims space through the hole punch; a later normal last-level compaction does
+  the tombstone / seqno GC.
 
 ## Configuration
 

--- a/src/abstract_tree.rs
+++ b/src/abstract_tree.rs
@@ -71,6 +71,26 @@ pub mod sealed {
     pub trait Sealed {}
 }
 
+/// Outcome of [`AbstractTree::refresh_table_checksum`].
+#[cfg(feature = "std")]
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChecksumRefreshOutcome {
+    /// The digest was installed into the manifest.
+    Refreshed,
+    /// Legitimate no-op: the table was compacted away, or its restriction no
+    /// longer matches the one the digest was computed for; the current view
+    /// carries its own (compaction-installed) digest for the next patrol to
+    /// reconcile.
+    Stale,
+    /// The install lock was held by a concurrent compaction (blocking on it
+    /// would invert the heal-lock / compaction-state order and deadlock). The
+    /// manifest digest stays stale against durable healed bytes: the caller
+    /// must surface this as a finding, keep the attestation, and let a later
+    /// patrol retry.
+    Contended,
+}
+
 /// Generic Tree API
 #[enum_dispatch::enum_dispatch]
 pub trait AbstractTree: sealed::Sealed {
@@ -101,6 +121,61 @@ pub trait AbstractTree: sealed::Sealed {
 
     #[doc(hidden)]
     fn current_version(&self) -> Version;
+
+    /// Records that the table with `table_id` now has the digest `checksum`,
+    /// persisting it to the manifest through a version upgrade.
+    ///
+    /// Called after an in-place heal rewrites a table's bytes: the healed
+    /// file's digest no longer matches the one captured at recovery, and
+    /// without the refresh a later [`verify`](crate::verify) pass (or a
+    /// repair) would flag the healed file as corrupted against the stale
+    /// manifest digest. A no-op when the table is no longer part of the
+    /// current version (compacted away while the heal ran — the old file is
+    /// on its way out).
+    ///
+    /// `expected_restriction` is the tight-space restriction bound the CALLER
+    /// computed `checksum` for (its captured view's [`restrict_lower_bound`]).
+    /// This method holds the install lock, so it re-checks it against the CURRENT
+    /// view under that lock and refuses the install (a no-op) if a compaction
+    /// swapped the view to a different restriction meanwhile: a whole-file digest
+    /// installed into a suffix-only restricted manifest (or vice versa) could
+    /// never match the punched file.
+    ///
+    /// Returns [`ChecksumRefreshOutcome::Refreshed`] when the digest was
+    /// installed, [`ChecksumRefreshOutcome::Stale`] on a legitimate no-op (the
+    /// table was compacted away, or its restriction no longer matches
+    /// `expected_restriction` — the current view carries its own digest), and
+    /// [`ChecksumRefreshOutcome::Contended`] when the install lock was held by
+    /// a concurrent compaction. The caller uses this to decide whether to clear
+    /// the heal attestation (only `Refreshed` may) and whether the pass stayed
+    /// clean: a contended skip leaves the manifest digest stale against durable
+    /// healed bytes, which must surface as a finding rather than a clean
+    /// report.
+    ///
+    /// [`restrict_lower_bound`]: crate::table::Table::restrict_lower_bound
+    #[cfg(feature = "std")]
+    #[doc(hidden)]
+    fn refresh_table_checksum(
+        &self,
+        table_id: TableId,
+        checksum: crate::checksum::Checksum,
+        expected_restriction: Option<&crate::UserKey>,
+    ) -> crate::Result<ChecksumRefreshOutcome>;
+
+    /// The tree's configured durability mode
+    /// ([`Config::sync_mode`](crate::config::Config::sync_mode)). Maintenance
+    /// paths that write outside the flush pipeline (the in-place heal) read
+    /// it here so their syncs honor the same durability the tree's own
+    /// writes use.
+    #[doc(hidden)]
+    fn sync_mode(&self) -> crate::fs::SyncMode;
+
+    /// The tree's configured prefix extractor, or `None` when it indexes no
+    /// prefixes. The patrol scrub's filter cross-check reads it here so it
+    /// can verify a rebuilt full filter carries the source's prefix hashes,
+    /// not just its complete-key hashes.
+    #[doc(hidden)]
+    fn prefix_extractor(&self) -> Option<alloc::sync::Arc<dyn crate::prefix::PrefixExtractor>>;
 
     /// Returns a read-only snapshot of the tree's on-disk storage footprint:
     /// total used bytes, entry count, the average shape of a stored entry

--- a/src/blob_tree/mod.rs
+++ b/src/blob_tree/mod.rs
@@ -387,6 +387,29 @@ impl AbstractTree for BlobTree {
         self.index.current_version()
     }
 
+    #[cfg(feature = "std")]
+    fn refresh_table_checksum(
+        &self,
+        table_id: crate::TableId,
+        checksum: crate::checksum::Checksum,
+        expected_restriction: Option<&crate::UserKey>,
+    ) -> crate::Result<crate::abstract_tree::ChecksumRefreshOutcome> {
+        // Tables live in the index tree's version; blob files carry no
+        // manifest digest.
+        self.index
+            .refresh_table_checksum(table_id, checksum, expected_restriction)
+    }
+
+    fn sync_mode(&self) -> crate::fs::SyncMode {
+        // SSTs live in the index tree; its durability mode governs them.
+        self.index.sync_mode()
+    }
+
+    fn prefix_extractor(&self) -> Option<alloc::sync::Arc<dyn crate::prefix::PrefixExtractor>> {
+        // The prefix filter is built over the index tree's SST keys.
+        self.index.prefix_extractor()
+    }
+
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
         // Forward the index tree's compaction state (the default impl would
         // always report idle), and mark value bytes as NOT user values: large

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -185,6 +185,16 @@ pub fn link_or_copy_cross_fs(
         && dst.parent().is_some_and(|p| dst_fs.capabilities(p).reflink)
     {
         dst_fs.reflink_file(src, dst)?;
+        // Sync the CLONE at the requested durability before treating it as
+        // complete. The streamed-copy fallback below syncs its destination; the
+        // real Linux / macOS `reflink_file` implementations do not, and the
+        // surrounding checkpoint code syncs only DIRECTORIES. Without this a
+        // power loss can leave the checkpoint's manifest and directory entries
+        // persisted while the cloned inode's extents are not — an immutable
+        // snapshot that verifies as corrupt on the next open.
+        let dst_file = dst_fs.open(dst, &FsOpenOptions::new().read(true))?;
+        FsFile::sync_all_with(&*dst_file, sync_mode)?;
+        drop(dst_file);
         return Ok(dst_fs.metadata(dst)?.len);
     }
 
@@ -336,6 +346,30 @@ pub fn link_tables(
         // the number of files, so plain adds cannot overflow.
         bytes += written;
         count += 1;
+
+        // A tight-space-restricted table keeps its EXACT recovery bound so a
+        // checkpoint that later needs manifest repair recovers the restriction;
+        // without it, repair of the backup finds a punched SST with no bound and
+        // conservatively discards the live suffix of its first readable block. Take
+        // the bound from the CAPTURED version view (`restrict_lower_bound`), not by
+        // re-reading the live `.restrict-bound` sidecar file: a concurrent
+        // tight-space compaction can be overwriting that sidecar (tightening the
+        // same SST id's bound) while we copy it, so a file read would race the
+        // snapshot. The captured view's bound is consistent with the SST bytes just
+        // linked, so write the checkpoint's own sidecar from it. An unrestricted
+        // table carries no bound and needs no sidecar.
+        if let Some(bound) = table.restrict_lower_bound() {
+            let dst_sidecar = crate::restrict_bound::sidecar_path(&dst);
+            crate::restrict_bound::write(
+                target_fs.as_ref(),
+                &dst,
+                table.encryption.as_deref(),
+                table.id(),
+                bound,
+                sync_mode,
+            )?;
+            bytes += target_fs.metadata(&dst_sidecar)?.len;
+        }
     }
     Ok((count, bytes))
 }
@@ -692,6 +726,30 @@ pub fn run_checkpoint<T: AbstractTree>(
     // tables / blob files that compaction marks as deleted are held back.
     let _pause = deletion_pause.acquire();
 
+    // Reconcile any table left with a PENDING in-place-heal attestation before
+    // the snapshot: such a table has healed bytes on disk but the live version
+    // still records its pre-heal digest, and the `.heal-attest` sidecar is not
+    // copied into the checkpoint. Linking it as-is would capture a digest that
+    // never matches the linked bytes, failing the immutable checkpoint's
+    // integrity check forever with no marker to reconcile. Reconciling here
+    // refreshes the digest and consumes the sidecar so the version captured
+    // below is self-consistent. Runs BEFORE `enter_link_window` because the
+    // reconcile takes each table's mutation window, which the link window (its
+    // write half) mutually excludes, so doing it after would deadlock.
+    #[cfg(feature = "page_ecc")]
+    crate::scrub::reconcile_pending_heals(tree)?;
+    // A build WITHOUT page_ecc cannot reconcile a pending heal (no ECC scan
+    // machinery), but a feature-enabled binary may have healed an SST and
+    // crashed before refreshing its manifest, leaving a `.heal-attest` marker.
+    // Linking that table would snapshot healed bytes under the stale pre-heal
+    // digest with no marker copied, so abort the checkpoint instead.
+    #[cfg(not(feature = "page_ecc"))]
+    crate::scrub::abort_checkpoint_if_pending_heals(
+        tree,
+        "this build is compiled without page_ecc, so it has no ECC scan machinery; \
+         run a scrub with a Page-ECC-enabled build",
+    )?;
+
     // Capture the seqno BEFORE the flush. Sampling later (between flush
     // and `current_version()`) is unsafe: a concurrent writer can land
     // in the freshly-rotated active memtable, advance `visible_seqno`,
@@ -718,7 +776,36 @@ pub fn run_checkpoint<T: AbstractTree>(
     // history readers below that watermark might need; using
     // `SeqNo::MAX` (a previous oversight) wiped every older version
     // of every key.
+    //
+    // The flush runs BEFORE the link window below, and must: its version
+    // install blocks on `compaction_state`, and holding the link window's
+    // write half across that wait closes a three-way cycle — a tight-space
+    // compaction holds `compaction_state` while waiting for a table's heal
+    // lock, and a heal patrol holds that heal lock while waiting for the
+    // link window's read half.
     tree.flush_active_memtable(0)?;
+
+    // Hold the link window from here on: an in-place heal that has already
+    // probed an SST's link count as exclusive must not observe this
+    // checkpoint linking that SST mid-heal (the snapshot would capture bytes
+    // the heal is about to change, under a digest the checkpoint manifest
+    // already recorded). The heal side holds the read half per table. Nothing
+    // under the window blocks on `compaction_state` (see the flush ordering
+    // above), so the window cannot participate in a lock cycle.
+    let _link_window = deletion_pause.enter_link_window();
+
+    // Residual-race guard: the pre-window reconciliation released each table's
+    // mutation window before the link window was taken, so a concurrent heal
+    // could have left a fresh pending marker in between (including during the
+    // flush above). Reconciling now is impossible (it needs the mutation
+    // window the link window excludes), so abort if any marker remains rather
+    // than snapshot a healed table under a stale digest. The operator retries;
+    // the next attempt reconciles it.
+    crate::scrub::abort_checkpoint_if_pending_heals(
+        tree,
+        "a concurrent heal left a pending marker after the pre-window reconcile, \
+         and the held link window excludes the mutation window reconciliation needs",
+    )?;
 
     let version = tree.current_version();
 
@@ -803,5 +890,5 @@ pub fn run_checkpoint<T: AbstractTree>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code")]
+#[expect(clippy::unwrap_used, clippy::expect_used, reason = "test code")]
 mod tests;

--- a/src/checkpoint/tests.rs
+++ b/src/checkpoint/tests.rs
@@ -55,6 +55,99 @@ fn cross_fs_link_or_copy_streams_through_trait() {
     assert_eq!(after, "mutated-via-mem-fs");
 }
 
+/// The checkpoint records a restricted table's recovery bound from the CAPTURED
+/// version view (`restrict_lower_bound`), NOT by re-reading the live
+/// `.restrict-bound` sidecar file — a concurrent tight-space compaction can be
+/// rewriting that file for the same SST id. Proven by leaving a STALE live sidecar
+/// (a DIFFERENT bound) beside the source SST: the checkpoint's sidecar must encode
+/// the captured bound, never the stale file's. Under the pre-fix copy-the-file
+/// logic the checkpoint carried the stale bound instead.
+#[test]
+fn checkpoint_binds_restrict_sidecar_to_captured_view_not_live_file() -> crate::Result<()> {
+    use crate::blob_tree::FragmentationMap;
+    use crate::cache::Cache;
+    use crate::descriptor_table::DescriptorTable;
+    use crate::table::{Table, Writer};
+    use crate::version::{BlobFileList, Level, Run, Version};
+    use crate::{InternalValue, TreeType, ValueType};
+
+    let src_dir = tempfile::tempdir()?;
+    let dst_dir = tempfile::tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let src_tables = src_dir.path().join(TABLES_FOLDER);
+    fs.create_dir_all(&src_tables)?;
+    let sst = src_tables.join("0");
+
+    // A multi-block SST so a restriction bound lands on a real block boundary.
+    let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0..256u32 {
+        w.write(InternalValue::from_components(
+            format!("k{i:05}").into_bytes(),
+            format!("v{i}").into_bytes(),
+            u64::from(i) + 1,
+            ValueType::Value,
+        ))?;
+    }
+    let (_, checksum) = w.finish()?.expect("table written");
+
+    // Recover, then build the restricted VIEW at k00100 (no punch needed here:
+    // reopen_restricted reads the live suffix digest off the whole file).
+    let table = Table::recover(
+        sst.clone(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(1_000_000)),
+        Some(Arc::new(DescriptorTable::new(10))),
+        Arc::clone(&fs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    let restricted = table.reopen_restricted(b"k00100".to_vec().into())?;
+
+    // A STALE live sidecar with a DIFFERENT bound beside the SOURCE SST: the copy
+    // path would carry this, the captured-bound path must ignore it.
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00050", SyncMode::Normal)?;
+
+    // Build a one-table version and checkpoint (link) it into dst.
+    let run = Arc::new(Run::new(vec![restricted]).expect("non-empty run"));
+    let version = Version::from_levels(
+        1,
+        TreeType::Standard,
+        vec![Level::from_runs(vec![run])],
+        BlobFileList::default(),
+        FragmentationMap::default(),
+    );
+    let dst_root = dst_dir.path();
+    fs.create_dir_all(&dst_root.join(TABLES_FOLDER))?;
+    link_tables(&version, dst_root, &fs, SyncMode::Normal, false)?;
+
+    // The checkpoint's sidecar encodes the CAPTURED bound (k00100), not the stale
+    // live file's (k00050).
+    let dst_sst = dst_root.join(TABLES_FOLDER).join("0");
+    match crate::restrict_bound::read(&*fs, &dst_sst, None)? {
+        crate::restrict_bound::SidecarRead::Present(id, bound) => {
+            assert_eq!(id, 0, "the sidecar binds the table id");
+            assert_eq!(
+                bound, b"k00100",
+                "checkpoint must record the captured bound, not the stale live file's",
+            );
+        }
+        _ => {
+            panic!("checkpoint must write a valid restrict-bound sidecar for the restricted table")
+        }
+    }
+    Ok(())
+}
+
 // Removed: `write_current_for_version_rejects_corrupt_footer_size_hint`.
 // The checkpoint write path now goes through
 // `ManifestArchiveReader::open` (canonical CURRENT digest path),
@@ -63,3 +156,96 @@ fn cross_fs_link_or_copy_streams_through_trait() {
 // behaviour. Tail / head-mirror bounds checks are covered by
 // `manifest_blocks::reader::tests::reader_fails_when_tail_corrupt_and_no_mirror`
 // and siblings.
+
+/// A [`Fs`] over `StdFs` that ADVERTISES reflink support and implements
+/// `reflink_file` as a plain byte copy (the semantics a real clone gives the
+/// caller: an independent destination inode). Used to drive the checkpoint's
+/// reflink fast path on any host filesystem.
+mod reflink_fs {
+    use crate::fs::{Fs, FsCapabilities, FsDirEntry, FsFile, FsMetadata, FsOpenOptions, StdFs};
+    use crate::io;
+    use std::path::Path;
+
+    pub(super) struct ReflinkFs;
+
+    impl Fs for ReflinkFs {
+        fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
+            StdFs.open(path, opts)
+        }
+        fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.create_dir_all(path)
+        }
+        fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
+            StdFs.read_dir(path)
+        }
+        fn remove_file(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_file(path)
+        }
+        fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_dir_all(path)
+        }
+        fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+            StdFs.rename(from, to)
+        }
+        fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
+            StdFs.metadata(path)
+        }
+        fn sync_directory(&self, path: &Path) -> io::Result<()> {
+            StdFs.sync_directory(path)
+        }
+        fn exists(&self, path: &Path) -> io::Result<bool> {
+            StdFs.exists(path)
+        }
+        fn backend_id(&self) -> Option<u64> {
+            StdFs.backend_id()
+        }
+        fn volume_id(&self, path: &Path) -> Option<u64> {
+            StdFs.volume_id(path)
+        }
+        fn capabilities(&self, path: &Path) -> FsCapabilities {
+            FsCapabilities {
+                reflink: true,
+                ..StdFs.capabilities(path)
+            }
+        }
+        fn reflink_file(&self, src: &Path, dst: &Path) -> io::Result<()> {
+            let bytes = std::fs::read(src)?;
+            std::fs::write(dst, bytes)?;
+            Ok(())
+        }
+    }
+}
+
+/// The reflink fast path must SYNC the cloned destination file before the
+/// checkpoint treats it as complete. The streamed-copy fallback already does;
+/// the real Linux / macOS `reflink_file` implementations never sync, and the
+/// surrounding checkpoint code syncs only DIRECTORIES. Without the file sync a
+/// power loss can leave the checkpoint's manifest and directory entries durable
+/// while the cloned extents are not. Faulting the file sync proves it happens:
+/// a build that skips it returns `Ok` and never sees the fault.
+#[test]
+fn reflink_checkpoint_copy_syncs_the_destination_file() {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("payload.bin");
+    std::fs::write(&src, b"reflink-payload").unwrap();
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let dst = dst_dir.join("payload.bin");
+
+    let fault = FaultFs::new(reflink_fs::ReflinkFs);
+    fault.injector().arm(FaultRule::new(
+        FaultOp::SyncAll,
+        Fault::Error(ErrorKind::Other),
+    ));
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let result = link_or_copy_cross_fs(&fs, &src, &fs, &dst, SyncMode::Full, true);
+    assert!(
+        result.is_err(),
+        "the reflinked destination must be synced at the requested durability \
+         before the clone counts as complete; got {result:?}",
+    );
+}

--- a/src/compaction/flavour.rs
+++ b/src/compaction/flavour.rs
@@ -44,7 +44,15 @@ fn drain_blobs<I: Iterator<Item = crate::Result<(ScanEntry, BlobFileId)>>>(
         let (entry, blob_file_id) = blob?;
 
         assert!(entry.key <= key, "vptr was not matched with blob");
-        record_consumed(blob_file_id, entry.frame_end);
+        // A RESYNCED entry's boundary is unproven (see `ScanEntry::resynced`):
+        // advancing the reclaim frontier to its `frame_end` could punch past —
+        // and then skip on resume — a later frame that is actually valid. Drop
+        // the tainted entry WITHOUT advancing the frontier, so a resumed scan
+        // re-reads from the last proven boundary (fail closed). The matched-vptr
+        // relocation path refuses a resynced frame outright for the same reason.
+        if !entry.resynced {
+            record_consumed(blob_file_id, entry.frame_end);
+        }
     }
 
     Ok(())
@@ -347,6 +355,14 @@ pub(super) fn install_merge(
 
     let tables_out = created_tables.len();
 
+    // Install the tree-wide deletion pause on every output BEFORE the version edit
+    // makes it visible. A flush registers this via `register_tables`; a compaction
+    // installs its outputs here, so without this an output's in-place heal would
+    // skip the checkpoint mutation window and could race a checkpoint hard-link.
+    for table in &created_tables {
+        table.install_deletion_pause(alloc::sync::Arc::clone(&opts.deletion_pause));
+    }
+
     // Globally-dead blob files are dropped once, from the install-time version.
     let current_version = super_version.latest_version();
     for blob_file in current_version.version.blob_files.iter() {
@@ -523,6 +539,19 @@ impl CompactionFlavour for RelocatingCompaction {
                     blob_entry.offset, indirection.vhandle.offset,
                     "matched blob has different offset than vptr",
                 );
+
+                // A RESYNCHRONIZED frame was reached by a byte-wise scan after
+                // damage: its boundary is unproven (the magic may sit inside a
+                // damaged record's user-controlled bytes, and every frame chained
+                // past it inherits that unanchored start). Relocating it would
+                // rewrite fabricated bytes as a genuine record. `salvage_blob_file`
+                // drops such frames; relocation must fail closed the same way.
+                if blob_entry.resynced {
+                    return Err(crate::Error::InvalidHeader(
+                        "resynchronized blob frame reached after damage; refusing to \
+                         relocate a record whose boundary cannot be proven original",
+                    ));
+                }
 
                 // Advance the consumed frontier past this relocated frame so the
                 // tight-space loop can punch / resume here once the slice installs.

--- a/src/compaction/flavour/tests.rs
+++ b/src/compaction/flavour/tests.rs
@@ -19,6 +19,7 @@ fn entry(
             // at the start itself, which would mislead any future test that
             // inspects the consumed-frontier argument.
             frame_end: offset + 1,
+            resynced: false,
         },
         blob_file_id,
     ))
@@ -83,5 +84,41 @@ fn drain_blobs_multiple_keys() -> crate::Result<()> {
 
     assert_eq!(entry(0, b"e", 0)?, iter.next().unwrap()?);
 
+    Ok(())
+}
+
+#[test]
+fn drain_blobs_does_not_advance_the_frontier_past_a_resynced_frame() -> crate::Result<()> {
+    // A RESYNCED entry's `frame_end` boundary is unproven (see
+    // `ScanEntry::resynced`). Draining it must NOT advance the reclaim frontier,
+    // or the tight-space loop could punch past that unanchored boundary and then
+    // skip a later frame that is actually valid when the scan resumes there.
+    let mut resync = entry(0, b"a", 3)?;
+    resync.0.resynced = true;
+    let mut iter = [entry(0, b"a", 0), entry(0, b"a", 1), Ok(resync)]
+        .into_iter()
+        .peekable();
+
+    let mut max_recorded = 0u64;
+    drain_blobs(
+        &mut iter,
+        b"a",
+        &BlobIndirection {
+            size: 0,
+            vhandle: ValueHandle {
+                blob_file_id: 0,
+                offset: 9,
+                on_disk_size: 0,
+            },
+        },
+        &mut |_, frame_end| max_recorded = max_recorded.max(frame_end),
+    )?;
+
+    // The last PROVEN frame (offset 1) ends at ordinal 2; the resynced frame
+    // (frame_end 4) must not have advanced the frontier past it.
+    assert_eq!(
+        max_recorded, 2,
+        "a resynced frame must not advance the reclaim frontier past the last proven boundary",
+    );
     Ok(())
 }

--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -80,6 +80,13 @@ pub struct Options {
 
     pub compaction_state: Arc<Mutex<CompactionState>>,
 
+    /// The tree-wide deletion pause, installed on every compaction-produced table
+    /// before it becomes visible. A flush registers it via `register_tables`, but
+    /// compaction installs its outputs directly (`install_merge` / tight-space),
+    /// so it must be threaded here — without it a Page-ECC output's in-place heal
+    /// skips the checkpoint mutation window and can race a checkpoint hard-link.
+    pub deletion_pause: Arc<crate::deletion_pause::DeletionPause>,
+
     /// Shared handle to the live runtime config. Compaction loads
     /// a fresh snapshot via [`crate::runtime_config::handle::RuntimeConfigHandle::load_full`]
     /// each time it writes the manifest, so toggles applied via
@@ -117,6 +124,7 @@ impl Options {
             mvcc_gc_watermark: 0,
 
             compaction_state: tree.compaction_state.clone(),
+            deletion_pause: tree.deletion_pause.clone(),
             runtime_config: tree.runtime_config.clone(),
             encryption: tree.config.encryption.clone(),
             rate_limiter: Arc::new(crate::rate_limiter::RateLimiter::new(
@@ -881,7 +889,18 @@ fn run_tight_space_compaction(
         .hide(payload.table_ids.iter().copied());
 
     let dst_lvl: usize = payload.canonical_level.into();
-    let is_last_level = payload.dest_level == opts.config.level_count - 1;
+    // Tight-space slice merges run WITHOUT bottommost GC (tombstone drop, seqno
+    // zeroing, range-tombstone application) even when the destination IS the last
+    // level. A slice restricts a surviving input and hides its consumed prefix; if a
+    // fully-consumed sibling carried the tombstone for a key that also lives in that
+    // prefix, last-level GC would drop the tombstone from the output. A crash window
+    // that leaves the survivor unrestricted (sidecar not yet written, prefix not yet
+    // punched) would then let manifest repair re-expose the deleted rows. Retaining
+    // every record makes the slice output a SUPERSET that shadows any surviving
+    // prefix in every crash window; a later normal last-level compaction reclaims
+    // the deferred GC. Space is still reclaimed here via the hole punch, which is
+    // what tight-space is for.
+    let bottommost_gc = false;
     let blobs_folder = opts.config.path.join(BLOBS_FOLDER);
     // Canonicalize range tombstones across all inputs (a boundary-spanning RT is
     // otherwise copied into every slice output).
@@ -935,16 +954,29 @@ fn run_tight_space_compaction(
                 &rts,
                 (lower.clone(), Bound::Excluded(boundary.clone())),
                 dst_lvl,
-                is_last_level,
+                bottommost_gc,
                 &blobs_folder,
                 reloc,
             )?;
             drop(version);
 
             let outputs: Vec<Table> = produced.created_tables().to_vec();
+            // Install the tree-wide deletion pause on each slice output before the
+            // version edit makes it visible (mirrors `install_merge` — a compaction
+            // output that skipped it could race a checkpoint hard-link on a later
+            // in-place heal).
+            for table in &outputs {
+                table.install_deletion_pause(Arc::clone(&opts.deletion_pause));
+            }
             // KV-separation: blob files this slice relocated live entries into,
             // plus the GC diff of entries it dropped.
             let mut new_blobs: Vec<BlobFile> = produced.created_blob_files().to_vec();
+            // Capture the rollback set NOW, before the reopened stale views are
+            // pushed onto `new_blobs` below: `mark_as_deleted` on a reopened view
+            // unlinks its SHARED path (the still-live stale blob the current version
+            // references), so a rollback must delete only the genuinely-new blob
+            // files this slice created, never the reopened views.
+            let blobs_for_cleanup = new_blobs.clone();
             let frag = produced.blob_frag_map().clone();
             let gc_diff = if frag.is_empty() { None } else { Some(frag) };
 
@@ -969,17 +1001,84 @@ fn run_tight_space_compaction(
             if relocating {
                 for sf in &current_stale {
                     if let Some(off) = resume_offsets.get(&sf.id()).copied() {
-                        new_blobs.push(sf.reopen()?);
+                        // The re-opened view serves only `[off, end)`: the prior
+                        // view punches everything below once its readers drain.
+                        // Capture the digest over that live suffix NOW, while the
+                        // file is still whole, and record `off` as the view's
+                        // frontier — a whole-file digest would never match the
+                        // punched file, and integrity checks hash from the
+                        // frontier for exactly this reason.
+                        new_blobs.push(sf.reopen_restricted(off)?);
                         prior_to_punch.push((sf.clone(), off));
                     }
                 }
             }
 
-            let blobs_for_cleanup = new_blobs.clone();
+            // Serialize each surviving input's suffix-digest capture (inside
+            // `reopen_restricted` below) and this slice's manifest install
+            // against a concurrent in-place heal on the same table identity. A
+            // patrol that heals a suffix block BETWEEN the digest read and the
+            // version edit would bind the restricted manifest to a pre-heal
+            // suffix digest; the patrol then sees the restriction change and
+            // skips its whole-file refresh, and its attestation binds whole-file
+            // (not suffix) digests, so once the prefix is punched the mismatch is
+            // permanently unattributable. Hold each restricted input's heal lock
+            // across the reopen AND the `upgrade_version` below (released when
+            // these guards drop at the end of this slice iteration). Only inputs
+            // that extend past the boundary (`max >= boundary`) are re-opened, so
+            // only those are locked. The patrol holds at most one table's heal
+            // lock at a time, so acquiring several here cannot deadlock it.
+            //
+            // Lock-order note: this path takes `compaction_state` (held from
+            // `do_compaction`) BEFORE these heal locks, while the patrol reconcile
+            // takes a heal lock and then `compaction_state` inside
+            // `refresh_table_checksum`. To keep that inversion from deadlocking,
+            // the patrol side `try_lock`s `compaction_state` and skips its refresh
+            // on contention rather than blocking — so it never waits on
+            // `compaction_state` while holding a heal lock this loop wants.
+            #[cfg(feature = "page_ecc")]
+            let heal_locks: Vec<Arc<parking_lot::Mutex<()>>> = current_views
+                .iter()
+                .filter(|v| {
+                    comparator.compare(v.metadata.key_range.max(), boundary)
+                        != core::cmp::Ordering::Less
+                })
+                .map(Table::heal_lock_arc)
+                .collect();
+            #[cfg(feature = "page_ecc")]
+            let _heal_guards: Vec<parking_lot::MutexGuard<'_, ()>> =
+                heal_locks.iter().map(|l| l.lock()).collect();
 
             // Classify each input at this boundary: restrict (extends past it) or
             // remove (fully consumed by this slice). Re-open restricted views as
             // distinct Inners so a prior view drops and punches independently.
+            //
+            // `run_subcompaction` above already finalized this slice's output SSTs
+            // and blob files, but the install below is what references them. A
+            // failure between here and the install (a sidecar write or a restricted
+            // reopen) returns before any version points at those outputs, so, like
+            // the install error path below, roll them back now instead of pinning
+            // the space until the next open's orphan sweep. Tight-space runs exactly
+            // when free space is scarce, so an ENOSPC here would otherwise both abort
+            // the reclaim and hold the bytes this slice just consumed.
+            // Pre-install rollback. The slice's finalized outputs/blobs are still
+            // unreferenced (no version points at them), so on any failure before the
+            // install commits they must be retracted or the scarce space stays pinned
+            // until the next orphan sweep. No `.restrict-bound` sidecar is touched
+            // here: the sidecar write is STRICTLY POST-COMMIT (the mark step below the
+            // install), so an aborted slice never publishes one and there is nothing
+            // to retract. That ordering is the crash-safety invariant — a sidecar on
+            // disk always denotes a committed restriction (see the mark step and
+            // `docs/manifest-recovery.md`).
+            let rollback = |e: crate::Error| -> crate::Error {
+                for t in &outputs {
+                    t.mark_as_deleted();
+                }
+                for b in &blobs_for_cleanup {
+                    b.mark_as_deleted();
+                }
+                e
+            };
             let mut restricted_pairs: Vec<(TableId, Table)> = Vec::new();
             let mut removed_ids: Vec<TableId> = Vec::new();
             let mut next_views: Vec<Table> = Vec::new();
@@ -989,7 +1088,13 @@ fn run_tight_space_compaction(
                 {
                     removed_ids.push(view.id());
                 } else {
-                    let restricted = view.reopen_restricted(boundary.clone())?;
+                    // Open the restricted view over the same physical SST. This is an
+                    // IN-MEMORY reopen (it reads the live suffix digest but writes
+                    // nothing to disk), so a failure here commits nothing and just
+                    // rolls back the finalized outputs. The `.restrict-bound` sidecar
+                    // that records this view's exact bound is written only AFTER the
+                    // install commits (the mark step below), never here.
+                    let restricted = view.reopen_restricted(boundary.clone()).map_err(rollback)?;
                     restricted_pairs.push((view.id(), restricted.clone()));
                     next_views.push(restricted);
                 }
@@ -1019,22 +1124,53 @@ fn run_tight_space_compaction(
                 opts.encryption.clone(),
             );
             if let Err(e) = install {
-                for t in &outputs {
-                    t.mark_as_deleted();
-                }
-                for b in &blobs_for_cleanup {
-                    b.mark_as_deleted();
-                }
-                return Err(e);
+                // The install did not commit, so no sidecar was written (the mark
+                // step below is strictly post-commit) and the punches never arm:
+                // retract only the finalized-but-unreferenced outputs so the scarce
+                // space is freed now instead of at the next orphan sweep.
+                return Err(rollback(e));
             }
 
-            // Arm each surviving prior SST view to punch its consumed prefix on
-            // drop; a fully-consumed input is deleted outright (data is in outputs).
+            // Mark, then punch. The install committed, so now record each restricted
+            // input's exact bound to its `.restrict-bound` sidecar — STRICTLY AFTER
+            // the commit, so a sidecar on disk always denotes a committed restriction
+            // (manifest repair honors it without a commit protocol). Then arm the
+            // prefix punch. A fully-consumed input is deleted outright (its data is in
+            // the outputs).
+            //
+            // A sidecar write that fails HERE is not fatal: the restriction is already
+            // durable in the manifest. Log it and leave that input UNPUNCHED, so a
+            // later manifest-loss repair sees no-sidecar + unpunched and keeps the
+            // whole input (the committed output shadows the redundant prefix, its own
+            // tombstones intact, so nothing resurrects). Punching an input whose
+            // sidecar did not land would instead force repair to derive a conservative
+            // bound and drop up to one live block — so never punch without the sidecar.
             for view in &current_views {
                 if removed_ids.contains(&view.id()) {
                     view.mark_as_deleted();
                 } else {
-                    view.mark_punch_on_drop(view.punch_offset_for(boundary)?);
+                    match view.write_restrict_sidecar(boundary, opts.config.sync_mode) {
+                        Ok(()) => match view.punch_offset_for(boundary) {
+                            Ok(off) => view.mark_punch_on_drop(off),
+                            // Post-commit, so a punch-offset lookup failure is non-fatal,
+                            // exactly like the sidecar-write failure below: the restriction
+                            // is already durable (manifest + sidecar), so leave the input
+                            // unpunched and let a later compaction reclaim it. Propagating
+                            // `?` here would abort an already-committed slice.
+                            Err(e) => log::error!(
+                                "tight-space could not resolve the punch offset for table \
+                                 {} after committing its restriction: {e}; leaving the input \
+                                 unpunched, a later compaction reclaims it",
+                                view.id(),
+                            ),
+                        },
+                        Err(e) => log::error!(
+                            "tight-space could not write the restrict-bound sidecar for \
+                             table {} after committing its restriction: {e}; leaving the \
+                             input unpunched, a later compaction rewrites it",
+                            view.id(),
+                        ),
+                    }
                 }
             }
             // Arm each re-opened stale blob file's prior view to punch its
@@ -1097,7 +1233,7 @@ fn run_tight_space_compaction(
             &rts,
             (lower.clone(), Bound::Unbounded),
             dst_lvl,
-            is_last_level,
+            bottommost_gc,
             &blobs_folder,
             tail_reloc,
         )?;

--- a/src/compaction/worker/tests.rs
+++ b/src/compaction/worker/tests.rs
@@ -8,6 +8,14 @@ use crate::{
 use std::sync::Arc;
 use test_log::test;
 
+/// Shared key count and formatter for the tight-space crash-recovery tests, so
+/// the writer (in `tight_space_crash_and_reopen`) and the reopen assertion loop
+/// always cover the identical key set.
+const TIGHT_SPACE_KEYS: u64 = 2_000;
+fn tight_space_key(i: u64) -> String {
+    format!("key{i:08}")
+}
+
 /// Ranks keys by their first byte only, so byte-distinct keys that share a
 /// first byte compare equal — exercises the comparator-aware dedup path that
 /// raw `dedup()` would miss.
@@ -129,71 +137,721 @@ fn failed_subcompaction_rolls_back_and_restores_inputs() -> crate::Result<()> {
 /// those still in the punched input's intact suffix) reads back.
 #[test]
 fn tight_space_crash_after_first_slice_recovers_all_keys_on_reopen() -> crate::Result<()> {
-    use core::sync::atomic::Ordering;
-
-    const N: u64 = 2_000;
-    let k = |i: u64| format!("key{i:08}");
-
     let dir = tempfile::tempdir()?;
     let mem = crate::fs::MemFs::with_capacity(u64::MAX);
+    // Force the single-table major compaction to be gated, opting in to
+    // tight-space reclaim by leaving only a quarter of the footprint free.
+    let reopened = tight_space_crash_and_reopen(
+        dir.path(),
+        Arc::new(mem.clone()),
+        |used| mem.set_capacity(used + used / 4),
+        || mem.punched_bytes(),
+    )?;
+    for i in 0..TIGHT_SPACE_KEYS {
+        assert!(
+            reopened
+                .get(tight_space_key(i).as_bytes(), crate::MAX_SEQNO)?
+                .is_some(),
+            "key {i} lost after a crash mid tight-space compaction + reopen",
+        );
+    }
+    Ok(())
+}
+
+/// A real-on-disk [`Fs`](crate::fs::Fs) wrapper (over
+/// [`StdFs`](crate::fs::StdFs)) that simulates disk pressure for the tight-space
+/// compaction test while keeping every byte in a real file under the test's
+/// `tempdir`. It reports a fixed `available_space`, advertises hole-punch
+/// support, and EMULATES `punch_hole` by zeroing the range in place (real
+/// `StdFs::punch_hole` is Linux-only, so emulation keeps the test
+/// cross-platform and locally runnable). `punched_bytes` counts the bytes
+/// punched so the test can assert the first slice reclaimed its prefix.
+mod capfs {
+    use crate::fs::{Fs, FsCapabilities, FsDirEntry, FsFile, FsMetadata, FsOpenOptions, StdFs};
+    use crate::io;
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use std::io::{Read as _, Seek as _, SeekFrom};
+    use std::path::Path;
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    pub(super) struct CapacityFs {
+        available: Arc<AtomicU64>,
+        punched: Arc<AtomicU64>,
+        /// Link count `hard_link_count` reports for every path. `1` (the
+        /// default) is an exclusively-owned file; `2` models an inode a
+        /// checkpoint has hard-linked, which in-place reclaim must not mutate.
+        link_count: Arc<AtomicU64>,
+    }
+
+    impl CapacityFs {
+        pub(super) fn new() -> Self {
+            Self {
+                available: Arc::new(AtomicU64::new(u64::MAX)),
+                punched: Arc::new(AtomicU64::new(0)),
+                link_count: Arc::new(AtomicU64::new(1)),
+            }
+        }
+
+        /// Makes every file report `n` hard links (see [`Self::link_count`]).
+        pub(super) fn set_link_count(&self, n: u64) {
+            self.link_count.store(n, Ordering::Relaxed);
+        }
+
+        /// Sets the fixed free-space figure `available_space` reports (the
+        /// simulated remaining disk).
+        pub(super) fn set_available_space(&self, bytes: u64) {
+            self.available.store(bytes, Ordering::Relaxed);
+        }
+
+        /// Total bytes passed to `punch_hole` so far.
+        pub(super) fn punched_bytes(&self) -> u64 {
+            self.punched.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Fs for CapacityFs {
+        fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
+            StdFs.open(path, opts)
+        }
+        fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.create_dir_all(path)
+        }
+        fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
+            StdFs.read_dir(path)
+        }
+        fn remove_file(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_file(path)
+        }
+        fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_dir_all(path)
+        }
+        fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+            StdFs.rename(from, to)
+        }
+        fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
+            StdFs.metadata(path)
+        }
+        fn sync_directory(&self, path: &Path) -> io::Result<()> {
+            StdFs.sync_directory(path)
+        }
+        fn exists(&self, path: &Path) -> io::Result<bool> {
+            StdFs.exists(path)
+        }
+        fn hard_link_count(&self, _path: &Path) -> io::Result<u64> {
+            Ok(self.link_count.load(Ordering::Relaxed))
+        }
+        fn backend_id(&self) -> Option<u64> {
+            StdFs.backend_id()
+        }
+        fn volume_id(&self, path: &Path) -> Option<u64> {
+            StdFs.volume_id(path)
+        }
+
+        // Simulated disk pressure: the fixed free-space figure the tight-space
+        // admission check reads to decide a full rewrite will not fit.
+        fn available_space(&self, _path: &Path) -> io::Result<u64> {
+            Ok(self.available.load(Ordering::Relaxed))
+        }
+
+        // Advertise hole-punch so the compaction takes the punch-and-reclaim
+        // path even on a platform whose real StdFs reports no support.
+        fn capabilities(&self, path: &Path) -> FsCapabilities {
+            FsCapabilities {
+                punch_hole: true,
+                ..StdFs.capabilities(path)
+            }
+        }
+
+        // Emulate a hole-punch by zeroing the range in place: the prefix then
+        // reads as zeros exactly as a real punch (`FALLOC_FL_KEEP_SIZE`) would,
+        // so the restricted view is byte-faithful and the file keeps its length.
+        // Count the bytes for the test's reclaim assertion.
+        fn punch_hole(&self, path: &Path, offset: u64, len: u64) -> io::Result<()> {
+            if len == 0 {
+                return Ok(());
+            }
+            let mut f = StdFs.open(path, &FsOpenOptions::new().write(true))?;
+            // Clamp to the bytes actually present from `offset` to EOF: a real
+            // punch (`FALLOC_FL_KEEP_SIZE`) never extends the file, so neither
+            // may this zero-fill emulation. The min-0 clamp IS the intended
+            // semantics here (an out-of-range offset punches nothing), so a
+            // saturating subtraction is correct rather than bug-masking.
+            let file_len = f.metadata()?.len;
+            let punch_len = len.min(file_len.saturating_sub(offset));
+            if punch_len == 0 {
+                return Ok(());
+            }
+            f.seek(SeekFrom::Start(offset))?;
+            // Stream the zero bytes over the range (no manual chunk buffer, so
+            // no indexing / cast / unwrap the crate lints forbid).
+            std::io::copy(&mut std::io::repeat(0u8).take(punch_len), &mut f)?;
+            f.sync_all()?;
+            // Count the bytes only AFTER the punch durably lands, so a failed
+            // open / seek / write / sync does not inflate the reclaim counter.
+            self.punched.fetch_add(punch_len, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+}
+
+/// The shared tight-space crash-and-reopen flow. On `shared_fs`: writes 2000
+/// keys, leaves the disk tight via `set_capacity(used)`, crashes the tight-space
+/// compaction right after its first slice is installed and punched (asserting
+/// the crash failpoint fired and `punched_bytes()` grew), then reopens so
+/// recovery rebuilds the restricted input, returning the reopened tree. Callers
+/// supply the filesystem and its capacity / reclaim accessors (a `MemFs` and a
+/// real-file `CapacityFs` configure these differently) and then run their own
+/// assertions on the returned tree.
+fn tight_space_crash_and_reopen(
+    dir: &std::path::Path,
+    shared_fs: Arc<dyn crate::fs::Fs>,
+    set_capacity: impl FnOnce(u64),
+    punched_bytes: impl Fn() -> u64,
+) -> crate::Result<crate::AnyTree> {
+    use core::sync::atomic::Ordering;
+
     let config = Config::new(
-        &dir,
+        dir,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
     .data_block_size_policy(BlockSizePolicy::all(512))
-    .with_shared_fs(Arc::new(mem.clone()));
+    .with_shared_fs(Arc::clone(&shared_fs));
     let failpoint = config.fail_tight_after_first_slice.clone();
     let tree = match config.open()? {
         crate::AnyTree::Standard(t) => t,
         crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
     };
 
-    for i in 0..N {
-        tree.insert(k(i).as_bytes(), vec![0xCDu8; 64], i);
+    for i in 0..TIGHT_SPACE_KEYS {
+        tree.insert(tight_space_key(i).as_bytes(), vec![0xCDu8; 64], i);
     }
     tree.flush_active_memtable(0)?;
     let used = tree.storage_stats()?.used_bytes;
 
-    // Force the single-table major compaction to be gated, and opt in to
-    // tight-space reclaim.
-    mem.set_capacity(used + used / 4);
+    set_capacity(used);
     tree.update_runtime_config(|c| {
         c.storage_admission_check = true;
         c.tight_space_compaction = true;
     })?;
 
-    // Crash right after the first slice is durably installed + punched.
     failpoint.store(true, Ordering::SeqCst);
     assert!(
         tree.major_compact(64 * 1024 * 1024, 0).is_err(),
         "the crash failpoint must abort the tight-space compaction",
     );
+    // The failpoint disarms itself when it fires: confirm the error came from the
+    // intended crash point, not an unrelated failure before the punch.
     assert!(
         !failpoint.load(Ordering::SeqCst),
-        "the failpoint should have fired and disarmed",
+        "the crash failpoint must have fired and disarmed",
     );
     assert!(
-        mem.punched_bytes() > 0,
+        punched_bytes() > 0,
         "the first slice must have punched before the crash",
     );
 
-    // Reopen on the same simulated disk: recovery must rebuild the restricted
-    // input from the persisted manifest restriction.
     drop(tree);
-    let reopened = Config::new(
-        &dir,
+    Config::new(
+        dir,
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
-    .with_shared_fs(Arc::new(mem))
-    .open()?;
-    for i in 0..N {
-        assert!(
-            reopened.get(k(i).as_bytes(), crate::MAX_SEQNO)?.is_some(),
-            "key {i} lost after a crash mid tight-space compaction + reopen",
+    .with_shared_fs(shared_fs)
+    .open()
+}
+
+/// A legitimately RESTRICTED table (a tight-space compaction crashed after
+/// punching its first slice, so its `[0, punch)` data-block prefix reads as
+/// zeros) must pass every heal-reconcile security gate AND the whole-file
+/// integrity verify. Each gate walks the data blocks and would, before
+/// restriction-awareness, try to decode the punched prefix and FALSELY reject
+/// the healthy restricted view, refusing to reconcile a legitimate heal and
+/// stranding recovery. Cross-checks the suffix only; the punched prefix is
+/// dead. This is the reopen state of
+/// [`tight_space_crash_after_first_slice_recovers_all_keys_on_reopen`], run on
+/// real on-disk files ([`capfs::CapacityFs`] over `StdFs`) so the scan exercises
+/// real filesystem read / seek / EOF behavior.
+#[test]
+fn restricted_view_passes_every_reconcile_gate() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let fs = capfs::CapacityFs::new();
+    // Leave only a quarter of the flushed footprint free so a full rewrite cannot
+    // fit and the compaction takes the tight-space slice-and-punch path.
+    let reopened = tight_space_crash_and_reopen(
+        dir.path(),
+        Arc::new(fs.clone()),
+        |used| fs.set_available_space(used / 4),
+        || fs.punched_bytes(),
+    )?;
+
+    // The whole-file digest verify must pass on the restricted table: it streams
+    // the SUFFIX digest for a restricted view (the punched prefix is excluded),
+    // so a legitimately punched file is not flagged as corrupt. Now testable
+    // because the table lives in a real on-disk file `verify_integrity` can read.
+    let integrity = crate::verify::verify_integrity(&reopened);
+    assert!(
+        integrity.is_ok(),
+        "verify_integrity must pass on a legitimately restricted table, got {:?}",
+        integrity.errors,
+    );
+
+    // Locate the restricted table and drive every heal-reconcile gate directly:
+    // each must accept the healthy suffix without decoding the punched prefix.
+    let version = reopened.current_version();
+    let Some(restricted) = version
+        .iter_tables()
+        .find(|t| t.restrict_lower_bound().is_some())
+    else {
+        panic!("the punched input must reopen as a restricted table");
+    };
+
+    restricted.verify_kv_checksums()?;
+    restricted.verify_blob_links()?;
+    restricted.verify_tli_mirrors()?;
+    restricted.verify_seqno_bounds()?;
+    restricted.verify_block_entry_counts()?;
+    restricted.verify_zone_map()?;
+    restricted.verify_locator()?;
+    restricted.verify_filter(None)?;
+    restricted.verify_block_layout()?;
+    restricted.verify_point_read_reachability()?;
+    restricted.verify_metadata_bounds()?;
+    Ok(())
+}
+
+/// Detaching a tight-space-restricted SST for an in-place heal (it was hard-linked
+/// into a checkpoint) must reproduce the source BYTE-FOR-BYTE. The detach punches
+/// only the reclaimed DATA-block extents below the frontier — the exact set
+/// `Inner::drop` reclaims (the block index yields only data-block handles) — and
+/// copies everything else, so any live index / filter block interleaved below the
+/// frontier is preserved rather than zeroed by a wholesale `[0, punch)` punch. This
+/// guards the scatter-copy against dropping or mis-placing a live block.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn unshare_for_heal_reproduces_the_source_faithfully() -> crate::Result<()> {
+    use crate::fs::{Fs, FsOpenOptions, SyncMode};
+
+    let dir = tempfile::tempdir()?;
+    let fs = capfs::CapacityFs::new();
+    let reopened = tight_space_crash_and_reopen(
+        dir.path(),
+        Arc::new(fs.clone()),
+        |used| fs.set_available_space(used / 4),
+        || fs.punched_bytes(),
+    )?;
+
+    let version = reopened.current_version();
+    let Some(restricted) = version
+        .iter_tables()
+        .find(|t| t.restrict_lower_bound().is_some())
+    else {
+        panic!("the punched input must reopen as a restricted table");
+    };
+    assert!(
+        restricted.punch_offset()? > 0,
+        "the restricted table has a punched prefix",
+    );
+
+    let shared: Arc<dyn Fs> = Arc::new(fs);
+    let read_all = |path: &std::path::Path| -> crate::Result<alloc::vec::Vec<u8>> {
+        let f = shared.open(path, &FsOpenOptions::new().read(true))?;
+        let len = usize::try_from(f.metadata()?.len).unwrap_or(usize::MAX);
+        let mut buf = alloc::vec![0u8; len];
+        let mut off = 0usize;
+        while off < len {
+            let got = f.read_at(
+                buf.get_mut(off..).unwrap_or(&mut []),
+                u64::try_from(off).unwrap_or(u64::MAX),
+            )?;
+            if got == 0 {
+                break;
+            }
+            off += got;
+        }
+        Ok(buf)
+    };
+
+    // Snapshot the source before the detach. It is a real punched restricted table:
+    // its bytes hold BOTH punched data blocks (zeros) and live blocks (non-zero).
+    let src = read_all(&restricted.path)?;
+    assert!(src.contains(&0), "the source has punched data blocks");
+    assert!(src.iter().any(|&b| b != 0), "the source has live blocks");
+
+    // Detach into a fresh copy, exactly as the in-place heal does for a
+    // checkpoint-shared inode.
+    let source = shared.open(&restricted.path, &FsOpenOptions::new().read(true))?;
+    let _copy = match restricted.unshare_for_heal(source.as_ref(), SyncMode::Normal) {
+        Ok(copy) => copy,
+        Err(e) => panic!("unshare_for_heal must succeed on a restricted table: {e}"),
+    };
+
+    // The copy the rename published must be byte-identical to the source.
+    let copy = read_all(&restricted.path)?;
+    assert_eq!(
+        copy, src,
+        "the detached heal copy must reproduce the source byte-for-byte",
+    );
+    Ok(())
+}
+
+/// A REAL tight-space compaction must record its punched input's exact bound in a
+/// `.restrict-bound` sidecar before punching, WITHOUT touching the SST. That
+/// sidecar bound must equal the manifest's restriction lower bound — the invariant
+/// that lets manifest repair recover the same restriction from the on-disk files
+/// alone. Reading it back also proves the sidecar survives the reopen.
+#[test]
+fn tight_space_writes_a_restrict_bound_sidecar_matching_the_manifest_bound() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let fs = capfs::CapacityFs::new();
+    let reopened = tight_space_crash_and_reopen(
+        dir.path(),
+        Arc::new(fs.clone()),
+        |used| fs.set_available_space(used / 4),
+        || fs.punched_bytes(),
+    )?;
+
+    let version = reopened.current_version();
+    let Some(restricted) = version
+        .iter_tables()
+        .find(|t| t.restrict_lower_bound().is_some())
+    else {
+        panic!("the punched input must reopen as a restricted table");
+    };
+    let Some(manifest_bound) = restricted.restrict_lower_bound().cloned() else {
+        panic!("restricted table has a manifest bound");
+    };
+
+    // The compaction published the exact bound to the SST's `.restrict-bound`
+    // sidecar; it must read back as the manifest bound.
+    match crate::restrict_bound::read(&fs, &restricted.path, None)? {
+        crate::restrict_bound::SidecarRead::Present(_id, bound) => {
+            assert_eq!(
+                bound.as_slice(),
+                manifest_bound.as_ref(),
+                "the sidecar bound must equal the manifest restriction bound",
+            );
+        }
+        _ => panic!("a punched table must carry a valid .restrict-bound sidecar"),
+    }
+    Ok(())
+}
+
+/// The `.restrict-bound` sidecar is written STRICTLY AFTER the slice's version
+/// install commits, so a fault on that (post-commit) write is NOT fatal: the
+/// restriction is already durable in the manifest. The slice logs the failure and
+/// leaves that input UNPUNCHED (never punching an input whose sidecar did not
+/// land, which would force a later repair to derive a conservative bound and drop
+/// a live block), so the compaction still SUCCEEDS and a reopen reads every key at
+/// its latest value — no data loss, no resurrection.
+#[test]
+fn tight_space_sidecar_write_fault_is_nonfatal_and_recovers() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let capfs = capfs::CapacityFs::new();
+    let fault = FaultFs::new(capfs.clone());
+    let injector = fault.injector();
+    let shared: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let config = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .with_shared_fs(Arc::clone(&shared));
+    let tree = match config.open()? {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..TIGHT_SPACE_KEYS {
+        tree.insert(tight_space_key(i).as_bytes(), vec![0xCDu8; 64], i);
+    }
+    tree.flush_active_memtable(0)?;
+    let used = tree.storage_stats()?.used_bytes;
+
+    // Leave only a quarter of the footprint free so a full rewrite cannot fit and
+    // the compaction takes the tight-space slice-and-punch path, then fail EVERY
+    // `.restrict-bound` sidecar write (post-commit under commit-then-mark) so no
+    // restricted input is punched.
+    capfs.set_available_space(used / 4);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.tight_space_compaction = true;
+    })?;
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).on_path("restrict-bound"),
+    );
+
+    // The sidecar fault is post-commit, so the compaction SUCCEEDS (it does not
+    // roll back a committed slice). Space is quartered, so a normal rewrite cannot
+    // fit — a `Merged` action proves the tight-space slice-and-punch path engaged
+    // (a plain merge would have been skipped for lack of headroom, never reaching
+    // the faulted `.restrict-bound` write).
+    let result = match tree.major_compact(64 * 1024 * 1024, 0) {
+        Ok(r) => r,
+        Err(e) => panic!("a post-commit sidecar-write fault must not fail the compaction: {e:?}"),
+    };
+    assert_eq!(
+        result.action,
+        crate::compaction::CompactionAction::Merged,
+        "tight-space must have engaged and merged, got {result:?}",
+    );
+    // Every restricted input whose sidecar write faulted must stay UNPUNCHED: a
+    // punched prefix with no sidecar would force a later repair to derive a
+    // conservative bound and drop up to one live block. With every sidecar write
+    // faulted, no input is punched at all.
+    assert_eq!(
+        capfs.punched_bytes(),
+        0,
+        "an input whose restrict-bound sidecar failed to land must stay unpunched",
+    );
+
+    // Correctness: reopen and read every key at its latest value. The manifest
+    // committed the restriction, so the unpunched-and-sidecarless input's redundant
+    // prefix is routed to the installed output — nothing is lost or resurrected.
+    drop(tree);
+    let reopened = match Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::clone(&shared))
+    .open()?
+    {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..TIGHT_SPACE_KEYS {
+        let got = reopened.get(tight_space_key(i).as_bytes(), crate::MAX_SEQNO)?;
+        assert_eq!(
+            got.as_deref(),
+            Some(&[0xCDu8; 64][..]),
+            "key {i} must read its latest value after the sidecar-fault reopen",
         );
     }
+    Ok(())
+}
+
+/// The `.restrict-bound` sidecar is written STRICTLY AFTER the version install
+/// commits, so an install FAILURE leaves NO sidecar (nothing to retract) and the
+/// slice's finalized outputs must be rolled back at once (marked deleted, so their
+/// blocks free on drop) rather than orphaned to pin the scarce space until the
+/// next open's sweep. Faulting the edit-log append (the install's durable commit)
+/// must abort with that fault, leave no full-size orphan output, and leave no
+/// `.restrict-bound` sidecar behind.
+#[test]
+fn tight_space_install_failure_rolls_back_outputs_and_leaves_no_sidecar() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let capfs = capfs::CapacityFs::new();
+    let fault = FaultFs::new(capfs.clone());
+    let injector = fault.injector();
+    let shared: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let config = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .with_shared_fs(Arc::clone(&shared));
+    let tree = match config.open()? {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    for i in 0..TIGHT_SPACE_KEYS {
+        tree.insert(tight_space_key(i).as_bytes(), vec![0xCDu8; 64], i);
+    }
+    tree.flush_active_memtable(0)?;
+    let used = tree.storage_stats()?.used_bytes;
+
+    let tables_dir = dir.path().join(crate::file::TABLES_FOLDER);
+    let numeric_files = || -> Vec<(std::ffi::OsString, u64)> {
+        std::fs::read_dir(&tables_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .bytes()
+                    .all(|b| b.is_ascii_digit())
+            })
+            .filter_map(|e| e.metadata().ok().map(|m| (e.file_name(), m.len())))
+            .collect()
+    };
+    let inputs: crate::HashSet<std::ffi::OsString> =
+        numeric_files().into_iter().map(|(name, _)| name).collect();
+    assert!(
+        !inputs.is_empty(),
+        "the flush produced at least one input SST"
+    );
+    let sidecar_count = || -> usize {
+        std::fs::read_dir(&tables_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".restrict-bound"))
+            .count()
+    };
+
+    capfs.set_available_space(used / 4);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.tight_space_compaction = true;
+    })?;
+    // Fault the slice's version install: the edit-log append is its durable commit.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path("edits")
+            .once(),
+    );
+
+    // Pin the abort to the INJECTED fault: a bare `is_err()` would also pass if the
+    // tight-space path stopped engaging or the admission gate refused the compaction
+    // before any output was finalized, silently not exercising the rollback.
+    let result = tree.major_compact(64 * 1024 * 1024, 0);
+    assert!(
+        matches!(&result, Err(crate::Error::Io(e)) if e.kind() == ErrorKind::Other),
+        "the tight-space compaction must abort with the injected install fault, got {result:?}",
+    );
+
+    // No NEW full-size table file may survive: the aborted slice's finalized outputs
+    // were rolled back, not orphaned, so the scarce space is freed at once.
+    for (name, len) in numeric_files() {
+        assert!(
+            len == 0 || inputs.contains(&name),
+            "a finalized slice output ({name:?}, {len} bytes) was orphaned instead of \
+             rolled back after the install failed",
+        );
+    }
+    // The sidecar write is post-install, so an install failure leaves none behind:
+    // there is no uncommitted boundary a later repair could honor.
+    assert_eq!(
+        sidecar_count(),
+        0,
+        "an install failure must leave no `.restrict-bound` sidecar (it is written \
+         only after the install commits)",
+    );
+    Ok(())
+}
+
+/// A tight-space slice must NOT garbage-collect a tombstone whose deleted key also
+/// lives in a SURVIVING (restricted) input's consumed prefix. If it did, a crash
+/// window that leaves the survivor unrestricted (sidecar not written, prefix not
+/// punched) would let manifest repair — which rebuilds from `tables/` and treats
+/// the survivor as a full table — re-expose the deleted key: the tombstone-bearing
+/// sibling was fully consumed and, with bottommost GC, the compacted output dropped
+/// BOTH records. Tight-space slice outputs keep every record (GC is deferred to a
+/// later normal compaction), so the output still shadows the survivor's prefix and
+/// the deleted key stays deleted.
+#[test]
+fn tight_space_slice_retains_a_tombstone_for_an_unrestricted_repair_survivor() -> crate::Result<()>
+{
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use core::sync::atomic::Ordering;
+
+    let dir = tempfile::tempdir()?;
+    let capfs = capfs::CapacityFs::new();
+    let fault = FaultFs::new(capfs.clone());
+    let injector = fault.injector();
+    let shared: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let config = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_size_policy(BlockSizePolicy::all(512))
+    .with_shared_fs(Arc::clone(&shared));
+    let failpoint = config.fail_tight_after_first_slice.clone();
+    let tree = match config.open()? {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+
+    // Input B: every key as a live value — the broad input that survives the first
+    // slice (restricted), with the deleted key in its consumed prefix.
+    for i in 0..TIGHT_SPACE_KEYS {
+        tree.insert(tight_space_key(i).as_bytes(), vec![0xCDu8; 64], i);
+    }
+    tree.flush_active_memtable(0)?;
+    // Input T: a tombstone for the FIRST key (smallest, so it lands in the first
+    // slice's consumed prefix and T is fully consumed). Newer than B's value.
+    let deleted = tight_space_key(0);
+    tree.remove(deleted.as_bytes(), TIGHT_SPACE_KEYS);
+    tree.flush_active_memtable(0)?;
+    let used = tree.storage_stats()?.used_bytes;
+
+    capfs.set_available_space(used / 4);
+    tree.update_runtime_config(|c| {
+        c.storage_admission_check = true;
+        c.tight_space_compaction = true;
+    })?;
+    // Fault EVERY restrict-bound sidecar write so the surviving input is left with no
+    // sidecar and unpunched, then crash right after the first slice installs so the
+    // survivor is not consumed by the tail. Together: a committed restriction with no
+    // recoverable bound over a still-full input — exactly #40's window.
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).on_path("restrict-bound"),
+    );
+    failpoint.store(true, Ordering::SeqCst);
+
+    // A watermark above every live seqno so bottommost GC would (without the fix)
+    // drop the consumed tombstone.
+    assert!(
+        tree.major_compact(64 * 1024 * 1024, TIGHT_SPACE_KEYS + 1)
+            .is_err(),
+        "the crash failpoint must abort the tight-space compaction",
+    );
+    assert!(
+        !failpoint.load(Ordering::SeqCst),
+        "the failpoint must have fired after the first slice",
+    );
+    assert_eq!(
+        capfs.punched_bytes(),
+        0,
+        "the faulted-sidecar survivor must be left unpunched",
+    );
+
+    // Rebuild the manifest from `tables/`: the survivor has no sidecar and is
+    // unpunched, so repair recovers it UNRESTRICTED. Clear the fault first so the
+    // rebuild's own I/O is not faulted.
+    injector.clear();
+    drop(tree);
+    Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::clone(&shared))
+    .repair_with_salvage(true)?;
+
+    let reopened = match Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(shared)
+    .open()?
+    {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+    assert!(
+        reopened
+            .get(deleted.as_bytes(), crate::MAX_SEQNO)?
+            .is_none(),
+        "a tombstone consumed by a tight-space slice must not be GC'd away, or manifest \
+         repair of the unrestricted survivor resurrects the deleted key",
+    );
     Ok(())
 }
 
@@ -1084,5 +1742,180 @@ fn space_gate_for_merge_narrows_a_full_run_that_exceeds_free() -> crate::Result<
         super::SpaceGate::Skip => panic!("expected Narrowed, got Skip (no pair admitted)"),
     }
 
+    Ok(())
+}
+
+/// Every compaction-produced table must inherit the tree's shared deletion pause
+/// before it becomes visible. A flush registers it (via `register_tables`), but a
+/// compaction installs its outputs directly in `install_merge` — so without an
+/// explicit install, a Page-ECC compaction output's in-place heal would skip the
+/// checkpoint mutation window (`deletion_pause.get()` is `None`), race a
+/// checkpoint that hard-links the SST, and overwrite the shared inode.
+#[test]
+fn compaction_outputs_inherit_the_deletion_pause() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let tree = match Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?
+    {
+        crate::AnyTree::Standard(t) => t,
+        crate::AnyTree::Blob(_) => panic!("expected Standard tree"),
+    };
+
+    // Two flushes → two L0 tables, then a major compaction merges them into one
+    // output installed via `install_merge`.
+    for i in 0..100u64 {
+        tree.insert(format!("k{i:05}").as_bytes(), vec![1u8; 16], i);
+    }
+    tree.flush_active_memtable(0)?;
+    for i in 100..200u64 {
+        tree.insert(format!("k{i:05}").as_bytes(), vec![1u8; 16], i);
+    }
+    tree.flush_active_memtable(0)?;
+    tree.major_compact(64 * 1024 * 1024, 0)?;
+
+    let version = tree.current_version();
+    let tables: Vec<_> = version.iter_tables().collect();
+    assert!(
+        !tables.is_empty(),
+        "the major compaction produced an output"
+    );
+    for t in &tables {
+        assert!(
+            t.deletion_pause.get().is_some(),
+            "compaction output table {} must inherit the deletion pause",
+            t.id(),
+        );
+    }
+    Ok(())
+}
+
+/// Builds a one-flush blob tree on `capfs`, then arms the tight-space prefix
+/// reclaim on its blob file and releases every reference so the drop path runs.
+/// Returns the bytes the reclaim punched.
+fn punch_blob_prefix_on_drop(capfs: &capfs::CapacityFs, link_count: u64) -> crate::Result<u64> {
+    use crate::{Config, KvSeparationOptions, SequenceNumberCounter};
+
+    let dir = tempfile::tempdir()?;
+    let tree = match Config::new(
+        &dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(capfs.clone()))
+    .with_kv_separation(Some(
+        KvSeparationOptions::default().separation_threshold(64),
+    ))
+    .open()?
+    {
+        crate::AnyTree::Blob(t) => t,
+        crate::AnyTree::Standard(_) => panic!("expected Blob tree"),
+    };
+
+    for i in 0..64u64 {
+        tree.insert(format!("k{i:05}").as_bytes(), vec![b'v'; 256], i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let blob = {
+        let version = tree.index.current_version();
+        let Some(bf) = version.blob_files.iter().next().cloned() else {
+            panic!("the flush spilled at least one blob file");
+        };
+        bf
+    };
+    let physical = blob.physical_size()?;
+    assert!(physical > 0, "the blob file has bytes to reclaim");
+
+    // The link count the reclaim probes: 1 = exclusively owned, 2 = an inode a
+    // checkpoint has hard-linked.
+    capfs.set_link_count(link_count);
+
+    // Arm the reclaim, then release EVERY reference (the tree's version holds
+    // one too) so the blob file's drop path — the code under test — runs.
+    blob.mark_punch_on_drop(physical);
+    drop(blob);
+    drop(tree);
+    Ok(capfs.punched_bytes())
+}
+
+/// A blob file whose consumed prefix was reclaimed in place must still verify
+/// clean: its recorded digest covers the LIVE SUFFIX from the frontier, and
+/// integrity checks hash from there. Hashing the whole file would fold in the
+/// punched (zeroed) prefix and report every successfully reclaimed blob file —
+/// and every checkpoint taken from that tree — as corrupt.
+#[test]
+fn reclaimed_blob_file_verifies_against_its_live_suffix() -> crate::Result<()> {
+    use crate::fs::Fs as _;
+
+    let dir = tempfile::tempdir()?;
+    let capfs = capfs::CapacityFs::new();
+    let tree = match Config::new(
+        &dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(capfs.clone()))
+    .with_kv_separation(Some(
+        KvSeparationOptions::default().separation_threshold(64),
+    ))
+    .open()?
+    {
+        crate::AnyTree::Blob(t) => t,
+        crate::AnyTree::Standard(_) => panic!("expected Blob tree"),
+    };
+    for i in 0..64u64 {
+        tree.insert(format!("k{i:05}").as_bytes(), vec![b'v'; 256], i);
+    }
+    tree.flush_active_memtable(0)?;
+
+    let blob = {
+        let version = tree.index.current_version();
+        let Some(bf) = version.blob_files.iter().next().cloned() else {
+            panic!("the flush spilled at least one blob file");
+        };
+        bf
+    };
+
+    // Install the restricted view the relocation slice would install, then
+    // punch the prefix it declares dead — the exact on-disk shape a completed
+    // reclaim leaves behind.
+    let frontier = blob.physical_size()? / 2;
+    let restricted = blob.reopen_restricted(frontier)?;
+    capfs.punch_hole(blob.path(), 0, frontier)?;
+
+    let got = crate::verify::stream_checksum_from(restricted.path(), restricted.live_data_start())?;
+    assert_eq!(
+        got,
+        restricted.checksum(),
+        "a reclaimed blob file must verify against its live suffix, not the \
+         punched prefix",
+    );
+    Ok(())
+}
+
+/// A tight-space blob-prefix reclaim must NOT punch an inode a checkpoint has
+/// hard-linked: the checkpoint's captured SSTs still reference values in that
+/// prefix, so zeroing it destroys data inside the supposedly immutable
+/// snapshot. The delete path already probes the link count before truncating;
+/// the punch path must apply the same guard. The exclusively-owned case is the
+/// positive control — it proves the reclaim really fires in this fixture.
+#[test]
+fn blob_prefix_reclaim_skips_a_hard_linked_inode() -> crate::Result<()> {
+    let owned = punch_blob_prefix_on_drop(&capfs::CapacityFs::new(), 1)?;
+    assert!(
+        owned > 0,
+        "control: an exclusively-owned blob file must have its prefix reclaimed",
+    );
+
+    let shared = punch_blob_prefix_on_drop(&capfs::CapacityFs::new(), 2)?;
+    assert_eq!(
+        shared, 0,
+        "a blob file shared with a checkpoint must not be punched: the snapshot \
+         still references values in the reclaimed prefix",
+    );
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -551,6 +551,14 @@ pub struct Config {
     /// satisfy it vacuously.
     pub(crate) directory_lock: bool,
 
+    /// Shared live-progress counters the repair / salvage paths tick while
+    /// they run, or `None` (the default) to skip publishing. Set via
+    /// [`Config::with_recovery_progress`]; observed by polling
+    /// [`RecoveryProgress::snapshot`](crate::RecoveryProgress::snapshot) from
+    /// another thread.
+    #[cfg(feature = "std")]
+    pub(crate) recovery_progress: Option<Arc<crate::RecoveryProgress>>,
+
     /// Edit-log size (bytes) past which the next manifest persist rotates: it
     /// writes a fresh full snapshot and starts an empty log instead of appending
     /// another [`VersionEdit`](crate::version::edit::VersionEdit). Bounds both
@@ -733,6 +741,8 @@ impl Default for Config {
             manifest_recovery_mode: ManifestRecoveryMode::AbsoluteConsistency,
             sync_mode: SyncMode::Normal,
             directory_lock: true,
+            #[cfg(feature = "std")]
+            recovery_progress: None,
             manifest_log_rotate_bytes: 1024 * 1024,
             compaction_rate_limit: 0,
 
@@ -1192,6 +1202,39 @@ impl Config {
     #[must_use]
     pub fn with_directory_lock(mut self, enabled: bool) -> Self {
         self.directory_lock = enabled;
+        self
+    }
+
+    /// Wires shared live-progress counters into the repair / salvage paths.
+    ///
+    /// A repair over a large store streams every SST and blob file and can run
+    /// for a long time; the handle set here is ticked as files are discovered
+    /// and blocks / rows are recovered, so another thread can poll
+    /// [`RecoveryProgress::snapshot`](crate::RecoveryProgress::snapshot) while
+    /// [`Config::repair`] (or a salvage it triggers) runs. Without it, repair
+    /// publishes no progress (zero overhead).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use lsm_tree::{Config, RecoveryProgress, SequenceNumberCounter};
+    /// use std::sync::Arc;
+    ///
+    /// let progress = Arc::new(RecoveryProgress::default());
+    /// let config = Config::new(
+    ///     "my-tree",
+    ///     SequenceNumberCounter::default(),
+    ///     SequenceNumberCounter::default(),
+    /// )
+    /// .with_recovery_progress(progress.clone());
+    /// // spawn the repair, then poll `progress.snapshot()` elsewhere
+    /// let report = config.repair()?;
+    /// # Ok::<_, lsm_tree::Error>(())
+    /// ```
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn with_recovery_progress(mut self, progress: Arc<crate::RecoveryProgress>) -> Self {
+        self.recovery_progress = Some(progress);
         self
     }
 

--- a/src/deletion_pause.rs
+++ b/src/deletion_pause.rs
@@ -57,6 +57,17 @@ pub struct DeletionPause {
 
     /// Paths queued for removal while at least one pause was active.
     queue: Mutex<Vec<QueuedDeletion>>,
+
+    /// Excludes a checkpoint's hard-link window from in-place file mutation
+    /// (the ECC autoheal): a checkpoint that links an SST between the heal's
+    /// link-count probe and its write-back would capture bytes the heal is
+    /// about to change, under a digest its immutable manifest already
+    /// recorded. Mutators hold the read side (distinct tables heal in
+    /// parallel), a checkpoint holds the write side for its whole copy/link
+    /// pass. `parking_lot` (not `spin`): both windows are long-lived,
+    /// blocking operations, so spinning would burn a core.
+    #[cfg(feature = "std")]
+    link_gate: parking_lot::RwLock<()>,
 }
 
 #[cfg_attr(
@@ -76,7 +87,8 @@ impl core::fmt::Debug for DeletionPause {
         f.debug_struct("DeletionPause")
             .field("active", &self.active.load(Ordering::Relaxed))
             .field("queued", &self.queue.lock().len())
-            .finish()
+            // `link_gate` is omitted: a lock has no meaningful debug state.
+            .finish_non_exhaustive()
     }
 }
 
@@ -140,6 +152,21 @@ impl DeletionPause {
         Pause {
             inner: Arc::clone(self),
         }
+    }
+
+    /// Enters an in-place-mutation window (blocks while a checkpoint's
+    /// link window is open). Mutators of DISTINCT files may hold windows
+    /// concurrently; see the `link_gate` field docs.
+    #[cfg(feature = "std")]
+    pub(crate) fn enter_mutation_window(&self) -> parking_lot::RwLockReadGuard<'_, ()> {
+        self.link_gate.read()
+    }
+
+    /// Enters a checkpoint link window (blocks while any in-place-mutation
+    /// window is open, and excludes new ones until dropped).
+    #[cfg(feature = "std")]
+    pub(crate) fn enter_link_window(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.link_gate.write()
     }
 }
 

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -244,10 +244,18 @@ pub struct Aes256GcmProvider {
     /// ([`encrypt_block_aad`](EncryptionProvider::encrypt_block_aad)). The
     /// opaque [`encrypt`](EncryptionProvider::encrypt) (manifest subsystem) uses
     /// `cipher` directly; the block path looks the key up by epoch here.
+    ///
+    /// This and the two fields below form the AAD-bound block state, read only by
+    /// `encrypt_block_aad` / `decrypt_block_aad`. Those entry points are
+    /// `zstd_any`-gated (they wrap the zstd `SkippableFrame`), so without zstd the
+    /// provider cannot do block AAD and these fields are unused — gate them with it.
+    #[cfg(zstd_any)]
     key_chain: crate::encryption::key_chain::StaticKeyChain,
     /// Active key epoch sealed into every block's `MetadataFrame`.
+    #[cfg(zstd_any)]
     key_epoch: u8,
     /// AEAD suite tag (AES-256-GCM) mirrored into the AAD.
+    #[cfg(zstd_any)]
     suite_id: crate::encryption::aad::SuiteId,
 }
 
@@ -274,8 +282,11 @@ impl Aes256GcmProvider {
             cipher: aes_gcm::Aes256Gcm::new(key.into()),
             // Single-epoch shortcut: the one supplied key is epoch 0. Deployments
             // that rotate keys construct a provider over a multi-epoch chain.
+            #[cfg(zstd_any)]
             key_chain: crate::encryption::key_chain::StaticKeyChain::new().with_key(0, *key),
+            #[cfg(zstd_any)]
             key_epoch: 0,
+            #[cfg(zstd_any)]
             suite_id: crate::encryption::aad::SuiteId::Aes256Gcm,
         }
     }

--- a/src/file_accessor.rs
+++ b/src/file_accessor.rs
@@ -41,6 +41,16 @@ impl FileAccessor {
         }
     }
 
+    /// Whether later accesses can be RETARGETED at a replacement inode:
+    /// the descriptor-table variant re-resolves the path after a cache
+    /// eviction, while a pinned FD is bound to its inode for the table's
+    /// lifetime (the in-place heal's unshare must refuse the detach then —
+    /// a rename would leave every later read on the dead inode).
+    #[must_use]
+    pub fn can_retarget(&self) -> bool {
+        matches!(self, Self::DescriptorTable { .. })
+    }
+
     /// Returns a table FD, opening via [`Fs`] on descriptor-table cache miss.
     ///
     /// Returns `(fd, None)` for pinned FDs (no cache involved),

--- a/src/format_version.rs
+++ b/src/format_version.rs
@@ -52,20 +52,18 @@
 /// 2. If that layer's current value has shipped to crates.io,
 ///    add a new variant / constant instead of amending in place.
 /// 3. The OTHER layer's value stays unless its layer also changed.
+/// ## Supported versions
+///
+/// **V5 is the ONLY supported on-disk format.** The engine neither reads
+/// nor migrates pre-V5 layouts: there are no legacy decode paths, no
+/// upgrade tooling, and no backward-compat variations anywhere in the
+/// codebase. Discriminants 1–4 are reserved history — opening a tree that
+/// carries one fails with [`crate::Error::InvalidVersion`] at the manifest
+/// gate. The same single-format rule applies to every subsidiary format
+/// (blob frames, manifest layout): each has exactly one readable shape,
+/// the one the current writer emits.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FormatVersion {
-    /// Version for 1.x.x releases
-    V1 = 1,
-
-    /// Version for 2.x.x releases
-    V2,
-
-    /// Version for 3.x.x releases
-    V3,
-
-    /// Version for range-tombstone SST semantics
-    V4,
-
     /// Two on-disk changes shipped together in this format version
     /// (V5 had not been released when both landed, so they collapse
     /// into the same version bump):
@@ -94,10 +92,10 @@ pub enum FormatVersion {
     ///    fails fast at block header decode rather than misreading the
     ///    new layout.
     ///
-    /// V3 / V4 ↔ V5 incompatibility is enforced primarily by the
+    /// Pre-V5 ↔ V5 incompatibility is enforced primarily by the
     /// manifest version gate at `Tree::open` (returns
     /// `InvalidVersion` for anything other than V5).
-    V5,
+    V5 = 5,
 }
 
 impl core::fmt::Display for FormatVersion {
@@ -109,10 +107,6 @@ impl core::fmt::Display for FormatVersion {
 impl From<FormatVersion> for u8 {
     fn from(value: FormatVersion) -> Self {
         match value {
-            FormatVersion::V1 => 1,
-            FormatVersion::V2 => 2,
-            FormatVersion::V3 => 3,
-            FormatVersion::V4 => 4,
             FormatVersion::V5 => 5,
         }
     }
@@ -121,12 +115,12 @@ impl From<FormatVersion> for u8 {
 impl TryFrom<u8> for FormatVersion {
     type Error = ();
 
+    /// Only the V5 discriminant decodes. Discriminants 1–4 named retired
+    /// formats no shipped reader supports; they fail here so the manifest
+    /// gate reports `InvalidVersion` instead of any code path pretending
+    /// a legacy layout is readable.
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            1 => Ok(Self::V1),
-            2 => Ok(Self::V2),
-            3 => Ok(Self::V3),
-            4 => Ok(Self::V4),
             5 => Ok(Self::V5),
             _ => Err(()),
         }

--- a/src/fs/crash_fs.rs
+++ b/src/fs/crash_fs.rs
@@ -209,12 +209,12 @@ impl CrashFs {
     /// The source's durable image comes from one of two places: an entry already
     /// in `durable` (synced or captured this run), or, for a source that is
     /// pre-existing and never touched this run, its on-disk baseline (the same
-    /// "current contents are initially durable" rule [`capture_first_touch`]
+    /// "current contents are initially durable" rule [`Self::capture_first_touch`]
     /// applies). A source that is touched but not durable holds un-synced bytes,
     /// so the copy correctly inherits no durable image and a crash removes it.
     ///
     /// Reads the baseline outside the state lock (mirroring
-    /// [`capture_first_touch`]) so backend I/O never runs under the mutex.
+    /// [`Self::capture_first_touch`]) so backend I/O never runs under the mutex.
     fn track_copy(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let (src_durable, src_touched) = {
             let state = self.state.lock();
@@ -369,6 +369,10 @@ impl Fs for CrashFs {
     fn available_space(&self, path: &Path) -> io::Result<u64> {
         self.inner.available_space(path)
     }
+
+    fn allocated_size(&self, path: &Path) -> io::Result<Option<u64>> {
+        self.inner.allocated_size(path)
+    }
 }
 
 /// A file handle that records its durable image on `fsync`.
@@ -441,6 +445,10 @@ impl FsFile for CrashFile {
 
     fn metadata(&self) -> io::Result<FsMetadata> {
         self.inner.metadata()
+    }
+
+    fn hard_link_count(&self) -> io::Result<u64> {
+        self.inner.hard_link_count()
     }
 
     fn set_len(&self, size: u64) -> io::Result<()> {

--- a/src/fs/fault_fs.rs
+++ b/src/fs/fault_fs.rs
@@ -84,6 +84,26 @@ pub enum FaultOp {
     SyncData,
     /// [`FsFile::set_len`] — truncate / extend.
     SetLen,
+    /// [`Fs::metadata`] — path metadata probe (existence / size). Failing it
+    /// models a stat that races file creation or an inaccessible path, e.g. to
+    /// exercise TOCTOU windows between an existence check and an open.
+    Metadata,
+    /// [`FsFile::hard_link_count`] — link-count probe consulted before
+    /// in-place mutation. Failing it exercises the fail-closed path (treat
+    /// the file as shared).
+    HardLinkCount,
+    /// [`Fs::hard_link`] — the destination link of a copy-style publish.
+    /// Failing it with [`io::ErrorKind::Unsupported`] models a backend that
+    /// leaves the trait default in place (no hard-link support).
+    HardLink,
+    /// [`Fs::allocated_size`] — the physical-allocation probe manifest repair
+    /// uses to detect a hole-punched SST. Failing it exercises the fail-closed
+    /// path (a probe error must not be read as "unpunched").
+    AllocatedSize,
+    /// [`Fs::punch_hole`] — the tight-space per-block prefix reclaim. Failing
+    /// it exercises the partial-punch geometry recovery (the reclaim stops at
+    /// the first failed punch so the resulting hole pattern stays classifiable).
+    PunchHole,
 }
 
 /// What a matched [`FaultRule`] does to the operation.
@@ -112,6 +132,7 @@ pub enum Fault {
 pub struct FaultRule {
     op: FaultOp,
     path_substr: Option<String>,
+    offset: Option<u64>,
     skip: u64,
     count: u64,
     fault: Fault,
@@ -120,13 +141,14 @@ pub struct FaultRule {
 impl FaultRule {
     /// Creates a rule that, by default, fires `fault` on **every** matching
     /// `op` (no path filter, no skip, unlimited fires). Refine with
-    /// [`on_path`](Self::on_path), [`skip`](Self::skip),
-    /// [`times`](Self::times), or [`once`](Self::once).
+    /// [`on_path`](Self::on_path), [`at_offset`](Self::at_offset),
+    /// [`skip`](Self::skip), [`times`](Self::times), or [`once`](Self::once).
     #[must_use]
     pub const fn new(op: FaultOp, fault: Fault) -> Self {
         Self {
             op,
             path_substr: None,
+            offset: None,
             skip: 0,
             count: u64::MAX,
             fault,
@@ -139,6 +161,25 @@ impl FaultRule {
     #[must_use]
     pub fn on_path(mut self, substr: impl Into<String>) -> Self {
         self.path_substr = Some(substr.into());
+        self
+    }
+
+    /// Restricts a [`FaultOp::ReadAt`] rule to positioned reads at exactly
+    /// `offset`. Lets a test fault ONE section of a file (e.g. a single data
+    /// block) while every other positioned read on the same file proceeds, so
+    /// a fault can isolate one decode-load from the reads a recovery pass makes
+    /// on the same path. Only [`FaultOp::ReadAt`] carries an offset: setting one
+    /// on any other op makes the rule UNMATCHABLE (it never fires), so the debug
+    /// assertion below catches that mistake instead of silently disabling it.
+    #[must_use]
+    pub fn at_offset(mut self, offset: u64) -> Self {
+        debug_assert!(
+            matches!(self.op, FaultOp::ReadAt),
+            "at_offset only applies to FaultOp::ReadAt; setting it on {:?} makes the rule \
+             unmatchable",
+            self.op,
+        );
+        self.offset = Some(offset);
         self
     }
 
@@ -165,10 +206,32 @@ impl FaultRule {
     }
 
     /// Returns `true` if this rule matches an operation of `op` at `path`.
+    ///
+    /// Offset-scoped rules ([`at_offset`](Self::at_offset)) never match here:
+    /// only the offset-aware [`FaultInjector::check_read_at`] path can fire
+    /// them, since a positioned offset is meaningful only for
+    /// [`FaultOp::ReadAt`].
     fn matches(&self, op: FaultOp, path: Option<&Path>) -> bool {
-        if self.op != op {
+        if self.op != op || self.offset.is_some() {
             return false;
         }
+        self.matches_path(path)
+    }
+
+    /// Returns `true` if this [`FaultOp::ReadAt`] rule matches a positioned read
+    /// at `offset` on `path`. An unset [`at_offset`](Self::at_offset) matches
+    /// any offset; a set one matches only that exact offset.
+    fn matches_read_at(&self, path: Option<&Path>, offset: u64) -> bool {
+        if self.op != FaultOp::ReadAt {
+            return false;
+        }
+        if self.offset.is_some_and(|want| want != offset) {
+            return false;
+        }
+        self.matches_path(path)
+    }
+
+    fn matches_path(&self, path: Option<&Path>) -> bool {
         match (&self.path_substr, path) {
             (None, _) => true,
             (Some(sub), Some(p)) => p.to_string_lossy().contains(sub.as_str()),
@@ -187,6 +250,11 @@ impl FaultRule {
 #[derive(Default)]
 pub struct FaultInjector {
     rules: spin::Mutex<Vec<FaultRule>>,
+    /// Observed `(path, mode)` pairs from every file-level `sync_all_with` /
+    /// `sync_data_with`, in call order — lets a test assert WHICH durability
+    /// mode a component synced its files at (e.g. a salvage writer honouring
+    /// `Config::sync_mode`), which the pass-through delegation cannot show.
+    sync_log: spin::Mutex<Vec<(PathBuf, SyncMode)>>,
 }
 
 impl FaultInjector {
@@ -204,9 +272,30 @@ impl FaultInjector {
         self.rules.lock().push(rule);
     }
 
-    /// Removes all armed rules.
+    /// Removes all armed rules AND the recorded sync observations, resetting the
+    /// injector so a later phase cannot see state (rules or `sync_modes_for`
+    /// entries) recorded before the `clear()`.
     pub fn clear(&self) {
         self.rules.lock().clear();
+        self.sync_log.lock().clear();
+    }
+
+    /// Records one file-level mode-carrying sync observation (see
+    /// [`Self::sync_modes_for`]).
+    fn record_sync(&self, path: &Path, mode: SyncMode) {
+        self.sync_log.lock().push((path.to_path_buf(), mode));
+    }
+
+    /// The [`SyncMode`]s observed via `sync_all_with` / `sync_data_with` on
+    /// files whose path contains `substr`, in call order.
+    #[must_use]
+    pub fn sync_modes_for(&self, substr: &str) -> Vec<SyncMode> {
+        self.sync_log
+            .lock()
+            .iter()
+            .filter(|(p, _)| p.to_string_lossy().contains(substr))
+            .map(|(_, m)| *m)
+            .collect()
     }
 
     /// Consults the rules for an operation of `op` at `path`, advancing the
@@ -218,20 +307,40 @@ impl FaultInjector {
             if !rule.matches(op, path) {
                 continue;
             }
-            // First matching rule owns this occurrence.
-            if rule.skip > 0 {
-                rule.skip -= 1;
-                return None;
-            }
-            if rule.count == 0 {
-                return None;
-            }
-            if rule.count != u64::MAX {
-                rule.count -= 1;
-            }
-            return Some(rule.fault);
+            return Self::fire(rule);
         }
         None
+    }
+
+    /// Consults the rules for a positioned [`FaultOp::ReadAt`] at `offset` on
+    /// `path`, honouring an [`at_offset`](FaultRule::at_offset) scope. Advances
+    /// the matched rule's skip/fire counters exactly like [`check`](Self::check).
+    fn check_read_at(&self, path: Option<&Path>, offset: u64) -> Option<Fault> {
+        let mut rules = self.rules.lock();
+        for rule in rules.iter_mut() {
+            if !rule.matches_read_at(path, offset) {
+                continue;
+            }
+            return Self::fire(rule);
+        }
+        None
+    }
+
+    /// Advances a matched rule's skip/fire budget and returns the [`Fault`] to
+    /// apply, or `None` when the rule is still skipping or is exhausted. The
+    /// first matching rule owns the occurrence.
+    fn fire(rule: &mut FaultRule) -> Option<Fault> {
+        if rule.skip > 0 {
+            rule.skip -= 1;
+            return None;
+        }
+        if rule.count == 0 {
+            return None;
+        }
+        if rule.count != u64::MAX {
+            rule.count -= 1;
+        }
+        Some(rule.fault)
     }
 }
 
@@ -338,6 +447,9 @@ impl<F: Fs> Fs for FaultFs<F> {
     }
 
     fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::Metadata, Some(path)) {
+            return Err(fault_error(kind, FaultOp::Metadata));
+        }
         self.inner.metadata(path)
     }
 
@@ -356,10 +468,20 @@ impl<F: Fs> Fs for FaultFs<F> {
     }
 
     fn exists(&self, path: &Path) -> io::Result<bool> {
+        // A `Metadata` fault on an existence probe models a stat that RACED file
+        // creation and saw the path absent (the TOCTOU window `FaultOp::Metadata`
+        // documents): report `Ok(false)` so the caller proceeds to create/open,
+        // where a concurrent creator's file then surfaces as `AlreadyExists`.
+        if let Some(Fault::Error(_)) = self.injector.check(FaultOp::Metadata, Some(path)) {
+            return Ok(false);
+        }
         self.inner.exists(path)
     }
 
     fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::HardLink, Some(dst)) {
+            return Err(fault_error(kind, FaultOp::HardLink));
+        }
         self.inner.hard_link(src, dst)
     }
 
@@ -380,6 +502,9 @@ impl<F: Fs> Fs for FaultFs<F> {
     }
 
     fn punch_hole(&self, path: &Path, offset: u64, len: u64) -> io::Result<()> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::PunchHole, Some(path)) {
+            return Err(fault_error(kind, FaultOp::PunchHole));
+        }
         self.inner.punch_hole(path, offset, len)
     }
 
@@ -392,11 +517,21 @@ impl<F: Fs> Fs for FaultFs<F> {
     }
 
     fn hard_link_count(&self, path: &Path) -> io::Result<u64> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::HardLinkCount, Some(path)) {
+            return Err(fault_error(kind, FaultOp::HardLinkCount));
+        }
         self.inner.hard_link_count(path)
     }
 
     fn available_space(&self, path: &Path) -> io::Result<u64> {
         self.inner.available_space(path)
+    }
+
+    fn allocated_size(&self, path: &Path) -> io::Result<Option<u64>> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::AllocatedSize, Some(path)) {
+            return Err(fault_error(kind, FaultOp::AllocatedSize));
+        }
+        self.inner.allocated_size(path)
     }
 }
 
@@ -475,6 +610,7 @@ impl FsFile for FaultFile {
     }
 
     fn sync_all_with(&self, mode: SyncMode) -> io::Result<()> {
+        self.injector.record_sync(&self.path, mode);
         if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::SyncAll, Some(&self.path)) {
             return Err(fault_error(kind, FaultOp::SyncAll));
         }
@@ -482,6 +618,7 @@ impl FsFile for FaultFile {
     }
 
     fn sync_data_with(&self, mode: SyncMode) -> io::Result<()> {
+        self.injector.record_sync(&self.path, mode);
         if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::SyncData, Some(&self.path)) {
             return Err(fault_error(kind, FaultOp::SyncData));
         }
@@ -489,7 +626,20 @@ impl FsFile for FaultFile {
     }
 
     fn metadata(&self) -> io::Result<FsMetadata> {
+        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::Metadata, Some(&self.path)) {
+            return Err(fault_error(kind, FaultOp::Metadata));
+        }
         self.inner.metadata()
+    }
+
+    fn hard_link_count(&self) -> io::Result<u64> {
+        if let Some(Fault::Error(kind)) = self
+            .injector
+            .check(FaultOp::HardLinkCount, Some(&self.path))
+        {
+            return Err(fault_error(kind, FaultOp::HardLinkCount));
+        }
+        self.inner.hard_link_count()
     }
 
     fn set_len(&self, size: u64) -> io::Result<()> {
@@ -500,7 +650,7 @@ impl FsFile for FaultFile {
     }
 
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-        if let Some(Fault::Error(kind)) = self.injector.check(FaultOp::ReadAt, Some(&self.path)) {
+        if let Some(Fault::Error(kind)) = self.injector.check_read_at(Some(&self.path), offset) {
             return Err(fault_error(kind, FaultOp::ReadAt));
         }
         self.inner.read_at(buf, offset)

--- a/src/fs/fault_fs/tests.rs
+++ b/src/fs/fault_fs/tests.rs
@@ -321,6 +321,35 @@ fn every_hookable_op_faults_when_armed() -> io::Result<()> {
 }
 
 #[test]
+fn hard_link_count_path_accessor_faults_when_armed() {
+    // The path-based `Fs::hard_link_count` accessor (used by the blob-file and
+    // table reclaim probes) must consult the injector, not delegate blind, so an
+    // armed `FaultOp::HardLinkCount` exercises its fail-closed path. MemFs's path
+    // accessor is `Unsupported`; the injected fault must override it with `Other`,
+    // which a blind delegation could not do.
+    let fs = FaultFs::new(MemFs::new());
+    let inj = fs.injector();
+
+    let unarmed = fs
+        .hard_link_count(Path::new("/d/f"))
+        .expect_err("MemFs's path accessor is Unsupported");
+    assert_eq!(unarmed.kind(), ErrorKind::Unsupported);
+
+    inj.arm(FaultRule::new(
+        FaultOp::HardLinkCount,
+        Fault::Error(ErrorKind::Other),
+    ));
+    let armed = fs
+        .hard_link_count(Path::new("/d/f"))
+        .expect_err("an armed FaultOp::HardLinkCount must gate the path accessor");
+    assert_eq!(
+        armed.kind(),
+        ErrorKind::Other,
+        "the injected fault must gate the path-based accessor, not delegate blind",
+    );
+}
+
+#[test]
 fn path_filtered_rule_never_matches_a_pathless_op() {
     // A rule with a path filter matches only operations that carry a path; a
     // path-less op (none of the current hook sites produce one, but the match

--- a/src/fs/io_uring_fs.rs
+++ b/src/fs/io_uring_fs.rs
@@ -238,6 +238,13 @@ impl Fs for IoUringFs {
         super::statvfs_available_space(path).map_err(crate::io::Error::from)
     }
 
+    fn allocated_size(&self, path: &Path) -> crate::io::Result<Option<u64>> {
+        // Cold-path stat; the shared unix helper reads `st_blocks` (this backend
+        // is Linux-only, so `std::fs::metadata` is available). A stat failure
+        // propagates as `Err` rather than being masked as `None` (unpunched).
+        Ok(super::unix_allocated_size(path)?)
+    }
+
     fn sync_directory(&self, path: &Path) -> crate::io::Result<()> {
         let dir = File::open(path)?;
         if !dir.metadata()?.is_dir() {
@@ -323,6 +330,11 @@ impl FsFile for IoUringFile {
             is_dir: m.is_dir(),
             is_file: m.is_file(),
         })
+    }
+
+    fn hard_link_count(&self) -> crate::io::Result<u64> {
+        use std::os::unix::fs::MetadataExt as _;
+        Ok(self.file.metadata()?.nlink())
     }
 
     fn set_len(&self, size: u64) -> crate::io::Result<()> {

--- a/src/fs/io_uring_raw.rs
+++ b/src/fs/io_uring_raw.rs
@@ -444,6 +444,10 @@ struct Statx {
 pub struct RawMetadata {
     /// File length in bytes (`stx_size`).
     pub size: u64,
+    /// Number of hard links to the underlying inode (`stx_nlink`). A count above
+    /// 1 means another name shares the same bytes, so in-place mutation would
+    /// rewrite that snapshot too.
+    pub nlink: u64,
     /// Whether the entry is a directory (`S_IFDIR`).
     pub is_dir: bool,
     /// Whether the entry is a regular file (`S_IFREG`).
@@ -475,6 +479,7 @@ pub fn fstat_raw(fd: i32) -> Result<RawMetadata, Error> {
     let kind = buf.stx_mode & S_IFMT;
     Ok(RawMetadata {
         size: buf.stx_size,
+        nlink: u64::from(buf.stx_nlink),
         is_dir: kind == S_IFDIR,
         is_file: kind == S_IFREG,
     })
@@ -640,6 +645,7 @@ pub fn statx_path_raw(path: &core::ffi::CStr) -> Result<Option<RawMetadata>, Err
             let kind = buf.stx_mode & S_IFMT;
             Ok(Some(RawMetadata {
                 size: buf.stx_size,
+                nlink: u64::from(buf.stx_nlink),
                 is_dir: kind == S_IFDIR,
                 is_file: kind == S_IFREG,
             }))
@@ -822,6 +828,13 @@ impl FsFile for IoUringRawFile {
             is_dir: m.is_dir,
             is_file: m.is_file,
         })
+    }
+
+    fn hard_link_count(&self) -> crate::io::Result<u64> {
+        // `statx` on the open descriptor reports `stx_nlink`, so the in-place
+        // heal path gets a real count instead of the `Unsupported` default that
+        // would make it conservatively skip every reclaim.
+        Ok(fstat_raw(self.fd)?.nlink)
     }
 
     fn set_len(&self, size: u64) -> crate::io::Result<()> {

--- a/src/fs/io_uring_raw/tests.rs
+++ b/src/fs/io_uring_raw/tests.rs
@@ -32,6 +32,14 @@ fn raw_file_fsfile_round_trips() {
         "metadata len must match what was written"
     );
 
+    // statx-backed hard-link count: a freshly created file has exactly one link
+    // (not the `Unsupported` default that would make in-place heal skip reclaim).
+    assert_eq!(
+        FsFile::hard_link_count(&file).expect("hard_link_count"),
+        1,
+        "a freshly created file has a single hard link"
+    );
+
     // Positioned fill-or-EOF read returns the exact bytes.
     let mut rb = vec![0u8; payload.len()];
     let n = FsFile::read_at(&file, &mut rb, 0).expect("read_at");

--- a/src/fs/mem_fs.rs
+++ b/src/fs/mem_fs.rs
@@ -509,6 +509,12 @@ impl FsFile for MemFile {
         })
     }
 
+    // MemFs has no inode concept ([`Fs::hard_link`] copies), so a file can
+    // never share its bytes with another name: the count is exactly 1.
+    fn hard_link_count(&self) -> io::Result<u64> {
+        Ok(1)
+    }
+
     fn set_len(&self, size: u64) -> io::Result<()> {
         if !self.writable {
             return Err(io::Error::other("set_len requires write access"));
@@ -971,6 +977,23 @@ impl Fs for MemFs {
         } else {
             Ok(capacity.saturating_sub(self.stored_bytes()))
         }
+    }
+
+    fn allocated_size(&self, path: &Path) -> io::Result<Option<u64>> {
+        let state = read_state(&self.state)?;
+        let Some(data) = state.files.get(path) else {
+            return Ok(None);
+        };
+        // Physically-backed bytes = logical length minus the bytes punched out of
+        // it (clipped to the current length), mirroring `stored_bytes`. A punched
+        // file reports `allocated < len`; a never-punched file reports `len`. The
+        // subtraction never underflows: `clipped_punched_len` clips to `len`.
+        let len = lock(data)?.len() as u64;
+        let punched = state
+            .punched
+            .get(path)
+            .map_or(0, |ranges| clipped_punched_len(ranges, len));
+        Ok(Some(len - punched))
     }
 
     fn sync_directory(&self, path: &Path) -> io::Result<()> {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -456,6 +456,33 @@ pub trait FsFile: Read + Write + Seek + Send + Sync {
     /// Returns an I/O error if metadata cannot be retrieved.
     fn metadata(&self) -> io::Result<FsMetadata>;
 
+    /// Returns the number of directory entries (hard links) referring to this
+    /// file's underlying object.
+    ///
+    /// In-place mutation paths consult this before writing through a path:
+    /// a count above 1 means another name (typically a checkpoint) shares the
+    /// same bytes, and writing in place would silently rewrite that snapshot
+    /// too.
+    ///
+    /// Backends with no hard-link concept ([`MemFs`], whose
+    /// [`Fs::hard_link`] copies) override this to return 1. The Unix file
+    /// backends report the real count from the inode's link field (`StdFs` via
+    /// `nlink`, the raw `io_uring` backend via `statx` `stx_nlink`). Backends that
+    /// CAN share inodes but cannot determine the count keep the default error, so
+    /// in-place mutation paths fail closed (treat the file as shared) instead
+    /// of overwriting a snapshot through an unrecognized link.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the link count cannot be retrieved; the
+    /// default returns [`ErrorKind::Unsupported`](crate::io::ErrorKind).
+    fn hard_link_count(&self) -> io::Result<u64> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "hard-link count unavailable",
+        ))
+    }
+
     /// Truncates or extends the file to the specified length.
     ///
     /// # Errors
@@ -1067,6 +1094,33 @@ pub trait Fs: Send + Sync + 'static {
         let _ = path;
         Ok(u64::MAX)
     }
+
+    /// Physically ALLOCATED bytes of the file at `path` (blocks actually backed
+    /// by storage), or `None` when the backend cannot report it.
+    ///
+    /// Differs from the file's logical length ([`FsMetadata::len`]) when the
+    /// file is SPARSE: a hole-punched range (via [`punch_hole`](Self::punch_hole))
+    /// frees physical blocks while the logical length is unchanged, so
+    /// `allocated_size < len`. Manifest repair uses this to recognize a
+    /// tight-space-punched SST (whose consumed prefix data blocks were reclaimed)
+    /// that a rebuilt manifest would otherwise open as an unrestricted table,
+    /// letting reads traverse the punched (zero-reading) blocks and fail.
+    ///
+    /// # Default implementation
+    ///
+    /// Returns `Ok(None)` ("cannot tell"): a backend that does not track physical
+    /// allocation (and thus never punches) reports nothing, and repair treats the
+    /// file as unpunched — its current behaviour. Backends that support hole
+    /// punching override it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the underlying probe fails on a backend that
+    /// supports it.
+    fn allocated_size(&self, path: &Path) -> io::Result<Option<u64>> {
+        let _ = path;
+        Ok(None)
+    }
 }
 
 /// Bytes available to an unprivileged process on the filesystem backing
@@ -1121,6 +1175,24 @@ pub(crate) fn statvfs_available_space(path: &Path) -> std::io::Result<u64> {
 pub(crate) fn unix_volume_id(path: &Path) -> Option<u64> {
     use std::os::unix::fs::MetadataExt;
     std::fs::metadata(path).ok().map(|m| m.dev())
+}
+
+/// Physically allocated bytes of `path` via `stat(2)`'s `st_blocks`
+/// (`blocks * 512`, the POSIX-fixed block unit — unrelated to the filesystem's
+/// I/O block size). Less than the logical length for a sparse / hole-punched
+/// file. Shared by the std and `io_uring` (libc) backends.
+///
+/// A stat FAILURE is PROPAGATED as `Err`, never mapped to `None`: manifest
+/// repair reads `Ok(None)` as "allocation-unaware backend" and hence "unpunched",
+/// so swallowing the error on a genuinely punched file would drop its restriction
+/// and expose the zeroed prefix. Every unix file has `st_blocks`, so a successful
+/// stat always yields `Ok(Some(_))`.
+#[cfg(all(unix, feature = "std"))]
+pub(crate) fn unix_allocated_size(path: &Path) -> std::io::Result<Option<u64>> {
+    use std::os::unix::fs::MetadataExt;
+    // `st_blocks` is always in 512-byte units per POSIX, regardless of the
+    // filesystem block size; multiply to bytes. `blocks()` is u64.
+    Ok(Some(std::fs::metadata(path)?.blocks() * 512))
 }
 
 /// Streamed independent copy of `src` to `dst` through `fs`'s own [`Fs::open`].

--- a/src/fs/std_fs.rs
+++ b/src/fs/std_fs.rs
@@ -83,6 +83,20 @@ impl FsFile for File {
         })
     }
 
+    #[cfg(unix)]
+    fn hard_link_count(&self) -> io::Result<u64> {
+        use std::os::unix::fs::MetadataExt as _;
+        Ok(Self::metadata(self)?.nlink())
+    }
+
+    // `std` exposes the NTFS link count only behind the unstable
+    // `windows_by_handle` feature, so query the Win32 API directly (same
+    // dependency-free pattern as `available_space_sys` below).
+    #[cfg(windows)]
+    fn hard_link_count(&self) -> io::Result<u64> {
+        hard_link_count_sys::hard_link_count(self).map_err(io::Error::from)
+    }
+
     fn set_len(&self, size: u64) -> io::Result<()> {
         Self::set_len(self, size).map_err(io::Error::from)
     }
@@ -249,6 +263,11 @@ impl Fs for StdFs {
     #[cfg(windows)]
     fn available_space(&self, path: &Path) -> io::Result<u64> {
         available_space_sys::disk_free_available(path).map_err(io::Error::from)
+    }
+
+    #[cfg(unix)]
+    fn allocated_size(&self, path: &Path) -> io::Result<Option<u64>> {
+        Ok(super::unix_allocated_size(path)?)
     }
 
     fn sync_directory(&self, path: &Path) -> io::Result<()> {
@@ -756,17 +775,17 @@ mod sys {
         #[expect(unsafe_code, reason = "LockFileEx FFI call with valid handle")]
         let ret = unsafe {
             LockFileEx(
-                handle as *mut std::ffi::c_void,
+                handle,
                 LOCKFILE_EXCLUSIVE_LOCK,
                 0,
                 u32::MAX,
                 u32::MAX,
-                &mut overlapped,
+                &raw mut overlapped,
             )
         };
 
         if ret == 0 {
-            return Err(std::io::Error::last_os_error().into());
+            return Err(std::io::Error::last_os_error());
         }
         Ok(())
     }
@@ -816,12 +835,12 @@ mod sys {
         #[expect(unsafe_code, reason = "LockFileEx FFI call with valid handle")]
         let ret = unsafe {
             LockFileEx(
-                handle as *mut std::ffi::c_void,
+                handle,
                 LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
                 0,
                 u32::MAX,
                 u32::MAX,
-                &mut overlapped,
+                &raw mut overlapped,
             )
         };
 
@@ -1255,6 +1274,61 @@ mod linux_caps {
 }
 
 // ---------------------------------------------------------------------------
+// Hard-link count probe (Windows)
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+mod hard_link_count_sys {
+    use std::io;
+    use std::os::windows::io::AsRawHandle as _;
+
+    /// `BY_HANDLE_FILE_INFORMATION` (Win32): 13 little-endian `DWORD`s. The
+    /// `FILETIME` pairs are flattened to `[u32; 2]` to keep the declaration
+    /// dependency-free; the layout is identical.
+    #[repr(C)]
+    #[allow(non_snake_case, reason = "Win32 API struct")]
+    #[derive(Default)]
+    struct ByHandleFileInformation {
+        dwFileAttributes: u32,
+        ftCreationTime: [u32; 2],
+        ftLastAccessTime: [u32; 2],
+        ftLastWriteTime: [u32; 2],
+        dwVolumeSerialNumber: u32,
+        nFileSizeHigh: u32,
+        nFileSizeLow: u32,
+        nNumberOfLinks: u32,
+        nFileIndexHigh: u32,
+        nFileIndexLow: u32,
+    }
+
+    // SAFETY (ABI): the signature matches the Win32
+    // `GetFileInformationByHandle` contract — a file handle plus an out
+    // pointer, returning a non-zero `BOOL` on success.
+    #[allow(non_snake_case, reason = "Win32 API signature")]
+    unsafe extern "system" {
+        fn GetFileInformationByHandle(
+            hFile: *mut core::ffi::c_void,
+            lpFileInformation: *mut ByHandleFileInformation,
+        ) -> i32;
+    }
+
+    pub(super) fn hard_link_count(file: &std::fs::File) -> io::Result<u64> {
+        let mut info = ByHandleFileInformation::default();
+        // SAFETY: the handle comes from a live `File` borrow; `info` is a
+        // valid out pointer; fields are read only on success.
+        #[expect(
+            unsafe_code,
+            reason = "GetFileInformationByHandle for the NTFS link count"
+        )]
+        let rc = unsafe { GetFileInformationByHandle(file.as_raw_handle(), &raw mut info) };
+        if rc == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(u64::from(info.nNumberOfLinks))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Filesystem free-space probe
 // ---------------------------------------------------------------------------
 
@@ -1302,7 +1376,7 @@ mod available_space_sys {
         let rc = unsafe {
             GetDiskFreeSpaceExW(
                 wide.as_ptr(),
-                &mut avail,
+                &raw mut avail,
                 core::ptr::null_mut(),
                 core::ptr::null_mut(),
             )

--- a/src/fs/std_fs/tests.rs
+++ b/src/fs/std_fs/tests.rs
@@ -809,3 +809,19 @@ fn try_disable_cow_linux_succeeds_or_noops() -> io::Result<()> {
     fs.try_disable_cow(&path)?;
     Ok(())
 }
+
+/// A stat failure in `allocated_size` propagates as `Err`, never masked as
+/// `Ok(None)`. Manifest repair reads `Ok(None)` as "allocation-unaware backend"
+/// (hence "unpunched"); swallowing the error on a genuinely punched file would
+/// drop its restriction and expose the zeroed prefix.
+#[cfg(unix)]
+#[test]
+fn allocated_size_missing_path_is_err_not_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist.sst");
+    let got = StdFs.allocated_size(&missing);
+    assert!(
+        got.is_err(),
+        "stat failure must propagate as Err, got {got:?}"
+    );
+}

--- a/src/fuzz_heal.rs
+++ b/src/fuzz_heal.rs
@@ -1,0 +1,365 @@
+//! Reproducible single-byte-bitrot fuzzer for the SST read / heal path.
+//!
+//! Builds a deterministic corpus of SSTs across option variations (block size,
+//! per-KV checksums, columnar layout, compression, encryption, Page-ECC), then —
+//! from a FIXED seed — repeatedly picks a corpus SST, flips one random bit, and
+//! reads every entry back through [`Table::recover`] + a full scan. Invariant on
+//! every mutation: the read path NEVER panics and NEVER returns a wrong value —
+//! a flipped block either heals (Page-ECC corrects the single-symbol error) or
+//! fails its block checksum and is surfaced as an error, but a corrupt block can
+//! never silently yield altered data.
+//!
+//! `#[ignore]`d so it stays out of the normal suite (which has a 30s per-test
+//! slow-timeout); a dedicated CI step runs it with `--run-ignored=only`. Bounded
+//! to ~45s of wall-clock; on failure it prints the seed + iteration + corpus
+//! label + byte offset + bit so the exact case reproduces.
+
+#![expect(clippy::unwrap_used, clippy::indexing_slicing, reason = "fuzz test")]
+// `allow`, not `expect`: whether a truncating cast fires depends on the target
+// pointer width (a `u64 as usize` truncates on 32-bit but not 64-bit), so an
+// `expect` would go unfulfilled on some entries of the cross-compile matrix.
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "fuzz test: intentional narrowing of RNG output"
+)]
+
+use crate::table::{Table, Writer};
+use crate::{InternalValue, ValueType};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Fixed seed: the whole fuzz sequence (corpus pick, byte offset, bit) is
+/// deterministic, so a failure reproduces exactly from the printed iteration.
+const SEED: u64 = 0x5eed_1234_abcd_ef01;
+/// Wall-clock budget. Kept under a minute for CI; the fixed seed makes the
+/// covered cases deterministic regardless of how many iterations fit.
+const BUDGET: Duration = Duration::from_secs(45);
+/// Entries per corpus SST.
+const KEYS: u32 = 400;
+
+/// `SplitMix64` — a tiny deterministic PRNG (no external `rand` crate, so the
+/// sequence is stable across toolchains).
+struct SplitMix64(u64);
+impl SplitMix64 {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+}
+
+fn key(i: u32) -> Vec<u8> {
+    format!("k{i:06}").into_bytes()
+}
+fn val(i: u32) -> Vec<u8> {
+    // A payload long enough to span the small-block boundary and vary per key.
+    format!(
+        "value-{i:06}-{:016x}",
+        u64::from(i).wrapping_mul(0x9e37_79b9)
+    )
+    .into_bytes()
+}
+
+struct CorpusEntry {
+    label: String,
+    bytes: Vec<u8>,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+}
+
+/// One writer configuration: a label plus the option closure applied to a fresh
+/// [`Writer`], and the provider the reader must supply to recover it.
+struct Variant {
+    label: &'static str,
+    configure: fn(Writer) -> Writer,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+}
+
+fn variants() -> Vec<Variant> {
+    let mut v: Vec<Variant> = Vec::new();
+    for &bs in &[128u32, 4096] {
+        v.push(Variant {
+            label: if bs == 128 { "small" } else { "big" },
+            configure: if bs == 128 {
+                |w| w.use_data_block_size(128)
+            } else {
+                |w| w.use_data_block_size(4096)
+            },
+            encryption: None,
+        });
+    }
+    // Per-KV checksum footers.
+    v.push(Variant {
+        label: "kvcheck",
+        configure: |w| {
+            w.use_data_block_size(256).use_kv_checksums(
+                crate::runtime_config::KvChecksumPolicy::AllLevels,
+                crate::runtime_config::ChecksumAlgorithm::Xxh3_64,
+            )
+        },
+        encryption: None,
+    });
+    #[cfg(feature = "lz4")]
+    v.push(Variant {
+        label: "lz4",
+        configure: |w| {
+            w.use_data_block_size(256)
+                .use_data_block_compression(crate::CompressionType::Lz4)
+        },
+        encryption: None,
+    });
+    #[cfg(feature = "columnar")]
+    v.push(Variant {
+        label: "columnar",
+        configure: |w| w.use_data_block_size(256).use_columnar(true),
+        encryption: None,
+    });
+    #[cfg(feature = "page_ecc")]
+    {
+        v.push(Variant {
+            label: "ecc-xor",
+            configure: |w| {
+                w.use_data_block_size(256).use_page_ecc(
+                    true,
+                    crate::runtime_config::EccScheme::Xor { data_shards: 4 },
+                )
+            },
+            encryption: None,
+        });
+        v.push(Variant {
+            label: "ecc-rs",
+            configure: |w| {
+                w.use_data_block_size(256).use_page_ecc(
+                    true,
+                    crate::runtime_config::EccScheme::ReedSolomon {
+                        data_shards: 4,
+                        parity_shards: 2,
+                    },
+                )
+            },
+            encryption: None,
+        });
+    }
+    #[cfg(feature = "encryption")]
+    v.push(Variant {
+        label: "encrypted",
+        configure: |w| w.use_data_block_size(256),
+        encryption: Some(Arc::new(crate::encryption::Aes256GcmProvider::new(
+            &[5u8; 32],
+        ))),
+    });
+    v
+}
+
+fn build_corpus(dir: &std::path::Path, fs: &Arc<dyn crate::fs::Fs>) -> Vec<CorpusEntry> {
+    let mut out = Vec::new();
+    for (n, variant) in variants().into_iter().enumerate() {
+        let sst = dir.join(format!("corpus-{n}"));
+        let base = Writer::new(sst.clone(), 0, 0, Arc::clone(fs))
+            .unwrap()
+            .use_encryption(variant.encryption.clone());
+        let mut w = (variant.configure)(base);
+        for i in 0..KEYS {
+            w.write(InternalValue::from_components(
+                key(i),
+                val(i),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))
+            .unwrap();
+        }
+        assert!(w.finish().unwrap().is_some(), "corpus SST is non-empty");
+        let bytes = std::fs::read(&sst).unwrap();
+        out.push(CorpusEntry {
+            label: variant.label.to_string(),
+            bytes,
+            encryption: variant.encryption,
+        });
+    }
+    out
+}
+
+/// Recovers the (possibly bit-flipped) SST at `path`, passing its FRESHLY
+/// recomputed whole-file checksum so recovery does not reject it on the
+/// whole-file digest — the per-block checksums / ECC are what this fuzzer
+/// exercises.
+fn recover(
+    path: &std::path::Path,
+    fs: &Arc<dyn crate::fs::Fs>,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+) -> crate::Result<Table> {
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, path)?);
+    Table::recover(
+        path.to_path_buf(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::Cache::with_capacity_bytes(1 << 20)),
+        None,
+        Arc::clone(fs),
+        false,
+        false,
+        encryption,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )
+}
+
+/// Recovers and fully scans the SST, checking every yielded entry against the
+/// expected map. Returns `Err` on any read failure (detected corruption — an
+/// acceptable outcome); PANICS only on the fuzzer invariant violation (a wrong
+/// value), which the caller surfaces with the reproducing case.
+fn recover_and_scan(
+    path: &std::path::Path,
+    fs: &Arc<dyn crate::fs::Fs>,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+    ctx: &str,
+) -> crate::Result<()> {
+    use crate::table::block_index::BlockIndex as _;
+    let table = recover(path, fs, encryption)?;
+    // Full scan: a corrupt block surfaces as `Err`, never a wrong value.
+    let mut seen = 0u32;
+    for item in table.range_iter(..) {
+        let iv = item?;
+        let k = iv.key.user_key.as_ref();
+        // Every yielded key belongs to a block that passed its checksum (or was
+        // ECC-healed), so it must be an original key with its original value.
+        let expected = k
+            .strip_prefix(b"k")
+            .and_then(|d| std::str::from_utf8(d).ok())
+            .and_then(|d| d.parse::<u32>().ok())
+            .map(val);
+        assert_eq!(
+            expected.as_deref(),
+            Some(iv.value.as_ref()),
+            "{ctx}: scan yielded a WRONG value for key {k:?} (silent corruption)",
+        );
+        seen += 1;
+    }
+    // Touch the block index too, so a corrupt index surfaces (as Err) rather than
+    // being skipped by an early scan short-circuit.
+    for handle in table.block_index.iter() {
+        handle?;
+    }
+    // Silent OMISSION is its own corruption class: a bit flip that truncates the
+    // scan or skips a block while every yielded value stays correct, with no error
+    // surfaced, would slip past the per-value check above. A clean scan means every
+    // block was checksum-clean or ECC-healed, so the FULL key set must be present.
+    assert_eq!(
+        seen, KEYS,
+        "{ctx}: the scan completed cleanly but yielded {seen}/{KEYS} keys (silent omission)",
+    );
+    Ok(())
+}
+
+/// Persists the exact bytes that failed (plus a `.txt` describing the case) to a
+/// stable path, and returns it. This is the ground-truth reproducer for a
+/// non-byte-deterministic corpus (encrypted / timestamped SSTs): re-running the
+/// read path over this file re-hits the failure directly, no seed replay needed.
+fn repro_dump(bytes: &[u8], ctx: &str, entry: &CorpusEntry) -> std::path::PathBuf {
+    // Resolve the dump directory EXPLICITLY, not from the process working
+    // directory (which need not be the crate root, e.g. once the crate lives in a
+    // workspace subdirectory): `FUZZ_HEAL_REPRO_DIR` overrides at runtime,
+    // otherwise the compile-time `CARGO_MANIFEST_DIR` (the crate root), otherwise
+    // the current directory as a last resort. The CI dump step reads the same
+    // resolved location, and the returned ABSOLUTE path goes into the panic
+    // message so the artifact is findable.
+    let base = std::env::var_os("FUZZ_HEAL_REPRO_DIR")
+        .map(std::path::PathBuf::from)
+        .or_else(|| option_env!("CARGO_MANIFEST_DIR").map(std::path::PathBuf::from))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let sst = base.join("fuzz_heal_repro.sst");
+    let _ = std::fs::write(&sst, bytes);
+    let _ = std::fs::write(
+        base.join("fuzz_heal_repro.txt"),
+        format!(
+            "{ctx}\nvariant={}\nencryption={}\nsst_len={}\n",
+            entry.label,
+            if entry.encryption.is_some() {
+                "Aes256Gcm key=[5u8;32]"
+            } else {
+                "none"
+            },
+            bytes.len(),
+        ),
+    );
+    sst
+}
+
+#[test]
+#[ignore = "long-running bitrot fuzzer; run explicitly in CI via --run-ignored=only"]
+fn fuzz_heal_bitrot() {
+    let dir = tempfile::tempdir().unwrap();
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(crate::fs::StdFs);
+    let corpus = build_corpus(dir.path(), &fs);
+    assert!(!corpus.is_empty(), "the corpus has at least one variant");
+
+    let scratch = dir.path().join("scratch");
+    let mut rng = SplitMix64(SEED);
+    let start = Instant::now();
+    let mut iters: u64 = 0;
+
+    while start.elapsed() < BUDGET {
+        iters += 1;
+        let entry = &corpus[(rng.next_u64() as usize) % corpus.len()];
+        let mut bytes = entry.bytes.clone();
+        let off = (rng.next_u64() as usize) % bytes.len();
+        let bit = (rng.next_u64() % 8) as u8;
+        bytes[off] ^= 1u8 << bit;
+        std::fs::write(&scratch, &bytes).unwrap();
+
+        let ctx = format!(
+            "seed={SEED:#x} iter={iters} variant={} off={off} bit={bit}",
+            entry.label
+        );
+        // Any error is an acceptable (detected) outcome; a PANIC or a wrong value
+        // is the bug this fuzzer hunts. Catch panics so the reproducing case is
+        // reported rather than an opaque unwind.
+        let enc = entry.encryption.clone();
+        let fs2 = Arc::clone(&fs);
+        let scratch2 = scratch.clone();
+        let ctx2 = ctx.clone();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _ = recover_and_scan(&scratch2, &fs2, enc, &ctx2);
+        }));
+        if outcome.is_err() {
+            // Encrypted / timestamped corpus SSTs are NOT byte-deterministic (a
+            // fresh AEAD nonce + `created_at` per build), so the seed alone cannot
+            // reproduce a failure in those. Persist the EXACT flipped bytes that
+            // failed — plus the context — so the case reproduces regardless. The
+            // repro path is stable across runs; a follow-up run overwrites it, but
+            // fail-fast stops at the first failure so the artifact survives.
+            let repro = repro_dump(&bytes, &ctx, entry);
+            panic!(
+                "read path PANICKED / returned a wrong value on a single-bit flip.\n  {ctx}\n  \
+                 reproduce with the exact failing SST at: {}\n  (variant \"{}\", encryption {})",
+                repro.display(),
+                entry.label,
+                if entry.encryption.is_some() {
+                    "Aes256Gcm key=[5u8;32]"
+                } else {
+                    "none"
+                },
+            );
+        }
+    }
+
+    eprintln!(
+        "fuzz_heal_bitrot: {iters} iterations across {} variants in {:?} (seed {SEED:#x})",
+        corpus.len(),
+        start.elapsed(),
+    );
+    // A per-iteration recover + full scan is fast, but a loaded / emulated runner
+    // can still fit few iterations into the fixed wall-clock budget. Require only
+    // enough to cover every corpus variant at least once, so the check catches a
+    // broken loop without turning host slowness into a spurious failure.
+    assert!(
+        iters >= corpus.len() as u64,
+        "the fuzzer must cover every corpus variant at least once",
+    );
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -67,6 +67,17 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    /// Whether this kind is an unambiguously TRANSIENT (retryable) I/O failure:
+    /// only [`Interrupted`](Self::Interrupted) (EINTR) and
+    /// [`WouldBlock`](Self::WouldBlock) (EAGAIN). Everything else — including the
+    /// ambiguous [`Other`](Self::Other), which real `EIO` and platform-specific
+    /// structural errors (e.g. a Windows negative-seek on a corrupt file) both
+    /// map to — is treated as persistent / structural. Shared so the repair and
+    /// integrity-verify paths classify I/O failures identically.
+    pub(crate) fn is_transient(self) -> bool {
+        matches!(self, Self::Interrupted | Self::WouldBlock)
+    }
+
     fn as_str(self) -> &'static str {
         match self {
             Self::AlreadyExists => "entity already exists",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,11 @@ pub mod restrict_bound;
 #[cfg(feature = "std")]
 pub mod salvage;
 
+/// Live progress counters for long-running recovery (repair / salvage).
+// std-only: its only producers (repair, salvage) are std-gated.
+#[cfg(feature = "std")]
+pub mod recovery_progress;
+
 pub(crate) mod active_tombstone_set;
 pub(crate) mod range_tombstone;
 pub(crate) mod range_tombstone_filter;
@@ -500,6 +505,8 @@ pub use encryption::Aes256GcmProvider;
 #[cfg(feature = "std")]
 pub use background_deleter::BackgroundDeleter;
 pub use pinnable_slice::PinnableSlice;
+#[cfg(feature = "std")]
+pub use recovery_progress::{RecoveryProgress, RecoveryProgressSnapshot};
 #[cfg(feature = "std")]
 pub use repair::RepairReport;
 pub use write_batch::WriteBatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,6 +324,11 @@ mod run_scanner;
 #[doc(hidden)]
 pub mod sfa;
 
+// Shared on-disk forgery helpers for corruption tests (std: reads/writes
+// real files through std::fs like the tests that consume it).
+#[cfg(all(test, feature = "std"))]
+pub(crate) mod test_forge;
+
 #[doc(hidden)]
 pub mod merge;
 
@@ -354,6 +359,13 @@ pub mod runtime_config;
 // std-only: scans table folders and rewrites the manifest via std::fs.
 #[cfg(feature = "std")]
 pub mod repair;
+
+// Tight-space restriction sidecar: `{id}.restrict-bound` records the exact
+// lower bound of a hole-punched SST next to it, so manifest repair recovers the
+// restriction without mutating (and thus invalidating the manifest checksum of)
+// the SST itself.
+#[cfg(feature = "std")]
+pub mod restrict_bound;
 
 // std-only: block-granular SST salvage; reads source blocks and writes a
 // recovered SST via std::fs (see also `crate::repair`, `crate::verify`).
@@ -437,6 +449,12 @@ pub use storage_stats::{
 
 mod version;
 mod vlog;
+
+// Reproducible single-byte-bitrot heal/read fuzzer. `#[ignore]`d, so it is
+// excluded from the normal suite and run as its own CI step; needs crate-internal
+// `Table` / `Writer` access, so it lives here rather than in `tests/`.
+#[cfg(all(test, feature = "std"))]
+mod fuzz_heal;
 
 /// User defined key (byte array)
 pub type UserKey = Slice;

--- a/src/range_tombstone.rs
+++ b/src/range_tombstone.rs
@@ -165,6 +165,25 @@ impl RangeTombstone {
             .then_with(|| other.seqno.cmp(&self.seqno))
             .then_with(|| comparator.compare(&self.end, &other.end))
     }
+
+    /// The `(start, seqno)` of the tombstone an RT-ONLY table records its
+    /// synthetic sentinel entry from: the `(seqno, start)`-minimal tombstone.
+    ///
+    /// The writer emits a weak-tombstone sentinel at this key/seqno ONLY when
+    /// the table has no real KV items (to force a valid index). Its seqno is
+    /// RT-derived and lies OUTSIDE the recorded KV seqno range, so any consumer
+    /// reconstructing the table's KV bounds from the decoded entries must
+    /// exclude the entry that matches it. `None` for an empty tombstone list.
+    ///
+    /// Ties on `(seqno, start)` keep the first, matching the writer's strict-`<`
+    /// update. Ordering is lexicographic on `start`, as the writer uses.
+    #[must_use]
+    pub(crate) fn sentinel(tombstones: &[Self]) -> Option<(&UserKey, SeqNo)> {
+        tombstones
+            .iter()
+            .min_by(|a, b| a.seqno.cmp(&b.seqno).then_with(|| a.start.cmp(&b.start)))
+            .map(|rt| (&rt.start, rt.seqno))
+    }
 }
 
 /// Ordered by `(start asc, seqno desc, end asc)`.

--- a/src/recovery_progress.rs
+++ b/src/recovery_progress.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Live progress counters for long-running recovery work.
+//!
+//! A manifest repair over a large store runs for minutes to hours (it streams
+//! every SST and blob file, and salvage walks corrupt tables block by block).
+//! [`RecoveryProgress`] is the observation seam: hand a shared handle to
+//! [`Config::with_recovery_progress`](crate::Config::with_recovery_progress)
+//! (or [`SalvageOptions::progress`](crate::salvage::SalvageOptions)) before
+//! starting the operation, then poll [`RecoveryProgress::snapshot`] from any
+//! other thread while it runs.
+
+use portable_atomic::AtomicU64;
+
+use core::sync::atomic::Ordering::Relaxed;
+
+/// Shared live-progress counters for a repair / salvage run.
+///
+/// All counters are cumulative for the lifetime of the handle and updated with
+/// relaxed atomics as the work proceeds — per discovered file, per walked
+/// block, per recovered row — so a UI thread can poll
+/// [`snapshot`](Self::snapshot) at any rate without synchronizing with the
+/// recovery. Reuse a fresh handle per operation to start the counts at zero.
+///
+/// In-place ECC heal events outside salvage (patrol scrub) are exported
+/// through the `metrics` feature's counters, not through this handle.
+///
+/// # Examples
+///
+/// ```
+/// use lsm_tree::RecoveryProgress;
+/// use std::sync::Arc;
+///
+/// let progress = Arc::new(RecoveryProgress::default());
+/// // Hand a clone to `Config::with_recovery_progress(..)`, run the repair on
+/// // another thread, and poll:
+/// let snap = progress.snapshot();
+/// assert_eq!(snap.blocks_scanned, 0);
+/// ```
+#[derive(Debug, Default)]
+pub struct RecoveryProgress {
+    tables_discovered: AtomicU64,
+    tables_recovered: AtomicU64,
+    blob_files_discovered: AtomicU64,
+    blob_files_recovered: AtomicU64,
+    blocks_scanned: AtomicU64,
+    blocks_recovered: AtomicU64,
+    blocks_dropped: AtomicU64,
+    blocks_healed: AtomicU64,
+    kvs_recovered: AtomicU64,
+    columns_recovered: AtomicU64,
+}
+
+impl RecoveryProgress {
+    /// Returns a point-in-time copy of every counter.
+    ///
+    /// Each field is read individually with relaxed ordering, so the snapshot
+    /// is not a single atomic cut across counters — adjacent fields can be a
+    /// few events apart — which is exactly enough for progress display.
+    #[must_use]
+    pub fn snapshot(&self) -> RecoveryProgressSnapshot {
+        RecoveryProgressSnapshot {
+            tables_discovered: self.tables_discovered.load(Relaxed),
+            tables_recovered: self.tables_recovered.load(Relaxed),
+            blob_files_discovered: self.blob_files_discovered.load(Relaxed),
+            blob_files_recovered: self.blob_files_recovered.load(Relaxed),
+            blocks_scanned: self.blocks_scanned.load(Relaxed),
+            blocks_recovered: self.blocks_recovered.load(Relaxed),
+            blocks_dropped: self.blocks_dropped.load(Relaxed),
+            blocks_healed: self.blocks_healed.load(Relaxed),
+            kvs_recovered: self.kvs_recovered.load(Relaxed),
+            columns_recovered: self.columns_recovered.load(Relaxed),
+        }
+    }
+
+    /// One table file recognized in the scan (by its numeric id).
+    pub(crate) fn table_discovered(&self) {
+        self.tables_discovered.fetch_add(1, Relaxed);
+    }
+
+    /// One table recovered into the rebuilt manifest (whole or salvaged).
+    pub(crate) fn table_recovered(&self) {
+        self.tables_recovered.fetch_add(1, Relaxed);
+    }
+
+    /// One blob file recognized in the scan (by its numeric id).
+    pub(crate) fn blob_file_discovered(&self) {
+        self.blob_files_discovered.fetch_add(1, Relaxed);
+    }
+
+    /// One blob file recovered into the rebuilt manifest.
+    pub(crate) fn blob_file_recovered(&self) {
+        self.blob_files_recovered.fetch_add(1, Relaxed);
+    }
+
+    /// Publishes a salvage walk's per-block deltas (scanned / re-emitted /
+    /// dropped / ECC-healed).
+    pub(crate) fn add_blocks(&self, scanned: u64, recovered: u64, dropped: u64, healed: u64) {
+        if scanned > 0 {
+            self.blocks_scanned.fetch_add(scanned, Relaxed);
+        }
+        if recovered > 0 {
+            self.blocks_recovered.fetch_add(recovered, Relaxed);
+        }
+        if dropped > 0 {
+            self.blocks_dropped.fetch_add(dropped, Relaxed);
+        }
+        if healed > 0 {
+            self.blocks_healed.fetch_add(healed, Relaxed);
+        }
+    }
+
+    /// Publishes a salvage walk's per-row deltas (KV entries and, for a
+    /// columnar source, the value sub-columns those rows carried).
+    pub(crate) fn add_rows(&self, kvs: u64, columns: u64) {
+        if kvs > 0 {
+            self.kvs_recovered.fetch_add(kvs, Relaxed);
+        }
+        if columns > 0 {
+            self.columns_recovered.fetch_add(columns, Relaxed);
+        }
+    }
+}
+
+/// A point-in-time copy of [`RecoveryProgress`], returned by
+/// [`RecoveryProgress::snapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RecoveryProgressSnapshot {
+    /// Table files recognized by the repair scan so far.
+    pub tables_discovered: u64,
+    /// Tables recovered into the rebuilt manifest (whole or salvaged).
+    pub tables_recovered: u64,
+    /// Blob files recognized by the repair scan so far.
+    pub blob_files_discovered: u64,
+    /// Blob files recovered into the rebuilt manifest.
+    pub blob_files_recovered: u64,
+    /// Data blocks a salvage walk has inspected.
+    pub blocks_scanned: u64,
+    /// Data blocks a salvage walk re-emitted into a recovered copy.
+    pub blocks_recovered: u64,
+    /// Data blocks a salvage walk had to drop (corrupt / undecodable).
+    pub blocks_dropped: u64,
+    /// Of [`blocks_recovered`](Self::blocks_recovered), how many needed ECC
+    /// recovery to read (their healed payload was re-encoded).
+    pub blocks_healed: u64,
+    /// KV entries re-emitted into recovered copies.
+    pub kvs_recovered: u64,
+    /// Value sub-columns carried by recovered columnar blocks.
+    pub columns_recovered: u64,
+}

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -1598,7 +1598,10 @@ fn derive_blob_frontier(
         const CHUNK: u64 = 64 * 1024;
         let mut pos = from;
         while pos < data_end {
-            #[expect(
+            // `#[allow]`, not `#[expect]`: target-width-dependent lint (`u64 as
+            // usize`) — on 64-bit targets Clippy proves the `min()` bound fits
+            // usize and an `#[expect]` would be unfulfilled under `-D warnings`.
+            #[allow(
                 clippy::cast_possible_truncation,
                 reason = "min() bounds the window by CHUNK, which fits usize"
             )]
@@ -1647,7 +1650,7 @@ fn derive_blob_frontier(
                 None => return Ok(committed),
                 Some(Ok(entry)) if !entry.resynced => pos = entry.frame_end,
                 Some(Err(e)) if is_transient_io(&e) => return Err(e),
-                Some(Ok(_)) | Some(Err(_)) => {
+                Some(Ok(_) | Err(_)) => {
                     // The frame starting at `pos` failed (or the scanner
                     // resynced past unproven bytes). Another zeroed hole
                     // continues the walk; anything else is content corruption

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -1529,6 +1529,130 @@ fn restrict_salvaged_output(
 ///
 /// Returns the recovered blob files and the per-file failure reasons (merged
 /// into the repair report's `unreadable_files`).
+/// Derives a blob file's tight-space live-data frontier from its on-disk punch
+/// geometry, for a manifest-loss repair.
+///
+/// The frontier — where a tight-space relocation's punched `[data_start,
+/// frontier)` prefix ends and the live suffix begins — is recorded only in the
+/// manifest's `blob_restrictions` section. Unlike an SST's restriction bound (a
+/// KEY, which the block-aligned punch cannot reproduce and which therefore
+/// needs its `.restrict-bound` sidecar), the blob frontier is a byte offset at
+/// a frame boundary, so the geometry recovers it EXACTLY: the punch zeroes
+/// precisely `[data_start, frontier)` and the first live frame's magic sits at
+/// `frontier`.
+///
+/// Anchoring is structural, never length-based: a zeroed run counts only when a
+/// frame decodes cleanly at its end, so a zero-filled value payload inside the
+/// live suffix (stepped over by frame framing) can never move the frontier. A
+/// partially completed punch (a crash mid-reclaim can leave intact-but-consumed
+/// frames between holes) is walked hole-by-hole, and the frontier is the end of
+/// the LAST zeroed run the anchored walk reaches. Non-zero bytes that fail to
+/// decode end the walk at the last anchored frontier: content corruption is not
+/// punch geometry, and it surfaces exactly as it would on an unpunched file.
+///
+/// Returns `0` (whole file) when the first data byte is non-zero: the punch
+/// always starts at the data start, so an unpunched file — including one whose
+/// committed punch never ran before a crash — short-circuits without a walk,
+/// keeping the common repair path at zero extra read cost. The redundant
+/// unpunched prefix is superseded by relocated copies and reclaimed later, the
+/// same safe fallback the SST path takes for a committed-but-unpunched slice.
+///
+/// # Errors
+///
+/// Propagates I/O and TOC errors (the caller classifies transient ones for
+/// retry, like every other per-file repair probe).
+fn derive_blob_frontier(
+    fs: &Arc<dyn crate::fs::Fs>,
+    path: &std::path::Path,
+    blob_id: crate::vlog::BlobFileId,
+) -> crate::Result<u64> {
+    let mut file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
+    let (data_start, data_end) = {
+        let reader = crate::sfa::Reader::from_reader(&mut file)?;
+        let data = reader
+            .toc()
+            .section(b"data")
+            .ok_or(crate::Error::InvalidHeader("BlobFile"))?;
+        let end = data
+            .pos()
+            .checked_add(data.len())
+            .ok_or(crate::Error::InvalidHeader("BlobFile"))?;
+        (data.pos(), end)
+    };
+    if data_start >= data_end {
+        return Ok(0);
+    }
+
+    // Ends of the contiguous all-zero run starting at `from` (chunked reads,
+    // capped by the data-section end).
+    let skip_zeros = |from: u64| -> crate::Result<u64> {
+        const CHUNK: u64 = 64 * 1024;
+        let mut pos = from;
+        while pos < data_end {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "min() bounds the window by CHUNK, which fits usize"
+            )]
+            let want = (data_end - pos).min(CHUNK) as usize;
+            let chunk = crate::file::read_exact(&*file, pos, want)?;
+            match chunk.iter().position(|b| *b != 0) {
+                Some(hit) => return Ok(pos + hit as u64),
+                None => pos += want as u64,
+            }
+        }
+        Ok(data_end)
+    };
+
+    // Fast path: an unpunched file's first frame magic (non-zero) sits at the
+    // data start.
+    if skip_zeros(data_start)? == data_start {
+        return Ok(0);
+    }
+
+    let mut pos = data_start;
+    // The last structure-anchored frontier: committed only once a frame has
+    // decoded cleanly at a zeroed run's end.
+    let mut committed: u64 = 0;
+    loop {
+        let run_end = skip_zeros(pos)?;
+        if run_end >= data_end {
+            // Zeros to the section end: the whole data region was consumed
+            // (the final slice's punch ran, its drop lagged the crash).
+            return Ok(data_end);
+        }
+        let mut scanner = crate::vlog::BlobFileScanner::resume(path, &**fs, blob_id, run_end)?;
+        match scanner.next() {
+            Some(Ok(entry)) if !entry.resynced => {
+                committed = run_end;
+                pos = entry.frame_end;
+            }
+            Some(Err(e)) if is_transient_io(&e) => return Err(e),
+            // The zeroed run is not punch geometry (no frame decodes at its
+            // end): keep the last anchored frontier.
+            _ => return Ok(committed),
+        }
+        // Chain frames from the anchor until the section ends cleanly or the
+        // chain breaks (another hole, or content corruption).
+        loop {
+            match scanner.next() {
+                None => return Ok(committed),
+                Some(Ok(entry)) if !entry.resynced => pos = entry.frame_end,
+                Some(Err(e)) if is_transient_io(&e) => return Err(e),
+                Some(Ok(_)) | Some(Err(_)) => {
+                    // The frame starting at `pos` failed (or the scanner
+                    // resynced past unproven bytes). Another zeroed hole
+                    // continues the walk; anything else is content corruption
+                    // and ends it at the last anchored frontier.
+                    if skip_zeros(pos)? == pos {
+                        return Ok(committed);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
 fn recover_blob_files(
     config: &Config,
 ) -> crate::Result<(Vec<crate::vlog::BlobFile>, UnreadableFiles)> {
@@ -1583,8 +1707,15 @@ fn recover_blob_files(
             continue;
         }
 
-        let checksum = match compute_table_checksum(&*config.fs, &blob_path) {
-            Ok(c) => crate::Checksum::from_raw(c),
+        // A tight-space-punched blob records its live-data frontier only in
+        // the manifest; with the manifest lost, re-derive it from the punch
+        // geometry so the rebuilt manifest restores the restriction (the
+        // snapshot encoder persists it from the recovered `live_data_start`).
+        // Rebuilding with frontier 0 would instead leave a later relocation
+        // scan starting inside the punched (zeroed) prefix. An unpunched file
+        // short-circuits to 0 on its first (non-zero) data byte.
+        let frontier = match derive_blob_frontier(&config.fs, &blob_path, blob_id) {
+            Ok(f) => f,
             // A TRANSIENT read (flaky I/O) is retryable: recording the blob
             // unreadable commits a manifest without the still-in-place file,
             // which the next open's orphan sweep then DELETES — permanent value
@@ -1598,7 +1729,23 @@ fn recover_blob_files(
             }
         };
 
-        match crate::vlog::recover_blob_file(&blob_path, blob_id, checksum, 0, &config.fs) {
+        // The digest covers the live region only — `[frontier, end)` for a
+        // punched file, the whole file for `frontier == 0` — matching what
+        // `reopen_restricted` records and what integrity checks recompute.
+        let checksum = match compute_table_checksum_from(&*config.fs, &blob_path, frontier) {
+            Ok(c) => crate::Checksum::from_raw(c),
+            // Same transient/persistent split as the frontier probe above.
+            Err(e) if is_transient_io(&e) => return Err(e),
+            Err(e) => {
+                seen_ids.remove(&blob_id);
+                unreadable.push((blob_path, e.to_string()));
+                continue;
+            }
+        };
+
+        match crate::vlog::recover_blob_file_from(
+            &blob_path, blob_id, checksum, 0, &config.fs, frontier,
+        ) {
             Ok(bf) => blob_files.push(bf),
             // Same transient/persistent split as the checksum read above.
             Err(e) if is_transient_io(&e) => return Err(e),

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -748,7 +748,13 @@ fn record_best(
     path: &std::path::Path,
     file_name: &str,
     sync_mode: crate::fs::SyncMode,
+    progress: Option<&crate::RecoveryProgress>,
 ) -> crate::Result<()> {
+    // Counts candidate recordings (per recovered FILE): a duplicate id later
+    // displaced by a better copy was still a recovered file.
+    if let Some(p) = progress {
+        p.table_recovered();
+    }
     let candidate = TableCandidate {
         table,
         complete,
@@ -1237,6 +1243,9 @@ fn try_salvage_table(
             // it the rebuilt filter loses the source's prefix hashes and
             // prefix scans see the salvaged copy as definitely absent.
             prefix_extractor: config.prefix_extractor.clone(),
+            // Forward the caller's live-progress handle so the block walk
+            // ticks per inspected / recovered block while it runs.
+            progress: config.recovery_progress.clone(),
         },
     )?;
     if report.salvaged_path.is_none() {
@@ -1707,6 +1716,10 @@ fn recover_blob_files(
             continue;
         }
 
+        if let Some(p) = &config.recovery_progress {
+            p.blob_file_discovered();
+        }
+
         // A tight-space-punched blob records its live-data frontier only in
         // the manifest; with the manifest lost, re-derive it from the punch
         // geometry so the rebuilt manifest restores the restriction (the
@@ -1746,7 +1759,12 @@ fn recover_blob_files(
         match crate::vlog::recover_blob_file_from(
             &blob_path, blob_id, checksum, 0, &config.fs, frontier,
         ) {
-            Ok(bf) => blob_files.push(bf),
+            Ok(bf) => {
+                if let Some(p) = &config.recovery_progress {
+                    p.blob_file_recovered();
+                }
+                blob_files.push(bf);
+            }
             // Same transient/persistent split as the checksum read above.
             Err(e) if is_transient_io(&e) => return Err(e),
             Err(e) => {
@@ -1971,6 +1989,10 @@ fn repair_tree(
                 ));
                 continue;
             };
+
+            if let Some(p) = &config.recovery_progress {
+                p.table_discovered();
+            }
 
             // Skip a duplicate id ONLY when we already hold a COMPLETE copy — a
             // duplicate cannot improve on it. A previously-seen LOSSY salvage does
@@ -2274,6 +2296,7 @@ fn repair_tree(
                                 &table_path,
                                 &file_name,
                                 config.sync_mode,
+                                config.recovery_progress.as_deref(),
                             )?;
                         }
                         RepairKeepDecision::Quarantine(reason) => {
@@ -2366,6 +2389,7 @@ fn repair_tree(
                                         &table_path,
                                         &file_name,
                                         config.sync_mode,
+                                        config.recovery_progress.as_deref(),
                                     )?;
                                 }
                                 Ok(SalvageOutcome::Unusable | SalvageOutcome::PunchedBoundLost) => {
@@ -2419,6 +2443,7 @@ fn repair_tree(
                         &table_path,
                         &file_name,
                         config.sync_mode,
+                        config.recovery_progress.as_deref(),
                     )?;
                 }
                 Err(e) if salvage => {
@@ -2566,6 +2591,7 @@ fn repair_tree(
                                 &table_path,
                                 &file_name,
                                 config.sync_mode,
+                                config.recovery_progress.as_deref(),
                             )?;
                         }
                         Ok(SalvageOutcome::Unusable) => {

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -86,25 +86,101 @@ pub struct RepairReport {
     pub warnings: Vec<&'static str>,
 }
 
+/// Streams `path` from byte `start` to end through XXH3-128. `start == 0`
+/// reproduces the whole-file digest a normal write accumulates; a non-zero
+/// `start` digests only the LIVE suffix of a tight-space RESTRICTED table,
+/// whose `[0, start)` prefix was hole-punched (reads back as zeros) once a
+/// superseding output table took over those keys. The suffix bytes are
+/// untouched by the punch, so this digest is stable across it.
+pub(crate) fn compute_table_checksum_from(
+    fs: &dyn crate::fs::Fs,
+    path: &std::path::Path,
+    start: u64,
+) -> crate::Result<u128> {
+    // The offset-only case is the override-splicing digest with no overrides.
+    compute_table_checksum_with_overrides(fs, path, start, &[])
+}
+
 /// Streams `path` start to end through XXH3-128, matching the digest a normal
 /// table write accumulates via `ChecksummedWriter`.
 pub(crate) fn compute_table_checksum(
     fs: &dyn crate::fs::Fs,
     path: &std::path::Path,
 ) -> crate::Result<u128> {
+    // The whole-file case is the override-splicing digest from offset 0 with no
+    // overrides: one shared read loop in `compute_table_checksum_with_overrides`.
+    compute_table_checksum_with_overrides(fs, path, 0, &[])
+}
+
+/// As [`compute_table_checksum`], but streams the file with `overrides` spliced
+/// in: each `(offset, bytes)` replaces the on-disk bytes at `[offset,
+/// offset + bytes.len())`. Used to predict the digest an in-place heal WILL
+/// produce, from the corrected block frames it will write, before any write
+/// lands — so the heal attestation can bind that intended post-heal state.
+///
+/// The overrides are size-preserving block frames at distinct, non-overlapping
+/// offsets (the heal rewrites each corrupt block at its existing offset and
+/// size), so splicing them is a byte-for-byte substitution that keeps the file
+/// length and every other byte unchanged. `start` matches
+/// [`compute_table_checksum_from`]: a restricted view predicts only its live
+/// suffix (its corrections all lie there), so the digest starts at the punch
+/// offset.
+pub(crate) fn compute_table_checksum_with_overrides(
+    fs: &dyn crate::fs::Fs,
+    path: &std::path::Path,
+    start: u64,
+    overrides: &[(u64, Vec<u8>)],
+) -> crate::Result<u128> {
+    use std::io::{Seek, SeekFrom};
     let mut file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
+    // Seek + sequential read (see `compute_table_checksum_from`): keeps the
+    // `start == 0` read pattern identical to the plain digest.
+    if start != 0 {
+        file.seek(SeekFrom::Start(start))?;
+    }
     let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
     let mut buf = vec![0u8; 256 * 1024];
+    let mut chunk_start = start;
     loop {
         let n = file.read(&mut buf)?;
         if n == 0 {
             break; // EOF
         }
-        // `get(..n)` rather than `buf[..n]` to satisfy
-        // `deny(clippy::indexing_slicing)`; `Read::read` guarantees
-        // `n <= buf.len()`, so this slice is always present.
-        let Some(chunk) = buf.get(..n) else { break };
-        hasher.update(chunk);
+        let chunk_end = chunk_start + n as u64;
+        let Some(chunk) = buf.get_mut(..n) else { break };
+        // Splice every override overlapping this chunk. Overrides are few (one
+        // per corrupt block), so scanning them per chunk is negligible.
+        for (off, bytes) in overrides {
+            let ov_end = *off + bytes.len() as u64;
+            let lo = (*off).max(chunk_start);
+            let hi = ov_end.min(chunk_end);
+            // Skip a non-overlapping override BEFORE computing relative offsets:
+            // the bound subtractions below are unsigned, and an override ending
+            // before this chunk (or starting after it) would otherwise underflow
+            // (a debug panic). Once `lo < hi` holds, `chunk_start <= lo < hi <=
+            // chunk_end` and `off <= lo < hi <= ov_end`, so all four differences
+            // are non-negative.
+            if lo >= hi {
+                continue;
+            }
+            // The overlap lies inside a `<= 256 KiB` chunk, so every difference
+            // fits `usize`; `try_from` handles the 32-bit target without a cast.
+            let (Ok(dst_lo), Ok(dst_hi), Ok(src_lo), Ok(src_hi)) = (
+                usize::try_from(lo - chunk_start),
+                usize::try_from(hi - chunk_start),
+                usize::try_from(lo - *off),
+                usize::try_from(hi - *off),
+            ) else {
+                continue;
+            };
+            if let (Some(dst), Some(src)) =
+                (chunk.get_mut(dst_lo..dst_hi), bytes.get(src_lo..src_hi))
+            {
+                dst.copy_from_slice(src);
+            }
+        }
+        hasher.update(&*chunk);
+        chunk_start = chunk_end;
     }
     Ok(hasher.digest128())
 }
@@ -143,47 +219,1028 @@ fn quarantine_file(
     table_base_folder: &std::path::Path,
     src: &std::path::Path,
     file_name: &str,
+    sync_mode: crate::fs::SyncMode,
 ) -> crate::Result<PathBuf> {
     let quarantine_dir = table_base_folder
         .parent()
         .unwrap_or(table_base_folder)
         .join("repair-quarantine");
+    // Creating the quarantine directory adds its entry to the PARENT directory.
+    // That entry is durable only once the parent is synced: the later syncs
+    // cover the source directory and the quarantine directory itself, but not
+    // the parent that now names it, so without this a power loss after repair
+    // returns can drop the whole quarantine directory (and the only preserved
+    // copy of the original). Sync UNCONDITIONALLY, before the rename: a prior
+    // repair that created the directory but crashed before its own parent sync
+    // leaves the entry non-durable, so a retry that skipped the sync (seeing the
+    // directory already present) would move the source in without ever making
+    // the parent durable. A redundant fsync on an already-durable parent is
+    // cheap; skipping it risks losing the whole directory across a
+    // crashed-then-retried repair.
     fs.create_dir_all(&quarantine_dir)?;
-    let dest = quarantine_dir.join(file_name);
+    if let Some(quarantine_parent) = quarantine_dir.parent() {
+        fs.sync_directory_with(quarantine_parent, sync_mode)?;
+    }
+    // Preserve any EARLIER quarantine copy of the same table: `rename` replaces
+    // the destination on Unix, so a fixed `{file_name}` would move the new
+    // corrupt source over the only copy of a previously quarantined original
+    // set aside for inspection. Probe for a free `{file_name}` / `{file_name}.N`
+    // name instead. (A tiny check-then-rename window is acceptable: repair runs
+    // single-process against a downed tree.)
+    let dest = {
+        let mut candidate = quarantine_dir.join(file_name);
+        let mut n: u64 = 1;
+        while fs.exists(&candidate)? {
+            candidate = quarantine_dir.join(format!("{file_name}.{n}"));
+            n = n.checked_add(1).ok_or(crate::Error::Unrecoverable)?;
+        }
+        candidate
+    };
     fs.rename(src, &dest)?;
+    // Everything after the first rename runs inside one fallible span so ANY
+    // failure — the sidecar's existence probe, the sidecar's rename, or the
+    // durability syncs — rolls the SST (and the sidecar, when it moved) back
+    // under `tables/`. Propagating with the table stranded in quarantine would
+    // mean the retried repair no longer discovers it and installs a manifest
+    // that omits it; a sync failure additionally means the move is not durably
+    // committed, so a later power loss could resurrect the source as an orphan
+    // the next open deletes. The rollback leaves both files exactly where a
+    // retry can find and re-quarantine them durably.
+    //
+    // Sidecar: a restricted SST carries its exact recovery bound in a sibling
+    // `.restrict-bound` file. Move it WITH the table: left behind in `tables/`,
+    // the next open's orphan sweep (the rebuilt manifest no longer names this
+    // id) deletes it, permanently stranding the quarantined punched file from
+    // its exact bound. Absent for unrestricted tables and for non-table
+    // quarantines (a rejected salvage replacement, a foreign file), a no-op
+    // there. Both sidecar and SST live in the same two directories, so the two
+    // syncs cover both.
+    //
+    // Sync ordering: a rename is durable only once BOTH affected directory
+    // entries are on disk. Sync the DESTINATION (quarantine) directory FIRST,
+    // then the source: if the source's deletion were made durable first, a
+    // power loss before the quarantine entry is durable would leave NEITHER
+    // name after reboot, destroying the only preserved original. This is the
+    // same ordering `restore_quarantined` uses for the inverse move.
+    let src_sidecar = crate::restrict_bound::sidecar_path(src);
+    let dest_sidecar = crate::restrict_bound::sidecar_path(&dest);
+    let commit_result = (|| -> crate::Result<()> {
+        if fs.exists(&src_sidecar)? {
+            fs.rename(&src_sidecar, &dest_sidecar)?;
+        }
+        fs.sync_directory_with(&quarantine_dir, sync_mode)?;
+        if let Some(src_dir) = src.parent() {
+            fs.sync_directory_with(src_dir, sync_mode)?;
+        }
+        Ok(())
+    })();
+    if let Err(e) = commit_result {
+        // Best-effort: undo BOTH moves and re-sync. The sidecar rollback is
+        // unconditional — a no-op rename failure (the sidecar never moved, or
+        // never existed) is harmless and ignored like the rest. A rollback that
+        // itself fails leaves nothing more we can safely do here; surface the
+        // original error.
+        let _ = fs.rename(&dest, src);
+        let _ = fs.rename(&dest_sidecar, &src_sidecar);
+        if let Some(src_dir) = src.parent() {
+            let _ = fs.sync_directory_with(src_dir, sync_mode);
+        }
+        let _ = fs.sync_directory_with(&quarantine_dir, sync_mode);
+        return Err(e);
+    }
     Ok(dest)
 }
 
-/// Block-salvages a corrupt SST during repair: quarantines the original (which
-/// frees its path), writes a fresh SST holding its recoverable blocks into that
-/// path, and reopens it.
+/// Marker path naming WHY a quarantined file was set aside: its restriction
+/// bound was unrecoverable at `resurrection = off`. A resurrection repair
+/// reclaims marked files back into `tables/` (see [`reclaim_resurrectable`]),
+/// keeping the resurrection knob two-way — no manual file move between a
+/// default repair and a resurrection re-run. The marker is NEVER written for
+/// flag-independent quarantines (duplicates, corrupt files, bulk-ingest
+/// rejects, salvage byproducts), so a reclaim can never resurrect those.
+fn resurrectable_marker_path(quarantined: &std::path::Path) -> PathBuf {
+    let mut name = quarantined.file_name().unwrap_or_default().to_os_string();
+    name.push(".resurrectable");
+    quarantined.with_file_name(name)
+}
+
+/// Durably writes the resurrectable marker beside a freshly quarantined file.
+/// The CALLER must treat a failure as "the set-aside did not commit": roll the
+/// quarantine move back (restore the file to `tables/`) and propagate, so a
+/// retry re-runs the whole classification instead of leaving an UNMARKED
+/// set-aside that a resurrection repair could never reclaim.
+fn mark_resurrectable(
+    fs: &dyn crate::fs::Fs,
+    quarantined: &std::path::Path,
+    sync_mode: crate::fs::SyncMode,
+) -> crate::Result<()> {
+    use std::io::Write;
+    let marker = resurrectable_marker_path(quarantined);
+    let mut file = fs.open(
+        &marker,
+        &crate::fs::FsOpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true),
+    )?;
+    file.write_all(b"resurrectable")?;
+    file.flush()?;
+    crate::fs::FsFile::sync_all_with(&*file, sync_mode)?;
+    drop(file);
+    if let Some(dir) = marker.parent() {
+        fs.sync_directory_with(dir, sync_mode)?;
+    }
+    Ok(())
+}
+
+/// Returns marked resurrectable set-asides from `repair-quarantine/` to
+/// `tables/`, so a resurrection repair recovers them like any other punched
+/// file — the flag's two-way half (the marker is written by the flag-dependent
+/// set-aside sites). Only files bearing a `.resurrectable` marker move; the
+/// marker is consumed by the move. A collision-suffixed quarantine name
+/// (`{id}.N`) reclaims to its plain `{id}`; an occupied target skips the file
+/// (kept marked for a later run) rather than clobbering. Crash-safe by
+/// idempotence: a file either still sits marked in quarantine (retried next
+/// run) or already sits in `tables/` (recovered normally; its stale marker is
+/// swept here).
+#[cfg(feature = "std")]
+fn reclaim_resurrectable(
+    fs: &dyn crate::fs::Fs,
+    table_base_folder: &std::path::Path,
+    sync_mode: crate::fs::SyncMode,
+) -> crate::Result<()> {
+    let quarantine_dir = table_base_folder
+        .parent()
+        .unwrap_or(table_base_folder)
+        .join("repair-quarantine");
+    if !fs.exists(&quarantine_dir)? {
+        return Ok(());
+    }
+    for entry in fs.read_dir(&quarantine_dir)? {
+        let Some(data_name) = entry.file_name.strip_suffix(".resurrectable") else {
+            continue;
+        };
+        let marker = quarantine_dir.join(&entry.file_name);
+        let data = quarantine_dir.join(data_name);
+        if !fs.exists(&data)? {
+            // A crash between a previous reclaim's move and its marker removal:
+            // the file already went back and was recovered; sweep the leftover.
+            let _ = fs.remove_file(&marker);
+            continue;
+        }
+        // A collision-suffixed quarantine name ({id}.N) reclaims to plain {id}.
+        let id_part = data_name.split('.').next().unwrap_or(data_name);
+        if id_part.parse::<TableId>().is_err() {
+            continue;
+        }
+        let target = table_base_folder.join(id_part);
+        if fs.exists(&target)? {
+            log::warn!(
+                "not reclaiming {}: {} is already occupied; kept marked for a later run",
+                data.display(),
+                target.display(),
+            );
+            continue;
+        }
+        fs.rename(&data, &target)?;
+        // Everything after the rename runs inside one fallible span: a failure
+        // must NOT return with the SST sitting in `tables/` unreferenced by the
+        // previously installed manifest — a caller that reacts to the failed
+        // repair by simply REOPENING the tree would then have orphan cleanup
+        // delete the only recovered copy. On failure the file (and any moved
+        // sidecar) rolls BACK into quarantine, marker intact, where the next
+        // resurrection repair rediscovers it; quarantine — not `tables/` — is
+        // the retry-safe location for THIS flow precisely because the marker
+        // machinery re-scans it. The marker is consumed only AFTER both syncs,
+        // so a crash inside the span also leaves a marked, reclaimable file
+        // (the un-synced rename either rolls back with its directory, or the
+        // file lands in `tables/`, is recovered, and the stale marker is swept
+        // next run).
+        let data_sidecar = crate::restrict_bound::sidecar_path(&data);
+        let target_sidecar = crate::restrict_bound::sidecar_path(&target);
+        let commit = (|| -> crate::Result<()> {
+            // Bring a companion sidecar back too (present only when a
+            // corrupt-but-existing sidecar traveled with the quarantine move; a
+            // corrupt sidecar is ignored by recovery, so this is harmless
+            // bookkeeping).
+            if fs.exists(&data_sidecar)? {
+                let _ = fs.rename(&data_sidecar, &target_sidecar);
+            }
+            // Destination first, then source: the same crash ordering the
+            // quarantine / restore moves use — the reclaimed name must be
+            // durable before its quarantine entry's removal is.
+            fs.sync_directory_with(table_base_folder, sync_mode)?;
+            fs.sync_directory_with(&quarantine_dir, sync_mode)?;
+            Ok(())
+        })();
+        if let Err(e) = commit {
+            // Best-effort: undo both moves and re-sync; surface the original
+            // error. A rollback that itself fails leaves nothing more we can
+            // safely do here — the marker still names the file for the next run.
+            let _ = fs.rename(&target, &data);
+            let _ = fs.rename(&target_sidecar, &data_sidecar);
+            let _ = fs.sync_directory_with(&quarantine_dir, sync_mode);
+            let _ = fs.sync_directory_with(table_base_folder, sync_mode);
+            return Err(e);
+        }
+        let _ = fs.remove_file(&marker);
+        log::info!(
+            "reclaimed resurrectable set-aside {} -> {}",
+            data.display(),
+            target.display(),
+        );
+    }
+    Ok(())
+}
+
+/// Moves a quarantined original back to its `table_path`, durably. The inverse of
+/// [`quarantine_file`], used when a TRANSIENT salvage failure must not strand the
+/// only copy in quarantine (which a retry, no longer finding it under `tables/`,
+/// would never rediscover). `rename` replaces any partial / salvaged output the
+/// aborted salvage left at `table_path`, and both affected directory entries are
+/// synced so the restore survives a power loss the same way the quarantine move
+/// does.
+fn restore_quarantined(
+    fs: &dyn crate::fs::Fs,
+    quarantined: &std::path::Path,
+    table_path: &std::path::Path,
+    encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+    sync_mode: crate::fs::SyncMode,
+) -> crate::Result<()> {
+    // Capture the companion sidecar's RAW bytes BEFORE anything moves: if the
+    // direct sidecar rename below fails after the SST is already restored, the
+    // bytes are re-published at the destination instead, so the exact bound is
+    // never stranded in quarantine (where the retried repair — which scans only
+    // `tables/` — would silently degrade the restored SST to the lossy
+    // geometry fallback). A TRANSIENT probe / read failure propagates while
+    // nothing has moved yet; a PERSISTENT one — or a file larger than any
+    // VALID sidecar encoding (an attacker-padded / corrupt file must not be
+    // trusted into a full-size allocation) — leaves no rescue copy, but the
+    // direct rename below (which never reads the content) may still succeed.
+    let quarantined_sidecar = crate::restrict_bound::sidecar_path(quarantined);
+    let sidecar_state: Option<(bool, Option<Vec<u8>>)> = if fs.exists(&quarantined_sidecar)? {
+        match read_raw_file(
+            fs,
+            &quarantined_sidecar,
+            crate::restrict_bound::max_encoded_len(encryption),
+        ) {
+            Ok(bytes) => Some((true, bytes)),
+            Err(e) if is_transient_io(&e) => return Err(e),
+            Err(_) => Some((true, None)),
+        }
+    } else {
+        None
+    };
+    fs.rename(quarantined, table_path)?;
+    // Restore the companion `.restrict-bound` sidecar too, mirroring the move
+    // `quarantine_file` made: a restored SST without its exact bound would fall
+    // back to a conservative punch-geometry bound on the next open. Both files
+    // share the same two directories, so the syncs below cover both.
+    //
+    // The SST is NEVER rolled back into quarantine on a sidecar failure: a
+    // pair stranded there is invisible to the retried repair entirely (a
+    // silent whole-table loss), while a restored SST with a degraded bound
+    // stays recoverable through the deterministic geometry path.
+    if let Some((_, bytes)) = sidecar_state {
+        let dest_sidecar = crate::restrict_bound::sidecar_path(table_path);
+        if let Err(rename_err) = fs.rename(&quarantined_sidecar, &dest_sidecar) {
+            match bytes {
+                Some(bytes) => {
+                    // Fallback: re-publish the captured bytes atomically at the
+                    // destination. A failure here propagates (the SST stays
+                    // restored; the retry handles the boundless punched table
+                    // deterministically).
+                    log::warn!(
+                        "restoring {}: sidecar rename failed ({rename_err}); re-publishing \
+                         the captured bytes instead",
+                        table_path.display(),
+                    );
+                    crate::restrict_bound::publish_raw(fs, table_path, &bytes, sync_mode)?;
+                    // Best-effort: drop the now-duplicated quarantine copy so a
+                    // stale bound cannot linger beside future quarantines.
+                    let _ = fs.remove_file(&quarantined_sidecar);
+                }
+                None => {
+                    // The sidecar could be neither read nor moved: its bound is
+                    // unrecoverable through any mechanism. Continue — the
+                    // restore itself succeeded, and the retry resolves the
+                    // boundless punched table deterministically (geometry
+                    // bound, or set-aside when the punch pattern is
+                    // ambiguous). Aborting here would change nothing the
+                    // retry could use.
+                    log::error!(
+                        "restoring {}: sidecar is unreadable and its rename failed \
+                         ({rename_err}); the exact restriction bound is lost",
+                        table_path.display(),
+                    );
+                }
+            }
+        }
+    }
+    if let Some(dst_dir) = table_path.parent() {
+        fs.sync_directory_with(dst_dir, sync_mode)?;
+    }
+    if let Some(src_dir) = quarantined.parent() {
+        fs.sync_directory_with(src_dir, sync_mode)?;
+    }
+    Ok(())
+}
+
+/// Reads a small file's complete contents, or `None` when the file exceeds
+/// `max_len` — the reported length is untrusted input, so it is validated
+/// BEFORE sizing the allocation. Used to capture sidecar bytes before a restore
+/// move so they can be re-published if the direct rename fails; an oversized
+/// file cannot be a valid sidecar and is not worth rescuing.
+#[cfg(feature = "std")]
+fn read_raw_file(
+    fs: &dyn crate::fs::Fs,
+    path: &std::path::Path,
+    max_len: u64,
+) -> crate::Result<Option<Vec<u8>>> {
+    let file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
+    let len = crate::fs::FsFile::metadata(&*file)?.len;
+    if len > max_len {
+        return Ok(None);
+    }
+    let n = usize::try_from(len).map_err(|_| crate::Error::Unrecoverable)?;
+    Ok(Some(crate::file::read_exact(&*file, 0, n)?.to_vec()))
+}
+
+/// Whether an error is an UNAMBIGUOUSLY TRANSIENT (retryable) I/O failure, as
+/// opposed to one a re-read cannot fix.
+///
+/// The allowlist is deliberately narrow: only `Interrupted` (`EINTR`) and
+/// `WouldBlock` (`EAGAIN`) — the interrupted-syscall errors a retry genuinely
+/// clears, and which a corrupt on-disk structure can NEVER produce.
+///
+/// `Other` is NOT treated as transient, even though an injected fault or a raw
+/// `EIO` lands there, because a STRUCTURAL corruption lands there too: a corrupt
+/// trailer that decodes to a bad offset makes the reader seek before the start of
+/// the file, which Windows reports as `ERROR_NEGATIVE_SEEK` — an unmapped OS
+/// error the `From<std::io::Error>` bridge folds into `ErrorKind::Other`. Treating
+/// `Other` as transient would then abort the WHOLE repair (blocking recovery of
+/// every healthy sibling table) on a single genuinely-corrupt SST, and the class
+/// is platform-dependent (the same corruption reads back `InvalidInput` on Unix).
+/// A hardware `EIO` is likewise usually a persistent bad-sector failure, so
+/// recording that table unreadable — while the rest recover — is the right
+/// outcome. Fault-injection tests therefore inject `Interrupted` to model a
+/// retryable fault.
+///
+/// This inspects the CRATE's [`crate::io::ErrorKind`], which is what a
+/// `crate::Error::Io` always carries.
+fn is_transient_io(e: &crate::Error) -> bool {
+    matches!(e, crate::Error::Io(io) if io.kind().is_transient())
+}
+
+/// Whether manifest repair must fail closed on a table because its bulk-ingest
+/// sequence offset cannot be reconstructed from the SST alone (the rebuilt
+/// manifest would install it with offset 0 and silently mis-order / mis-expose
+/// its entries).
+///
+/// - `Some(true)`: authoritatively bulk-ingested — always fail closed.
+/// - `Some(false)`: a newer non-ingested table — safe (offset genuinely 0), even
+///   when its entries all sit at seqno 0 (a fresh tree's first batch).
+/// - `None`: a LEGACY SST written before the provenance flag existed — UNKNOWN.
+///   Treat it as bulk-ingested ONLY when its entries carry the ingest signature
+///   (present, and every LOCAL seqno 0), which a legacy bulk-ingest produces. A
+///   legacy first-batch-at-seqno-0 flush matches too and is conservatively
+///   quarantined; the ambiguity is unavoidable without the flag.
+fn has_unrecoverable_ingest_offset(
+    bulk_ingested: Option<bool>,
+    item_count: u64,
+    max_local_seqno: crate::SeqNo,
+) -> bool {
+    match bulk_ingested {
+        Some(flagged) => flagged,
+        None => item_count > 0 && max_local_seqno == 0,
+    }
+}
+
+/// A recovered table plus whether its recovery was COMPLETE (a clean whole-file
+/// recovery) or a LOSSY block-salvage that may have dropped corrupt blocks'
+/// keys. Repair keeps the best copy per table id, so a duplicate id in another
+/// table folder can supersede an earlier DAMAGED copy.
+///
+/// The physical location (`fs` / `base_folder` / `path` / `file_name`) travels
+/// with the candidate so that when a duplicate SUPERSEDES it, the loser's file
+/// can be quarantined out of `tables/`. The rebuilt manifest records only
+/// `id + checksum`, so two same-id files left in different folders would let
+/// recovery resolve the stale one by folder order and reopen it against the kept
+/// copy's mismatched checksum.
+struct TableCandidate {
+    table: Table,
+    complete: bool,
+    fs: Arc<dyn crate::fs::Fs>,
+    base_folder: PathBuf,
+    path: PathBuf,
+    file_name: String,
+}
+
+/// Records `candidate` for `id`, keeping the BETTER of the existing and the new
+/// copy: a COMPLETE recovery replaces a lossy salvage, so an intact duplicate in
+/// a later-scanned folder supersedes an earlier lossy one. Two completes (or two
+/// salvages) are equivalent for the rebuilt manifest — which needs only one
+/// readable copy per id — so the first-seen stays.
+///
+/// Returns the DISPLACED loser (the rejected new candidate, or the superseded old
+/// one) so the caller can quarantine its on-disk file; `None` when `id` was
+/// previously unseen (nothing displaced).
+#[must_use = "the displaced duplicate's file must be quarantined out of tables/"]
+fn keep_best_candidate(
+    map: &mut crate::HashMap<TableId, TableCandidate>,
+    id: TableId,
+    candidate: TableCandidate,
+) -> Option<TableCandidate> {
+    match map.get(&id) {
+        // Keep the existing copy when it is already complete, or when the new one
+        // is not an improvement (a lossy duplicate of a lossy copy): the NEW
+        // candidate is displaced.
+        Some(existing) if existing.complete || !candidate.complete => Some(candidate),
+        // The new candidate supersedes: `insert` returns the displaced old copy.
+        _ => map.insert(id, candidate),
+    }
+}
+
+/// Whether `a` and `b` name the SAME physical file — a symlink, junction, or
+/// case-insensitive alias resolving to one directory entry (two configured table
+/// folders pointing at the same location). Used so a repeated sighting of one SST
+/// through an alias is never quarantined as a "duplicate" (which would move the
+/// kept copy and orphan the manifest entry).
+///
+/// The two candidates must live in the SAME filesystem namespace for a path
+/// comparison to mean anything: a virtual (`MemFs`) table can sit at a path that
+/// also exists on the host filesystem, and canonicalizing both spellings through
+/// the host would call those distinct files aliases — the loser would then escape
+/// quarantine and a later reopen could resolve that leftover against the kept
+/// copy's manifest checksum. Backends advertise namespace identity through
+/// [`Fs::backend_id`](crate::fs::Fs::backend_id), whose `None` means "no shared
+/// namespace guarantee" and is therefore treated as DISTINCT.
+///
+/// Canonicalization that fails on EITHER path (e.g. a virtual path with no OS
+/// presence) conservatively returns `false` too — treat the paths as distinct —
+/// so a genuine duplicate is still quarantined.
+#[cfg(feature = "std")]
+fn same_physical_file(
+    fs_a: &dyn crate::fs::Fs,
+    a: &std::path::Path,
+    fs_b: &dyn crate::fs::Fs,
+    b: &std::path::Path,
+) -> bool {
+    match (fs_a.backend_id(), fs_b.backend_id()) {
+        (Some(id_a), Some(id_b)) if id_a == id_b => {}
+        // Different backends, or a backend that gives no namespace guarantee:
+        // path spellings are not comparable, so never alias them.
+        _ => return false,
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Quarantines a duplicate table file that lost to a better same-id copy, moving
+/// it out of `tables/` (so recovery cannot resolve it) and recording it as
+/// considered-but-not-referenced. A failed quarantine aborts the whole repair:
+/// leaving both same-id files in place would let recovery reopen the wrong one.
+#[cfg(feature = "std")]
+fn quarantine_duplicate(
+    loser: TableCandidate,
+    unreadable_files: &mut Vec<(PathBuf, String)>,
+    sync_mode: crate::fs::SyncMode,
+) -> crate::Result<()> {
+    let TableCandidate {
+        table,
+        fs,
+        base_folder,
+        path,
+        file_name,
+        ..
+    } = loser;
+    drop(table); // release the open file handle before the move
+    let dest = quarantine_file(&*fs, &base_folder, &path, &file_name, sync_mode)?;
+    unreadable_files.push((
+        path,
+        format!(
+            "duplicate table id superseded by another copy; quarantined to {}",
+            dest.display()
+        ),
+    ));
+    Ok(())
+}
+
+/// Builds a [`TableCandidate`] from a recovered table plus its physical location,
+/// records it as the best copy for `id`, and quarantines any duplicate displaced
+/// by the decision. The one path every recovered table takes to enter the
+/// manifest, so a superseded same-id file is never left discoverable.
+#[cfg(feature = "std")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "location + report threaded through"
+)]
+fn record_best(
+    map: &mut crate::HashMap<TableId, TableCandidate>,
+    unreadable_files: &mut Vec<(PathBuf, String)>,
+    id: TableId,
+    table: Table,
+    complete: bool,
+    fs: &Arc<dyn crate::fs::Fs>,
+    base_folder: &std::path::Path,
+    path: &std::path::Path,
+    file_name: &str,
+    sync_mode: crate::fs::SyncMode,
+) -> crate::Result<()> {
+    let candidate = TableCandidate {
+        table,
+        complete,
+        fs: Arc::clone(fs),
+        base_folder: base_folder.to_path_buf(),
+        path: path.to_path_buf(),
+        file_name: file_name.to_string(),
+    };
+    if let Some(loser) = keep_best_candidate(map, id, candidate) {
+        // If the displaced copy physically ALIASES the kept one (same directory
+        // entry via a symlink / junction / case-insensitive path), it is the SAME
+        // file — quarantining it would move the kept copy and orphan the manifest
+        // entry. Drop the loser's handle in place instead of quarantining.
+        let is_alias = map
+            .get(&id)
+            .is_some_and(|kept| same_physical_file(&*loser.fs, &loser.path, &*kept.fs, &kept.path));
+        if !is_alias {
+            quarantine_duplicate(loser, unreadable_files, sync_mode)?;
+        }
+    }
+    Ok(())
+}
+
+/// Block-salvages a corrupt SST during repair: reads the ALREADY-QUARANTINED
+/// original (the caller performs the move, which frees `table_path`), writes a
+/// fresh SST holding its recoverable blocks into that path, and reopens it.
 ///
 /// Returns `Ok(None)` when nothing was recoverable (the original stays in
 /// quarantine and the path is left empty), or `Err` when even salvage cannot
 /// open the source (its metadata / index / SFA trailer is itself unreadable).
+/// Whether a freshly-recovered SST passes the salvage-mode block verify.
+///
+/// One uniform path for encrypted and unencrypted tables: the out-of-band
+/// section walk. Block headers and payload checksums are PLAINTEXT, so the
+/// walk needs the provider only to decode the meta block (the per-SST ECC
+/// descriptor); every section — data, index/TLI, filter, zone map, delete
+/// bitmap, locator, meta — is then verified against its raw on-disk checksum,
+/// which flags even a persistent ECC-CORRECTABLE fault (a live read would
+/// silently heal it in memory while the corrupt bytes stay on disk).
+/// Classifies a block-verifier result for the salvage gate. A structural
+/// divergence (a checksum / decode / cross-check mismatch) is genuine
+/// corruption: `Ok(true)`, route the table through salvage. Only a TRANSIENT
+/// [`crate::Error::Io`] (the [`is_transient_io`] allowlist) aborts the repair
+/// (`Err`) for a retry, rather than dropping a healthy block into a partial
+/// replacement. A PERSISTENT I/O failure is NOT retryable — a bad sector, or a
+/// structural corruption surfacing as `Io(Other)` on some platforms — so it is
+/// graded as corruption and salvaged too, rather than aborting the whole repair
+/// and stranding every other healthy table on one unrecoverable read.
+fn is_corruption(res: crate::Result<()>) -> crate::Result<bool> {
+    match res {
+        Ok(()) => Ok(false),
+        Err(e) if is_transient_io(&e) => Err(e),
+        Err(_) => Ok(true),
+    }
+}
+
+fn block_verify_verdict(
+    config: &Config,
+    folder_fs: &Arc<dyn crate::fs::Fs>,
+    table_path: &std::path::Path,
+    table: &Table,
+) -> crate::Result<BlockVerifyVerdict> {
+    // Walk only the recovered view's LIVE data: for a tight-space RESTRICTED view
+    // (a valid `.restrict-bound` sidecar was accepted) the `[0, punch_offset)`
+    // prefix is hole-punched and reads as zeros, so starting at byte 0 would
+    // report those dead blocks as corruption and salvage would then quarantine an
+    // otherwise-healthy restricted SST. `punch_offset()` is `0` for a normal table.
+    let data_start = table.punch_offset()?;
+    let report = crate::verify::verify_sst_file_with_context(
+        &**folder_fs,
+        table_path,
+        config.encryption.as_deref(),
+        // Repair KNOWS the durable id (recovery already cross-checked it
+        // against the file name), so the verify probe enforces the same meta
+        // id check — a checksum-clean forged tail meta falls back to the
+        // intact MID mirror instead of dictating a forged ECC descriptor.
+        Some(table.metadata.id),
+        data_start,
+    );
+    // A TRANSIENT read failure DURING the walk (a retryable `Interrupted` /
+    // `WouldBlock`) is not block corruption: routing it through salvage would
+    // re-read the same bytes and drop a healthy block. Propagate it so the repair
+    // aborts and the operator retries, mirroring the decode-load gate below. Any
+    // OTHER kind falls through to the corruption verdict: a truncation
+    // (`UnexpectedEof`) is genuine on-disk damage, and a PERSISTENT failure
+    // (`Other` / EIO, `PermissionDenied`) is not fixed by a retry either, so
+    // aborting forever would strand every healthy sibling table on one bad SST.
+    // This matches the `is_corruption` allowlist policy exactly.
+    //
+    // This gate depends on the walk CLASSIFYING transient faults as one of these
+    // two I/O-bearing variants: a mid-walk seek failure, a transient block-header
+    // read, and a raw-section read all surface as `DataReadError` rather than
+    // being folded into `HeaderCorrupted` / `TocCorrupted`, so a flaky read here
+    // is not mistaken for corruption and salvaged.
+    for e in &report.errors {
+        if let crate::verify::BlockVerifyError::SstFileUnreadable { error, .. }
+        | crate::verify::BlockVerifyError::DataReadError { error, .. } = e
+            && error.kind().is_transient()
+        {
+            // Preserve the transient ErrorKind: re-wrapping as `Other` would make
+            // the caller's `is_transient_io` check see a non-transient kind and
+            // re-grade this retryable failure as corruption, defeating the
+            // transient-propagation intent of this very gate.
+            return Err(crate::Error::Io(crate::io::Error::new(
+                error.kind(),
+                error.to_string(),
+            )));
+        }
+    }
+
+    // A non-parity error is corruption regardless of any warnings.
+    let verdict = if !report
+        .errors
+        .iter()
+        .all(|e| matches!(e, crate::verify::BlockVerifyError::EccParityMismatch { .. }))
+    {
+        BlockVerifyVerdict::Corrupt
+    } else if report
+        .warnings
+        .iter()
+        .any(|w| matches!(w, crate::verify::BlockVerifyWarning::UnrecognizedEcc { .. }))
+    {
+        // Unrecognized ECC descriptor: the walk SKIPPED the SST-block
+        // sections entirely (their trailer length is underivable), so
+        // NOTHING about the data was verified — a stronger degradation
+        // than a checked-but-unverifiable-parity report. Graded BEFORE the
+        // parity-only arm below: parity mismatches in the still-walked
+        // self-describing meta blocks must not mask the skipped data /
+        // index sections.
+        BlockVerifyVerdict::DegradedUnscanned
+    } else if is_corruption(table.verify_kv_checksums())? {
+        // The walk verifies raw block checksums but never DECODES entries,
+        // so a stale per-KV footer behind a re-stamped block checksum still
+        // reads clean at the block level. Footer-bearing tables must pass
+        // the per-KV verification (a no-op without footers) BEFORE the
+        // degradation arms below: a forged footer also leaves the parity
+        // trailer mismatched, and grading that "parity-only degradation"
+        // would let the keep-decision retain a table with a KNOWN-stale
+        // entry digest. The salvage row path validates footers and drops
+        // the forged block, so route it there. (Runs after the
+        // unrecognized-ECC arm: the live table opened under its OWN
+        // recovered descriptor, but an out-of-band unrecognized descriptor
+        // already means nothing about the data was verified.)
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_blob_links())? {
+        // Same reasoning for the blob-link list: the section carries no
+        // per-section checksum, so the walk can only validate its SHAPE — a
+        // flipped blob id passes it. Cross-check against the table's own
+        // indirection entries (a no-op without the section); a mismatch is
+        // corruption, and salvage derives the links from the recovered
+        // indirections rather than copying the forged list.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_tli_mirrors())? {
+        // Each TLI mirror is independently checksum-clean to the walk, but a
+        // forged copy that DECODES to a different handle list would steer
+        // the next recovery (which prefers the tail) away from real blocks.
+        // Diverging decoded mirrors are corruption; salvage walks the HEAD
+        // copy, so the recovered SST is rebuilt from a single, fully
+        // re-verified handle list. BOTH mirrors forged to the SAME list that
+        // OMITS a physical block are covered too: the salvage walk
+        // cross-checks the index against the physical data-section tiling
+        // and frames the uncovered bytes from their block headers, so the
+        // hidden block is recovered (or reported dropped), never silently
+        // missing from an apparently complete copy.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_seqno_bounds())? {
+        // The seqno_bounds block is checksum-clean to the walk even when
+        // its payload was re-stamped to another structurally valid map, and
+        // scan_since_seqno trusts it to SKIP blocks — keeping the table
+        // would silently omit live entries from every seqno-scoped scan.
+        // Salvage re-derives the bounds from the re-emitted entries.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_block_entry_counts())? {
+        // The out-of-band walk verifies only the outer frame and the per-KV
+        // gate is a no-op without footers, so a checksum-clean block whose
+        // trailer declares more entries than it decodes (a valid prefix, a
+        // malformed tail) grades clean while a later scan silently omits the
+        // tail. Full-decode every block; a count mismatch routes the table
+        // through salvage (whose row path drops the under-decoding block).
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_zone_map())? {
+        // A checksum-clean zone_map re-stamped to another structurally valid
+        // map would let a predicate scan skip blocks its forged min/max
+        // excludes, silently omitting matching rows. Diverging stats are
+        // corruption; salvage re-derives the zone map from the re-emitted
+        // blocks.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_locator())? {
+        // A checksum-clean locator re-stamped to resolve a key to a block
+        // other than its newest-version block would make point_read return a
+        // stale value without falling back to the sorted index. A mapping
+        // that disagrees with the decoded blocks is corruption; salvage
+        // rebuilds the locator from the re-emitted entries.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_filter(config.prefix_extractor.as_ref()))? {
+        // A checksum-clean filter re-stamped to another parseable filter
+        // makes check_bloom silently skip point reads for any key turned
+        // into a false negative. An existing key the filter reports as
+        // definitely absent is corruption; salvage rebuilds the filter from
+        // the re-emitted keys.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_block_layout())? {
+        // A checksum-clean block_layout re-stamped to another structurally
+        // valid boundary set mis-maps the partial range-read path's
+        // decompression bounds, silently omitting keys. Boundaries that
+        // disagree with the frames' actual inner blocks are corruption;
+        // salvage re-derives the layout when re-encoding.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_point_read_reachability())? {
+        // A checksum-clean embedded hash / binary index re-stamped to hide a
+        // key (a MARKER_FREE bucket, a misdirected offset) makes point_read
+        // miss existing data. Keys the block decodes but point_read cannot
+        // retrieve are corruption; salvage re-emits the block with fresh
+        // indexes.
+        BlockVerifyVerdict::Corrupt
+    } else if is_corruption(table.verify_metadata_bounds())? {
+        // Both meta mirrors re-stamped CONSISTENTLY pass the mirror
+        // comparison, yet run selection trusts the recorded key range — a
+        // narrowed range hides real keys (and the range tombstones masking
+        // older tables). Bounds that disagree with the decoded contents are
+        // corruption; salvage re-derives the metadata from the re-emitted
+        // entries.
+        BlockVerifyVerdict::Corrupt
+    } else if !report.is_ok() {
+        // Parity-ONLY rot: every payload checksum verified clean, only the
+        // recovery margin is dead. The data is fully readable, so it grades
+        // like a warning-bearing report — salvage preferred (the rewrite
+        // regenerates fresh parity), but never at the cost of dropping data
+        // salvage cannot re-emit.
+        BlockVerifyVerdict::DegradedButReadable
+    } else if report.has_warnings() {
+        // Everything scanned verified clean, but the parity trailers could
+        // not be recomputed (a parity-less build). The caller decides
+        // between salvage (a rewrite under fully-verifiable framing) and
+        // keeping the table when salvage cannot re-emit it.
+        BlockVerifyVerdict::DegradedButReadable
+    } else {
+        BlockVerifyVerdict::Clean
+    };
+    Ok(verdict)
+}
+
+/// Outcome of the salvage-mode block verify, from the repair gate's point of
+/// view (see [`block_verify_verdict`]).
+enum BlockVerifyVerdict {
+    /// Every section verified against its raw on-disk checksum.
+    Clean,
+    /// Every payload the walk checked verified clean, but the table is
+    /// DEGRADED: its parity trailers rotted or could not be recomputed while
+    /// the payloads stayed intact. Prefer a salvage rewrite, but never at
+    /// the cost of dropping data salvage cannot re-emit.
+    DegradedButReadable,
+    /// The walk could not scan the SST-block sections at all (an
+    /// unrecognized ECC descriptor): the data is UNVERIFIED, not merely
+    /// degraded — any keep decision must first verify it another way.
+    DegradedUnscanned,
+    /// At least one payload / section failed verification.
+    Corrupt,
+}
+
+/// What the repair should do with a freshly-recovered table, based on the
+/// salvage-mode block verify.
+#[derive(Debug)]
+enum RepairKeepDecision {
+    /// The table joins the rebuilt manifest as-is.
+    Keep,
+    /// The table is routed through block salvage (quarantine + rewrite).
+    Salvage,
+    /// The table can be neither trusted nor faithfully salvaged under the
+    /// active resurrection policy: it is EXCLUDED from the rebuilt manifest and
+    /// its file set aside (protecting it from the orphan cleanup a later open
+    /// runs) with this reason. The tree still opens; the excluded table is
+    /// re-admitted by recompaction or, where the reason allows, by enabling
+    /// resurrection.
+    Quarantine(&'static str),
+}
+
+/// Whether the on-disk TOC catalogue could HIDE a deletion section — see
+/// [`crate::verify::toc_may_hide_deletion_section`]. A STRUCTURAL catalogue
+/// ambiguity grades `Ok(true)` (fail closed): if the catalogue cannot be parsed
+/// to prove no section is hidden, salvage must not trust the parsed absence of
+/// deletion metadata.
+///
+/// # Errors
+///
+/// Propagates a TRANSIENT [`crate::Error::Io`] from opening or reading the
+/// trailer. Grading a retryable read as `true` would send a table
+/// [`repair_with_salvage`](Self) already found corrupt to `Quarantine` — dropping
+/// its healthy ranges from the rebuilt manifest — when a retry of the probe could
+/// have let block salvage recover them.
+pub(crate) fn toc_may_hide_deletions(
+    folder_fs: &Arc<dyn crate::fs::Fs>,
+    table_path: &std::path::Path,
+) -> crate::Result<bool> {
+    let mut file = match folder_fs.open(table_path, &crate::fs::FsOpenOptions::new().read(true)) {
+        Ok(file) => file,
+        // A TRANSIENT open failure propagates (a retry could open the file and
+        // prove no hidden section); a PERSISTENT one fails closed as catalogue
+        // ambiguity — we cannot read the TOC to prove it hides no deletion
+        // section, so `true` quarantines rather than resurrecting masked rows.
+        Err(e) => {
+            let err = crate::Error::Io(e);
+            return if is_transient_io(&err) {
+                Err(err)
+            } else {
+                Ok(true)
+            };
+        }
+    };
+    match crate::sfa::Reader::from_reader(&mut file) {
+        Ok(reader) => Ok(crate::verify::toc_may_hide_deletion_section(
+            reader.toc(),
+            reader.toc_pos(),
+        )),
+        // A transient trailer read propagates (retry could prove no hidden
+        // section); a persistent I/O failure or a structural trailer failure is
+        // genuine catalogue ambiguity that fails closed.
+        Err(crate::sfa::Error::Io(e)) => {
+            let err = crate::Error::Io(e);
+            if is_transient_io(&err) {
+                Err(err)
+            } else {
+                Ok(true)
+            }
+        }
+        Err(_) => Ok(true),
+    }
+}
+
+/// Grades a freshly-recovered table into a [`RepairKeepDecision`].
+///
+/// `Corrupt` always salvages. `DegradedButReadable` (payloads verified clean,
+/// only the parity trailers rotted or could not be recomputed) salvages ONLY
+/// when salvage can faithfully re-emit the table: a range-tombstone SST is
+/// rejected by the block walk, so routing it through salvage would drop
+/// healthy, verified data over dead parity — it is kept as-is (with an
+/// operator-facing warning) instead. `DegradedUnscanned` (unrecognized ECC
+/// descriptor: the walk verified NOTHING about the data) never keeps: a
+/// rewritable table salvages, and a range-tombstone table — which cannot be
+/// verified in full (every lazy side structure would need its own
+/// handle-based check) and cannot be re-emitted — is excluded (recompact under
+/// a supported scheme to re-admit it) instead of riding unverified into the
+/// rebuilt manifest.
+///
+/// `allow_resurrection` governs the one ambiguous case: a corrupt catalogue
+/// that could conceal a deletion section. Off (default) excludes the table (its
+/// visibility is unrecoverable, so admitting it would resurrect masked rows);
+/// on, it salvages, accepting that suppressed rows reappear.
+fn verify_keep_decision(
+    config: &Config,
+    folder_fs: &Arc<dyn crate::fs::Fs>,
+    table_path: &std::path::Path,
+    table: &Table,
+    allow_resurrection: bool,
+) -> crate::Result<RepairKeepDecision> {
+    Ok(
+        match block_verify_verdict(config, folder_fs, table_path, table)? {
+            BlockVerifyVerdict::Clean => RepairKeepDecision::Keep,
+            BlockVerifyVerdict::Corrupt => {
+                // A `Corrupt` verdict from a catalogue that could HIDE a deletion
+                // section (an omitted / renamed / shadowed `range_tombstones` or
+                // `delete_bitmap`) makes the table's visibility unrecoverable: the
+                // positional salvage walk reopens the same forged TOC, sees no
+                // deletion section in the parsed state, and re-emits the suppressed
+                // rows as LIVE. The salvage-side resurrection guard only inspects
+                // the PARSED deletion state, which the concealment defeats, so the
+                // decision has to happen here, governed by the resurrection flag:
+                // off, exclude the table (admitting it would resurrect masked
+                // rows); on, salvage and accept the resurrection. A relabel that
+                // keeps the tiling intact but re-roles the block is caught inside
+                // salvage itself (`salvage_with_context` fails closed on a corrupt
+                // rebuildable section when no deletion is visible), which both this
+                // path and the recovery-failure salvage path funnel through.
+                if toc_may_hide_deletions(folder_fs, table_path)? && !allow_resurrection {
+                    RepairKeepDecision::Quarantine(
+                        "TOC corruption may hide deletion metadata (range tombstones \
+                     / delete bitmap); its visibility is unrecoverable, so the table \
+                     is excluded to avoid resurrecting masked rows. Enable \
+                     resurrection to salvage it, accepting that suppressed rows \
+                     reappear",
+                    )
+                } else {
+                    RepairKeepDecision::Salvage
+                }
+            }
+            BlockVerifyVerdict::DegradedButReadable => {
+                if table.range_tombstones().is_empty() {
+                    RepairKeepDecision::Salvage
+                } else {
+                    log::warn!(
+                        "table {} at {}: every payload verified clean but its ECC is \
+                     partially uncheckable or rotted, and salvage cannot re-emit its \
+                     range tombstones — keeping the table as-is; recompact to re-stamp \
+                     it under fresh, verifiable parity",
+                        table.metadata.id,
+                        table_path.display(),
+                    );
+                    RepairKeepDecision::Keep
+                }
+            }
+            BlockVerifyVerdict::DegradedUnscanned => {
+                if table.range_tombstones().is_empty() {
+                    RepairKeepDecision::Salvage
+                } else {
+                    RepairKeepDecision::Quarantine(
+                        "ECC descriptor unrecognized (the block walk cannot verify the \
+                     table) and salvage cannot re-emit its range tombstones; the table \
+                     is excluded (recompact it under a supported scheme to re-admit it)",
+                    )
+                }
+            }
+        },
+    )
+}
+
+/// Outcome of [`try_salvage_table`].
+enum SalvageOutcome {
+    /// A clean replacement was written and reopened, ready to install.
+    Salvaged(Table),
+    /// Nothing was recoverable, or the replacement was rejected (an
+    /// unreconstructible bulk-ingest offset); the caller records the table
+    /// unreadable. The original stays quarantined for inspection.
+    Unusable,
+    /// The `reject_punched_without_bound` guard fired: a salvage-dropped data
+    /// extent of the source reads as zeros (the hole-punch signature), so the
+    /// source lost data to a punch whose bound is unrecoverable. The
+    /// unrestricted replacement was rejected and quarantined — installing it
+    /// would resurrect the reclaimed region's superseded rows.
+    PunchedBoundLost,
+}
+
 fn try_salvage_table(
     config: &Config,
-    table_base_folder: &std::path::Path,
     fs: &Arc<dyn crate::fs::Fs>,
+    allow_resurrection: bool,
+    // The already-quarantined corrupt original (the salvage source). The
+    // CALLER performs the quarantine move and aborts the whole repair when it
+    // fails — a manifest omitting a still-in-place file would let the next
+    // open's orphan cleanup delete the only copy. An error returned from HERE
+    // is therefore always post-quarantine: the original is safely preserved,
+    // and the caller records the failure instead of aborting.
+    quarantined: &std::path::Path,
     table_path: &std::path::Path,
-    file_name: &str,
     table_id: TableId,
-) -> crate::Result<Option<Table>> {
-    // Move the corrupt original aside first: this frees `table_path` so salvage
-    // can write the recovered copy straight into it (no temp-file rename), and
-    // preserves the corrupt bytes for the operator to inspect.
-    let quarantined = quarantine_file(&**fs, table_base_folder, table_path, file_name)?;
-
-    // Salvage under the tree's configured comparator so the rewritten SST opens
-    // and orders consistently with the rest of the tree on reopen.
-    let report = crate::salvage::salvage_sst_with_comparator(
-        &quarantined,
+    // Fail closed when the salvage walk reveals the source was PUNCHED (a
+    // dropped data extent reads as zeros) — set by the recovery-failure arm
+    // when it has no recoverable restriction bound and resurrection is off.
+    // The pre-salvage first-bytes probe catches a punched FIRST block cheaply,
+    // but a partial punch (the punch-on-drop reclaim continues past an
+    // individual `punch_hole` failure) can leave the first block intact while
+    // later prefix blocks are zeroed; only the walk sees those. The
+    // verification arm passes `false`: it derives the bound from its restricted
+    // view, so its salvage output is re-restricted, never ambiguous.
+    reject_punched_without_bound: bool,
+) -> crate::Result<SalvageOutcome> {
+    // Salvage under the tree's configured comparator + crypto/dictionary context
+    // so the rewritten SST opens, orders, and decrypts / decompresses consistently
+    // with the rest of the tree on reopen (the reopen below uses the same
+    // `config.encryption` / `config.zstd_dictionary`).
+    let report = crate::salvage::salvage_with_context(
+        quarantined,
         table_path.to_path_buf(),
         fs,
         &config.comparator,
+        &crate::salvage::SalvageOptions {
+            encryption: config.encryption.clone(),
+            #[cfg(zstd_any)]
+            zstd_dictionary: config.zstd_dictionary.clone(),
+            // The real table id, so encrypted block AAD (which binds it) decrypts
+            // and the recovered copy reopens under the same id below.
+            table_id,
+            // Repair KNOWS the durable id (the file name), so the salvage
+            // open cross-checks the meta payload against it: a forged tail
+            // id falls back to the intact MID mirror instead of stamping the
+            // recovered copy with an identity the reopen below would reject.
+            expected_stored_id: Some(table_id),
+            // Governed by the recovery-wide resurrection flag: off (default), a
+            // delete-bearing SST whose bitmap cannot be authenticated is excluded
+            // rather than masked against an unverified bitmap; on, its rows are
+            // re-emitted live, accepting that deleted rows reappear.
+            allow_delete_resurrection: allow_resurrection,
+            // The recovered SST is persisted at the tree's configured
+            // durability, matching the manifest rebuilt around it.
+            sync_mode: config.sync_mode,
+            // The extractor is configuration, not persisted state: without
+            // it the rebuilt filter loses the source's prefix hashes and
+            // prefix scans see the salvaged copy as definitely absent.
+            prefix_extractor: config.prefix_extractor.clone(),
+        },
     )?;
     if report.salvaged_path.is_none() {
-        return Ok(None);
+        return Ok(SalvageOutcome::Unusable);
     }
     if !report.dropped.is_empty() {
         log::warn!(
@@ -191,6 +1248,23 @@ fn try_salvage_table(
             report.blocks_salvaged,
             report.dropped.len(),
         );
+    }
+    if reject_punched_without_bound
+        && dropped_data_extent_is_zeroed(&**fs, quarantined, &report.dropped)?
+    {
+        // The source was punched but its bound is unrecoverable: the salvaged
+        // replacement re-emits every intact block — including consumed,
+        // superseded blocks a partial punch left inside the reclaimed prefix —
+        // with nothing to restrict them. Reject it: quarantine the fresh copy
+        // (see the bulk-ingest rejection below for why a plain remove is not
+        // enough) and let the caller set the table aside.
+        let base = table_path.parent().ok_or(crate::Error::Unrecoverable)?;
+        let name = table_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or(crate::Error::Unrecoverable)?;
+        quarantine_file(&**fs, base, table_path, name, config.sync_mode)?;
+        return Ok(SalvageOutcome::PunchedBoundLost);
     }
 
     // Reopen the freshly-written (clean) salvaged SST so it joins the rebuilt
@@ -214,7 +1288,232 @@ fn try_salvage_table(
         #[cfg(feature = "metrics")]
         Arc::new(crate::metrics::Metrics::default()),
     )?;
-    Ok(Some(table))
+    // A salvaged copy of a bulk-ingested source still relies on the manifest-only
+    // global_seqno offset the rebuilt manifest cannot recover: its entries stay at
+    // local seqno 0, so installing it with offset 0 would silently mis-order and
+    // over-expose them. Treat it as unsalvageable — drop the freshly-written copy
+    // (a leftover reads back as a harmless orphan) and let the caller record it
+    // unreadable; the original stays set aside for inspection.
+    if has_unrecoverable_ingest_offset(
+        table.metadata.bulk_ingested,
+        table.metadata.item_count,
+        table.max_local_seqno(),
+    ) {
+        drop(table);
+        // QUARANTINE the rejected replacement, don't try-and-forget its removal. A
+        // discarded `remove_file` error would leave the freshly-written numeric SST
+        // in `tables/`; repair would still install a manifest that omits it and
+        // report success, but the next open classifies it as an orphan and fails on
+        // the SAME persistent deletion, so the "repaired" tree cannot reopen. Moving
+        // it out of `tables/` makes it a non-orphan. A quarantine failure propagates:
+        // it is post-quarantine of the ORIGINAL (safely preserved), so the caller
+        // records it as unreadable rather than aborting.
+        let base = table_path.parent().ok_or(crate::Error::Unrecoverable)?;
+        let name = table_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or(crate::Error::Unrecoverable)?;
+        quarantine_file(&**fs, base, table_path, name, config.sync_mode)?;
+        return Ok(SalvageOutcome::Unusable);
+    }
+    Ok(SalvageOutcome::Salvaged(table))
+}
+
+/// Whether any salvage-dropped DATA extent of `source` contains a
+/// block-aligned all-zero run — the hole-punch signature. A real data block's
+/// bytes are never all zero across a whole block, so such a run inside a
+/// dropped extent was physically reclaimed, not merely corrupted. Restricting
+/// the scan to the DROPPED extents keeps legitimate zero runs inside intact
+/// (checksum-clean) blocks from false-positiving.
+///
+/// The scan covers each dropped extent IN FULL, up to the next dropped extent
+/// or the end of the `data` section, not just its opening window: when the
+/// physical chain breaks, the salvage walk surrenders the whole remaining tail
+/// as ONE extent whose offset is the first DAMAGED (nonzero) frame, so punched
+/// blocks deeper inside it would otherwise stay invisible and the salvaged
+/// output would publish consumed records unrestricted.
+///
+/// # Errors
+///
+/// Propagates the open / read failure (a transient one aborts the repair for a
+/// retry, exactly like the other salvage-path reads).
+#[cfg(feature = "std")]
+fn dropped_data_extent_is_zeroed(
+    fs: &dyn crate::fs::Fs,
+    source: &std::path::Path,
+    dropped: &[crate::salvage::DroppedBlock],
+) -> crate::Result<bool> {
+    // Shortest run accepted as a punch. A hole is punched per DATA BLOCK, so a
+    // punched block contributes a zero run at least a block long — while inside
+    // an intact block a zero run is bounded by its framing (header, key/value
+    // lengths and checksums are never all zero across a whole block). The
+    // block-header length is the smallest possible block, so a run of that many
+    // zeros cannot come from one intact framed block.
+    const MIN_RUN: u64 = crate::table::block::Header::MIN_LEN as u64;
+    if dropped.is_empty() {
+        return Ok(false);
+    }
+    let mut file = fs.open(source, &crate::fs::FsOpenOptions::new().read(true))?;
+    let file_len = crate::fs::FsFile::metadata(&*file)?.len;
+    // The `data` section's physical end bounds every extent: a dropped extent
+    // runs to the next dropped one or to that end, whichever comes first.
+    let data_end = match crate::sfa::Reader::from_reader(&mut file) {
+        Ok(reader) => reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"data")
+            .map_or(file_len, |e| e.pos().saturating_add(e.len()).min(file_len)),
+        // No readable TOC (the very corruption salvage is recovering from):
+        // fall back to the file end — a superset of the data section, and the
+        // per-extent scan below is bounded by the next extent anyway.
+        Err(_) => file_len,
+    };
+    let mut starts: Vec<u64> = dropped
+        .iter()
+        .filter(|d| d.section == b"data" && d.offset < data_end)
+        .map(|d| d.offset)
+        .collect();
+    starts.sort_unstable();
+    starts.dedup();
+    const CHUNK: usize = 64 * 1024;
+    for (i, &start) in starts.iter().enumerate() {
+        let end = starts.get(i + 1).copied().unwrap_or(data_end).min(data_end);
+        let mut offset = start;
+        let mut run: u64 = 0;
+        while offset < end {
+            let want = usize::try_from(end - offset).unwrap_or(CHUNK).min(CHUNK);
+            let bytes = crate::file::read_exact(&*file, offset, want)?;
+            for &b in bytes.iter() {
+                if b == 0 {
+                    run += 1;
+                    if run >= MIN_RUN {
+                        return Ok(true);
+                    }
+                } else {
+                    run = 0;
+                }
+            }
+            offset += want as u64;
+        }
+    }
+    Ok(false)
+}
+
+/// Whether the source SST's first data block reads as all zeros, the signature of
+/// a hole-punched prefix. Probed at offset 0 (the `data` section is written first)
+/// over a small window that stays WITHIN the first block, so even a punch of only
+/// the first block is detected; a real data block's opening bytes (its first
+/// entry's key-length varint and key) are never all zero, so an unpunched SST can
+/// never false-positive.
+///
+/// Used by the recovery-failure salvage arm to fail closed on a PUNCHED source
+/// whose bound is unrecoverable (missing / corrupt sidecar and no `Table` to
+/// derive from): salvaging it into an unrestricted output would resurrect the
+/// straddling block's sub-bound rows.
+///
+/// This is the CHEAP pre-salvage fast path only: a PARTIAL punch (the
+/// punch-on-drop reclaim continues past an individual `punch_hole` failure) can
+/// leave the first block intact while later prefix blocks are zeroed, which this
+/// probe cannot see. [`dropped_data_extent_is_zeroed`] closes that gap after the
+/// salvage walk, whose dropped extents expose every zeroed block.
+///
+/// # Errors
+///
+/// Propagates the open / read failure.
+#[cfg(feature = "std")]
+fn source_prefix_is_punched(
+    fs: &dyn crate::fs::Fs,
+    table_path: &std::path::Path,
+) -> crate::Result<bool> {
+    const PROBE: usize = 64;
+    let file = fs.open(table_path, &crate::fs::FsOpenOptions::new().read(true))?;
+    let len = crate::fs::FsFile::metadata(&*file)?.len;
+    if len == 0 {
+        return Ok(false);
+    }
+    let n = usize::try_from(len).unwrap_or(PROBE).min(PROBE);
+    let bytes = crate::file::read_exact(&*file, 0, n)?;
+    Ok(bytes.iter().all(|&b| b == 0))
+}
+
+/// Re-imposes a tight-space restriction on a SALVAGED replacement SST, the single
+/// point every salvage output funnels through so the restriction can never be
+/// dropped on one path and kept on another.
+///
+/// Salvage rewrites its source as a fresh, UNPUNCHED table that re-emits the
+/// straddling block's sub-bound rows, so a punched source's restriction must be
+/// re-applied to the output or those superseded / deleted rows resurrect. With a
+/// known `bound` and resurrection off, the sidecar is re-written (so a later
+/// manifest-loss repair honors it against the now-unpunched file) and the table
+/// reopened restricted. Otherwise (resurrection on, or no recoverable bound) the
+/// salvaged table is kept whole and any stale sidecar cleared, since a lingering
+/// sidecar would wrongly restrict the unpunched replacement on a later repair.
+///
+/// ANY failure re-imposing the restriction (sidecar write or restricted reopen)
+/// restores the quarantined original to `table_path` before propagating, mirroring
+/// the salvage-error path. Otherwise the unpunched, sidecar-less salvaged
+/// replacement would be left in place, and a retry would recover it UNRESTRICTED
+/// and resurrect the sub-bound rows. This holds for a PERSISTENT failure
+/// (an ENOSPC on the sidecar write) as much as a transient one: the retry cannot
+/// re-derive the bound from a fresh unpunched output, so the punched original must
+/// be back in place for it to re-salvage and re-restrict from.
+#[cfg(feature = "std")]
+fn restrict_salvaged_output(
+    folder_fs: &dyn crate::fs::Fs,
+    config: &Config,
+    table_path: &std::path::Path,
+    quarantined: &std::path::Path,
+    salvaged: Table,
+    restrict_bound: Option<crate::UserKey>,
+    allow_resurrection: bool,
+) -> crate::Result<Table> {
+    match restrict_bound {
+        Some(bound) if !allow_resurrection => {
+            let table_id = salvaged.metadata.id;
+            let restricted = crate::restrict_bound::write(
+                folder_fs,
+                table_path,
+                config.encryption.as_deref(),
+                table_id,
+                &bound,
+                config.sync_mode,
+            )
+            .and_then(|()| salvaged.reopen_restricted(bound));
+            match restricted {
+                Ok(table) => Ok(table),
+                Err(e) => {
+                    // Drop the salvaged handle's open file BEFORE restoring. The
+                    // restore renames the quarantined original back over
+                    // `table_path`, and a backend that rejects replacing an OPEN
+                    // destination (Windows; the deletion path closes handles for
+                    // this same reason) would fail the rename while `salvaged` still
+                    // holds `table_path` open. A failed restore leaves the unpunched
+                    // salvaged SST in place with no bound, so the next repair would
+                    // recover it UNRESTRICTED and resurrect the sub-bound rows.
+                    drop(salvaged);
+                    // Restore on EVERY failure, transient or persistent: the
+                    // salvaged replacement sits at `table_path` unpunched with no
+                    // valid sidecar, so a retry that finds it there recovers it
+                    // UNRESTRICTED and resurrects the sub-bound rows. Putting the
+                    // punched original back lets the retry re-salvage and
+                    // re-restrict from a known state (a `rename` needs no free
+                    // space, so it survives the ENOSPC that may have caused `e`).
+                    restore_quarantined(
+                        folder_fs,
+                        quarantined,
+                        table_path,
+                        config.encryption.as_deref(),
+                        config.sync_mode,
+                    )?;
+                    Err(e)
+                }
+            }
+        }
+        _ => {
+            crate::restrict_bound::remove(folder_fs, table_path, config.sync_mode);
+            Ok(salvaged)
+        }
+    }
 }
 
 /// Discovers the blob files of a KV-separated tree for `repair` by scanning the
@@ -263,7 +1562,13 @@ fn recover_blob_files(
             // quarantine itself fails the bad name stays in place and the tree
             // would not reopen, so fail the repair rather than report a false
             // success.
-            let dest = quarantine_file(&*config.fs, &blobs_folder, &blob_path, &file_name)?;
+            let dest = quarantine_file(
+                &*config.fs,
+                &blobs_folder,
+                &blob_path,
+                &file_name,
+                config.sync_mode,
+            )?;
             unreadable.push((
                 blob_path,
                 format!(
@@ -280,6 +1585,12 @@ fn recover_blob_files(
 
         let checksum = match compute_table_checksum(&*config.fs, &blob_path) {
             Ok(c) => crate::Checksum::from_raw(c),
+            // A TRANSIENT read (flaky I/O) is retryable: recording the blob
+            // unreadable commits a manifest without the still-in-place file,
+            // which the next open's orphan sweep then DELETES — permanent value
+            // loss from a one-shot failure. Propagate so a retry re-reads it,
+            // mirroring the table-recovery path.
+            Err(e) if is_transient_io(&e) => return Err(e),
             Err(e) => {
                 seen_ids.remove(&blob_id);
                 unreadable.push((blob_path, e.to_string()));
@@ -289,6 +1600,8 @@ fn recover_blob_files(
 
         match crate::vlog::recover_blob_file(&blob_path, blob_id, checksum, 0, &config.fs) {
             Ok(bf) => blob_files.push(bf),
+            // Same transient/persistent split as the checksum read above.
+            Err(e) if is_transient_io(&e) => return Err(e),
             Err(e) => {
                 seen_ids.remove(&blob_id);
                 unreadable.push((blob_path, e.to_string()));
@@ -346,7 +1659,7 @@ impl Config {
     /// # Ok::<(), lsm_tree::Error>(())
     /// ```
     pub fn repair(&self) -> crate::Result<RepairReport> {
-        repair_tree(self, false)
+        repair_tree(self, false, false)
     }
 
     /// Like [`repair`](Self::repair), but when an SST fails whole-file recovery
@@ -384,13 +1697,39 @@ impl Config {
     /// # Ok::<(), lsm_tree::Error>(())
     /// ```
     pub fn repair_with_salvage(&self, salvage: bool) -> crate::Result<RepairReport> {
-        repair_tree(self, salvage)
+        repair_tree(self, salvage, false)
+    }
+
+    /// Like [`repair_with_salvage`](Self::repair_with_salvage), but with an
+    /// explicit `allow_resurrection` policy. When `false` (the default the other
+    /// entry points use), recovery drops data whose visibility became ambiguous
+    /// after a lost restriction bound or a lost / forged delete mask; when
+    /// `true`, it keeps that data, accepting that superseded or deleted rows may
+    /// reappear. Either setting yields a valid, openable tree; the flag is the
+    /// ONLY recovery decision an operator makes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tables directory cannot be scanned or a transient
+    /// I/O fault interrupts recovery (retryable), or if the rebuilt manifest
+    /// cannot be durably installed. See
+    /// [`repair_with_salvage`](Self::repair_with_salvage).
+    pub fn repair_with_resurrection(
+        &self,
+        salvage: bool,
+        allow_resurrection: bool,
+    ) -> crate::Result<RepairReport> {
+        repair_tree(self, salvage, allow_resurrection)
     }
 }
 
 /// Core repair routine. Separated from the [`Config::repair`] entry point so the
 /// logic is testable against a borrowed config.
-fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
+fn repair_tree(
+    config: &Config,
+    salvage: bool,
+    allow_resurrection: bool,
+) -> crate::Result<RepairReport> {
     // Hold the cross-process directory lock for the whole repair: it rewrites
     // CURRENT, writes a fresh snapshot, and sweeps `edits-*` in place, so a
     // concurrent open / repair of the same directory would corrupt the manifest.
@@ -401,19 +1740,26 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
     let _directory_lock =
         crate::config::acquire_directory_lock(&*config.fs, &config.path, config.directory_lock)?;
 
-    let mut recovered_tables: Vec<Table> = Vec::new();
-    let mut salvaged = 0usize;
+    // Best recovered copy per table id: a complete recovery beats a lossy salvage,
+    // so a duplicate id across aliased / routed table folders keeps only the best
+    // (and is never added to two L0 runs). See `keep_best_candidate`.
+    let mut recovered_by_id: crate::HashMap<TableId, TableCandidate> = crate::HashMap::default();
     let mut unreadable_files: Vec<(PathBuf, String)> = Vec::new();
-    // Guard against the same file surfacing twice (symlinked / aliased table
-    // folders) so a table is not added to two L0 runs.
-    let mut seen_ids: crate::HashSet<TableId> = crate::HashSet::default();
 
     for (table_base_folder, folder_fs) in config.all_tables_folders() {
         if !folder_fs.exists(&table_base_folder)? {
             continue;
         }
 
-        for dirent in folder_fs.read_dir(&table_base_folder)? {
+        // The two-way half of the resurrection knob: a prior default repair may
+        // have set punched-boundless files aside with a resurrectable marker;
+        // a resurrection repair returns them to `tables/` FIRST so the scan
+        // below recovers them greedily like any other punched file.
+        if allow_resurrection {
+            reclaim_resurrectable(&*folder_fs, &table_base_folder, config.sync_mode)?;
+        }
+
+        'dirent: for dirent in folder_fs.read_dir(&table_base_folder)? {
             let crate::fs::FsDirEntry {
                 path: table_path,
                 file_name,
@@ -425,6 +1771,35 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
                 continue;
             }
 
+            // Heal artifacts are not table files: `Tree::open` recognizes them
+            // and PRESERVES the live `{id}.heal-attest` sidecar (the next scrub
+            // reconciles a crashed digest refresh through it). Repair must not
+            // quarantine it, or a rebuild that fails before committing the
+            // manifest would strand the healed table under its stale pre-heal
+            // digest. Match the exact shapes recovery owns (numeric id + heal
+            // suffix); a foreign name merely containing the suffix falls through
+            // to the id parse below and is quarantined as before.
+            let is_sidecar_artifact = file_name
+                .strip_suffix(".heal-attest")
+                .or_else(|| file_name.strip_suffix(".heal-attest.tmp"))
+                // The `.restrict-bound` sidecar (and its crashed `.tmp`) carries a
+                // punched SST's restriction bound; repair reads it FOR its SST (via
+                // `restrict_bound::read`), so the sidecar file itself is never a
+                // table and must not be parsed / quarantined as one.
+                .or_else(|| file_name.strip_suffix(".restrict-bound"))
+                .or_else(|| file_name.strip_suffix(".restrict-bound.tmp"))
+                .is_some_and(|id| id.parse::<TableId>().is_ok())
+                // {id}.healtmp-{n}: BOTH the id and the numeric sequence must
+                // parse, matching recovery's ownership check. A foreign name like
+                // `5.healtmp-backup` is NOT owned (recovery would fail its
+                // non-numeric name), so it must fall through to quarantine here.
+                || file_name.split_once(".healtmp-").is_some_and(|(id, seq)| {
+                    id.parse::<TableId>().is_ok() && seq.parse::<u64>().is_ok()
+                });
+            if is_sidecar_artifact {
+                continue;
+            }
+
             let Ok(table_id) = file_name.parse::<TableId>() else {
                 // A non-numeric name cannot be a table id, and `Tree::open`
                 // rejects such a file outright (recovery parses every name in
@@ -433,8 +1808,13 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
                 // `tables/` into a sibling quarantine dir; report where it went.
                 // If the quarantine itself fails the bad name stays in place, so
                 // fail the repair rather than report a false success.
-                let dest =
-                    quarantine_file(&*folder_fs, &table_base_folder, &table_path, &file_name)?;
+                let dest = quarantine_file(
+                    &*folder_fs,
+                    &table_base_folder,
+                    &table_path,
+                    &file_name,
+                    config.sync_mode,
+                )?;
                 unreadable_files.push((
                     table_path,
                     format!(
@@ -445,107 +1825,603 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
                 continue;
             };
 
-            if !seen_ids.insert(table_id) {
-                // Already recovered via another scanned folder; skip silently.
+            // Skip a duplicate id ONLY when we already hold a COMPLETE copy — a
+            // duplicate cannot improve on it. A previously-seen LOSSY salvage does
+            // NOT skip: this copy is still evaluated and may supersede it.
+            if let Some(existing) = recovered_by_id.get(&table_id).filter(|c| c.complete) {
+                // If this path physically ALIASES the retained copy (a symlink /
+                // junction / case-insensitive alias resolving to the same directory
+                // entry, e.g. two configured folders pointing at one location), it
+                // is the SAME file, not a genuine duplicate. Quarantining it would
+                // MOVE the kept copy and leave the manifest referencing a missing
+                // SST, so skip it IN PLACE.
+                if same_physical_file(&*folder_fs, &table_path, &*existing.fs, &existing.path) {
+                    continue;
+                }
+                // A genuine duplicate: quarantine it out of `tables/` so recovery
+                // cannot later resolve it instead of the kept copy (the manifest
+                // records only id + checksum, not a path).
+                let dest = quarantine_file(
+                    &*folder_fs,
+                    &table_base_folder,
+                    &table_path,
+                    &file_name,
+                    config.sync_mode,
+                )?;
+                unreadable_files.push((
+                    table_path,
+                    format!(
+                        "duplicate table id; a complete copy is already held; \
+                         quarantined to {}",
+                        dest.display()
+                    ),
+                ));
                 continue;
             }
 
-            let checksum = match compute_table_checksum(&*folder_fs, &table_path) {
-                Ok(c) => crate::Checksum::from_raw(c),
-                Err(e) => {
-                    // Mirror the `Table::recover` failure path below: free the id
-                    // so an aliased copy in another scanned folder can still be
-                    // retried.
-                    seen_ids.remove(&table_id);
-                    unreadable_files.push((table_path, e.to_string()));
-                    continue;
-                }
+            // Hash the file and open it. A non-transient hashing failure (a bad
+            // data sector) is FOLDED into the recover Result so the salvage arm
+            // below can recover the table's intact blocks, instead of recording
+            // the whole table unreadable — which the next open's orphan cleanup
+            // would then delete. Table::recover would fail on the same bytes, so
+            // skip it; block salvage opens with a placeholder digest and drops
+            // only the unreadable blocks. global_seqno = 0: a recovered table's
+            // intrinsic sequence numbers are authoritative; there is no
+            // ingestion-time translation offset. tree_id = 0 and
+            // descriptor_table = None keep the transient open from polluting any
+            // shared cache keyed by the real tree id (the tree reopens fresh
+            // after repair).
+            let recovered = match compute_table_checksum(&*folder_fs, &table_path) {
+                Ok(c) => Table::recover(
+                    table_path.clone(),
+                    crate::Checksum::from_raw(c),
+                    0,
+                    0,
+                    table_id,
+                    config.cache.clone(),
+                    None,
+                    folder_fs.clone(),
+                    false,
+                    false,
+                    config.encryption.clone(),
+                    #[cfg(zstd_any)]
+                    config.zstd_dictionary.clone(),
+                    config.comparator.clone(),
+                    #[cfg(feature = "metrics")]
+                    Arc::new(crate::metrics::Metrics::default()),
+                ),
+                // A TRANSIENT read (flaky I/O) while hashing is retryable:
+                // recording it unreadable commits a manifest without the
+                // still-in-place file, which the next open's orphan cleanup then
+                // deletes — permanent loss from a one-shot failure. Propagate it
+                // so a retry re-reads the table, mirroring the recover arms below.
+                Err(e) if is_transient_io(&e) => return Err(e),
+                // A PERSISTENT read failure (a bad data sector, a corrupt trailer)
+                // is genuine damage but does not doom the whole table: fold it into
+                // the recover Result so the structural-failure salvage arm below
+                // recovers the intact blocks (or records it unreadable with salvage
+                // off).
+                Err(e) => Err(e),
             };
 
-            // global_seqno = 0: a recovered table's intrinsic sequence numbers
-            // are authoritative; there is no ingestion-time translation offset
-            // to reapply. tree_id = 0 and descriptor_table = None keep the
-            // transient open from polluting any shared cache keyed by the real
-            // tree id (the tree is reopened fresh after repair).
-            let recovered = Table::recover(
-                table_path.clone(),
-                checksum,
-                0,
-                0,
-                table_id,
-                config.cache.clone(),
-                None,
-                folder_fs.clone(),
-                false,
-                false,
-                config.encryption.clone(),
-                #[cfg(zstd_any)]
-                config.zstd_dictionary.clone(),
-                config.comparator.clone(),
-                #[cfg(feature = "metrics")]
-                Arc::new(crate::metrics::Metrics::default()),
-            );
+            // Fail closed on a table whose bulk-ingest sequence offset cannot be
+            // reconstructed. A bulk-ingested SST stores every entry at LOCAL seqno
+            // 0 and relies on a manifest-only `global_seqno` for its effective MVCC
+            // ordering; the on-disk seqnos carry no trace of it. The rebuilt
+            // manifest hard-codes offset 0, so keeping such a table would make its
+            // entries appear OLDER than they are — visible to snapshots that never
+            // saw them and sorted into the wrong L0 order. Quarantine it instead of
+            // silently corrupting MVCC (see `has_unrecoverable_ingest_offset`).
+            if matches!(&recovered, Ok(t) if has_unrecoverable_ingest_offset(
+                t.metadata.bulk_ingested,
+                t.metadata.item_count,
+                t.max_local_seqno(),
+            )) {
+                drop(recovered); // release the file handle before the move
+                match quarantine_file(
+                    &*folder_fs,
+                    &table_base_folder,
+                    &table_path,
+                    &file_name,
+                    config.sync_mode,
+                ) {
+                    Ok(dest) => unreadable_files.push((
+                        table_path,
+                        format!(
+                            "bulk-ingest sequence offset cannot be reconstructed from the SST; \
+                             quarantined to {}",
+                            dest.display()
+                        ),
+                    )),
+                    // A FAILED quarantine aborts the whole repair: a manifest
+                    // omitting a still-in-place file would let the next open's
+                    // orphan cleanup DELETE the only copy meant to be preserved.
+                    Err(e) => return Err(e),
+                }
+                continue;
+            }
+
+            // Rebuild the restricted view of a tight-space-PUNCHED SST. Tight-space
+            // compaction reclaims a table's consumed prefix data blocks in place
+            // (hole-punched, reading back as zeros) and records the exact bound in a
+            // `.restrict-bound` sidecar beside the SST. A rebuilt manifest must
+            // re-apply that restriction, or later reads and compactions traverse the
+            // punched blocks and fail. The bound comes from the sidecar (the SST
+            // itself is never mutated, so its whole-file checksum stays valid);
+            // written strictly post-commit, a valid sidecar is itself proof of a
+            // committed restriction, so its bound is honored directly (see below).
+            let recovered = 'restrict: {
+                let Ok(table) = recovered else {
+                    break 'restrict recovered;
+                };
+                // Read the input's `.restrict-bound` sidecar. A TRANSIENT read
+                // (Interrupted / WouldBlock) is retryable, so it propagates. A
+                // MISSING / id-MISMATCHED / CORRUPT sidecar or a PERSISTENT read
+                // leaves no trustworthy exact bound and falls to the punch-geometry
+                // path below. See `docs/manifest-recovery.md`.
+                let sidecar_bound: Option<crate::UserKey> = match crate::restrict_bound::read(
+                    &*folder_fs,
+                    &table_path,
+                    config.encryption.as_deref(),
+                ) {
+                    Ok(crate::restrict_bound::SidecarRead::Present(id, b)) if id == table_id => {
+                        Some(b.into())
+                    }
+                    Err(e) if is_transient_io(&e) => break 'restrict Err(e),
+                    Ok(_) | Err(_) => None,
+                };
+
+                // A valid sidecar always denotes a COMMITTED restriction: tight-space
+                // writes it STRICTLY AFTER the slice's version install commits (see
+                // `Table::write_restrict_sidecar` and `docs/manifest-recovery.md`), so
+                // an aborted slice never leaves one. Honor its exact bound DIRECTLY,
+                // without probing the below-bound prefix: whether or not the punch has
+                // run, reopening at the bound is correct. If the prefix is not yet
+                // punched (the crash window between the durable commit and the punch,
+                // or a punch deferred by a live reader), the committed output already
+                // covers the dropped prefix, so honoring resurrects nothing; if it is
+                // punched, the reopened view digests only the live suffix. Reading the
+                // dead prefix to decide is not just unnecessary — a persistently
+                // unreadable sector there would otherwise discard the exact bound and,
+                // with salvage off, quarantine the whole table despite its intact live
+                // suffix. `reopen_restricted` reads only from the punch offset up, so a
+                // genuinely unreadable SUFFIX still surfaces its error there.
+                if let Some(bound) = &sidecar_bound {
+                    break 'restrict table.reopen_restricted(bound.clone());
+                }
+
+                // No trustworthy exact bound. An unpunched table never carried a
+                // restriction, so it opens unrestricted. A punched table lost its
+                // exact bound and falls to the punch geometry: with resurrection
+                // on, restrict to the FIRST key of the first readable block past
+                // the punched region, keeping the whole ambiguous readable region
+                // (its consumed rows resurrected, as the flag contracts). With
+                // resurrection OFF the geometry is trusted only when the zeroed
+                // blocks form a CLEAN prefix — the pattern of a fully successful
+                // punch — and the bound is that prefix's straddling block's END
+                // key, never resurrecting a superseded key. An IRREGULAR pattern
+                // (a readable block below a zeroed one) is positive evidence of
+                // failed punches, after which no geometry bound can separate
+                // intact-but-consumed blocks from live ones: the table is set
+                // aside (see `DerivedRestriction::IrregularPunch`), matching the
+                // recovery-failure arm's fail-closed guard for the same state. A
+                // fully-punched SST with no live data is set aside too, losing
+                // nothing the flag could have kept.
+                match table.has_punched_data_block() {
+                    Ok(false) => break 'restrict Ok(table),
+                    Err(e) => break 'restrict Err(e),
+                    Ok(true) => {
+                        use crate::table::DerivedRestriction;
+                        let derived = if allow_resurrection {
+                            match table.derive_resurrection_bound() {
+                                Ok(Some(bound)) => Ok(DerivedRestriction::Bound(bound)),
+                                Ok(None) => Ok(DerivedRestriction::NoLiveData),
+                                Err(e) => Err(e),
+                            }
+                        } else {
+                            table.derive_restriction_bound()
+                        };
+                        match derived {
+                            Ok(DerivedRestriction::Bound(bound)) => {
+                                break 'restrict table.reopen_restricted(bound);
+                            }
+                            Err(e) => break 'restrict Err(e),
+                            Ok(
+                                reason @ (DerivedRestriction::NoLiveData
+                                | DerivedRestriction::IrregularPunch),
+                            ) => {
+                                // FLAG-DEPENDENT set-aside: resurrection would
+                                // have kept the readable region, so mark it
+                                // reclaimable — a NoLiveData table has nothing
+                                // either flag could keep, so it stays unmarked.
+                                let resurrectable =
+                                    matches!(reason, DerivedRestriction::IrregularPunch);
+                                let reason = match reason {
+                                    DerivedRestriction::NoLiveData => {
+                                        "fully hole-punched SST with no live data"
+                                    }
+                                    _ => {
+                                        "partially punched SST with punch failures and no \
+                                         trustworthy bound; the consumed/live boundary is \
+                                         unknowable (a resurrection repair reclaims it and \
+                                         keeps the readable region)"
+                                    }
+                                };
+                                drop(table);
+                                crate::restrict_bound::remove(
+                                    &*folder_fs,
+                                    &table_path,
+                                    config.sync_mode,
+                                );
+                                match quarantine_file(
+                                    &*folder_fs,
+                                    &table_base_folder,
+                                    &table_path,
+                                    &file_name,
+                                    config.sync_mode,
+                                ) {
+                                    Ok(dest) => {
+                                        // An unmarked flag-dependent set-aside
+                                        // could never be reclaimed: on marker
+                                        // failure, undo the set-aside so a
+                                        // retry re-runs the classification.
+                                        if resurrectable
+                                            && let Err(e) = mark_resurrectable(
+                                                &*folder_fs,
+                                                &dest,
+                                                config.sync_mode,
+                                            )
+                                        {
+                                            restore_quarantined(
+                                                &*folder_fs,
+                                                &dest,
+                                                &table_path,
+                                                config.encryption.as_deref(),
+                                                config.sync_mode,
+                                            )?;
+                                            return Err(e);
+                                        }
+                                        unreadable_files.push((
+                                            table_path,
+                                            format!("{reason}; set aside at {}", dest.display()),
+                                        ));
+                                    }
+                                    Err(e) => return Err(e),
+                                }
+                                continue 'dirent;
+                            }
+                        }
+                    }
+                }
+            };
 
             match recovered {
                 // In salvage mode a table whose whole-file recovery succeeded can
                 // still hold corrupt data blocks (recovery is lazy on the data
                 // section). Block-verify it; if any block is corrupt, salvage it
-                // rather than keep a table that errors on read.
-                Ok(table)
-                    if salvage
-                        && !crate::verify::verify_sst_file_with_fs(&*folder_fs, &table_path)
-                            .is_ok() =>
-                {
-                    drop(table);
-                    match try_salvage_table(
+                // rather than keep a table that errors on read. Encrypted and
+                // unencrypted tables take the SAME encryption-aware out-of-band
+                // walk (block headers and payload checksums are plaintext; the
+                // provider only decodes the meta block) — the recovered `table`
+                // merely supplies the id the encrypted meta's AAD binds. Without
+                // the provider the walk could not decode an encrypted meta block
+                // and would misreport every healthy encrypted table as corrupt,
+                // rewriting it on every repair.
+                Ok(table) if salvage => {
+                    match verify_keep_decision(
                         config,
-                        &table_base_folder,
                         &folder_fs,
                         &table_path,
-                        &file_name,
-                        table_id,
-                    ) {
-                        Ok(Some(table)) => {
-                            salvaged += 1;
-                            recovered_tables.push(table);
+                        &table,
+                        allow_resurrection,
+                    )? {
+                        RepairKeepDecision::Keep => {
+                            record_best(
+                                &mut recovered_by_id,
+                                &mut unreadable_files,
+                                table_id,
+                                table,
+                                true,
+                                &folder_fs,
+                                &table_base_folder,
+                                &table_path,
+                                &file_name,
+                                config.sync_mode,
+                            )?;
                         }
-                        Ok(None) => {
-                            seen_ids.remove(&table_id);
-                            unreadable_files.push((
-                                table_path,
-                                "verify found corrupt blocks; nothing salvageable".to_string(),
-                            ));
+                        RepairKeepDecision::Quarantine(reason) => {
+                            drop(table);
+                            // Quarantine (not leave-in-place): a later
+                            // `Tree::open` orphan-cleans table files the
+                            // rebuilt manifest does not reference, so an
+                            // unquarantined original would be DELETED.
+                            match quarantine_file(
+                                &*folder_fs,
+                                &table_base_folder,
+                                &table_path,
+                                &file_name,
+                                config.sync_mode,
+                            ) {
+                                Ok(dest) => unreadable_files.push((
+                                    table_path,
+                                    format!("{reason}; quarantined to {}", dest.display()),
+                                )),
+                                // A FAILED quarantine aborts the whole repair:
+                                // installing a manifest that omits the
+                                // still-in-place file would let the next
+                                // open's orphan cleanup DELETE the only copy
+                                // set aside for later inspection.
+                                Err(e) => return Err(e),
+                            }
                         }
-                        Err(salvage_err) => {
-                            seen_ids.remove(&table_id);
-                            unreadable_files.push((
-                                table_path,
-                                format!(
-                                    "verify found corrupt blocks; salvage failed ({salvage_err})"
-                                ),
-                            ));
+                        RepairKeepDecision::Salvage => {
+                            // A tight-space RESTRICTED punched SST whose live suffix
+                            // is ALSO corrupt (a rare double failure) is block-
+                            // salvaged like any other, then RE-RESTRICTED to its
+                            // original bound: salvage recovers the readable blocks
+                            // into a fresh, unpunched SST (dropping the zeroed prefix
+                            // and the corrupt blocks), and reopening that restricted
+                            // to the recorded bound masks the straddling block's
+                            // sub-bound rows again, so nothing superseded is
+                            // resurrected. A sidecar re-records the bound so a later
+                            // manifest-loss repair honors it (the fresh file is
+                            // unpunched). With resurrection on, the whole readable
+                            // region is kept instead. The live suffix is never
+                            // discarded to a dead-end quarantine.
+                            let restrict_bound = table.restrict_lower_bound().cloned();
+                            drop(table);
+                            // Quarantine BEFORE salvage, aborting the repair
+                            // on failure: a manifest omitting a still-in-place
+                            // file would let the next open's orphan cleanup
+                            // delete the only copy. A salvage error AFTER a
+                            // successful move is recorded instead: the
+                            // original is safely preserved in quarantine.
+                            let quarantined = quarantine_file(
+                                &*folder_fs,
+                                &table_base_folder,
+                                &table_path,
+                                &file_name,
+                                config.sync_mode,
+                            )?;
+                            match try_salvage_table(
+                                config,
+                                &folder_fs,
+                                allow_resurrection,
+                                &quarantined,
+                                &table_path,
+                                table_id,
+                                // The bound (when any) comes from the restricted
+                                // view and is re-imposed below, so a punched
+                                // source is never ambiguous on this arm.
+                                false,
+                            ) {
+                                Ok(SalvageOutcome::Salvaged(salvaged)) => {
+                                    // Re-impose the tight-space restriction on the
+                                    // salvaged output (fail-closed unless resurrection
+                                    // is on), the shared path both salvage arms use.
+                                    let table = restrict_salvaged_output(
+                                        &*folder_fs,
+                                        config,
+                                        &table_path,
+                                        &quarantined,
+                                        salvaged,
+                                        restrict_bound.clone(),
+                                        allow_resurrection,
+                                    )?;
+                                    record_best(
+                                        &mut recovered_by_id,
+                                        &mut unreadable_files,
+                                        table_id,
+                                        table,
+                                        false,
+                                        &folder_fs,
+                                        &table_base_folder,
+                                        &table_path,
+                                        &file_name,
+                                        config.sync_mode,
+                                    )?;
+                                }
+                                Ok(SalvageOutcome::Unusable | SalvageOutcome::PunchedBoundLost) => {
+                                    unreadable_files.push((
+                                        table_path,
+                                        "verify found corrupt blocks; nothing salvageable"
+                                            .to_string(),
+                                    ));
+                                }
+                                Err(salvage_err) => {
+                                    // A TRANSIENT I/O salvage failure is retryable:
+                                    // committing a manifest that omits the table
+                                    // would lose it permanently (the original is in
+                                    // quarantine, which the next repair won't
+                                    // rediscover). Restore the original to its path
+                                    // and abort the whole repair so a retry can
+                                    // salvage it. A STRUCTURAL failure is genuine
+                                    // unsalvageability: record it (the original
+                                    // stays set aside for inspection).
+                                    if is_transient_io(&salvage_err) {
+                                        restore_quarantined(
+                                            &*folder_fs,
+                                            &quarantined,
+                                            &table_path,
+                                            config.encryption.as_deref(),
+                                            config.sync_mode,
+                                        )?;
+                                        return Err(salvage_err);
+                                    }
+                                    unreadable_files.push((
+                                        table_path,
+                                        format!(
+                                            "verify found corrupt blocks; salvage failed \
+                                             ({salvage_err})"
+                                        ),
+                                    ));
+                                }
+                            }
                         }
                     }
                 }
-                Ok(table) => recovered_tables.push(table),
-                Err(e) if salvage => {
-                    // Whole-file recovery failed; try block-level salvage: the
-                    // corrupt original is quarantined and a fresh SST holding
-                    // its recoverable blocks is written in its place.
-                    match try_salvage_table(
-                        config,
-                        &table_base_folder,
+                Ok(table) => {
+                    record_best(
+                        &mut recovered_by_id,
+                        &mut unreadable_files,
+                        table_id,
+                        table,
+                        true,
                         &folder_fs,
+                        &table_base_folder,
                         &table_path,
                         &file_name,
-                        table_id,
+                        config.sync_mode,
+                    )?;
+                }
+                Err(e) if salvage => {
+                    // A TRANSIENT recovery failure (Io) is retryable and must NOT
+                    // be routed through salvage: quarantining the healthy SST and
+                    // salvaging it would, for a range-tombstone table, fail
+                    // deterministically with FeatureUnsupported (a non-Io error
+                    // recorded as unsalvageable), committing a manifest without the
+                    // table — turning a one-shot read failure into permanent loss.
+                    // Propagate the I/O error BEFORE moving the file so a retry
+                    // re-recovers it, mirroring the verification / salvage-error
+                    // paths.
+                    if is_transient_io(&e) {
+                        return Err(e);
+                    }
+                    // A tight-space-punched SST that fails whole-file recovery still
+                    // carries its restriction in the `.restrict-bound` sidecar, but
+                    // recovery produced no `Table` to read the bound from. Read it
+                    // directly BEFORE quarantining moves the SST (the sidecar is a
+                    // sibling file, so its bound is captured while both are in place),
+                    // and re-impose it on the salvaged output below, exactly as the
+                    // verification-failure arm does. A TRANSIENT sidecar read
+                    // propagates; anything else leaves no trustworthy bound, so the
+                    // salvaged output stays unrestricted (a genuinely unpunched SST).
+                    let restrict_bound: Option<crate::UserKey> = match crate::restrict_bound::read(
+                        &*folder_fs,
+                        &table_path,
+                        config.encryption.as_deref(),
                     ) {
-                        Ok(Some(table)) => {
-                            salvaged += 1;
-                            recovered_tables.push(table);
+                        Ok(crate::restrict_bound::SidecarRead::Present(id, b))
+                            if id == table_id =>
+                        {
+                            Some(b.into())
                         }
-                        Ok(None) => {
-                            seen_ids.remove(&table_id);
+                        Err(read_err) if is_transient_io(&read_err) => return Err(read_err),
+                        Ok(_) | Err(_) => None,
+                    };
+                    // A PUNCHED source with no trustworthy bound (missing / corrupt
+                    // sidecar) cannot be salvaged into an UNRESTRICTED output:
+                    // recovery produced no `Table` to derive a geometry bound from,
+                    // and salvage drops the zeroed prefix but re-emits the straddling
+                    // block's sub-bound rows, which would resurrect with nothing to
+                    // restrict them. Fail closed: set it aside. An UNPUNCHED source
+                    // (the common corrupt-table case) has no zeroed prefix and
+                    // salvages normally. Resurrection-on skips the guard, accepting
+                    // the re-exposure.
+                    if restrict_bound.is_none()
+                        && !allow_resurrection
+                        && source_prefix_is_punched(&*folder_fs, &table_path)?
+                    {
+                        match quarantine_file(
+                            &*folder_fs,
+                            &table_base_folder,
+                            &table_path,
+                            &file_name,
+                            config.sync_mode,
+                        ) {
+                            Ok(dest) => {
+                                // FLAG-DEPENDENT set-aside: mark it so a
+                                // resurrection repair reclaims and salvages it.
+                                // On marker failure, undo the set-aside so a
+                                // retry re-runs the classification instead of
+                                // leaving an unreclaimable file.
+                                if let Err(e) =
+                                    mark_resurrectable(&*folder_fs, &dest, config.sync_mode)
+                                {
+                                    restore_quarantined(
+                                        &*folder_fs,
+                                        &dest,
+                                        &table_path,
+                                        config.encryption.as_deref(),
+                                        config.sync_mode,
+                                    )?;
+                                    return Err(e);
+                                }
+                                crate::restrict_bound::remove(
+                                    &*folder_fs,
+                                    &table_path,
+                                    config.sync_mode,
+                                );
+                                unreadable_files.push((
+                                    table_path,
+                                    format!(
+                                        "punched SST with no recoverable restriction bound \
+                                         (missing / corrupt sidecar and failed recovery); set \
+                                         aside to {} (a resurrection repair reclaims it)",
+                                        dest.display()
+                                    ),
+                                ));
+                            }
+                            Err(e) => return Err(e),
+                        }
+                        continue;
+                    }
+                    // Whole-file recovery failed structurally; try block-level
+                    // salvage: the corrupt original is quarantined and a fresh SST
+                    // holding its recoverable blocks is written in its place. A
+                    // FAILED quarantine aborts the repair (the `?`): a manifest
+                    // omitting a still-in-place file would let the next open's
+                    // orphan cleanup delete the only copy.
+                    let quarantined = quarantine_file(
+                        &*folder_fs,
+                        &table_base_folder,
+                        &table_path,
+                        &file_name,
+                        config.sync_mode,
+                    )?;
+                    // Fail closed when the salvage walk reveals a punched source
+                    // with no recoverable bound: the pre-salvage first-bytes
+                    // probe above catches a punched FIRST block, but a partial
+                    // punch can leave that block intact while later prefix
+                    // blocks are zeroed — only the walk's dropped extents expose
+                    // those.
+                    let reject_punched = restrict_bound.is_none() && !allow_resurrection;
+                    match try_salvage_table(
+                        config,
+                        &folder_fs,
+                        allow_resurrection,
+                        &quarantined,
+                        &table_path,
+                        table_id,
+                        reject_punched,
+                    ) {
+                        Ok(SalvageOutcome::Salvaged(salvaged)) => {
+                            // Re-impose the tight-space restriction on the salvaged
+                            // output (fail-closed unless resurrection is on), the
+                            // shared path both salvage arms use.
+                            let table = restrict_salvaged_output(
+                                &*folder_fs,
+                                config,
+                                &table_path,
+                                &quarantined,
+                                salvaged,
+                                restrict_bound,
+                                allow_resurrection,
+                            )?;
+                            record_best(
+                                &mut recovered_by_id,
+                                &mut unreadable_files,
+                                table_id,
+                                table,
+                                false,
+                                &folder_fs,
+                                &table_base_folder,
+                                &table_path,
+                                &file_name,
+                                config.sync_mode,
+                            )?;
+                        }
+                        Ok(SalvageOutcome::Unusable) => {
                             unreadable_files.push((
                                 table_path,
                                 format!(
@@ -553,8 +2429,49 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
                                 ),
                             ));
                         }
+                        Ok(SalvageOutcome::PunchedBoundLost) => {
+                            // FLAG-DEPENDENT set-aside: mark the quarantined
+                            // ORIGINAL (the punched source; the rejected
+                            // salvage byproduct stays unmarked) so a
+                            // resurrection repair reclaims and re-salvages it.
+                            // On marker failure, undo the set-aside so a retry
+                            // re-runs the classification.
+                            if let Err(marker_err) =
+                                mark_resurrectable(&*folder_fs, &quarantined, config.sync_mode)
+                            {
+                                restore_quarantined(
+                                    &*folder_fs,
+                                    &quarantined,
+                                    &table_path,
+                                    config.encryption.as_deref(),
+                                    config.sync_mode,
+                                )?;
+                                return Err(marker_err);
+                            }
+                            unreadable_files.push((
+                                table_path,
+                                format!(
+                                    "punched SST with no recoverable restriction bound \
+                                     (missing / corrupt sidecar and failed recovery, punched \
+                                     extents found during salvage); set aside ({e}); a \
+                                     resurrection repair reclaims it"
+                                ),
+                            ));
+                        }
                         Err(salvage_err) => {
-                            seen_ids.remove(&table_id);
+                            // Transient I/O salvage failure: restore the original
+                            // and abort so a retry can recover it (see the sibling
+                            // salvage arm above). A structural failure is recorded.
+                            if is_transient_io(&salvage_err) {
+                                restore_quarantined(
+                                    &*folder_fs,
+                                    &quarantined,
+                                    &table_path,
+                                    config.encryption.as_deref(),
+                                    config.sync_mode,
+                                )?;
+                                return Err(salvage_err);
+                            }
                             unreadable_files.push((
                                 table_path,
                                 format!("recovery failed ({e}); salvage failed ({salvage_err})"),
@@ -563,16 +2480,112 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
                     }
                 }
                 Err(e) => {
-                    seen_ids.remove(&table_id);
-                    unreadable_files.push((table_path, e.to_string()));
+                    // A TRANSIENT recovery failure (Io) is retryable: recording it
+                    // unreadable commits a manifest without the still-in-place
+                    // file, which the next open's orphan cleanup then DELETES —
+                    // permanent loss from a one-shot read failure. Propagate it so
+                    // a retry re-recovers the table; only a structural failure is a
+                    // genuine unreadable report.
+                    if is_transient_io(&e) {
+                        return Err(e);
+                    }
+                    // QUARANTINE before recording unreadable: the rebuilt manifest
+                    // omits this file, so a later `Tree::open` would orphan-clean
+                    // (DELETE) it from `tables/`, contradicting the report's promise
+                    // that an operator can still investigate / recover it. Moving it
+                    // to the repair quarantine preserves it. A FAILED quarantine
+                    // aborts the whole repair (the file must not be both omitted and
+                    // left in place).
+                    match quarantine_file(
+                        &*folder_fs,
+                        &table_base_folder,
+                        &table_path,
+                        &file_name,
+                        config.sync_mode,
+                    ) {
+                        Ok(dest) => unreadable_files.push((
+                            table_path,
+                            format!("{e}; quarantined to {}", dest.display()),
+                        )),
+                        Err(qe) => return Err(qe),
+                    }
                 }
             }
         }
     }
 
+    // Collect the best copy per id. `salvaged` is derived from the FINAL
+    // candidates (a lossy copy later superseded by a complete duplicate must not
+    // count), not incremented inline.
+    let salvaged = recovered_by_id.values().filter(|c| !c.complete).count();
+    let mut recovered_tables: Vec<Table> = recovered_by_id.into_values().map(|c| c.table).collect();
+
     // Newest first: higher sequence number nearer the L0 head, matching the
     // ordering the merge reader expects for its newest-run-first short-circuit.
     recovered_tables.sort_by_key(|t| std::cmp::Reverse(t.get_highest_seqno()));
+
+    // KV-separated (blob) trees additionally carry a blob-file list. Discover the
+    // blob files from the `blobs/` folder (no manifest to filter against) and
+    // record them in the rebuilt manifest with the matching `TreeType::Blob` so
+    // the tree reopens (the reopened tree's type must match its config's
+    // `kv_separation_opts`). Fragmentation stats are NOT reconstructable from a
+    // directory scan (they are derived from compaction history), so they start
+    // empty: blob GC is advisory and re-learns them over time. The empty start
+    // never drops live data; it only resets GC's view of reclaimable space.
+    //
+    // Runs BEFORE the L0 runs are built: a table whose indirections point into a
+    // blob file this scan could NOT recover must not be published (see the
+    // dependency check below), so the surviving blob ids have to be known first.
+    let (tree_type, blob_file_list) = if config.kv_separation_opts.is_some() {
+        let (blob_files, blob_unreadable) = recover_blob_files(config)?;
+        unreadable_files.extend(blob_unreadable);
+        let map: crate::HashMap<crate::vlog::BlobFileId, crate::vlog::BlobFile> =
+            blob_files.into_iter().map(|bf| (bf.id(), bf)).collect();
+        (TreeType::Blob, BlobFileList::new(map))
+    } else {
+        (
+            TreeType::Standard,
+            BlobFileList::new(crate::HashMap::default()),
+        )
+    };
+
+    // Drop any recovered table that still references a blob file the scan could
+    // not recover. Publishing the pair yields a manifest that opens fine while a
+    // read of an affected key resolves a handle into a blob file that is not
+    // there. A table whose `linked_blob_files` section cannot be read is treated
+    // the same way: its dependencies are unknown, so it cannot be proven safe.
+    if config.kv_separation_opts.is_some() {
+        let mut kept: Vec<Table> = Vec::with_capacity(recovered_tables.len());
+        for table in recovered_tables {
+            let missing: Option<String> = match table.list_blob_file_references() {
+                Ok(Some(links)) => links
+                    .iter()
+                    .find(|l| !blob_file_list.contains_key(l.blob_file_id))
+                    .map(|l| format!("blob file {} is not recoverable", l.blob_file_id)),
+                Ok(None) => None,
+                Err(e) if is_transient_io(&e) => return Err(e),
+                Err(e) => Some(format!("blob-file reference list unreadable ({e})")),
+            };
+            let Some(reason) = missing else {
+                kept.push(table);
+                continue;
+            };
+            let path = (*table.path).clone();
+            let (Some(base), Some(name)) = (
+                path.parent().map(std::path::Path::to_path_buf),
+                path.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string),
+            ) else {
+                return Err(crate::Error::Unrecoverable);
+            };
+            let fs = table.fs.clone();
+            drop(table); // release the handle before the quarantine move
+            let dest = quarantine_file(&*fs, &base, &path, &name, config.sync_mode)?;
+            unreadable_files.push((path, format!("{reason}; set aside at {}", dest.display())));
+        }
+        recovered_tables = kept;
+    }
 
     // Each recovered table becomes its own single-table L0 run. L0 permits
     // overlapping runs, so this is always legal regardless of key overlap;
@@ -600,27 +2613,6 @@ fn repair_tree(config: &Config, salvage: bool) -> crate::Result<RepairReport> {
     let version_id = match highest_existing_version_id(&*config.fs, &config.path)? {
         Some(max) => max.checked_add(1).ok_or(crate::Error::Unrecoverable)?,
         None => 0,
-    };
-
-    // KV-separated (blob) trees additionally carry a blob-file list. Discover the
-    // blob files from the `blobs/` folder (no manifest to filter against) and
-    // record them in the rebuilt manifest with the matching `TreeType::Blob` so
-    // the tree reopens (the reopened tree's type must match its config's
-    // `kv_separation_opts`). Fragmentation stats are NOT reconstructable from a
-    // directory scan (they are derived from compaction history), so they start
-    // empty: blob GC is advisory and re-learns them over time. The empty start
-    // never drops live data; it only resets GC's view of reclaimable space.
-    let (tree_type, blob_file_list) = if config.kv_separation_opts.is_some() {
-        let (blob_files, blob_unreadable) = recover_blob_files(config)?;
-        unreadable_files.extend(blob_unreadable);
-        let map: crate::HashMap<crate::vlog::BlobFileId, crate::vlog::BlobFile> =
-            blob_files.into_iter().map(|bf| (bf.id(), bf)).collect();
-        (TreeType::Blob, BlobFileList::new(map))
-    } else {
-        (
-            TreeType::Standard,
-            BlobFileList::new(crate::HashMap::default()),
-        )
     };
 
     let version = Version::from_levels(

--- a/src/repair/tests.rs
+++ b/src/repair/tests.rs
@@ -5535,17 +5535,111 @@ fn is_corruption_aborts_the_repair_on_a_transient_io() {
     );
 }
 
-/// A TRANSIENT read failure while checksumming a blob file must PROPAGATE, not
-/// land in `unreadable`: recording it there installs a manifest that omits the
-/// blob, and the next open's orphan sweep then deletes the healthy file —
-/// permanent value loss from a one-shot I/O fault. The table-recovery path
-/// already propagates; the blob scan must match it.
+/// Manifest-loss repair of a tight-space-punched blob file must restore the
+/// live-data frontier from the punch geometry: the manifest's
+/// `blob_restrictions` record is the frontier's only durable copy, and a repair
+/// that rebuilds the blob with frontier `0` (plus a whole-file digest over the
+/// zeroed prefix) leaves a later relocation scan starting inside the punched
+/// region. The frontier is a byte offset at a frame boundary, so — unlike the
+/// SST bound, which is a key and needs its sidecar — the geometry recovers it
+/// EXACTLY: the zeroed run from the data-section start ends where a valid
+/// frame decodes.
+///
+/// The second live frame's value is ALL ZEROS: the probe must anchor on frame
+/// structure, never on zero runs alone, so a zero-filled payload inside the
+/// live suffix cannot move the frontier.
+#[test]
+fn blob_recovery_derives_the_frontier_of_a_punched_blob_file() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let root = std::path::absolute("/db")?;
+    let blobs = root.join(crate::file::BLOBS_FOLDER);
+    memfs.create_dir_all(&blobs)?;
+    let punched_path = blobs.join("0");
+    let whole_path = blobs.join("1");
+
+    let fs_dyn: Arc<dyn Fs> = memfs.clone();
+    for path in [&punched_path, &whole_path] {
+        let mut w = crate::vlog::blob_file::writer::Writer::new(path, 0, 0, &*fs_dyn)?;
+        w.write(b"a", 1, &[b'x'; 300])?;
+        w.write(b"b", 2, &vec![0u8; 400])?; // zero payload in the live suffix
+        w.write(b"c", 3, &[b'y'; 300])?;
+        w.finish()?;
+    }
+
+    // Frontier = the first frame's end boundary (what a tight-space slice
+    // records after relocating frame 0), data start from the SFA TOC.
+    let entries: Vec<_> = crate::vlog::BlobFileScanner::new(&punched_path, &*fs_dyn, 0)?
+        .collect::<crate::Result<Vec<_>>>()?;
+    assert_eq!(entries.len(), 3, "three frames written");
+    let frontier = entries[0].frame_end;
+    let data_start = {
+        let mut file = fs_dyn.open(&punched_path, &crate::fs::FsOpenOptions::new().read(true))?;
+        let reader = crate::sfa::Reader::from_reader(&mut file)?;
+        reader
+            .toc()
+            .section(b"data")
+            .expect("blob file has a data section")
+            .pos()
+    };
+
+    // The tight-space punch: the consumed prefix reads as zeros.
+    memfs.punch_hole(&punched_path, data_start, frontier - data_start)?;
+
+    let config = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(memfs.clone());
+
+    let (files, unreadable) = super::recover_blob_files(&config)?;
+    assert!(
+        unreadable.is_empty(),
+        "both blob files recover: {unreadable:?}"
+    );
+    assert_eq!(files.len(), 2, "both blob files recovered");
+    let punched = files.iter().find(|f| f.id() == 0).expect("punched file");
+    let whole = files.iter().find(|f| f.id() == 1).expect("whole file");
+
+    assert_eq!(
+        punched.live_data_start(),
+        frontier,
+        "repair must derive the punched file's frontier from its geometry"
+    );
+    let suffix_digest = crate::Checksum::from_raw(super::compute_table_checksum_from(
+        &*config.fs,
+        &punched_path,
+        frontier,
+    )?);
+    assert_eq!(
+        punched.checksum(),
+        suffix_digest,
+        "the recorded digest must cover the live suffix, not the zeroed prefix"
+    );
+
+    assert_eq!(
+        whole.live_data_start(),
+        0,
+        "an unpunched file keeps the whole-file frontier"
+    );
+    Ok(())
+}
+
+/// A TRANSIENT read failure while reading a blob file (the frontier probe or
+/// the streaming checksum) must PROPAGATE, not land in `unreadable`: recording
+/// it there installs a manifest that omits the blob, and the next open's
+/// orphan sweep then deletes the healthy file — permanent value loss from a
+/// one-shot I/O fault. The table-recovery path already propagates; the blob
+/// scan must match it.
 #[test]
 fn blob_recovery_propagates_a_transient_checksum_failure() -> crate::Result<()> {
     use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
     use crate::io::ErrorKind;
     use crate::{Config, SequenceNumberCounter};
-    use std::io::Write;
     use std::sync::Arc;
 
     let memfs = Arc::new(MemFs::new());
@@ -5553,19 +5647,25 @@ fn blob_recovery_propagates_a_transient_checksum_failure() -> crate::Result<()> 
     let blobs = root.join(crate::file::BLOBS_FOLDER);
     memfs.create_dir_all(&blobs)?;
     {
-        let mut f = memfs.open(
-            &blobs.join("0"),
-            &crate::fs::FsOpenOptions::new().write(true).create(true),
-        )?;
-        f.write_all(b"blob bytes")?;
+        // A VALID blob file, so the transient fault is the only obstacle (a
+        // garbage file would classify persistent-unreadable before any read
+        // could be faulted).
+        let fs_dyn: Arc<dyn Fs> = memfs.clone();
+        let mut w = crate::vlog::blob_file::writer::Writer::new(&blobs.join("0"), 0, 0, &*fs_dyn)?;
+        w.write(b"k", 1, b"blob bytes")?;
+        w.finish()?;
     }
 
-    // Fault the streaming read the whole-file checksum performs, with a
-    // RETRYABLE kind.
+    // Fault the per-file streaming reads (frontier probe + whole-file
+    // checksum) with a RETRYABLE kind. `WouldBlock` (EAGAIN), not
+    // `Interrupted` (EINTR): both classify transient, but `std::io`'s
+    // `read_exact` transparently retries `Interrupted`, so a permanently
+    // armed EINTR would spin the probe's buffered reads forever instead of
+    // surfacing.
     let fault = FaultFs::new(memfs.as_ref().clone());
     fault
         .injector()
-        .arm(FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Interrupted)).on_path("blobs"));
+        .arm(FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::WouldBlock)).on_path("blobs"));
 
     let config = Config::new(
         &root,

--- a/src/repair/tests.rs
+++ b/src/repair/tests.rs
@@ -5549,6 +5549,7 @@ fn is_corruption_aborts_the_repair_on_a_transient_io() {
 /// structure, never on zero runs alone, so a zero-filled payload inside the
 /// live suffix cannot move the frontier.
 #[test]
+#[expect(clippy::expect_used, reason = "test code")]
 fn blob_recovery_derives_the_frontier_of_a_punched_blob_file() -> crate::Result<()> {
     use crate::fs::{Fs, MemFs};
     use crate::{Config, SequenceNumberCounter};
@@ -5575,7 +5576,7 @@ fn blob_recovery_derives_the_frontier_of_a_punched_blob_file() -> crate::Result<
     let entries: Vec<_> = crate::vlog::BlobFileScanner::new(&punched_path, &*fs_dyn, 0)?
         .collect::<crate::Result<Vec<_>>>()?;
     assert_eq!(entries.len(), 3, "three frames written");
-    let frontier = entries[0].frame_end;
+    let frontier = entries.first().expect("first frame").frame_end;
     let data_start = {
         let mut file = fs_dyn.open(&punched_path, &crate::fs::FsOpenOptions::new().read(true))?;
         let reader = crate::sfa::Reader::from_reader(&mut file)?;
@@ -5594,7 +5595,7 @@ fn blob_recovery_derives_the_frontier_of_a_punched_blob_file() -> crate::Result<
         SequenceNumberCounter::default(),
         SequenceNumberCounter::default(),
     )
-    .with_shared_fs(memfs.clone());
+    .with_shared_fs(memfs);
 
     let (files, unreadable) = super::recover_blob_files(&config)?;
     assert!(
@@ -5651,7 +5652,7 @@ fn blob_recovery_propagates_a_transient_checksum_failure() -> crate::Result<()> 
         // garbage file would classify persistent-unreadable before any read
         // could be faulted).
         let fs_dyn: Arc<dyn Fs> = memfs.clone();
-        let mut w = crate::vlog::blob_file::writer::Writer::new(&blobs.join("0"), 0, 0, &*fs_dyn)?;
+        let mut w = crate::vlog::blob_file::writer::Writer::new(blobs.join("0"), 0, 0, &*fs_dyn)?;
         w.write(b"k", 1, b"blob bytes")?;
         w.finish()?;
     }

--- a/src/repair/tests.rs
+++ b/src/repair/tests.rs
@@ -1,6 +1,348 @@
-use super::{compute_table_checksum, highest_existing_version_id};
+use super::{
+    compute_table_checksum, compute_table_checksum_with_overrides, highest_existing_version_id,
+    quarantine_file, toc_may_hide_deletions, verify_keep_decision,
+};
 use crate::fs::StdFs;
 use test_log::test;
+
+/// `toc_may_hide_deletions` must PROPAGATE a transient open failure rather than
+/// grade it `true` (fail closed): on a table `repair_with_salvage` already found
+/// corrupt, a `true` verdict routes it to Quarantine — dropping the healthy
+/// ranges block salvage could recover — when a retry of the probe could have
+/// allowed that recovery. `true` is reserved for STRUCTURAL catalogue ambiguity.
+/// A single Open fault on the probe reproduces the transient failure; the pre-fix
+/// `let Ok else true` swallowed it and returned `true`.
+#[test]
+fn toc_may_hide_deletions_propagates_a_transient_open_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = crate::table::Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    writer.write(crate::InternalValue::from_components(
+        b"k".to_vec(),
+        b"v".to_vec(),
+        1,
+        crate::ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Interrupted))
+            .on_path("source")
+            .once(),
+    );
+    let result = toc_may_hide_deletions(&fs, &source);
+    assert!(
+        matches!(result, Err(crate::Error::Io(_))),
+        "a transient open failure must propagate, not grade the catalogue as hiding a \
+         deletion section: {result:?}",
+    );
+    Ok(())
+}
+
+/// The mirror of [`toc_may_hide_deletions_propagates_a_transient_open_failure`]:
+/// a PERSISTENT open failure (outside the transient allowlist) cannot be proven
+/// harmless by a retry, so it fails closed (`Ok(true)`) — the corrupt table is
+/// quarantined rather than salvaged into resurrected rows — instead of aborting
+/// the whole repair.
+#[test]
+fn toc_may_hide_deletions_fails_closed_on_a_persistent_open_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = crate::table::Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    writer.write(crate::InternalValue::from_components(
+        b"k".to_vec(),
+        b"v".to_vec(),
+        1,
+        crate::ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other))
+            .on_path("source")
+            .once(),
+    );
+    let result = toc_may_hide_deletions(&fs, &source);
+    assert!(
+        matches!(result, Ok(true)),
+        "a persistent open failure must fail closed (quarantine), not propagate: {result:?}",
+    );
+    Ok(())
+}
+
+/// `compute_table_checksum_with_overrides` splices corrections chunk by chunk
+/// (256 KiB). An override that does NOT overlap the current chunk must be
+/// skipped cleanly. Before the overlap guard was hoisted above the bound
+/// subtractions, a multi-chunk file underflowed an unsigned difference (e.g.
+/// `hi - chunk_start` for an override that ends before the chunk starts) and
+/// panicked in debug builds while predicting the post-heal digest. The result
+/// must equal a manual splice.
+#[test]
+fn checksum_with_overrides_skips_non_overlapping_overrides_across_chunks() -> crate::Result<()> {
+    use crate::fs::{Fs, FsOpenOptions};
+    use std::io::Write;
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("multi-chunk.sst");
+
+    // Three 256 KiB chunks plus a tail, deterministic bytes.
+    let len: usize = 3 * 256 * 1024 + 777;
+    let mut data: Vec<u8> = (0..len)
+        .map(|i| u8::try_from(i % 251).unwrap_or(0))
+        .collect();
+
+    let fs = StdFs;
+    {
+        let mut f = fs.open(
+            &path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        f.write_all(&data)?;
+    }
+
+    // One override entirely within the FIRST chunk: chunks 1 and 2 do not
+    // overlap it, which is exactly the non-overlap path that used to underflow.
+    let ov_off: usize = 100;
+    let ov_bytes = vec![0xABu8; 4096];
+    let overrides = vec![(ov_off as u64, ov_bytes.clone())];
+
+    // Manual splice for the expected digest (mirrors the streaming hasher the
+    // implementation uses).
+    if let Some(slot) = data.get_mut(ov_off..ov_off + ov_bytes.len()) {
+        slot.copy_from_slice(&ov_bytes);
+    }
+    let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+    hasher.update(&data);
+    let expected = hasher.digest128();
+
+    let got = compute_table_checksum_with_overrides(&fs, &path, 0, &overrides)?;
+    assert_eq!(
+        got, expected,
+        "the spliced digest must match a manual splice and must not panic on \
+         chunks the override does not overlap",
+    );
+    Ok(())
+}
+
+/// `quarantine_file` must fsync BOTH affected directories (the source's parent
+/// and the `repair-quarantine/` destination) before returning success: a
+/// rename is durable only once both directory entries are on disk. Without it a
+/// power loss after repair returns can lose the destination entry or restore
+/// the source under `tables/`, and the next open's orphan cleanup then deletes
+/// the only copy meant for manual recovery. Fault-inject the
+/// destination-directory fsync: a build that never syncs the directory never
+/// triggers the fault and wrongly reports the move durable.
+#[test]
+fn quarantine_file_syncs_the_affected_directories() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let src = tables.join("junk-name");
+    std::fs::write(&src, b"orphan")?;
+
+    let fs = FaultFs::new(StdFs);
+    fs.injector().arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other))
+            .on_path("repair-quarantine"),
+    );
+
+    assert!(
+        quarantine_file(&fs, &tables, &src, "junk-name", SyncMode::Full).is_err(),
+        "the destination-directory fsync fault must surface",
+    );
+
+    // The SOURCE directory entry must be synced too: a power loss can otherwise
+    // restore the file under `tables/`, where the next open's orphan cleanup
+    // deletes it. Arm the fault on the source parent so this case fails
+    // independently if the src.parent() sync is dropped.
+    let src2 = tables.join("junk-name-2");
+    std::fs::write(&src2, b"orphan")?;
+    let fs2 = FaultFs::new(StdFs);
+    fs2.injector().arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other)).on_path("tables"),
+    );
+    assert!(
+        quarantine_file(&fs2, &tables, &src2, "junk-name-2", SyncMode::Full).is_err(),
+        "the source-directory fsync fault must surface",
+    );
+    Ok(())
+}
+
+/// Creating the `repair-quarantine/` directory adds its entry to the PARENT
+/// directory; that entry must be fsynced before the move so a power loss after
+/// repair returns cannot drop the whole quarantine directory (and the only
+/// preserved copy of the original). The parent sync runs right after the
+/// directory is created — BEFORE the rename — so faulting the first directory
+/// sync leaves the source UNMOVED. Without the parent sync the first sync is
+/// the post-rename source sync, by which point the file is already moved: the
+/// surviving-source assertion then fails, proving the fresh directory's parent
+/// entry was never made durable.
+#[test]
+fn quarantine_file_syncs_the_freshly_created_quarantine_parent() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let src = tables.join("junk-name");
+    std::fs::write(&src, b"orphan")?;
+
+    // Fail the FIRST directory sync. The quarantine directory does not exist
+    // yet, so the fix's parent sync (post-create, pre-rename) is that first
+    // sync — its failure aborts before the rename moves the source.
+    let fs = FaultFs::new(StdFs);
+    fs.injector()
+        .arm(FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other)).once());
+
+    assert!(
+        quarantine_file(&fs, &tables, &src, "junk-name", SyncMode::Full).is_err(),
+        "the quarantine-parent fsync fault must surface",
+    );
+    assert!(
+        std::fs::metadata(&src).is_ok(),
+        "the pre-rename parent-sync failure must leave the source in place",
+    );
+    Ok(())
+}
+
+/// The parent sync must run on EVERY quarantine, not only when the directory is
+/// freshly created. A previous repair that created `repair-quarantine` but
+/// crashed before syncing its parent leaves that directory entry non-durable; a
+/// retry that skips the sync (because the directory now exists) moves the only
+/// preserved source in without ever making the parent durable, so a power loss
+/// loses the whole quarantine directory. With an already-present quarantine
+/// directory, faulting the first sync must still abort BEFORE the rename —
+/// leaving the source in place — which proves the parent is synced every time.
+#[test]
+fn quarantine_file_syncs_the_parent_on_a_retry_with_a_preexisting_dir() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    // A prior repair already created the quarantine directory.
+    std::fs::create_dir_all(dir.path().join("repair-quarantine"))?;
+    let src = tables.join("junk-name");
+    std::fs::write(&src, b"orphan")?;
+
+    // Fail the FIRST directory sync. Because the parent sync is unconditional, it
+    // is that first sync (post-create, pre-rename) even though the directory
+    // already exists, so its failure aborts before the rename moves the source.
+    let fs = FaultFs::new(StdFs);
+    fs.injector()
+        .arm(FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other)).once());
+
+    assert!(
+        quarantine_file(&fs, &tables, &src, "junk-name", SyncMode::Full).is_err(),
+        "the quarantine-parent fsync fault must surface on a retry",
+    );
+    assert!(
+        std::fs::metadata(&src).is_ok(),
+        "the pre-rename parent-sync failure must leave the source in place on a retry",
+    );
+    Ok(())
+}
+
+/// A POST-rename directory-sync failure must ROLL THE RENAME BACK: the move is
+/// not durably committed, so leaving the source in quarantine lets a retry
+/// install a manifest omitting it; after which a power loss that rolls the
+/// un-synced rename back resurrects the source as an orphan the next open
+/// deletes, losing the only recovery copy. The source must return to `tables/`
+/// so a retry can still find and re-quarantine it durably. The quarantine-dir
+/// sync (which fires only AFTER the rename) is faulted, so the failure lands
+/// with the source already moved.
+#[test]
+fn quarantine_file_rolls_the_rename_back_on_a_post_move_sync_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let src = tables.join("junk-name");
+    std::fs::write(&src, b"orphan")?;
+
+    // Fault the quarantine-directory sync only: it runs AFTER the rename (the
+    // pre-rename parent sync targets `dir.path()`, which does not contain
+    // "repair-quarantine"), so the failure lands with the source already moved.
+    let fs = FaultFs::new(StdFs);
+    fs.injector().arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other))
+            .on_path("repair-quarantine"),
+    );
+
+    assert!(
+        quarantine_file(&fs, &tables, &src, "junk-name", SyncMode::Full).is_err(),
+        "the post-move directory-sync fault must surface",
+    );
+    assert!(
+        std::fs::metadata(&src).is_ok(),
+        "the rename must be rolled back so the source stays under tables/ for a retry",
+    );
+    assert!(
+        std::fs::metadata(dir.path().join("repair-quarantine").join("junk-name")).is_err(),
+        "the half-committed move must not linger in quarantine",
+    );
+    Ok(())
+}
+
+/// A second repair of the same table must NOT overwrite an earlier quarantine
+/// copy: `rename` replaces the destination on Unix, so a fixed
+/// `repair-quarantine/{id}` name would destroy the only copy of the previous
+/// corrupt original kept for manual recovery. The move must land on a distinct,
+/// create-new name instead.
+#[test]
+fn quarantine_file_preserves_an_earlier_copy_of_the_same_table() -> crate::Result<()> {
+    use crate::fs::SyncMode;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+
+    let src1 = tables.join("7");
+    std::fs::write(&src1, b"first-copy")?;
+    let dest1 = quarantine_file(&StdFs, &tables, &src1, "7", SyncMode::Normal)?;
+    assert_eq!(std::fs::read(&dest1)?, b"first-copy");
+
+    // A later repair of the SAME table id produces a new corrupt file at the
+    // same name; quarantining it must preserve the earlier copy.
+    let src2 = tables.join("7");
+    std::fs::write(&src2, b"second-copy")?;
+    let dest2 = quarantine_file(&StdFs, &tables, &src2, "7", SyncMode::Normal)?;
+
+    assert_ne!(
+        dest1, dest2,
+        "the second quarantine must land on a distinct name",
+    );
+    assert_eq!(
+        std::fs::read(&dest1)?,
+        b"first-copy",
+        "the earlier quarantine copy must survive the second repair",
+    );
+    assert_eq!(std::fs::read(&dest2)?, b"second-copy");
+    Ok(())
+}
 
 #[test]
 fn compute_table_checksum_matches_oneshot_xxh3() -> crate::Result<()> {
@@ -73,36 +415,7 @@ fn repair_with_salvage_reports_a_sole_corrupt_block_as_unsalvageable() -> crate:
     // byte just past its header so the block fails its checksum. The container,
     // index and meta stay intact, so whole-file recovery still opens it (data is
     // read lazily) and only verification trips.
-    let offset = {
-        let checksum = crate::Checksum::from_raw(compute_table_checksum(&*fs, &sst)?);
-        let table = crate::table::Table::recover(
-            sst.clone(),
-            checksum,
-            0,
-            0,
-            0,
-            Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
-            None,
-            Arc::clone(&fs),
-            false,
-            false,
-            None,
-            #[cfg(zstd_any)]
-            None,
-            crate::comparator::default_comparator(),
-            #[cfg(feature = "metrics")]
-            Arc::new(crate::Metrics::default()),
-        )?;
-        let offsets: alloc::vec::Vec<u64> = table
-            .data_block_handles()
-            .filter_map(Result::ok)
-            .map(|kh| *kh.as_ref().offset())
-            .collect();
-        let [only] = offsets.as_slice() else {
-            panic!("expected a single data block, got {offsets:?}");
-        };
-        *only
-    };
+    let offset = sole_data_block_offset(&recover_table(sst.clone(), &fs)?);
     let flip = usize::try_from(offset).unwrap_or(0) + 16;
     let mut bytes = std::fs::read(&sst)?;
     if let Some(b) = bytes.get_mut(flip) {
@@ -135,6 +448,401 @@ fn repair_with_salvage_reports_a_sole_corrupt_block_as_unsalvageable() -> crate:
     assert!(
         reason.contains("nothing salvageable"),
         "the reason names the empty salvage, got: {reason}",
+    );
+    Ok(())
+}
+
+/// A PERSISTENT read failure while hashing the whole file (a bad data sector)
+/// must not doom a salvageable table: pre-fix, repair recorded it unreadable
+/// BEFORE block-salvage could run, and the next open's orphan cleanup then
+/// deleted its intact blocks. With `repair_with_salvage(true)` the whole-file
+/// hash failure is folded into the recovery path, so block-salvage recovers the
+/// readable blocks. The fault fires once on the preliminary hash of the
+/// original (block-salvage reads the quarantined copy and the reopened salvaged
+/// copy, both unaffected).
+#[test]
+fn repair_with_salvage_recovers_a_table_whose_whole_file_hash_faults() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    // Several small blocks: block-salvage can recover them all (the fault is on
+    // the whole-file hash, not on any block read).
+    {
+        let build_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&build_fs))?.use_data_block_size(128);
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Fault the FIRST streaming read of the original SST (the preliminary
+    // whole-file hash) with a persistent `Other`/EIO. `.once()` leaves the
+    // block-salvage reads of the quarantined copy — and the reopen-hash of the
+    // clean salvaged copy — unfaulted, so recovery proceeds.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    injector.clear();
+
+    assert_eq!(
+        report.unreadable, 0,
+        "a whole-file hash fault must not record the table unreadable: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.salvaged, 1,
+        "the table is recovered through block-salvage"
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the salvaged table joins the rebuilt manifest"
+    );
+    Ok(())
+}
+
+/// A tight-space-punched, RESTRICTED SST whose WHOLE-FILE recovery fails
+/// persistently (a bad sector on the preliminary hash) is block-salvaged AND
+/// re-restricted to its sidecar bound. The recovery-failure salvage arm produced
+/// no `Table` to read the bound from, so it reads the `.restrict-bound` sidecar
+/// directly before quarantining and reopens the salvaged replacement restricted:
+/// no superseded sub-bound row resurrects under the default fail-closed policy.
+/// Without the re-restriction the salvage walk re-emits the straddling block's
+/// sub-bound rows unrestricted.
+#[test]
+fn repair_restricts_a_punched_sst_whose_whole_file_recovery_faults() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+
+    // A multi-block SST punched at k00050, its exact bound recorded in the sidecar.
+    let sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+    let bound = b"k00050".to_vec();
+    crate::restrict_bound::write(&*fs, &sst, None, 0, &bound, crate::fs::SyncMode::Normal)?;
+
+    // Fault the FIRST streaming read of the original (the whole-file hash) so
+    // whole-file recovery fails structurally and repair falls to block-salvage.
+    // `.once()` leaves the sidecar read and the salvage reads unfaulted.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    injector.clear();
+
+    assert_eq!(
+        report.recovered, 1,
+        "the salvaged table joins the manifest: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // No sub-bound key resurrects, despite the whole-file recovery failure.
+    for i in 0..50u32 {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_none(),
+            "sub-bound key {} must not resurrect after recovery-failure salvage",
+            String::from_utf8_lossy(&key),
+        );
+    }
+    // The live suffix survives.
+    assert!(
+        tree.get(b"k00200", crate::MAX_SEQNO)?.is_some(),
+        "the live suffix must survive salvage",
+    );
+    Ok(())
+}
+
+/// A BULK-INGESTED SST whose whole-file recovery fails must NOT be recovered
+/// through block-salvage: `try_salvage_table` reopens the salvaged copy with
+/// `global_seqno` 0, and the copy still relies on the manifest-only offset (its
+/// entries stay at local seqno 0), so registering it would silently mis-order
+/// them. The salvage guard drops the copy and records the table unreadable.
+#[test]
+fn repair_with_salvage_quarantines_a_bulk_ingested_sst_that_fails_recovery() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    // A bulk-ingested SST (flag set, entries at local seqno 0).
+    {
+        let build_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&build_fs))?
+            .use_bulk_ingested(Some(true))
+            .use_data_block_size(128);
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                0,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Fail whole-file recovery (persistent hash fault) so the table routes to
+    // block-salvage; salvage then reopens the copy, which carries the flag.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    injector.clear();
+
+    assert_eq!(
+        report.recovered, 0,
+        "a bulk-ingested SST whose offset is lost must not be salvaged-and-kept: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 1,
+        "the bulk-ingested SST is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+
+    // The rejected salvage replacement must be QUARANTINED, not removed-and-forgotten:
+    // a discarded removal error would leave it as a numeric orphan in `tables/` that
+    // blocks the next open. `repair-quarantine/` therefore holds BOTH the corrupt
+    // original (set aside by the caller) AND the rejected replacement.
+    let quarantine = dir.path().join("repair-quarantine");
+    let quarantined: usize = std::fs::read_dir(&quarantine)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .count();
+    assert_eq!(
+        quarantined, 2,
+        "both the corrupt original and the rejected salvage replacement must be \
+         quarantined (found {quarantined})",
+    );
+    // No numeric SST may linger in `tables/` to orphan the next open.
+    let orphans: usize = std::fs::read_dir(dir.path().join("tables"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().parse::<u64>().is_ok())
+        .count();
+    assert_eq!(orphans, 0, "no rejected replacement may linger in tables/");
+    Ok(())
+}
+
+/// A LEGACY SST (no `descriptor#bulk_ingested` key at all — written before the
+/// descriptor existed) whose entries sit at local seqno 0 has UNKNOWN provenance:
+/// it may have been bulk-ingested with a manifest-only `global_seqno`. When
+/// whole-file recovery fails and it routes to block-salvage, the salvaged copy
+/// must PRESERVE that unknown (`None`) provenance, not stamp "not ingested" —
+/// otherwise the salvage guard's seqno heuristic never fires and the table is
+/// kept with `global_seqno` 0, silently mis-ordering it. The mirror writer omits
+/// the key for a `None` source, so the reopened copy re-parses as `None` and the
+/// guard quarantines it.
+#[test]
+fn repair_with_salvage_quarantines_a_legacy_seqno0_sst_that_fails_recovery() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    // A LEGACY SST: provenance UNKNOWN (no flag key), entries at local seqno 0.
+    {
+        let build_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&build_fs))?
+            .use_bulk_ingested(None)
+            .use_data_block_size(128);
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                0,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Fail whole-file recovery (persistent hash fault) so the table routes to
+    // block-salvage; salvage reopens the copy, which must re-parse as `None`.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    injector.clear();
+
+    assert_eq!(
+        report.recovered, 0,
+        "a legacy seqno-0 SST of unknown provenance must not be salvaged-and-kept: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 1,
+        "the legacy seqno-0 SST is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// A TRANSIENT I/O failure during block-salvage must not commit a manifest that
+/// OMITS the table: the original is already in `repair-quarantine`, so a retry
+/// (no longer finding it under `tables/`) would never rediscover it and the SST
+/// would be permanently lost. Repair must instead RESTORE the quarantined
+/// original to its path and abort, so the operator can retry. Fault the salvage's
+/// open of the quarantined source; pre-fix, repair recorded it unreadable and
+/// committed a manifest without the table.
+#[test]
+fn repair_with_salvage_restores_the_original_on_a_transient_salvage_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+
+    // A single-block SST whose sole data block is corrupt: repair routes it to
+    // salvage (verdict Corrupt).
+    {
+        let build_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&build_fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+        let offset = sole_data_block_offset(&recover_table(sst.clone(), &build_fs)?);
+        let flip = usize::try_from(offset).unwrap_or(0) + 16;
+        let mut bytes = std::fs::read(&sst)?;
+        if let Some(b) = bytes.get_mut(flip) {
+            *b ^= 0xFF;
+        }
+        std::fs::write(&sst, &bytes)?;
+    }
+
+    // Fault the salvage's open of the quarantined source (the first open of a
+    // `repair-quarantine/` path) with an interrupted-syscall error (the
+    // unambiguously transient kind): try_salvage_table then fails transiently.
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Interrupted))
+            .on_path("repair-quarantine")
+            .once(),
+    );
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true);
+    injector.clear();
+
+    assert!(
+        result.is_err(),
+        "a transient salvage failure must abort the repair, not commit without the table: \
+         {result:?}",
+    );
+    assert!(
+        sst.exists(),
+        "the quarantined original must be restored to its path so a retry can recover it",
+    );
+    let quarantine = dir.path().join("repair-quarantine");
+    let stranded = quarantine.exists()
+        && std::fs::read_dir(&quarantine)?
+            .find_map(Result::ok)
+            .is_some();
+    assert!(
+        !stranded,
+        "the original must be moved OUT of quarantine, not stranded there",
     );
     Ok(())
 }
@@ -176,36 +884,7 @@ fn repair_with_salvage_reports_a_range_tombstone_sst_as_unsalvageable() -> crate
 
     // Corrupt the sole data block (offset from the intact index) so whole-file
     // recovery opens it but verification fails, driving repair into salvage.
-    let offset = {
-        let checksum = crate::Checksum::from_raw(compute_table_checksum(&*fs, &sst)?);
-        let table = crate::table::Table::recover(
-            sst.clone(),
-            checksum,
-            0,
-            0,
-            0,
-            Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
-            None,
-            Arc::clone(&fs),
-            false,
-            false,
-            None,
-            #[cfg(zstd_any)]
-            None,
-            crate::comparator::default_comparator(),
-            #[cfg(feature = "metrics")]
-            Arc::new(crate::Metrics::default()),
-        )?;
-        let offsets: alloc::vec::Vec<u64> = table
-            .data_block_handles()
-            .filter_map(Result::ok)
-            .map(|kh| *kh.as_ref().offset())
-            .collect();
-        let [only] = offsets.as_slice() else {
-            panic!("expected a single data block, got {offsets:?}");
-        };
-        *only
-    };
+    let offset = sole_data_block_offset(&recover_table(sst.clone(), &fs)?);
     let mut bytes = std::fs::read(&sst)?;
     if let Some(b) = bytes.get_mut(usize::try_from(offset).unwrap_or(0) + 16) {
         *b ^= 0xFF;
@@ -236,11 +915,81 @@ fn repair_with_salvage_reports_a_range_tombstone_sst_as_unsalvageable() -> crate
     Ok(())
 }
 
+/// A TRANSIENT read failure while HASHING an SST during repair must not lose the
+/// table: recording it unreadable commits a manifest that omits the still-in-
+/// place file, which the next open's orphan cleanup then deletes. Repair must
+/// propagate the transient I/O and abort so a retry re-reads the table. Fault the
+/// first open of the file (the checksum hash's open); targeting the op by path,
+/// not a per-file open COUNT, keeps the test platform-independent (the count
+/// differs across OSes).
+#[test]
+fn repair_aborts_on_a_transient_checksum_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+
+    {
+        let build_fs: Arc<dyn Fs> = Arc::new(StdFs);
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&build_fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // compute_table_checksum is the FIRST thing the per-table loop does, and it
+    // hashes the file with sequential reads. Fault the first READ under `tables/`
+    // with an interrupted-syscall error (the unambiguously transient kind): the
+    // directory scan does not read file bytes, so this lands on the hash's read.
+    // Matching by the `tables` path component (not `tables/0`) and by the op (not
+    // an open COUNT) keeps it platform-independent.
+    injector.arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Interrupted))
+            .on_path("tables")
+            .once(),
+    );
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true);
+    injector.clear();
+
+    assert!(
+        result.is_err(),
+        "a transient checksum-hash failure must abort the repair, not record the table \
+         unreadable and commit without it: {result:?}",
+    );
+    assert!(
+        sst.exists(),
+        "the healthy SST must be left in place for a retry",
+    );
+    Ok(())
+}
+
 /// `repair_with_salvage` on a columnar SST whose delete-bitmap AND sole data
 /// block are both corrupt: whole-file recovery refuses it (the corrupt bitmap
-/// would resurrect deleted rows) and block-salvage, though it opens in salvage
-/// mode, finds the one block unreadable, so the table is reported unreadable
-/// rather than half-recovered.
+/// would resurrect deleted rows) and automated block-salvage fails closed on
+/// the unreadable bitmap before even walking the blocks, so the table is
+/// reported unreadable rather than half-recovered.
 #[cfg(feature = "columnar")]
 #[test]
 fn repair_with_salvage_reports_a_corrupt_bitmap_and_block_sst_as_unsalvageable() -> crate::Result<()>
@@ -278,36 +1027,7 @@ fn repair_with_salvage_reports_a_corrupt_bitmap_and_block_sst_as_unsalvageable()
 
     // Resolve the sole data block's offset from the intact index before any
     // corruption shifts nothing (the flip is in place, lengths are unchanged).
-    let block_offset = {
-        let checksum = crate::Checksum::from_raw(compute_table_checksum(&*fs, &sst)?);
-        let table = crate::table::Table::recover(
-            sst.clone(),
-            checksum,
-            0,
-            0,
-            0,
-            Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
-            None,
-            Arc::clone(&fs),
-            false,
-            false,
-            None,
-            #[cfg(zstd_any)]
-            None,
-            crate::comparator::default_comparator(),
-            #[cfg(feature = "metrics")]
-            Arc::new(crate::Metrics::default()),
-        )?;
-        let offsets: alloc::vec::Vec<u64> = table
-            .data_block_handles()
-            .filter_map(Result::ok)
-            .map(|kh| *kh.as_ref().offset())
-            .collect();
-        let [only] = offsets.as_slice() else {
-            panic!("expected a single data block, got {offsets:?}");
-        };
-        *only
-    };
+    let block_offset = sole_data_block_offset(&recover_table(sst.clone(), &fs)?);
     let bitmap = {
         let mut f = std::fs::File::open(&sst)?;
         let reader = match crate::sfa::Reader::from_reader(&mut f) {
@@ -339,7 +1059,7 @@ fn repair_with_salvage_reports_a_corrupt_bitmap_and_block_sst_as_unsalvageable()
     .repair_with_salvage(true)?;
     assert_eq!(
         report.salvaged, 0,
-        "the sole block is corrupt: nothing to salvage"
+        "the bitmap is unreadable: automated salvage fails closed"
     );
     assert_eq!(report.recovered, 0, "no table joins the rebuilt manifest");
     let [(_, reason)] = report.unreadable_files.as_slice() else {
@@ -349,19 +1069,3753 @@ fn repair_with_salvage_reports_a_corrupt_bitmap_and_block_sst_as_unsalvageable()
         );
     };
     assert!(
-        reason.contains("nothing salvageable"),
-        "the reason names the empty salvage, got: {reason}",
+        reason.contains("salvage failed"),
+        "the reason names the failed salvage, got: {reason}",
     );
     Ok(())
 }
 
-/// `repair_with_salvage` recovers an SST that normal recovery refuses: a
-/// columnar segment whose delete-bitmap section is corrupt fails whole-file
-/// recovery (it would resurrect deleted rows), but salvage degrades it to "all
-/// rows live" and the rebuilt manifest references the recovered table.
+/// `repair_with_salvage` must not accept a table whose ECC descriptor this
+/// build cannot interpret: the out-of-band verify skips the SST-block
+/// sections for such a table (their parity-trailer length is underivable), so
+/// its report carries a WARNING and the on-disk bytes are effectively
+/// unchecked. A gate that only checks `is_ok()` stamps those unchecked bytes
+/// into the rebuilt manifest; the repair must instead salvage the table
+/// (re-encode under a recognized descriptor) so the result is verifiable.
+#[test]
+fn repair_with_salvage_rewrites_an_unrecognized_ecc_sst() -> crate::Result<()> {
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..n {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Forge an UNRECOGNIZED ECC descriptor into both meta blocks (`meta` and
+    // its `meta_mid` mirror) and re-stamp their checksums. Meta blocks are
+    // written with restart interval 1 (no prefix truncation), so the key
+    // appears verbatim in the payload, followed by a one-byte value length
+    // (4) and the 4-byte descriptor. `[0, 8, 2, 1]` is a non-canonical "off"
+    // (junk reserved bytes) that decodes to `ecc_unrecognized = true`: reads
+    // still work (payload framed by data_length), but the out-of-band verify
+    // cannot size the parity trailers, so the SST-block sections are skipped
+    // with a warning — the table's on-disk bytes are effectively UNCHECKED.
+    forge_unrecognized_ecc_descriptor(&sst)?;
+    // Precondition: the forged table opens and is flagged unrecognized.
+    assert!(
+        recover_table(sst.clone(), &fs)?.metadata.ecc_unrecognized,
+        "the forged descriptor must flag the table as unrecognized-ECC",
+    );
+
+    // Salvage-mode repair must NOT stamp a table whose block sections could
+    // not be verified into the rebuilt manifest as-is: the warning-bearing
+    // verify report means the bytes are unchecked, so the table is salvaged
+    // (re-encoded under a recognized descriptor) instead.
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "an unverifiable unrecognized-ECC table is rewritten, not accepted \
+         as-is: {report:?}",
+    );
+    assert!(
+        report.unreadable_files.is_empty(),
+        "every row is recoverable: {:?}",
+        report.unreadable_files,
+    );
+
+    // The rewritten table carries a recognized descriptor and every row.
+    let table = recover_table(sst, &fs)?;
+    assert!(
+        !table.metadata.ecc_unrecognized,
+        "the salvaged copy is re-stamped with a recognized descriptor",
+    );
+    assert_eq!(table.metadata.item_count, u64::from(n));
+    Ok(())
+}
+
+/// Recovers the SST at `path` as a `Table`, stamping the open with the file's
+/// current digest.
+fn recover_table(
+    path: std::path::PathBuf,
+    fs: &std::sync::Arc<dyn crate::fs::Fs>,
+) -> crate::Result<crate::table::Table> {
+    use std::sync::Arc;
+    let checksum = crate::Checksum::from_raw(super::compute_table_checksum(&**fs, &path)?);
+    crate::table::Table::recover(
+        path,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(fs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )
+}
+
+/// The offset of the SOLE data block in `table`, panicking if there is not
+/// exactly one. The salvage / repair tests build single-data-block SSTs, so
+/// this collapses the repeated "collect handles, assert one, take its offset".
+fn sole_data_block_offset(table: &crate::table::Table) -> u64 {
+    let offsets: alloc::vec::Vec<u64> = table
+        .data_block_handles()
+        .filter_map(Result::ok)
+        .map(|kh| *kh.as_ref().offset())
+        .collect();
+    let [only] = offsets.as_slice() else {
+        panic!("expected a single data block, got {offsets:?}");
+    };
+    *only
+}
+
+/// A TRANSIENT read error while block-verifying a healthy table must abort the
+/// repair, not be laundered into a corruption verdict: routing it through
+/// salvage would drop the "unreadable" block and install a partial replacement,
+/// turning a retryable I/O failure into permanent missing data. The intact
+/// block stays on disk, so the operator retries and the next attempt reads it.
+#[test]
+fn repair_with_salvage_propagates_a_transient_verify_io_error() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // A single-data-block SST whose bytes are entirely intact.
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Resolve the sole data block's offset, then fault ONLY the positioned read
+    // at that offset, exactly once. The raw-checksum verify walk streams the
+    // file (sequential `Read`), and whole-file recovery is lazy on the data
+    // section, so neither trips: the first positioned read at this offset is the
+    // block-verify DECODE-load, which then surfaces a transient `Io` error.
+    // `Interrupted` is the genuine transient kind (the `is_transient_io`
+    // allowlist): a persistent `Other` would instead grade as corruption and
+    // salvage, which is the sibling `is_corruption_routes_a_persistent_io...` case.
+    let offset = sole_data_block_offset(&recover_table(sst.clone(), &fs)?);
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Interrupted))
+            .at_offset(offset)
+            .once(),
+    );
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(fault))
+    .repair_with_salvage(true);
+    injector.clear();
+
+    assert!(
+        result.is_err(),
+        "a transient read error during block verification must abort the repair \
+         (not salvage a healthy block into missing data), got {result:?}",
+    );
+    // The intact original is untouched: the abort happens before any quarantine
+    // move, so the operator can retry.
+    assert!(
+        fs.metadata(&sst).is_ok(),
+        "the original file stays in place after the aborted repair",
+    );
+    Ok(())
+}
+
+/// A pending `{id}.heal-attest` sidecar must be PRESERVED by repair, not
+/// quarantined: `Tree::open` recognizes and keeps it (the next scrub reconciles
+/// a crashed digest refresh through it). Repair quarantining it would strand the
+/// healed table under its stale pre-heal digest if the manifest rebuild later
+/// failed before committing. The sidecar must still sit next to its SST after a
+/// successful repair.
+#[test]
+fn repair_preserves_a_pending_heal_attestation_sidecar() -> crate::Result<()> {
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let sidecar = tables.join("0.heal-attest");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    // A pending heal marker left next to the SST (its bytes are opaque to the
+    // repair scan; only the file name matters here).
+    std::fs::write(&sidecar, b"pending-heal-marker")?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(report.recovered, 1, "the table is recovered: {report:?}");
+    assert!(
+        sidecar.exists(),
+        "the heal-attest sidecar stays next to its SST (not quarantined)",
+    );
+    Ok(())
+}
+
+/// A table flagged `descriptor#bulk_ingested` must be QUARANTINED, not
+/// registered with `global_seqno` 0. A bulk-ingested SST stores every entry at
+/// local seqno 0 and relies on a manifest-only offset for its effective MVCC
+/// ordering; the rebuilt manifest cannot recover that offset from the SST, so
+/// keeping the table with offset 0 would make its entries appear older than they
+/// are (MVCC corruption). Repair fails closed instead. The flag is precise — a
+/// normal flush at seqno 0 (unflagged) is recovered as usual (see
+/// `repair_clears_torn_edit_log_tail_and_reopens_under_default`).
+#[test]
+fn repair_quarantines_a_table_with_an_unrecoverable_ingest_offset() -> crate::Result<()> {
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // A bulk-ingested table: entries at local seqno 0, flagged bulk-ingested (as
+    // the ingest path writes them), so its effective ordering lives in a
+    // manifest-only global_seqno the rebuilt manifest cannot recover.
+    {
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&fs))?.use_bulk_ingested(Some(true));
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                0,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, 0,
+        "a table with an unrecoverable ingest offset must not join the manifest: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 1,
+        "the ambiguous-offset table is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    let [(_, reason)] = report.unreadable_files.as_slice() else {
+        panic!(
+            "expected exactly one unreadable file, got {:?}",
+            report.unreadable_files,
+        );
+    };
+    assert!(
+        reason.contains("sequence offset"),
+        "the reason names the unrecoverable ingest offset, got: {reason}",
+    );
+    Ok(())
+}
+
+/// `has_unrecoverable_ingest_offset` must fail closed on an authoritatively
+/// bulk-ingested table AND on a LEGACY table (absent flag) whose entries carry
+/// the ingest signature (all at local seqno 0), while keeping a newer
+/// non-ingested table — even one whose entries happen to sit at seqno 0.
+#[test]
+fn has_unrecoverable_ingest_offset_classifies_provenance() {
+    use super::has_unrecoverable_ingest_offset;
+
+    // Authoritative flag wins outright.
+    assert!(has_unrecoverable_ingest_offset(Some(true), 8, 0));
+    assert!(has_unrecoverable_ingest_offset(Some(true), 8, 5));
+    // A newer non-ingested table is safe, even at all-seqno-0 (offset genuinely 0).
+    assert!(!has_unrecoverable_ingest_offset(Some(false), 8, 0));
+    assert!(!has_unrecoverable_ingest_offset(Some(false), 8, 5));
+    // Legacy (absent flag): the ingest signature (entries present, max local
+    // seqno 0) is treated as ambiguous → fail closed.
+    assert!(has_unrecoverable_ingest_offset(None, 8, 0));
+    // Legacy with a non-zero max seqno cannot be all-local-0 → safe.
+    assert!(!has_unrecoverable_ingest_offset(None, 8, 5));
+    // Legacy empty table: nothing to mis-order.
+    assert!(!has_unrecoverable_ingest_offset(None, 0, 0));
+}
+
+/// Opens an SST as a `Table` under a given filesystem, stamping the open with
+/// the file's CURRENT whole-file digest (matching what repair computes). Used to
+/// inspect block layout and to re-read a punched file.
+fn recover_sst(
+    path: std::path::PathBuf,
+    fs: &std::sync::Arc<dyn crate::fs::Fs>,
+) -> crate::Result<crate::Table> {
+    let checksum = crate::Checksum::from_raw(compute_table_checksum(&**fs, &path)?);
+    crate::Table::recover(
+        path,
+        checksum,
+        0,
+        0,
+        0,
+        std::sync::Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(std::sync::Arc::new(
+            crate::descriptor_table::DescriptorTable::new(8),
+        )),
+        std::sync::Arc::clone(fs),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        std::sync::Arc::new(crate::Metrics::default()),
+    )
+}
+
+/// A tight-space-PUNCHED SST records its restriction bound only in the manifest.
+/// When manifest repair rebuilds without that bound, the punched table would open
+/// UNRESTRICTED and later reads would traverse its zero-reading (punched) blocks
+/// and fail. Compaction records the exact bound in a `.restrict-bound` sidecar
+/// beside the SST (without touching the SST). Repair reads the sidecar and — after
+/// confirming the prefix is really punched — restricts to the EXACT bound, so a
+/// MID-BLOCK boundary recovers with zero loss of the block's live suffix (#60) and
+/// zero resurrection of its consumed prefix. Probes every key: served IFF key >=
+/// exact bound. Uses `MemFs` for a byte-precise punch.
+#[test]
+fn repair_restricts_a_tight_space_punched_table() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::table::Writer;
+    use crate::{AbstractTree, Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    // An SST with several small data blocks so a prefix can be punched.
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..256u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // A restriction bound chosen to fall MID-BLOCK: `k00130` is a real key, and
+    // its straddling block also holds keys below it (the consumed prefix repair
+    // must hide) and at/above it (the live suffix repair must keep).
+    let bound = b"k00130".to_vec();
+    {
+        let table = recover_sst(sst.clone(), &fs)?;
+
+        // Publish the exact bound to the sidecar (what tight-space compaction does
+        // before punching), then punch the consumed prefix. `punch_offset_for`
+        // returns the offset of the block that STRADDLES the bound, so `[0, offset)`
+        // is the whole blocks strictly below it; the straddling block (holding both
+        // the sub-bound consumed keys and the live suffix) survives. The
+        // served-iff-key>=bound probe below proves the mid-block split is exact.
+        crate::restrict_bound::write(&*fs, &sst, None, 0, &bound, crate::fs::SyncMode::Normal)?;
+        let punch_offset = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, punch_offset)?;
+    }
+
+    // Repair rebuilds the manifest, recovering the punched table RESTRICTED to the
+    // EXACT bound read from the sidecar.
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair()?;
+    assert_eq!(
+        report.recovered, 1,
+        "the punched table is recovered restricted: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    // Reopen and probe EVERY key: served IFF key >= exact bound. The lower half
+    // (no key below the bound served) is the no-resurrection guard; the upper half
+    // (every key at/above the bound served, INCLUDING the straddling block's live
+    // suffix `[k00130, block_end)`) is the no-loss guard that #60 demands.
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    for i in 0..256u32 {
+        let key = format!("k{i:05}").into_bytes();
+        let served = tree.get(&key, crate::MAX_SEQNO)?.is_some();
+        assert_eq!(
+            served,
+            key.as_slice() >= bound.as_slice(),
+            "key {key:?} served={served}; expected served == (key >= {bound:?}) \
+             (a served key below the bound is resurrected; an unserved key at/above \
+             it is lost)",
+        );
+    }
+    Ok(())
+}
+
+/// With salvage ENABLED, an otherwise-healthy tight-space RESTRICTED SST (a valid
+/// `.restrict-bound` sidecar, fully punch-backed) must be KEPT restricted, not
+/// salvaged away. The salvage-gate block walk must start at the view's live data
+/// start (`punch_offset`), not byte 0: walking the hole-punched `[0, punch)` prefix
+/// reads zeroed block headers, reports them as corruption, and the restricted-table
+/// safeguard then quarantines the healthy SST, dropping it from the manifest
+/// precisely because salvage was enabled (#79).
+#[test]
+fn repair_with_salvage_keeps_a_healthy_restricted_punched_table() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    write_multiblock_sst(&sst, &fs)?;
+
+    // A mid-block bound, published to the sidecar, with the whole prefix below it
+    // punched: a legitimately restricted, otherwise-healthy view.
+    let bound = b"k00130".to_vec();
+    {
+        let table = recover_sst(sst.clone(), &fs)?;
+        crate::restrict_bound::write(&*fs, &sst, None, 0, &bound, crate::fs::SyncMode::Normal)?;
+        let punch = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, punch)?;
+    }
+
+    // Salvage ENABLED is the trigger: the salvage gate's block walk runs only here.
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "a healthy restricted SST must be kept restricted even with salvage on: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 0,
+        "the healthy restricted SST must NOT be quarantined: {:?}",
+        report.unreadable_files,
+    );
+
+    // Probe every key: served IFF key >= bound, so the restriction survived intact.
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    for i in 0..256u32 {
+        let key = format!("k{i:05}").into_bytes();
+        let served = tree.get(&key, crate::MAX_SEQNO)?.is_some();
+        assert_eq!(
+            served,
+            key.as_slice() >= bound.as_slice(),
+            "key {key:?} served={served}; expected served == (key >= {bound:?})",
+        );
+    }
+    Ok(())
+}
+
+/// Builds a multi-data-block SST under `fs` at `path` (keys `k00000..k00255`).
+fn write_multiblock_sst(
+    path: &std::path::Path,
+    fs: &std::sync::Arc<dyn crate::fs::Fs>,
+) -> crate::Result<()> {
+    use crate::{InternalValue, ValueType};
+    let mut w = crate::table::Writer::new(path.to_path_buf(), 0, 0, std::sync::Arc::clone(fs))?
+        .use_data_block_size(128);
+    for i in 0..256u32 {
+        w.write(InternalValue::from_components(
+            format!("k{i:05}").into_bytes(),
+            format!("v{i}").into_bytes(),
+            u64::from(i) + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(w.finish()?.is_some(), "the SST is non-empty");
+    Ok(())
+}
+
+/// Builds a multi-block SST at `tables/0` under `memfs`, then punches its consumed
+/// prefix `[0, punch(k00050))`, the on-disk state of a tight-space-PUNCHED SST.
+/// The caller then publishes (or withholds / corrupts / mismatches) a
+/// `.restrict-bound` sidecar to drive repair through each no-trustworthy-bound
+/// path. Returns the SST path.
+fn build_punched_prefix_sst(
+    memfs: &std::sync::Arc<crate::fs::MemFs>,
+    fs: &std::sync::Arc<dyn crate::fs::Fs>,
+    tables: &std::path::Path,
+) -> crate::Result<std::path::PathBuf> {
+    use crate::fs::Fs;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, fs)?;
+    let committed = recover_sst(sst.clone(), fs)?.punch_offset_for(b"k00050")?;
+    memfs.punch_hole(&sst, 0, committed)?;
+    Ok(sst)
+}
+
+/// Builds a multi-block SST at `tables/0`, then PARTIALLY punches its consumed
+/// prefix `[0, punch(k00050))`: every prefix data block EXCEPT THE FIRST is
+/// zeroed, modeling a punch-on-drop reclaim whose first `punch_hole` failed (the
+/// reclaim logs and continues per block). The first block stays intact while
+/// later prefix blocks read as zeros — the state a first-block-only punch probe
+/// misreads as "unpunched". No sidecar is published. Returns the SST path.
+fn build_partially_punched_prefix_sst(
+    memfs: &std::sync::Arc<crate::fs::MemFs>,
+    fs: &std::sync::Arc<dyn crate::fs::Fs>,
+    tables: &std::path::Path,
+) -> crate::Result<std::path::PathBuf> {
+    use crate::fs::Fs;
+    use crate::table::block_index::BlockIndex;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, fs)?;
+    let table = recover_sst(sst.clone(), fs)?;
+    let committed = table.punch_offset_for(b"k00050")?;
+    let mut punched = 0u32;
+    for handle in table.block_index.iter() {
+        let handle = handle?;
+        let off = handle.offset().0;
+        if off > 0 && off < committed {
+            memfs.punch_hole(&sst, off, u64::from(handle.size()))?;
+            punched += 1;
+        }
+    }
+    assert!(
+        punched >= 2,
+        "precondition: the consumed prefix spans several blocks past the first",
+    );
+    Ok(sst)
+}
+
+/// A PARTIALLY punched SST (intact first block, zeroed later prefix blocks)
+/// with no trustworthy sidecar must be SET ASIDE under default repair
+/// (resurrection off): the interleaved intact block is positive evidence that
+/// `punch_hole` failed mid-reclaim, and then ANY readable block above the last
+/// hole may equally be an intact-but-consumed block whose punch also failed —
+/// no geometry bound can separate consumed from live, so restricting to one
+/// would resurrect superseded rows. Only a CLEAN zeroed prefix (no intact
+/// block below a zeroed one) supports the classical geometry bound.
+#[test]
+fn repair_sets_aside_a_partially_punched_sst_without_a_trustworthy_bound() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "an irregularly punched SST with no exact bound must be set aside, not \
+         restricted to a guessed bound that resurrects consumed rows: {report:?}",
+    );
+    assert_eq!(report.unreadable, 1, "{:?}", report.unreadable_files);
+    assert!(
+        report
+            .unreadable_files
+            .first()
+            .is_some_and(|(_, reason)| reason.contains("punch failures")),
+        "the reason names the failed punches that made the bound unknowable: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// The RESURRECTION counterpart with salvage OFF: a partially punched SST
+/// (intact first block, zeroed later prefix blocks, no sidecar) must be
+/// restricted PAST the last zeroed block. Unrestricted, a read in the zeroed
+/// region would error after a supposedly successful repair; a bound anchored at
+/// the intact FIRST block would leave the zeroed blocks inside the served view
+/// with the same effect.
+#[test]
+fn resurrection_restricts_a_partially_punched_sst_past_the_zeroed_blocks() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(false, true)?;
+    assert_eq!(report.recovered, 1, "{report:?}");
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // A key in a ZEROED prefix block must miss CLEANLY: unrestricted (or
+    // restricted only to the intact first block's key) this get would route to
+    // a zeroed block and error, failing the test through the `?`.
+    assert!(
+        tree.get(b"k00020", crate::MAX_SEQNO)?.is_none(),
+        "a key in a zeroed block must miss cleanly, not error",
+    );
+    // The intact first block is below the punched region: a single lower bound
+    // cannot keep it while excluding the zeroed blocks above it, and its rows
+    // are superseded by the committed output anyway.
+    assert!(
+        tree.get(b"k00000", crate::MAX_SEQNO)?.is_none(),
+        "the intact-but-superseded first block must not be served",
+    );
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the live suffix must be served",
+    );
+    Ok(())
+}
+
+/// The recovery-FAILURE counterpart: a partially punched, sidecar-less SST that
+/// also fails whole-file recovery must be set aside, not block-salvaged into an
+/// unrestricted output. The cheap pre-salvage probe reads only the FIRST bytes
+/// and cannot see a punch that left the first block intact; the salvage walk's
+/// dropped all-zero extents must catch it instead.
+#[test]
+fn repair_sets_aside_a_partially_punched_sidecarless_sst_that_fails_recovery() -> crate::Result<()>
+{
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // A PERSISTENT fault on the FIRST streaming read (the preliminary whole-file
+    // hash) fails whole-file recovery and routes repair to the salvage arm; the
+    // salvage itself (reading the quarantined copy) runs unfaulted and WOULD
+    // succeed, resurrecting the intact-but-superseded first block unrestricted.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a partially punched sidecar-less SST that fails recovery is set aside, \
+         not salvaged into an unrestricted output: {report:?}",
+    );
+    assert_eq!(report.unreadable, 1, "{:?}", report.unreadable_files);
+    assert!(
+        report
+            .unreadable_files
+            .first()
+            .is_some_and(|(_, reason)| reason.contains("punched extents found during salvage")),
+        "the reason names the punched extents the walk found: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// The punch-on-drop reclaim must leave a CLASSIFIABLE hole pattern when
+/// individual `punch_hole` calls fail: punching top-down and STOPPING at the
+/// first failure guarantees any failure (or crash) leaves intact blocks BELOW
+/// the zeroed ones — the irregular signature default repair sets aside. The
+/// old bottom-up continue-past-failures order left trailing intact-but-consumed
+/// blocks ABOVE a clean zeroed prefix, indistinguishable from a live suffix, so
+/// a sidecar-less repair restricted to a bound that resurrected their
+/// superseded rows.
+#[test]
+fn punch_failures_leave_a_classifiable_pattern() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let faultfs = FaultFs::new(memfs.as_ref().clone());
+    let injector = faultfs.injector();
+    let fs: Arc<dyn Fs> = Arc::new(faultfs);
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+
+    // Arm a PERSISTENT punch fault that lets the first two attempts through:
+    // top-down with stop-on-first-failure this zeroes only the top two consumed
+    // blocks and leaves everything below intact (an irregular, classifiable
+    // pattern). Bottom-up with continue-past-failures it would zero the two
+    // LOWEST blocks and leave trailing consumed blocks that read as a clean
+    // zeroed prefix plus a plausible live suffix.
+    let table = recover_sst(sst, &fs)?;
+    let committed = table.punch_offset_for(b"k00130")?;
+    table.mark_punch_on_drop(committed);
+    injector.arm(FaultRule::new(FaultOp::PunchHole, Fault::Error(ErrorKind::Other)).skip(2));
+    drop(table);
+    injector.clear();
+
+    // Default repair with NO sidecar must classify the pattern as an irregular
+    // punch and set the table aside — never restrict to a bound that serves the
+    // intact-but-consumed blocks the failed punches left behind.
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a punch-failure pattern must be set aside, not restricted to a bound \
+         that resurrects the unpunched consumed blocks: {report:?}",
+    );
+    assert_eq!(report.unreadable, 1, "{:?}", report.unreadable_files);
+    assert!(
+        report
+            .unreadable_files
+            .first()
+            .is_some_and(|(_, reason)| reason.contains("punch failures")),
+        "{:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// The restore's raw sidecar capture must apply the same size cap
+/// `restrict_bound::read` enforces: an attacker-padded or corrupt oversized
+/// sidecar must be classified unreadable (no rescue copy), not trusted into a
+/// full-size allocation and re-published verbatim by the rename fallback.
+#[test]
+fn restore_does_not_republish_an_oversized_sidecar() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, SyncMode};
+    use crate::io::ErrorKind;
+    use std::io::Write;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    std::fs::write(&sst, b"sst bytes")?;
+
+    let fs = FaultFs::new(StdFs);
+    // An oversized "sidecar": larger than any valid header + max key + checksum
+    // (+ encryption overhead) encoding.
+    let sidecar = crate::restrict_bound::sidecar_path(&sst);
+    {
+        let mut f = fs.open(
+            &sidecar,
+            &crate::fs::FsOpenOptions::new().write(true).create(true),
+        )?;
+        f.write_all(&vec![0x42u8; (usize::from(u16::MAX)) * 2])?;
+    }
+    let dest = super::quarantine_file(&fs, &tables, &sst, "0", SyncMode::Normal)?;
+
+    // Fault the direct sidecar rename on the way back: with no rescue copy
+    // captured (oversized = unreadable), the restore must complete WITHOUT
+    // re-publishing the junk at the destination.
+    fs.injector().arm(
+        FaultRule::new(FaultOp::Rename, Fault::Error(ErrorKind::Other))
+            .on_path("restrict-bound")
+            .once(),
+    );
+    super::restore_quarantined(&fs, &dest, &sst, None, SyncMode::Normal)?;
+    assert!(fs.exists(&sst)?, "the SST is restored to tables/");
+    assert!(
+        !fs.exists(&crate::restrict_bound::sidecar_path(&sst))?,
+        "an oversized (corrupt) sidecar must not be re-published beside the SST",
+    );
+    Ok(())
+}
+
+/// A flag-dependent set-aside must keep the resurrection knob TWO-WAY: a
+/// default (resurrection-off) repair sets an irregularly punched SST aside
+/// because its bound is unknowable, but a later resurrection repair must
+/// reclaim it from quarantine automatically — no manual file move — and
+/// recover its readable region greedily. Unrelated quarantined files (which
+/// carry no resurrectable marker) are never reclaimed.
+#[test]
+fn resurrection_reclaims_an_irregularly_punched_set_aside() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // Default repair: the irregular punch makes the bound unknowable → set aside.
+    let first = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(first.recovered, 0, "{first:?}");
+    assert_eq!(first.unreadable, 1, "{:?}", first.unreadable_files);
+
+    // Unrelated quarantine content without a marker must survive the reclaim.
+    let quarantine = root.join("repair-quarantine");
+    let junk = quarantine.join("junk-name");
+    {
+        use std::io::Write;
+        let mut f = fs.open(
+            &junk,
+            &crate::fs::FsOpenOptions::new().write(true).create(true),
+        )?;
+        f.write_all(b"not a table")?;
+    }
+
+    // Resurrection repair: the marked set-aside is reclaimed and recovered
+    // greedily, with no manual step in between.
+    let second = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(false, true)?;
+    assert_eq!(
+        second.recovered, 1,
+        "the resurrection repair must reclaim the marked set-aside: {second:?}",
+    );
+    assert_eq!(second.unreadable, 0, "{:?}", second.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    assert!(
+        tree.get(b"k00020", crate::MAX_SEQNO)?.is_none(),
+        "a key in a zeroed block still misses cleanly",
+    );
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the readable region is served under resurrection",
+    );
+    drop(tree);
+
+    assert!(
+        !fs.exists(&quarantine.join("0"))?,
+        "the reclaimed SST must leave quarantine",
+    );
+    assert!(
+        !fs.exists(&quarantine.join("0.resurrectable"))?,
+        "the marker is consumed by the reclaim",
+    );
+    assert!(
+        fs.exists(&junk)?,
+        "unmarked quarantine content is never reclaimed",
+    );
+    Ok(())
+}
+
+/// The salvage-walk punch guard must scan the WHOLE surrendered extent, not
+/// just its opening window: when the physical chain breaks, the walk can
+/// surrender the entire remaining data tail as ONE dropped extent whose offset
+/// is the first DAMAGED (nonzero) frame, leaving punched blocks further down
+/// invisible to a 64-byte probe. With no sidecar and an intact first block,
+/// both punch guards would then pass and the salvaged output would publish the
+/// consumed records unrestricted, resurrecting superseded data.
+#[test]
+fn salvage_guard_finds_punched_blocks_deep_in_a_surrendered_extent() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+
+    // Punch a MIDDLE data block (not the first), so the file's opening bytes
+    // stay intact and the zeroed region sits deep inside the data section —
+    // exactly the shape a surrendered tail hides from an opening-window probe.
+    let table = recover_sst(sst.clone(), &fs)?;
+    let mut handles = Vec::new();
+    {
+        use crate::table::block_index::BlockIndex;
+        for handle in table.block_index.iter() {
+            let handle = handle?;
+            handles.push((handle.offset().0, handle.size()));
+        }
+    }
+    assert!(handles.len() >= 4, "fixture needs several data blocks");
+    let (Some(&(mid_off, mid_size)), Some(&(first_off, _))) =
+        (handles.get(handles.len() / 2), handles.first())
+    else {
+        panic!("fixture has >= 4 data blocks, so both lookups resolve");
+    };
+    drop(table);
+    memfs.punch_hole(&sst, mid_off, u64::from(mid_size))?;
+
+    // The whole data section, surrendered as ONE extent starting at its first
+    // byte (the shape `salvage_attempt` produces after a broken chain): the
+    // opening window is intact data, the punched block is deeper in.
+    let dropped = vec![crate::salvage::DroppedBlock {
+        offset: first_off,
+        section: b"data".to_vec(),
+        reason: crate::salvage::DropReason::HeaderCorrupted("surrendered tail".to_owned()),
+        key_range: None,
+    }];
+    assert!(
+        super::dropped_data_extent_is_zeroed(&*fs, &sst, &dropped)?,
+        "a punched block deeper inside the surrendered extent must be found",
+    );
+
+    // An unpunched source must still not false-positive.
+    let clean = tables.join("1");
+    write_multiblock_sst(&clean, &fs)?;
+    assert!(
+        !super::dropped_data_extent_is_zeroed(&*fs, &clean, &dropped)?,
+        "an unpunched source must never be reported as punched",
+    );
+    Ok(())
+}
+
+/// The standalone out-of-band verify must not condemn a healthy restricted
+/// punched SST: with a valid colocated sidecar attesting the committed
+/// restriction, the leading zeroed (punched) region is the reclaimed prefix
+/// and the walk starts at the live frontier, verifying the suffix clean.
+/// WITHOUT the sidecar the zeros stay part of the walk and flag loudly:
+/// zeroed-out data on an unrestricted table is destruction, not reclaim.
+#[test]
+fn verify_sst_file_honors_a_restricted_punched_prefix() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs, SyncMode};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00130", SyncMode::Normal)?;
+    let punch = recover_sst(sst.clone(), &fs)?.punch_offset_for(b"k00130")?;
+    memfs.punch_hole(&sst, 0, punch)?;
+
+    let report = crate::verify::verify_sst_file_with_fs(&*fs, &sst);
+    assert!(
+        report.is_ok(),
+        "a healthy restricted punched SST must verify clean through the \
+         out-of-band walk: errors {:?}, warnings {:?}",
+        report.errors,
+        report.warnings,
+    );
+    assert!(
+        report.blocks_scanned > 0,
+        "the live suffix must actually be walked: {report:?}",
+    );
+
+    // Without the attesting sidecar the zeroed region must flag loudly.
+    crate::restrict_bound::remove(&*fs, &sst, SyncMode::Normal);
+    let report = crate::verify::verify_sst_file_with_fs(&*fs, &sst);
+    assert!(
+        !report.is_ok(),
+        "leading zeros without a restriction sidecar are destroyed data and \
+         must fail verification: {report:?}",
+    );
+    Ok(())
+}
+
+/// Two same-id copies living in DIFFERENT filesystem namespaces are distinct
+/// files even when their paths spell the same string: canonicalizing both
+/// through the host filesystem would call them aliases and skip quarantining
+/// the loser, leaving a same-id leftover that a later reopen can resolve
+/// against the kept copy's manifest checksum. The alias test must therefore
+/// compare backend identity too, and treat "no shared-namespace guarantee"
+/// (`backend_id() == None`) as distinct.
+#[test]
+fn same_physical_file_requires_a_shared_namespace() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs, StdFs};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let real = dir.path().join("0");
+    std::fs::write(&real, b"real bytes")?;
+
+    let memfs: Arc<dyn Fs> = Arc::new(MemFs::new());
+    let stdfs: Arc<dyn Fs> = Arc::new(StdFs);
+    // A MemFs file at the very path that also exists on the host filesystem.
+    if let Some(parent) = real.parent() {
+        memfs.create_dir_all(parent)?;
+    }
+    {
+        use std::io::Write;
+        let mut f = memfs.open(
+            &real,
+            &crate::fs::FsOpenOptions::new().write(true).create(true),
+        )?;
+        f.write_all(b"virtual bytes")?;
+    }
+
+    assert!(
+        !super::same_physical_file(&*memfs, &real, &*stdfs, &real),
+        "same path spelling in DIFFERENT namespaces is not an alias",
+    );
+    assert!(
+        super::same_physical_file(&*stdfs, &real, &*stdfs, &real),
+        "the same host path through one namespace IS an alias",
+    );
+    Ok(())
+}
+
+/// A zero run INSIDE a live value must never move the frontier: the derive
+/// anchors only on a run whose end is a VALIDATED block header (magic +
+/// header checksum), so a value carrying `Header::MIN_LEN` zeros — perfectly
+/// legal payload — cannot make the walk start mid-frame and condemn (or
+/// silently skip part of) a healthy SST.
+#[test]
+fn verify_sst_file_ignores_zero_runs_inside_live_values() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs, SyncMode};
+    use crate::table::Writer;
+    use crate::{InternalValue, ValueType};
+    use std::sync::Arc;
+
+    let fs: Arc<dyn Fs> = Arc::new(MemFs::new());
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    // Values are long all-zero byte strings — legal payload that contains far
+    // more than `Header::MIN_LEN` consecutive zeros. No punch anywhere.
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                vec![0u8; 256],
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    // A sidecar makes the derive eligible: without it the derive short-circuits
+    // and the zero runs could not move the frontier anyway.
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00010", SyncMode::Normal)?;
+
+    let report = crate::verify::verify_sst_file_with_fs(&*fs, &sst);
+    assert!(
+        report.is_ok(),
+        "zero-filled VALUES are legal payload and must not move the frontier: \
+         errors {:?}, warnings {:?}",
+        report.errors,
+        report.warnings,
+    );
+    assert!(
+        report.blocks_scanned > 0,
+        "every live block must still be walked: {report:?}",
+    );
+    Ok(())
+}
+
+/// The frontier derive must clear the LAST punched extent, not stop at the
+/// first nonzero byte: the reclaim punches top-down and stops at its first
+/// failure, so a partial reclaim leaves intact consumed blocks BELOW the holes
+/// it did punch. Anchoring at the first nonzero byte would put those holes
+/// back inside the walk and condemn a healthy sidecar-backed SST as corrupt.
+#[test]
+fn verify_sst_file_clears_partial_top_down_holes() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs, SyncMode};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00130", SyncMode::Normal)?;
+
+    // A PARTIAL top-down reclaim: punch the consumed blocks nearest the bound
+    // and leave the lowest ones intact (the shape a failed / crashed reclaim
+    // leaves, since the pass stops at its first failure).
+    let table = recover_sst(sst.clone(), &fs)?;
+    let committed = table.punch_offset_for(b"k00130")?;
+    let mut consumed = Vec::new();
+    {
+        use crate::table::block_index::BlockIndex;
+        for handle in table.block_index.iter() {
+            let handle = handle?;
+            if handle.offset().0 < committed {
+                consumed.push((handle.offset().0, handle.size()));
+            }
+        }
+    }
+    assert!(consumed.len() >= 3, "fixture needs several consumed blocks");
+    drop(table);
+    for &(off, size) in consumed.iter().skip(1) {
+        memfs.punch_hole(&sst, off, u64::from(size))?;
+    }
+
+    let report = crate::verify::verify_sst_file_with_fs(&*fs, &sst);
+    assert!(
+        report.is_ok(),
+        "a partially reclaimed sidecar-backed SST must verify clean: errors \
+         {:?}, warnings {:?}",
+        report.errors,
+        report.warnings,
+    );
+    assert!(
+        report.blocks_scanned > 0,
+        "the live suffix must still be walked: {report:?}",
+    );
+    Ok(())
+}
+
+/// A reclaim whose post-rename step fails must not leave the SST in `tables/`
+/// unreferenced: the previously installed manifest omits it, so a caller that
+/// responds to the failed repair by simply REOPENING the tree lets orphan
+/// cleanup delete the only recovered copy. Every failure after the rename must
+/// roll the file back into quarantine, marker intact, where the next
+/// resurrection repair rediscovers it.
+#[test]
+fn reclaim_rolls_back_to_quarantine_when_a_post_rename_step_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // Default repair sets the irregularly punched SST aside with a marker.
+    let first = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(first.recovered, 0, "{first:?}");
+
+    // Fault the reclaim's first destination-directory sync (the only tables/
+    // sync before the scan starts on a resurrection run): the rename back into
+    // tables/ has already happened by then.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let second = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_resurrection(true, true);
+    assert!(second.is_err(), "the faulted reclaim sync must surface");
+
+    let quarantine = root.join("repair-quarantine");
+    assert!(
+        !fs.exists(&tables.join("0"))?,
+        "the reclaimed SST must not be left in tables/ where a plain reopen's \
+         orphan cleanup would delete it",
+    );
+    assert!(
+        fs.exists(&quarantine.join("0"))?,
+        "the SST must be rolled back into quarantine",
+    );
+    assert!(
+        fs.exists(&quarantine.join("0.resurrectable"))?,
+        "the marker must survive the rollback so a retry rediscovers the file",
+    );
+
+    // The retry (no fault) reclaims and recovers it.
+    let third = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(third.recovered, 1, "{third:?}");
+    Ok(())
+}
+
+/// The pre-salvage first-bytes guard's set-aside (a FULLY punched, sidecar-less
+/// SST that fails whole-file recovery) is two-way as well: default repair sets
+/// it aside marked, and a later resurrection repair reclaims and recovers its
+/// readable region.
+#[test]
+fn resurrection_reclaims_a_fully_punched_set_aside() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+    let punch = recover_sst(sst.clone(), &fs)?.punch_offset_for(b"k00130")?;
+    memfs.punch_hole(&sst, 0, punch)?;
+
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let first = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    assert_eq!(first.recovered, 0, "{first:?}");
+
+    let second = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(
+        second.recovered, 1,
+        "the resurrection repair must reclaim the marked set-aside: {second:?}",
+    );
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the readable region is served under resurrection",
+    );
+    Ok(())
+}
+
+/// The recovery-failure arm's flag-dependent set-asides are two-way too: a
+/// partially punched, sidecar-less SST whose whole-file recovery also failed is
+/// set aside by default repair, and a later resurrection repair reclaims and
+/// recovers it (the transient recovery fault is gone on the re-run).
+#[test]
+fn resurrection_reclaims_a_punched_set_aside_from_the_salvage_arm() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    build_partially_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // One-shot read fault fails the whole-file hash → recovery-failure arm →
+    // salvage detects the punched dropped extents → set aside (bound lost).
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let first = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    assert_eq!(first.recovered, 0, "{first:?}");
+
+    // Resurrection repair on the clean fs reclaims the marked original and
+    // recovers its readable region.
+    let second = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(
+        second.recovered, 1,
+        "the resurrection repair must reclaim the marked set-aside: {second:?}",
+    );
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the readable region is served under resurrection",
+    );
+    Ok(())
+}
+
+/// Writing the `.restrict-bound` sidecar must NEVER mutate the SST — that is the
+/// point of a separate file: the manifest's whole-file checksum for the SST stays
+/// valid across the write, so a crash between the sidecar write and the manifest
+/// commit can never make a scrub see the SST as corrupt or a checkpoint hard-link
+/// modified bytes under a stale digest (#64).
+#[test]
+fn writing_the_sidecar_does_not_mutate_the_sst() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::table::Writer;
+    use crate::{InternalValue, ValueType};
+    use std::sync::Arc;
+
+    let fs: Arc<dyn Fs> = Arc::new(MemFs::new());
+    // Absolute so the MemFs directory key matches what `Writer::new` writes (it
+    // rewrites through `std::path::absolute`, prepending the drive on Windows).
+    let base = std::path::absolute("/d")?;
+    fs.create_dir_all(&base)?;
+    let sst = base.join("0");
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    let before = compute_table_checksum(&*fs, &sst)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00030", crate::fs::SyncMode::Normal)?;
+    let after = compute_table_checksum(&*fs, &sst)?;
+    assert_eq!(
+        before, after,
+        "publishing the sidecar must leave the SST byte-identical",
+    );
+    Ok(())
+}
+
+/// A restricted, punched SST whose LIVE suffix is ALSO corrupt (a rare double
+/// failure) is recovered, not stranded: salvage recovers the readable suffix
+/// blocks (dropping the zeroed prefix and the corrupt straddling block), then the
+/// result is reopened restricted to the recorded bound and its sidecar is
+/// re-written, so the live suffix survives while nothing below the bound is
+/// resurrected (#65). The corrupt straddling block's keys are the only casualty:
+/// that is the price of the corruption, not of the restriction.
+#[test]
+fn repair_salvages_a_restricted_punched_sst_with_a_corrupt_suffix() -> crate::Result<()> {
+    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use crate::table::Writer;
+    use crate::{AbstractTree, Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::io::{Seek, SeekFrom, Write};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..256u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Record the bound, punch the consumed prefix, then CORRUPT the first live
+    // (straddling) block so the restricted view's verify flags it for salvage.
+    let bound = b"k00130".to_vec();
+    let punch_offset = {
+        let table = recover_sst(sst.clone(), &fs)?;
+        crate::restrict_bound::write(&*fs, &sst, None, 0, &bound, crate::fs::SyncMode::Normal)?;
+        let off = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, off)?;
+        off
+    };
+    {
+        let mut f = fs.open(&sst, &FsOpenOptions::new().write(true))?;
+        f.seek(SeekFrom::Start(punch_offset + 20))?;
+        f.write_all(&[0xFFu8])?;
+        f.sync_all()?;
+    }
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the restricted SST's readable live suffix is salvaged, not stranded: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+    // The salvaged replacement re-records its bound so a later manifest-loss
+    // repair honors it (the fresh file is unpunched).
+    assert!(
+        crate::restrict_bound::exists(&*fs, &sst)?,
+        "the salvaged restricted SST re-writes its `.restrict-bound` sidecar",
+    );
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // No sub-bound key is resurrected, whatever the corrupt block cost above it.
+    for i in 0..130u32 {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_none(),
+            "sub-bound key {} must never be resurrected",
+            String::from_utf8_lossy(&key),
+        );
+    }
+    // The live suffix well above the dropped straddling block survives.
+    for i in [200u32, 255] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_some(),
+            "live suffix key {} must survive salvage",
+            String::from_utf8_lossy(&key),
+        );
+    }
+    Ok(())
+}
+
+/// Builds a punched, restricted SST at `tables/0` whose first LIVE (straddling)
+/// block is corrupt, the shape that drives repair through salvage and forces it to
+/// re-impose the restriction on the salvaged output. Returns the state-sharing
+/// `MemFs` and the absolute root. The re-restriction-fault tests below arm a fault
+/// on the sidecar write and assert the quarantined original is restored.
+#[cfg(feature = "std")]
+fn build_restricted_corrupt_sst()
+-> crate::Result<(std::sync::Arc<crate::fs::MemFs>, std::path::PathBuf)> {
+    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use crate::table::Writer;
+    use crate::{InternalValue, ValueType};
+    use std::io::{Seek, SeekFrom, Write};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..256u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    let bound = b"k00130".to_vec();
+    let punch_offset = {
+        let table = recover_sst(sst.clone(), &fs)?;
+        crate::restrict_bound::write(&*fs, &sst, None, 0, &bound, crate::fs::SyncMode::Normal)?;
+        let off = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, off)?;
+        off
+    };
+    {
+        let mut f = fs.open(&sst, &FsOpenOptions::new().write(true))?;
+        f.seek(SeekFrom::Start(punch_offset + 20))?;
+        f.write_all(&[0xFFu8])?;
+        f.sync_all()?;
+    }
+    Ok((memfs, root))
+}
+
+/// A fault (of the given kind) on the RE-RESTRICTION sidecar write (the SECOND
+/// `.restrict-bound` open; the first is repair reading the recorded bound) must
+/// restore the quarantined original and propagate, never leave the unpunched,
+/// sidecar-less salvaged replacement in place: a later recovery would open THAT
+/// unrestricted and resurrect the sub-bound rows. This must hold for a PERSISTENT
+/// failure (ENOSPC-class) as well as a transient one, since the retry cannot
+/// re-derive the bound from a fresh unpunched output.
+#[cfg(feature = "std")]
+fn assert_re_restriction_fault_restores_the_original(
+    fault_kind: crate::io::ErrorKind,
+) -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs};
+    use crate::{Config, SequenceNumberCounter};
+
+    let (memfs, root) = build_restricted_corrupt_sst()?;
+    let sst = root.join("tables").join("0");
+
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(fault_kind))
+            .on_path("restrict-bound")
+            .skip(1)
+            .once(),
+    );
+
+    let result = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true);
+    assert!(
+        matches!(&result, Err(crate::Error::Io(e)) if e.kind() == fault_kind),
+        "the re-restriction fault must propagate, got {result:?}",
+    );
+
+    // The distinguishing evidence of the restore: NO stranded original is left in
+    // quarantine. Without the restore the salvaged replacement stays at the table
+    // path and the punched original is orphaned in `repair-quarantine/0` forever, a
+    // copy no retry under `tables/` can ever reach.
+    assert!(
+        !memfs.exists(&root.join("repair-quarantine").join("0"))?,
+        "the fault must restore the original, leaving nothing in quarantine",
+    );
+    assert!(
+        memfs.exists(&sst)?,
+        "the original SST is back at its table path after the restore",
+    );
+    Ok(())
+}
+
+/// A TRANSIENT fault re-imposing the restriction on a salvaged output restores the
+/// quarantined original and propagates for retry. The retry then recovers the
+/// table restricted, with no sub-bound resurrection.
+#[test]
+fn repair_restores_the_original_when_re_restriction_faults_transiently() -> crate::Result<()> {
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    assert_re_restriction_fault_restores_the_original(ErrorKind::Interrupted)?;
+
+    // The retry (no fault) recovers the table restricted: no sub-bound resurrection.
+    let (memfs, root) = build_restricted_corrupt_sst()?;
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the retry recovers the table: {report:?}"
+    );
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    assert!(
+        tree.get(b"k00000", crate::MAX_SEQNO)?.is_none(),
+        "no sub-bound key resurrects after the retry",
+    );
+    Ok(())
+}
+
+/// The PERSISTENT counterpart: an ENOSPC-class (non-transient) fault re-imposing
+/// the restriction must ALSO restore the quarantined original, not only transient
+/// ones. Recovery cannot re-derive the bound from the fresh unpunched salvaged
+/// output, so leaving it in place would let a retry install it UNRESTRICTED and
+/// resurrect the sub-bound rows.
+#[test]
+fn repair_restores_the_original_when_re_restriction_faults_persistently() -> crate::Result<()> {
+    use crate::io::ErrorKind;
+
+    assert_re_restriction_fault_restores_the_original(ErrorKind::Other)
+}
+
+/// A PUNCHED SST with no trustworthy bound (missing sidecar) that ALSO fails
+/// whole-file recovery must be set aside, NOT block-salvaged into an unrestricted
+/// output: recovery leaves no `Table` to derive a geometry bound from, and salvage
+/// re-emits the straddling block's sub-bound rows with nothing to restrict them.
+/// Fail closed on the ambiguity.
+#[test]
+fn repair_sets_aside_a_punched_sidecarless_sst_that_fails_recovery() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..256u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    // Punch the consumed prefix (zeroes block 0) WITHOUT recording a sidecar. The
+    // tail (meta/index) stays intact, so block salvage still succeeds; only the
+    // whole-file recovery is made to fail below.
+    let punch_offset = recover_sst(sst.clone(), &fs)?.punch_offset_for(b"k00130")?;
+    memfs.punch_hole(&sst, 0, punch_offset)?;
+
+    // A PERSISTENT fault on the FIRST streaming read (the preliminary whole-file
+    // hash) fails whole-file recovery and routes repair to the salvage arm, while
+    // salvage (reading the quarantined copy) and the punch probe run unfaulted. So
+    // salvage WOULD succeed and, without the fail-closed guard, install the
+    // unpunched output UNRESTRICTED, resurrecting the straddling block's sub-bound
+    // rows. The guard sets it aside instead.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a punched sidecar-less SST that fails recovery is set aside, not salvaged \
+         into an unrestricted output: {report:?}",
+    );
+    assert_eq!(report.unreadable, 1, "{:?}", report.unreadable_files);
+    assert!(
+        report
+            .unreadable_files
+            .first()
+            .is_some_and(|(_, reason)| reason.contains("no recoverable restriction bound")),
+        "the reason names the unrecoverable punched bound: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// Quarantining a RESTRICTED SST must carry its `.restrict-bound` sidecar along:
+/// left behind in `tables/`, the next open's orphan sweep (the rebuilt manifest no
+/// longer names the id) deletes it, permanently stranding the quarantined punched
+/// file from its exact recovery boundary. `restore_quarantined` moves it back the
+/// same way.
+#[test]
+fn quarantine_moves_the_restriction_sidecar_with_the_sst() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs, SyncMode};
+    use std::sync::Arc;
+
+    let fs: Arc<dyn Fs> = Arc::new(MemFs::new());
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &fs)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00050", SyncMode::Normal)?;
+
+    let src_sidecar = crate::restrict_bound::sidecar_path(&sst);
+    assert!(
+        fs.exists(&src_sidecar)?,
+        "precondition: the sidecar was written"
+    );
+
+    // Quarantine the SST; its sidecar must follow it out of `tables/`.
+    let dest = super::quarantine_file(&*fs, &tables, &sst, "0", SyncMode::Normal)?;
+    let dest_sidecar = crate::restrict_bound::sidecar_path(&dest);
+    assert!(
+        fs.exists(&dest_sidecar)?,
+        "the sidecar must move into repair-quarantine/ next to its SST",
+    );
+    assert!(
+        !fs.exists(&src_sidecar)?,
+        "no orphaned sidecar may be left in tables/ for the orphan sweep to delete",
+    );
+    assert!(!fs.exists(&sst)?, "the SST itself moved out of tables/");
+
+    // Restoring the original brings the sidecar back with it.
+    super::restore_quarantined(&*fs, &dest, &sst, None, SyncMode::Normal)?;
+    assert!(fs.exists(&sst)?, "the SST is restored to tables/");
+    assert!(
+        fs.exists(&src_sidecar)?,
+        "the sidecar is restored alongside the SST",
+    );
+    assert!(
+        !fs.exists(&dest_sidecar)?,
+        "no sidecar may be left orphaned in repair-quarantine/ after restore",
+    );
+    Ok(())
+}
+
+/// A failure while moving the companion sidecar (after the SST itself already
+/// moved into `repair-quarantine/`) must roll the SST back under `tables/`:
+/// propagating with the table stranded in quarantine means the retried repair no
+/// longer discovers it and installs a manifest that omits it — permanent loss
+/// from a one-shot rename fault. The rollback leaves both files exactly where a
+/// retry can find and re-quarantine them.
+#[test]
+fn quarantine_rolls_back_the_sst_when_the_sidecar_move_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    std::fs::write(&sst, b"sst bytes")?;
+
+    let fs = FaultFs::new(StdFs);
+    crate::restrict_bound::write(&fs, &sst, None, 0, b"k00050", SyncMode::Normal)?;
+    let src_sidecar = crate::restrict_bound::sidecar_path(&sst);
+    assert!(fs.exists(&src_sidecar)?, "precondition: sidecar written");
+
+    // Fault the SIDECAR's rename only: `Rename` matches the destination path,
+    // and only the sidecar's destination contains "restrict-bound" (the SST
+    // moves to a bare numeric name). The SST rename has succeeded by then.
+    fs.injector().arm(
+        FaultRule::new(FaultOp::Rename, Fault::Error(ErrorKind::Interrupted))
+            .on_path("restrict-bound"),
+    );
+
+    assert!(
+        quarantine_file(&fs, &tables, &sst, "0", SyncMode::Normal).is_err(),
+        "the sidecar rename fault must surface",
+    );
+    assert!(
+        fs.exists(&sst)?,
+        "the SST must be rolled back under tables/ so a retry rediscovers it",
+    );
+    assert!(
+        fs.exists(&src_sidecar)?,
+        "the sidecar must stay beside the SST under tables/",
+    );
+    let quarantine = dir.path().join("repair-quarantine");
+    assert!(
+        !fs.exists(&quarantine.join("0"))?,
+        "no stranded SST may be left in repair-quarantine/",
+    );
+    Ok(())
+}
+
+/// A failed sidecar rename during `restore_quarantined` must not strand the
+/// exact bound in quarantine (where the retried repair never looks, silently
+/// degrading the restored SST to the lossy geometry fallback): the restore
+/// falls back to RE-PUBLISHING the sidecar bytes captured before the move, so
+/// it completes and a retry recovers the EXACT bound. The SST itself is never
+/// rolled back into quarantine — a pair stranded there is invisible to the
+/// retry entirely.
+#[test]
+fn restore_republishes_the_sidecar_when_its_rename_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, SyncMode};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    std::fs::write(&sst, b"sst bytes")?;
+
+    let fs = FaultFs::new(StdFs);
+    crate::restrict_bound::write(&fs, &sst, None, 0, b"k00050", SyncMode::Normal)?;
+    let dest = super::quarantine_file(&fs, &tables, &sst, "0", SyncMode::Normal)?;
+    let dest_sidecar = crate::restrict_bound::sidecar_path(&dest);
+    assert!(
+        fs.exists(&dest_sidecar)?,
+        "precondition: sidecar quarantined"
+    );
+
+    // Fault the sidecar's direct rename on the way BACK (`Rename` matches the
+    // destination path; only the sidecar's destination contains
+    // "restrict-bound"). `.once()` so the fallback's own tmp → final rename
+    // succeeds.
+    fs.injector().arm(
+        FaultRule::new(FaultOp::Rename, Fault::Error(ErrorKind::Other))
+            .on_path("restrict-bound")
+            .once(),
+    );
+
+    super::restore_quarantined(&fs, &dest, &sst, None, SyncMode::Normal)?;
+    assert!(fs.exists(&sst)?, "the SST is restored to tables/");
+    let src_sidecar = crate::restrict_bound::sidecar_path(&sst);
+    assert!(
+        fs.exists(&src_sidecar)?,
+        "the sidecar must be re-published beside the restored SST",
+    );
+    match crate::restrict_bound::read(&fs, &sst, None)? {
+        crate::restrict_bound::SidecarRead::Present(id, bound) => {
+            assert_eq!(id, 0);
+            assert_eq!(bound, b"k00050", "the re-published bound is byte-intact");
+        }
+        _ => panic!("the re-published sidecar must decode to the exact bound"),
+    }
+    assert!(
+        !fs.exists(&dest_sidecar)?,
+        "no stale sidecar may linger in quarantine after the re-publish",
+    );
+    Ok(())
+}
+
+/// Asserts a punched SST at `tables/0` was recovered RESTRICTED to the exact
+/// sidecar `bound` by default repair (resurrection off): the table joins the
+/// manifest, nothing is set aside, and a key is served IFF it is at or above the
+/// bound. Shared by the honor-the-bound tests (a valid sidecar the punch does not
+/// fully back).
+fn assert_recovered_restricted_to(
+    memfs: &std::sync::Arc<crate::fs::MemFs>,
+    root: &std::path::Path,
+    bound: &[u8],
+) -> crate::Result<()> {
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    let report = Config::new(
+        root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the SST is recovered restricted to its bound, not set aside: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    for i in 0..256u32 {
+        let key = format!("k{i:05}").into_bytes();
+        let served = tree.get(&key, crate::MAX_SEQNO)?.is_some();
+        assert_eq!(
+            served,
+            key.as_slice() >= bound,
+            "key {key:?} served={served}; expected served == (key >= {bound:?})",
+        );
+    }
+    Ok(())
+}
+
+/// A `.restrict-bound` sidecar whose bound reaches PAST the actually-punched
+/// extent is not fully backed by the punch (an earlier slice punched `[0, B1)`
+/// but a later, larger bound `B2 > B1` never committed, so `[B1, B2)` stays live).
+/// With resurrection off, repair honors the recorded bound: it restricts to `B2`,
+/// dropping the ambiguous prefix (including the live `[B1, B2)`) rather than
+/// resurrecting the superseded sub-`B1` rows an unrestricted open would expose.
+/// The live suffix above `B2` is always kept.
+#[test]
+fn repair_restricts_a_punched_sst_whose_sidecar_bound_overshoots_the_punch() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+
+    // Punch `[0, punch(k00050))`, but publish a LARGER sidecar bound `k00130` (as
+    // if a later slice's install never landed).
+    let sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00130", crate::fs::SyncMode::Normal)?;
+
+    assert_recovered_restricted_to(&memfs, &root, b"k00130")
+}
+
+/// A VALID `.restrict-bound` sidecar for this id over an UNPUNCHED SST denotes a
+/// COMMITTED restriction whose punch had not yet run: tight-space writes the
+/// sidecar STRICTLY AFTER the slice's version install commits, so an aborted
+/// slice never leaves one. Repair honors the recorded bound, restricting to it
+/// and dropping the prefix (the committed output covers it) rather than
+/// resurrecting a superseded sub-bound row. The live suffix is kept.
+#[test]
+fn repair_honors_a_valid_sidecar_over_an_unpunched_sst() -> crate::Result<()> {
+    let (memfs, root) = build_unpunched_sidecar_sst(b"k00130")?;
+    assert_recovered_restricted_to(&memfs, &root, b"k00130")
+}
+
+/// Builds `tables/0`: a multi-block SST with a VALID `.restrict-bound` sidecar
+/// for its own id at `bound`, but NO physical punch — the post-install /
+/// pre-punch crash state. Returns the `MemFs` and its absolute root.
+fn build_unpunched_sidecar_sst(
+    bound: &[u8],
+) -> crate::Result<(std::sync::Arc<crate::fs::MemFs>, std::path::PathBuf)> {
+    use crate::fs::{Fs, MemFs};
+    use crate::table::Writer;
+    use crate::{InternalValue, ValueType};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+        for i in 0..256u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    crate::restrict_bound::write(&*fs, &sst, None, 0, bound, crate::fs::SyncMode::Normal)?;
+
+    Ok((memfs, root))
+}
+
+/// A committed restriction is honored REGARDLESS of the resurrection flag. Because
+/// a valid sidecar over an unpunched SST is provably committed (written strictly
+/// after the install), enabling resurrection does NOT reopen the whole table: the
+/// flag governs LOST tombstones / restrictions, and this restriction is neither
+/// lost nor ambiguous. Repair still restricts to the recorded bound, so no
+/// superseded sub-bound row is served. Under the pre-`commit-then-mark` ordering
+/// the sidecar could outlive an uncommitted restriction, so resurrection kept the
+/// whole table (serving `k00000`); this test pins the committed-honor behaviour.
+#[test]
+fn repair_with_resurrection_honors_a_committed_unpunched_sidecar() -> crate::Result<()> {
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    let (memfs, root) = build_unpunched_sidecar_sst(b"k00130")?;
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the committed restriction is recovered restricted, not set aside: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // The bound is honored even with resurrection ON: keys below it stay dropped,
+    // the live suffix at/above it is served.
+    assert!(
+        tree.get(b"k00000", crate::MAX_SEQNO)?.is_none(),
+        "a committed restriction must not be reopened whole by the resurrection flag",
+    );
+    assert!(
+        tree.get(b"k00129", crate::MAX_SEQNO)?.is_none(),
+        "the row just below the bound stays dropped",
+    );
+    assert!(
+        tree.get(b"k00130", crate::MAX_SEQNO)?.is_some(),
+        "the bound key is served",
+    );
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the live suffix is served",
+    );
+    Ok(())
+}
+
+/// Asserts a punched SST at `tables/0` under `memfs` was recovered RESTRICTED by
+/// default repair (resurrection off): the table joins the rebuilt manifest,
+/// nothing is set aside, no key below the punch (a superseded prefix row) is
+/// resurrected, and the live suffix survives. Shared by the no-exact-bound
+/// punched-SST tests, which resolve the bound from the punch geometry. The build
+/// helper punches `[0, punch(k00050))`, so the conservative derived bound sits at
+/// or just above `k00050`.
+fn assert_punched_sst_recovered_restricted(
+    memfs: &std::sync::Arc<crate::fs::MemFs>,
+    root: &std::path::Path,
+) -> crate::Result<()> {
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    let report = Config::new(
+        root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the punched SST is recovered restricted, not set aside: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 0,
+        "nothing is set aside: {:?}",
+        report.unreadable_files,
+    );
+
+    let tree = Config::new(
+        root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // No superseded prefix row (below the k00050 punch) is resurrected.
+    for i in [0u32, 10, 49] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_none(),
+            "key {key:?} is below the punch and must NOT be resurrected",
+        );
+    }
+    // The live suffix survives (the derived bound sits just above the punch, so
+    // keys well above it are served).
+    for i in [100u32, 200, 255] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_some(),
+            "live-suffix key {key:?} must be served",
+        );
+    }
+    Ok(())
+}
+
+/// A punched SST with NO `.restrict-bound` sidecar (a legacy punched SST predating
+/// sidecars, or one whose sidecar was lost) has no exact bound. With resurrection
+/// off, repair derives a conservative bound from the punch geometry and recovers
+/// the table restricted: the live suffix survives and no superseded prefix row is
+/// resurrected. It is never opened unrestricted (which would resurrect the prefix)
+/// nor set aside (which would discard the live suffix).
+#[test]
+fn repair_restricts_a_punched_sst_with_no_sidecar() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    // Punch the prefix but publish NO sidecar.
+    let _sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    assert_punched_sst_recovered_restricted(&memfs, &root)
+}
+
+/// A punched SST whose `.restrict-bound` sidecar reads back MALFORMED (a flipped
+/// byte fails its checksum) has no trustworthy exact bound. With resurrection off,
+/// repair derives a conservative bound from the punch geometry and recovers the
+/// table restricted, rather than routing it through the generic salvage path
+/// (which would rewrite it unpunched and re-emit the superseded prefix rows).
+#[test]
+fn repair_restricts_a_punched_sst_with_a_corrupt_sidecar() -> crate::Result<()> {
+    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // Publish a valid, punch-backed sidecar, then flip its first byte so it reads
+    // back with a mismatched checksum (Corrupt).
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00050", crate::fs::SyncMode::Normal)?;
+    let sidecar = crate::restrict_bound::sidecar_path(&sst);
+    {
+        let mut buf = Vec::new();
+        fs.open(&sidecar, &FsOpenOptions::new().read(true))?
+            .read_to_end(&mut buf)?;
+        if let Some(b) = buf.first_mut() {
+            *b ^= 0xFF;
+        }
+        let mut f = fs.open(&sidecar, &FsOpenOptions::new().write(true))?;
+        f.seek(SeekFrom::Start(0))?;
+        f.write_all(&buf)?;
+        f.sync_all()?;
+    }
+
+    assert_punched_sst_recovered_restricted(&memfs, &root)
+}
+
+/// A punched SST whose `.restrict-bound` sidecar binds a DIFFERENT table id (a
+/// stale sidecar left by a reused id) does not authenticate this SST's bound, so
+/// there is no trustworthy exact bound. With resurrection off, repair derives a
+/// conservative bound from the punch geometry and recovers the table restricted,
+/// rather than opening the punched SST whole (which would resurrect its prefix).
+#[test]
+fn repair_restricts_a_punched_sst_with_a_mismatched_sidecar_id() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    let sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // A bound that WOULD be trustworthy (fully punch-backed) but recorded under the
+    // WRONG table id, so it never authenticates this SST (named "0", id 0).
+    crate::restrict_bound::write(
+        &*fs,
+        &sst,
+        None,
+        999,
+        b"k00050",
+        crate::fs::SyncMode::Normal,
+    )?;
+
+    assert_punched_sst_recovered_restricted(&memfs, &root)
+}
+
+/// A punched SST with no exact bound, recovered with resurrection ENABLED, keeps
+/// its whole readable region instead of restricting: the live suffix survives and
+/// the readable prefix keys the conservative derive would have dropped are served
+/// again. It is still recovered into a valid tree, never set aside.
+#[test]
+fn repair_with_resurrection_keeps_a_punched_sst_unrestricted() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    // Punch `[0, punch(k00050))`, publish NO sidecar: no exact bound survives.
+    let _sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "resurrection recovers the punched SST unrestricted, not set aside: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    // The live suffix survives, and at least one key the conservative derive drops
+    // (the readable straddling block just above the punch) is resurrected, so the
+    // resurrection view serves strictly more than the default restricted one.
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the live suffix must be served under resurrection",
+    );
+    let resurrected = (50u32..100)
+        .filter_map(|i| {
+            let key = format!("k{i:05}").into_bytes();
+            tree.get(&key, crate::MAX_SEQNO).ok().flatten().map(|_| i)
+        })
+        .count();
+    assert!(
+        resurrected > 0,
+        "resurrection must serve readable keys the conservative derive would drop",
+    );
+    Ok(())
+}
+
+/// A punched SST with no trustworthy sidecar, recovered with resurrection ON but
+/// salvage OFF, must NOT be opened unrestricted: its reclaimed prefix is zeroed
+/// block frames, so a read routed to one of them would fail with block corruption
+/// after a supposedly successful repair. Resurrection restricts to the first
+/// readable block's key (keeping the whole straddling block), so a read below the
+/// frontier misses cleanly while the live suffix is served.
+#[test]
+fn repair_with_resurrection_but_no_salvage_does_not_expose_punched_blocks() -> crate::Result<()> {
+    use crate::fs::{Fs, MemFs};
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes (see the
+    // sibling tests for the Windows drive-relative rationale).
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+    // Punch `[0, punch(k00050))`, publish NO sidecar: no exact bound survives.
+    let _sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+
+    // salvage OFF (no rewrite to drop the zeroed blocks), resurrection ON.
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .repair_with_resurrection(false, true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the punched SST is recovered: {report:?}"
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    // A read in the punched prefix must MISS cleanly. Unrestricted, this get would
+    // route to a zeroed block and error (the `?` would propagate it, failing the
+    // test) — the restriction makes it miss below the frontier instead.
+    assert!(
+        tree.get(b"k00000", crate::MAX_SEQNO)?.is_none(),
+        "a key in the punched prefix must miss cleanly, not error on a zeroed block",
+    );
+    assert!(
+        tree.get(b"k00255", crate::MAX_SEQNO)?.is_some(),
+        "the live suffix must be served",
+    );
+    Ok(())
+}
+
+/// Repair must PROPAGATE a transient `.restrict-bound` sidecar read on a punched
+/// SST, not silently open it unrestricted (which would expose the zeroed prefix).
+/// A one-shot `Interrupted` opening the sidecar is retryable, so `read` returns an
+/// I/O error that repair classifies as transient and re-raises, rather than
+/// installing a manifest without the restriction.
+#[test]
+fn repair_propagates_a_transient_restrict_bound_read() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let membase: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    membase.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &membase)?;
+
+    // Record a mid-block bound in the sidecar, then punch the consumed prefix.
+    let bound = b"k00130".to_vec();
+    {
+        let table = recover_sst(sst.clone(), &membase)?;
+        crate::restrict_bound::write(
+            &*membase,
+            &sst,
+            None,
+            0,
+            &bound,
+            crate::fs::SyncMode::Normal,
+        )?;
+        let punch = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, punch)?;
+    }
+
+    // Fault the sidecar OPEN with a TRANSIENT kind.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Interrupted))
+            .on_path("restrict-bound"),
+    );
+
+    let result = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true);
+    assert!(
+        result.is_err(),
+        "a transient sidecar read on a punched SST must propagate, not silently \
+         open it unrestricted: {result:?}",
+    );
+    Ok(())
+}
+
+/// A PERSISTENT `.restrict-bound` sidecar read error (EIO / `PermissionDenied`,
+/// outside the transient allowlist) on a punched SST leaves no trustworthy exact
+/// bound. With resurrection off, repair derives a conservative bound from the
+/// punch geometry and recovers the table restricted, rather than routing it
+/// through the generic salvage path (which would rewrite it unpunched and re-emit
+/// the superseded prefix rows).
+#[test]
+fn repair_restricts_a_punched_sst_on_a_persistent_sidecar_read() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let membase: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes: the
+    // writer rewrites its output path through `std::path::absolute`, which on
+    // Windows prepends the current drive (`/db` -> `D:\db`). Building the root the
+    // same way keeps `create_dir_all` and the writer agreed on one namespace.
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    membase.create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    write_multiblock_sst(&sst, &membase)?;
+
+    // A valid bound plus a real punch of the consumed prefix.
+    let bound = b"k00130".to_vec();
+    {
+        let table = recover_sst(sst.clone(), &membase)?;
+        crate::restrict_bound::write(
+            &*membase,
+            &sst,
+            None,
+            0,
+            &bound,
+            crate::fs::SyncMode::Normal,
+        )?;
+        let punch = table.punch_offset_for(&bound)?;
+        memfs.punch_hole(&sst, 0, punch)?;
+    }
+
+    // Fault the sidecar OPEN with a PERSISTENT kind (not in the retry allowlist).
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::PermissionDenied))
+            .on_path("restrict-bound"),
+    );
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the punched SST is recovered restricted, not set aside: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    // The punch reclaimed `[0, punch(k00130))`, so the derived bound sits at or
+    // just above k00130: no key below the punch is resurrected, and the live
+    // suffix well above it survives.
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    for i in [0u32, 50, 129] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_none(),
+            "key {key:?} is below the punch and must NOT be resurrected",
+        );
+    }
+    for i in [150u32, 200, 255] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_some(),
+            "live-suffix key {key:?} must be served",
+        );
+    }
+    Ok(())
+}
+
+/// A VALID post-commit sidecar is proof enough of a committed restriction: repair
+/// must honor its exact bound WITHOUT first probing the already-dead below-bound
+/// prefix. A persistently-unreadable sector in a punched (dead) prefix block must
+/// not cost the intact live suffix. Here the sidecar bound `k00050` is valid, the
+/// prefix is punched, and the first (dead) data block's positioned read faults
+/// persistently. With salvage OFF (the default), reopening straight at the bound
+/// recovers the readable suffix; probing the dead prefix first would discard the
+/// exact bound and quarantine the whole table.
+#[test]
+fn repair_honors_a_valid_sidecar_despite_a_persistent_dead_prefix_read() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let fs: Arc<dyn Fs> = memfs.clone();
+    // Absolute so the MemFs directory keys match what `Writer::new` writes (it
+    // rewrites through `std::path::absolute`, prepending the drive on Windows).
+    let root = std::path::absolute("/db")?;
+    let tables = root.join("tables");
+    fs.create_dir_all(&tables)?;
+
+    // Punch `[0, punch(k00050))` and publish a VALID sidecar bound at k00050.
+    let sst = build_punched_prefix_sst(&memfs, &fs, &tables)?;
+    crate::restrict_bound::write(&*fs, &sst, None, 0, b"k00050", crate::fs::SyncMode::Normal)?;
+
+    // Fault the FIRST data block's positioned read (offset 0, a dead below-bound
+    // block) with a PERSISTENT kind. Only the dead-prefix probe and geometry
+    // fallback read offset 0; the suffix digest reads strictly above the punch.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other)).at_offset(0));
+
+    let report = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault)
+    .repair_with_salvage(false)?;
+    assert_eq!(
+        report.recovered, 1,
+        "a valid sidecar must be honored despite an unreadable dead prefix, not \
+         quarantined: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    let tree = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(memfs.as_ref().clone())
+    .open()?;
+    for i in 0..256u32 {
+        let key = format!("k{i:05}").into_bytes();
+        let served = tree.get(&key, crate::MAX_SEQNO)?.is_some();
+        assert_eq!(
+            served,
+            key.as_slice() >= b"k00050".as_slice(),
+            "key {key:?} served={served}; expected served == (key >= k00050)",
+        );
+    }
+    Ok(())
+}
+
+/// A file whose name only LOOKS like a heal-temp — `{id}.healtmp-{non-numeric}`
+/// (e.g. `5.healtmp-backup`) — must NOT be skipped as an owned artifact: recovery
+/// owns only `{id}.healtmp-{numeric}`, so leaving it in place makes the next
+/// `Tree::open` reject its non-numeric name instead of sweeping it, leaving the
+/// repaired database unopenable. Repair must quarantine it like any foreign file.
+#[test]
+fn repair_quarantines_a_foreign_healtmp_suffix() -> crate::Result<()> {
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    // Prefix parses as a table id, but the sequence does not parse as u64.
+    let foreign = tables.join("5.healtmp-backup");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst, 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    std::fs::write(&foreign, b"not a real heal temp")?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, 1,
+        "the real table is recovered: {report:?}"
+    );
+    assert!(
+        !foreign.exists(),
+        "the foreign .healtmp- file is quarantined out of tables/, not left to \
+         break the next open",
+    );
+    Ok(())
+}
+
+/// A PERSISTENT read failure DURING the block-verify walk (not the decode-load)
+/// is graded as corruption, not an abort: `verify_sst_file_with_context` reports
+/// it as `SstFileUnreadable` / `DataReadError`, and a retry can never fix a bad
+/// sector, so aborting the whole repair forever would strand every healthy
+/// sibling table. The corrupt table is routed to salvage instead. (Only the
+/// transient allowlist — `Interrupted` / `WouldBlock` — aborts for a retry, but
+/// those kinds are absorbed by the read layer's own EINTR retry before reaching
+/// this gate, so the abort arm is defensive.) The table is recovered on a clean
+/// fs, then the walk runs on a fs whose read faults once, so only the walk trips.
+#[test]
+fn verify_keep_decision_grades_a_persistent_walk_io_error_as_corruption() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let clean: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&clean))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    let table = recover_table(sst.clone(), &clean)?;
+
+    // A single persistent `Other` fault on the walk read: the verdict must NOT
+    // abort (that is the transient contract), so `verify_keep_decision` returns a
+    // decision rather than propagating the error.
+    let fault = FaultFs::new(StdFs);
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other)).once());
+    let faulting: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let config = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    );
+    let decision = verify_keep_decision(&config, &faulting, &sst, &table, false);
+    assert!(
+        decision.is_ok(),
+        "a persistent walk read error must be graded as corruption (a decision), not \
+         abort the whole repair, got {decision:?}",
+    );
+    Ok(())
+}
+
+/// PARITY-ONLY rot (every payload checksum still clean) on a table salvage
+/// cannot faithfully re-emit (range tombstones) must also KEEP the table:
+/// the data is fully readable, only its recovery margin is degraded, and
+/// quarantining it through a salvage that is guaranteed to refuse would
+/// throw the table away over dead parity.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn repair_with_salvage_keeps_a_parity_rotted_range_tombstone_sst() -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::table::block::{EccParams, Header};
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_ecc(Some(EccParams::try_new(4, 2)?));
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Rot one byte of the sole data block's PARITY trailer: the payload
+    // checksum still verifies, so the out-of-band walk reports only an
+    // EccParityMismatch — the data itself is untouched.
+    let block_off = usize::try_from(sole_data_block_offset(&recover_table(sst.clone(), &fs)?))
+        .unwrap_or(usize::MAX);
+    let mut bytes = std::fs::read(&sst)?;
+    let Some(mut cursor) = bytes.get(block_off..) else {
+        panic!("data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos =
+        block_off + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert!(
+        report.unreadable_files.is_empty(),
+        "a readable table must not be dropped over parity-only rot: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the range-tombstone table joins the rebuilt manifest as-is: {report:?}",
+    );
+    assert_eq!(
+        report.salvaged, 0,
+        "salvage is never attempted when it cannot re-emit the range tombstones",
+    );
+    Ok(())
+}
+
+/// The unrecognized-ECC degraded grade is different from parity-only rot: the
+/// out-of-band walk SKIPPED the SST-block sections entirely (their trailer
+/// length is underivable), so nothing about the data was verified. The
+/// range-tombstone keep-guard must therefore NOT keep such a table blindly —
+/// a corrupt lazy data block would ride into the rebuilt manifest. The table
+/// is verified through handle-based reads instead (they frame the payload by
+/// `data_length` and checksum-verify it regardless of the descriptor); a
+/// corrupt block then routes to salvage, which refuses range tombstones, so
+/// the table is reported unreadable rather than silently kept.
+#[test]
+fn repair_with_salvage_rejects_a_corrupt_unrecognized_ecc_tombstone_sst() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Forge the unrecognized descriptor (the out-of-band walk then skips the
+    // data section) AND corrupt the sole data block's payload.
+    forge_unrecognized_ecc_descriptor(&sst)?;
+    let block_off = usize::try_from(sole_data_block_offset(&recover_table(sst.clone(), &fs)?))
+        .unwrap_or(usize::MAX);
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(block_off + 40) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a corrupt table whose sections the walk could not scan must not be \
+         kept over the range-tombstone escape hatch: {report:?}",
+    );
+    let [(_, reason)] = report.unreadable_files.as_slice() else {
+        panic!(
+            "expected exactly one unreadable file, got {:?}",
+            report.unreadable_files,
+        );
+    };
+    assert!(
+        reason.contains("range tombstones"),
+        "the reason names the refused range-tombstone salvage, got: {reason}",
+    );
+    Ok(())
+}
+
+/// An unrecognized-ECC range-tombstone table can be neither verified in full
+/// (the block walk skips its sections; every lazy side structure would need
+/// its own handle-based check) nor faithfully salvaged (range tombstones are
+/// not re-emittable) — even a HEALTHY one is therefore QUARANTINED for
+/// manual recovery rather than riding unverified into the rebuilt manifest,
+/// and the quarantine protects it from the orphan cleanup a later open runs.
+#[test]
+fn repair_with_salvage_quarantines_an_unrecognized_ecc_tombstone_sst() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    forge_unrecognized_ecc_descriptor(&sst)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "an unverifiable table never joins the rebuilt manifest: {report:?}",
+    );
+    assert_eq!(
+        report.salvaged, 0,
+        "salvage cannot re-emit range tombstones"
+    );
+    let [(_, reason)] = report.unreadable_files.as_slice() else {
+        panic!(
+            "expected exactly one unreadable file, got {:?}",
+            report.unreadable_files,
+        );
+    };
+    assert!(
+        reason.contains("quarantined") && reason.contains("recompact"),
+        "the reason names the quarantine and the recovery path, got: {reason}",
+    );
+    // The original bytes survive in the quarantine (a later open's orphan
+    // cleanup would delete an unquarantined file the manifest ignores).
+    let quarantined = dir.path().join("repair-quarantine").join("0");
+    assert!(
+        fs.metadata(&quarantined).is_ok(),
+        "the original file is preserved in the quarantine",
+    );
+    Ok(())
+}
+
+/// Repair's out-of-band block verify must apply the SAME caller-known-id
+/// cross-check as recovery when it reads the meta block for the ECC
+/// descriptor: a checksum-clean TAIL meta whose `table_id` AND ECC descriptor
+/// were forged (MID intact) is rejected by recovery's id check and falls back
+/// to the intact MID — but a verify probe that skips the id check for
+/// unencrypted reads accepts the forged tail, grades the healthy table
+/// degraded-UNSCANNED off the forged descriptor, and (for a range-tombstone
+/// SST salvage cannot re-emit) quarantines a perfectly healthy table.
+#[test]
+fn repair_with_salvage_keeps_a_healthy_rt_sst_with_a_forged_tail_meta() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("7");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // A HEALTHY range-tombstone SST under id 7 (salvage cannot re-emit range
+    // tombstones, so a wrong degraded-unscanned verdict is terminal for it).
+    {
+        let mut w = Writer::new(sst.clone(), 7, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    // Forge ONLY the tail meta (id 7 → 99 AND an unrecognized ECC
+    // descriptor); the MID mirror keeps the true id and descriptor.
+    forge_tail_meta_table_id(&sst, Some(99), Some([0u8, 8, 2, 1]))?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the healthy table joins the rebuilt manifest via the intact MID \
+         meta: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.unreadable, 0,
+        "no quarantine for a healthy table whose forged tail the id \
+         cross-check rejects: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// A tail meta whose table id is CORRECT but whose ECC descriptor alone was
+/// forged (checksum restamped) passes the verify probe's id cross-check, so
+/// the probe must not stop there: it has to fall back to the intact MID
+/// mirror before treating the table as unscanned. Without the fallback a
+/// healthy range-tombstone SST is graded degraded-unscanned off the forged
+/// descriptor and quarantined even though the MID copy carries the valid one.
+#[test]
+fn repair_with_salvage_keeps_a_healthy_rt_sst_with_a_forged_tail_descriptor_only()
+-> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("7");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // A HEALTHY range-tombstone SST under id 7 (salvage cannot re-emit range
+    // tombstones, so a wrong degraded-unscanned verdict is terminal for it).
+    {
+        let mut w = Writer::new(sst.clone(), 7, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    // Forge ONLY the tail meta's ECC descriptor — its table id stays the
+    // TRUE 7, so the id cross-check passes; the MID mirror keeps the valid
+    // descriptor.
+    forge_tail_meta_table_id(&sst, None, Some([0u8, 8, 2, 1]))?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "the healthy table joins the rebuilt manifest via the MID mirror's \
+         valid descriptor: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.unreadable, 0,
+        "no quarantine for a healthy table whose forged tail descriptor the \
+         MID fallback overrides: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// A FAILED quarantine must abort the repair: the rebuilt manifest omits the
+/// unverifiable table, so a later `Tree::open` orphan-cleans the still-in-place
+/// original — installing that manifest after the move failed would let the
+/// next open DELETE the only copy instead of preserving it for manual
+/// recovery. The repair must propagate the quarantine error and leave no
+/// rebuilt manifest behind.
+#[test]
+fn repair_aborts_when_the_quarantine_move_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // An unverifiable range-tombstone SST: the repair routes it to quarantine.
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    forge_unrecognized_ecc_descriptor(&sst)?;
+
+    // Fail the quarantine move (rename matched against its destination).
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::Rename, Fault::Error(ErrorKind::Other))
+            .on_path("repair-quarantine")
+            .once(),
+    );
+
+    let result = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_shared_fs(Arc::new(fault))
+    .repair_with_salvage(true);
+    injector.clear();
+
+    assert!(
+        result.is_err(),
+        "a failed quarantine must abort the repair (a rebuilt manifest \
+         omitting the still-in-place file would let the next open delete the \
+         only copy), got {result:?}",
+    );
+    // The original is still where it was — nothing moved, nothing lost.
+    assert!(
+        fs.metadata(&sst).is_ok(),
+        "the original file stays in place after the aborted repair",
+    );
+    Ok(())
+}
+
+/// The escape-hatch fallback scrub must be trusted only when it saw EVERY
+/// block: `scrub_data_blocks` records a block-index walk failure in `errors`
+/// WITHOUT counting an uncorrectable block, so a gate that only checks
+/// `is_ok()` treats a table whose data blocks were never enumerated (a
+/// corrupt partitioned-index leaf) as verified clean and keeps it.
+#[test]
+fn repair_with_salvage_rejects_an_unrecognized_ecc_tombstone_sst_with_a_corrupt_index()
+-> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        // Partitioned index: its leaf blocks load lazily, so a corrupt leaf
+        // survives recovery and only surfaces when the fallback scrub walks
+        // the block index.
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?.use_partitioned_index();
+        for i in 0..200u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Forge the unrecognized descriptor (out-of-band walk skips the data AND
+    // index sections) and corrupt an index leaf so the handle-based fallback
+    // cannot enumerate the data blocks.
+    forge_unrecognized_ecc_descriptor(&sst)?;
+    let (index_pos, index_len) = {
+        let mut f = std::fs::File::open(&sst)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"index") else {
+            panic!("a partitioned-index SST must carry an index section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let flip = usize::try_from(index_pos + index_len / 2).unwrap_or(0);
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a table whose data blocks the fallback scrub could not enumerate \
+         must not be kept: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable_files.len(),
+        1,
+        "the unverifiable table is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// An unrecognized ECC descriptor combined with parity-only errors in the
+/// still-walked self-describing meta blocks must grade as UNSCANNED, not
+/// merely degraded: the SST data/index sections were skipped entirely, so
+/// the range-tombstone escape hatch must run the handle-based scrub — which
+/// here finds the corrupt data block and refuses the keep.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn repair_with_salvage_rejects_a_corrupt_unrecognized_ecc_tombstone_sst_with_parity_errors()
+-> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::table::block::EccParams;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        // An ECC table: its meta blocks carry SELF-DESCRIBING parity, which
+        // the forge below leaves stale (it re-stamps the payload checksum
+        // without recomputing the trailer) — producing exactly the
+        // EccParityMismatch-only error set on a walk that skipped the data.
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_ecc(Some(EccParams::try_new(4, 2)?));
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    forge_unrecognized_ecc_descriptor(&sst)?;
+    // Corrupt the sole data block: the out-of-band walk cannot see it (the
+    // data section is skipped under the unrecognized descriptor), so only
+    // the handle-based fallback can catch it.
+    let block_off = usize::try_from(sole_data_block_offset(&recover_table(sst.clone(), &fs)?))
+        .unwrap_or(usize::MAX);
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(block_off + 40) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "parity-only meta errors must not mask the unscanned data sections: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable_files.len(),
+        1,
+        "the corrupt table is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// The fallback verification behind the unscanned escape hatch must also
+/// cover the LAZY side blocks a data scrub never touches: the full bloom
+/// filter only loads on the first point read, so a table with clean data
+/// blocks but a corrupt filter would otherwise be kept and fail point reads
+/// once the rebuilt manifest goes live.
+#[test]
+fn repair_with_salvage_rejects_an_unrecognized_ecc_tombstone_sst_with_a_corrupt_filter()
+-> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..200u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Forge the unrecognized descriptor and corrupt the FILTER section: the
+    // out-of-band walk skips it (unrecognized descriptor), the data scrub
+    // never loads it (the full bloom filter is lazy), so only a point read
+    // can surface the damage.
+    forge_unrecognized_ecc_descriptor(&sst)?;
+    let (filter_pos, filter_len) = {
+        let mut f = std::fs::File::open(&sst)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"filter") else {
+            panic!("the SST must carry a filter section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let flip = usize::try_from(filter_pos + filter_len / 2).unwrap_or(0);
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.recovered, 0,
+        "a table whose lazy filter is corrupt must not be kept over the \
+         range-tombstone escape hatch: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable_files.len(),
+        1,
+        "the unverifiable table is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// Patches `descriptor#page_ecc` to a non-canonical (unrecognized) value in
+/// both meta blocks of the SST at `path`, re-stamping each block's checksum
+/// so the frames stay checksum-clean.
+/// Overwrites the TAIL meta copy's `table_id` value with `forged_id` (when
+/// `Some`) and/or its `descriptor#page_ecc` value with `forge_descriptor`
+/// (when `Some` — an unrecognized OR forged-recognized 4-byte descriptor),
+/// restamping that block's checksum and leaving the mirrored `meta_mid`
+/// copy intact — the "only the tail rotted" scenario a normal recovery
+/// survives via its expected-id cross-check + MID fallback.
+fn forge_tail_meta_table_id(
+    path: &std::path::Path,
+    forged_id: Option<u64>,
+    forge_descriptor: Option<[u8; 4]>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"meta") else {
+            panic!("the SST must carry a meta section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).unwrap_or(usize::MAX);
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("meta block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("meta payload within the file");
+        };
+        if let Some(forged_id) = forged_id {
+            let needle = b"table_id";
+            let Some(key_pos) = payload
+                .windows(needle.len())
+                .position(|w| w == needle.as_slice())
+            else {
+                panic!("table_id key present verbatim (restart interval 1)");
+            };
+            // Entry layout after the key bytes: value length (LEB128, one
+            // byte for 8), then the 8-byte little-endian id.
+            let val_at = key_pos + needle.len();
+            assert_eq!(
+                payload.get(val_at).copied(),
+                Some(8),
+                "table_id value length prefix",
+            );
+            let Some(value) = payload.get_mut(val_at + 1..val_at + 9) else {
+                panic!("table_id value within the payload");
+            };
+            value.copy_from_slice(&forged_id.to_le_bytes());
+        }
+
+        if let Some(descriptor) = forge_descriptor {
+            let needle = b"descriptor#page_ecc";
+            let Some(key_pos) = payload
+                .windows(needle.len())
+                .position(|w| w == needle.as_slice())
+            else {
+                panic!("descriptor key present verbatim (restart interval 1)");
+            };
+            let val_at = key_pos + needle.len();
+            assert_eq!(
+                payload.get(val_at).copied(),
+                Some(4),
+                "descriptor value length prefix",
+            );
+            let Some(value) = payload.get_mut(val_at + 1..val_at + 5) else {
+                panic!("descriptor value within the payload");
+            };
+            value.copy_from_slice(&descriptor);
+        }
+    }
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("meta payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("meta header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    // A parity-bearing meta frame (self-describing blocks always use the
+    // fixed RS(4,2) layout) must have its trailer recomputed over the
+    // forged payload, or the walk would flag the forge ITSELF as parity
+    // rot and mask what a test actually exercises.
+    #[cfg(feature = "page_ecc")]
+    {
+        let payload_end = payload_range.end;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("meta section length fits usize");
+        };
+        let frame_end = block_off + section_len;
+        if frame_end > payload_end {
+            let Some(payload) = bytes.get(payload_range) else {
+                panic!("meta payload within the file");
+            };
+            let parity = crate::ecc::encode_parity(payload, 4, 2)?;
+            assert_eq!(
+                frame_end - payload_end,
+                parity.len(),
+                "the meta frame's trailer length matches the fixed RS(4,2) layout",
+            );
+            let Some(dst) = bytes.get_mut(payload_end..frame_end) else {
+                panic!("meta parity trailer within the file");
+            };
+            dst.copy_from_slice(&parity);
+        }
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = section_len;
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// A repair salvage knows the durable table id from the SST's file name; the
+/// salvage-mode open must cross-check it so a checksum-clean TAIL meta whose
+/// `table_id` field was forged falls back to the intact MID mirror (exactly
+/// like normal recovery) instead of stamping the recovered copy with the
+/// forged id — which would fail the post-salvage reopen under the file-name
+/// id and quarantine a recoverable table.
+#[test]
+fn repair_with_salvage_preserves_the_file_name_id_over_a_forged_tail_meta_id() -> crate::Result<()>
+{
+    use crate::table::Writer;
+    use crate::{AbstractTree, Config, InternalValue, MAX_SEQNO, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("7");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // Enough data for SEVERAL blocks: one gets corrupted (triggering salvage),
+    // the rest stay recoverable.
+    {
+        let mut w = Writer::new(sst.clone(), 7, 0, Arc::clone(&fs))?;
+        for i in 0..600u32 {
+            w.write(InternalValue::from_components(
+                format!("key{i:05}").into_bytes(),
+                format!("{i:08}").repeat(8).into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Corrupt the FIRST data block so verification routes the table through
+    // salvage.
+    let offset = {
+        let checksum = crate::Checksum::from_raw(compute_table_checksum(&*fs, &sst)?);
+        let table = crate::table::Table::recover(
+            sst.clone(),
+            checksum,
+            0,
+            0,
+            7,
+            Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+            None,
+            Arc::clone(&fs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            Arc::new(crate::Metrics::default()),
+        )?;
+        let offsets: alloc::vec::Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|kh| *kh.as_ref().offset())
+            .collect();
+        assert!(offsets.len() >= 2, "need several blocks, got {offsets:?}");
+        let Some(&first) = offsets.first() else {
+            panic!("a first data block exists");
+        };
+        first
+    };
+    let flip = usize::try_from(offset).unwrap_or(0) + 16;
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    // Forge ONLY the tail meta's table_id (7 → 99); the MID mirror keeps 7.
+    forge_tail_meta_table_id(&sst, Some(99), None)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "the readable blocks are salvaged under the file-name id: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.unreadable, 0,
+        "no quarantine for a recoverable table: {:?}",
+        report.unreadable_files,
+    );
+
+    // The recovered copy reopens under the durable file-name id and serves
+    // the surviving keys.
+    let crate::AnyTree::Standard(tree) = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?
+    else {
+        unreachable!("standard tree");
+    };
+    let got = tree.get(b"key00599", MAX_SEQNO)?;
+    assert!(
+        got.is_some(),
+        "a key outside the corrupt block survives the salvage",
+    );
+    Ok(())
+}
+
+fn forge_unrecognized_ecc_descriptor(path: &std::path::Path) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let sections: Vec<(u64, u64)> = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        [b"meta".as_slice(), b"meta_mid".as_slice()]
+            .iter()
+            .map(|name| {
+                let Some(entry) = reader.toc().iter().find(|e| e.name() == *name) else {
+                    panic!(
+                        "the SST must carry a {} section",
+                        String::from_utf8_lossy(name)
+                    );
+                };
+                (entry.pos(), entry.len())
+            })
+            .collect()
+    };
+    for (pos, _len) in sections {
+        let block_off = usize::try_from(pos).unwrap_or(usize::MAX);
+        let Some(block) = bytes.get(block_off..) else {
+            panic!("meta block within the file");
+        };
+        let mut cursor = block;
+        let header = Header::decode_from(&mut cursor)?;
+        let header_len = Header::header_len(header.block_type);
+        let payload_range =
+            block_off + header_len..block_off + header_len + header.data_length as usize;
+        {
+            let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+                panic!("meta payload within the file");
+            };
+            let needle = b"descriptor#page_ecc";
+            let Some(key_pos) = payload
+                .windows(needle.len())
+                .position(|w| w == needle.as_slice())
+            else {
+                panic!("descriptor key present verbatim (restart interval 1)");
+            };
+            // Entry layout after the key bytes: value length (LEB128, one
+            // byte for 4), then the 4-byte descriptor value.
+            let val_at = key_pos + needle.len();
+            assert_eq!(
+                payload.get(val_at).copied(),
+                Some(4),
+                "descriptor value length prefix",
+            );
+            let Some(value) = payload.get_mut(val_at + 1..val_at + 5) else {
+                panic!("descriptor value within the payload");
+            };
+            assert_ne!(value, [0u8, 8, 2, 1], "descriptor not already forged");
+            value.copy_from_slice(&[0u8, 8, 2, 1]);
+        }
+        let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(
+            bytes.get(payload_range).unwrap_or(&[]),
+        ));
+        let new_header = Header {
+            checksum: new_checksum,
+            ..header
+        };
+        let mut hdr_bytes = Vec::with_capacity(header_len);
+        new_header.encode_into(&mut hdr_bytes)?;
+        let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+            panic!("meta header within the file");
+        };
+        hdr_dst.copy_from_slice(&hdr_bytes);
+    }
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// `repair_with_salvage` QUARANTINES an SST whose delete-bitmap section is
+/// corrupt rather than recovering it: whole-file recovery refuses it (a corrupt
+/// bitmap would resurrect deleted rows) and automated salvage fails closed for
+/// the same reason — the "all rows live" degradation is an explicit
+/// `SalvageOptions::allow_delete_resurrection` opt-in that automated repair
+/// never takes. The original stays in quarantine for a manual opt-in salvage.
 #[cfg(feature = "columnar")]
 #[test]
-fn repair_with_salvage_recovers_a_corrupt_delete_bitmap_sst() -> crate::Result<()> {
+fn repair_with_salvage_quarantines_a_corrupt_delete_bitmap_sst() -> crate::Result<()> {
     use crate::config::DeleteStrategy;
     use crate::table::Writer;
     use crate::{Config, InternalValue, SequenceNumberCounter, ValueType};
@@ -421,10 +4875,711 @@ fn repair_with_salvage_recovers_a_corrupt_delete_bitmap_sst() -> crate::Result<(
     )
     .repair_with_salvage(true)?;
     assert_eq!(
-        report.salvaged, 1,
-        "the corrupt-bitmap SST is salvaged: {:?}",
+        report.salvaged, 0,
+        "automated repair refuses to resurrect deleted rows: {:?}",
         report.unreadable_files,
     );
-    assert_eq!(report.recovered, 1, "the salvaged table joins the manifest");
+    assert_eq!(report.recovered, 0, "no table joins the rebuilt manifest");
+    let [(_, reason)] = report.unreadable_files.as_slice() else {
+        panic!(
+            "expected exactly one unreadable file, got {:?}",
+            report.unreadable_files,
+        );
+    };
+    assert!(
+        reason.contains("salvage failed") && reason.contains("resurrect"),
+        "the reason names the refused delete resurrection, got: {reason}",
+    );
+    Ok(())
+}
+
+/// With resurrection ENABLED, the same corrupt-delete-bitmap SST is recovered
+/// instead of excluded: its bitmap cannot be authenticated, so the rows are
+/// re-emitted live, bringing the deleted rows back. The tree opens with the whole
+/// table present.
+#[cfg(feature = "columnar")]
+#[test]
+fn repair_with_resurrection_recovers_a_corrupt_delete_bitmap_sst() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+    use crate::table::Writer;
+    use crate::{AbstractTree, Config, InternalValue, SequenceNumberCounter, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_columnar(true)
+            .use_zone_map(true)
+            .delete_strategy(DeleteStrategy::MergeOnRead);
+        for i in 0..n {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        for pos in [5u32, 50, 150] {
+            w.delete_bitmap_mut().insert(pos);
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Corrupt the delete_bitmap section so its content cannot be authenticated.
+    let (pos, len) = {
+        let mut f = std::fs::File::open(&sst)?;
+        let reader = crate::sfa::Reader::from_reader(&mut f)?;
+        let entry = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"delete_bitmap")
+            .ok_or(crate::Error::Unrecoverable)?;
+        (entry.pos(), entry.len())
+    };
+    let flip = usize::try_from(pos + len / 2).unwrap_or(0);
+    let mut bytes = std::fs::read(&sst)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst, &bytes)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_resurrection(true, true)?;
+    assert_eq!(
+        report.recovered, 1,
+        "resurrection recovers the table instead of excluding it: {report:?}",
+    );
+    assert_eq!(report.unreadable, 0, "{:?}", report.unreadable_files);
+
+    // Every row is live, including the ones the lost bitmap had deleted.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    for i in [5u32, 50, 100, 150] {
+        let key = format!("k{i:05}").into_bytes();
+        assert!(
+            tree.get(&key, crate::MAX_SEQNO)?.is_some(),
+            "key {key:?} must be served under resurrection",
+        );
+    }
+    Ok(())
+}
+
+/// `repair_with_salvage` must QUARANTINE (not salvage) an SST whose TOC HIDES a
+/// deletion section: an omitted `range_tombstones` entry makes the parsed table
+/// report NO tombstones, so the positional salvage walk would re-emit the keys
+/// the tombstone covered as LIVE — resurrecting data the deletion suppressed.
+/// Unlike a corrupt-but-present deletion section (which the salvage guard
+/// catches on the parsed state), a hidden section is invisible to that guard;
+/// the catalogue tiling gap is the only trace, so the repair verdict must
+/// refuse salvage before it reopens the forged catalogue.
+#[test]
+fn repair_with_salvage_quarantines_a_toc_hidden_range_tombstone_sst() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        // The range tombstone gives the SST the optional `range_tombstones`
+        // section whose hiding resurrects the keys it covers.
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Drop the `range_tombstones` TOC entry: the parsed table now reports no
+    // tombstones (the covered keys look live), and the only out-of-band trace
+    // is the gap the omission leaves in the section tiling.
+    crate::test_forge::forge_section_omitted(&sst, b"range_tombstones")?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+
+    assert_eq!(
+        report.salvaged, 0,
+        "salvage must not re-emit a TOC-hidden tombstone's covered keys as \
+         live: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(report.recovered, 0, "no table joins the rebuilt manifest");
+    assert_eq!(
+        report.unreadable_files.len(),
+        1,
+        "the hidden-deletion table is reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    // Pin the specific gate: a whole-file recovery failure would quarantine
+    // with the same counts, so require the refusal to name the TOC-concealment
+    // check rather than accepting any quarantine path.
+    assert!(
+        report
+            .unreadable_files
+            .iter()
+            .any(|(_, reason)| reason.contains("may hide deletion metadata")),
+        "the refusal must come from the TOC concealment gate: {:?}",
+        report.unreadable_files,
+    );
+    // The original SST is set aside for inspection, not left in `tables/`
+    // (where the next open's orphan cleanup would delete it).
+    let quarantine = dir.path().join("repair-quarantine").join("0");
+    assert!(
+        quarantine.exists(),
+        "the original SST must be set aside, got {:?}",
+        report.unreadable_files,
+    );
+    assert!(
+        !tables.join("0").exists(),
+        "the corrupt original must not stay in tables/",
+    );
+    Ok(())
+}
+
+/// The resurrection-on counterpart of
+/// [`repair_with_salvage_quarantines_a_toc_hidden_range_tombstone_sst`], pinning
+/// the boundary between POLICY and MECHANISM. The resurrection flag governs
+/// policy (keep possibly-superseded data vs drop it), but it cannot exceed what
+/// salvage can mechanically rebuild: salvage cannot re-emit a range-tombstone
+/// table, so a TOC-hidden range tombstone is excluded whatever the flag. Flag-on
+/// still routes it through salvage (rather than the pre-emptive concealment
+/// gate), salvage reports the table unsalvageable, and the tree opens without
+/// it. The outcome is a valid tree with no manual step, not a resurrection: the
+/// flag opens the door, but there is no re-emitter behind it for range
+/// tombstones. (The flag's observable effect lives on the delete-bitmap path,
+/// where salvage CAN re-emit.)
+#[test]
+fn repair_with_resurrection_still_excludes_a_toc_hidden_range_tombstone_sst() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{AbstractTree, Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+    crate::test_forge::forge_section_omitted(&sst, b"range_tombstones")?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_resurrection(true, true)?;
+    // Flag-on cannot conjure a range-tombstone re-emitter salvage does not have:
+    // the table is excluded, but the tree is still valid and needs no manual step.
+    assert_eq!(
+        report.recovered, 0,
+        "salvage cannot re-emit a range-tombstone table, so flag-on still excludes it: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(report.unreadable, 1, "{:?}", report.unreadable_files);
+    // The exclusion now comes from salvage's mechanical refusal, not the
+    // pre-emptive concealment gate: the flag DID route it to salvage.
+    assert!(
+        report
+            .unreadable_files
+            .iter()
+            .any(|(_, reason)| reason.contains("range tombstones")),
+        "flag-on routes to salvage, which reports the range-tombstone table \
+         unsalvageable: {:?}",
+        report.unreadable_files,
+    );
+    // A valid tree opens with the table absent (no key of it survives) and no
+    // manual recovery step.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?;
+    assert!(
+        tree.get(b"k00000", crate::MAX_SEQNO)?.is_none(),
+        "the whole excluded table is absent, not partially resurrected",
+    );
+    Ok(())
+}
+
+/// `repair_with_salvage` must QUARANTINE (not salvage) a table whose
+/// `range_tombstones` section is RENAMED to another recognized name (here
+/// `filter_tli`) with its block role re-stamped to match. The catalogue stays
+/// uniquely named and perfectly tiled, so the deletion-hiding TOC check clears
+/// it, but the relabeled section is graded corrupt (its bytes are not a filter
+/// index) and salvage would DISCARD it while re-emitting the covered keys as
+/// live, resurrecting the deletion. A corrupt REBUILDABLE side section must
+/// fail closed: it may be a relabeled deletion salvage cannot see.
+#[test]
+fn repair_with_salvage_quarantines_a_range_tombstone_renamed_to_a_rebuildable_section()
+-> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::table::block::BlockType;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?;
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Rename `range_tombstones` -> `filter_tli` and re-stamp its block role to
+    // Index: the parsed table now reports no tombstones, and the catalogue is
+    // uniquely named and tiled.
+    crate::test_forge::forge_duplicate_section_name(
+        &sst,
+        b"range_tombstones",
+        b"filter_tli",
+        BlockType::Index,
+    )?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+
+    assert_eq!(
+        report.salvaged, 0,
+        "a relabeled range_tombstones must not be salvaged into a live copy: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(report.recovered, 0, "no table joins the rebuilt manifest");
+    // Pin the specific gate: a generic whole-file recovery failure would
+    // quarantine with the same counts. This table carried a range tombstone, so
+    // the persisted-count cross-check refuses it (ahead of the degraded-section
+    // flag, which a delete-free relabel exercises separately).
+    assert!(
+        report
+            .unreadable_files
+            .iter()
+            .any(|(_, reason)| reason.contains("range tombstones")),
+        "the refusal must come from the range-tombstone gate: {:?}",
+        report.unreadable_files,
+    );
+    assert!(
+        dir.path().join("repair-quarantine").join("0").exists(),
+        "the relabeled table must be quarantined for manual recovery: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// A tail meta whose ECC descriptor is forged to a DIFFERENT recognized
+/// scheme (here: `Off`) while its table id stays valid must not dictate the
+/// walk's trailer sizing: the probe must arbitrate against the intact MID
+/// mirror, and when two decodable copies disagree, fail safe (skip the
+/// ECC-dependent sections with a warning, plus the single mirror-divergence
+/// finding) instead of mis-walking parity bytes as block headers and
+/// condemning a healthy SST.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn verify_probe_distrusts_disagreeing_recognized_ecc_descriptors() -> crate::Result<()> {
+    use crate::table::Writer;
+    use crate::{InternalValue, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("7");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    {
+        let mut w = Writer::new(sst.clone(), 7, 0, Arc::clone(&fs))?
+            .use_ecc(Some(crate::table::block::EccParams::RS_4_2));
+        for i in 0..64u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Forge ONLY the tail descriptor to canonical `Off` (a RECOGNIZED
+    // state); the id stays valid, so the expected-id cross-check passes,
+    // and the MID mirror keeps the true RS descriptor.
+    forge_tail_meta_table_id(&sst, None, Some([0u8, 0, 0, 0]))?;
+
+    let report = crate::verify::verify_sst_file_with_fs(&*fs, &sst);
+    // The forged tail IS a real finding: the full mirror comparison reports
+    // the divergence. What must NOT happen is the walk mis-sizing every
+    // parity trailer as a block header and condemning the data blocks — so
+    // the only error is the single mirror-divergence finding, never a
+    // HeaderCorrupted storm.
+    assert!(
+        report
+            .errors
+            .iter()
+            .all(|e| matches!(e, crate::verify::BlockVerifyError::TocCorrupted { .. })),
+        "a forged recognized descriptor must not condemn the data blocks — \
+         the walk mis-sizes every parity trailer as a block header: {report:?}",
+    );
+    assert_eq!(
+        report.errors.len(),
+        1,
+        "exactly the mirror-divergence finding: {report:?}",
+    );
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| matches!(w, crate::verify::BlockVerifyWarning::UnrecognizedEcc { .. })),
+        "disagreeing decodable descriptors must surface as an \
+         indeterminate-ECC warning: {report:?}",
+    );
+    Ok(())
+}
+
+/// The per-KV gate must run BEFORE the parity-only degradation arm: on a
+/// footer-bearing Page-ECC SST, a stale footer behind a re-stamped block
+/// checksum also leaves the parity trailer mismatched, so the walk reports
+/// ONLY `EccParityMismatch` and the verdict graded the table
+/// `DegradedButReadable` — with range tombstones (which salvage refuses to
+/// re-emit) the keep-decision then rebuilt the manifest around an entry
+/// whose per-KV digest is known stale, instead of quarantining the table
+/// as corrupt.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn repair_grades_a_stale_kv_footer_corrupt_over_parity_only_degradation() -> crate::Result<()> {
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::Writer;
+    use crate::{Config, InternalValue, SequenceNumberCounter, UserKey, ValueType};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir()?;
+    let tables = dir.path().join("tables");
+    std::fs::create_dir_all(&tables)?;
+    let sst = tables.join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+
+    // A footer-bearing Page-ECC SST WITH a range tombstone, so salvage
+    // refuses it and the keep-decision path is the one under test.
+    {
+        use crate::runtime_config::{ChecksumAlgorithm, KvChecksumPolicy};
+
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_ecc(Some(crate::table::block::EccParams::RS_4_2))
+            .use_kv_checksums(KvChecksumPolicy::AllLevels, ChecksumAlgorithm::Xxh3_64);
+        for i in 0..8u32 {
+            w.write(InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        w.write_range_tombstone(RangeTombstone::new(
+            UserKey::from(b"k00002".as_slice()),
+            UserKey::from(b"k00005".as_slice()),
+            2,
+        ));
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Stale footer + re-stamped block checksum: the parity trailer (not
+    // re-stamped) now mismatches too, so the walk reports ONLY
+    // EccParityMismatch while the block checksum reads clean.
+    crate::test_forge::forge_stale_kv_footer(&sst)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+
+    // The table is KNOWN corrupt (stale per-KV digest), and salvage cannot
+    // re-emit its range tombstones: it must be quarantined, never kept as a
+    // merely parity-degraded table.
+    assert_eq!(
+        report.recovered, 0,
+        "a stale-footer table must not be kept as parity-only degradation: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 1,
+        "the corrupt table lands in quarantine: {report:?}",
+    );
+    Ok(())
+}
+
+/// The repair verdict must not declare a table clean on block checksums
+/// alone: a STALE per-KV footer behind a re-stamped block checksum passes
+/// the out-of-band walk, so repair would record a fresh whole-file digest
+/// over a table `verify_kv_checksums` rejects — while the salvage row path
+/// (which repair skipped) validates footers and would have dropped the
+/// forged block.
+#[test]
+fn repair_routes_a_stale_kv_footer_through_salvage() -> crate::Result<()> {
+    use crate::runtime_config::KvChecksumPolicy;
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    let dir = tempfile::tempdir()?;
+
+    // Flush one footer-bearing, uncompressed SST.
+    let sst_path = {
+        let crate::AnyTree::Standard(tree) = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(crate::config::CompressionPolicy::all(
+            crate::CompressionType::None,
+        ))
+        .open()?
+        else {
+            unreachable!("standard tree configured");
+        };
+        tree.update_runtime_config(|c| c.kv_checksums = KvChecksumPolicy::AllLevels)?;
+        for i in 0u64..500 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(500)?;
+        let binding = tree.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+
+    // Forge a stale footer behind a re-stamped block checksum so the
+    // block-level walk reads clean while per-KV verification rejects it.
+    crate::test_forge::forge_stale_kv_footer(&sst_path)?;
+
+    // Repair with salvage: the verdict must route the table through
+    // salvage (which drops the forged block) instead of recording a fresh
+    // digest over content the per-KV scrub rejects.
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "the stale-footer table must be routed through salvage: {report:?}",
+    );
+
+    // The salvaged copy passes per-KV verification (the forged block was
+    // dropped, not laundered into the copy).
+    let crate::AnyTree::Standard(tree) = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?
+    else {
+        unreachable!("standard tree configured");
+    };
+    crate::verify::verify_kv_checksums(&tree)?;
+    Ok(())
+}
+
+/// A FOOTER-LESS SST whose data block declares more entries than it decodes
+/// (a re-stamped trailer item count) must be routed through salvage, not
+/// graded Clean. `verify_kv_checksums` is a no-op without footers and the
+/// out-of-band walk verifies only the outer frame, so only a full-decode
+/// completeness check catches the truncated tail before repair rebuilds the
+/// manifest around a block whose keys a later scan silently omits.
+#[test]
+fn repair_routes_an_under_decoding_footerless_block_through_salvage() -> crate::Result<()> {
+    use crate::{AbstractTree, Config, SequenceNumberCounter};
+
+    let dir = tempfile::tempdir()?;
+
+    // Flush one uncompressed, FOOTER-LESS SST (default kv_checksums = Off).
+    let sst_path = {
+        let crate::AnyTree::Standard(tree) = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(crate::config::CompressionPolicy::all(
+            crate::CompressionType::None,
+        ))
+        .open()?
+        else {
+            unreachable!("standard tree configured");
+        };
+        for i in 0u64..500 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(500)?;
+        let binding = tree.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+
+    // Inflate the first data block's trailer item count behind a re-stamped
+    // block checksum: iteration yields fewer entries than declared.
+    crate::test_forge::forge_inflated_item_count(&sst_path)?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "the under-decoding footer-less table must be routed through salvage: {report:?}",
+    );
+    Ok(())
+}
+
+/// `is_corruption` grades a block-verify result for the salvage gate. Only the
+/// transient allowlist (`Interrupted`, `WouldBlock`) aborts the repair for a
+/// retry; a PERSISTENT I/O failure — a genuine bad sector, or a structural
+/// corruption that surfaces as `Io(Other)` on some platforms (e.g. Windows
+/// negative-seek) — is not resolved by a retry, so it must be graded as
+/// corruption (`Ok(true)`) and routed to salvage rather than aborting the whole
+/// repair and permanently stranding every other healthy table.
+#[test]
+fn is_corruption_routes_a_persistent_io_to_salvage() {
+    let persistent = crate::Error::Io(crate::io::Error::other("bad sector"));
+    assert!(
+        matches!(super::is_corruption(Err(persistent)), Ok(true)),
+        "a persistent I/O failure must grade as corruption, not abort the repair",
+    );
+}
+
+/// The mirror of [`is_corruption_routes_a_persistent_io_to_salvage`]: a genuine
+/// transient failure still aborts the repair so the caller can retry, rather
+/// than dropping a healthy block into a partial salvaged replacement.
+#[test]
+fn is_corruption_aborts_the_repair_on_a_transient_io() {
+    let transient = crate::Error::Io(crate::io::Error::from_kind(
+        crate::io::ErrorKind::Interrupted,
+    ));
+    assert!(
+        super::is_corruption(Err(transient)).is_err(),
+        "a transient I/O failure must propagate so the repair can retry",
+    );
+}
+
+/// A TRANSIENT read failure while checksumming a blob file must PROPAGATE, not
+/// land in `unreadable`: recording it there installs a manifest that omits the
+/// blob, and the next open's orphan sweep then deletes the healthy file —
+/// permanent value loss from a one-shot I/O fault. The table-recovery path
+/// already propagates; the blob scan must match it.
+#[test]
+fn blob_recovery_propagates_a_transient_checksum_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, Fs, MemFs};
+    use crate::io::ErrorKind;
+    use crate::{Config, SequenceNumberCounter};
+    use std::io::Write;
+    use std::sync::Arc;
+
+    let memfs = Arc::new(MemFs::new());
+    let root = std::path::absolute("/db")?;
+    let blobs = root.join(crate::file::BLOBS_FOLDER);
+    memfs.create_dir_all(&blobs)?;
+    {
+        let mut f = memfs.open(
+            &blobs.join("0"),
+            &crate::fs::FsOpenOptions::new().write(true).create(true),
+        )?;
+        f.write_all(b"blob bytes")?;
+    }
+
+    // Fault the streaming read the whole-file checksum performs, with a
+    // RETRYABLE kind.
+    let fault = FaultFs::new(memfs.as_ref().clone());
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Interrupted)).on_path("blobs"));
+
+    let config = Config::new(
+        &root,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_fs(fault);
+
+    let result = super::recover_blob_files(&config);
+    assert!(
+        result.is_err(),
+        "a transient blob checksum failure must propagate for a retry, not be \
+         recorded as unreadable: {:?}",
+        result.map(|(files, unreadable)| (files.len(), unreadable)),
+    );
     Ok(())
 }

--- a/src/restrict_bound.rs
+++ b/src/restrict_bound.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Sidecar recording a tight-space-punched SST's restriction lower bound.
+//!
+//! Tight-space compaction reclaims a table's consumed prefix data blocks in
+//! place (hole-punched, reading back as zeros) and restricts the surviving view
+//! to keys `>= bound`. The bound lives in the manifest, but manifest repair
+//! rebuilds the manifest from the on-disk files alone and so cannot recover it.
+//!
+//! This sidecar makes the bound recoverable WITHOUT mutating the SST. Writing the
+//! bound into the SST's own meta would change the SST bytes while the manifest
+//! still references it by a whole-file checksum, opening a crash window where the
+//! two disagree (a scrub then reports false corruption and a checkpoint can
+//! hard-link the modified bytes under the stale digest). A separate sidecar
+//! avoids that entirely: the SST is never touched, so its manifest checksum stays
+//! valid in every crash window, and the sidecar is published through a single
+//! atomic `temp + fsync + rename` — never two mirrors that can diverge.
+//!
+//! # Threat model
+//!
+//! For an ENCRYPTED table the payload is AEAD-sealed with the table's provider,
+//! so an offline attacker without the key cannot forge a bound `decrypt` accepts.
+//! For an UNENCRYPTED table the payload carries an XXH3-128 checksum that detects
+//! corruption; forging a *valid* sidecar needs the same directory write access
+//! that could tamper with the SST or manifest directly, so it opens no new attack
+//! surface. Repair uses the physical punch to grade the bound, not to gate it:
+//! when the prefix below a valid bound reads as fully hole-punched the bound is
+//! exact; when it does NOT (the crash window between a durable install and the
+//! punch that follows it, or a stale sidecar over a never-restricted file) the two
+//! are indistinguishable on disk, so recovery follows the resurrection policy. By
+//! default it HONORS the bound (restricting, dropping the ambiguous prefix, which
+//! never resurrects a superseded row); with `allow_resurrection` it keeps the
+//! whole table. See `docs/manifest-recovery.md`.
+
+use crate::encryption::EncryptionProvider;
+use crate::fs::{Fs, FsOpenOptions, SyncMode};
+use alloc::vec::Vec;
+use std::path::{Path, PathBuf};
+
+/// Fixed header length: `table_id` (u64) + `bound_len` (u32).
+const HEADER_LEN: usize = 8 + 4;
+/// Trailing integrity checksum length: XXH3-128.
+const CHECKSUM_LEN: usize = 16;
+
+/// The sidecar sits next to the SST with a `.restrict-bound` suffix APPENDED (not
+/// a replaced extension), so it never collides with the SST's own numeric name.
+#[must_use]
+pub fn sidecar_path(table_path: &Path) -> PathBuf {
+    let mut name = table_path.as_os_str().to_os_string();
+    name.push(".restrict-bound");
+    PathBuf::from(name)
+}
+
+/// The staging path the sidecar is written + synced to before its atomic rename
+/// onto [`sidecar_path`]. A crash between the temp write and the rename leaves
+/// this `{id}.restrict-bound.tmp` behind; tree recovery sweeps it (it is
+/// disposable — either the live sidecar it would have replaced still exists, or
+/// the compaction is simply re-run).
+#[must_use]
+fn sidecar_tmp_path(table_path: &Path) -> PathBuf {
+    let mut name = sidecar_path(table_path).into_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
+/// Serializes `(table_id, bound)` with a trailing XXH3-128 checksum over the
+/// header + bound (the checksum detects accidental corruption; an encrypted
+/// payload is additionally AEAD-authenticated by the provider).
+fn serialize(table_id: u64, bound: &[u8]) -> Vec<u8> {
+    // `bound` is a user key; its length is bounded by the same limits the writer
+    // enforces on stored keys, well within u32.
+    let bound_len = u32::try_from(bound.len()).unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(HEADER_LEN + bound.len() + CHECKSUM_LEN);
+    out.extend_from_slice(&table_id.to_le_bytes());
+    out.extend_from_slice(&bound_len.to_le_bytes());
+    out.extend_from_slice(bound);
+    let checksum = crate::hash::hash128(&out);
+    out.extend_from_slice(&checksum.to_le_bytes());
+    out
+}
+
+/// Parses a serialized payload, validating the checksum and length framing.
+/// Returns `(table_id, bound)` or `None` on any malformation.
+fn deserialize(plain: &[u8]) -> Option<(u64, Vec<u8>)> {
+    if plain.len() < HEADER_LEN + CHECKSUM_LEN {
+        return None;
+    }
+    let (body, checksum_bytes) = plain.split_at(plain.len() - CHECKSUM_LEN);
+    let stored = u128::from_le_bytes(checksum_bytes.try_into().ok()?);
+    if crate::hash::hash128(body) != stored {
+        return None;
+    }
+    let table_id = u64::from_le_bytes(body.get(0..8)?.try_into().ok()?);
+    let bound_len = u32::from_le_bytes(body.get(8..12)?.try_into().ok()?) as usize;
+    let bound = body.get(HEADER_LEN..)?;
+    if bound.len() != bound_len {
+        return None;
+    }
+    Some((table_id, bound.to_vec()))
+}
+
+/// Publishes the restriction bound for `table_id` next to `table_path`.
+///
+/// Written through an atomic synced `temp + rename`, and MUST be called (and
+/// returned) BEFORE the prefix is hole-punched, so a crash leaves the sidecar
+/// either fully present or absent — never partial — beside an SST whose bytes were
+/// never touched.
+///
+/// # Errors
+///
+/// Propagates encryption or filesystem failures from the atomic write.
+pub fn write(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    bound: &[u8],
+    sync_mode: SyncMode,
+) -> crate::Result<()> {
+    // A bound is a user key, at most `u16::MAX` bytes. `read` rejects a sidecar
+    // whose payload exceeds that limit as corrupt, so reject an oversized bound
+    // HERE rather than publishing a sidecar a later repair would read as corrupt,
+    // silently dropping the restriction and resurrecting the punched prefix.
+    if bound.len() > u16::MAX as usize {
+        return Err(crate::Error::InvalidHeader(
+            "restriction bound exceeds the maximum key length",
+        ));
+    }
+    let plain = serialize(table_id, bound);
+    let content = match encryption {
+        Some(enc) => enc.encrypt(&plain)?,
+        None => plain,
+    };
+    publish_raw(fs, table_path, &content, sync_mode)
+}
+
+/// Atomically publishes already-encoded sidecar `content` beside `table_path`
+/// through the synced `temp + rename` protocol [`write`] uses. Also the
+/// re-publish path for raw bytes captured from an existing sidecar (a
+/// quarantine restore whose direct sidecar rename failed), which must land
+/// verbatim — they are already serialized (and possibly encrypted).
+///
+/// # Errors
+///
+/// Propagates filesystem failures from the atomic write; a failed publish
+/// leaves no partial sidecar (the temp is removed best-effort).
+pub(crate) fn publish_raw(
+    fs: &dyn Fs,
+    table_path: &Path,
+    content: &[u8],
+    sync_mode: SyncMode,
+) -> crate::Result<()> {
+    // Write to a sidecar-specific `.restrict-bound.tmp` and atomically rename it
+    // onto the live path. A dedicated temp suffix (not a generic `.tmp_*`) lets
+    // tree recovery recognize and sweep an abandoned temp in the tables folder by
+    // name, instead of failing to parse it as a table id.
+    let path = sidecar_path(table_path);
+    let tmp = sidecar_tmp_path(table_path);
+    let publish = (|| -> crate::Result<()> {
+        let mut file = fs.open(
+            &tmp,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        file.write_all(content)?;
+        file.flush()?;
+        crate::fs::FsFile::sync_all_with(&*file, sync_mode)?;
+        drop(file);
+        fs.rename(&tmp, &path)?;
+        if let Some(parent) = path.parent() {
+            fs.sync_directory_with(parent, sync_mode)?;
+        }
+        Ok(())
+    })();
+    if publish.is_err() {
+        let _ = fs.remove_file(&tmp);
+    }
+    publish
+}
+
+/// The largest on-disk size a VALID sidecar can have: header + bound + checksum
+/// (plaintext), plus the provider's AEAD overhead when encrypted. A user key is
+/// at most `u16::MAX` bytes (the writer's key-size limit). Everything that
+/// reads sidecar bytes — [`read`] and the repair restore's raw rescue capture —
+/// rejects anything larger BEFORE allocating, so a corrupt / attacker-padded
+/// sidecar cannot force a huge allocation.
+pub(crate) fn max_encoded_len(encryption: Option<&dyn EncryptionProvider>) -> u64 {
+    HEADER_LEN as u64
+        + u64::from(u16::MAX)
+        + CHECKSUM_LEN as u64
+        + u64::from(encryption.map_or(0, EncryptionProvider::max_overhead))
+}
+
+/// Outcome of reading the sidecar.
+///
+/// A genuine I/O failure (open other than not-found, or a read failure) is
+/// returned as `Err` from [`read`] so the caller can classify it (transient →
+/// retry, persistent → salvage); these variants cover the conclusive on-disk
+/// states.
+pub enum SidecarRead {
+    /// Decoded and checksum-validated `(table_id, bound)`.
+    Present(u64, Vec<u8>),
+    /// Conclusively absent (the file does not exist): the SST is unrestricted.
+    Missing,
+    /// The sidecar was read but its payload is malformed — a failed checksum,
+    /// bad length framing, an AEAD rejection, or an over-long file. PERSISTENT
+    /// (a retry reads the same bytes): the bound is unrecoverable, so a caller
+    /// facing a genuinely punched SST must fail closed rather than guess.
+    Corrupt,
+}
+
+/// Reads and validates the restriction sidecar beside `table_path`.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error when the sidecar exists but its open / read
+/// fails (not a not-found, which is [`SidecarRead::Missing`]). The caller
+/// classifies it — transient (retry) vs persistent (salvage). A payload that
+/// reads but does not validate is [`SidecarRead::Corrupt`], not an error.
+pub fn read(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+) -> crate::Result<SidecarRead> {
+    let path = sidecar_path(table_path);
+    let mut file = match fs.open(&path, &FsOpenOptions::new().read(true)) {
+        Ok(file) => file,
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => return Ok(SidecarRead::Missing),
+        Err(e) => return Err(crate::Error::from(e)),
+    };
+    let max_len = max_encoded_len(encryption);
+    if file.metadata()?.len > max_len {
+        return Ok(SidecarRead::Corrupt);
+    }
+    let mut content = Vec::new();
+    // Cap the reader at the same bound as the metadata probe, so the allocation
+    // limit holds even if the file grew after the probe (a concurrent writer, or a
+    // backend whose metadata disagrees with its data). Reading `max_len + 1` bytes
+    // lets an over-long payload surface as `Corrupt` below.
+    std::io::Read::read_to_end(
+        &mut std::io::Read::take(&mut file, max_len.saturating_add(1)),
+        &mut content,
+    )
+    .map_err(crate::Error::from)?;
+    if content.len() as u64 > max_len {
+        return Ok(SidecarRead::Corrupt);
+    }
+    let plain = match encryption {
+        Some(enc) => match enc.decrypt(&content) {
+            Ok(plain) => plain,
+            Err(_) => return Ok(SidecarRead::Corrupt),
+        },
+        None => content,
+    };
+    match deserialize(&plain) {
+        Some((table_id, bound)) => Ok(SidecarRead::Present(table_id, bound)),
+        None => Ok(SidecarRead::Corrupt),
+    }
+}
+
+/// Removes the sidecar (best-effort), syncing the parent so the removal is durable.
+///
+/// Called when a restricted table is compacted away / deleted, so a stale sidecar
+/// does not linger to restrict an unrelated later file that reuses the id.
+pub fn remove(fs: &dyn Fs, table_path: &Path, sync_mode: SyncMode) {
+    let path = sidecar_path(table_path);
+    if fs.remove_file(&path).is_ok()
+        && let Some(parent) = path.parent()
+    {
+        let _ = fs.sync_directory_with(parent, sync_mode);
+    }
+}
+
+/// True when a `.restrict-bound` sidecar exists beside `table_path`.
+///
+/// # Errors
+///
+/// Propagates the underlying [`Fs::exists`] error.
+pub fn exists(fs: &dyn Fs, table_path: &Path) -> crate::io::Result<bool> {
+    fs.exists(&sidecar_path(table_path))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/restrict_bound/tests.rs
+++ b/src/restrict_bound/tests.rs
@@ -1,0 +1,189 @@
+#![expect(clippy::unwrap_used, clippy::indexing_slicing, reason = "test code")]
+
+use super::*;
+use crate::fs::StdFs;
+use test_log::test;
+
+/// A written bound round-trips: `read` returns the same `(table_id, bound)`.
+#[test]
+fn write_then_read_roundtrips_the_bound() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    write(&StdFs, &sst, None, 7, b"k00130", SyncMode::Normal).unwrap();
+    match read(&StdFs, &sst, None).unwrap() {
+        SidecarRead::Present(id, bound) => {
+            assert_eq!(id, 7);
+            assert_eq!(bound, b"k00130");
+        }
+        _ => panic!("expected Present"),
+    }
+}
+
+/// The sidecar carries the table id in its own payload, so `read` returns the
+/// STORED id verbatim, not one inferred from the file name. A foreign id (distinct
+/// from the SST's numeric name) must round-trip, so repair's `id == table_id`
+/// cross-check (which tells a sidecar for THIS table apart from a stale one left
+/// behind by a reused id) compares against the true stored id.
+#[test]
+fn write_then_read_roundtrips_a_foreign_table_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    let foreign_id = 0xDEAD_BEEF_u64;
+    write(&StdFs, &sst, None, foreign_id, b"k00130", SyncMode::Normal).unwrap();
+    match read(&StdFs, &sst, None).unwrap() {
+        SidecarRead::Present(id, bound) => {
+            assert_eq!(
+                id, foreign_id,
+                "the stored id round-trips, not the file name"
+            );
+            assert_eq!(bound, b"k00130");
+        }
+        _ => panic!("expected Present"),
+    }
+}
+
+/// An absent sidecar reads as `Missing` (the SST is unrestricted), never an error.
+#[test]
+fn absent_sidecar_reads_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Missing
+    ));
+}
+
+/// A corrupted payload (flipped byte in the body) fails the checksum and reads as
+/// `Corrupt`, never a wrong `Present` bound.
+#[test]
+fn corrupted_payload_reads_corrupt() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    write(&StdFs, &sst, None, 7, b"k00130", SyncMode::Normal).unwrap();
+
+    // Flip a byte in the middle of the sidecar (inside the bound region).
+    let path = sidecar_path(&sst);
+    let mut bytes = std::fs::read(&path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    std::fs::write(&path, &bytes).unwrap();
+
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Corrupt
+    ));
+}
+
+/// A truncated sidecar (shorter than header + checksum) reads as `Corrupt`.
+#[test]
+fn truncated_sidecar_reads_corrupt() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    write(&StdFs, &sst, None, 7, b"k00130", SyncMode::Normal).unwrap();
+    let path = sidecar_path(&sst);
+    std::fs::write(&path, b"short").unwrap();
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Corrupt
+    ));
+}
+
+/// An OVER-LONG sidecar (larger than a valid header + max-length bound + checksum)
+/// reads as `Corrupt` and never forces a large allocation: the read is bounded, so
+/// a corrupt / padded file is rejected at the size branch before it is
+/// materialized.
+#[test]
+fn oversized_sidecar_reads_corrupt() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    write(&StdFs, &sst, None, 7, b"k00130", SyncMode::Normal).unwrap();
+
+    // One byte past the largest a valid plaintext sidecar can be.
+    let over = HEADER_LEN + u16::MAX as usize + CHECKSUM_LEN + 1;
+    std::fs::write(sidecar_path(&sst), vec![0u8; over]).unwrap();
+
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Corrupt
+    ));
+}
+
+/// `remove` deletes the sidecar; a subsequent read is `Missing`.
+#[test]
+fn remove_deletes_the_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    write(&StdFs, &sst, None, 7, b"k00130", SyncMode::Normal).unwrap();
+    assert!(exists(&StdFs, &sst).unwrap());
+    remove(&StdFs, &sst, SyncMode::Normal);
+    assert!(!exists(&StdFs, &sst).unwrap());
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Missing
+    ));
+}
+
+/// A publish whose atomic RENAME fails must leave NO artifact: the synced temp is
+/// removed (best-effort) and a later `read` sees `Missing`, never a half-published
+/// sidecar.
+#[test]
+fn failed_publish_cleans_up_the_temp() {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    let fault = FaultFs::new(StdFs);
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Rename, Fault::Error(ErrorKind::Other)).on_path("restrict-bound"),
+    );
+
+    // The final rename that publishes the sidecar fails, so `write` errors...
+    assert!(write(&fault, &sst, None, 7, b"k00130", SyncMode::Normal).is_err());
+    // ...leaving no temp behind...
+    assert!(
+        !sidecar_tmp_path(&sst).exists(),
+        "the synced temp must be cleaned up after a failed publish",
+    );
+    // ...and the sidecar reads as absent, never half-published.
+    assert!(matches!(
+        read(&StdFs, &sst, None).unwrap(),
+        SidecarRead::Missing
+    ));
+}
+
+/// An ENCRYPTED sidecar round-trips through the provider, and a WRONG key fails
+/// the AEAD open (`Corrupt`), never a forged bound.
+#[cfg(feature = "encryption")]
+#[test]
+fn encrypted_sidecar_roundtrips_and_rejects_a_wrong_key() {
+    use crate::encryption::{Aes256GcmProvider, EncryptionProvider};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sst = dir.path().join("7");
+    let provider: Arc<dyn EncryptionProvider> = Arc::new(Aes256GcmProvider::new(&[3u8; 32]));
+    write(
+        &StdFs,
+        &sst,
+        Some(provider.as_ref()),
+        7,
+        b"k00130",
+        SyncMode::Normal,
+    )
+    .unwrap();
+
+    match read(&StdFs, &sst, Some(provider.as_ref())).unwrap() {
+        SidecarRead::Present(id, bound) => {
+            assert_eq!(id, 7);
+            assert_eq!(bound, b"k00130");
+        }
+        _ => panic!("expected Present with the right key"),
+    }
+
+    let wrong: Arc<dyn EncryptionProvider> = Arc::new(Aes256GcmProvider::new(&[9u8; 32]));
+    assert!(matches!(
+        read(&StdFs, &sst, Some(wrong.as_ref())).unwrap(),
+        SidecarRead::Corrupt,
+    ));
+}

--- a/src/salvage.rs
+++ b/src/salvage.rs
@@ -16,9 +16,73 @@
 //! the corruption is not propagated into the recovered copy.
 
 use crate::UserKey;
+use crate::encryption::EncryptionProvider;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use std::path::PathBuf;
+
+/// The recovery + write context salvage needs to recover an SST that is
+/// encrypted and/or zstd-dictionary compressed.
+///
+/// Block salvage opens the source and rewrites the recovered copy through the
+/// normal table path, so both ends need the same crypto / dictionary context as
+/// the live tree: without the [`EncryptionProvider`] an encrypted source cannot
+/// be decrypted to read its blocks (and the rewritten copy would be plaintext,
+/// inconsistent with an encrypted reopen); without the dictionary a
+/// dictionary-compressed source cannot be decompressed (and the copy could not
+/// be re-compressed to match). [`crate::repair`] fills this from the tree's
+/// `Config`; [`salvage_sst`] defaults it to empty (a plain, unencrypted source).
+#[derive(Clone, Default)]
+pub struct SalvageOptions {
+    /// Encryption provider matching the source's at-rest encryption, or `None`
+    /// for an unencrypted source.
+    pub encryption: Option<Arc<dyn EncryptionProvider>>,
+    /// zstd dictionary matching the source's dictionary compression, or `None`
+    /// when the source uses no dictionary.
+    #[cfg(zstd_any)]
+    pub zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+    /// The open / decrypt context id for an ENCRYPTED source: block AAD binds
+    /// the table identity, so an encrypted source sealed under a non-zero id
+    /// only decrypts when the same id is supplied here.
+    /// [`crate::repair`] passes the table's real id; the standalone default of
+    /// `0` matches an unencrypted or id-`0` encrypted source. An UNENCRYPTED
+    /// source needs no id at all — the salvage-mode open reads the stored one
+    /// from the metadata — and the recovered copy is always stamped with the
+    /// SOURCE's stored id (its identity), never with this field.
+    pub table_id: crate::TableId,
+    /// The durable table id the caller knows OUT-OF-BAND (the SST file name /
+    /// manifest entry), or `None` (the standalone default) when the source's
+    /// stored id is the identity. When `Some`, the salvage open cross-checks
+    /// the meta payload against it — with fallback to the mirrored MID meta
+    /// copy — so a checksum-clean tail meta whose stored id was forged cannot
+    /// poison the recovered copy's identity. [`crate::repair`] passes the id
+    /// derived from the file name.
+    pub expected_stored_id: Option<crate::TableId>,
+    /// Opt-in to salvaging a delete-bearing columnar SST whose positional
+    /// delete bitmap cannot be applied (the bitmap section is unreadable, or a
+    /// readable bitmap's positioning zone map is unreadable). The degraded
+    /// recovery emits EVERY row live — positionally-deleted rows are
+    /// resurrected in the salvaged copy. `false` (the default) fails such a
+    /// salvage closed instead, preserving delete semantics at the cost of
+    /// recovering nothing from that SST.
+    pub allow_delete_resurrection: bool,
+    /// Durability mode for the recovered copy's final sync (file + parent
+    /// directory). [`crate::repair`] passes the tree's `Config::sync_mode`,
+    /// so a Full-durability repair persists the salvaged SST as strongly as
+    /// the manifest it rebuilds around it; the standalone default is
+    /// [`crate::fs::SyncMode::Normal`].
+    pub sync_mode: crate::fs::SyncMode,
+    /// Prefix extractor matching the tree's
+    /// [`Config::prefix_extractor`](crate::config::Config::prefix_extractor),
+    /// or `None` when the tree indexes no prefixes. The extractor is not
+    /// persisted in the SST (it is configuration), so the rebuilt filter can
+    /// only carry the source's prefix hashes when the caller supplies it —
+    /// without it, prefix scans see the salvaged copy as a false negative
+    /// and its matching rows vanish from every prefix read.
+    /// [`crate::repair`] passes the tree's configured extractor.
+    pub prefix_extractor: Option<Arc<dyn crate::prefix::PrefixExtractor>>,
+}
 
 /// Why a block could not be salvaged and had to be dropped.
 #[derive(Debug, Clone)]
@@ -65,14 +129,38 @@ pub struct SalvageReport {
     /// Path of the freshly written salvaged SST, or `None` when no block was
     /// recoverable and nothing was written.
     pub salvaged_path: Option<PathBuf>,
-    /// Total data blocks the walk inspected (recovered plus dropped).
+    /// Total data blocks the walk INSPECTED. This is not partitioned by
+    /// `blocks_salvaged + dropped.len()`: a columnar block whose rows were all
+    /// positionally deleted is inspected and counted here, yet re-emits nothing
+    /// (not in `blocks_salvaged`) and loses nothing (not in `dropped`). Derive
+    /// completeness from [`is_complete`](Self::is_complete) (`dropped.is_empty()`),
+    /// never from `blocks_salvaged == blocks_total`.
     pub blocks_total: usize,
     /// Data blocks successfully re-emitted into the salvaged SST.
     pub blocks_salvaged: usize,
+    /// Of [`blocks_salvaged`](Self::blocks_salvaged), how many read back cleanly
+    /// (checksum passed without ECC recovery) and were copied through **verbatim**
+    /// — their raw on-disk bytes byte-copied, skipping the decode + re-encode +
+    /// recompression the rest pay. The remainder
+    /// (`blocks_salvaged - blocks_copied_verbatim`) were re-emitted rather than
+    /// byte-copied: ECC-recovered blocks (re-encoded from their healed payload)
+    /// and, for a columnar SST that carries deletes, its clean blocks too
+    /// (re-emitted with the delete mask applied so deleted rows are not
+    /// resurrected). A high ratio means a mostly-healthy, delete-free SST was
+    /// recovered cheaply.
+    pub blocks_copied_verbatim: usize,
     /// Entries recovered into the salvaged SST.
     pub entries_salvaged: u64,
     /// Blocks the walk had to drop, with their key ranges where known.
     pub dropped: Vec<DroppedBlock>,
+    /// `true` when the source carried positional deletes that could NOT be
+    /// applied faithfully and [`SalvageOptions::allow_delete_resurrection`] let
+    /// the salvage proceed anyway: the recovered copy re-emits those rows LIVE,
+    /// so positionally-deleted rows came back. Always `false` for a normal
+    /// salvage (and when the opt-in is set but no unappliable delete mask was
+    /// encountered), so a caller can warn ONLY when resurrection actually
+    /// happened.
+    pub delete_rows_resurrected: bool,
 }
 
 impl SalvageReport {
@@ -94,8 +182,10 @@ impl SalvageReport {
     ///     salvaged_path: None,
     ///     blocks_total: 4,
     ///     blocks_salvaged: 4,
+    ///     blocks_copied_verbatim: 4,
     ///     entries_salvaged: 100,
     ///     dropped: Vec::new(),
+    ///     delete_rows_resurrected: false,
     /// };
     /// assert!(clean.is_complete());
     /// ```
@@ -116,12 +206,19 @@ impl SalvageReport {
 /// filter: a single corrupt source block costs only its own key range, not the
 /// whole file.
 ///
-/// The salvaged copy preserves the source's data-block compression and
-/// error-correcting parameters. A columnar source is recovered as rows (the
-/// loader reconstructs row entries), holding the same keys and values; the
-/// columnar sidecars (zone map, delete bitmap) are not carried over yet. The
-/// source is opened in salvage mode, so a corrupt delete-bitmap degrades to
-/// "all rows live" rather than failing the open.
+/// The salvaged copy mirrors the source's persisted layout (data + index
+/// compression, ECC, restart interval, columnar layout with a regenerated zone
+/// map, per-KV checksum footers). A columnar source is recovered as columnar:
+/// the recovered rows are transposed back into PAX blocks, so the copy keeps the
+/// columnar layout and its zone map (a readable delete-bitmap is applied on
+/// read, so the surviving rows are already post-delete and the copy needs no
+/// delete-bitmap). Per-field value sub-columns collapse to a single value
+/// column in this row round-trip; preserving them verbatim is a separate step.
+/// When the delete bitmap CANNOT be applied (an unreadable bitmap section, or a
+/// readable bitmap whose positioning zone map is unreadable), the salvage fails
+/// closed by default — recovering "all rows live" would resurrect
+/// positionally-deleted rows — unless the caller opts in via
+/// [`SalvageOptions::allow_delete_resurrection`].
 ///
 /// The positional walk re-emits only point entries, so an SST that carries
 /// range tombstones cannot be salvaged without dropping them (which would let
@@ -138,9 +235,11 @@ impl SalvageReport {
 ///
 /// Returns an error when `source` cannot be opened at all (its metadata, index,
 /// or SFA trailer is unreadable), when it carries range tombstones (salvage
-/// fails closed rather than dropping them), or when writing `dest` fails.
-/// Per-block corruption is not an error: such blocks are dropped and listed in
-/// the returned [`SalvageReport`].
+/// fails closed rather than dropping them), when its positional delete bitmap
+/// cannot be applied (fails closed rather than resurrecting deleted rows; see
+/// [`SalvageOptions::allow_delete_resurrection`]), or when writing `dest`
+/// fails. Per-block corruption is not an error: such blocks are dropped and
+/// listed in the returned [`SalvageReport`].
 ///
 /// # Examples
 ///
@@ -167,26 +266,441 @@ pub fn salvage_sst(
     dest: std::path::PathBuf,
     fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
 ) -> crate::Result<SalvageReport> {
-    salvage_sst_with_comparator(source, dest, fs, &crate::comparator::default_comparator())
+    salvage_sst_with_options(source, dest, fs, &SalvageOptions::default())
 }
 
-/// Salvages `source` into `dest` under a caller-supplied `comparator`.
+/// Salvages `source` into `dest` with an explicit recovery + write context.
 ///
-/// [`crate::repair`] calls this with the tree's configured comparator so the
-/// rewritten SST opens and orders consistently with the rest of the tree; the
-/// public [`salvage_sst`] wraps it with the default lexicographic comparator.
-pub(crate) fn salvage_sst_with_comparator(
+/// Use this over [`salvage_sst`] to salvage an SST that is encrypted and/or
+/// zstd-dictionary compressed: supply the matching [`EncryptionProvider`] and
+/// dictionary in `options` so the source can be decrypted / decompressed to read
+/// its blocks and the recovered copy is written under the same context. Opens and
+/// rewrites under the default lexicographic comparator; [`crate::repair`] uses the
+/// tree's configured comparator instead via the crate-internal path.
+///
+/// # Errors
+///
+/// As [`salvage_sst`]; additionally fails to open the source when `options` does
+/// not carry the encryption / dictionary context the source was written with.
+pub fn salvage_sst_with_options(
+    source: &std::path::Path,
+    dest: std::path::PathBuf,
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    options: &SalvageOptions,
+) -> crate::Result<SalvageReport> {
+    salvage_with_context(
+        source,
+        dest,
+        fs,
+        &crate::comparator::default_comparator(),
+        options,
+    )
+}
+
+/// Salvages `source` into `dest` under a caller-supplied `comparator` and
+/// recovery context.
+///
+/// [`crate::repair`] calls this with the tree's configured comparator and the
+/// `Config`'s encryption provider + zstd dictionary, so the rewritten SST opens,
+/// orders, and decrypts / decompresses consistently with the rest of the tree;
+/// the public entry points wrap it with the default lexicographic comparator.
+pub(crate) fn salvage_with_context(
     source: &std::path::Path,
     dest: std::path::PathBuf,
     fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
     comparator: &crate::comparator::SharedComparator,
+    options: &SalvageOptions,
 ) -> crate::Result<SalvageReport> {
-    use alloc::sync::Arc;
+    // Arbitrate DIVERGENT meta mirrors. When both copies decode under the
+    // expected id but disagree in ANY field, neither is provably genuine: an
+    // internally-consistent forged tail (a changed compression tag, a changed
+    // columnar descriptor) would make the tail-first open mis-decode every
+    // healthy data block and drop it — repair would then quarantine a table
+    // whose intact MID mirror recovers everything. Since no copy can be
+    // proven authoritative, run the walk under BOTH mirror orders and keep
+    // the attempt that recovers more.
+    let diverged = meta_mirrors_diverge(source, fs, options)?;
+    // Divergent mirrors disable the verbatim copy-through: neither copy is
+    // provably genuine, and a divergence confined to a DECODE-TRANSPARENT
+    // layout field (a re-stamped restart interval — full block decoding is
+    // trailer-driven) would byte-copy blocks whose encoding disagrees with
+    // the chosen meta, silently truncating the partial-decode read path's
+    // synthesized blocks. Re-encoding under the chosen meta keeps the copy
+    // self-consistent whichever mirror wins.
+    if !diverged {
+        // No arbitration: write directly to `dest`. There is no second attempt,
+        // so `dest` is never a live intermediate another process could replace.
+        return salvage_attempt(source, dest, fs, comparator, options, false, true);
+    }
+    // Divergent mirrors: run BOTH attempts to PRIVATE temp paths and publish
+    // only the selected winner, so `dest` is never a live intermediate a foreign
+    // process could atomically replace and this path then delete. Verbatim
+    // copy-through stays disabled — neither mirror is provably genuine.
+    let tail_dest = next_arb_temp(fs, &dest)?;
+    let tail = salvage_attempt(
+        source,
+        tail_dest.clone(),
+        fs,
+        comparator,
+        options,
+        false,
+        false,
+    );
+    // A tail attempt that saw blocks and dropped nothing cannot be improved on:
+    // the tie-break prefers the tail (authoritative-by-convention) copy.
+    if let Ok(r) = &tail
+        && r.blocks_total > 0
+        && r.dropped.is_empty()
+    {
+        return publish_from_temp(fs, tail, &tail_dest, &dest, options);
+    }
+    let mid_dest = next_arb_temp(fs, &dest)?;
+    let mid = salvage_attempt(
+        source,
+        mid_dest.clone(),
+        fs,
+        comparator,
+        options,
+        true,
+        false,
+    );
 
+    // Publish the winner from its temp; discard the loser's temp first so no
+    // artifact lingers outside the `.healtmp-` sweep namespace, but ONLY when
+    // this invocation actually created that temp. An attempt whose `create_new`
+    // lost a race to a concurrent salvage returns `AlreadyExists` WITHOUT
+    // creating the file, so discarding its path would delete the file the race
+    // winner owns (see [`attempt_owns_temp`]).
+    match arbitrate_mirrors(&tail, &mid) {
+        MirrorArbitration::Propagate => {
+            // A transient failure lost only to an INCOMPLETE success; a retry
+            // could recover the dropped blocks. Clean up any temp this
+            // invocation created, then propagate the transient error so the
+            // caller retries the whole salvage.
+            if attempt_owns_temp(&tail) {
+                discard_partial(fs, &tail_dest);
+            }
+            if attempt_owns_temp(&mid) {
+                discard_partial(fs, &mid_dest);
+            }
+            // Return whichever attempt raised the transient error.
+            if matches!(&tail, Err(crate::Error::Io(e)) if e.kind().is_transient()) {
+                tail
+            } else {
+                mid
+            }
+        }
+        MirrorArbitration::PublishMid => {
+            if attempt_owns_temp(&tail) {
+                discard_partial(fs, &tail_dest);
+            }
+            publish_from_temp(fs, mid, &mid_dest, &dest, options)
+        }
+        MirrorArbitration::PublishTail => {
+            if attempt_owns_temp(&mid) {
+                discard_partial(fs, &mid_dest);
+            }
+            publish_from_temp(fs, tail, &tail_dest, &dest, options)
+        }
+    }
+}
+
+/// Whether a salvage attempt left a destination temp for the caller to clean up.
+///
+/// Ownership is proven by the actual OUTCOME — a present `salvaged_path` — not
+/// inferred from the final error kind. An attempt leaves a temp to discard ONLY
+/// when it succeeded AND actually wrote one (`Ok` with `salvaged_path == Some`).
+/// Every other outcome leaves nothing for the caller to remove:
+/// - an error BEFORE `Writer::new` (a checksum / recover / range-tombstone /
+///   deletion-guard failure) never created the temp — inferring ownership from
+///   the non-`AlreadyExists` error kind would delete a concurrent creator's file
+///   on shared storage;
+/// - an error AFTER `Writer::new` (a walk / finish failure) already discarded its
+///   partial output internally;
+/// - an `AlreadyExists` from `create_new` lost the race and created nothing;
+/// - an `Ok` attempt that recovered nothing discarded its empty temp too
+///   (`salvaged_path == None`).
+fn attempt_owns_temp(result: &crate::Result<SalvageReport>) -> bool {
+    matches!(result, Ok(r) if r.salvaged_path.is_some())
+}
+
+/// Which divergent-mirror attempt to publish, or whether to propagate a
+/// transient failure.
+#[derive(Debug, PartialEq, Eq)]
+enum MirrorArbitration {
+    /// Publish the tail (authoritative-by-convention) attempt.
+    PublishTail,
+    /// Publish the mid attempt.
+    PublishMid,
+    /// Propagate the transient failure: a retry could recover more than the
+    /// incomplete success it would otherwise lose to.
+    Propagate,
+}
+
+/// Chooses which divergent-mirror attempt to publish, or whether to propagate a
+/// transient failure so the caller retries.
+///
+/// A TRANSIENT failure on one attempt must NOT lose to an INCOMPLETE success on
+/// the other: a retry of the transiently-failing mirror could recover the blocks
+/// the incomplete winner dropped, so propagate it. A COMPLETE success still wins
+/// (a retry cannot improve on it), and a PERSISTENT failure always loses to any
+/// success (a retry cannot help there). Between two successes the strictly more
+/// complete recovery wins; an exact tie keeps the tail copy (authoritative by
+/// convention — the recovered copy re-derives every authoritative field from the
+/// re-emitted entries, so the losing mirror's non-derivable metadata never
+/// reaches it and the tie-break only chooses which layout drives the re-encode).
+fn arbitrate_mirrors(
+    tail: &crate::Result<SalvageReport>,
+    mid: &crate::Result<SalvageReport>,
+) -> MirrorArbitration {
+    let is_transient = |r: &crate::Result<SalvageReport>| matches!(r, Err(crate::Error::Io(e)) if e.kind().is_transient());
+    let complete = |r: &crate::Result<SalvageReport>| matches!(r, Ok(rep) if rep.is_complete());
+    if (is_transient(tail) && !complete(mid)) || (is_transient(mid) && !complete(tail)) {
+        return MirrorArbitration::Propagate;
+    }
+    // Completeness ranking: more recovered blocks first, then more recovered
+    // entries (equal block counts can hold different key counts — block sizes
+    // vary), then fewer dropped blocks.
+    let completeness = |rep: &SalvageReport| {
+        (
+            rep.blocks_salvaged,
+            rep.entries_salvaged,
+            core::cmp::Reverse(rep.dropped.len()),
+        )
+    };
+    match (tail, mid) {
+        (Err(_), Ok(_)) => MirrorArbitration::PublishMid,
+        (_, Err(_)) => MirrorArbitration::PublishTail,
+        (Ok(t), Ok(m)) => {
+            if completeness(m) > completeness(t) {
+                MirrorArbitration::PublishMid
+            } else {
+                MirrorArbitration::PublishTail
+            }
+        }
+    }
+}
+
+/// Probes forward from a process-local counter to a free `.healtmp-{n}` sibling
+/// of `dest` for an arbitration attempt's PRIVATE output. The `.healtmp-`
+/// namespace is the recovery-owned temp space a hard crash leaves for the next
+/// open to sweep. A foreign artifact is never reclaimed (it may belong to a
+/// concurrent salvage); termination holds because every probe advances the
+/// counter and the on-disk artifacts are finite.
+fn next_arb_temp(
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    dest: &std::path::Path,
+) -> crate::Result<std::path::PathBuf> {
+    static ARB_TMP_SEQ: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+    // Fold the process id into the HIGH bits so two concurrent standalone salvage
+    // processes never select the SAME temp name: without this both process-local
+    // counters start at 0, and a loser reading a shared name could `discard_partial`
+    // the winner's in-progress output. The result stays a single u64, so recovery
+    // still parses and sweeps `{id}.healtmp-{numeric}` on a crash. Pid reuse after
+    // exit is handled by the exists-probe / AlreadyExists retry below.
+    let pid_hi = u64::from(std::process::id()) << 32;
+    loop {
+        let counter = ARB_TMP_SEQ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        let seq = pid_hi | (counter & 0xFFFF_FFFF);
+        let candidate = dest.with_extension(alloc::format!("healtmp-{seq}"));
+        match fs.exists(&candidate) {
+            Ok(false) => return Ok(candidate),
+            Ok(true) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+/// Publishes the winning arbitration attempt (`result`, written to `temp`) to
+/// `dest` with NO-REPLACE semantics, so a foreign file already at `dest` is
+/// never destroyed — the whole reason both attempts write to private temps.
+/// `hard_link` claims `dest` atomically (it fails `AlreadyExists` if anything is
+/// there); a backend without `hard_link` falls back to a probe-then-rename. On
+/// any failure the temp is discarded and the error propagates, so a retry and
+/// the repair caller both see `dest` as it was (free, or still owned by whoever
+/// holds it). A successful publish is made durable before the temp name drops.
+fn publish_from_temp(
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    result: crate::Result<SalvageReport>,
+    temp: &std::path::Path,
+    dest: &std::path::Path,
+    options: &SalvageOptions,
+) -> crate::Result<SalvageReport> {
+    let already_exists = || {
+        crate::Error::Io(crate::io::Error::new(
+            crate::io::ErrorKind::AlreadyExists,
+            "salvage destination already exists",
+        ))
+    };
+    let mut rep = match result {
+        Ok(rep) => rep,
+        Err(e) => {
+            // An erroring attempt leaves nothing for the caller to remove, so
+            // NEVER discard `temp` here (ownership is proven by the OUTCOME, not
+            // inferred from the error kind — see [`attempt_owns_temp`]): a
+            // failure BEFORE `Writer::new` never created `temp` (deleting it
+            // would remove a concurrent creator's file on shared storage, e.g.
+            // across PID namespaces with the same numeric id), a failure AFTER
+            // `Writer::new` already discarded its own partial internally, and an
+            // `AlreadyExists` race loser created nothing.
+            return Err(e);
+        }
+    };
+    if rep.salvaged_path.is_none() {
+        // The attempt wrote nothing (an empty source, or a failure that left no
+        // file): there is nothing to publish.
+        return Ok(rep);
+    }
+    match fs.hard_link(temp, dest) {
+        Ok(()) => {}
+        Err(e) if e.kind() == crate::io::ErrorKind::AlreadyExists => {
+            discard_partial(fs, temp);
+            return Err(already_exists());
+        }
+        Err(e) if e.kind() == crate::io::ErrorKind::Unsupported => {
+            // A backend without `hard_link` can still create + rename ordinary
+            // files; fall back to a best-effort no-replace publish. This reopens
+            // a narrow check-then-rename window, but ONLY on backends that cannot
+            // claim a destination atomically at all — every in-tree `Fs`
+            // implements `hard_link`.
+            match fs.exists(dest) {
+                Ok(false) => {
+                    if let Err(e) = fs.rename(temp, dest) {
+                        discard_partial(fs, temp);
+                        return Err(e.into());
+                    }
+                }
+                Ok(true) => {
+                    discard_partial(fs, temp);
+                    return Err(already_exists());
+                }
+                Err(e) => {
+                    discard_partial(fs, temp);
+                    return Err(e.into());
+                }
+            }
+        }
+        Err(e) => {
+            discard_partial(fs, temp);
+            return Err(e.into());
+        }
+    }
+    // `dest` now links the copy, but the new directory entry is a fresh
+    // mutation: without its own sync a power loss can leave the manifest
+    // referencing a `dest` that survives only under the temp name. Make the
+    // entry durable BEFORE dropping the temp. A sync failure removes the
+    // just-published copy (and the temp) and propagates, so a retry and the
+    // repair caller both see the destination free.
+    if let Err(e) = fs.sync_directory_with(entry_directory(dest), options.sync_mode) {
+        discard_partial(fs, dest);
+        discard_partial(fs, temp);
+        return Err(e.into());
+    }
+    // Durable; drop the temp name (the inode lives on under `dest`). A crash
+    // before this leaves the temp in the recovery-owned `.healtmp-` namespace.
+    discard_partial(fs, temp);
+    rep.salvaged_path = Some(dest.to_path_buf());
+    Ok(rep)
+}
+
+/// Decodes BOTH meta mirrors under the caller's id/encryption context and
+/// reports whether they decode to DIVERGENT contents. Any unreadable copy is
+/// `false` — the ordinary tail-with-MID-fallback machinery already covers
+/// broken mirrors; arbitration is only for two VALID copies that disagree.
+fn meta_mirrors_diverge(
+    source: &std::path::Path,
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    options: &SalvageOptions,
+) -> crate::Result<bool> {
+    // A TRANSIENT open failure must not return Ok(false) (which would skip the
+    // dual-attempt arbitration and salvage from the tail view alone): the source
+    // is being salvaged, so it EXISTS — a failure to open it is a retryable I/O
+    // fault, not a structurally-absent mirror. `Fs::open` only ever fails with an
+    // `io::Error`, so propagate it; the caller (repair) then retries instead of
+    // publishing a tail-preferred recovery that omits healthy blocks a divergent
+    // MID mirror would have kept.
+    let mut file = match fs.open(source, &crate::fs::FsOpenOptions::new().read(true)) {
+        Ok(f) => f,
+        Err(e) => return Err(crate::Error::Io(e)),
+    };
+    // A TRANSIENT trailer read must not return Ok(false) (which would skip the
+    // dual-attempt arbitration and salvage directly from the tail view): a source
+    // with divergent mirrors could then be re-encoded under a forged layout.
+    // Propagate sfa::Error::Io; reserve Ok(false) for structural unreadability.
+    let trailer = match crate::sfa::Reader::from_reader(&mut file) {
+        Ok(t) => t,
+        Err(crate::sfa::Error::Io(e)) => return Err(crate::Error::Io(e)),
+        Err(_) => return Ok(false),
+    };
+    let Ok(regions) = crate::table::regions::ParsedRegions::parse_from_toc(trailer.toc()) else {
+        return Ok(false);
+    };
+    let Some(mid_handle) = regions.metadata_mid else {
+        return Ok(false);
+    };
+    // Mirror recover_inner's id policy: an encrypted open always binds the
+    // caller's AAD id; an unencrypted one uses the out-of-band durable id
+    // when the caller knows it (repair), else no cross-check.
+    let expected_id = if options.encryption.is_some() {
+        Some(options.table_id)
+    } else {
+        options.expected_stored_id
+    };
+    let tail = crate::table::meta::ParsedMeta::load_with_handle(
+        &*file,
+        &regions.metadata,
+        expected_id,
+        options.encryption.as_deref(),
+    );
+    let mid = crate::table::meta::ParsedMeta::load_with_handle(
+        &*file,
+        &mid_handle,
+        expected_id,
+        options.encryption.as_deref(),
+    );
+    match (tail, mid) {
+        (Ok(t), Ok(m)) => Ok(t != m),
+        // Only a TRANSIENT read on either mirror must not masquerade as "mirrors
+        // agree" (which would skip the MID recovery attempt and salvage under a
+        // possibly forged tail): propagate it so the caller retries.
+        (Err(crate::Error::Io(io)), _) | (_, Err(crate::Error::Io(io)))
+            if io.kind().is_transient() =>
+        {
+            Err(crate::Error::Io(io))
+        }
+        // A structurally unreadable mirror OR a PERSISTENT I/O failure of one
+        // mirror is the ordinary tail-with-MID-fallback case (`recover_inner`
+        // recovers from the readable copy): arbitration is only for two valid
+        // copies that disagree, and a retry cannot make a persistently unreadable
+        // mirror decode.
+        _ => Ok(false),
+    }
+}
+
+/// One salvage walk of `source` into `dest` under a fixed meta-mirror order
+/// (`prefer_mid_meta`; see [`salvage_with_context`] for the arbitration).
+fn salvage_attempt(
+    source: &std::path::Path,
+    dest: std::path::PathBuf,
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    comparator: &crate::comparator::SharedComparator,
+    options: &SalvageOptions,
+    prefer_mid_meta: bool,
+    allow_verbatim: bool,
+) -> crate::Result<SalvageReport> {
     // Digest the source through the injected `Fs`, not `std::fs`: salvage runs
     // over MemFs / fault-injected / routed backends (repair passes its own `fs`),
     // where a direct `std::fs` read would miss the file or hash the wrong bytes.
-    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, source)?);
+    // A persistent bad sector fails the whole-file digest, but salvage does not
+    // need it: the block walk classifies unreadable blocks itself, and the
+    // recovered copy is written under its own fresh digest. Fall back to a
+    // placeholder so a bad-sector source still reaches block-level recovery
+    // (mirrors the blob salvage path, which also opens with `from_raw(0)`); a
+    // healthy source keeps its real digest.
+    let checksum = match crate::repair::compute_table_checksum(&**fs, source) {
+        Ok(c) => crate::Checksum::from_raw(c),
+        Err(_) => crate::Checksum::from_raw(0),
+    };
     let cache = Arc::new(crate::cache::Cache::with_capacity_bytes(8 * 1024 * 1024));
     let descriptor = Arc::new(crate::descriptor_table::DescriptorTable::new(64));
     #[cfg(feature = "metrics")]
@@ -197,39 +711,190 @@ pub(crate) fn salvage_sst_with_comparator(
         checksum,
         0,
         0,
-        0,
+        // The source's table id: encrypted block AAD binds it, so an encrypted
+        // source only decrypts when opened under the same id (`0` for the legacy
+        // standalone / unencrypted path).
+        options.table_id,
         cache,
         Some(descriptor),
         Arc::clone(fs),
         false,
         false,
-        None,
+        // Decrypt / decompress the source with the caller's context: without it an
+        // encrypted or dictionary-compressed source cannot be read at all.
+        options.encryption.clone(),
         #[cfg(zstd_any)]
-        None,
+        options.zstd_dictionary.clone(),
         comparator.clone(),
         #[cfg(feature = "metrics")]
         metrics,
         // Salvage mode: a corrupt delete-bitmap / missing zone map degrades to
-        // "all rows live" instead of failing, so a damaged sidecar still opens.
-        true,
+        // "all rows live" instead of failing, so a damaged sidecar still
+        // opens. A caller-known durable id (repair) keeps the meta id
+        // cross-check live, so a forged tail id falls back to the MID mirror.
+        crate::table::RecoveryMode::Salvage {
+            expected_id: options.expected_stored_id,
+            prefer_mid_meta,
+        },
     )?;
 
-    // Fail closed on range tombstones: the positional walk re-emits only point
-    // entries, so salvaging an SST that carries range tombstones would drop them
-    // and let lower-level keys they cover reappear after repair (a merge-semantics
-    // violation). Reject until the writer path can re-emit them, the same way
-    // encrypted / dictionary SSTs fall back to quarantine.
-    if !table.range_tombstones().is_empty() {
+    // Fail closed on range tombstones, present OR hidden: the positional walk
+    // re-emits only point entries, so salvaging an SST that carries range
+    // tombstones would drop them and let lower-level keys they cover reappear
+    // after repair (a merge-semantics violation). A re-stamped TOC can also
+    // RENAME the range_tombstones section to a recognized name whose block
+    // decodes cleanly (an empty `filter`), hiding it from `range_tombstones()`
+    // without tripping the degradation flag — but the persisted
+    // `range_tombstone_count` still records it, so cross-check the count too.
+    // Reject either way until the writer path can re-emit range tombstones.
+    if !table.range_tombstones().is_empty() || table.metadata.range_tombstone_count > 0 {
         return Err(crate::Error::FeatureUnsupported(
             "salvage of an SST with range tombstones",
         ));
     }
 
-    let writer = crate::table::Writer::new(dest.clone(), table.id(), 0, Arc::clone(fs))?
-        .use_data_block_compression(table.metadata.data_block_compression)
-        .use_ecc(table.metadata.ecc_params);
+    // Fail closed when the salvage open DEGRADED a rebuildable side section
+    // (filter / filter_tli, seqno bounds, zone map, locator) AND the table
+    // exposes NO deletion metadata. A re-stamped TOC can rename a
+    // `range_tombstones` / `delete_bitmap` section to one of those names and
+    // re-role its block: it passes the byte-level walk AND the tiling check
+    // (the catalogue stays uniquely named), and the parsed table reports no
+    // deletion, but its CONTENT is not what the name claims, so the open
+    // degrades it. Salvage re-derives every such section from the recovered
+    // entries, so it would DISCARD the relabeled deletion and re-emit the
+    // suppressed rows as live. A genuinely rotted section is indistinguishable
+    // from the relabel, so both fail closed; the operator recovers the
+    // quarantined original by hand. The signal is purely STRUCTURAL (each
+    // section decodes its own bytes, independent of the data blocks), so a
+    // corrupt DATA block still salvages. A table that DOES carry a visible
+    // deletion (a delete bitmap; range tombstones were rejected above) is
+    // exempt: its deletions are accounted for and applied.
+    #[cfg(feature = "columnar")]
+    let has_visible_deletion = table.has_delete_bitmap_section();
+    #[cfg(not(feature = "columnar"))]
+    let has_visible_deletion = false;
+    if !has_visible_deletion && table.salvage_degraded_a_rebuildable_section() {
+        return Err(crate::Error::FeatureUnsupported(
+            "salvage of an SST with a degraded rebuildable section that may hide \
+             a relabeled deletion",
+        ));
+    }
 
-    let walk = match salvage_blocks(&table, writer, comparator) {
+    // Fail closed when the on-disk TOC catalogue could CONCEAL a deletion section
+    // without degrading any block: an OMITTED, RENAMED, SHADOWED, or gap-leaving
+    // `delete_bitmap` / `range_tombstones` entry (behind a re-stamped TOC
+    // checksum) leaves the parsed table reporting no deletion while every
+    // remaining block still passes its byte-level checks: the relabel guard
+    // above only catches a re-roled block whose catalogue stays perfectly tiled.
+    // Repair routes such a table to quarantine via this same check, but the
+    // standalone `salvage_sst` / CLI path never runs the repair verifier, so a
+    // positional walk here would re-emit the suppressed rows as live. A read
+    // structural ambiguity grades closed, a transient read PROPAGATES (see
+    // [`crate::repair::toc_may_hide_deletions`]) so a flaky probe aborts salvage
+    // for a retry rather than refusing a recoverable table. A table with a VISIBLE
+    // deletion is exempt: its deletions are applied.
+    if !has_visible_deletion && crate::repair::toc_may_hide_deletions(fs, source)? {
+        return Err(crate::Error::FeatureUnsupported(
+            "salvage of an SST whose TOC may hide a deletion section \
+             (an omitted, renamed, or shadowed entry)",
+        ));
+    }
+
+    // Fail closed when the delete mask cannot be applied FAITHFULLY: the
+    // salvage-mode open degraded it (an unreadable bitmap, or a readable
+    // bitmap whose zone map was unreadable), or the zone map decodes but its
+    // claimed positions do not match the actual per-block row counts (a
+    // checksum-repatched tamper that would silently mask the WRONG rows).
+    // Emitting "all rows live" instead resurrects positionally-deleted rows,
+    // which the caller must explicitly opt into via
+    // `allow_delete_resurrection`; under that opt-in the walk re-emits
+    // UNMASKED — it never masks against unverified positions.
+    #[cfg(feature = "columnar")]
+    let delete_mask_unpositionable = table.delete_bitmap_degraded
+        // A PRESENT delete_bitmap section that decodes to an EMPTY bitmap is a
+        // forge: the writer only emits the section when it holds positions, so a
+        // checksum-consistent corruption to empty would otherwise pass as
+        // positionable and let the masked path re-emit every deleted row live.
+        || (table.has_delete_bitmap_section() && table.delete_bitmap().is_empty())
+        // A transient I/O fault while cross-checking the delete positions aborts
+        // salvage (propagated so repair retries) rather than being read as a
+        // persistent unpositionable mask — which under the default
+        // `allow_delete_resurrection == false` would drop the table from the
+        // rebuilt manifest a retry could have recovered.
+        || (!table.delete_bitmap().is_empty() && !table.delete_positions_verified()?)
+        // Authenticate the bitmap CONTENTS, not just its positions: an
+        // equal-cardinality substitution (a different, checksum-valid bitmap) is
+        // structurally positionable yet masks the WRONG rows. With no original
+        // whole-file digest here, the meta-recorded content hash is the only way to
+        // catch it; a present section without a matching hash cannot be
+        // authenticated, so mask it as unpositionable (fail closed).
+        || !table.delete_bitmap_authenticated();
+    #[cfg(not(feature = "columnar"))]
+    let delete_mask_unpositionable = table.delete_bitmap_degraded;
+    if delete_mask_unpositionable && !options.allow_delete_resurrection {
+        return Err(crate::Error::InvalidHeader(
+            "salvage: the delete bitmap cannot be applied; recovering would resurrect deleted \
+             rows (opt in with allow_delete_resurrection)",
+        ));
+    }
+
+    // The recovered copy is written under the SAME layout as the source —
+    // compression, ECC, restart interval, columnar (+ zone map), per-KV
+    // checksums (`mirror_from`) — plus the caller's encryption provider and zstd
+    // dictionary, so a columnar / encrypted / dictionary source salvages into a
+    // faithful copy that reopens under the live tree's `Config` instead of a
+    // degraded row-major / plaintext mismatch.
+    // The recovered copy is stamped with the SOURCE's stored table id (its
+    // identity), not the caller's open/AAD context id: an unencrypted
+    // salvage-mode open accepts any stored id (`options.table_id` stays the
+    // default 0), and the copy must keep the source's identity so it reopens
+    // consistently when swapped in for the original. For an encrypted source
+    // the two are necessarily equal (the open's AAD binds the caller's id).
+    // A KV-separated source's entries hold ValueHandles into blob files, and
+    // blob GC / relocation consults the table's linked_blob_files section to
+    // decide whether a blob is still referenced. The SOURCE's list is IGNORED
+    // entirely — it is not authoritative in either direction: a forged count
+    // word can under-report (hiding a blob GC would then delete) and a forged
+    // record can OVER-report an id that exists nowhere (a corrupt reference
+    // downstream consumers must never see). The walk derives the copy's links
+    // exactly from the indirections of its recovered rows: a dropped block's
+    // indirections do not exist in the copy, so no source-only id can ever be
+    // needed by it.
+    let writer = crate::table::Writer::new(dest.clone(), table.metadata.id, 0, Arc::clone(fs))?
+        .mirror_from(
+            &table.metadata,
+            table.has_zone_map(),
+            table.has_seqno_bounds(),
+        )
+        .use_sync_mode(options.sync_mode)
+        // The extractor is configuration (never persisted in the SST), so
+        // the rebuilt filter only carries the source's prefix hashes when
+        // the caller supplies it.
+        .use_prefix_extractor(options.prefix_extractor.clone())
+        .use_encryption(options.encryption.clone());
+    // Without an extractor, DISABLE the filter entirely rather than rebuild one
+    // from complete-key hashes: the source's prefix-indexing intent is
+    // unknowable (the extractor is not persisted and cannot be inferred), and a
+    // complete-key-only filter answers `maybe_contains_prefix` DEFINITELY-ABSENT
+    // for a source that came from a prefix-indexed tree, silently dropping every
+    // recovered row from prefix scans. No filter answers "maybe present" (a full
+    // block read), which is always correct; the point-lookup speedup is
+    // sacrificed for correctness.
+    let writer = if options.prefix_extractor.is_none() {
+        writer.use_bloom_policy(crate::config::BloomConstructionPolicy::BitsPerKey(0.0))
+    } else {
+        writer
+    };
+    #[cfg(zstd_any)]
+    let writer = writer.use_zstd_dictionary(options.zstd_dictionary.clone());
+
+    let walk = match salvage_blocks(
+        &table,
+        writer,
+        comparator,
+        !delete_mask_unpositionable,
+        allow_verbatim,
+    ) {
         Ok(walk) => walk,
         Err(e) => {
             // A `write` / `finish` failure after `Writer::new` created `dest`
@@ -255,8 +920,13 @@ pub(crate) fn salvage_sst_with_comparator(
         salvaged_path,
         blocks_total: walk.blocks_total,
         blocks_salvaged: walk.blocks_salvaged,
+        blocks_copied_verbatim: walk.blocks_copied_verbatim,
         entries_salvaged: walk.entries_salvaged,
         dropped: walk.dropped,
+        // Resurrection happened exactly when the delete mask was unappliable and
+        // the opt-in let the walk re-emit unmasked (the fail-closed branch above
+        // already returned otherwise).
+        delete_rows_resurrected: delete_mask_unpositionable && options.allow_delete_resurrection,
     })
 }
 
@@ -266,6 +936,7 @@ pub(crate) fn salvage_sst_with_comparator(
 struct SalvageWalk {
     blocks_total: usize,
     blocks_salvaged: usize,
+    blocks_copied_verbatim: usize,
     entries_salvaged: u64,
     dropped: Vec<DroppedBlock>,
     wrote: bool,
@@ -285,102 +956,950 @@ fn discard_partial(fs: &alloc::sync::Arc<dyn crate::fs::Fs>, dest: &std::path::P
     }
 }
 
+/// The directory to fsync so `path`'s new directory entry is durable.
+///
+/// [`std::path::Path::parent`] yields an EMPTY path for a bare relative
+/// destination (`Path::new("blob").parent() == Some("")`), which is not a
+/// syncable directory: fsyncing it fails and the caller would discard the
+/// recovered file it had just written. Map the empty (and absent) parent to the
+/// current directory so a bare relative destination still gets its entry synced.
+fn entry_directory(path: &std::path::Path) -> &std::path::Path {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => std::path::Path::new("."),
+    }
+}
+
+/// Classifies a block load / read failure into a [`DroppedBlock`], distinguishing
+/// a bit-rot checksum mismatch from a structural decode error from a raw
+/// read / decompress failure, and attaching the block's `(prev_end, end_key]`
+/// range as the lower/upper bound of the lost keys.
+fn classify_drop(
+    e: &crate::Error,
+    offset: u64,
+    prev_end: Option<&UserKey>,
+    end_key: Option<&UserKey>,
+) -> DroppedBlock {
+    use alloc::format;
+    let reason = match e {
+        crate::Error::ChecksumMismatch { .. } => DropReason::ChecksumMismatch,
+        crate::Error::InvalidHeader(_) | crate::Error::InvalidTag(_) => {
+            DropReason::DecodeError(format!("{e:?}"))
+        }
+        _ => DropReason::ReadError(format!("{e:?}")),
+    };
+    DroppedBlock {
+        offset,
+        section: b"data".to_vec(),
+        reason,
+        // A gap-probed block (omitted by a forged index) has no separator,
+        // so its key range is unknown until decode — `None`, like a block
+        // whose index entry is lost.
+        key_range: end_key.map(|ek| (prev_end.cloned().unwrap_or_else(UserKey::empty), ek.clone())),
+    }
+}
+
+/// Decodes the [`crate::blob_tree::handle::BlobIndirection`] of every
+/// indirection entry in `entries`. An entry TAGGED as an indirection whose
+/// value fails to decode is corrupt content the live read path could not
+/// follow either — the caller drops the block rather than laundering it into
+/// the recovered copy.
+fn collect_indirections(
+    entries: &[crate::InternalValue],
+) -> crate::Result<Vec<crate::blob_tree::handle::BlobIndirection>> {
+    use crate::coding::Decode;
+
+    let mut out = Vec::new();
+    for entry in entries {
+        if entry.key.value_type == crate::ValueType::Indirection {
+            let mut cursor = &entry.value[..];
+            out.push(crate::blob_tree::handle::BlobIndirection::decode_from(
+                &mut cursor,
+            )?);
+        }
+    }
+    Ok(out)
+}
+
+/// [`collect_indirections`] for a columnar batch: a cheap value-type-column
+/// scan first, so the per-row materialization is only paid when the batch
+/// actually holds indirections (KV-separated columnar sources are rare).
+#[cfg(feature = "columnar")]
+fn collect_columnar_indirections(
+    batch: &crate::table::columnar::ColumnBatch,
+) -> crate::Result<Vec<crate::blob_tree::handle::BlobIndirection>> {
+    let tag = u8::from(crate::ValueType::Indirection);
+    // Columns are key / seqno / value-type / values...; the value-type column
+    // holds one tag byte per row.
+    let has_indirections = batch.columns.get(2).is_some_and(|c| c.data.contains(&tag));
+    if !has_indirections {
+        return Ok(Vec::new());
+    }
+    let entries = crate::table::columnar::column_batch_to_entries(batch)?;
+    collect_indirections(&entries)
+}
+
+/// Folds one block's recovered indirections into the walk's derived blob-link
+/// map, mirroring the accumulation the live write path does per entry.
+fn fold_blob_links(
+    derived: &mut crate::HashMap<crate::vlog::BlobFileId, crate::table::writer::LinkedFile>,
+    indirections: &[crate::blob_tree::handle::BlobIndirection],
+) {
+    for ind in indirections {
+        derived
+            .entry(ind.vhandle.blob_file_id)
+            .and_modify(|link| {
+                link.bytes += u64::from(ind.size);
+                link.on_disk_bytes += u64::from(ind.vhandle.on_disk_size);
+                link.len += 1;
+            })
+            .or_insert_with(|| crate::table::writer::LinkedFile {
+                blob_file_id: ind.vhandle.blob_file_id,
+                bytes: u64::from(ind.size),
+                on_disk_bytes: u64::from(ind.vhandle.on_disk_size),
+                len: 1,
+            });
+    }
+}
+
 /// Walks `table`'s data blocks in index order, re-emitting every block that
 /// loads and decodes cleanly into `writer` and recording the rest.
+///
+/// `apply_delete_mask` gates the delete-masked re-emit of a delete-bearing
+/// columnar source: `false` means the mask is unpositionable (degraded bitmap
+/// or unverified zone-map positions) and the caller explicitly opted into
+/// resurrection — the walk then re-emits every row LIVE rather than masking
+/// against unverified positions. Ignored for sources without a delete-bitmap
+/// section.
 ///
 /// Consumes `writer`: on success it is finished (when at least one block was
 /// emitted) or dropped (when none were). On a `write` / `finish` error the
 /// writer is dropped as the error unwinds, so the caller must remove the partial
 /// destination it left behind.
+#[cfg_attr(
+    not(feature = "columnar"),
+    expect(
+        unused_variables,
+        reason = "the delete mask exists only for columnar sources; without the feature the flag has no consumer"
+    )
+)]
 fn salvage_blocks(
     table: &crate::table::Table,
     mut writer: crate::table::Writer,
     comparator: &crate::comparator::SharedComparator,
+    apply_delete_mask: bool,
+    allow_verbatim: bool,
 ) -> crate::Result<SalvageWalk> {
     use crate::table::block::ParsedItem;
     use alloc::format;
 
     let mut blocks_total = 0usize;
     let mut blocks_salvaged = 0usize;
+    let mut blocks_copied_verbatim = 0usize;
     let mut entries_salvaged = 0u64;
     let mut dropped: Vec<DroppedBlock> = Vec::new();
+    // Blob links DERIVED from the recovered entries' indirections, keyed by
+    // blob file id — exact for the recovered copy (only emitted rows count).
+    // The source's own linked_blob_files section is deliberately not
+    // consulted: it is not authoritative in either direction (see the caller).
+    let mut derived_blob_links: crate::HashMap<
+        crate::vlog::BlobFileId,
+        crate::table::writer::LinkedFile,
+    > = crate::HashMap::default();
     // Lower bound for a dropped block's range: the previous block's last key,
     // since the index stores each block's last key (so block N covers
     // `(end_key[N-1], end_key[N]]`).
     let mut prev_end: Option<UserKey> = None;
 
+    // Enumerate the index handles first. A corrupt index entry stops the
+    // collection after reporting it: once the index stream desyncs, later
+    // entries are unknowable. This is NOT the end of recovery — the physical
+    // data section is still writer-ordered and self-framing, so the tiling
+    // walk below recovers every block the broken enumeration could not reach
+    // (a mid-partition rot must not cost the failed and later partitions).
+    // Capture (do NOT yet record) a broken enumeration: whether it is data loss
+    // depends on the fallback below. When the physical data section is readable,
+    // the tiling walk recovers every block INDEPENDENTLY of the index, so a
+    // corrupt index partition costs nothing and must not be reported as a
+    // dropped block; only when there is no physical fallback (unreadable TOC) is
+    // the un-enumerated remainder truly lost.
+    let mut indexed: Vec<crate::table::KeyedBlockHandle> = Vec::new();
+    let mut index_enum_error: Option<String> = None;
     for handle in table.data_block_handles() {
-        blocks_total += 1;
-        let keyed = match handle {
-            Ok(k) => k,
+        match handle {
+            Ok(k) => indexed.push(k),
             Err(e) => {
-                // A corrupt index entry: the block's handle and range are
-                // unknown, and once the index stream desyncs later offsets are
-                // unknowable too, so stop the walk after reporting it.
-                dropped.push(DroppedBlock {
-                    offset: 0,
-                    section: b"index".to_vec(),
-                    reason: DropReason::HeaderCorrupted(format!("{e:?}")),
-                    key_range: None,
-                });
+                index_enum_error = Some(format!("{e:?}"));
                 break;
             }
-        };
-        let end_key = keyed.end_key().clone();
-        let offset = *keyed.as_ref().offset();
-        match table.load_data_block(keyed.as_ref()) {
-            // `try_iter`, not `iter`: a checksum-clean but structurally malformed
-            // block (e.g. an invalid trailer) must be reported as a dropped
-            // `DecodeError`, never panic the salvage walk. `blocks_salvaged` is
-            // counted only once the whole block decoded and was written.
-            Ok(Some(block)) => match block.try_iter(comparator.clone()) {
-                Ok(iter) => {
-                    for parsed in iter {
-                        writer.write(parsed.materialize(block.as_slice()))?;
-                        entries_salvaged += 1;
-                    }
-                    blocks_salvaged += 1;
-                }
-                Err(e) => dropped.push(DroppedBlock {
-                    offset,
-                    section: b"data".to_vec(),
-                    reason: DropReason::DecodeError(format!("{e:?}")),
-                    key_range: Some((
-                        prev_end.clone().unwrap_or_else(UserKey::empty),
-                        end_key.clone(),
-                    )),
-                }),
-            },
-            // A wholly-deleted columnar block carries no live keys: nothing to
-            // recover and nothing lost.
-            Ok(None) => {}
-            Err(e) => {
-                // Classify the failure so the report distinguishes a bit-rot
-                // checksum mismatch from a structural decode error from a raw
-                // read / decompress failure.
-                let reason = match &e {
-                    crate::Error::ChecksumMismatch { .. } => DropReason::ChecksumMismatch,
-                    crate::Error::InvalidHeader(_) | crate::Error::InvalidTag(_) => {
-                        DropReason::DecodeError(format!("{e:?}"))
-                    }
-                    _ => DropReason::ReadError(format!("{e:?}")),
-                };
-                dropped.push(DroppedBlock {
-                    offset,
-                    section: b"data".to_vec(),
-                    reason,
-                    key_range: Some((
-                        prev_end.clone().unwrap_or_else(UserKey::empty),
-                        end_key.clone(),
-                    )),
-                });
-            }
         }
-        prev_end = Some(end_key);
+    }
+
+    // Walk the PHYSICAL data section regardless of how the index enumeration
+    // went. Two failure modes both need it:
+    // - A CLEANLY enumerated index can still OMIT a handle (both TLI mirrors
+    //   forged to the same truncated list pass every byte-level check and the
+    //   mirror comparison), invisible to the open.
+    // - A BROKEN index (a rotted leaf partition) yields only a prefix, leaving
+    //   the failed and later partitions' blocks unreferenced.
+    // The writer emits blocks back-to-back, so the section tiling is the only
+    // ground truth: frame each uncovered byte range from its block headers and
+    // salvage those blocks too (their end key is unknown until decode); an
+    // unframeable gap is reported dropped, never silently skipped. The index
+    // handles that DID enumerate still contribute their end keys.
+    let mut items: Vec<(crate::table::BlockHandle, Option<UserKey>)> = Vec::new();
+    let data_section = {
+        let mut file = table
+            .fs
+            .open(&table.path, &crate::fs::FsOpenOptions::new().read(true))?;
+        match crate::sfa::Reader::from_reader(&mut file) {
+            Ok(t) => {
+                let toc_pos = t.toc_pos();
+                t.toc().section(b"data").and_then(|s| {
+                    // checked, not saturating: a re-stamped `data` length that
+                    // overflows `pos + len` must NOT saturate to a `u64::MAX`
+                    // section end — the byte-at-a-time resync loop below would then
+                    // probe every nonexistent offset up to it, hanging salvage. A
+                    // section that ends past where the TOC begins is equally corrupt
+                    // (it would overlap the index / meta / TOC), so require the end
+                    // to land at or before `toc_pos`.
+                    let end = s.pos().checked_add(s.len())?;
+                    (end <= toc_pos).then_some((s.pos(), end))
+                })
+            }
+            // Only a TRANSIENT I/O error re-reading the trailer would silently
+            // disable the physical walk that recovers index-omitted blocks: if the
+            // index is checksum-consistent but omits a block, salvage would then
+            // publish the indexed subset and report a COMPLETE recovery while
+            // losing the omitted keys. Abort so the caller retries. A PERSISTENT
+            // I/O failure (a retry cannot fix a bad sector / truncated trailer) or
+            // a STRUCTURAL trailer error is the genuine "no physical fallback" case
+            // (an unreadable TOC): fall back to the index enumeration alone, so the
+            // already-open table's indexed blocks stay recoverable.
+            Err(crate::sfa::Error::Io(e)) if e.kind().is_transient() => {
+                return Err(crate::Error::Io(e));
+            }
+            Err(_) => None,
+        }
+    };
+    if let Some((section_pos, section_end)) = data_section {
+        // One open handle for the WHOLE physical walk: the resync scan steps one
+        // byte at a time (block starts are not aligned), so opening the file per
+        // probe would make salvage O(section_len) opens instead of O(blocks).
+        let probe_file = table
+            .fs
+            .open(&table.path, &crate::fs::FsOpenOptions::new().read(true))?;
+        // The gap walk must accept a candidate only after its PAYLOAD loads, not
+        // just its header frame: a header-checksum-valid but FAKE header inside
+        // corrupt bytes can declare a forged size that spans real blocks after
+        // it. Advancing by that unvalidated size would skip the intact blocks
+        // (the later load pass drops only the fake candidate, losing the rest).
+        // So fully load each candidate here; the block type matches the SST.
+        let probe_block_type = {
+            #[cfg(feature = "columnar")]
+            {
+                if table.metadata.columnar {
+                    crate::table::block::BlockType::Columnar
+                } else {
+                    crate::table::block::BlockType::Data
+                }
+            }
+            #[cfg(not(feature = "columnar"))]
+            {
+                crate::table::block::BlockType::Data
+            }
+        };
+        // A candidate is REAL only if its header frames AND its payload loads.
+        // `Ok(Some)` = a framed, loaded block; `Ok(None)` = structurally not a
+        // block, or a PERSISTENTLY unreadable one (a header that did not frame, a
+        // payload that did not decode, or a bad-sector read a retry can't fix) —
+        // the gap walk treats it as a chain break and drops it. `Err(Io)` is
+        // reserved for a TRANSIENT read failure, propagated so a retryable fault
+        // is never mis-recorded as a permanently dropped gap.
+        let frames_and_loads = |at: u64,
+                                to: u64|
+         -> crate::Result<Option<crate::table::BlockHandle>> {
+            match table.probe_block_handle_in(&*probe_file, at, to) {
+                Ok(h) => match table.salvage_load_block(&h, probe_block_type) {
+                    Ok(_) => Ok(Some(h)),
+                    Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                        Err(crate::Error::Io(io))
+                    }
+                    Err(_) => Ok(None),
+                },
+                Err(crate::Error::Io(io)) if io.kind().is_transient() => Err(crate::Error::Io(io)),
+                Err(_) => Ok(None),
+            }
+        };
+        // Returns `true` when the gap `[from, to)` tiled CONTIGUOUSLY to `to`
+        // (so `to` is a proven boundary), `false` when the chain broke before
+        // reaching it.
+        let probe_gap = |from: u64,
+                         to: u64,
+                         items: &mut Vec<(crate::table::BlockHandle, Option<UserKey>)>,
+                         dropped: &mut Vec<DroppedBlock>|
+         -> crate::Result<bool> {
+            // `from` is a TRUSTED boundary: the data section start, or the end
+            // of a block whose frame this walk already validated. Blocks that
+            // tile CONTIGUOUSLY from it inherit that provenance — each
+            // framed-and-loaded block's validated size anchors the next offset.
+            // The moment an offset does NOT frame a loadable block, the chain
+            // breaks: every later offset is reachable only by byte scanning,
+            // which cannot prove a boundary. An uncompressed block can carry a
+            // complete checksum-valid SST block inside a user value, so a scan
+            // that resynced past a broken header could frame that NESTED forge
+            // and re-emit its interior entries as genuine data. Fail closed
+            // exactly as the blob resync path does: drop the whole remaining gap
+            // rather than emit unanchored candidates. A contiguous intact
+            // section still recovers every block; only bytes after a broken
+            // boundary are surrendered.
+            let mut at = from;
+            while at < to {
+                if let Some(h) = frames_and_loads(at, to)? {
+                    let next = at + u64::from(h.size());
+                    // A zero-size frame would not advance `at` (an infinite loop)
+                    // and cannot anchor the next offset. Treat it as a broken
+                    // boundary: fall through to the drop-and-stop below rather
+                    // than spin or emit an unanchored candidate.
+                    if next > at {
+                        items.push((h, None));
+                        at = next;
+                        continue;
+                    }
+                }
+                // The contiguous chain broke here (a header that did not frame,
+                // or one that framed with a checksum-valid but FAKE size whose
+                // payload does not load). Report the unanchored remainder as one
+                // dropped region and stop — no resync-and-emit, because a byte
+                // scan past this point cannot distinguish an original block
+                // start from a nested frame inside a corrupt block's user bytes.
+                dropped.push(DroppedBlock {
+                    offset: at,
+                    section: b"data".to_vec(),
+                    reason: DropReason::HeaderCorrupted(
+                        "unanchored bytes after a broken block boundary; the tail \
+                         cannot be proven to be original block starts"
+                            .to_owned(),
+                    ),
+                    key_range: None,
+                });
+                return Ok(false);
+            }
+            Ok(true)
+        };
+        // Records an indexed handle the walk surrenders because the physical
+        // chain broke below its offset: with no proven boundary, a forged index
+        // could point it at a checksum-valid frame nested in a corrupt block's
+        // value bytes, so its own claimed key range is untrusted too (`None`).
+        let drop_unanchored_handle = |off: u64, dropped: &mut Vec<DroppedBlock>| {
+            dropped.push(DroppedBlock {
+                offset: off,
+                section: b"data".to_vec(),
+                reason: DropReason::HeaderCorrupted(
+                    "indexed block after a broken physical chain has no \
+                         authenticated boundary"
+                        .to_owned(),
+                ),
+                key_range: None,
+            });
+        };
+        let mut cursor = section_pos;
+        // The tiling below is offset-driven, but the index yields KEY order,
+        // which a forged index can decouple from the physical order: an
+        // out-of-place handle would be covered twice (once by the gap probe,
+        // once by itself), and the duplicate emit would be rejected as an
+        // ordering violation — misreporting an intact block as dropped.
+        // Offset order equals the writer's key order for the blocks
+        // themselves, so re-sorting also keeps the emit order valid.
+        indexed.sort_unstable_by_key(|k| *k.as_ref().offset());
+        // Whether the index (TLI + its mirror) is TRUSTWORTHY: the mirrors agree,
+        // the binary-index pointers authenticate, and the decoded handles TILE
+        // their section. A checksum-restamped index that points a handle at a
+        // frame nested inside another block's value bytes fails the tiling check
+        // (the nested offset overlaps its host block), so a passing verification
+        // proves every indexed offset is an ORIGINAL block boundary. With that
+        // proof, each indexed offset is its own provenance: a block whose header
+        // is corrupt costs only its own keys and the walk recovers the rest by
+        // their trusted offsets (block-granular salvage). WITHOUT it, an indexed
+        // offset is no more trustworthy than a byte-scanned one — a forged index
+        // could point it at a nested frame — so the physical chain is the only
+        // provenance and the walk fails closed past the first break.
+        // A transient I/O fault while authenticating the index STRUCTURE aborts
+        // the walk (propagated up so repair retries) instead of degrading to
+        // physical-chain-only provenance: reading `false` here would surrender
+        // every indexed block past the first header break, dropping healthy keys
+        // the intact TLI could anchor on retry.
+        let tli_trusted = table.tli_structure_authenticated()?;
+        // Tracks the contiguous physical chain from `section_pos`, consulted only
+        // when the index is NOT trusted. Once a boundary breaks there, every
+        // later offset is reachable only past unprovable bytes, so it is
+        // surrendered rather than trusted.
+        let mut chain_anchored = true;
+        for keyed in indexed {
+            let off = *keyed.as_ref().offset();
+            // A handle whose offset is at or beyond the section end points
+            // outside the data region (a checksum-repatched / forged index).
+            // Probing the gap up to it would scan past the section, potentially
+            // to an attacker-controlled u64 (an unbounded hang, and later SST
+            // sections framed as data). Skip it; the final gap probe still
+            // covers the rest of the section from the cursor.
+            if off >= section_end {
+                continue;
+            }
+            // A handle starting inside already-covered bytes (a duplicate or
+            // overlapping forge) is skipped: its span was walked physically as
+            // part of the anchored prefix.
+            if off < cursor {
+                continue;
+            }
+            // Untrusted index only: the chain already broke below this offset,
+            // so it has no proven boundary — surrender it (and every one after).
+            if !chain_anchored {
+                drop_unanchored_handle(off, &mut dropped);
+                continue;
+            }
+            if off > cursor {
+                let reached = probe_gap(cursor, off, &mut items, &mut dropped)?;
+                if !reached && !tli_trusted {
+                    // Untrusted index: the gap up to this handle broke, so `off`
+                    // sits past the last proven boundary and is unanchored too.
+                    // Surrender it and arm the flag for the rest of the walk.
+                    chain_anchored = false;
+                    drop_unanchored_handle(off, &mut dropped);
+                    continue;
+                }
+                // The gap tiled cleanly, OR the trusted index proves `off` is an
+                // original boundary regardless of the intervening (now dropped)
+                // index-omitted bytes. Either way `off` is a boundary.
+                cursor = off;
+            }
+            // Trust the indexed SPAN only after the block's own header
+            // confirms it: an oversized forged handle would otherwise
+            // advance the cursor past back-to-back blocks the gap walk
+            // should discover (the oversized non-ECC frame still decodes
+            // its first payload, so nothing later would flag the loss).
+            let (handle, end_key) =
+                match table.probe_block_handle_in(&*probe_file, off, section_end) {
+                    Ok(probed) if probed.size() == keyed.as_ref().size() => {
+                        (*keyed.as_ref(), Some(keyed.end_key().clone()))
+                    }
+                    // The physical frame disagrees: walk the physically framed
+                    // block instead (the lying handle's separator is just as
+                    // untrusted as its span).
+                    Ok(probed) => (probed, None),
+                    // Only a TRANSIENT read failure is retryable: propagate it
+                    // rather than surrender the block (and, when untrusted, the
+                    // whole tail) to a permanent drop over a flaky read. A
+                    // PERSISTENT read failure is not fixed by a retry, so it falls
+                    // through to the unframeable-header arm below and drops just
+                    // this block instead of aborting the whole salvage.
+                    Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                        return Err(crate::Error::Io(io));
+                    }
+                    // The indexed block's header does not frame, so its size is
+                    // UNVERIFIED. With a TRUSTED index the block's offset is still
+                    // an original boundary, so leave the cursor here and let the
+                    // next handle's gap probe frame from it — it records the
+                    // corrupt block as a drop and recovers the intact blocks after
+                    // it by their trusted offsets (block-granular). With an
+                    // UNTRUSTED index the byte range past this unframeable header
+                    // cannot be proven to be original block starts (a nested forge
+                    // would frame just as well), so surrender this block and every
+                    // offset after it.
+                    Err(_) => {
+                        if !tli_trusted {
+                            chain_anchored = false;
+                            drop_unanchored_handle(off, &mut dropped);
+                        }
+                        continue;
+                    }
+                };
+            // Both surviving arms probed the frame within `section_end`, so the
+            // block ends there by construction: `off + size <= section_end`,
+            // which cannot overflow a `u64` bounded by the validated section.
+            let next = (off + u64::from(handle.size())).min(section_end);
+            items.push((handle, end_key));
+            cursor = cursor.max(next);
+        }
+        // The trailing gap is probed only while the chain is still anchored:
+        // once it broke, the remaining bytes were already surrendered above.
+        if chain_anchored && cursor < section_end {
+            probe_gap(cursor, section_end, &mut items, &mut dropped)?;
+        }
+    } else {
+        // Unreadable TOC (no physical data section to tile against): walk
+        // exactly what the index enumeration gave. Here a broken enumeration IS
+        // data loss: with no physical fallback, the un-enumerated handles are
+        // unrecoverable, so record the structural index error as a drop.
+        if let Some(reason) = index_enum_error {
+            dropped.push(DroppedBlock {
+                offset: 0,
+                section: b"index".to_vec(),
+                reason: DropReason::HeaderCorrupted(reason),
+                key_range: None,
+            });
+        }
+        for keyed in indexed {
+            let handle = *keyed.as_ref();
+            items.push((handle, Some(keyed.end_key().clone())));
+        }
+    }
+
+    // Drops recorded BEFORE the emit loop (a corrupt index entry and every
+    // `probe_gap` region: a header-corrupt block the tiling walk resynced past)
+    // never enter `items`, so the per-item increment below would miss them.
+    // They were still INSPECTED and lost, so count them in the total: without
+    // this a header-corrupt block yields `blocks_total == blocks_salvaged`
+    // while a block was dropped, reporting full coverage despite the loss.
+    blocks_total += dropped.len();
+
+    for (block_handle, end_key) in items {
+        blocks_total += 1;
+        let offset = *block_handle.offset();
+
+        // Columnar source: a clean block is byte-copied verbatim — preserving its
+        // PAX value sub-columns, zone map, and per-row seqnos without the transpose
+        // + recompression a re-encode pays — and an ECC-recovered block is
+        // re-emitted from its healed `ColumnBatch`. When the SST carries
+        // materialized positional deletes, a verbatim copy would resurrect deleted
+        // rows (the bitmap is not carried into the recovered SST), so every block
+        // is instead re-emitted as a delete-masked batch. Per-block corruption is
+        // isolated either way.
+        #[cfg(feature = "columnar")]
+        if table.metadata.columnar {
+            // A delete-bearing SST (it carries a delete-bitmap section) always
+            // takes the re-emit path: byte-copying its blocks verbatim would
+            // resurrect positionally-deleted rows (the recovered copy carries no
+            // bitmap), and a salvage-mode open degrades a corrupt bitmap to empty,
+            // so `delete_bitmap().is_empty()` cannot tell "no deletes" from "deletes
+            // whose bitmap was lost". A degraded bitmap still recovers all rows
+            // live (the documented salvage degradation) — but never via a verbatim
+            // copy. Only a genuinely delete-free SST is eligible for copy-through.
+            // The MASKED re-emit additionally requires verified positions
+            // (`apply_delete_mask`); an unpositionable mask under the explicit
+            // resurrection opt-in re-emits every row live via the unmasked arm.
+            if table.has_delete_bitmap_section() && apply_delete_mask {
+                // An INDEX-OMITTED block (recovered by the physical gap walk,
+                // `end_key` unknown) has no verified delete-start position:
+                // `delete_positions_verified` walked only the indexed blocks,
+                // and the masked load would treat an unmapped batch as all
+                // rows live — permanently resurrecting the rows the bitmap
+                // marked there, without the resurrection opt-in. Fail closed
+                // per block: drop it and report the loss.
+                if end_key.is_none() {
+                    dropped.push(classify_drop(
+                        &crate::Error::InvalidHeader(
+                            "delete positions unverifiable for an index-omitted block",
+                        ),
+                        offset,
+                        prev_end.as_ref(),
+                        None,
+                    ));
+                    continue;
+                }
+                // Re-emit each block as a delete-masked batch so the recovered copy
+                // keeps any (readable) deletes applied.
+                match table.load_columnar_block_masked(&block_handle) {
+                    Ok(Some(batch)) => {
+                        let rows = u64::from(batch.row_count);
+                        // Indirections of the SURVIVING (unmasked) rows,
+                        // BEFORE emit: an undecodable indirection is corrupt
+                        // content — drop the block, don't launder it.
+                        let block_links = match collect_columnar_indirections(&batch) {
+                            Ok(links) => links,
+                            Err(e) => {
+                                dropped.push(classify_drop(
+                                    &e,
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                                prev_end = end_key.or(prev_end);
+                                continue;
+                            }
+                        };
+                        // A writer REJECTION (ordering / framing validation,
+                        // `InvalidHeader` / `InvalidTag`) is block-local
+                        // malformed content — drop the block and keep walking;
+                        // destination I/O errors stay hard.
+                        match writer.write_columnar_block_verbatim(&batch, comparator) {
+                            Ok(_) => {
+                                entries_salvaged += rows;
+                                blocks_salvaged += 1;
+                                fold_blob_links(&mut derived_blob_links, &block_links);
+                            }
+                            Err(
+                                e @ (crate::Error::InvalidHeader(_) | crate::Error::InvalidTag(_)),
+                            ) => {
+                                dropped.push(classify_drop(
+                                    &e,
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+                    // Wholly-deleted block: nothing to recover, nothing lost.
+                    Ok(None) => {}
+                    // Only a TRANSIENT read (a masked block re-read after cache
+                    // eviction) propagates so repair retries; a persistent I/O
+                    // failure or a structural failure drops just this block,
+                    // mirroring the unmasked salvage_load_block arm — a truncated
+                    // or unreadable block must not sink every intact sibling.
+                    Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                        return Err(crate::Error::Io(io));
+                    }
+                    Err(e) => dropped.push(classify_drop(
+                        &e,
+                        offset,
+                        prev_end.as_ref(),
+                        end_key.as_ref(),
+                    )),
+                }
+            } else {
+                match table
+                    .salvage_load_block(&block_handle, crate::table::block::BlockType::Columnar)
+                {
+                    // Row materialization validates the batch content (framing,
+                    // value-type tags, key invariants) beyond the outer frame
+                    // decode. A checksum-consistent block that fails EITHER step
+                    // is malformed content — drop this one block and keep
+                    // walking, exactly like a row-major block whose entries fail
+                    // to decode. Only writer errors (I/O to the destination)
+                    // stay hard errors.
+                    Ok(mut sb) => {
+                        if !allow_verbatim {
+                            sb.verbatim = None;
+                        }
+                        match crate::table::columnar::ColumnBatch::decode(&sb.block.data).and_then(
+                            |batch| {
+                                crate::table::columnar::column_batch_to_entries(&batch)
+                                    .map(|entries| (batch, entries))
+                            },
+                        ) {
+                            // A real writer never emits an empty data block, so a
+                            // checksum-clean ZERO-ROW batch is malformed input:
+                            // the writer primitives below would emit NOTHING for
+                            // it, and counting it as salvaged would misreport an
+                            // unrecovered block (an SST whose only block is empty
+                            // would even report a salvaged path that the
+                            // empty-table finish just removed).
+                            Ok((batch, _)) if batch.row_count == 0 => {
+                                dropped.push(classify_drop(
+                                    &crate::Error::InvalidHeader("columnar: zero-row data block"),
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                            }
+                            Ok((batch, entries)) => {
+                                let rows = u64::from(batch.row_count);
+                                // Indirections BEFORE emit: an entry tagged as an
+                                // indirection whose value fails to decode is
+                                // corrupt content — drop the block rather than
+                                // laundering it into the copy.
+                                let block_links = match collect_indirections(&entries) {
+                                    Ok(links) => links,
+                                    Err(e) => {
+                                        dropped.push(classify_drop(
+                                            &e,
+                                            offset,
+                                            prev_end.as_ref(),
+                                            end_key.as_ref(),
+                                        ));
+                                        prev_end = end_key.or(prev_end);
+                                        continue;
+                                    }
+                                };
+                                // A delete-bearing SST is never byte-copied, even
+                                // on this unmasked (resurrection opt-in) arm: the
+                                // re-encode keeps the recovered copy's layout
+                                // consistent with the degraded-bitmap path.
+                                let verbatim_source = if table.has_delete_bitmap_section() {
+                                    None
+                                } else {
+                                    sb.verbatim
+                                };
+                                // A writer REJECTION (ordering / framing validation)
+                                // is block-local malformed content — drop the block
+                                // and keep walking; destination I/O errors stay hard.
+                                let emitted = match verbatim_source {
+                                    // Clean: copy the block's raw bytes as-is,
+                                    // carrying the block's per-column zone-map
+                                    // stats (this is the columnar path, so the
+                                    // synthetic row-block stat would be rejected
+                                    // by the copy's own `verify_zone_map`).
+                                    Some((raw, header, layout)) => writer
+                                        .append_verbatim_data_block(
+                                            &raw,
+                                            header,
+                                            layout,
+                                            &entries,
+                                            Some(batch.zone_stats()),
+                                            comparator,
+                                        )
+                                        .map(|_| true),
+                                    // ECC-recovered (or delete-bearing): re-encode the
+                                    // batch so the recovered copy carries clean bytes.
+                                    None => writer
+                                        .write_columnar_block_verbatim(&batch, comparator)
+                                        .map(|_| false),
+                                };
+                                match emitted {
+                                    Ok(verbatim) => {
+                                        if verbatim {
+                                            blocks_copied_verbatim += 1;
+                                        }
+                                        entries_salvaged += rows;
+                                        blocks_salvaged += 1;
+                                        fold_blob_links(&mut derived_blob_links, &block_links);
+                                    }
+                                    Err(
+                                        e @ (crate::Error::InvalidHeader(_)
+                                        | crate::Error::InvalidTag(_)),
+                                    ) => {
+                                        dropped.push(classify_drop(
+                                            &e,
+                                            offset,
+                                            prev_end.as_ref(),
+                                            end_key.as_ref(),
+                                        ));
+                                    }
+                                    Err(e) => return Err(e),
+                                }
+                            }
+                            // Only a transient I/O read is retryable and propagates,
+                            // so a partial columnar table is not published with
+                            // healthy rows permanently lost. A persistent or
+                            // structural failure drops just this block (truncation /
+                            // an unreadable block must not sink its intact siblings).
+                            Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                                return Err(crate::Error::Io(io));
+                            }
+                            Err(e) => {
+                                dropped.push(classify_drop(
+                                    &e,
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                            }
+                        }
+                    }
+                    // Same transient-only I/O propagation for the delete-masked arm.
+                    Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                        return Err(crate::Error::Io(io));
+                    }
+                    Err(e) => dropped.push(classify_drop(
+                        &e,
+                        offset,
+                        prev_end.as_ref(),
+                        end_key.as_ref(),
+                    )),
+                }
+            }
+            prev_end = end_key.or(prev_end);
+            continue;
+        }
+
+        // Row source: a clean block is byte-copied verbatim; an ECC-recovered block
+        // is re-emitted entry by entry from its healed payload.
+        match table.salvage_load_block(&block_handle, crate::table::block::BlockType::Data) {
+            Ok(mut sb) => {
+                if !allow_verbatim {
+                    sb.verbatim = None;
+                }
+                // Footer presence is a per-SST property (`kv_checksum_algo`), not a
+                // per-block header flag, so the descriptor supplies it here.
+                let has_kv_footer = table.metadata.kv_checksum_algo.is_some();
+                // Verify the per-KV digests BEFORE stripping the footer: a
+                // block-checksum-re-stamped entry whose stored digest no
+                // longer matches its bytes would otherwise be recovered (even
+                // byte-copied verbatim) into a copy the live per-KV scrub
+                // rejects — laundering the corruption. A mismatch is
+                // block-local malformed content: drop the block, keep walking.
+                if has_kv_footer
+                    && let Err(e) = crate::table::DataBlock::verify_kv_checked(
+                        &sb.block.data,
+                        sb.block.header,
+                        comparator.clone(),
+                        table.metadata.kv_checksum_algo,
+                    )
+                {
+                    dropped.push(classify_drop(
+                        &e,
+                        offset,
+                        prev_end.as_ref(),
+                        end_key.as_ref(),
+                    ));
+                    prev_end = end_key.or(prev_end);
+                    continue;
+                }
+                match crate::table::DataBlock::from_loaded(sb.block, has_kv_footer) {
+                    // `try_iter`, not `iter`: a checksum-clean but structurally
+                    // malformed block (e.g. an invalid trailer) must be reported as
+                    // a dropped `DecodeError`, never panic the salvage walk.
+                    Ok(data_block) => match data_block.try_iter(comparator.clone()) {
+                        Ok(iter) => {
+                            let entries: Vec<crate::InternalValue> =
+                                iter.map(|p| p.materialize(data_block.as_slice())).collect();
+                            // A real writer never emits an empty data block, so
+                            // checksum-clean ZERO entries are malformed input:
+                            // the emit below would write nothing, and counting
+                            // the block as salvaged would misreport it (see the
+                            // columnar zero-row arm above).
+                            if entries.is_empty() {
+                                dropped.push(classify_drop(
+                                    &crate::Error::InvalidHeader(
+                                        "row block decodes to zero entries",
+                                    ),
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                                prev_end = end_key.or(prev_end);
+                                continue;
+                            }
+                            // The entry decoder turns a mid-stream parse
+                            // failure into an ordinary end of iteration, so a
+                            // checksum-clean block with a valid prefix and a
+                            // malformed tail yields FEWER entries than its
+                            // trailer declares. Accepting the prefix would
+                            // silently lose the remaining keys (or byte-copy
+                            // the still-malformed block verbatim) — drop the
+                            // block instead.
+                            if entries.len() != data_block.len() {
+                                dropped.push(classify_drop(
+                                    &crate::Error::InvalidHeader(
+                                        "row block iterates to fewer entries than its \
+                                         trailer declares",
+                                    ),
+                                    offset,
+                                    prev_end.as_ref(),
+                                    end_key.as_ref(),
+                                ));
+                                prev_end = end_key.or(prev_end);
+                                continue;
+                            }
+                            let count = entries.len() as u64;
+                            // Indirections BEFORE emit: an entry tagged as an
+                            // indirection whose value fails to decode is
+                            // corrupt content — drop the block rather than
+                            // laundering it into the copy.
+                            let block_links = match collect_indirections(&entries) {
+                                Ok(links) => links,
+                                Err(e) => {
+                                    dropped.push(classify_drop(
+                                        &e,
+                                        offset,
+                                        prev_end.as_ref(),
+                                        end_key.as_ref(),
+                                    ));
+                                    prev_end = end_key.or(prev_end);
+                                    continue;
+                                }
+                            };
+                            // Ordering guard for BOTH emit paths: the verbatim
+                            // append validates internally, but the row-by-row
+                            // re-emit (`writer.write`) trusts its input, so a
+                            // tampered checksum-repatched block must be caught
+                            // here. A validation rejection is block-local
+                            // malformed content — drop the block and keep
+                            // walking; destination I/O errors stay hard.
+                            let emitted = writer
+                                .validate_direct_block_order(&entries, comparator)
+                                .and_then(|()| {
+                                    if let Some((raw, header, layout)) = sb.verbatim {
+                                        writer
+                                            .append_verbatim_data_block(
+                                                &raw, header, layout, &entries, None, comparator,
+                                            )
+                                            .map(|_| true)
+                                    } else {
+                                        for e in entries {
+                                            writer.write(e)?;
+                                        }
+                                        Ok(false)
+                                    }
+                                });
+                            match emitted {
+                                Ok(verbatim) => {
+                                    if verbatim {
+                                        blocks_copied_verbatim += 1;
+                                    }
+                                    entries_salvaged += count;
+                                    blocks_salvaged += 1;
+                                    fold_blob_links(&mut derived_blob_links, &block_links);
+                                }
+                                Err(
+                                    e @ (crate::Error::InvalidHeader(_)
+                                    | crate::Error::InvalidTag(_)),
+                                ) => {
+                                    dropped.push(classify_drop(
+                                        &e,
+                                        offset,
+                                        prev_end.as_ref(),
+                                        end_key.as_ref(),
+                                    ));
+                                }
+                                Err(e) => return Err(e),
+                            }
+                        }
+                        Err(e) => dropped.push(DroppedBlock {
+                            offset,
+                            section: b"data".to_vec(),
+                            reason: DropReason::DecodeError(format!("{e:?}")),
+                            key_range: end_key.as_ref().map(|ek| {
+                                (prev_end.clone().unwrap_or_else(UserKey::empty), ek.clone())
+                            }),
+                        }),
+                    },
+                    Err(e) => dropped.push(DroppedBlock {
+                        offset,
+                        section: b"data".to_vec(),
+                        reason: DropReason::DecodeError(format!("{e:?}")),
+                        key_range: end_key.as_ref().map(|ek| {
+                            (prev_end.clone().unwrap_or_else(UserKey::empty), ek.clone())
+                        }),
+                    }),
+                }
+            }
+            // Only a TRANSIENT I/O error on the block read is retryable: dropping
+            // the block and finishing dest would let repair install a partial
+            // replacement missing keys a retry would recover, so abort and let the
+            // caller discard the partial dest. A PERSISTENT I/O failure (a
+            // bad-sector `Other` / EIO, `PermissionDenied`) or a truncated final
+            // block (`UnexpectedEof`) is not fixed by a retry, so it drops just
+            // this block — a persistently-unreadable tail block must not prevent
+            // every intact earlier block from being recovered.
+            Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                return Err(crate::Error::Io(io));
+            }
+            Err(e) => dropped.push(classify_drop(
+                &e,
+                offset,
+                prev_end.as_ref(),
+                end_key.as_ref(),
+            )),
+        }
+        prev_end = end_key.or(prev_end);
     }
 
     let wrote = blocks_salvaged > 0;
     if wrote {
+        // Blob links: EXACTLY the derived map. A dropped block's indirections
+        // do not exist in the copy, so no id beyond the recovered rows can be
+        // needed — and copying a source-only id would let a forged record
+        // plant a reference to a blob that exists nowhere.
+        let mut links: Vec<crate::table::writer::LinkedFile> =
+            derived_blob_links.into_values().collect();
+        // Deterministic section order regardless of hash-map iteration.
+        links.sort_unstable_by_key(|l| l.blob_file_id);
+        for link in links {
+            writer.link_blob_file(link.blob_file_id, link.len, link.bytes, link.on_disk_bytes);
+        }
         writer.finish()?;
     } else {
         drop(writer);
@@ -389,9 +1908,370 @@ fn salvage_blocks(
     Ok(SalvageWalk {
         blocks_total,
         blocks_salvaged,
+        blocks_copied_verbatim,
         entries_salvaged,
         dropped,
         wrote,
+    })
+}
+
+/// Why a blob (vlog) record could not be salvaged.
+#[derive(Debug, Clone)]
+pub enum BlobDropReason {
+    /// The record's stored checksum did not match its key + value bytes
+    /// (bit-rot). The walk re-syncs at the next record, so only this record is
+    /// lost.
+    ChecksumMismatch,
+    /// A structural failure (bad frame magic, header CRC, or a frame that runs
+    /// past the data section) that desynchronizes the record stream: the walk
+    /// cannot locate later records and stops at this point.
+    Corrupt(String),
+}
+
+/// A blob record the salvage walk could not recover.
+#[derive(Debug, Clone)]
+pub struct DroppedBlob {
+    /// Why the record was dropped.
+    pub reason: BlobDropReason,
+}
+
+/// The outcome of salvaging a single blob (vlog) file.
+///
+/// Inspect [`is_complete`](BlobSalvageReport::is_complete) to tell a clean
+/// recovery (every record re-emitted) from a lossy one; [`dropped`] lists what
+/// was lost. Always check [`salvaged_path`] before using the recovered copy.
+///
+/// [`dropped`]: BlobSalvageReport::dropped
+/// [`salvaged_path`]: BlobSalvageReport::salvaged_path
+#[derive(Debug)]
+pub struct BlobSalvageReport {
+    /// Path of the freshly written salvaged blob file, or `None` when no record
+    /// was recoverable and nothing was written.
+    pub salvaged_path: Option<PathBuf>,
+    /// Total records the walk inspected (recovered plus dropped).
+    pub records_total: usize,
+    /// Records successfully re-emitted into the salvaged blob file.
+    pub records_salvaged: usize,
+    /// `(source_offset, salvaged_offset)` for every re-emitted record, in walk
+    /// order. The salvaged file is written COMPACTED — after the first dropped
+    /// record every later record lands at a NEW offset — so existing SST
+    /// entries whose `ValueHandle::offset` points into the source file must be
+    /// remapped through this table before the salvaged file can replace the
+    /// original under the same id. A source offset absent from this map (and
+    /// implied by [`Self::dropped`]) is lost: its handle has no target.
+    pub offset_remap: Vec<(u64, u64)>,
+    /// Records the walk had to drop.
+    pub dropped: Vec<DroppedBlob>,
+}
+
+impl BlobSalvageReport {
+    /// Returns `true` when no record had to be dropped.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.dropped.is_empty()
+    }
+}
+
+/// Whether `entry`'s internal key sorts BEFORE `prev` under the blob-file order
+/// (ascending user key, ties broken by DESCENDING seqno, newest first). A `None`
+/// `prev` (the first accepted record) never regresses. The user-key ordering uses
+/// the tree's `comparator`, not raw bytes: a KV-separated tree may be configured
+/// with a reverse or otherwise non-lexicographic comparator, and a valid blob
+/// file from such a tree must not be judged as regressing.
+fn blob_key_regresses(
+    comparator: &crate::comparator::SharedComparator,
+    prev: Option<&(crate::UserKey, crate::SeqNo)>,
+    entry: &crate::vlog::blob_file::scanner::ScanEntry,
+) -> bool {
+    let Some((prev_key, prev_seqno)) = prev else {
+        return false;
+    };
+    match comparator.compare(entry.key.as_ref(), prev_key.as_ref()) {
+        core::cmp::Ordering::Less => true,
+        // Same user key: newest-first means the higher seqno comes first, so a
+        // seqno ABOVE the previous one at an equal key is out of order.
+        core::cmp::Ordering::Equal => entry.seqno > *prev_seqno,
+        core::cmp::Ordering::Greater => false,
+    }
+}
+
+/// Salvages the readable records of the blob (vlog) file at `source` into a fresh
+/// blob file at `dest`.
+///
+/// Where [`crate::repair`] rebuilds the blob-file *manifest* around whole files,
+/// this walks one blob file record by record and re-emits every record whose
+/// checksum verifies, recording the rest. Corruption that leaves the frame
+/// header intact (a checksum mismatch, or a header-CRC / structural break) makes
+/// the record stream re-synchronize at the next frame magic. That magic (and
+/// every frame chained after it) has an UNPROVEN boundary (it may be nested in
+/// the damaged frame's user bytes), so the walk drops the ENTIRE tail past the
+/// first resync (fail closed): the conservative loss is more than one record
+/// (as much as everything after the first damage), because a fabricated chain of
+/// checksum-valid frames is byte-for-byte indistinguishable from genuine ones
+/// and re-emitting it would forge records. Only the records BEFORE the first
+/// resync are re-emitted; a genuine truncation (a frame running past the data
+/// section) still terminates the walk cleanly.
+///
+/// `blob_file_id` is the source's id (its file name), recorded in the recovered
+/// file's metadata. The recovered file is written with no value compression, so
+/// a **compressed** source is rejected with [`Error::FeatureUnsupported`] rather
+/// than re-emitted under a mismatched descriptor (the scanner yields on-disk
+/// bytes; faithfully recompressing them is a separate step).
+///
+/// The salvaged file is written COMPACTED: after the first dropped record,
+/// every later record lands at a new offset, so it is **not a drop-in
+/// replacement** for the source while SST entries still hold
+/// `ValueHandle::offset` values into it. Re-target those handles through
+/// [`BlobSalvageReport::offset_remap`] first; a source offset absent from the
+/// map is a lost record.
+///
+/// [`Error::FeatureUnsupported`]: crate::Error::FeatureUnsupported
+///
+/// # Errors
+///
+/// Returns an error when `source` cannot be opened at all (its metadata / SFA
+/// trailer is unreadable), when it is a compressed blob file, or when writing
+/// `dest` fails. Per-record corruption is not an error: such records are dropped
+/// and listed in the returned [`BlobSalvageReport`].
+pub fn salvage_blob_file(
+    source: &std::path::Path,
+    dest: std::path::PathBuf,
+    fs: &alloc::sync::Arc<dyn crate::fs::Fs>,
+    blob_file_id: crate::vlog::BlobFileId,
+    comparator: &crate::comparator::SharedComparator,
+) -> crate::Result<BlobSalvageReport> {
+    use crate::vlog::blob_file::{scanner::Scanner, writer::Writer as BlobWriter};
+    use alloc::format;
+
+    // Read the source's metadata (only the TOC + meta section, NOT the data
+    // section, so a data-corrupt file still opens) to reject a compressed source:
+    // the scanner yields on-disk (compressed) bytes, and re-emitting them verbatim
+    // under a no-compression descriptor would store undecodable values. Fail
+    // closed, the same way SST salvage fails closed on range tombstones.
+    //
+    // A placeholder checksum is passed on purpose: `recover_blob_file` only STORES
+    // it (it never verifies the source against it), and only `compression()` is
+    // read from the handle. Computing the real whole-file digest here would stream
+    // every byte — including a persistently unreadable later frame or truncated
+    // tail sector — and abort before the scanner and writer are even created,
+    // making the valid-prefix recovery below unreachable. The salvaged dest gets
+    // its own digest on finish.
+    let source_handle =
+        crate::vlog::recover_blob_file(source, blob_file_id, crate::Checksum::from_raw(0), 0, fs)?;
+    if source_handle.compression() != crate::CompressionType::None {
+        return Err(crate::Error::FeatureUnsupported(
+            "salvage of a compressed blob file",
+        ));
+    }
+
+    let scanner = Scanner::new(source, &**fs, blob_file_id)?;
+    // Destination ownership is decided by the writer's `create_new` open, and
+    // the CONSTRUCTOR owns cleanup of any partial file it created: on a
+    // constructor error this call created nothing (or the constructor already
+    // removed it), so no caller-side cleanup — an existence pre-check here
+    // would race a concurrent creator (TOCTOU) and delete a file this salvage
+    // does not own. Later `write` / `finish` failures still clean up below:
+    // by then `create_new` has proven `dest` is ours.
+    // Blob salvage is a rare recovery operation, so sync at the strongest
+    // durability: the writer fsyncs the file's bytes and the parent directory is
+    // synced below, so the recovered file survives a power loss the moment the
+    // report claims success.
+    let sync_mode = crate::fs::SyncMode::Full;
+    let mut writer = BlobWriter::new(&dest, blob_file_id, 0, &**fs)?.use_sync_mode(sync_mode);
+
+    let mut records_total = 0usize;
+    let mut records_salvaged = 0usize;
+    let mut offset_remap: Vec<(u64, u64)> = Vec::new();
+    let mut dropped: Vec<DroppedBlob> = Vec::new();
+    // The internal key of the last record accepted for re-emit, to enforce the
+    // `BlobWriter` sorted-input contract on the salvaged file (see the accept
+    // arm). Blob files order by user key ascending, ties broken by DESCENDING
+    // seqno (newest first).
+    let mut prev_written: Option<(crate::UserKey, crate::SeqNo)> = None;
+    // Emit every recoverable record. A `write` failure here (not a per-record
+    // checksum/corruption drop, which the match arms absorb) is a hard error: it
+    // leaves a partial `dest`, removed on the error path below the same way the
+    // SST salvage path removes its partial output.
+    let walk = (|| -> crate::Result<()> {
+        for item in scanner {
+            records_total += 1;
+            match item {
+                // A frame the scanner reached at or after a byte-wise RESYNC has
+                // an UNPROVEN boundary: the resync magic may be an original frame
+                // boundary OR a checksum-valid `BLO4` frame nested inside the
+                // damaged frame's user-controlled value bytes, and every frame
+                // CHAINED past it inherits that unanchored start; the two are
+                // byte-for-byte indistinguishable. The taint is sticky, so this
+                // arm drops the ENTIRE tail after the first resync: re-emitting
+                // any of it would FABRICATE records (and bogus `offset_remap`
+                // entries pointing inside the damaged region), which is worse
+                // than losing the tail (fail closed on unprovable provenance).
+                Ok(entry) if entry.resynced => {
+                    // The taint is STICKY: every frame from here to EOF inherits the
+                    // same unprovable boundary, so the whole tail is surrendered.
+                    // Record the loss ONCE and STOP the walk. Continuing would
+                    // re-drop each tainted frame (wasted work plus an allocation per
+                    // record) and, worse, keep reading the already-surrendered tail,
+                    // where a TRANSIENT read fault would reach the transient-error
+                    // arm and abort the whole salvage, discarding the valid prefix
+                    // output that needed none of those bytes.
+                    let _ = entry;
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt(
+                            "tail surrendered at the first resync: every frame past a \
+                             damaged frame has an unprovable boundary, dropped as one"
+                                .to_string(),
+                        ),
+                    });
+                    break;
+                }
+                // A frame whose CRCs are internally consistent but whose
+                // key_len is ZERO is malformed input (the writer's ingest
+                // never emits an empty key and asserts against one): route it
+                // through the corrupt-record path — the scanner is already
+                // positioned past the frame, so the walk continues.
+                Ok(entry) if entry.key.is_empty() => {
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt("frame carries an empty key".to_string()),
+                    });
+                }
+                // A frame whose declared `real_val_len` disagrees with the
+                // bytes actually stored (`on_disk_val_len`; this path only
+                // salvages UNCOMPRESSED sources, so the two must be equal) is
+                // rejected by the live blob reader — re-emitting it would
+                // restamp a consistent length and launder a record live reads
+                // treat as corrupt. Drop it; the scanner is already past the
+                // frame, so the walk continues.
+                Ok(entry) if entry.uncompressed_len as usize != entry.value.len() => {
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt(
+                            "frame's declared value length disagrees with its stored bytes"
+                                .to_string(),
+                        ),
+                    });
+                }
+                // A frame whose internal key regresses below the last accepted
+                // record: `BlobWriter` requires records in key order (ascending
+                // user key, ties by descending seqno), and re-emitting an
+                // out-of-order frame would corrupt the salvaged file's key range
+                // and break the later merge scanner's per-reader sorted-input
+                // assumption (mismatched blob relocation, or a panic in the
+                // relocating compaction). The frame's own checksum is intact, so
+                // this is not payload rot; drop it and keep the sorted prefix.
+                Ok(entry) if blob_key_regresses(comparator, prev_written.as_ref(), &entry) => {
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt(
+                            "frame's internal key regresses below the previous salvaged \
+                             record; re-emitting it would violate the blob writer's \
+                             sorted-input contract"
+                                .to_string(),
+                        ),
+                    });
+                }
+                Ok(entry) => {
+                    // Record the frame relocation BEFORE the write advances the
+                    // writer: existing SST ValueHandles point at SOURCE frame
+                    // offsets, and the compacted rewrite shifts every record
+                    // after the first drop, so the caller needs this map to
+                    // re-target handles before the salvaged file can replace
+                    // the original.
+                    let salvaged_offset = writer.offset();
+                    writer.write(&entry.key, entry.seqno, &entry.value)?;
+                    offset_remap.push((entry.offset, salvaged_offset));
+                    prev_written = Some((entry.key.clone(), entry.seqno));
+                    records_salvaged += 1;
+                }
+                // Payload rot: the checksum failed, so the scanner RESYNCS at the
+                // next magic and arms the sticky taint. This record drops here;
+                // every frame after it comes back through the `resynced` arm
+                // above and drops too (the tail's provenance is now unprovable).
+                Err(crate::Error::ChecksumMismatch { .. }) => dropped.push(DroppedBlob {
+                    reason: BlobDropReason::ChecksumMismatch,
+                }),
+                // Header rot (rotted magic or a length field caught by the
+                // header CRC): the scanner has RESYNCHRONIZED at the next
+                // frame magic (arming the sticky taint, so the tail after it
+                // drops) or TERMINATED, when the CRC-vouched frame end overruns
+                // the data section (real truncation). Either way the walk is safe.
+                Err(
+                    e @ (crate::Error::HeaderCrcMismatch { .. } | crate::Error::InvalidHeader(_)),
+                ) => {
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt(format!("{e:?}")),
+                    });
+                }
+                // Only a TRANSIENT I/O error is retryable and distinguishable: it
+                // may strike AFTER at least one record was emitted, so recording
+                // it as corruption and finishing `dest` would publish a lossy
+                // report whose offset map silently omits the healthy UNREAD tail.
+                // Propagate it so the caller retries and the partial dest is
+                // discarded (below) rather than accepting avoidable data loss.
+                Err(crate::Error::Io(io)) if io.kind().is_transient() => {
+                    return Err(crate::Error::Io(io));
+                }
+                // Any other error — a PERSISTENT I/O failure (a bad-sector `Other`,
+                // `PermissionDenied`, or a truncated tail `UnexpectedEof`, none
+                // fixed by a retry), an allocation failure, or a decode fault the
+                // scanner does not re-sync from: an error that leaves the read
+                // position before `data_end` without terminating would make the
+                // iterator keep yielding it. Record the corrupt tail as a drop and
+                // stop the walk, keeping the valid prefix salvageable — this is
+                // the last record it can inspect.
+                Err(e) => {
+                    dropped.push(DroppedBlob {
+                        reason: BlobDropReason::Corrupt(format!("{e:?}")),
+                    });
+                    break;
+                }
+            }
+        }
+        Ok(())
+    })();
+
+    let salvaged_path = match walk {
+        // A write failed mid-walk: drop the writer and remove the partial dest
+        // before propagating, so a retry / repair caller never sees a half-written
+        // blob file.
+        Err(e) => {
+            drop(writer);
+            discard_partial(fs, &dest);
+            return Err(e);
+        }
+        Ok(()) if records_salvaged > 0 => {
+            // A `finish` failure likewise leaves a partial dest — remove it before
+            // propagating.
+            if let Err(e) = writer.finish() {
+                discard_partial(fs, &dest);
+                return Err(e);
+            }
+            // The writer synced the file's bytes; sync the parent directory too
+            // so the new directory entry is durable before the report claims
+            // success (without it a power loss can discard the entry). A bare
+            // relative `dest` has an EMPTY parent, so resolve it to the current
+            // directory first — otherwise the sync fails and this discards the
+            // recovered file. A sync failure removes the file and propagates, so
+            // a caller never sees a salvaged_path whose entry is not durable.
+            if let Err(e) = fs.sync_directory_with(entry_directory(&dest), sync_mode) {
+                discard_partial(fs, &dest);
+                return Err(e.into());
+            }
+            Some(dest)
+        }
+        // Nothing recoverable: `BlobWriter::new` created `dest`, so remove the
+        // empty placeholder a repair caller would otherwise re-quarantine.
+        Ok(()) => {
+            drop(writer);
+            discard_partial(fs, &dest);
+            None
+        }
+    };
+
+    Ok(BlobSalvageReport {
+        salvaged_path,
+        records_total,
+        records_salvaged,
+        offset_remap,
+        dropped,
     })
 }
 

--- a/src/salvage.rs
+++ b/src/salvage.rs
@@ -82,6 +82,14 @@ pub struct SalvageOptions {
     /// and its matching rows vanish from every prefix read.
     /// [`crate::repair`] passes the tree's configured extractor.
     pub prefix_extractor: Option<Arc<dyn crate::prefix::PrefixExtractor>>,
+    /// Shared live-progress counters the block walk ticks per inspected /
+    /// re-emitted / dropped block and per recovered row, or `None` (the
+    /// default) to skip publishing. [`crate::repair`] forwards the handle set
+    /// via [`Config::with_recovery_progress`](crate::Config::with_recovery_progress);
+    /// a standalone [`salvage_sst_with_options`] caller sets it directly and
+    /// polls [`RecoveryProgress::snapshot`](crate::RecoveryProgress::snapshot)
+    /// from another thread.
+    pub progress: Option<Arc<crate::RecoveryProgress>>,
 }
 
 /// Why a block could not be salvaged and had to be dropped.
@@ -894,6 +902,7 @@ fn salvage_attempt(
         comparator,
         !delete_mask_unpositionable,
         allow_verbatim,
+        options.progress.as_deref(),
     ) {
         Ok(walk) => walk,
         Err(e) => {
@@ -1083,12 +1092,60 @@ fn fold_blob_links(
         reason = "the delete mask exists only for columnar sources; without the feature the flag has no consumer"
     )
 )]
+/// The walk totals already published to a [`crate::RecoveryProgress`] handle,
+/// so each [`publish_progress`] call sends only the delta (the shared counters
+/// are cumulative across every table of one repair).
+#[derive(Default)]
+struct PublishedProgress {
+    blocks_scanned: usize,
+    blocks_recovered: usize,
+    blocks_dropped: usize,
+    blocks_healed: u64,
+    kvs: u64,
+    columns: u64,
+}
+
+/// Publishes the walk's running totals as deltas against `published`, then
+/// records them as published. A `None` handle is a no-op.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "a plain projection of the walk's running totals; bundling them into a struct would only rename the call sites"
+)]
+fn publish_progress(
+    progress: Option<&crate::RecoveryProgress>,
+    published: &mut PublishedProgress,
+    blocks_scanned: usize,
+    blocks_recovered: usize,
+    blocks_dropped: usize,
+    blocks_healed: u64,
+    kvs: u64,
+    columns: u64,
+) {
+    let Some(p) = progress else { return };
+    p.add_blocks(
+        (blocks_scanned - published.blocks_scanned) as u64,
+        (blocks_recovered - published.blocks_recovered) as u64,
+        (blocks_dropped - published.blocks_dropped) as u64,
+        blocks_healed - published.blocks_healed,
+    );
+    p.add_rows(kvs - published.kvs, columns - published.columns);
+    *published = PublishedProgress {
+        blocks_scanned,
+        blocks_recovered,
+        blocks_dropped,
+        blocks_healed,
+        kvs,
+        columns,
+    };
+}
+
 fn salvage_blocks(
     table: &crate::table::Table,
     mut writer: crate::table::Writer,
     comparator: &crate::comparator::SharedComparator,
     apply_delete_mask: bool,
     allow_verbatim: bool,
+    progress: Option<&crate::RecoveryProgress>,
 ) -> crate::Result<SalvageWalk> {
     use crate::table::block::ParsedItem;
     use alloc::format;
@@ -1097,6 +1154,9 @@ fn salvage_blocks(
     let mut blocks_salvaged = 0usize;
     let mut blocks_copied_verbatim = 0usize;
     let mut entries_salvaged = 0u64;
+    let mut blocks_healed = 0u64;
+    let mut columns_salvaged = 0u64;
+    let mut published = PublishedProgress::default();
     let mut dropped: Vec<DroppedBlock> = Vec::new();
     // Blob links DERIVED from the recovered entries' indirections, keyed by
     // blob file id — exact for the recovered copy (only emitted rows count).
@@ -1454,6 +1514,19 @@ fn salvage_blocks(
     blocks_total += dropped.len();
 
     for (block_handle, end_key) in items {
+        // Publish the previous iteration's outcome (top-of-loop so every
+        // `continue` path is covered; the totals-vs-published delta form makes
+        // the call idempotent per state).
+        publish_progress(
+            progress,
+            &mut published,
+            blocks_total,
+            blocks_salvaged,
+            dropped.len(),
+            blocks_healed,
+            entries_salvaged,
+            columns_salvaged,
+        );
         blocks_total += 1;
         let offset = *block_handle.offset();
 
@@ -1526,6 +1599,7 @@ fn salvage_blocks(
                             Ok(_) => {
                                 entries_salvaged += rows;
                                 blocks_salvaged += 1;
+                                columns_salvaged += batch.columns.len() as u64;
                                 fold_blob_links(&mut derived_blob_links, &block_links);
                             }
                             Err(
@@ -1570,6 +1644,7 @@ fn salvage_blocks(
                     // to decode. Only writer errors (I/O to the destination)
                     // stay hard errors.
                     Ok(mut sb) => {
+                        let ecc_healed = sb.ecc_recovered;
                         if !allow_verbatim {
                             sb.verbatim = None;
                         }
@@ -1652,8 +1727,12 @@ fn salvage_blocks(
                                         if verbatim {
                                             blocks_copied_verbatim += 1;
                                         }
+                                        if ecc_healed {
+                                            blocks_healed += 1;
+                                        }
                                         entries_salvaged += rows;
                                         blocks_salvaged += 1;
+                                        columns_salvaged += batch.columns.len() as u64;
                                         fold_blob_links(&mut derived_blob_links, &block_links);
                                     }
                                     Err(
@@ -1708,6 +1787,7 @@ fn salvage_blocks(
         // is re-emitted entry by entry from its healed payload.
         match table.salvage_load_block(&block_handle, crate::table::block::BlockType::Data) {
             Ok(mut sb) => {
+                let ecc_healed = sb.ecc_recovered;
                 if !allow_verbatim {
                     sb.verbatim = None;
                 }
@@ -1829,6 +1909,9 @@ fn salvage_blocks(
                                     if verbatim {
                                         blocks_copied_verbatim += 1;
                                     }
+                                    if ecc_healed {
+                                        blocks_healed += 1;
+                                    }
                                     entries_salvaged += count;
                                     blocks_salvaged += 1;
                                     fold_blob_links(&mut derived_blob_links, &block_links);
@@ -1886,6 +1969,18 @@ fn salvage_blocks(
         }
         prev_end = end_key.or(prev_end);
     }
+    // Final publish: the last iteration's outcome (the loop publishes at the
+    // TOP, so the tail is otherwise unaccounted).
+    publish_progress(
+        progress,
+        &mut published,
+        blocks_total,
+        blocks_salvaged,
+        dropped.len(),
+        blocks_healed,
+        entries_salvaged,
+        columns_salvaged,
+    );
 
     let wrote = blocks_salvaged > 0;
     if wrote {

--- a/src/salvage/tests.rs
+++ b/src/salvage/tests.rs
@@ -7025,6 +7025,7 @@ fn salvage_recovers_an_encrypted_sst_with_the_provider() -> crate::Result<()> {
         allow_delete_resurrection: false,
         sync_mode: crate::fs::SyncMode::Normal,
         prefix_extractor: None,
+        progress: None,
     };
     let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
     assert_eq!(
@@ -7119,6 +7120,7 @@ fn salvage_recovers_a_dictionary_sst_with_the_dictionary() -> crate::Result<()> 
         allow_delete_resurrection: false,
         sync_mode: crate::fs::SyncMode::Normal,
         prefix_extractor: None,
+        progress: None,
     };
     let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
     assert_eq!(
@@ -7206,6 +7208,7 @@ fn salvage_recovers_an_encrypted_sst_with_a_nonzero_table_id() -> crate::Result<
         allow_delete_resurrection: false,
         sync_mode: crate::fs::SyncMode::Normal,
         prefix_extractor: None,
+        progress: None,
     };
     let recovered_wrong = salvage_sst_with_options(&source, dest.clone(), &fs, &wrong)
         .map_or(0, |r| r.entries_salvaged);
@@ -7224,6 +7227,7 @@ fn salvage_recovers_an_encrypted_sst_with_a_nonzero_table_id() -> crate::Result<
         allow_delete_resurrection: false,
         sync_mode: crate::fs::SyncMode::Normal,
         prefix_extractor: None,
+        progress: None,
     };
     let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
     assert_eq!(

--- a/src/salvage/tests.rs
+++ b/src/salvage/tests.rs
@@ -1,4 +1,9 @@
-use super::{DropReason, salvage_sst};
+use super::{BlobDropReason, DropReason, salvage_blob_file, salvage_sst};
+// The options-bearing entry is exercised on every feature set: the
+// prefix-extractor round-trip below is ungated (extractors are core
+// configuration), so the import must not hide behind the encrypted /
+// dictionary / delete-resurrection gates its other consumers carry.
+use super::{SalvageOptions, salvage_sst_with_options};
 use crate::comparator::default_comparator;
 use crate::fs::{Fs, StdFs};
 use crate::table::{Table, Writer};
@@ -6,6 +11,2327 @@ use crate::{InternalValue, ValueType};
 use alloc::sync::Arc;
 use tempfile::tempdir;
 use test_log::test;
+
+/// Rot in a frame's length field is caught by the header CRC, after which the
+/// consumed lengths cannot locate the next frame: the salvage walk resyncs at
+/// the next magic instead of stopping. But the resync magic may be an original
+/// boundary OR a `BLO4` frame nested in the rotted frame's user bytes, and every
+/// frame CHAINED past it inherits that unproven anchor: a fabricated chain can
+/// plant one valid frame after another. There is no independent anchor
+/// mid-stream, so the taint is STICKY: the whole tail after the first resync is
+/// dropped (fail closed), not just the frame reached immediately by the scan.
+#[test]
+fn salvage_blob_file_drops_the_whole_tail_after_a_resync() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_rot");
+    let dest = dir.path().join("blob_rot_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    build_blob(
+        &source,
+        &fs,
+        &[
+            (b"aaaa", b"AAAAAAAA"),
+            (b"bbbb", b"BBBBBBBB"),
+            (b"cccc", b"CCCCCCCC"),
+            (b"dddd", b"DDDDDDDD"),
+        ],
+    )?;
+
+    // Rot the SECOND frame's key_len (4 -> 6). Frame layout: magic 4 |
+    // checksum 16 | seqno 8 | key_len 2 | real_val_len 4 | on_disk_val_len 4
+    // | header_crc 4 | key | value = 42 + 4 + 8 bytes; the data section
+    // starts at file offset 0.
+    let frame_len = 42 + 4 + 8;
+    let kl_off = frame_len + 4 + 16 + 8;
+    let mut bytes = std::fs::read(&source)?;
+    let Some(slot) = bytes.get_mut(kl_off..kl_off + 2) else {
+        panic!("second frame's key_len within the file");
+    };
+    slot.copy_from_slice(&6u16.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest, &fs, 0, &default_comparator())?;
+    // aaaa recovered; bbbb drops (header CRC) and arms the resync taint; cccc is
+    // the first frame reached by the byte scan (unproven boundary). The taint is
+    // sticky, so the walk STOPS there and reports the whole surrendered tail
+    // (cccc and everything chained past it) as ONE drop. Only the frame BEFORE the
+    // rot survives.
+    assert_eq!(
+        report.records_salvaged, 1,
+        "only the frame before the rot is provable; the whole tail after the resync drops: {report:?}",
+    );
+    assert!(
+        report
+            .dropped
+            .iter()
+            .any(|d| matches!(&d.reason, BlobDropReason::Corrupt(msg) if msg.contains("HeaderCrcMismatch"))),
+        "the rotted frame drops as a header CRC mismatch: {report:?}",
+    );
+    assert_eq!(
+        report
+            .dropped
+            .iter()
+            .filter(
+                |d| matches!(&d.reason, BlobDropReason::Corrupt(msg) if msg.contains("surrendered"))
+            )
+            .count(),
+        1,
+        "the surrendered tail is recorded ONCE, not per tainted frame: {report:?}",
+    );
+
+    // The recovered copy carries only the single provable record.
+    let Some(salvaged) = report.salvaged_path else {
+        panic!("one record was salvaged");
+    };
+    let keys: Vec<Vec<u8>> = BlobScanner::new(&salvaged, &*fs, 0)?
+        .map(|r| r.map(|e| e.key.to_vec()))
+        .collect::<crate::Result<_>>()?;
+    assert_eq!(keys, vec![b"aaaa".to_vec()]);
+    Ok(())
+}
+
+/// A forged `tli_tail` that DROPS a handle passes every byte-level check
+/// (fresh checksum, valid framing, Index role): a walk following the tail
+/// would silently skip the hidden block and "recover" a copy missing its
+/// keys — no drop, no error, just vanished rows. Pins that the salvage open
+/// walks the HEAD `tli` copy, so a forged tail cannot steer which blocks
+/// are recovered.
+#[test]
+fn salvage_recovers_all_blocks_under_a_forged_tli_tail() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Tiny block budget so the SST spills several data blocks (several TLI
+    // handles — the forge needs at least two).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    crate::test_forge::forge_tli_tail_truncated(&source, 0, None)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.dropped.is_empty(),
+        "every block is intact, nothing may drop: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 64,
+        "the block the forged tail hides must still be recovered: {report:?}",
+    );
+    Ok(())
+}
+
+/// BOTH TLI mirrors forged to the SAME truncated handle list pass every
+/// byte-level check AND the mirror comparison (two forged copies prove
+/// nothing), so the salvage open's block index simply omits the hidden
+/// block. A walk trusting that index neither recovers the block nor
+/// reports it dropped — repair then installs an apparently complete copy
+/// with the block's keys silently missing. The physical data-section
+/// tiling is the only ground truth: salvage must frame and recover the
+/// bytes the index does not cover.
+#[test]
+fn salvage_recovers_a_block_hidden_by_forged_tli_mirrors() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Tiny block budget so the SST spills several data blocks (several TLI
+    // handles — the forge needs at least two).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    crate::test_forge::forge_tli_mirrors_truncated(&source, 0, None)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.dropped.is_empty(),
+        "every block is intact, nothing may drop: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 64,
+        "the block both forged mirrors hide must still be recovered: {report:?}",
+    );
+    Ok(())
+}
+
+/// BOTH TLI mirrors re-encoded with the first two handles SWAPPED keep
+/// every block present and the section fully covered — but the stored
+/// order is no longer the offset order the physical tiling assumes. A
+/// tiling pass trusting that order frames the out-of-place block through
+/// the gap probe AND pushes its handle again: the duplicate emit is
+/// rejected by the writer's ordering validation, so an intact block is
+/// reported dropped and the block totals are inflated. The tiling must
+/// re-sort by offset and skip spans it already covered.
+#[test]
+fn salvage_recovers_all_blocks_under_a_reordered_tli() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    crate::test_forge::forge_tli_mirrors_swap_first_two(&source, 0, None)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.dropped.is_empty(),
+        "every block is intact and covered once, nothing may drop: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 64,
+        "a reordered index must not double-walk or lose blocks: {report:?}",
+    );
+    Ok(())
+}
+
+/// A partitioned index whose MIDDLE leaf partition is corrupt yields only the
+/// earlier partitions' handles before erroring, setting `index_broken`. The
+/// physical data section is still intact, writer-ordered, and self-framing, so
+/// salvage must walk it independently and recover EVERY data block instead of
+/// re-emitting only the enumerated prefix and silently dropping the failed and
+/// later partitions' blocks.
+#[test]
+fn salvage_recovers_physical_blocks_past_a_broken_index_partition() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Tiny data blocks + a partitioned index spread the 256 blocks across
+    // several leaf partitions (no range tombstone, so salvage re-emits rather
+    // than failing closed).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(128)
+        .use_partitioned_index();
+    for i in 0u64..256 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Corrupt the middle of the `index` section (a leaf partition), desyncing
+    // the handle enumeration partway while leaving the data section intact.
+    let (index_pos, index_len) = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = crate::sfa::Reader::from_reader(&mut f)?;
+        let Some((pos, len)) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"index")
+            .map(|e| (e.pos(), e.len()))
+        else {
+            panic!("a partitioned-index SST must carry an index section");
+        };
+        (pos, len)
+    };
+    let Ok(flip) = usize::try_from(index_pos + index_len / 2) else {
+        panic!("the index-section offset fits usize");
+    };
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 256,
+        "every data block must be recovered via the physical walk when the \
+         index enumeration breaks: {report:?}",
+    );
+    // The index enumeration broke, but the physical walk recovered every data
+    // block: that structural index damage is NOT data loss, so the report must
+    // grade complete rather than counting the index error as a dropped block.
+    assert!(
+        report.is_complete(),
+        "a broken index the physical walk fully recovers around is not data loss: {report:?}",
+    );
+    Ok(())
+}
+
+/// A range tombstone hidden by RENAMING its section to a recognized name whose
+/// block decodes cleanly (here an empty `filter`, since filtering is disabled)
+/// must fail salvage closed. The rename keeps the catalogue uniquely named and
+/// tiled and the block loads without degrading, so neither the TOC-concealment
+/// check nor the rebuildable-section degradation flag fires — but the persisted
+/// `range_tombstone_count` still records the tombstone, so salvage cross-checks
+/// it and refuses rather than re-emitting the covered keys as live.
+#[test]
+fn salvage_refuses_a_range_tombstone_hidden_as_a_recognized_section() -> crate::Result<()> {
+    use crate::UserKey;
+    use crate::config::BloomConstructionPolicy;
+    use crate::range_tombstone::RangeTombstone;
+    use crate::table::block::BlockType;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Filtering disabled, so renaming range_tombstones to `filter` yields a
+    // UNIQUE recognized name (no existing filter to duplicate).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_bloom_policy(BloomConstructionPolicy::BitsPerKey(0.0));
+    for i in 0u64..8 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    writer.write_range_tombstone(RangeTombstone::new(
+        UserKey::from(b"key-002".as_slice()),
+        UserKey::from(b"key-005".as_slice()),
+        9,
+    ));
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Rename range_tombstones -> filter and re-role its block to Filter: the
+    // block loads as a (garbage) filter WITHOUT degrading, so the
+    // rebuildable-section flag stays clear and the parsed table reports no range
+    // tombstones — but the persisted count still records them.
+    crate::test_forge::forge_duplicate_section_name(
+        &source,
+        b"range_tombstones",
+        b"filter",
+        BlockType::Filter,
+    )?;
+
+    let Err(err) = salvage_sst(&source, dest, &fs) else {
+        panic!("a hidden range tombstone must fail salvage");
+    };
+    let crate::Error::FeatureUnsupported(reason) = &err else {
+        panic!("the refusal must be FeatureUnsupported, got {err:?}");
+    };
+    assert!(
+        reason.contains("range tombstones"),
+        "the refusal must name range tombstones specifically, got {reason:?}",
+    );
+    Ok(())
+}
+
+/// When the index is UNTRUSTED (its mirror comparison, binary-index
+/// authentication, or section tiling fails), an indexed offset is no more
+/// provable than a byte-scanned one: a checksum-restamped TLI could point a
+/// handle at a frame nested inside a corrupt block's value bytes. So once the
+/// physical chain breaks, later indexed handles must be dropped too — the walk
+/// recovers only the anchored prefix. (With a TRUSTED index the same corruption
+/// stays block-granular; that path is covered by the recovery tests.)
+#[test]
+fn salvage_drops_indexed_blocks_after_a_break_when_the_index_is_untrusted() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(128)
+        .use_partitioned_index();
+    for i in 0u64..256 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Resolve a middle block offset BEFORE forging (data blocks precede the TLI,
+    // so the TLI forge below leaves this offset valid).
+    let smash_offset = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|h| *h.as_ref().offset())
+            .collect();
+        let Some(&off) = offsets.get(offsets.len() / 2) else {
+            panic!("need several data blocks, got {}", offsets.len());
+        };
+        off
+    };
+
+    // Corrupt the tli_tail mirror so it disagrees with the head: the index
+    // structure no longer authenticates (the mirrors diverge — exactly a
+    // checksum-restamped-TLI signal), though head enumeration still yields
+    // every handle.
+    crate::test_forge::forge_flip_section_last_payload_byte(&source, b"tli_tail", None)?;
+
+    // Smash the header of the middle data block: the physical chain breaks there.
+    {
+        let mut bytes = std::fs::read(&source)?;
+        let Ok(at) = usize::try_from(smash_offset) else {
+            panic!("data block offset {smash_offset} fits usize");
+        };
+        let Some(b) = bytes.get_mut(at) else {
+            panic!("the block header at {at} lies within the file");
+        };
+        *b ^= 0xFF;
+        std::fs::write(&source, &bytes)?;
+    }
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+
+    // The anchored prefix before the smash recovers.
+    assert!(
+        reopen_get(dest.clone(), &fs, b"key-000")?.is_some(),
+        "the contiguous prefix before the broken chain must recover: {report:?}",
+    );
+    // A key in a block AFTER the smash is reachable only through its UNTRUSTED
+    // index entry, past a broken boundary — it must NOT be re-emitted.
+    assert!(
+        reopen_get(dest, &fs, b"key-250")?.is_none(),
+        "an indexed block after a broken chain, under an untrusted index, must \
+         be dropped, not emitted: {report:?}",
+    );
+    assert!(
+        report.dropped.iter().any(|d| matches!(
+            &d.reason,
+            DropReason::HeaderCorrupted(msg) if msg.contains("broken")
+        )),
+        "the surrendered tail must be reported as a broken-chain drop: {report:?}",
+    );
+    Ok(())
+}
+
+/// A PERSISTENT read failure on one block (a bad-sector `Other` / EIO, or a
+/// truncated final block) must drop just that block, not abort the whole salvage
+/// — otherwise one unreadable block sinks every intact sibling. Only a TRANSIENT
+/// read aborts for a retry. The victim block's positioned read faults once with a
+/// persistent kind; the rest of the file is intact.
+#[test]
+fn salvage_drops_a_persistently_unreadable_block_and_keeps_the_rest() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let clean: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer =
+        Writer::new(source.clone(), 0, 0, Arc::clone(&clean))?.use_data_block_size(128);
+    for i in 0u64..256 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Resolve a MIDDLE data block's offset.
+    let victim_offset = {
+        let table = open(source.clone(), &clean)?;
+        let offsets: Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|h| *h.as_ref().offset())
+            .collect();
+        let Some(&off) = offsets.get(offsets.len() / 2) else {
+            panic!("need several data blocks, got {}", offsets.len());
+        };
+        off
+    };
+
+    // Salvage through a fs whose positioned read of that ONE block ALWAYS fails
+    // (a persistent bad sector); every read at a different offset succeeds.
+    let fault = FaultFs::new(StdFs);
+    fault.injector().arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other)).at_offset(victim_offset),
+    );
+    let faulting: Arc<dyn Fs> = Arc::new(fault);
+
+    // Before the fix this aborted (`Err`); now it recovers, dropping just the
+    // unreadable block. (The trusted index resolves the probe failure to a
+    // broken-boundary drop rather than a ReadError, but the point is that ONE
+    // unreadable block no longer sinks the salvage.)
+    let report = salvage_sst(&source, dest.clone(), &faulting)?;
+    assert!(
+        !report.dropped.is_empty(),
+        "a persistently unreadable block must be dropped, not abort the salvage: {report:?}",
+    );
+    assert!(
+        report.blocks_salvaged >= report.blocks_total - report.dropped.len(),
+        "every block except the dropped one is salvaged: {report:?}",
+    );
+    assert!(
+        reopen_get(dest, &clean, b"key-000")?.is_some(),
+        "an intact block must still be recovered past the dropped one: {report:?}",
+    );
+    Ok(())
+}
+
+/// When the broken-index physical walk hits an UNFRAMEABLE block header, the
+/// bytes after it are reachable only by byte-scan resync, so their block
+/// boundaries are unprovable: an uncompressed block can carry a complete
+/// checksum-valid SST block inside a user value, and a resync would frame that
+/// NESTED forge and re-emit its interior entries as genuine data. The walk must
+/// fail closed like the blob resync path — drop the whole gap tail after the
+/// broken boundary rather than emit unanchored candidates. Only the contiguous,
+/// fully-framed prefix (anchored to the trusted section start) is recovered.
+#[test]
+fn salvage_drops_the_gap_tail_after_an_unframeable_block() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(128)
+        .use_partitioned_index();
+    for i in 0u64..256 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Smash the header of a block in the FIRST THIRD of the data section (its
+    // first byte, so `probe_block_handle_at` cannot frame it). The blocks after
+    // it are reachable only by resync, so they must be dropped, not emitted.
+    let smash_offset = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|h| *h.as_ref().offset())
+            .collect();
+        let Some(&off) = offsets.get(offsets.len() / 3) else {
+            panic!("need several data blocks, got {}", offsets.len());
+        };
+        off
+    };
+    {
+        let mut bytes = std::fs::read(&source)?;
+        let Ok(at) = usize::try_from(smash_offset) else {
+            panic!("data block offset {smash_offset} fits usize");
+        };
+        let Some(b) = bytes.get_mut(at) else {
+            panic!("the block header at {at} lies within the file");
+        };
+        *b ^= 0xFF;
+        std::fs::write(&source, &bytes)?;
+    }
+
+    // Corrupt the `index` section so enumeration breaks and the physical walk
+    // tiles the whole data section from the start.
+    let (index_pos, index_len) = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = crate::sfa::Reader::from_reader(&mut f)?;
+        let Some((pos, len)) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"index")
+            .map(|e| (e.pos(), e.len()))
+        else {
+            panic!("a partitioned-index SST must carry an index section");
+        };
+        (pos, len)
+    };
+    let Ok(flip) = usize::try_from(index_pos + index_len / 2) else {
+        panic!("the index-section offset fits usize");
+    };
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+
+    // The anchored prefix (contiguous from the trusted section start) recovers.
+    assert!(
+        reopen_get(dest.clone(), &fs, b"key-000")?.is_some(),
+        "the contiguous prefix before the broken boundary must recover: {report:?}",
+    );
+    // A late key past the smashed block is reachable only by resync, so it must
+    // NOT be re-emitted — its boundary cannot be proven original.
+    assert!(
+        reopen_get(dest, &fs, b"key-250")?.is_none(),
+        "a block reached only by resync must be dropped, not emitted: {report:?}",
+    );
+    // The dropped tail is reported once with the unanchored reason.
+    assert!(
+        report.dropped.iter().any(|d| matches!(
+            &d.reason,
+            DropReason::HeaderCorrupted(msg) if msg.contains("unanchored")
+        )),
+        "the resync tail must be reported as an unanchored drop: {report:?}",
+    );
+    Ok(())
+}
+
+/// A header-checksum-valid FAKE header can declare an oversized `data_length`
+/// that spans the real blocks after it. The walk LOADS each candidate so it
+/// never advances by the unvalidated framed size, but the load failure it hits
+/// at the fake header breaks the contiguous chain: the swallowed span is then
+/// reachable only by byte-scan resync, whose boundaries are unprovable (a
+/// nested checksum-valid frame in a user value is indistinguishable from a real
+/// block). The walk must fail closed — drop the tail past the fake header
+/// rather than resync into it. The anchored prefix before the forge recovers.
+#[test]
+fn salvage_drops_the_tail_past_a_fake_oversized_block_header() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(128)
+        .use_partitioned_index();
+    for i in 0u64..256 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Re-stamp a block a quarter of the way in so its header FRAMES (valid
+    // header checksum) but claims a size reaching the three-quarter mark — a
+    // fake oversized header whose enlarged payload cannot load. The blocks it
+    // swallows hold real, mid-table keys.
+    let (forge_off, forged_end) = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|h| *h.as_ref().offset())
+            .collect();
+        let n = offsets.len();
+        assert!(n >= 8, "need several data blocks, got {n}");
+        let (Some(&off), Some(&end)) = (offsets.get(n / 4), offsets.get(3 * n / 4)) else {
+            panic!("the quarter and three-quarter block boundaries exist");
+        };
+        (off, end)
+    };
+    crate::test_forge::forge_data_block_oversized_header(&source, forge_off, forged_end)?;
+
+    // Corrupt the `index` section so enumeration breaks and the physical walk
+    // tiles the whole data section, reaching the fake header.
+    let (index_pos, index_len) = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = crate::sfa::Reader::from_reader(&mut f)?;
+        let Some((pos, len)) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"index")
+            .map(|e| (e.pos(), e.len()))
+        else {
+            panic!("a partitioned-index SST must carry an index section");
+        };
+        (pos, len)
+    };
+    let Ok(flip) = usize::try_from(index_pos + index_len / 2) else {
+        panic!("the index-section offset fits usize");
+    };
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+
+    // The anchored prefix before the forge (a quarter of the way in) recovers.
+    assert!(
+        reopen_get(dest.clone(), &fs, b"key-010")?.is_some(),
+        "the contiguous prefix before the fake header must recover: {report:?}",
+    );
+    // A key inside the swallowed span is reachable only by resync past the fake
+    // header, so it must NOT be re-emitted.
+    assert!(
+        reopen_get(dest, &fs, b"key-128")?.is_none(),
+        "a block reached only by resync past the fake header must drop: {report:?}",
+    );
+    // Only the anchored prefix survives, so the count reflects the first
+    // quarter, not the near-full 256 an unbounded resync would emit.
+    assert!(
+        report.entries_salvaged < 200,
+        "the resync tail must not be recovered, got {} of 256: {report:?}",
+        report.entries_salvaged,
+    );
+    assert!(
+        report.dropped.iter().any(|d| matches!(
+            &d.reason,
+            DropReason::HeaderCorrupted(msg) if msg.contains("unanchored")
+        )),
+        "the swallowed tail must be reported as an unanchored drop: {report:?}",
+    );
+    Ok(())
+}
+
+/// An INTERIOR handle omitted from both forged mirrors leaves the hidden
+/// block between two indexed neighbours, exercising the mid-list gap
+/// probe (the truncated-mirror sibling only covers the section-tail
+/// probe). The block must be framed from the physical tiling and
+/// recovered like any indexed block.
+#[test]
+fn salvage_recovers_an_interior_block_hidden_by_forged_tli_mirrors() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    crate::test_forge::forge_tli_mirrors_drop_interior(&source, 0, None)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.dropped.is_empty(),
+        "every block is intact, nothing may drop: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 64,
+        "the interior block both forged mirrors hide must still be recovered: {report:?}",
+    );
+    Ok(())
+}
+
+/// BOTH TLI mirrors re-encoded as a SINGLE handle spanning the whole data
+/// section pass the cumulative tiling (one span covers the section), the
+/// mirror comparison, and the separator cross-check (only the FIRST
+/// payload decodes; the tail reads as an unrecognized trailer on a
+/// non-ECC block) — yet every later physical block is unreachable through
+/// the index, so reads silently miss its keys after the table is
+/// accepted. Each handle must frame EXACTLY one physical block.
+#[test]
+fn verify_tli_mirrors_rejects_a_section_spanning_handle() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Sanity: the intact table passes the mirror gate.
+    open(source.clone(), &fs)?.verify_tli_mirrors()?;
+
+    crate::test_forge::forge_tli_mirrors_span_single_handle(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    // Match the frame-check reason specifically: the gate returns several
+    // distinct InvalidHeader reasons, and an unrelated one would keep this
+    // green without proving the per-handle physical-frame check ran.
+    let Err(err) = table.verify_tli_mirrors() else {
+        panic!("a handle spanning several physical blocks must fail the mirror gate");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "an index handle's size disagrees with its block's physical frame"
+            )
+        ),
+        "the spanning handle must be rejected by the physical-frame check, got {err:?}",
+    );
+    Ok(())
+}
+
+/// BOTH TLI mirrors re-encoded as a SINGLE handle spanning the whole data
+/// section must not blind the SALVAGE walk: advancing the physical cursor
+/// by the untrusted indexed size skips every later block, and the oversized
+/// non-ECC handle still decodes its first payload — one block "salvaged",
+/// zero drops, and repair installs a copy with the rest silently lost. The
+/// tiler must trust each handle's span only after the block's own header
+/// confirms it, falling back to the physically framed span otherwise.
+#[test]
+fn salvage_recovers_all_blocks_under_a_section_spanning_handle() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    crate::test_forge::forge_tli_mirrors_span_single_handle(&source, 0)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.dropped.is_empty(),
+        "every block is intact, nothing may drop: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 64,
+        "the blocks a spanning handle hides must still be recovered: {report:?}",
+    );
+    Ok(())
+}
+
+/// An index handle whose offset sits BEYOND the data section (a checksum-
+/// repatched / forged entry) must not set the gap-probe's upper bound: probing
+/// the range from the cursor up to that out-of-section offset would scan past
+/// the section, potentially to an attacker-controlled `u64` (an unbounded hang,
+/// and later SST sections read as candidate data frames). The tiler must skip
+/// the out-of-section handle and bound the walk by the section end.
+#[test]
+fn salvage_ignores_an_index_handle_beyond_the_data_section() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    let n = 64u32;
+    for i in 0..u64::from(n) {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Append an index handle at u64::MAX/2 (far past the data section). The real
+    // handles stay intact, so a walk that bounds the gap probe to the section
+    // recovers every block and finishes; the pre-fix walk scans up to the bogus
+    // offset instead. The nextest slow-timeout terminates a hang, so completing
+    // at all — with the full key range recovered — is the proof.
+    crate::test_forge::forge_tli_mirrors_offset_beyond_section(&source, 0)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n),
+        "every real block is recovered once the out-of-section handle is skipped: {report:?}",
+    );
+    assert!(
+        reopen_get(dest, &fs, b"key-060")?.is_some(),
+        "a late key must survive the bounded walk: {report:?}",
+    );
+    Ok(())
+}
+
+/// A cleanly enumerated index handle whose block header does NOT frame and
+/// whose stored span is oversized (a spanning forge with a smashed header)
+/// must not advance the physical cursor by that UNVERIFIED size: trusting it
+/// covers the whole remaining data section, hiding later blocks from the gap
+/// walk. The tiler leaves the cursor where it is and lets the physical walk
+/// tile the gap, but the smashed header breaks the contiguous chain at the
+/// section start, so the tail is reachable only by unprovable byte-scan resync.
+/// The walk must fail closed and drop that tail rather than emit it.
+#[test]
+fn salvage_drops_the_tail_after_an_unframeable_oversized_handle() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Resolve the FIRST data block's offset (the block the spanning handle
+    // keeps) BEFORE the forge — the data section is first, so the tli rewrite
+    // that follows only shifts later sections and leaves this offset valid.
+    let first_off = {
+        let table = open(source.clone(), &fs)?;
+        let Some(off) = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|h| *h.as_ref().offset())
+            .next()
+        else {
+            panic!("the source carries data blocks");
+        };
+        off
+    };
+
+    // Collapse both TLI mirrors into ONE handle spanning the whole data section
+    // (size = sum of every block size), then smash that block's header first
+    // byte so it cannot frame: the handle enumerates cleanly through the
+    // mirror gate, but its oversized span is now UNVERIFIABLE.
+    crate::test_forge::forge_tli_mirrors_span_single_handle(&source, 0)?;
+    {
+        let mut bytes = std::fs::read(&source)?;
+        let Ok(at) = usize::try_from(first_off) else {
+            panic!("data block offset {first_off} fits usize");
+        };
+        let Some(b) = bytes.get_mut(at) else {
+            panic!("the block header lies within the file");
+        };
+        *b ^= 0xFF;
+        std::fs::write(&source, &bytes)?;
+    }
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+
+    // The smashed header is the FIRST data block, so the contiguous chain never
+    // starts: the whole section is reachable only by unprovable resync and must
+    // drop. Nothing is recovered, so no salvaged table is written.
+    assert_eq!(
+        report.entries_salvaged, 0,
+        "nothing is anchored, so no entry is recovered: {report:?}",
+    );
+    assert!(
+        !dest.exists(),
+        "an all-dropped section produces no salvaged table: {report:?}",
+    );
+    assert!(
+        report.dropped.iter().any(|d| matches!(
+            &d.reason,
+            DropReason::HeaderCorrupted(msg) if msg.contains("broken")
+        )),
+        "the dropped section must be reported as a broken-chain drop: {report:?}",
+    );
+    Ok(())
+}
+
+/// A forged `data` SFA-section length whose `pos + len` OVERFLOWS `u64` breaks
+/// the TOC tiling: the catalogue can no longer prove that no deletion section is
+/// concealed, so standalone salvage fails CLOSED, the same decision repair
+/// reaches by quarantining such a table. It must reject PROMPTLY (the coverage
+/// check reads the TOC, never scans to the overflowed bound), so the hang the
+/// naive byte-at-a-time resync would suffer is avoided by refusing before the
+/// walk rather than by tiling to a rejected bound.
+#[test]
+fn salvage_refuses_an_overflowing_data_section() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    let n = 64u32;
+    for i in 0..u64::from(n) {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Forge the `data` section's advertised length to `u64::MAX` so its end
+    // overflows: the tiling can no longer be proven, so a deletion section could
+    // be hidden behind the oversized span.
+    crate::test_forge::forge_section_len(&source, b"data", u64::MAX)?;
+
+    // The nextest slow-timeout terminates a hang; a prompt error (before any
+    // scan to the overflowed bound) is the proof the coverage check rejected
+    // the catalogue instead of tiling to it.
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("an overflowing data section must fail salvage closed");
+    };
+    assert!(
+        matches!(err, crate::Error::FeatureUnsupported(msg) if msg.contains("TOC may hide a deletion section")),
+        "the refusal must name the TOC-coverage gate, not any other refusal, got {err:?}",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "no salvaged copy is produced when the catalogue may hide a deletion",
+    );
+    Ok(())
+}
+
+/// A source whose `seqno_bounds` section is PRESENT but does not decode must
+/// fail SALVAGE closed on a table that exposes NO deletion metadata: a
+/// re-stamped TOC can rename a `range_tombstones` / `delete_bitmap` section to
+/// `seqno_bounds` and re-role its block, leaving a uniquely named, tiled
+/// catalogue whose parsed table reports no deletion. Salvage re-derives the
+/// seqno bounds from the recovered entries, so it would discard that section
+/// and re-emit the suppressed rows as live. A genuinely rotted seqno-bounds
+/// section is indistinguishable from the relabel, so both fail closed; the
+/// operator recovers the quarantined original by hand.
+#[test]
+fn salvage_refuses_a_corrupt_seqno_bounds_that_may_hide_a_deletion() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_seqno_in_index(true);
+    for i in 0u64..50 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Rot one payload byte of the seqno_bounds block WITHOUT re-stamping its
+    // checksum: the recover-time load fails and degrades the map to empty.
+    {
+        let pos = {
+            let mut f = std::fs::File::open(&source)?;
+            let reader = match crate::sfa::Reader::from_reader(&mut f) {
+                Ok(r) => r,
+                Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+            };
+            let Some(entry) = reader.toc().iter().find(|e| e.name() == b"seqno_bounds") else {
+                panic!("the source carries a seqno_bounds section");
+            };
+            let Ok(pos) = usize::try_from(entry.pos()) else {
+                panic!("pos fits usize");
+            };
+            pos
+        };
+        let mut bytes = std::fs::read(&source)?;
+        // Past the block header, inside the payload.
+        let at = pos + 40;
+        let Some(slot) = bytes.get_mut(at) else {
+            panic!("payload byte within the file");
+        };
+        *slot ^= 0xFF;
+        std::fs::write(&source, bytes)?;
+    }
+
+    // Salvage fails closed: the seqno-bounds section did not decode and the
+    // table exposes no deletion, so it may be a relabeled deletion salvage
+    // would discard — quarantine for manual recovery instead of resurrecting
+    // rows.
+    let Err(err) = salvage_sst(&source, dest, &fs) else {
+        panic!("a corrupt seqno-bounds section with no visible deletion must fail salvage");
+    };
+    assert!(
+        matches!(err, crate::Error::FeatureUnsupported(_)),
+        "the refusal names the unsupported salvage, got {err:?}",
+    );
+    Ok(())
+}
+
+/// When BOTH meta mirrors decode under the expected id but DIVERGE (a forged,
+/// internally-consistent tail: `compression#data` re-stamped None -> Lz4,
+/// `meta_mid` untouched), the tail-first open decodes every data block under
+/// the wrong codec, drops them all, and repair would quarantine a table whose
+/// intact MID mirror recovers everything. Salvage must arbitrate the mirrors
+/// and keep the attempt that recovers more.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_arbitrates_divergent_meta_mirrors() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Forge the TAIL meta's data-block compression from the written None
+    // (tag 0) to Lz4 (tag 1) — fresh block checksum, `meta_mid` untouched.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(report.blocks_total > 0, "the walk saw the data blocks");
+    assert_eq!(
+        report.blocks_salvaged, report.blocks_total,
+        "every block is recoverable through the intact MID mirror: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "all rows recovered: {report:?}"
+    );
+    assert!(
+        report.dropped.is_empty(),
+        "nothing should drop under the intact mirror: {report:?}",
+    );
+    assert!(report.salvaged_path.is_some(), "a copy was written");
+
+    // The MID attempt's sibling temp path must not survive the arbitration:
+    // the winner is renamed over dest, the loser is discarded.
+    for entry in std::fs::read_dir(dir.path())? {
+        let name = entry?.file_name().to_string_lossy().into_owned();
+        assert!(
+            !name.contains(".healtmp-"),
+            "the arbitration temp file must be renamed or removed, found {name:?}",
+        );
+    }
+    Ok(())
+}
+
+/// A MID-arbitration publish whose post-rename directory sync FAILS must not
+/// leave the owned destination behind: the rename already populated `dest`,
+/// so returning the durability error without cleanup would leave a partial
+/// SST a standalone retry's `create_new` open trips over (and the repair
+/// caller's rebuilt manifest omits, leaving an orphan). Every other salvage
+/// failure path removes its owned destination; this one must too.
+///
+/// `lz4`-gated: the divergent-mirror arbitration is driven by a
+/// `compression#data` forge to Lz4, so the tail attempt only mis-decodes
+/// (and the MID attempt wins, taking the publish path) when lz4 is built.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_removes_the_mid_copy_when_the_publish_dir_sync_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors so the MID attempt wins and publishes via rename.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // Fail the publish's post-rename directory sync. The tail attempt
+    // mis-decodes under the forged codec and drops its only block, so it
+    // never finishes (no sync); the MID writer's finish syncs the parent
+    // once, and the publish after the MID rename syncs it again. Skip the
+    // MID writer's sync and fire on the publish.
+    injector.arm(FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other)).skip(1));
+
+    // The error must be the INJECTED directory-sync fault: only the publish
+    // path both consumes the fault and propagates it. If a future change
+    // adds an earlier directory sync, `skip(1)` fires on the MID writer's
+    // finish instead — `mid` fails, the arbitration returns the tail
+    // attempt's (different) mis-decode error, and this assertion flags that
+    // the test no longer covers the publish-sync cleanup path.
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a failed publish directory sync must fail the salvage");
+    };
+    assert!(
+        err.to_string().contains("injected fault on SyncDirectory"),
+        "the salvage error must be the injected publish-sync fault, got {err:?}",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "the owned MID copy must be removed when the publish sync fails",
+    );
+    for entry in std::fs::read_dir(dir.path())? {
+        let name = entry?.file_name().to_string_lossy().into_owned();
+        assert!(
+            !name.contains(".healtmp-"),
+            "the MID temp copy must not survive either, found {name:?}",
+        );
+    }
+    Ok(())
+}
+
+/// The MID publish must fall back to a best-effort rename when the backend
+/// leaves `Fs::hard_link` unsupported. Such a backend can still create and
+/// rename ordinary files, so a divergent-meta salvage must still publish the
+/// recovered copy rather than drop a recoverable table.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_publishes_the_mid_copy_when_hard_link_is_unsupported() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors so the MID attempt wins and reaches the publish path.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // The backend cannot hard-link: the publish must fall back to a rename.
+    injector.arm(FaultRule::new(
+        FaultOp::HardLink,
+        Fault::Error(ErrorKind::Unsupported),
+    ));
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.salvaged_path.as_deref(),
+        Some(dest.as_path()),
+        "the MID copy must be published via the rename fallback: {report:?}",
+    );
+    assert!(
+        report.entries_salvaged > 0,
+        "the recovered table must carry entries: {report:?}",
+    );
+    assert!(
+        std::path::Path::new(&dest).exists(),
+        "the recovered table must land at the destination",
+    );
+    Ok(())
+}
+
+/// The MID publish must claim `dest` with an atomic no-replace operation, never
+/// a blind rename that clobbers an unowned file. When `dest` is already
+/// occupied, the tail attempt's `create_new` open fails against it (so the MID
+/// attempt wins and reaches the publish path), and the publish must surface an
+/// error while leaving the occupant's bytes untouched and leaking no temp copy.
+///
+/// The narrower check-then-rename TOCTOU — `dest` appearing only AFTER an
+/// existence probe reports it free — is not deterministically reachable through
+/// the current fault surface (it cannot force `Fs::exists` to report a present
+/// file absent); the no-replace `hard_link` publish closes that window
+/// structurally rather than by a racy probe.
+///
+/// `lz4`-gated: the MID attempt only runs when the meta mirrors DIVERGE, driven
+/// by a `compression#data` forge to Lz4 (as in the sibling MID-arbitration
+/// tests). Without divergence `salvage_with_context` returns the tail attempt
+/// and never reaches the publish path this test targets.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_does_not_clobber_an_occupied_destination_when_the_mid_attempt_wins() -> crate::Result<()>
+{
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Diverge the meta mirrors so the MID attempt actually runs (the tail
+    // attempt mis-decodes under the forged Lz4 codec and drops its block).
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // A racing worker already owns `dest`. The tail attempt's `create_new` open
+    // fails against it, so the tail errors and the MID attempt (writing to a
+    // temp) wins arbitration and must PUBLISH into the occupied path.
+    std::fs::write(&dest, b"racing worker's file")?;
+
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "publishing over an occupied destination must fail, got {result:?}",
+    );
+    assert_eq!(
+        std::fs::read(&dest)?,
+        b"racing worker's file",
+        "the occupant's bytes must survive the failed publish",
+    );
+    for entry in std::fs::read_dir(dir.path())? {
+        let name = entry?.file_name().to_string_lossy().into_owned();
+        assert!(
+            !name.contains(".healtmp-"),
+            "the MID temp copy must not leak, found {name:?}",
+        );
+    }
+    Ok(())
+}
+
+/// A STALE arbitration temp file left by a crashed predecessor must not
+/// block the MID attempt: the temp-name sequence is process-local, so a
+/// fresh process would otherwise pick the same `.healtmp-0` name, fail its
+/// `create_new` open, and return the tail attempt's inferior (or failing)
+/// result without ever trying the recoverable MID mirror — and tree
+/// recovery only sweeps this namespace inside table folders, so a
+/// standalone salvage destination stays blocked indefinitely. The
+/// arbitration must probe forward to a free name; the foreign artifact is
+/// never reclaimed (it may belong to a concurrently running salvage).
+///
+/// `lz4`-gated: the divergent-mirror arbitration is driven by a
+/// `compression#data` forge to Lz4 (see the sibling MID-cleanup test).
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_arbitration_skips_a_stale_crash_artifact() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors so the MID attempt wins and publishes via rename.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // A crashed predecessor's artifact occupies the FIRST temp name this
+    // process would pick (the sequence is a process-local counter and
+    // nextest runs each test in its own process, so it starts at zero).
+    let stale = dest.with_extension("healtmp-0");
+    std::fs::write(&stale, b"crashed predecessor artifact")?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "the MID attempt must pick a fresh temp name past the stale artifact: {report:?}",
+    );
+    assert!(
+        std::path::Path::new(&stale).exists(),
+        "a foreign artifact is never reclaimed",
+    );
+    assert_eq!(
+        std::fs::read(&stale)?,
+        b"crashed predecessor artifact".to_vec(),
+        "the stale artifact's bytes stay untouched",
+    );
+    Ok(())
+}
+
+/// When two processes salvage the SAME divergent-mirror SST concurrently, the
+/// process-local temp counter can hand both the same `.healtmp-0` name if one's
+/// existence probe RACES the other's creation. The loser's `create_new` then
+/// fails `AlreadyExists`, and it must NOT discard that path: the file there is
+/// the winner's in-progress output. A stale existence probe (a Metadata fault
+/// that reports the occupied name absent) plus a pre-existing foreign temp
+/// reproduces the race: the tail attempt loses, mid wins, and the foreign
+/// `.healtmp-0` must survive the arbitration cleanup.
+///
+/// `lz4`-gated: the divergent-mirror arbitration is driven by a
+/// `compression#data` forge to Lz4.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_arbitration_keeps_a_foreign_temp_it_did_not_create() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors so the arbitration runs both attempts.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // A concurrent process's in-progress temp already occupies the FIRST name
+    // this process would pick.
+    let foreign = dest.with_extension("healtmp-0");
+    let sentinel = b"concurrent salvage in-progress output".to_vec();
+    std::fs::write(&foreign, &sentinel)?;
+
+    // The tail attempt's existence probe RACES: a Metadata fault makes it see
+    // `.healtmp-0` as absent, so it returns that name and the tail's create_new
+    // then fails AlreadyExists against the foreign file. The mid attempt picks
+    // `.healtmp-1` and wins.
+    injector.arm(
+        FaultRule::new(FaultOp::Metadata, Fault::Error(ErrorKind::Other))
+            .on_path("healtmp-0")
+            .once(),
+    );
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "the mid attempt recovers every entry: {report:?}",
+    );
+    assert!(
+        std::path::Path::new(&foreign).exists(),
+        "the foreign concurrent temp must not be discarded by this salvage",
+    );
+    assert_eq!(
+        std::fs::read(&foreign)?,
+        sentinel,
+        "the foreign temp's bytes stay untouched",
+    );
+    Ok(())
+}
+
+/// A TRANSIENT failure to open the source for the mirror-divergence probe must
+/// not be laundered into `Ok(false)`: that would skip the dual-mirror
+/// arbitration and salvage from the tail view alone, so a divergent source (a
+/// forged tail layout) could omit healthy blocks the intact MID mirror keeps.
+/// The source is being salvaged, so it EXISTS — an open failure here is
+/// retryable I/O and must propagate, aborting the salvage so repair retries.
+///
+/// A single `Open` fault on the source hits exactly the probe's open (the first
+/// source open in the flow); the later `salvage_attempt` opens then succeed, so
+/// WITHOUT the fix salvage completes on the tail alone (`Ok`). WITH the fix it
+/// returns the propagated I/O error.
+///
+/// `lz4`-gated: the divergent mirror is forged via `compression#data` → Lz4.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_propagates_a_transient_open_failure_from_the_mirror_probe() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors: without the fault, the probe would return `Ok(true)`
+    // and run the arbitration. The transient open fault must abort instead.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other))
+            .on_path("source")
+            .once(),
+    );
+
+    let result = salvage_sst(&source, dest, &fs);
+    assert!(
+        matches!(result, Err(crate::Error::Io(_))),
+        "a transient open failure in the mirror-divergence probe must propagate, not \
+         skip arbitration and salvage tail-only: {result:?}",
+    );
+    Ok(())
+}
+
+/// A PRE-EXISTING destination must survive a divergent-mirror salvage: the
+/// tail attempt correctly fails its `create_new` open, but the MID attempt
+/// writes to a sibling temp path and wins the arbitration — publishing it
+/// by renaming over `dest` would silently destroy an unrelated file that an
+/// API call refusing "destination occupied" is supposed to leave untouched.
+///
+/// `lz4`-gated: the divergent-mirror arbitration is driven by a
+/// `compression#data` forge to Lz4 (see the sibling MID-cleanup test).
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_refuses_to_overwrite_a_preexisting_destination() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Divergent mirrors, so the arbitration runs a MID attempt after the
+    // tail attempt fails on the occupied destination.
+    crate::test_forge::forge_tail_meta_value(&source, b"compression#data", &[1])?;
+
+    // An unrelated file already occupies the destination.
+    let sentinel = b"unrelated pre-existing file".to_vec();
+    std::fs::write(&dest, &sentinel)?;
+
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "an occupied destination must fail the salvage: {result:?}",
+    );
+    assert_eq!(
+        std::fs::read(&dest)?,
+        sentinel,
+        "the pre-existing destination must survive byte-for-byte",
+    );
+    // The losing / refused MID copy must not leak its temp file either.
+    for entry in std::fs::read_dir(dir.path())? {
+        let name = entry?.file_name().to_string_lossy().into_owned();
+        assert!(
+            !name.contains(".healtmp-"),
+            "the refused MID attempt must clean up its temp copy, found {name:?}",
+        );
+    }
+    Ok(())
+}
+
+/// DIVERGENT meta mirrors disable the verbatim copy-through: a divergence
+/// confined to a DECODE-TRANSPARENT layout field (`restart_interval#data` —
+/// full block decoding is trailer-driven, so every block still reads clean
+/// and nothing drops) lets the tail-first attempt finish perfectly, yet a
+/// byte-copied block keeps the ORIGINAL encoding while the copy's meta is
+/// stamped with the forged interval. The partial-decode read path
+/// reconstructs prefix-compressed entries FROM that metadata interval, so
+/// the inconsistent pair silently truncates synthesized blocks. Since
+/// neither mirror is provably genuine, every block must be RE-ENCODED under
+/// the chosen meta — self-consistent whichever mirror wins.
+#[test]
+fn salvage_reencodes_all_blocks_when_meta_mirrors_diverge() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Forge the TAIL meta's data restart interval from the written 16 to 4 —
+    // fresh block checksum, `meta_mid` untouched. Blocks keep decoding
+    // (trailer-driven), so the tail attempt sees zero drops.
+    crate::test_forge::forge_tail_meta_value(&source, b"restart_interval#data", &[4])?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "all rows recovered: {report:?}"
+    );
+    assert!(report.salvaged_path.is_some(), "a copy was written");
+    assert_eq!(
+        report.blocks_copied_verbatim, 0,
+        "divergent mirrors must force the re-encode path: a byte-copied \
+         block would keep the original encoding under the chosen meta's \
+         forged layout: {report:?}",
+    );
+    Ok(())
+}
+
+/// When the meta mirrors diverge ONLY in `created_at`, both salvage attempts
+/// recover identical blocks and entries, so the completeness tie-break picks the
+/// tail. That is SAFE because the recovered copy re-stamps `created_at` fresh at
+/// finish and re-derives every other authoritative field (key range, seqnos,
+/// counts) from the actual re-emitted entries; the layout is mirrored but
+/// re-encoded, so a backdated tail cannot be laundered into the copy. This
+/// regression guards that property: if a future change ever carried the source
+/// `created_at` forward, the forged backdated value would surface here.
+#[test]
+fn salvage_does_not_carry_a_forged_created_at_into_the_copy() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..100 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    let backdated: u128 = 1;
+    crate::test_forge::forge_tail_meta_value(&source, b"created_at", &backdated.to_le_bytes())?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(report.entries_salvaged, 100, "{report:?}");
+    let recovered = open(dest, &fs)?;
+    assert_ne!(
+        *recovered.metadata.created_at, backdated,
+        "the recovered copy must not carry the forged backdated created_at",
+    );
+    Ok(())
+}
+
+/// The point-read reachability walk must reject a cross-block internal-key
+/// order inversion. A checksum-restamped later block that raises the seqno of a
+/// key ending the previous block leaves both blocks decoding and probing
+/// cleanly on their own, yet the global (user key ASC, seqno DESC) order is
+/// broken across the boundary: after reopen the index seeks the first block and
+/// a later compaction could persist the stale (lower-seqno) version.
+#[test]
+fn verify_point_read_reachability_rejects_a_cross_block_seqno_inversion() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Two versions of the SAME key, one per block (a 1-byte block budget forces
+    // each entry into its own block), so the key's versions span the boundary:
+    // block 0 = kkk@2, block 1 = kkk@1 (equal key, descending seqno: valid).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(1);
+    writer.write(InternalValue::from_components(
+        b"kkk",
+        b"v2",
+        2,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"kkk",
+        b"v1",
+        1,
+        ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Raise the SECOND block's first entry seqno from 1 to 3: block 0 now ends
+    // kkk@2 and block 1 starts kkk@3 (equal key, seqno RAISED across the
+    // boundary: the invalid inversion).
+    let block1_off = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: alloc::vec::Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|kh| *kh.as_ref().offset())
+            .collect();
+        let Some(&second) = offsets.get(1) else {
+            panic!("the key's versions must span two blocks, got {offsets:?}");
+        };
+        let Ok(off) = usize::try_from(second) else {
+            panic!("the block offset fits usize");
+        };
+        off
+    };
+    crate::test_forge::forge_raise_data_block_first_seqno(&source, block1_off, 3)?;
+
+    let table = open(source, &fs)?;
+    let result = table.verify_point_read_reachability();
+    assert!(
+        matches!(&result, Err(crate::Error::InvalidHeader(msg)) if msg.contains("out of order")),
+        "a cross-block seqno inversion must be rejected, got {result:?}",
+    );
+    Ok(())
+}
+
+/// A checksum-clean row block that ITERATES to fewer entries than its
+/// trailer declares must be dropped, not marked recovered: the entry decoder
+/// turns a mid-stream parse failure into an ordinary end of iteration, so a
+/// block with a valid prefix and a malformed tail would otherwise be
+/// counted salvaged while silently losing the remaining keys (or byte-copied
+/// verbatim, still malformed).
+#[test]
+fn salvage_drops_a_row_block_that_decodes_fewer_entries_than_declared() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..3 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Inflate the trailer's item count by one behind a re-stamped block
+    // checksum: iteration now yields fewer entries than the block declares.
+    crate::test_forge::forge_inflated_item_count(&source)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 0,
+        "an under-decoding block must not contribute recovered entries: {report:?}",
+    );
+    assert!(
+        report
+            .dropped
+            .iter()
+            .any(|d| matches!(d.reason, DropReason::DecodeError(_))),
+        "the count mismatch is a dropped DecodeError, not a clean recovery: {report:?}",
+    );
+    Ok(())
+}
+
+/// Regression: a data block can hold several MVCC versions of one user key
+/// (same key, descending seqno). The verbatim copy-through path must accept
+/// equal user keys — only columnar *ingest* requires strictly-unique keys — so
+/// salvaging such a block recovers every version instead of erroring.
+#[test]
+fn salvage_recovers_a_block_with_multiple_versions_of_one_key() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // One block holding the same user key at several seqnos, surrounded by unique
+    // keys. Valid SST order: user key ascending, seqno descending within a key.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    writer.write(InternalValue::from_components(
+        b"a".to_vec(),
+        b"a".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    for seqno in [3u64, 2, 1] {
+        writer.write(InternalValue::from_components(
+            b"dup".to_vec(),
+            format!("v{seqno}").into_bytes(),
+            seqno,
+            ValueType::Value,
+        ))?;
+    }
+    writer.write(InternalValue::from_components(
+        b"z".to_vec(),
+        b"z".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "a healthy SST with MVCC duplicates salvages cleanly: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged, 5,
+        "every version is recovered, including all 3 of `dup`: {report:?}",
+    );
+
+    let recovered = open(dest, &fs)?;
+    assert_eq!(
+        recovered.metadata.item_count, 5,
+        "all 5 entries (3 versions of `dup`) are recovered",
+    );
+    Ok(())
+}
+
+/// A block where a weak tombstone is immediately followed by a value for the
+/// same key (a reclaimable pair) salvages verbatim and recovers both entries —
+/// exercising the reclaimable-weak-tombstone accounting on the copy-through path.
+#[test]
+fn salvage_recovers_a_reclaimable_weak_tombstone_pair() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // SST order is user key ascending, seqno descending: the weak tombstone
+    // (higher seqno) precedes the value it reclaims (lower seqno) for `dup`.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    writer.write(InternalValue::from_components(
+        b"a".to_vec(),
+        b"a".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"dup".to_vec(),
+        b"".to_vec(),
+        3,
+        ValueType::WeakTombstone,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"dup".to_vec(),
+        b"v1".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    let report = salvage_sst(&source, dest, &fs)?;
+    assert!(
+        report.is_complete(),
+        "healthy SST salvages cleanly: {report:?}"
+    );
+    assert_eq!(
+        report.entries_salvaged, 3,
+        "the weak tombstone and both values are recovered: {report:?}",
+    );
+    assert!(
+        report.blocks_copied_verbatim >= 1,
+        "the clean block is copied verbatim: {report:?}",
+    );
+    Ok(())
+}
+
+/// `verify_locator` must validate the SLOT hint, not only the block id: a
+/// `Restart`-precision locator can keep the correct block id yet redirect
+/// a key's slot to a later restart interval holding an older version, so
+/// `point_read_at_slot` returns the stale value without falling back to
+/// the sorted index. The `Writer` is driven directly (two versions of one
+/// key in one block, `restart_interval = 1`, locator enabled) and the
+/// locator section is rebuilt with that key's slot pushed from the newest
+/// head (0) to the older head (1).
+#[test]
+fn verify_locator_rejects_a_slot_hint_pointing_at_an_older_version() -> crate::Result<()> {
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::runtime_config::{ChecksumAlgorithm, KvChecksumPolicy};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_restart_interval(1)
+        .use_kv_checksums(KvChecksumPolicy::AllLevels, ChecksumAlgorithm::Xxh3_64)
+        .use_locator(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        });
+    // Restart heads (restart_interval = 1) in one block: key-a@2 (head 0),
+    // key-a@1 (head 1), key-b (head 2), key-c (head 3).
+    writer.write(InternalValue::from_components(
+        b"key-a".to_vec(),
+        b"new".to_vec(),
+        2,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"key-a".to_vec(),
+        b"old".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"key-b".to_vec(),
+        b"vb".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"key-c".to_vec(),
+        b"vc".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Sanity: the honest locator passes the gate.
+    open(source.clone(), &fs)?.verify_locator()?;
+
+    // Rebuild the locator with key-a's slot pushed to head 1 (the older
+    // version); key-b / key-c keep their honest heads (2 / 3). block_id 0
+    // for the single block.
+    let h = |k: &[u8]| crate::hash::hash64(k);
+    crate::test_forge::forge_locator_slots(
+        &source,
+        0,
+        &[
+            (h(b"key-a"), 0, 1),
+            (h(b"key-b"), 0, 2),
+            (h(b"key-c"), 0, 3),
+        ],
+    )?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_locator() else {
+        panic!("a slot hint pointing at an older version must fail the gate");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "locator slot hint does not resolve a key's newest version"
+            )
+        ),
+        "the redirect must be rejected by the slot-hint check, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_locator` must reject a present locator that gives NO answer for a
+/// decoded key. The writer omits the section when it cannot build one and
+/// otherwise encodes every unique key, so a no-answer locator is a forgery (a
+/// `delete_bitmap` relabeled to a locator that resolves nothing). The read path
+/// falls back to the sorted index on a miss, but the verifier must treat the
+/// unanswered key as corrupt so the relabel cannot pass as deletion-free.
+#[test]
+fn verify_locator_rejects_a_no_answer_locator() -> crate::Result<()> {
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::runtime_config::{ChecksumAlgorithm, KvChecksumPolicy};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_restart_interval(1)
+        .use_kv_checksums(KvChecksumPolicy::AllLevels, ChecksumAlgorithm::Xxh3_64)
+        .use_locator(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Restart,
+            block_id_bits: None,
+            slot_bits: None,
+        });
+    for k in [b"key-a".as_slice(), b"key-b", b"key-c"] {
+        writer.write(InternalValue::from_components(
+            k.to_vec(),
+            b"v".to_vec(),
+            1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Sanity: the honest locator passes the gate.
+    open(source.clone(), &fs)?.verify_locator()?;
+
+    // Rebuild the locator so key-c resolves to an OUT-OF-RANGE block id: the
+    // handle lookup fails and `locate_block` yields no answer for that decoded
+    // key (the read path would fall back to the sorted index; the verifier must
+    // not). key-a / key-b keep their honest block 0.
+    let h = |k: &[u8]| crate::hash::hash64(k);
+    crate::test_forge::forge_locator_slots(
+        &source,
+        0,
+        &[
+            (h(b"key-a"), 0, 0),
+            (h(b"key-b"), 0, 1),
+            (h(b"key-c"), 99, 2),
+        ],
+    )?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_locator() else {
+        panic!("a locator that gives no answer for a decoded key must fail the gate");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "locator gives no answer for a decoded key it should resolve"
+            )
+        ),
+        "the miss must be rejected by the no-answer check, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_filter` must probe the extractor's PREFIX hashes, not only
+/// complete-key hashes: a full filter built WITHOUT the configured
+/// extractor (a salvage that dropped it, or a forge) still answers every
+/// complete-key probe, yet `maybe_contains_prefix` treats the table as
+/// definitely absent and prefix scans silently omit its rows. No forge is
+/// needed — a `Writer` run without the extractor produces exactly the
+/// filter that lacks the prefix hashes.
+#[test]
+fn verify_filter_rejects_missing_prefix_hashes() -> crate::Result<()> {
+    /// First four key bytes (keys are `keyNNNNN`, so the prefix is `key0`).
+    struct FixedLengthPrefix;
+    impl crate::prefix::PrefixExtractor for FixedLengthPrefix {
+        fn prefixes<'a>(&self, key: &'a [u8]) -> Box<dyn Iterator<Item = &'a [u8]> + 'a> {
+            key.get(..4).map_or_else(
+                || Box::new(std::iter::empty()) as Box<dyn Iterator<Item = &'a [u8]>>,
+                |p| Box::new(std::iter::once(p)),
+            )
+        }
+
+        fn is_valid_scan_boundary(&self, prefix: &[u8]) -> bool {
+            prefix.len() == 4
+        }
+    }
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let extractor: Arc<dyn crate::prefix::PrefixExtractor> = Arc::new(FixedLengthPrefix);
+
+    // Written WITHOUT the extractor: the full filter holds only complete-key
+    // hashes, exactly the state a salvage-without-extractor leaves behind.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u32..100 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    let table = open(source, &fs)?;
+    // Without an extractor the gate only probes complete keys and passes.
+    table.verify_filter(None)?;
+    // WITH the extractor it probes each key's prefix hash, which the filter
+    // never indexed — a false negative on an existing key's prefix.
+    let Err(err) = table.verify_filter(Some(&extractor)) else {
+        panic!("a filter missing the prefix hashes must fail the gate");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "filter reports an existing key's prefix as definitely absent"
+            )
+        ),
+        "the missing prefix hash must be the rejection reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// The point-read reachability gate must require the probe to return the
+/// NEWEST version of a key, not merely SOME version. A key spanning two
+/// restart intervals has a CONFLICT-marked hash bucket; redirecting that
+/// bucket to the later interval (an OLDER version) still makes
+/// `point_read(MAX_SEQNO)` return `Some`, so an `is_none` check would pass
+/// — yet reads after reopen return the stale value. The `Writer` is driven
+/// directly (two versions of one key in one block, `restart_interval = 1`,
+/// hashed, footered) because a memtable flush deduplicates shadowed
+/// versions and cannot produce this layout.
+#[test]
+fn verify_point_read_reachability_rejects_a_bucket_redirected_to_an_older_version()
+-> crate::Result<()> {
+    use crate::runtime_config::{ChecksumAlgorithm, KvChecksumPolicy};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_hash_ratio(2.0)
+        .use_data_block_restart_interval(1)
+        .use_kv_checksums(KvChecksumPolicy::AllLevels, ChecksumAlgorithm::Xxh3_64);
+    // "key-a" twice: newest (seqno 2) then older (seqno 1), so both are
+    // restart heads in the first block and the key's bucket conflicts.
+    writer.write(InternalValue::from_components(
+        b"key-a".to_vec(),
+        b"new".to_vec(),
+        2,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"key-a".to_vec(),
+        b"old".to_vec(),
+        1,
+        ValueType::Value,
+    ))?;
+    for k in [b"key-b", b"key-c"] {
+        writer.write(InternalValue::from_components(
+            k.to_vec(),
+            b"v".to_vec(),
+            1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Sanity: the intact table passes the reachability gate.
+    open(source.clone(), &fs)?.verify_point_read_reachability()?;
+
+    // Redirect the conflicting bucket to binary-index pos 1 — the second
+    // restart head, holding the OLDER (seqno 1) version.
+    crate::test_forge::forge_hash_index_bucket(&source, b"key-a", 1, None)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_point_read_reachability() else {
+        panic!("a bucket redirected to an older version must fail the gate");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "a decoded key's point_read does not return its newest version \
+                 (an in-block index disagrees with the entries)"
+            )
+        ),
+        "the redirect must be rejected by the newest-version check, got {err:?}",
+    );
+    Ok(())
+}
+
+/// A `filter_tli` block that does not decode as a filter index must fail
+/// SALVAGE closed on a table that exposes NO deletion metadata: a re-stamped
+/// TOC can rename a `range_tombstones` / `delete_bitmap` section to
+/// `filter_tli` and re-role its block, leaving a uniquely named, tiled
+/// catalogue whose parsed table reports no deletion. Salvage re-derives the
+/// filter from the recovered keys, so it would discard that section and
+/// re-emit the suppressed rows as live. A genuinely rotted filter index is
+/// indistinguishable from the relabel, so both fail closed; the operator
+/// recovers the quarantined original by hand.
+#[test]
+fn salvage_refuses_a_corrupt_filter_index_that_may_hide_a_deletion() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_partitioned_filter()
+        // A tiny partition budget so several filter partitions spill and
+        // the writer emits the `filter_tli` top-level index over them.
+        .use_meta_partition_size(3);
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Rot one payload byte of the filter_tli block WITHOUT re-stamping its
+    // checksum, so loading it fails like any bit-rotted block.
+    {
+        let pos = {
+            let mut f = std::fs::File::open(&source)?;
+            let reader = match crate::sfa::Reader::from_reader(&mut f) {
+                Ok(r) => r,
+                Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+            };
+            let Some(entry) = reader.toc().iter().find(|e| e.name() == b"filter_tli") else {
+                panic!("the source carries a filter_tli section");
+            };
+            let Ok(pos) = usize::try_from(entry.pos()) else {
+                panic!("pos fits usize");
+            };
+            pos
+        };
+        let mut bytes = std::fs::read(&source)?;
+        // First payload byte, derived from the block header length (filter_tli
+        // is an Index block) so a header-layout change cannot slide the flip
+        // into the header and leave the payload untouched.
+        let at =
+            pos + crate::table::block::Header::header_len(crate::table::block::BlockType::Index);
+        let Some(slot) = bytes.get_mut(at) else {
+            panic!("payload byte within the file");
+        };
+        *slot ^= 0xFF;
+        std::fs::write(&source, bytes)?;
+    }
+
+    // Provably corrupt: a LIVE open fails closed on the rotted filter index.
+    assert!(
+        open(source.clone(), &fs).is_err(),
+        "the rotted filter index must fail a live open",
+    );
+
+    // Salvage fails closed: the filter index did not decode and the table
+    // exposes no deletion, so it may be a relabeled deletion salvage would
+    // discard — quarantine for manual recovery instead of resurrecting rows.
+    let Err(err) = salvage_sst(&source, dest, &fs) else {
+        panic!("a corrupt filter index with no visible deletion must fail salvage");
+    };
+    assert!(
+        matches!(err, crate::Error::FeatureUnsupported(_)),
+        "the refusal names the unsupported salvage, got {err:?}",
+    );
+    Ok(())
+}
+
+/// The rebuilt filter must carry the source's PREFIX hashes: the extractor
+/// is configuration (not persisted in the SST), so the salvage writer can
+/// only index prefixes when the caller threads the tree's extractor
+/// through [`SalvageOptions::prefix_extractor`]. Without it the salvaged
+/// copy's filter holds complete-key hashes only, `maybe_contains_prefix`
+/// reports every indexed prefix as definitely absent, and the copy's rows
+/// silently vanish from prefix scans.
+#[test]
+fn salvage_preserves_prefix_filter_hashes() -> crate::Result<()> {
+    /// First four key bytes, mirroring the tree-level extractor fixtures.
+    struct FixedLengthPrefix;
+    impl crate::prefix::PrefixExtractor for FixedLengthPrefix {
+        fn prefixes<'a>(&self, key: &'a [u8]) -> Box<dyn Iterator<Item = &'a [u8]> + 'a> {
+            key.get(..4).map_or_else(
+                || Box::new(std::iter::empty()) as Box<dyn Iterator<Item = &'a [u8]>>,
+                |p| Box::new(std::iter::once(p)),
+            )
+        }
+
+        fn is_valid_scan_boundary(&self, prefix: &[u8]) -> bool {
+            prefix.len() == 4
+        }
+    }
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let extractor: Arc<dyn crate::prefix::PrefixExtractor> = Arc::new(FixedLengthPrefix);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_prefix_extractor(Some(Arc::clone(&extractor)));
+    for i in 0u32..100 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Sanity: the SOURCE's filter answers the prefix probes (keys are
+    // `key000NN`, so the indexed 4-byte prefixes are `key0`).
+    let prefix_hash = crate::hash::hash64(b"key0");
+    {
+        let table = open(source.clone(), &fs)?;
+        assert!(
+            table.maybe_contains_prefix(prefix_hash)?,
+            "the source filter indexes the prefix",
+        );
+    }
+
+    let options = SalvageOptions {
+        prefix_extractor: Some(Arc::clone(&extractor)),
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "all rows recovered: {report:?}"
+    );
+
+    // A missing prefix hash is a DEFINITE-absent answer from the rebuilt
+    // filter — the salvaged copy would silently vanish from prefix scans.
+    let table = open(dest, &fs)?;
+    assert!(
+        table.maybe_contains_prefix(prefix_hash)?,
+        "the salvaged copy's filter must keep the source's prefix hashes",
+    );
+    Ok(())
+}
+
+/// Without a prefix extractor, salvage must NOT emit a filter at all. The
+/// extractor is not persisted in the SST and cannot be inferred, so a filter
+/// rebuilt from complete-key hashes only would answer `maybe_contains_prefix`
+/// with a DEFINITE-absent for a source that came from a prefix-indexed tree,
+/// silently dropping every recovered row from prefix scans once the copy is
+/// reinstalled. Omitting the filter answers "maybe present" (a full block read),
+/// which is always correct; the point-lookup speedup is sacrificed for
+/// correctness because the source's indexing intent is unknowable here.
+#[test]
+fn salvage_omits_the_filter_without_a_prefix_extractor() -> crate::Result<()> {
+    /// First four key bytes, mirroring the tree-level extractor fixtures.
+    struct FixedLengthPrefix;
+    impl crate::prefix::PrefixExtractor for FixedLengthPrefix {
+        fn prefixes<'a>(&self, key: &'a [u8]) -> Box<dyn Iterator<Item = &'a [u8]> + 'a> {
+            key.get(..4).map_or_else(
+                || Box::new(std::iter::empty()) as Box<dyn Iterator<Item = &'a [u8]>>,
+                |p| Box::new(std::iter::once(p)),
+            )
+        }
+
+        fn is_valid_scan_boundary(&self, prefix: &[u8]) -> bool {
+            prefix.len() == 4
+        }
+    }
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let extractor: Arc<dyn crate::prefix::PrefixExtractor> = Arc::new(FixedLengthPrefix);
+
+    // Source built WITH a prefix extractor: its filter indexes the 4-byte
+    // prefixes (`key0` for keys `key000NN`).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_prefix_extractor(Some(Arc::clone(&extractor)));
+    for i in 0u32..100 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Salvage via the default path with NO extractor threaded (the CLI / API
+    // default), so the source's prefix indexing intent is unknown here.
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.entries_salvaged, 100,
+        "all rows recovered: {report:?}"
+    );
+
+    // The recovered copy must NOT answer a prefix probe definitely-absent: with
+    // no extractor the safe rebuilt filter is none, so `maybe_contains_prefix`
+    // falls back to "maybe present" instead of a false negative that would hide
+    // every recovered row from a prefix scan.
+    let prefix_hash = crate::hash::hash64(b"key0");
+    let table = open(dest, &fs)?;
+    assert!(
+        table.maybe_contains_prefix(prefix_hash)?,
+        "without the extractor the salvaged copy must not report a prefix as definitely absent",
+    );
+    Ok(())
+}
 
 fn iv(i: u32) -> InternalValue {
     InternalValue::from_components(
@@ -16,16 +2342,46 @@ fn iv(i: u32) -> InternalValue {
     )
 }
 
+/// File offset of the named SFA section, for a fault rule that targets one
+/// section's positional read.
+fn section_pos(path: &std::path::Path, name: &[u8]) -> u64 {
+    let mut f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) => panic!("opening the source failed: {e:?}"),
+    };
+    let reader = match crate::sfa::Reader::from_reader(&mut f) {
+        Ok(r) => r,
+        Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+    };
+    let Some(entry) = reader.toc().iter().find(|e| e.name() == name) else {
+        panic!(
+            "source must carry a {} section",
+            String::from_utf8_lossy(name)
+        );
+    };
+    entry.pos()
+}
+
 /// Opens an SST as a `Table`, stamping the open with the file's current digest
 /// (the source may be corrupt; per-block checksums catch the actual damage).
 fn open(path: std::path::PathBuf, fs: &Arc<dyn Fs>) -> crate::Result<Table> {
+    open_with_id(path, fs, 0)
+}
+
+/// As [`open`] but under an explicit expected table id (the recover
+/// cross-checks it against the SST's stored `table_id`).
+fn open_with_id(
+    path: std::path::PathBuf,
+    fs: &Arc<dyn Fs>,
+    table_id: crate::TableId,
+) -> crate::Result<Table> {
     let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, &path)?);
     Table::recover(
         path,
         checksum,
         0,
         0,
-        0,
+        table_id,
         Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
         Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
         Arc::clone(fs),
@@ -40,9 +2396,1686 @@ fn open(path: std::path::PathBuf, fs: &Arc<dyn Fs>) -> crate::Result<Table> {
     )
 }
 
+/// As [`open`] but threads an encryption provider so a keyed SST recovers.
+#[cfg(feature = "encryption")]
+fn open_encrypted(
+    path: std::path::PathBuf,
+    fs: &Arc<dyn Fs>,
+    encryption: Arc<dyn crate::encryption::EncryptionProvider>,
+) -> crate::Result<Table> {
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, &path)?);
+    Table::recover(
+        path,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(fs),
+        false,
+        false,
+        Some(encryption),
+        #[cfg(zstd_any)]
+        None,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )
+}
+
 /// A reopen of a salvaged SST: recover it and return its live item count.
 fn reopen_item_count(path: std::path::PathBuf, fs: &Arc<dyn Fs>) -> crate::Result<u64> {
     Ok(open(path, fs)?.metadata.item_count)
+}
+
+/// Point-reads `key` from the SST at `path` at the latest snapshot — the
+/// LOGICAL visibility check behind the physical row counts (a delete either
+/// masks the key or, under the resurrection opt-in, leaves it readable).
+fn reopen_get(
+    path: std::path::PathBuf,
+    fs: &Arc<dyn Fs>,
+    key: &[u8],
+) -> crate::Result<Option<crate::InternalValue>> {
+    open(path, fs)?.get(key, crate::MAX_SEQNO, crate::hash::hash64(key))
+}
+
+/// An SST from a KV-separated tree carries a `linked_blob_files` section
+/// naming every blob file its `ValueHandle`s point into; blob GC / relocation
+/// consults it (via `list_blob_file_references`) to decide whether a blob is
+/// still referenced. The salvaged copy must carry the SOURCE's links —
+/// omitting the section would let GC rewrite or delete a blob that only this
+/// table still references, silently breaking its indirections.
+#[test]
+fn salvage_preserves_the_source_linked_blob_files() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A KV-separated tree: large values go to a blob file, the SST holds
+    // indirections plus a linked_blob_files section.
+    let crate::AnyTree::Blob(tree) = crate::Config::new(
+        dir.path(),
+        crate::SequenceNumberCounter::default(),
+        crate::SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let source = {
+        let binding = tree.index.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    let dest = dir.path().join("salvaged");
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(report.is_complete(), "healthy SST: {report:?}");
+
+    // The source's blob links survive into the recovered copy.
+    let Some(source_links) = open(source, &fs)?.list_blob_file_references()? else {
+        panic!("the source carries a linked_blob_files section");
+    };
+    assert!(!source_links.is_empty(), "the source references blob files");
+    let Some(recovered_links) = open(dest, &fs)?.list_blob_file_references()? else {
+        panic!("the salvaged copy carries a linked_blob_files section");
+    };
+    assert_eq!(
+        recovered_links, source_links,
+        "the salvaged copy references the same blob files as the source",
+    );
+    Ok(())
+}
+
+/// `verify_blob_links` must reject a table that still carries indirection
+/// entries but advertises NO `linked_blob_files` section (dropped or renamed
+/// away): returning `Ok` there lets a healed-digest refresh or salvage accept a
+/// table with `ValueHandle`s but no blob references, after which blob GC — which
+/// consults `list_blob_file_references()` for liveness — can rewrite or drop a
+/// blob file this table still points into.
+#[test]
+fn verify_blob_links_rejects_a_missing_section_with_live_indirections() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let crate::AnyTree::Blob(tree) = crate::Config::new(
+        dir.path(),
+        crate::SequenceNumberCounter::default(),
+        crate::SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let source = {
+        let binding = tree.index.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    // Drop the linked_blob_files section from the TOC: the table keeps its
+    // indirection entries but now advertises no blob references.
+    crate::test_forge::forge_section_omitted(&source, b"linked_blob_files")?;
+
+    let table = open(source, &fs)?;
+    assert!(
+        table.list_blob_file_references()?.is_none(),
+        "the forge must leave the table with no blob-link section",
+    );
+    let Err(err) = table.verify_blob_links() else {
+        panic!("a table with live indirections but no blob-link section must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "table carries indirection entries but no linked_blob_files section"
+            )
+        ),
+        "the rejection names the missing-blob-link-section reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_blob_links` must reject a PRESENT but empty (zero-count)
+/// `linked_blob_files` section. The writer omits the section when there are no
+/// blob references, so a present-but-blobless section is a forgery: a
+/// `delete_bitmap` replaced by a four-byte zero-count `linked_blob_files` leaves
+/// both the derived and recorded maps empty, so the equality check passes and
+/// the table is kept after its deletion metadata vanished.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_blob_links_rejects_a_present_empty_section() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A columnar delete-bearing SST with NO blob indirections (so no real
+    // linked_blob_files section exists to duplicate).
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Replace the delete_bitmap section with a four-byte zero-count
+    // linked_blob_files (raw shape valid, records no blob references).
+    crate::test_forge::forge_rename_and_replace_section(
+        &source,
+        b"delete_bitmap",
+        b"linked_blob_files",
+        &[0, 0, 0, 0],
+    )?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_blob_links() else {
+        panic!("a present zero-count linked_blob_files section must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "linked_blob_files section is present but records no blob references"
+            )
+        ),
+        "the rejection names the present-empty blob-link reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// Standalone salvage must REFUSE a delete-bearing SST whose `delete_bitmap`
+/// entry was OMITTED from a re-stamped TOC. The parsed table then reports no
+/// deletion (the section's bytes linger unreferenced), no side section
+/// degrades, and the mask is not unpositionable, so the relabel and
+/// unpositionable guards both pass, and a naive walk would re-emit every
+/// physically-present row as live, resurrecting the deleted ones. The repair
+/// verifier catches the TOC tiling gap, but `salvage_sst` never runs it: the
+/// coverage check must live inside salvage too.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_refuses_a_toc_that_omits_a_delete_bitmap() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // OMIT the delete_bitmap TOC entry (bytes remain, nothing references them),
+    // re-stamping the trailer so the archive stays internally consistent.
+    crate::test_forge::forge_section_omitted(&source, b"delete_bitmap")?;
+
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a TOC that hides a deletion section must be refused, not resurrected");
+    };
+    assert!(
+        matches!(err, crate::Error::FeatureUnsupported(msg) if msg.contains("TOC may hide a deletion section")),
+        "the refusal must name the hidden-deletion gate, not any other refusal, got {err:?}",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "no salvaged copy is produced when the deletion section may be hidden",
+    );
+    Ok(())
+}
+
+/// A delete-bearing SST whose `delete_bitmap` section is HIDDEN (renamed away or
+/// replaced by another valid optional section) must be rejected by the metadata
+/// cross-check: the authenticated `descriptor#delete_bitmap_len` still records
+/// the positions, so a `> 0` count with no readable bitmap section is a forgery
+/// that would resurrect every positionally-deleted row. Uses omission (a
+/// recognized-name rename or a valid filter replacement reaches the same state:
+/// the count disagrees with the absent section).
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_metadata_bounds_rejects_a_hidden_delete_bitmap() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Hide the delete_bitmap section while the authenticated meta count still
+    // records its 3 positions.
+    crate::test_forge::forge_section_omitted(&source, b"delete_bitmap")?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("a hidden delete_bitmap with a recorded count > 0 must be rejected");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("delete_bitmap count disagrees")),
+        "the rejection must name the delete_bitmap count mismatch, got {err:?}",
+    );
+    Ok(())
+}
+
+/// An EQUAL-CARDINALITY `delete_bitmap` substitution (a different, checksum-valid
+/// bitmap with the same number of positions) passes the count-only cross-check
+/// but must be rejected by the content hash: during manifest repair, with no
+/// original whole-file digest, it would otherwise resurrect the originally
+/// deleted rows and drop different live ones.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_metadata_bounds_rejects_an_equal_cardinality_delete_bitmap_substitution()
+-> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Replace the bitmap with a DIFFERENT set of three positions (same chunk,
+    // same cardinality and encoded length, so the count cross-check still
+    // passes) — only the CONTENTS differ.
+    crate::test_forge::forge_delete_bitmap_substitute(&source, 0, &[6, 21, 41])?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("an equal-cardinality bitmap substitution must be rejected by the content hash");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("delete_bitmap contents disagree")),
+        "the rejection must name the delete_bitmap content-hash mismatch, got {err:?}",
+    );
+    Ok(())
+}
+
+/// The SALVAGE walk must authenticate the delete-bitmap CONTENTS, not just its
+/// positions: an equal-cardinality substitution (a different, checksum-valid
+/// bitmap) is structurally positionable, so without a content check salvage
+/// applies it and masks the WRONG rows, resurrecting the authentically-deleted
+/// rows and dropping different live ones. Salvage has no original whole-file
+/// digest, so with the default (no resurrection opt-in) it must fail closed on an
+/// unauthenticated bitmap (#90).
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_authenticates_the_delete_bitmap_before_masking() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("dest");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Substitute an equal-cardinality bitmap: same count, different positions,
+    // checksum-valid, but the meta content hash still records the original.
+    crate::test_forge::forge_delete_bitmap_substitute(&source, 0, &[6, 21, 41])?;
+
+    // Default options do NOT opt into resurrection: salvage must refuse rather
+    // than apply the unauthenticated (substituted) mask.
+    let result = super::salvage_sst(&source, dest, &fs);
+    assert!(
+        matches!(&result, Err(crate::Error::InvalidHeader(msg)) if msg.contains("resurrect")),
+        "an unauthenticated delete-bitmap substitution must fail closed, got {result:?}",
+    );
+    Ok(())
+}
+
+/// `attempt_owns_temp` must prove ownership from the OUTCOME (a written temp),
+/// not infer it from the error kind: a salvage attempt that errors BEFORE
+/// `Writer::new` (e.g. a range-tombstone refusal) never created the temp, so the
+/// arbitration cleanup must NOT discard that path — on shared storage it could be
+/// a concurrent creator's file.
+#[test]
+fn attempt_owns_temp_tracks_the_written_outcome_not_the_error_kind() {
+    let report = |salvaged_path| super::SalvageReport {
+        salvaged_path,
+        blocks_total: 1,
+        blocks_salvaged: 1,
+        blocks_copied_verbatim: 0,
+        entries_salvaged: 1,
+        dropped: alloc::vec::Vec::new(),
+        delete_rows_resurrected: false,
+    };
+
+    // Wrote a temp → owned.
+    assert!(super::attempt_owns_temp(&Ok(report(Some(
+        std::path::PathBuf::from("/x")
+    )))));
+    // Recovered nothing (empty temp already discarded) → not owned.
+    assert!(!super::attempt_owns_temp(&Ok(report(None))));
+    // Errored BEFORE create (range tombstones) → temp never created → not owned.
+    assert!(!super::attempt_owns_temp(&Err(
+        crate::Error::FeatureUnsupported("range tombstones")
+    )));
+}
+
+/// Divergent-mirror arbitration must not let a TRANSIENT failure on one attempt
+/// lose to an INCOMPLETE success on the other: a retry of the transient mirror
+/// could recover the blocks the incomplete winner dropped, so the arbitration
+/// propagates the transient error. A COMPLETE success still wins (a retry cannot
+/// improve on it), and a PERSISTENT failure always loses to any success.
+#[test]
+fn arbitrate_mirrors_propagates_a_transient_loss_to_an_incomplete_success() {
+    use super::{DropReason, DroppedBlock, MirrorArbitration, SalvageReport, arbitrate_mirrors};
+
+    let report = |dropped: usize| SalvageReport {
+        salvaged_path: Some(std::path::PathBuf::from("/x")),
+        blocks_total: 4,
+        blocks_salvaged: 4 - dropped,
+        blocks_copied_verbatim: 0,
+        entries_salvaged: 4,
+        dropped: (0..dropped)
+            .map(|i| DroppedBlock {
+                offset: i as u64,
+                section: b"data".to_vec(),
+                reason: DropReason::ChecksumMismatch,
+                key_range: None,
+            })
+            .collect(),
+        delete_rows_resurrected: false,
+    };
+    let complete = || Ok(report(0));
+    let incomplete = || Ok(report(1));
+    let transient = || {
+        Err(crate::Error::Io(crate::io::Error::from(
+            crate::io::ErrorKind::Interrupted,
+        )))
+    };
+    let persistent = || {
+        Err(crate::Error::Io(crate::io::Error::from(
+            crate::io::ErrorKind::Other,
+        )))
+    };
+
+    // Transient loss vs an INCOMPLETE success → propagate (either side).
+    assert_eq!(
+        arbitrate_mirrors(&transient(), &incomplete()),
+        MirrorArbitration::Propagate,
+    );
+    assert_eq!(
+        arbitrate_mirrors(&incomplete(), &transient()),
+        MirrorArbitration::Propagate,
+    );
+    // Transient loss vs a COMPLETE success → the complete success wins.
+    assert_eq!(
+        arbitrate_mirrors(&transient(), &complete()),
+        MirrorArbitration::PublishMid,
+    );
+    assert_eq!(
+        arbitrate_mirrors(&complete(), &transient()),
+        MirrorArbitration::PublishTail,
+    );
+    // PERSISTENT failure vs an incomplete success → the success wins (a retry
+    // cannot help the persistent failure).
+    assert_eq!(
+        arbitrate_mirrors(&persistent(), &incomplete()),
+        MirrorArbitration::PublishMid,
+    );
+}
+
+/// `publish_from_temp` must not delete `temp` when the winning attempt ERRORED:
+/// a failure BEFORE `Writer::new` never created it, and a failure after already
+/// discarded its own partial, so the caller owns nothing to remove. Ownership is
+/// proven by the OUTCOME, never inferred from the error kind — otherwise, on
+/// shared storage, an attempt whose `temp` path collides with a concurrent
+/// process's file (e.g. across PID namespaces with the same numeric id) would
+/// delete that process's file. Regression for the winner-publication arm, the
+/// sibling of the arbitration loser-cleanup fix.
+#[test]
+fn publish_from_temp_keeps_a_foreign_temp_on_an_erroring_attempt() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let temp = dir.path().join("dest.healtmp-0");
+    let dest = dir.path().join("dest");
+
+    // A concurrent process owns the temp path; THIS attempt never created it.
+    std::fs::write(&temp, b"foreign process output")?;
+
+    // The published attempt errored BEFORE `Writer::new` (a deletion-guard
+    // refusal is a FeatureUnsupported, not an AlreadyExists race loss).
+    let result = Err(crate::Error::FeatureUnsupported("deletion guard"));
+    let Err(err) = super::publish_from_temp(&fs, result, &temp, &dest, &SalvageOptions::default())
+    else {
+        panic!("an erroring attempt must propagate its error");
+    };
+    assert!(
+        matches!(err, crate::Error::FeatureUnsupported("deletion guard")),
+        "the original error propagates unchanged, got {err:?}",
+    );
+    assert!(
+        temp.exists(),
+        "the foreign temp must survive: this attempt never created it",
+    );
+    Ok(())
+}
+
+/// A PRESENT `delete_bitmap` section that decodes to an EMPTY bitmap must fail
+/// salvage closed. The writer only emits the section when the bitmap is
+/// non-empty, so a checksum-consistent corruption to empty is a forge: it keeps
+/// the section visible (exempting the concealment guards) yet carries no
+/// positions, so the masked columnar path would re-emit every deleted row live
+/// without the resurrection opt-in.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_refuses_a_present_but_empty_delete_bitmap() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Re-stamp the delete_bitmap section as a valid but EMPTY bitmap.
+    crate::test_forge::forge_delete_bitmap_empty(&source, 0)?;
+
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a present-but-empty delete bitmap must fail salvage closed");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("delete bitmap cannot be applied")),
+        "the refusal must name the unpositionable delete mask, got {err:?}",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "no salvaged copy is produced when the delete bitmap is corrupt to empty",
+    );
+    Ok(())
+}
+
+/// A `delete_bitmap` section that is PRESENT and non-empty while the
+/// authenticated `descriptor#delete_bitmap_len` records ZERO must be rejected.
+/// The writer stamps the count as `0` precisely when no bitmap section is
+/// written, so a `0` count paired with a live section is a forge: a
+/// checksum-restamped TOC that grafts another table's bitmap (or relabels an
+/// optional section to `delete_bitmap`) onto a no-delete table makes reads
+/// apply that mask and silently drop live rows. The guard must compare the
+/// count and the section state in BOTH directions, not only reject `count > 0`
+/// with no section.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_metadata_bounds_rejects_a_zero_count_with_a_live_bitmap() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Zero the authenticated count in both mirrors while the section keeps its
+    // three live positions: the state a TOC forge reaches by grafting a bitmap
+    // onto a genuinely no-delete table (recorded count 0).
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &source,
+        b"descriptor#delete_bitmap_len",
+        &0u64.to_le_bytes(),
+    )?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("a recorded count of 0 with a present non-empty bitmap must be rejected");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("delete_bitmap count disagrees")),
+        "the rejection must name the delete_bitmap count mismatch, got {err:?}",
+    );
+    Ok(())
+}
+
+/// A forged TLI that REORDERS columnar block handles must fail salvage closed.
+/// `delete_block_starts` is built by walking the index, so a reorder rebuilds
+/// the starts in that same reordered sequence and `delete_positions_verified`
+/// self-validates against them. But the bitmap positions were assigned in the
+/// writer's PHYSICAL block order, so the salvage walk (which sorts blocks back
+/// to physical order) would mask against the wrong starts, deleting live rows
+/// and resurrecting deleted ones without the opt-in. Anchoring the verification
+/// to monotonic physical offsets detects the reorder.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_refuses_a_reordered_columnar_index_with_deletes() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Small blocks so the SST spills several columnar data blocks; deletes land
+    // across them.
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 60, 120] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Swap the first two block handles in both TLI mirrors. The index and
+    // delete_block_starts now agree with each other but not with the physical
+    // bitmap positions.
+    crate::test_forge::forge_tli_mirrors_swap_first_two(&source, 0, None)?;
+
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a reordered columnar index with deletes must fail salvage closed");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("delete bitmap cannot be applied")),
+        "the refusal must name the unpositionable delete mask, got {err:?}",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "no salvaged copy is produced when the delete bitmap cannot be positioned",
+    );
+    Ok(())
+}
+
+/// `verify_seqno_bounds` must reject a PRESENT `seqno_bounds` section that
+/// decodes to an EMPTY map on a table that still holds data blocks: every real
+/// writer emits one entry per block, so an empty map (a `delete_bitmap` renamed
+/// to `seqno_bounds` and re-stamped empty) means the table's real bounds/deletes
+/// metadata was laundered away. Accepting it lets a healed-digest refresh grade
+/// the table clean and reopen it without its deletion metadata, resurrecting
+/// positionally deleted rows.
+#[test]
+fn verify_seqno_bounds_rejects_a_present_empty_map_on_a_nonempty_table() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A PLAIN table with the per-block seqno_bounds section enabled.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_seqno_in_index(true)
+        .use_data_block_size(128);
+    for i in 0u64..64 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Re-stamp the seqno_bounds section as a valid but EMPTY map.
+    crate::test_forge::forge_seqno_bounds_empty(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_seqno_bounds() else {
+        panic!("an empty seqno_bounds on a table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader("seqno_bounds is missing a data block's entry")
+        ),
+        "the rejection names the missing-block-entry reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_block_layout` must reject a PRESENT `block_layout` section that
+/// decodes to an EMPTY map on a table that carries multi-inner-block frames:
+/// the writer only emits the section when it has boundaries to record, so an
+/// empty map (a `delete_bitmap` renamed and re-roled to an empty `block_layout`)
+/// means the deletion metadata was laundered away. The per-block loop cannot
+/// catch it (a block absent from the map is skipped), so accepting it lets a
+/// healed-digest refresh keep the table without its delete bitmap.
+#[cfg(feature = "zstd")]
+#[test]
+fn verify_block_layout_rejects_a_present_empty_map_on_a_nonempty_table() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // 256 KiB blocks at zstd L19 split into many inner blocks, so the writer
+    // records a real block_layout section.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256 * 1024)
+        .use_data_block_compression(crate::CompressionType::Zstd(19));
+    for i in 0u64..20_000 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:012}").into_bytes(),
+            format!("value-{i:08}-payload").into_bytes(),
+            1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Re-stamp the block_layout section as a valid but EMPTY map.
+    crate::test_forge::forge_block_layout_empty(&source, 0, None)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_block_layout() else {
+        panic!("an empty block_layout on a table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "block_layout section is present but empty on a table with data blocks"
+            )
+        ),
+        "the rejection names the present-empty block_layout reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_block_layout` must run the present-but-empty rejection on builds
+/// WITHOUT zstd too. The function used to return `Ok(())` for the whole
+/// non-zstd build before reading the section, so a columnar SST with positional
+/// deletes whose `delete_bitmap` was relabeled to an empty `block_layout` graded
+/// clean and reopened without its deletion metadata. The emptiness check now
+/// runs independent of the zstd frame cross-check.
+#[cfg(all(feature = "columnar", not(feature = "zstd")))]
+#[test]
+fn verify_block_layout_rejects_an_empty_map_without_zstd() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Relabel the delete_bitmap section to an empty block_layout (the writer
+    // never emits a real one on a non-zstd build, so synthesise the forgery).
+    crate::test_forge::forge_delete_bitmap_as_empty_block_layout(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_block_layout() else {
+        panic!("an empty block_layout on a non-zstd table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "block_layout section is present but empty on a table with data blocks"
+            )
+        ),
+        "the rejection names the present-empty block_layout reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_filter` must reject a PRESENT full `filter` section that decodes to
+/// the empty "no filter installed" sentinel on a table with data blocks: the
+/// writer omits the section when filtering is disabled, so a present-empty
+/// filter is a forgery (a `delete_bitmap` renamed and re-roled to an empty
+/// filter). The read-path probe treats an empty payload permissively — `Ok(true)`
+/// for every key — so without this rejection the relabel passes the whole check,
+/// a healed digest keeps the table, and reopening resurrects the deleted rows.
+#[test]
+fn verify_filter_rejects_a_present_empty_full_filter() -> crate::Result<()> {
+    use crate::config::BloomConstructionPolicy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_bloom_policy(BloomConstructionPolicy::BitsPerKey(10.0));
+    for i in 0u32..200 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Re-stamp the full filter section as a valid but EMPTY payload.
+    crate::test_forge::forge_filter_empty(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_filter(None) else {
+        panic!("an empty full filter on a table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "filter section is present but empty on a table with data blocks"
+            )
+        ),
+        "the rejection names the present-empty filter reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_filter` must reject an empty PARTITION too, not just an empty full
+/// filter. The partitioned path seeks the partition for a key and probes it; on
+/// the empty "no filter" sentinel `maybe_contains_hash` answers `Ok(true)` for
+/// every key, so a partition the writer would never leave empty (a `delete_bitmap`
+/// relabeled to an empty filter partition under a re-stamped `filter_tli`) would
+/// pass the probe and keep the table as deletion-free.
+#[test]
+fn verify_filter_rejects_an_empty_partition_for_an_existing_key() -> crate::Result<()> {
+    use crate::config::BloomConstructionPolicy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A partitioned filter with a tiny partition budget so several partitions
+    // spill and the writer emits the filter_tli over them.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_partitioned_filter()
+        .use_meta_partition_size(3)
+        .use_bloom_policy(BloomConstructionPolicy::BitsPerKey(10.0));
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Empty the first partition in place (the one covering the lowest keys).
+    crate::test_forge::forge_filter_first_partition_empty(&source)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_filter(None) else {
+        panic!("an empty filter partition covering an existing key must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "filter partition is present but empty for an existing key"
+            )
+        ),
+        "the rejection names the present-empty partition reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_zone_map` must reject a PRESENT `zone_map` section that decodes to an
+/// EMPTY map on a table with data blocks: the writer emits one entry per data
+/// block whenever the section exists, so an empty map (a `delete_bitmap`
+/// relabeled and re-roled to an empty `zone_map`) means the deletion metadata
+/// was laundered away while every semantic gate still passes.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_zone_map_rejects_a_present_empty_map_on_a_nonempty_table() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+zonemap SST is non-empty"
+    );
+
+    // Re-stamp the zone_map section as a valid but EMPTY map.
+    crate::test_forge::forge_zone_map_empty(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_zone_map() else {
+        panic!("an empty zone_map on a table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "zone_map section is present but empty on a table with data blocks"
+            )
+        ),
+        "the rejection names the present-empty zone_map reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// On a ROW table `verify_zone_map` must authenticate the synthetic column's
+/// IDENTITY, not only its min / max / row count. The writer stamps every
+/// whole-block column with `column_id == 0` and zero type / codec / null
+/// fields; a re-stamped map can change that id to a consumer value-column id
+/// while leaving the key bounds untouched. The bounds check then passes, repair
+/// keeps the table, and `ColumnRangePredicate::can_skip_block` reads those key
+/// bounds as value-column statistics and can skip blocks holding matching rows.
+#[test]
+fn verify_zone_map_rejects_a_forged_synthetic_column_id() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_zone_map(true);
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source row+zonemap SST is non-empty"
+    );
+
+    // Repurpose the first block's whole-block key statistic as a value-column
+    // statistic by changing its id, leaving min / max / row count intact.
+    crate::test_forge::forge_zone_map_column_id(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_zone_map() else {
+        panic!("a non-zero synthetic column id must be rejected");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("zone_map synthetic column")),
+        "the rejection must name the synthetic column identity, got {err:?}",
+    );
+    Ok(())
+}
+
+/// On a COLUMNAR table `verify_zone_map` authenticates the FULL per-column map
+/// by re-deriving it from each decoded block: a columnar block records one entry
+/// per stored column, so a re-stamped id (here the user-key column's id flipped
+/// to a consumer value-column id) no longer matches the re-derivation and is
+/// rejected. This is the columnar counterpart of the row-block synthetic-column
+/// identity check.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_zone_map_rejects_a_forged_columnar_column_id() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+zonemap SST is non-empty"
+    );
+
+    // Flip the first block's first (user-key) column id, leaving every other
+    // recorded field intact: the re-derived per-column map still expects the
+    // user-key column at id 0, so the mismatch is caught.
+    crate::test_forge::forge_zone_map_column_id(&source, 0)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_zone_map() else {
+        panic!("a forged columnar column id must be rejected");
+    };
+    assert!(
+        matches!(err, crate::Error::InvalidHeader(msg) if msg.contains("per-column statistics")),
+        "the rejection must name the columnar per-column mismatch, got {err:?}",
+    );
+    Ok(())
+}
+
+/// A salvaged COLUMNAR table must keep its per-column zone-map statistics. The
+/// clean-block verbatim copy-through re-emits columnar blocks byte-for-byte via
+/// `append_verbatim_data_block`; if that path recorded the row-block synthetic
+/// column-0 statistic instead of the per-column stats, the salvaged table would
+/// fail its own `verify_zone_map` forgery cross-check (the verifier re-derives
+/// per-column stats from the decoded columnar block).
+#[cfg(feature = "columnar")]
+#[test]
+fn salvaged_columnar_table_keeps_per_column_zone_statistics() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A clean columnar SST with a zone map and several small data blocks, so at
+    // least one clean block is byte-copied verbatim during salvage.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(128);
+    for i in 0u32..64 {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.salvaged_path.is_some(),
+        "the clean SST salvages: {report:?}",
+    );
+    assert!(
+        report.blocks_copied_verbatim > 0,
+        "at least one clean columnar block is byte-copied verbatim: {report:?}",
+    );
+
+    let table = open(dest, &fs)?;
+    assert!(table.has_zone_map(), "the salvaged copy carries a zone map");
+    // The per-column stats the copy-through recorded must equal what the
+    // verifier re-derives from each decoded columnar block.
+    table.verify_zone_map()?;
+    Ok(())
+}
+
+/// `verify_block_layout` must apply the present-empty rejection to ENCRYPTED
+/// tables too. The emptiness check used to sit AFTER the `self.encryption`
+/// early return, so an encrypted table's empty `block_layout` (a `delete_bitmap`
+/// relabeled to `block_layout`) slipped through. Decoding the section with the
+/// provider both runs the check and, for a genuine relabel, fails the AEAD open
+/// (the block-type AAD binds the real role).
+#[cfg(all(feature = "encryption", feature = "zstd"))]
+#[test]
+fn verify_block_layout_rejects_an_empty_map_on_an_encrypted_table() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let enc: Arc<dyn crate::encryption::EncryptionProvider> =
+        Arc::new(crate::encryption::Aes256GcmProvider::new(&[0x42; 32]));
+
+    // 256 KiB blocks at zstd L19 split into many inner blocks, so the writer
+    // records a real block_layout section even under encryption.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256 * 1024)
+        .use_data_block_compression(crate::CompressionType::Zstd(19))
+        .use_encryption(Some(Arc::clone(&enc)));
+    for i in 0u64..20_000 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:012}").into_bytes(),
+            format!("value-{i:08}-payload").into_bytes(),
+            1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source encrypted SST is non-empty",
+    );
+
+    // Re-stamp the block_layout section as a valid but EMPTY encrypted map.
+    crate::test_forge::forge_block_layout_empty(&source, 0, Some(&*enc))?;
+
+    let table = open_encrypted(source, &fs, Arc::clone(&enc))?;
+    let Err(err) = table.verify_block_layout() else {
+        panic!("an empty block_layout on an encrypted table with data blocks must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "block_layout section is present but empty on a table with data blocks"
+            )
+        ),
+        "the rejection names the present-empty block_layout reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_metadata_bounds` must cross-check `seqno#min` against the decoded
+/// entries even on a RANGE-TOMBSTONE-bearing table. The synthetic sentinel is
+/// only written when the table has NO real KV items, so a table with both point
+/// entries AND range tombstones has no sentinel and its decoded seqnos are all
+/// real. Skipping the check for every RT-bearing table let both meta mirrors be
+/// re-stamped with `seqno#min` raised above a real KV seqno, hiding live
+/// versions from snapshots at/below the forged minimum after reopen.
+#[test]
+fn verify_metadata_bounds_rejects_a_raised_seqno_min_on_a_range_tombstone_table()
+-> crate::Result<()> {
+    use crate::UserKey;
+    use crate::range_tombstone::RangeTombstone;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Point entries at seqnos 1..=8 PLUS a range tombstone: the table carries a
+    // range_tombstones section but, having real KV items, writes no sentinel.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..8 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    writer.write_range_tombstone(RangeTombstone::new(
+        UserKey::from(b"key-002".as_slice()),
+        UserKey::from(b"key-005".as_slice()),
+        9,
+    ));
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Raise seqno#min above the real minimum KV seqno (1) in BOTH meta mirrors.
+    crate::test_forge::forge_meta_value_both_mirrors(&source, b"seqno#min", &5u64.to_le_bytes())?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("a seqno#min above the real minimum must be rejected even with range tombstones");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader("meta seqno#min is above the decoded minimum seqno")
+        ),
+        "the rejection names the seqno#min branch specifically, got {err:?}",
+    );
+    Ok(())
+}
+
+/// The synthetic-sentinel exclusion must NOT fire on a table with REAL KV
+/// entries. Only an RT-ONLY table carries a synthetic sentinel, whose RT-derived
+/// seqno the writer keeps ABOVE `highest_kv_seqno`. On an RT+KV table a real weak
+/// tombstone whose key and seqno happen to match the RT-minimal `(start, seqno)`
+/// contributed to `highest_kv_seqno` (so its seqno is `<=` it) and must be counted
+/// toward the seqno bounds — excluding it as if it were the sentinel drops the
+/// true minimum, letting a `seqno#min` restamped above that entry pass and hide
+/// the live version from snapshots at/below the forged minimum.
+#[test]
+fn verify_metadata_bounds_keeps_a_real_weak_tombstone_matching_the_rt_sentinel() -> crate::Result<()>
+{
+    use crate::UserKey;
+    use crate::range_tombstone::RangeTombstone;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // key-002 is a REAL weak tombstone at seqno 3 — the TRUE minimum seqno — and
+    // its (key, seqno) equals the (seqno, start)-minimal range tombstone's, so
+    // the old code mistook it for the synthetic RT-only sentinel and excluded it.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    writer.write(InternalValue::from_components(
+        b"key-000".to_vec(),
+        b"val-000".to_vec(),
+        4,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::from_components(
+        b"key-001".to_vec(),
+        b"val-001".to_vec(),
+        5,
+        ValueType::Value,
+    ))?;
+    writer.write(InternalValue::new_weak_tombstone(
+        UserKey::from(b"key-002".as_slice()),
+        3,
+    ))?;
+    for i in 3u64..8 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 3,
+            ValueType::Value,
+        ))?;
+    }
+    // The (seqno, start)-minimal range tombstone is (start = key-002, seqno = 3),
+    // so the derived sentinel is exactly the real weak tombstone above. Its end
+    // stays within the table key range (max key-007) so coverage passes.
+    writer.write_range_tombstone(RangeTombstone::new(
+        UserKey::from(b"key-002".as_slice()),
+        UserKey::from(b"key-005".as_slice()),
+        3,
+    ));
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Raise seqno#min to 4 (above the real minimum 3, at the next-lowest seqno):
+    // caught only if the seqno-3 weak tombstone is counted. With the sentinel
+    // wrongly excluding it, the decoded minimum becomes 4 and 4 > 4 is false, so
+    // the forge slips through.
+    crate::test_forge::forge_meta_value_both_mirrors(&source, b"seqno#min", &4u64.to_le_bytes())?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("a seqno#min above a real weak tombstone matching the RT sentinel must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader("meta seqno#min is above the decoded minimum seqno")
+        ),
+        "the rejection names the seqno#min branch specifically, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_metadata_bounds` must reject a `range_tombstones` section whose
+/// decoded count disagrees with the recorded `range_tombstone_count`: a dropped
+/// section (or a re-stamped block decoding to a subset) passes coverage for its
+/// surviving entries, but the missing ranges no longer mask lower-level data —
+/// reads resurrect the keys those tombstones deleted. The recorded count lives
+/// in the (separately authenticated) meta block, so a mismatch is a forgery.
+#[test]
+fn verify_metadata_bounds_rejects_a_range_tombstone_count_mismatch() -> crate::Result<()> {
+    use crate::UserKey;
+    use crate::range_tombstone::RangeTombstone;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0u64..8 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:03}").into_bytes(),
+            format!("val-{i:03}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    writer.write_range_tombstone(RangeTombstone::new(
+        UserKey::from(b"key-002".as_slice()),
+        UserKey::from(b"key-005".as_slice()),
+        9,
+    ));
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Drop the range_tombstones section: the meta block still records
+    // range_tombstone_count = 1, so the decoded count (0) disagrees.
+    crate::test_forge::forge_section_omitted(&source, b"range_tombstones")?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_metadata_bounds() else {
+        panic!("a range_tombstones count mismatch must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "range_tombstones count disagrees with the recorded range_tombstone_count"
+            )
+        ),
+        "the rejection names the RT count-mismatch reason, got {err:?}",
+    );
+    Ok(())
+}
+
+/// `verify_tli_mirrors` must cross-check each PARTITIONED top-level separator
+/// against its partition's last data-block separator. Lowering a top-level
+/// separator (in both mirrors) keeps the mirrors equal, the handles tiling, and
+/// every LEAF separator matching its block — yet `TwoLevelBlockIndex` seeks by
+/// the top-level separator and would route reads to the wrong partition,
+/// skipping the keys the real partition holds. Only comparing the top-level
+/// separator with the partition's decoded last key catches it.
+#[test]
+fn verify_tli_mirrors_rejects_a_forged_partition_boundary() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A partitioned index with many small data blocks yields >= 2 top-level
+    // partitions, so the forge lowers a real partition BOUNDARY (not a leaf).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_partitioned_index()
+        .use_data_block_size(128)
+        .use_meta_partition_size(2);
+    for i in 0u64..512 {
+        writer.write(InternalValue::from_components(
+            format!("key-{i:05}").into_bytes(),
+            format!("val-{i:05}").into_bytes(),
+            i + 1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Lower the FIRST top-level separator in both TLI mirrors.
+    crate::test_forge::forge_tli_mirrors_lower_first_separator(&source, 0, None)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_tli_mirrors() else {
+        panic!("a forged partition boundary must be rejected");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "tli separator disagrees with its partition's last separator"
+            )
+        ),
+        "the rejection names the partition-boundary mismatch, got {err:?}",
+    );
+    Ok(())
+}
+
+/// A `linked_blob_files` section that PARSES but under-reports its contents
+/// (count word forged to 0, record bytes left in place) must not be trusted
+/// as the sole source of the recovered copy's links: the recovered entries
+/// still hold `ValueHandle` indirections into the blob file, and blob GC /
+/// relocation consults the links to decide liveness — an under-reported list
+/// would let GC delete or rewrite a blob the copy still references. Salvage
+/// derives the links from the recovered indirections and unions them with
+/// the source list.
+#[test]
+fn salvage_rebuilds_blob_links_from_recovered_indirections() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let crate::AnyTree::Blob(tree) = crate::Config::new(
+        dir.path(),
+        crate::SequenceNumberCounter::default(),
+        crate::SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let source = {
+        let binding = tree.index.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    // The TRUE links, before the forgery.
+    let Some(true_links) = open(source.clone(), &fs)?.list_blob_file_references()? else {
+        panic!("the source carries a linked_blob_files section");
+    };
+    assert!(!true_links.is_empty(), "the source references blob files");
+
+    // Forge the count word to 0: the section still parses (the bound check
+    // passes trivially) but reports NO links.
+    let pos = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"linked_blob_files")
+        else {
+            panic!("the source must carry a linked_blob_files section");
+        };
+        usize::try_from(entry.pos()).unwrap_or(usize::MAX)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(count) = bytes.get_mut(pos..pos + 4) else {
+        panic!("linked_blob_files count header within the file");
+    };
+    count.copy_from_slice(&0u32.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    // Sanity: the forgery took — the source now under-reports.
+    let Some(forged) = open(source.clone(), &fs)?.list_blob_file_references()? else {
+        panic!("the forged section still parses");
+    };
+    assert!(forged.is_empty(), "the forged count hides every link");
+
+    let dest = dir.path().join("salvaged");
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(report.is_complete(), "data blocks are healthy: {report:?}");
+
+    // The copy's links are derived from its recovered indirections, not
+    // parroted from the forged source list.
+    let Some(recovered_links) = open(dest, &fs)?.list_blob_file_references()? else {
+        panic!("the salvaged copy must carry links derived from its indirections");
+    };
+    for link in &true_links {
+        assert!(
+            recovered_links
+                .iter()
+                .any(|l| l.blob_file_id == link.blob_file_id),
+            "blob file {} is referenced by recovered indirections but missing \
+             from the copy's links: {recovered_links:?}",
+            link.blob_file_id,
+        );
+    }
+    Ok(())
+}
+
+/// A parseable `linked_blob_files` section that OVER-reports — carries a blob
+/// id no recovered `ValueHandle` actually references — must not have that
+/// source-only id copied into the salvaged table: the id may not exist under
+/// `blobs/` at all (a forged record), and a manifest whose table links a blob
+/// absent from the blob-file list is a corrupt reference downstream consumers
+/// must never see. The copy's links are the recovered indirections, exactly.
+#[test]
+fn salvage_drops_source_only_blob_links() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let crate::AnyTree::Blob(tree) = crate::Config::new(
+        dir.path(),
+        crate::SequenceNumberCounter::default(),
+        crate::SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let source = {
+        let binding = tree.index.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    // Forge the FIRST link record's blob id (the leading u64 of the 32-byte
+    // record, right after the LE u32 count) to an id that exists nowhere.
+    const FORGED_ID: u64 = 9_999_999;
+    let pos = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"linked_blob_files")
+        else {
+            panic!("the source must carry a linked_blob_files section");
+        };
+        usize::try_from(entry.pos()).unwrap_or(usize::MAX)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(id_slot) = bytes.get_mut(pos + 4..pos + 12) else {
+        panic!("first link record within the file");
+    };
+    id_slot.copy_from_slice(&FORGED_ID.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    // Sanity: the forgery took — the source reports the forged id.
+    let Some(forged) = open(source.clone(), &fs)?.list_blob_file_references()? else {
+        panic!("the forged section still parses");
+    };
+    assert!(
+        forged.iter().any(|l| l.blob_file_id == FORGED_ID),
+        "the source's section carries the forged id",
+    );
+
+    let dest = dir.path().join("salvaged");
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(report.is_complete(), "data blocks are healthy: {report:?}");
+
+    let Some(recovered_links) = open(dest, &fs)?.list_blob_file_references()? else {
+        panic!("the salvaged copy carries links derived from its indirections");
+    };
+    assert!(
+        !recovered_links.is_empty(),
+        "the recovered indirections reference the real blob file",
+    );
+    assert!(
+        !recovered_links.iter().any(|l| l.blob_file_id == FORGED_ID),
+        "a source-only id no recovered indirection references must not be \
+         copied into the salvaged table: {recovered_links:?}",
+    );
+    Ok(())
+}
+
+/// A KV-separated source whose `linked_blob_files` section is UNREADABLE (a
+/// count header claiming more records than the section holds) must not abort
+/// the salvage: the section is not authoritative — the walk derives the
+/// copy's links from the recovered `ValueHandle` indirections — so the
+/// readable data blocks are still recovered and the copy carries the derived
+/// links. Failing here would leave the whole table unrecovered over a
+/// non-authoritative side section.
+#[test]
+fn salvage_recovers_with_derived_links_when_the_blob_link_section_is_unreadable()
+-> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempdir()?;
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let crate::AnyTree::Blob(tree) = crate::Config::new(
+        dir.path(),
+        crate::SequenceNumberCounter::default(),
+        crate::SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let source = {
+        let binding = tree.index.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    // Overwrite the linked_blob_files count header (leading LE u32) with a
+    // value far larger than the section can hold, so parsing the records
+    // hits EOF and list_blob_file_references errors.
+    let pos = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"linked_blob_files")
+        else {
+            panic!("the source must carry a linked_blob_files section");
+        };
+        usize::try_from(entry.pos()).unwrap_or(usize::MAX)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(count) = bytes.get_mut(pos..pos + 4) else {
+        panic!("linked_blob_files count header within the file");
+    };
+    count.copy_from_slice(&u32::MAX.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    let dest = dir.path().join("salvaged");
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(report.is_complete(), "data blocks are healthy: {report:?}");
+
+    // The copy's links are derived from its recovered indirections; the
+    // unreadable source section contributes nothing.
+    let Some(recovered_links) = open(dest, &fs)?.list_blob_file_references()? else {
+        panic!("the salvaged copy must carry links derived from its indirections");
+    };
+    assert!(
+        !recovered_links.is_empty(),
+        "the recovered indirections reference at least one blob file",
+    );
+    Ok(())
+}
+
+/// Standalone salvage preserves the SOURCE's persisted table id: an
+/// unencrypted SST written under a non-zero id salvages WITHOUT the caller
+/// supplying that id (the salvage-mode open reads it from the metadata
+/// instead of failing the id cross-check against the options default of 0),
+/// and the recovered copy is stamped with the source's id — so it keeps its
+/// identity when an operator swaps it in for the original.
+#[test]
+fn salvage_preserves_a_nonzero_source_table_id() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    const TID: crate::TableId = 7;
+    let mut writer = Writer::new(source.clone(), TID, 0, Arc::clone(&fs))?.use_data_block_size(256);
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Default options (table_id = 0): the salvage must still open the source
+    // and carry its real id through.
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "a healthy non-zero-id SST salvages completely: {report:?}",
+    );
+
+    // The recovered copy reopens under the SOURCE's id (the recover
+    // cross-checks the stored table_id against the expected one).
+    let recovered = open_with_id(dest, &fs, TID)?;
+    assert_eq!(
+        recovered.metadata.id, TID,
+        "the salvaged copy is stamped with the source's table id",
+    );
+    assert_eq!(recovered.metadata.item_count, u64::from(n));
+    Ok(())
 }
 
 #[test]
@@ -87,11 +4120,73 @@ fn salvage_of_a_healthy_sst_recovers_every_block() -> crate::Result<()> {
         "a salvaged file is written when at least one block is recovered",
     );
 
+    // Every block of a healthy SST reads back clean, so every salvaged block is
+    // copied through verbatim — none re-encoded.
+    assert_eq!(
+        report.blocks_copied_verbatim, report.blocks_salvaged,
+        "a healthy SST's blocks are all copied verbatim",
+    );
+
     // The salvaged copy is a valid SST that reopens and holds every key.
     assert_eq!(
         reopen_item_count(dest, &fs)?,
         u64::from(n),
         "the salvaged SST reopens with the full item count",
+    );
+    Ok(())
+}
+
+/// A clean block is byte-copied verbatim, not decoded and re-encoded: its raw
+/// on-disk bytes in the salvaged SST are identical to the source's, and the walk
+/// reports it under `blocks_copied_verbatim`.
+#[test]
+fn salvage_copies_a_clean_block_verbatim() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(256);
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "healthy SST salvages clean: {report:?}"
+    );
+    assert_eq!(
+        report.blocks_copied_verbatim, report.blocks_total,
+        "every clean block is copied verbatim, none re-encoded",
+    );
+
+    // The first data block's raw on-disk bytes must be byte-identical between the
+    // source and the salvaged copy (each resolved through its own intact index).
+    let first_block = |path: &std::path::Path| -> crate::Result<(usize, usize)> {
+        let table = open(path.to_path_buf(), &fs)?;
+        let Some(kh) = table.data_block_handles().find_map(Result::ok) else {
+            panic!("a non-empty SST has at least one data block");
+        };
+        let off = usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX);
+        Ok((off, kh.as_ref().size() as usize))
+    };
+    let (src_off, src_size) = first_block(&source)?;
+    let (dst_off, dst_size) = first_block(&dest)?;
+    assert_eq!(
+        src_size, dst_size,
+        "the verbatim copy preserves the block's on-disk size",
+    );
+
+    let src_bytes = std::fs::read(&source)?;
+    let dst_bytes = std::fs::read(&dest)?;
+    let src_block = src_bytes.get(src_off..src_off + src_size);
+    let dst_block = dst_bytes.get(dst_off..dst_off + dst_size);
+    assert!(
+        src_block.is_some() && src_block == dst_block,
+        "the clean block is copied byte-for-byte into the salvaged SST",
     );
     Ok(())
 }
@@ -114,9 +4209,11 @@ fn salvage_drops_a_corrupted_block_and_keeps_the_rest() -> crate::Result<()> {
     assert!(writer.finish()?.is_some(), "source SST is non-empty");
 
     // Resolve the second data block's on-disk offset from the (intact) index,
-    // then flip a byte a little past its header so the block's data checksum
-    // fails on load. load_data_block reads the block by the index handle's size,
-    // so the corruption surfaces as that one block failing, not a desync.
+    // then flip a byte inside its PAYLOAD (past the fixed-size block header) so
+    // the header still frames but the block's data checksum fails on load.
+    // load_data_block reads the block by the index handle's size, so the
+    // corruption surfaces as that one block failing at load — kept via the
+    // index, dropped as a checksum mismatch — not as a physical-walk desync.
     let target = {
         let table = open(source.clone(), &fs)?;
         let offsets: alloc::vec::Vec<u64> = table
@@ -129,7 +4226,13 @@ fn salvage_drops_a_corrupted_block_and_keeps_the_rest() -> crate::Result<()> {
         };
         second
     };
-    let flip = usize::try_from(target).unwrap_or(0) + 16;
+    // Land well past the fixed data-block header (magic + type + checksums +
+    // lengths) so the frame stays intact and only the payload rots.
+    let header_len = crate::table::block::Header::header_len(crate::table::block::BlockType::Data);
+    let Ok(target_usize) = usize::try_from(target) else {
+        panic!("data block offset {target} does not fit usize on this target");
+    };
+    let flip = target_usize + header_len + 8;
     let mut bytes = std::fs::read(&source)?;
     if let Some(b) = bytes.get_mut(flip) {
         *b ^= 0xFF;
@@ -174,6 +4277,225 @@ fn salvage_drops_a_corrupted_block_and_keeps_the_rest() -> crate::Result<()> {
     Ok(())
 }
 
+/// A data block whose HEADER no longer frames is dropped by the physical gap
+/// walk, not the load path: the index still points at it, but `probe_gap`
+/// records the region rather than placing it in `items`. It must still count
+/// toward `blocks_total` (the walk INSPECTED it and found it unframeable), so
+/// the `blocks_total == recovered + dropped` contract holds. Previously a
+/// header-corrupt block dropped without being counted, so `blocks_total`
+/// equalled `blocks_salvaged` while a block had been lost: recovery ratios
+/// reported full coverage despite the loss.
+#[test]
+fn salvage_counts_a_header_corrupt_block_in_blocks_total() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(256);
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Flip a byte INSIDE the second data block's header (its magic), so the
+    // physical frame no longer parses: the tiling walk cannot trust the index
+    // span and resyncs PAST the block, dropping it through the gap probe rather
+    // than the load path: a `dropped` entry that never enters `items`.
+    let target = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: alloc::vec::Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|kh| *kh.as_ref().offset())
+            .collect();
+        let Some(&second) = offsets.get(1) else {
+            panic!("source SST must have at least two data blocks, got {offsets:?}");
+        };
+        second
+    };
+    let Ok(target_usize) = usize::try_from(target) else {
+        panic!("data block offset {target} does not fit usize on this target");
+    };
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(target_usize) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest, &fs)?;
+
+    assert!(
+        !report.dropped.is_empty(),
+        "the header-corrupt block must be reported dropped: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_total,
+        report.blocks_salvaged + report.dropped.len(),
+        "every inspected block is either recovered or dropped, a header-corrupt \
+         block must count toward the total, not vanish from it: {report:?}",
+    );
+    Ok(())
+}
+
+/// A data block that needs ECC recovery to read is NOT copied verbatim — its
+/// on-disk bytes are faulty, so propagating them would carry the corruption into
+/// the recovered copy. Salvage re-encodes the healed payload instead (clean bytes
+/// in the copy), while the surrounding clean blocks are still copied verbatim.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn salvage_reencodes_an_ecc_recovered_block_rather_than_copying_it() -> crate::Result<()> {
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Data blocks carry RS(4,2) parity, so a small corruption is healed on read
+    // rather than failing the block.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_ecc(Some(EccParams::RS_4_2));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Flip one payload byte of the FIRST data block so reading it must repair via
+    // RS parity (an ECC-recovered read, not a clean one).
+    let first_off = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().find_map(Result::ok) else {
+            panic!("a non-empty SST has at least one data block");
+        };
+        *kh.as_ref().offset()
+    };
+    let pos = usize::try_from(first_off).unwrap_or(usize::MAX) + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(pos) {
+        *b ^= 0x80;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+
+    // The healed block is recovered, not dropped — nothing is lost.
+    assert!(
+        report.is_complete(),
+        "an ECC-recoverable block is healed, not dropped: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_salvaged, report.blocks_total,
+        "every block is recovered",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n),
+        "every entry is recovered",
+    );
+    // Exactly the healed block was re-encoded; the rest were copied verbatim.
+    assert_eq!(
+        report.blocks_copied_verbatim,
+        report.blocks_salvaged - 1,
+        "the ECC-recovered block is re-encoded, not copied verbatim",
+    );
+
+    // The salvaged copy reopens with every key; its bytes are freshly encoded, so
+    // they no longer need ECC repair.
+    assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n));
+    Ok(())
+}
+
+/// Bit rot confined to a block's PARITY trailer reads as clean (the payload
+/// checksum passes and parity is only consulted on a mismatch), so a verbatim
+/// copy would carry the rotted parity into the salvaged SST as latent ECC
+/// corruption. Salvage must verify the trailer before copying and re-encode
+/// (regenerating fresh parity) when it disagrees: every data block of the
+/// recovered copy must carry parity that matches its payload.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn salvage_regenerates_a_rotted_parity_trailer_rather_than_copying_it() -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::table::block::{EccParams, Header, expected_parity_len};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_ecc(Some(EccParams::RS_4_2));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Flip one byte INSIDE the first data block's parity trailer (right after
+    // its `data_length` payload). The payload checksum still verifies, so the
+    // block reads back clean with no ECC recovery.
+    let first_off = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().find_map(Result::ok) else {
+            panic!("a non-empty SST has at least one data block");
+        };
+        usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(mut cursor) = bytes.get(first_off..) else {
+        panic!("first data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos =
+        first_off + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "the payload is intact, every block is recovered: {report:?}",
+    );
+    assert_eq!(reopen_item_count(dest.clone(), &fs)?, u64::from(n));
+
+    // Every data block of the salvaged copy carries parity that matches its
+    // payload — the rotted trailer was regenerated, not byte-copied.
+    let dest_bytes = std::fs::read(&dest)?;
+    let dest_table = open(dest, &fs)?;
+    let (ds, ps) = EccParams::RS_4_2.as_shards();
+    for kh in dest_table.data_block_handles() {
+        let kh = kh?;
+        let off = usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX);
+        let Some(mut cursor) = dest_bytes.get(off..) else {
+            panic!("block at offset {off} within the file");
+        };
+        let hdr = Header::decode_from(&mut cursor)?;
+        let hlen = Header::header_len(hdr.block_type);
+        let dl = hdr.data_length as usize;
+        let Some(payload) = dest_bytes.get(off + hlen..off + hlen + dl) else {
+            panic!("payload of block at offset {off} within the file");
+        };
+        let plen = expected_parity_len(hdr.data_length, EccParams::RS_4_2) as usize;
+        let Some(trailer) = dest_bytes.get(off + hlen + dl..off + hlen + dl + plen) else {
+            panic!("parity trailer of block at offset {off} within the file");
+        };
+        let fresh = crate::ecc::encode_parity(payload, ds, ps)?;
+        assert_eq!(
+            trailer,
+            fresh.as_slice(),
+            "block at offset {off}: the salvaged copy's parity matches its payload",
+        );
+    }
+    Ok(())
+}
+
 /// A columnar source with one corrupted PAX data block: the columnar loader
 /// fails to reconstruct that block (a torn sub-column frame), so salvage drops
 /// it and recovers every other block, writing the survivors as a plain row SST.
@@ -200,8 +4522,9 @@ fn salvage_drops_a_corrupted_columnar_block_and_keeps_the_rest() -> crate::Resul
         "source columnar SST is non-empty"
     );
 
-    // Corrupt the second columnar data block's bytes (offset from the intact
-    // index, a little past its header) so its reconstruction fails on load.
+    // Corrupt the second columnar data block's PAYLOAD (offset from the intact
+    // index, past the fixed block header) so the frame stays intact but its
+    // reconstruction fails on load — kept via the index, dropped at load.
     let target = {
         let table = open(source.clone(), &fs)?;
         let offsets: alloc::vec::Vec<u64> = table
@@ -214,7 +4537,13 @@ fn salvage_drops_a_corrupted_columnar_block_and_keeps_the_rest() -> crate::Resul
         };
         second
     };
-    let flip = usize::try_from(target).unwrap_or(0) + 16;
+    // Land well past the fixed data-block header so only the payload rots and
+    // the header still frames (otherwise the physical walk resyncs past it).
+    let header_len = crate::table::block::Header::header_len(crate::table::block::BlockType::Data);
+    let Ok(target_usize) = usize::try_from(target) else {
+        panic!("data block offset {target} does not fit usize on this target");
+    };
+    let flip = target_usize + header_len + 8;
     let mut bytes = std::fs::read(&source)?;
     if let Some(b) = bytes.get_mut(flip) {
         *b ^= 0xFF;
@@ -240,15 +4569,1163 @@ fn salvage_drops_a_corrupted_columnar_block_and_keeps_the_rest() -> crate::Resul
     );
     assert_eq!(report.salvaged_path.as_deref(), Some(dest.as_path()));
 
-    // The salvaged copy is a valid (row-format) SST holding the recovered rows.
-    assert_eq!(reopen_item_count(dest, &fs)?, report.entries_salvaged);
+    // The salvaged copy stays COLUMNAR (mirrored from the source) and holds the
+    // recovered rows — no longer degraded to a row-major copy.
+    let recovered = open(dest, &fs)?;
+    assert_eq!(recovered.metadata.item_count, report.entries_salvaged);
+    assert!(
+        recovered.metadata.columnar,
+        "a columnar source salvages into a columnar copy, not a row-major one",
+    );
+    Ok(())
+}
+
+/// A columnar block whose outer `ColumnBatch` frame decodes but whose row
+/// materialization fails (an invalid value-type byte in an otherwise
+/// checksum-consistent block) is dropped like any other block-local decode
+/// failure — one malformed block must not abort the whole salvage and discard
+/// the destination while later blocks are still recoverable.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_drops_a_columnar_block_with_an_invalid_value_type() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+    use crate::table::columnar::{CodecId, ColumnBatch};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    // Poison the SECOND data block: decode its ColumnBatch, stamp an invalid
+    // value-type tag into the first row, re-encode under the writer's Plain
+    // codec (byte-identical framing => same length), and re-stamp the header
+    // checksum. The block stays checksum-consistent, so the failure surfaces
+    // in row materialization — not as an ordinary checksum drop.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let Some(payload) = block.get(header_len..header_len + header.data_length as usize) else {
+        panic!("payload range within the block");
+    };
+    let mut batch = ColumnBatch::decode(payload)?;
+    let poisoned_rows = u64::from(batch.row_count);
+    // Columns are ordered (key, seqno, value-type, values...); 0xFF is not a
+    // defined ValueType tag.
+    let Some(vt_byte) = batch.columns.get_mut(2).and_then(|col| col.data.get_mut(0)) else {
+        panic!("value-type column present and non-empty");
+    };
+    *vt_byte = 0xFF;
+    let new_payload = batch.encode(CodecId::Plain)?;
+    assert_eq!(
+        new_payload.len(),
+        payload.len(),
+        "a one-byte in-place mutation re-encodes to the same length",
+    );
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    assert_eq!(
+        new_block.len(),
+        header_len,
+        "header re-encodes to its length"
+    );
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    // Salvage drops exactly the poisoned block and recovers every other one.
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the poisoned block is dropped: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(DropReason::DecodeError(_))
+        ),
+        "the invalid value-type tag classifies as a decode error: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n) - poisoned_rows,
+        "every row outside the poisoned block is recovered",
+    );
+    assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n) - poisoned_rows);
+    Ok(())
+}
+
+/// A checksum-consistent columnar block whose entries are OUT OF internal-key
+/// order (two adjacent keys swapped) must be dropped, not emitted: verbatim
+/// paths skip the ingest ordering checks, so an unvalidated malformed block
+/// would register a wrong last-key in the recovered SST's index and corrupt
+/// binary search / scan order. The rest of the SST still salvages.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_drops_a_columnar_block_with_out_of_order_keys() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+    use crate::table::columnar::{CodecId, ColumnBatch};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    // Poison the SECOND data block: swap the first two rows' user keys inside
+    // the key column (equal-length keys keep the Bytes framing intact),
+    // re-encode, and re-stamp the header checksum. The block stays
+    // checksum-consistent and its rows materialize fine — only the ordering
+    // invariant is broken.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let Some(payload) = block.get(header_len..header_len + header.data_length as usize) else {
+        panic!("payload range within the block");
+    };
+    let mut batch = ColumnBatch::decode(payload)?;
+    let poisoned_rows = u64::from(batch.row_count);
+    assert!(batch.row_count >= 2, "block holds at least two rows");
+    {
+        // Key column framing: (row_count + 1) LE u32 offsets, then payload.
+        let Some(key_col) = batch.columns.first_mut() else {
+            panic!("key column present");
+        };
+        let table_len = (batch.row_count as usize + 1) * 4;
+        let off = |data: &[u8], idx: usize| -> usize {
+            let Some(b) = data.get(idx * 4..idx * 4 + 4) else {
+                panic!("offset {idx} within the frame table");
+            };
+            u32::from_le_bytes(b.try_into().unwrap_or([0; 4])) as usize
+        };
+        let (o0, o1, o2) = (
+            off(&key_col.data, 0),
+            off(&key_col.data, 1),
+            off(&key_col.data, 2),
+        );
+        assert_eq!(o1 - o0, o2 - o1, "adjacent keys are equal-length");
+        let len = o1 - o0;
+        let Some(first) = key_col.data.get(table_len + o0..table_len + o0 + len) else {
+            panic!("first key within the column");
+        };
+        let first = first.to_vec();
+        let Some(second) = key_col.data.get(table_len + o1..table_len + o1 + len) else {
+            panic!("second key within the column");
+        };
+        let second = second.to_vec();
+        let Some(dst0) = key_col.data.get_mut(table_len + o0..table_len + o0 + len) else {
+            panic!("first key range within the column");
+        };
+        dst0.copy_from_slice(&second);
+        let Some(dst1) = key_col.data.get_mut(table_len + o1..table_len + o1 + len) else {
+            panic!("second key range within the column");
+        };
+        dst1.copy_from_slice(&first);
+    }
+    let new_payload = batch.encode(CodecId::Plain)?;
+    assert_eq!(
+        new_payload.len(),
+        payload.len(),
+        "an in-place key swap re-encodes to the same length",
+    );
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    // Salvage drops exactly the out-of-order block and recovers every other one.
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the out-of-order block is dropped: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(DropReason::DecodeError(_))
+        ),
+        "the ordering violation classifies as a decode error: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n) - poisoned_rows,
+        "every row outside the poisoned block is recovered",
+    );
+    assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n) - poisoned_rows);
+    Ok(())
+}
+
+/// `verify_point_read_reachability` must enforce the GLOBAL internal-key order
+/// for a COLUMNAR table too: it has no in-block key index to probe, but
+/// `column_batch_match_entries` binary-searches the key column assuming it is
+/// sorted. A checksum-consistent columnar block with two swapped keys — which the
+/// other columnar gates (count / zone bounds) tolerate — would otherwise pass
+/// salvage-mode repair and be KEPT, then miss the key or return a stale version.
+#[cfg(feature = "columnar")]
+#[test]
+fn verify_point_read_reachability_rejects_a_reordered_columnar_block() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+    use crate::table::columnar::{CodecId, ColumnBatch};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    // Swap the first two rows' user keys inside the second block's key column
+    // (equal-length keys keep the framing), re-encode, and re-stamp the header
+    // checksum: the block stays checksum-consistent and its rows materialize,
+    // only the ordering invariant is broken.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let Some(payload) = block.get(header_len..header_len + header.data_length as usize) else {
+        panic!("payload range within the block");
+    };
+    let mut batch = ColumnBatch::decode(payload)?;
+    assert!(batch.row_count >= 2, "block holds at least two rows");
+    {
+        let Some(key_col) = batch.columns.first_mut() else {
+            panic!("key column present");
+        };
+        let table_len = (batch.row_count as usize + 1) * 4;
+        let off = |data: &[u8], idx: usize| -> usize {
+            let Some(b) = data.get(idx * 4..idx * 4 + 4) else {
+                panic!("offset {idx} within the frame table");
+            };
+            u32::from_le_bytes(b.try_into().unwrap_or([0; 4])) as usize
+        };
+        let (o0, o1, o2) = (
+            off(&key_col.data, 0),
+            off(&key_col.data, 1),
+            off(&key_col.data, 2),
+        );
+        assert_eq!(o1 - o0, o2 - o1, "adjacent keys are equal-length");
+        let len = o1 - o0;
+        let Some(first) = key_col.data.get(table_len + o0..table_len + o0 + len) else {
+            panic!("first key within the column");
+        };
+        let first = first.to_vec();
+        let Some(second) = key_col.data.get(table_len + o1..table_len + o1 + len) else {
+            panic!("second key within the column");
+        };
+        let second = second.to_vec();
+        let Some(dst0) = key_col.data.get_mut(table_len + o0..table_len + o0 + len) else {
+            panic!("first key range within the column");
+        };
+        dst0.copy_from_slice(&second);
+        let Some(dst1) = key_col.data.get_mut(table_len + o1..table_len + o1 + len) else {
+            panic!("second key range within the column");
+        };
+        dst1.copy_from_slice(&first);
+    }
+    let new_payload = batch.encode(CodecId::Plain)?;
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    let table = open(source, &fs)?;
+    let Err(err) = table.verify_point_read_reachability() else {
+        panic!("a reordered columnar block must be rejected, not declared clean");
+    };
+    assert!(
+        matches!(
+            err,
+            crate::Error::InvalidHeader(
+                "columnar entries are out of order (a user key decreased, or an equal key's \
+                 seqno did not strictly decrease) across the walk"
+            )
+        ),
+        "the rejection names the columnar order violation, got {err:?}",
+    );
+    Ok(())
+}
+
+/// A checksum-clean columnar block that decodes as a ZERO-ROW `ColumnBatch`
+/// is malformed input (a real writer never emits an empty block): the writer
+/// primitive emits nothing for it, so counting it as salvaged would let an
+/// SST whose only block is empty report `salvaged_path = Some(dest)` while
+/// the empty-table `finish` REMOVES `dest` — and a mixed SST would
+/// under-report its dropped key ranges. Such a block must be dropped as a
+/// decode error.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_drops_a_zero_row_columnar_block() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+    use crate::table::columnar::{
+        COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
+    };
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A single-block columnar SST (few rows, default block size). An ODD row
+    // count lets the retry below flip the payload-length parity by growing
+    // every value one byte.
+    let n = 9u32;
+    let build = |value_pad: usize| -> crate::Result<()> {
+        let _ = std::fs::remove_file(&source);
+        let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?.use_columnar(true);
+        for i in 0..n {
+            writer.write(InternalValue::from_components(
+                format!("key{i:05}").into_bytes(),
+                format!("val{i:05}{}", "x".repeat(value_pad)).into_bytes(),
+                1,
+                ValueType::Value,
+            ))?;
+        }
+        assert!(writer.finish()?.is_some(), "source SST is non-empty");
+        Ok(())
+    };
+    build(0)?;
+
+    // The zero-row replacement encodes to 8 (row/column counts) + 44 bytes of
+    // intrinsic + value column headers, padded to the ORIGINAL payload length
+    // with extra empty value sub-columns (Fixed = 10 bytes, Bytes = 14 — every
+    // reachable length is even, so an odd source payload is rebuilt one byte
+    // per value larger to flip its parity).
+    let payload_len = |src: &std::path::Path| -> crate::Result<usize> {
+        let bytes = std::fs::read(src)?;
+        let mut cursor = bytes.as_slice();
+        let header = Header::decode_from(&mut cursor)?;
+        Ok(header.data_length as usize)
+    };
+    let mut target_len = payload_len(&source)?;
+    if target_len % 2 != 0 {
+        build(1)?;
+        target_len = payload_len(&source)?;
+    }
+    assert_eq!(target_len % 2, 0, "an even payload length is reachable");
+
+    let empty_fixed = |id: u16, width: u8| Column {
+        column_id: id,
+        type_tag: TypeTag::Fixed(width),
+        validity: None,
+        data: Vec::new(),
+    };
+    let mut columns = vec![
+        Column {
+            column_id: COL_USER_KEY,
+            type_tag: TypeTag::Bytes,
+            validity: None,
+            // A zero-row Bytes column is exactly its (row_count + 1) * 4 = 4
+            // byte offset table.
+            data: vec![0u8; 4],
+        },
+        empty_fixed(COL_SEQNO, 8),
+        empty_fixed(COL_VALUE_TYPE, 1),
+        empty_fixed(COL_VALUE, 1),
+    ];
+    let Some(mut rem) = target_len.checked_sub(8 + 14 + 10 + 10 + 10) else {
+        panic!("source payload larger than the zero-row skeleton");
+    };
+    let mut next_id = COL_VALUE + 1;
+    // Greedy fill: Bytes columns (+14) until the remainder is divisible by
+    // 10, then Fixed columns (+10).
+    while rem % 10 != 0 {
+        columns.push(Column {
+            column_id: next_id,
+            type_tag: TypeTag::Bytes,
+            validity: None,
+            data: vec![0u8; 4],
+        });
+        next_id += 1;
+        let Some(next_rem) = rem.checked_sub(14) else {
+            panic!("remainder covers a Bytes column");
+        };
+        rem = next_rem;
+    }
+    while rem > 0 {
+        columns.push(empty_fixed(next_id, 1));
+        next_id += 1;
+        rem -= 10;
+    }
+    let batch = ColumnBatch {
+        row_count: 0,
+        columns,
+    };
+    let new_payload = batch.encode(CodecId::Plain)?;
+    assert_eq!(
+        new_payload.len(),
+        target_len,
+        "the zero-row batch pads to the original payload length",
+    );
+
+    // Splice it under a re-stamped checksum (frame length unchanged).
+    let mut bytes = std::fs::read(&source)?;
+    let mut cursor = bytes.as_slice();
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block: Vec<u8> = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(..new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    // The zero-row block is DROPPED, so nothing is recoverable: no destination
+    // is left behind and no salvaged path is reported (the pre-fix behavior
+    // counted it as salvaged, reporting Some(dest) for a file the empty-table
+    // finish had just removed).
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "the zero-row block is dropped as malformed: {report:?}",
+    );
+    assert_eq!(report.blocks_salvaged, 0, "{report:?}");
+    assert_eq!(
+        report.salvaged_path, None,
+        "an SST whose only block is empty reports nothing salvaged",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind",
+    );
+    Ok(())
+}
+
+/// The ROW-source twin of the columnar out-of-order drop: a checksum-clean
+/// row block with two adjacent keys swapped passes frame decode and row
+/// materialization, so the ordering guard before the emit is the only thing
+/// standing between it and a recovered SST with a corrupt index order. The
+/// rejection is block-local: the block drops, the rest still salvages.
+#[test]
+fn salvage_drops_a_row_block_with_out_of_order_keys() -> crate::Result<()> {
+    use crate::coding::Encode;
+    use crate::comparator::default_comparator;
+    use crate::table::block::Header;
+    use crate::table::block::decoder::ParsedItem as _;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    // Restart interval 1 + no hash index: every entry stores its full key, so
+    // swapping two equal-length keys re-encodes to a byte-identical length.
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_data_block_restart_interval(1)
+        .use_data_block_hash_ratio(0.0);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Poison the SECOND data block: decode its entries, swap the first two
+    // (equal-length keys), re-encode under the same block parameters, and
+    // re-stamp the header checksum.
+    let (block_off, poisoned_rows, new_block) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        let block_off = usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX);
+        let sb = table.salvage_load_block(kh.as_ref(), crate::table::block::BlockType::Data)?;
+        let header = sb.block.header;
+        let db = crate::table::DataBlock::from_loaded(sb.block, false)?;
+        let iter = db.try_iter(default_comparator())?;
+        let mut entries: alloc::vec::Vec<crate::InternalValue> =
+            iter.map(|p| p.materialize(db.as_slice())).collect();
+        assert!(entries.len() >= 2, "block holds at least two rows");
+        entries.swap(0, 1);
+        let mut new_payload: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        crate::table::DataBlock::encode_into(&mut new_payload, &entries, 1, 0.0)?;
+        assert_eq!(
+            new_payload.len(),
+            header.data_length as usize,
+            "an adjacent equal-length key swap re-encodes to the same length",
+        );
+        let header_len = Header::header_len(header.block_type);
+        let new_header = Header {
+            checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+            ..header
+        };
+        let mut new_block: alloc::vec::Vec<u8> =
+            alloc::vec::Vec::with_capacity(header_len + new_payload.len());
+        new_header.encode_into(&mut new_block)?;
+        new_block.extend_from_slice(&new_payload);
+        (block_off, entries.len() as u64, new_block)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the out-of-order block is dropped: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(DropReason::DecodeError(_))
+        ),
+        "the ordering violation classifies as a decode error: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n) - poisoned_rows,
+        "every row outside the poisoned block is recovered",
+    );
+    assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n) - poisoned_rows);
+    Ok(())
+}
+
+/// A delete-bearing columnar SST whose TLI mirrors AND zone map both omit
+/// the same TRAILING block: the positioning chain over the remaining
+/// indexed blocks stays self-consistent, so `delete_positions_verified`
+/// passes and the walk takes the masked re-emit — but the hidden block is
+/// recovered by the PHYSICAL gap walk with no verified start position,
+/// and masking it as "all rows live" would permanently resurrect the rows
+/// the delete bitmap marked there, without the explicit resurrection
+/// opt-in. The masked path must DROP an index-omitted block instead.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_does_not_resurrect_deletes_in_an_index_omitted_block() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    // Deletes land in the LAST block (the one both forges will hide).
+    let deleted = [n - 1, n - 2, n - 3];
+    for pos in deleted {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Row count of the block both forges hide, for the loss accounting.
+    let hidden_rows = {
+        let table = open(source.clone(), &fs)?;
+        let Some(last) = table.data_block_handles().filter_map(Result::ok).last() else {
+            panic!("source must have data blocks");
+        };
+        let Some(batch) = table.load_columnar_block_masked(last.as_ref())? else {
+            panic!("the last block holds live rows");
+        };
+        // The masked load on the INTACT source applies the bitmap, so add
+        // the deletes back for the block's physical row count.
+        u64::from(batch.row_count) + deleted.len() as u64
+    };
+
+    // Consistent forge: the zone map loses its last entry FIRST (the TLI
+    // still addresses the block for the entry lookup), then both TLI
+    // mirrors hide the same trailing block.
+    crate::test_forge::forge_zone_map_drop_last_entry(&source, 0)?;
+    crate::test_forge::forge_tli_mirrors_truncated(&source, 0, None)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "the index-omitted block has no verified delete position and must \
+         drop, never re-emit live: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n) - deleted.len() as u64 - (hidden_rows - deleted.len() as u64),
+        "every indexed block's surviving rows are recovered: {report:?}",
+    );
+    for pos in deleted {
+        let key = format!("key{pos:05}");
+        assert!(
+            reopen_get(dest.clone(), &fs, key.as_bytes())?.is_none(),
+            "a positionally deleted row must not resurrect via the gap walk",
+        );
+    }
+    Ok(())
+}
+
+/// The DELETE-BEARING twin of the columnar out-of-order drop: the swapped
+/// keys keep every block's row count intact, so the delete positions still
+/// verify and the walk takes the masked re-emit — whose writer then rejects
+/// the broken ordering. The rejection stays block-local: only the poisoned
+/// block drops, deletes still apply to every other block.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_drops_an_out_of_order_columnar_block_in_a_delete_bearing_sst() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::config::DeleteStrategy;
+    use crate::table::block::Header;
+    use crate::table::columnar::{CodecId, ColumnBatch};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    let deletes = [5u32, 50, 150];
+    for pos in deletes {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Poison the SECOND data block exactly like the delete-free variant: swap
+    // the first two rows' user keys inside the key column and re-stamp the
+    // checksum. Row counts stay intact, so the delete positions still verify.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let Some(payload) = block.get(header_len..header_len + header.data_length as usize) else {
+        panic!("payload range within the block");
+    };
+    let mut batch = ColumnBatch::decode(payload)?;
+    let poisoned_rows = u64::from(batch.row_count);
+    assert!(batch.row_count >= 2, "block holds at least two rows");
+    {
+        let Some(key_col) = batch.columns.first_mut() else {
+            panic!("key column present");
+        };
+        let table_len = (batch.row_count as usize + 1) * 4;
+        let off = |data: &[u8], idx: usize| -> usize {
+            let Some(b) = data.get(idx * 4..idx * 4 + 4) else {
+                panic!("offset {idx} within the frame table");
+            };
+            u32::from_le_bytes(b.try_into().unwrap_or([0; 4])) as usize
+        };
+        let (o0, o1, o2) = (
+            off(&key_col.data, 0),
+            off(&key_col.data, 1),
+            off(&key_col.data, 2),
+        );
+        assert_eq!(o1 - o0, o2 - o1, "adjacent keys are equal-length");
+        let len = o1 - o0;
+        let Some(first) = key_col.data.get(table_len + o0..table_len + o0 + len) else {
+            panic!("first key within the column");
+        };
+        let first = first.to_vec();
+        let Some(second) = key_col.data.get(table_len + o1..table_len + o1 + len) else {
+            panic!("second key within the column");
+        };
+        let second = second.to_vec();
+        let Some(dst0) = key_col.data.get_mut(table_len + o0..table_len + o0 + len) else {
+            panic!("first key range within the column");
+        };
+        dst0.copy_from_slice(&second);
+        let Some(dst1) = key_col.data.get_mut(table_len + o1..table_len + o1 + len) else {
+            panic!("second key range within the column");
+        };
+        dst1.copy_from_slice(&first);
+    }
+    let new_payload = batch.encode(CodecId::Plain)?;
+    assert_eq!(
+        new_payload.len(),
+        payload.len(),
+        "an in-place key swap re-encodes to the same length",
+    );
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the out-of-order block is dropped: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(DropReason::DecodeError(_))
+        ),
+        "the ordering violation classifies as a decode error: {report:?}",
+    );
+    // Every row outside the poisoned block is recovered, minus the deletes
+    // that fall outside it (none of 5 / 50 / 150 land in the second block,
+    // which spans rows ~17..34 at 256-byte blocks).
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n) - poisoned_rows - deletes.len() as u64,
+        "rows outside the poisoned block are recovered with deletes applied",
+    );
+    // LOGICAL visibility: the deletes were applied faithfully, so the deleted
+    // keys stay masked while a neighbouring live key reads back.
+    for pos in deletes {
+        assert!(
+            reopen_get(dest.clone(), &fs, format!("key{pos:05}").as_bytes())?.is_none(),
+            "the deleted key at position {pos} stays masked in the recovered copy",
+        );
+    }
+    assert!(
+        reopen_get(dest, &fs, b"key00051")?.is_some(),
+        "a neighbouring live key reads back from the recovered copy",
+    );
+    Ok(())
+}
+
+/// A DESTINATION write failure mid-walk is a hard error, not a dropped block:
+/// the salvage propagates it and removes the partial destination so a retry
+/// or repair caller never sees half-written output.
+#[test]
+fn salvage_sst_errors_and_discards_the_dest_on_a_write_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    // Values big enough that the destination's buffered writer flushes
+    // mid-walk (so the failure surfaces through a block emit, not finish).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0..200u32 {
+        writer.write(InternalValue::from_components(
+            format!("key{i:05}").into_bytes(),
+            vec![0xAB; 1_024],
+            1,
+            ValueType::Value,
+        ))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path("salvaged")
+            .once(),
+    );
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    injector.clear();
+
+    assert!(
+        result.is_err(),
+        "a destination write failure errors the whole salvage: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "the partial destination is removed on a write failure",
+    );
+    Ok(())
+}
+
+/// A delete-bearing columnar SST whose `delete_bitmap` section is renamed and
+/// re-roled to a full `filter` launders the deletion metadata: the TOC still
+/// tiles with unique recognized names (nothing catches the rename), no delete
+/// bitmap remains visible, and (unlike range tombstones) there is no persisted
+/// count to cross-check. The relabeled block's payload is not a real `BuRR`
+/// filter, so salvage must PROBE the full filter even though it never pins it —
+/// the unparsable payload trips the rebuildable-section degradation and the
+/// guard fails closed instead of re-emitting the deleted rows live.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_refuses_a_delete_bitmap_relabeled_to_a_full_filter() -> crate::Result<()> {
+    use crate::config::{BloomConstructionPolicy, DeleteStrategy};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Filtering disabled, so renaming delete_bitmap to `filter` yields a UNIQUE
+    // recognized name (no existing filter to duplicate).
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .use_bloom_policy(BloomConstructionPolicy::BitsPerKey(0.0))
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Rename delete_bitmap -> filter and re-role its block to Filter.
+    crate::test_forge::forge_duplicate_section_name(
+        &source,
+        b"delete_bitmap",
+        b"filter",
+        crate::table::block::BlockType::Filter,
+    )?;
+
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a delete_bitmap relabeled to a filter must fail salvage");
+    };
+    let crate::Error::FeatureUnsupported(reason) = &err else {
+        panic!("the refusal must be FeatureUnsupported, got {err:?}");
+    };
+    assert!(
+        reason.contains("rebuildable"),
+        "the refusal must name the degraded rebuildable section, got {reason:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+    Ok(())
+}
+
+/// A `delete_bitmap` RENAMED to `filter` in the TOC WITHOUT re-roling its block
+/// header still launders the deletion: the block loads (its own checksum is
+/// valid) but its role is `DeleteBitmap`, so the filter load returns an
+/// `InvalidTag` role mismatch. Salvage must treat that STRUCTURAL failure as a
+/// degraded rebuildable section (a byte-flip would break the checksum first, so
+/// reaching `InvalidTag` means a valid block of the wrong name), not swallow it as
+/// genuine bit-rot, so the guard fails closed rather than re-emitting the rows.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_refuses_a_delete_bitmap_renamed_to_a_filter_without_reroling() -> crate::Result<()> {
+    use crate::config::{BloomConstructionPolicy, DeleteStrategy};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .use_bloom_policy(BloomConstructionPolicy::BitsPerKey(0.0))
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Rename delete_bitmap -> filter in the TOC but KEEP its DeleteBitmap block
+    // role (to_role == the original role re-stamps the same header).
+    crate::test_forge::forge_duplicate_section_name(
+        &source,
+        b"delete_bitmap",
+        b"filter",
+        crate::table::block::BlockType::DeleteBitmap,
+    )?;
+
+    let Err(err) = salvage_sst(&source, dest.clone(), &fs) else {
+        panic!("a delete_bitmap renamed to a filter without re-roling must fail salvage");
+    };
+    let crate::Error::FeatureUnsupported(reason) = &err else {
+        panic!("the refusal must be FeatureUnsupported, got {err:?}");
+    };
+    assert!(
+        reason.contains("rebuildable"),
+        "the refusal must name the degraded rebuildable section, got {reason:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+    Ok(())
+}
+
+/// By default salvage FAILS CLOSED on a delete-bearing SST whose delete
+/// bitmap is unreadable: recovering "all rows live" would resurrect
+/// positionally-deleted rows, so that degradation requires the caller's
+/// explicit [`SalvageOptions::allow_delete_resurrection`] opt-in. No
+/// destination file is left behind.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_a_corrupt_delete_bitmap_by_default() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Corrupt the `delete_bitmap` SFA section (data blocks stay intact).
+    let (db_pos, db_len) = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"delete_bitmap") else {
+            panic!("source must carry a delete_bitmap section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let flip = usize::try_from(db_pos + db_len / 2).unwrap_or(0);
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "default salvage refuses to resurrect deleted rows: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+    Ok(())
+}
+
+/// Same fail-closed default for the other degradation: a READABLE delete
+/// bitmap whose positioning zone map is corrupt cannot be applied, so the
+/// default salvage refuses rather than recovering all rows live.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_an_unpositionable_delete_bitmap_by_default() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Corrupt the `zone_map` section (the bitmap stays readable but can no
+    // longer be positioned).
+    let (zm_pos, zm_len) = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"zone_map") else {
+            panic!("source must carry a zone_map section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let flip = usize::try_from(zm_pos + zm_len / 2).unwrap_or(0);
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "default salvage refuses to resurrect deleted rows: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
     Ok(())
 }
 
 /// A columnar source carrying deletes whose `delete_bitmap` section is
 /// corrupted (data blocks intact): normal recovery refuses to open it (opening
-/// would resurrect deleted rows), but salvage degrades to "all rows live" and
-/// recovers every block.
+/// would resurrect deleted rows) and default salvage fails closed, but a
+/// caller who explicitly opts into [`SalvageOptions::allow_delete_resurrection`]
+/// degrades to "all rows live" and recovers every block.
 #[cfg(feature = "columnar")]
 #[test]
 fn salvage_tolerates_a_corrupt_delete_bitmap_as_all_live() -> crate::Result<()> {
@@ -303,8 +5780,13 @@ fn salvage_tolerates_a_corrupt_delete_bitmap_as_all_live() -> crate::Result<()> 
         "normal recovery must fail closed on a corrupt delete-bitmap",
     );
 
-    // Salvage degrades to "all rows live": every block recovers, nothing masked.
-    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    // With the explicit opt-in, salvage degrades to "all rows live": every
+    // block recovers, nothing masked.
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
     assert!(
         report.is_complete(),
         "the data blocks are intact; only the sidecar was corrupt: {report:?}",
@@ -314,14 +5796,836 @@ fn salvage_tolerates_a_corrupt_delete_bitmap_as_all_live() -> crate::Result<()> 
         u64::from(n),
         "every row is recovered live, the corrupt bitmap is ignored",
     );
+    // The SST was written WITH deletes (it carries a delete-bitmap section), so
+    // even though the degraded bitmap reads as empty, salvage must NOT take the
+    // verbatim copy-through fast path: that would byte-copy the physical blocks
+    // (including positionally-deleted rows) without the bitmap. It re-emits
+    // instead, so nothing is copied verbatim here.
+    assert_eq!(
+        report.blocks_copied_verbatim, 0,
+        "a delete-bearing SST is never copied verbatim, even with a degraded bitmap: {report:?}",
+    );
     assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n));
+    Ok(())
+}
+
+/// A PERSISTENT read failure of the delete-bitmap SECTION (a bad sector) must
+/// honor the salvage opt-in, not abort recovery unconditionally. It fails closed
+/// by default, but with the explicit
+/// [`SalvageOptions::allow_delete_resurrection`] opt-in it degrades the mask to
+/// "all rows live" and recovers every block — the same outcome as a
+/// decode-level corruption, reached through the I/O path. Only a TRANSIENT read
+/// still propagates for a retry.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_tolerates_a_persistently_unreadable_delete_bitmap_as_all_live() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let clean: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&clean))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Resolve the delete-bitmap section's file offset.
+    let db_pos = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"delete_bitmap") else {
+            panic!("source must carry a delete_bitmap section");
+        };
+        entry.pos()
+    };
+
+    // Every positional read of the delete-bitmap section fails with a persistent
+    // `Other`/EIO; the data blocks (at other offsets) stay readable.
+    let fault = FaultFs::new(StdFs);
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other)).at_offset(db_pos));
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    // Default policy fails closed: an unreadable bitmap would resurrect deleted rows.
+    assert!(
+        salvage_sst(&source, dest.clone(), &fs).is_err(),
+        "default salvage must fail closed on a persistently unreadable delete-bitmap",
+    );
+
+    // With the opt-in, salvage degrades to "all rows live" and recovers every block.
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n),
+        "every row is recovered live once the unreadable bitmap degrades: {report:?}",
+    );
+    assert_eq!(reopen_item_count(dest, &fs)?, u64::from(n));
+    Ok(())
+}
+
+/// A PERSISTENT read failure of the derived `zone_map` SECTION must not fail the
+/// whole `Table::recover`: the zone map is a rebuildable block-skip
+/// optimization, so a bad sector in it degrades to an empty map (block-skip
+/// disabled) rather than making an otherwise-readable SST unopenable. Only a
+/// transient read propagates for a retry.
+#[test]
+fn recover_degrades_a_persistently_unreadable_zone_map_section() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let clean: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&clean))?.use_zone_map(true);
+    for i in 0..64u32 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+    let zm_pos = section_pos(&source, b"zone_map");
+
+    let fault = FaultFs::new(StdFs);
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other)).at_offset(zm_pos));
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    // Open must SUCCEED with block-skip disabled, not abort on the bad sector.
+    let table = open(source, &fs)?;
+    assert!(
+        table.zone_map.is_empty(),
+        "the persistently unreadable zone map degrades to an empty map",
+    );
+    Ok(())
+}
+
+/// As above for the derived `seqno_bounds` SECTION: a persistent read failure
+/// disables the seqno block-skip rather than failing `Table::recover`.
+#[test]
+fn recover_degrades_a_persistently_unreadable_seqno_bounds_section() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let clean: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let mut writer =
+        Writer::new(source.clone(), 0, 0, Arc::clone(&clean))?.use_seqno_in_index(true);
+    for i in 0..64u32 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+    let sb_pos = section_pos(&source, b"seqno_bounds");
+
+    let fault = FaultFs::new(StdFs);
+    fault
+        .injector()
+        .arm(FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other)).at_offset(sb_pos));
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    // Open must SUCCEED with the seqno block-skip disabled, not abort.
+    let table = open(source, &fs)?;
+    assert!(
+        table.seqno_bounds.is_empty(),
+        "the persistently unreadable seqno-bounds section degrades to an empty map",
+    );
+    Ok(())
+}
+
+/// An UNREADABLE data block inside a delete-bearing columnar SST makes every
+/// later delete position unverifiable: the block's actual row count is
+/// unknowable, and trusting the zone map's claim for it would let a
+/// checksum-repatched count on exactly that block shift the masks of all
+/// later readable blocks undetected. Default salvage must fail closed; the
+/// explicit [`SalvageOptions::allow_delete_resurrection`] opt-in recovers the
+/// readable rows live (never masking against unverified positions).
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_an_unreadable_block_in_a_delete_bearing_sst() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Corrupt the SECOND data block's bytes (a plain checksum break): the
+    // block becomes unreadable, so its actual row count is unknowable.
+    let target = {
+        let table = open(source.clone(), &fs)?;
+        let offsets: alloc::vec::Vec<u64> = table
+            .data_block_handles()
+            .filter_map(Result::ok)
+            .map(|kh| *kh.as_ref().offset())
+            .collect();
+        let Some(&second) = offsets.get(1) else {
+            panic!("source must have at least two data blocks, got {offsets:?}");
+        };
+        second
+    };
+    let flip = usize::try_from(target).unwrap_or(0) + 16;
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    // Default: fail closed — the delete positions past the unreadable block
+    // cannot be proven faithful.
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "unverifiable delete positions fail the default salvage: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+
+    // Explicit opt-in: the readable rows are recovered LIVE; only the corrupt
+    // block's rows are lost.
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block is dropped: {report:?}",
+    );
+    assert!(
+        report.entries_salvaged < u64::from(n),
+        "the dropped block's rows are lost: {report:?}",
+    );
+    assert_eq!(
+        reopen_item_count(dest.clone(), &fs)?,
+        report.entries_salvaged,
+        "the recovered copy reopens with every salvaged row live",
+    );
+    // LOGICAL visibility of the resurrection: the deleted positions live
+    // outside the corrupt block, so under the opt-in their keys read back.
+    for pos in [5u32, 50, 150] {
+        assert!(
+            reopen_get(dest.clone(), &fs, format!("key{pos:05}").as_bytes())?.is_some(),
+            "the opt-in resurrects the deleted key at position {pos}",
+        );
+    }
+    Ok(())
+}
+
+/// A delete-bearing columnar SST where one block was REPLACED by a zero-row
+/// batch and the zone map's claim for it patched to 0: the position verifier
+/// would accept the block (decoded count 0 matches the claim) while the walk
+/// drops it as malformed — leaving later blocks masked at starts that no
+/// longer reflect the ORIGINAL row layout the bitmap was built against.
+/// A zero-row batch is malformed input everywhere else in the salvage
+/// pipeline, so the verifier must reject it too and fail the salvage closed.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_a_zero_row_block_in_a_delete_bearing_sst() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::config::DeleteStrategy;
+    use crate::table::block::Header;
+    use crate::table::columnar::{
+        COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, CodecId, Column, ColumnBatch, TypeTag,
+    };
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Replace the SECOND data block with a length-preserving ZERO-ROW batch
+    // (skeleton + padding columns, checksum re-stamped) — the same forgery
+    // the plain zero-row test uses.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let target_len = header.data_length as usize;
+    assert_eq!(
+        target_len % 2,
+        0,
+        "the padded skeleton needs an even length"
+    );
+    let empty_fixed = |id: u16, width: u8| Column {
+        column_id: id,
+        type_tag: TypeTag::Fixed(width),
+        validity: None,
+        data: Vec::new(),
+    };
+    let mut columns = vec![
+        Column {
+            column_id: COL_USER_KEY,
+            type_tag: TypeTag::Bytes,
+            validity: None,
+            data: vec![0u8; 4],
+        },
+        empty_fixed(COL_SEQNO, 8),
+        empty_fixed(COL_VALUE_TYPE, 1),
+        empty_fixed(COL_VALUE, 1),
+    ];
+    let Some(mut rem) = target_len.checked_sub(8 + 14 + 10 + 10 + 10) else {
+        panic!("source payload larger than the zero-row skeleton");
+    };
+    let mut next_id = COL_VALUE + 1;
+    while rem % 10 != 0 {
+        columns.push(Column {
+            column_id: next_id,
+            type_tag: TypeTag::Bytes,
+            validity: None,
+            data: vec![0u8; 4],
+        });
+        next_id += 1;
+        let Some(next_rem) = rem.checked_sub(14) else {
+            panic!("remainder covers a Bytes column");
+        };
+        rem = next_rem;
+    }
+    while rem > 0 {
+        columns.push(empty_fixed(next_id, 1));
+        next_id += 1;
+        rem -= 10;
+    }
+    let new_payload = ColumnBatch {
+        row_count: 0,
+        columns,
+    }
+    .encode(CodecId::Plain)?;
+    assert_eq!(new_payload.len(), target_len, "length-preserving forgery");
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&new_payload)),
+        ..header
+    };
+    let mut new_block: Vec<u8> = Vec::with_capacity(header_len + new_payload.len());
+    new_header.encode_into(&mut new_block)?;
+    new_block.extend_from_slice(&new_payload);
+    let Some(target) = bytes.get_mut(block_off..block_off + new_block.len()) else {
+        panic!("block range within the file");
+    };
+    target.copy_from_slice(&new_block);
+
+    // Patch the zone map's row_count claim for the second block to 0 (the
+    // first column's count drives the derived delete starts) and re-stamp
+    // the zone-map block checksum, so the tampered chain is self-consistent.
+    let zm_pos = {
+        let mut f = std::io::Cursor::new(&bytes);
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"zone_map") else {
+            panic!("source must carry a zone_map section");
+        };
+        usize::try_from(entry.pos()).unwrap_or(usize::MAX)
+    };
+    let Some(mut zm_cursor) = bytes.get(zm_pos..) else {
+        panic!("zone_map section within the file");
+    };
+    let zm_header = Header::decode_from(&mut zm_cursor)?;
+    let zm_header_len = Header::header_len(zm_header.block_type);
+    let zm_payload_range =
+        zm_pos + zm_header_len..zm_pos + zm_header_len + zm_header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(zm_payload_range.clone()) else {
+            panic!("zone_map payload within the file");
+        };
+        // Walk the wire layout (count u32; per block: block_offset u64 +
+        // n_columns u16; per column: id u32 + type u8 + codec u8 +
+        // null_count u32 + row_count u32 + min_len u32 + min + max_len u32
+        // + max) to the SECOND block's FIRST column row_count — the field
+        // the derived delete starts are built from.
+        let read_u32 = |data: &[u8], at: usize| -> u32 {
+            let Some(b) = data.get(at..at + 4) else {
+                panic!("u32 at {at} within the zone map payload");
+            };
+            u32::from_le_bytes(b.try_into().unwrap_or([0; 4]))
+        };
+        let read_u16 = |data: &[u8], at: usize| -> u16 {
+            let Some(b) = data.get(at..at + 2) else {
+                panic!("u16 at {at} within the zone map payload");
+            };
+            u16::from_le_bytes(b.try_into().unwrap_or([0; 2]))
+        };
+        let mut at = 4; // past the block count
+        // Skip block 1 entirely: offset u64 + n_columns u16, then each
+        // column's fixed 14 bytes + variable min/max.
+        at += 8;
+        let block1_cols = read_u16(payload, at);
+        at += 2;
+        for _ in 0..block1_cols {
+            at += 10; // id + type + codec + null_count
+            at += 4; // row_count
+            let min_len = read_u32(payload, at) as usize;
+            at += 4 + min_len;
+            let max_len = read_u32(payload, at) as usize;
+            at += 4 + max_len;
+        }
+        // Block 2: seek to its first column's row_count and zero it.
+        at += 8; // block_offset
+        at += 2; // n_columns
+        at += 10; // first column's id + type + codec + null_count
+        let claimed = read_u32(payload, at);
+        assert!(claimed > 0, "the second block originally holds rows");
+        let Some(rc) = payload.get_mut(at..at + 4) else {
+            panic!("second block's first row_count within the zone map payload");
+        };
+        rc.copy_from_slice(&0u32.to_le_bytes());
+    }
+    let new_zm_checksum = crate::Checksum::from_raw(crate::hash::hash128(
+        bytes.get(zm_payload_range).unwrap_or(&[]),
+    ));
+    let new_zm_header = Header {
+        checksum: new_zm_checksum,
+        ..zm_header
+    };
+    let mut zm_hdr_bytes: Vec<u8> = Vec::with_capacity(zm_header_len);
+    new_zm_header.encode_into(&mut zm_hdr_bytes)?;
+    let Some(zm_dst) = bytes.get_mut(zm_pos..zm_pos + zm_header_len) else {
+        panic!("zone_map header within the file");
+    };
+    zm_dst.copy_from_slice(&zm_hdr_bytes);
+    std::fs::write(&source, &bytes)?;
+
+    // Default: fail closed — the zero-row block is unpositionable input (the
+    // walk drops it while later blocks would be masked at starts the bitmap
+    // was never built against).
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "a zero-row block in a delete-bearing SST fails the default salvage: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+    Ok(())
+}
+
+/// A footer-bearing row SST (per-KV checksums) whose block checksum was
+/// re-stamped over a tampered entry: the BLOCK checksum verifies, but the
+/// entry no longer matches its per-KV digest. Salvage must verify the footer
+/// before emitting (verbatim or re-encoded) — otherwise it recovers a block
+/// the live per-KV scrub would reject, laundering the corruption into a
+/// "fully valid" copy.
+#[test]
+fn salvage_drops_a_row_block_with_a_stale_kv_digest() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::runtime_config::{ChecksumAlgorithm, KvChecksumPolicy};
+    use crate::table::block::Header;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_kv_checksums(KvChecksumPolicy::AllLevels, ChecksumAlgorithm::Xxh3_64);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Tamper one entry byte inside the SECOND block's inner payload and
+    // re-stamp the BLOCK checksum: the frame verifies clean, but the entry's
+    // stored per-KV digest no longer matches its bytes.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("payload range within the block");
+        };
+        // A byte inside the first entry's value bytes (past the entry header),
+        // well before the per-KV footer at the payload tail.
+        let Some(b) = payload.get_mut(12) else {
+            panic!("entry byte within the payload");
+        };
+        *b ^= 0xFF;
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(
+        bytes.get(payload_range).unwrap_or(&[]),
+    ));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes: Vec<u8> = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("block header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "the block with a stale per-KV digest is dropped: {report:?}",
+    );
+    assert!(
+        report.entries_salvaged < u64::from(n),
+        "the tampered block's rows are not laundered into the copy: {report:?}",
+    );
+    assert_eq!(reopen_item_count(dest, &fs)?, report.entries_salvaged);
+    Ok(())
+}
+
+/// A delete-bearing columnar SST with a checksum-clean block whose
+/// `ColumnBatch` does NOT decode (a repatched tamper that keeps the leading
+/// row-count u32 intact but breaks the column framing): the block's ACTUAL row
+/// count is unknowable, so every later block's delete positions are
+/// unverifiable — the position verifier must fully decode each block rather
+/// than trust the leading four bytes, and the default salvage must fail
+/// closed instead of dropping the block and masking later rows at positions
+/// it could not prove.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_an_undecodable_checksum_clean_block_with_deletes() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::config::DeleteStrategy;
+    use crate::table::block::Header;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Poison the SECOND data block: stamp an invalid type tag into the first
+    // column's header (payload layout: row_count u32, column_count u32, then
+    // per column id u16 + type u8 + ... — so the first type byte sits at
+    // payload offset 10) and re-stamp the block checksum. The leading
+    // row-count u32 stays intact, the frame stays checksum-consistent, but
+    // `ColumnBatch::decode` fails on the unknown tag.
+    let (block_off, block_size) = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().filter_map(Result::ok).nth(1) else {
+            panic!("source must have at least two data blocks");
+        };
+        (
+            usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX),
+            kh.as_ref().size() as usize,
+        )
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(block) = bytes.get(block_off..block_off + block_size) else {
+        panic!("block range within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("payload range within the block");
+        };
+        let Some(tag) = payload.get_mut(10) else {
+            panic!("first column's type byte within the payload");
+        };
+        *tag = 0xEE;
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(
+        bytes.get(payload_range).unwrap_or(&[]),
+    ));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("block header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(&source, &bytes)?;
+
+    // Default: fail closed — the block reads back checksum-clean but cannot
+    // be decoded, so its actual row count (and every later block's delete
+    // positions) cannot be proven faithful.
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "unverifiable delete positions fail the default salvage: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+
+    // Explicit opt-in: the poisoned block is dropped, every other row is
+    // recovered LIVE (never masked against unproven positions).
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the poisoned block is dropped: {report:?}",
+    );
+    assert!(
+        report.entries_salvaged < u64::from(n),
+        "the poisoned block's rows are lost: {report:?}",
+    );
+    assert_eq!(
+        reopen_item_count(dest.clone(), &fs)?,
+        report.entries_salvaged,
+        "the recovered copy reopens with every salvaged row live",
+    );
+    // LOGICAL visibility of the resurrection: the deleted positions live
+    // outside the poisoned block, so under the opt-in their keys read back.
+    for pos in [5u32, 50, 150] {
+        assert!(
+            reopen_get(dest.clone(), &fs, format!("key{pos:05}").as_bytes())?.is_some(),
+            "the opt-in resurrects the deleted key at position {pos}",
+        );
+    }
+    Ok(())
+}
+
+/// A zone map that DECODES but carries wrong per-block row counts (a
+/// checksum-repatched tamper) would misposition the delete bitmap: the masked
+/// re-emit derives each block's start row from the zone map, so deletes land
+/// on the wrong rows — deleted rows resurrect AND live rows vanish, silently.
+/// Salvage must cross-check the claimed positions against the actual decoded
+/// row counts and fail closed on a mismatch; with the explicit
+/// [`SalvageOptions::allow_delete_resurrection`] opt-in it recovers all rows
+/// live instead of masking against the wrong positions.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_fails_closed_on_a_zone_map_with_wrong_row_counts() -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::config::DeleteStrategy;
+    use crate::table::block::Header;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let n = 200u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 50, 150] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Tamper the FIRST block's row count inside the zone map (wire layout:
+    // count u32, then block_offset u64 + n_columns u16, then per column
+    // id u32 + type_tag u8 + codec_id u8 + null_count u32 + row_count u32 —
+    // so the first row_count sits at payload bytes 24..28) and re-stamp the
+    // section block's checksum. The zone map still DECODES — only its claimed
+    // positions are shifted for every block after the first.
+    let zm_pos = {
+        let mut f = std::fs::File::open(&source)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"zone_map") else {
+            panic!("source must carry a zone_map section");
+        };
+        usize::try_from(entry.pos()).unwrap_or(usize::MAX)
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let Some(mut cursor) = bytes.get(zm_pos..) else {
+        panic!("zone_map section within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range = zm_pos + header_len..zm_pos + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("zone_map payload within the file");
+        };
+        let Some(rc) = payload.get_mut(24..28) else {
+            panic!("first row_count within the zone map payload");
+        };
+        let claimed = u32::from_le_bytes(rc.try_into().unwrap_or([0; 4]));
+        assert!(claimed >= 2, "the first block holds at least two rows");
+        rc.copy_from_slice(&(claimed - 1).to_le_bytes());
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(
+        bytes.get(payload_range).unwrap_or(&[]),
+    ));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(zm_pos..zm_pos + header_len) else {
+        panic!("zone_map header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(&source, &bytes)?;
+
+    // Default: fail closed — masking against the shifted positions would
+    // silently corrupt visibility in the recovered SST.
+    let result = salvage_sst(&source, dest.clone(), &fs);
+    assert!(
+        result.is_err(),
+        "a mispositioning zone map fails the default salvage: {result:?}",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "no destination file is left behind by the refused salvage",
+    );
+
+    // Explicit opt-in: recover all rows LIVE (never mask against the wrong
+    // positions).
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert!(
+        report.is_complete(),
+        "the data blocks are intact; only the zone map lies: {report:?}",
+    );
+    assert_eq!(
+        report.entries_salvaged,
+        u64::from(n),
+        "every row is recovered live under the opt-in",
+    );
+    assert_eq!(reopen_item_count(dest.clone(), &fs)?, u64::from(n));
+    // LOGICAL visibility of the resurrection: "all rows live" means the keys
+    // at the deleted positions read back.
+    for pos in [5u32, 50, 150] {
+        assert!(
+            reopen_get(dest.clone(), &fs, format!("key{pos:05}").as_bytes())?.is_some(),
+            "the opt-in resurrects the deleted key at position {pos}",
+        );
+    }
     Ok(())
 }
 
 /// A columnar SST with deletes whose ZONE MAP is corrupt (the bitmap stays
 /// readable): the bitmap cannot be positioned without the zone map, so normal
-/// recovery fails closed, but salvage ignores the bitmap ("all rows live") and
-/// recovers every row.
+/// recovery and default salvage fail closed, but a caller who explicitly opts
+/// into [`SalvageOptions::allow_delete_resurrection`] ignores the bitmap
+/// ("all rows live") and recovers every row.
 #[cfg(feature = "columnar")]
 #[test]
 fn salvage_ignores_a_delete_bitmap_without_a_readable_zone_map() -> crate::Result<()> {
@@ -375,8 +6679,13 @@ fn salvage_ignores_a_delete_bitmap_without_a_readable_zone_map() -> crate::Resul
         "normal recovery must reject a bitmap with no readable zone map",
     );
 
-    // Salvage ignores the unpositionable bitmap and recovers every row live.
-    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    // With the explicit opt-in, salvage ignores the unpositionable bitmap and
+    // recovers every row live.
+    let options = SalvageOptions {
+        allow_delete_resurrection: true,
+        ..SalvageOptions::default()
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
     assert!(
         report.is_complete(),
         "the data blocks are intact; only the zone map was corrupt: {report:?}",
@@ -611,5 +6920,1510 @@ fn salvage_sst_reads_and_writes_through_the_injected_fs() -> crate::Result<()> {
         u64::from(n),
         "the salvaged SST reopens through the same in-memory backend",
     );
+    Ok(())
+}
+
+// --- Forwarded recovery context: encrypted + dictionary-compressed sources ---
+
+/// Reads the second data block's on-disk offset from a context-aware reopen of
+/// `source`, then flips a byte just past that block's header so its checksum /
+/// AEAD tag fails on load while every other block stays intact.
+#[cfg(any(feature = "encryption", zstd_any))]
+fn corrupt_second_data_block(
+    source: &std::path::Path,
+    fs: &Arc<dyn Fs>,
+    table_id: crate::table::TableId,
+    encryption: Option<Arc<dyn crate::encryption::EncryptionProvider>>,
+    #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
+) -> crate::Result<()> {
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&**fs, source)?);
+    let table = Table::recover(
+        source.to_path_buf(),
+        checksum,
+        0,
+        0,
+        // Open under the source's table id so an encrypted index (AAD binds the
+        // id) decrypts when reading the block offsets.
+        table_id,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(fs),
+        false,
+        false,
+        encryption,
+        #[cfg(zstd_any)]
+        zstd_dictionary,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    let offsets: alloc::vec::Vec<u64> = table
+        .data_block_handles()
+        .filter_map(Result::ok)
+        .map(|kh| *kh.as_ref().offset())
+        .collect();
+    let Some(&second) = offsets.get(1) else {
+        panic!("source SST must have at least two data blocks, got {offsets:?}");
+    };
+    let flip = usize::try_from(second).unwrap_or(0) + 16;
+    let mut bytes = std::fs::read(source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(source, &bytes)?;
+    Ok(())
+}
+
+/// An encrypted source: salvage cannot open it without the provider (the gap this
+/// closes), but with the provider in `SalvageOptions` it block-salvages like a
+/// plain SST and the recovered copy reopens under the same encryption.
+#[cfg(feature = "encryption")]
+#[test]
+fn salvage_recovers_an_encrypted_sst_with_the_provider() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let enc: Arc<dyn crate::encryption::EncryptionProvider> =
+        Arc::new(crate::encryption::Aes256GcmProvider::new(&[0x42; 32]));
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_encryption(Some(Arc::clone(&enc)));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source encrypted SST is non-empty"
+    );
+
+    corrupt_second_data_block(
+        &source,
+        &fs,
+        0,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    // Without the provider, the encrypted source cannot even be opened.
+    assert!(
+        salvage_sst(&source, dest.clone(), &fs).is_err(),
+        "an encrypted SST must not salvage without the provider",
+    );
+
+    // With the provider, it block-salvages: the corrupt block is dropped, the
+    // rest recovered, and the copy is written encrypted.
+    let options = SalvageOptions {
+        encryption: Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        zstd_dictionary: None,
+        table_id: 0,
+        expected_stored_id: None,
+        allow_delete_resurrection: false,
+        sync_mode: crate::fs::SyncMode::Normal,
+        prefix_extractor: None,
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block drops: {report:?}"
+    );
+    assert!(
+        report.entries_salvaged > 0 && report.entries_salvaged < u64::from(n),
+        "a partial key range is recovered, got {} of {n}",
+        report.entries_salvaged,
+    );
+
+    // The salvaged copy reopens UNDER ENCRYPTION (a plaintext copy would fail the
+    // encrypted reopen) and holds exactly the recovered entries.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &dest)?);
+    let reopened = Table::recover(
+        dest,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(&fs),
+        false,
+        false,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    assert_eq!(
+        reopened.metadata.item_count, report.entries_salvaged,
+        "the encrypted salvaged copy reopens with exactly the recovered entries",
+    );
+    Ok(())
+}
+
+/// A zstd-dictionary-compressed source: salvage cannot decompress it without the
+/// dictionary, but with the dictionary in `SalvageOptions` it block-salvages and
+/// the recovered copy reopens under the same dictionary.
+#[cfg(zstd_any)]
+#[test]
+fn salvage_recovers_a_dictionary_sst_with_the_dictionary() -> crate::Result<()> {
+    use crate::CompressionType;
+    use crate::compression::ZstdDictionary;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A small training corpus so the dictionary has content to match against.
+    let samples: alloc::vec::Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
+    let dict = Arc::new(ZstdDictionary::new(&samples));
+    let compression = CompressionType::ZstdDict {
+        level: 3,
+        dict_id: dict.id(),
+    };
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_data_block_compression(compression)
+        .use_zstd_dictionary(Some(Arc::clone(&dict)));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source dictionary SST is non-empty"
+    );
+
+    corrupt_second_data_block(&source, &fs, 0, None, Some(Arc::clone(&dict)))?;
+
+    // Without the dictionary, the source cannot even be opened: `recover_inner`
+    // fail-fasts on the ZstdDict-id mismatch at open time (before any block
+    // walk), so salvage returns `Err`, not a zero-recovered report.
+    assert!(
+        salvage_sst(&source, dest.clone(), &fs).is_err(),
+        "a dictionary SST must not salvage without the dictionary",
+    );
+
+    let options = SalvageOptions {
+        encryption: None,
+        zstd_dictionary: Some(Arc::clone(&dict)),
+        table_id: 0,
+        expected_stored_id: None,
+        allow_delete_resurrection: false,
+        sync_mode: crate::fs::SyncMode::Normal,
+        prefix_extractor: None,
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block drops: {report:?}"
+    );
+    assert!(
+        report.entries_salvaged > 0 && report.entries_salvaged < u64::from(n),
+        "a partial key range is recovered, got {} of {n}",
+        report.entries_salvaged,
+    );
+
+    // The salvaged copy reopens UNDER THE DICTIONARY with the recovered entries.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &dest)?);
+    let reopened = Table::recover(
+        dest,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(&fs),
+        false,
+        false,
+        None,
+        Some(Arc::clone(&dict)),
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    assert_eq!(
+        reopened.metadata.item_count, report.entries_salvaged,
+        "the dictionary salvaged copy reopens with exactly the recovered entries",
+    );
+    Ok(())
+}
+
+/// An encrypted source sealed under a NON-ZERO table id: the encrypted-block AAD
+/// binds the table id, so salvage must be given that id. With the wrong id the
+/// AAD-bound blocks cannot be decrypted (the gap repair hit when it passed a
+/// hardcoded `0`); with the right id it block-salvages and the copy reopens.
+#[cfg(feature = "encryption")]
+#[test]
+fn salvage_recovers_an_encrypted_sst_with_a_nonzero_table_id() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let enc: Arc<dyn crate::encryption::EncryptionProvider> =
+        Arc::new(crate::encryption::Aes256GcmProvider::new(&[0x37; 32]));
+    const TID: crate::table::TableId = 7;
+
+    let mut writer = Writer::new(source.clone(), TID, 0, Arc::clone(&fs))?
+        .use_data_block_size(256)
+        .use_encryption(Some(Arc::clone(&enc)));
+    let n = 200u32;
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source encrypted SST is non-empty"
+    );
+
+    corrupt_second_data_block(
+        &source,
+        &fs,
+        TID,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    // Wrong table id (the legacy hardcoded 0): the AAD-bound blocks cannot be
+    // decrypted, so nothing is recovered (salvage either fails to open or drops
+    // every block).
+    let wrong = SalvageOptions {
+        encryption: Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        zstd_dictionary: None,
+        table_id: 0,
+        expected_stored_id: None,
+        allow_delete_resurrection: false,
+        sync_mode: crate::fs::SyncMode::Normal,
+        prefix_extractor: None,
+    };
+    let recovered_wrong = salvage_sst_with_options(&source, dest.clone(), &fs, &wrong)
+        .map_or(0, |r| r.entries_salvaged);
+    assert_eq!(
+        recovered_wrong, 0,
+        "the wrong table id cannot decrypt the AAD-bound encrypted source",
+    );
+
+    // Right table id: block-salvages, dropping only the corrupt block.
+    let options = SalvageOptions {
+        encryption: Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        zstd_dictionary: None,
+        table_id: TID,
+        expected_stored_id: None,
+        allow_delete_resurrection: false,
+        sync_mode: crate::fs::SyncMode::Normal,
+        prefix_extractor: None,
+    };
+    let report = salvage_sst_with_options(&source, dest.clone(), &fs, &options)?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "exactly the corrupt block drops: {report:?}"
+    );
+    assert!(
+        report.entries_salvaged > 0 && report.entries_salvaged < u64::from(n),
+        "a partial key range is recovered, got {} of {n}",
+        report.entries_salvaged,
+    );
+
+    // The recovered copy reopens under the same table id + encryption.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &dest)?);
+    let reopened = Table::recover(
+        dest,
+        checksum,
+        0,
+        0,
+        TID,
+        Arc::new(crate::cache::Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(8))),
+        Arc::clone(&fs),
+        false,
+        false,
+        Some(Arc::clone(&enc)),
+        #[cfg(zstd_any)]
+        None,
+        default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::Metrics::default()),
+    )?;
+    assert_eq!(
+        reopened.metadata.item_count, report.entries_salvaged,
+        "the recovered copy reopens under the same table id with the recovered entries",
+    );
+    Ok(())
+}
+
+// --- Blob (vlog) file record-granular salvage ---
+
+use crate::vlog::blob_file::scanner::Scanner as BlobScanner;
+use crate::vlog::blob_file::writer::Writer as BlobWriter;
+
+/// Builds a blob file at `path` from `(key, value)` records (seqno 0, no
+/// compression).
+fn build_blob(
+    path: &std::path::Path,
+    fs: &Arc<dyn Fs>,
+    records: &[(&[u8], &[u8])],
+) -> crate::Result<()> {
+    let mut writer = BlobWriter::new(path, 0, 0, &**fs)?;
+    for (k, v) in records {
+        writer.write(k, 0, v)?;
+    }
+    writer.finish()?;
+    Ok(())
+}
+
+/// Scans a blob file into its `(key, value)` records (Ok records only).
+fn scan_blob(path: &std::path::Path, fs: &Arc<dyn Fs>) -> crate::Result<Vec<(Vec<u8>, Vec<u8>)>> {
+    Ok(BlobScanner::new(path, &**fs, 0)?
+        .filter_map(Result::ok)
+        .map(|e| (e.key.to_vec(), e.value.to_vec()))
+        .collect())
+}
+
+#[test]
+fn salvage_blob_file_recovers_every_record_of_a_healthy_file() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let records: Vec<(&[u8], &[u8])> = vec![
+        (b"k0", b"v0"),
+        (b"k1", b"v1"),
+        (b"k2", b"v2"),
+        (b"k3", b"v3"),
+    ];
+    build_blob(&source, &fs, &records)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert!(
+        report.is_complete(),
+        "a healthy blob file drops nothing: {report:?}"
+    );
+    assert_eq!(report.records_salvaged, 4);
+    assert_eq!(report.salvaged_path.as_deref(), Some(dest.as_path()));
+
+    let recovered = scan_blob(&dest, &fs)?;
+    let expected: Vec<(Vec<u8>, Vec<u8>)> = records
+        .iter()
+        .map(|(k, v)| (k.to_vec(), v.to_vec()))
+        .collect();
+    assert_eq!(
+        recovered, expected,
+        "every record round-trips through salvage"
+    );
+    Ok(())
+}
+
+/// A checksum-consistent frame whose key regresses below the previous salvaged
+/// record must be DROPPED, not re-emitted: `BlobWriter` requires records in
+/// key order, and a salvaged file that violates it corrupts its own key range
+/// and later breaks the merge scanner's per-reader sorted-input assumption. The
+/// source here is written physically out of order (the writer does not enforce
+/// its precondition), so every frame is individually valid but the sequence is
+/// not sorted.
+#[test]
+fn salvage_blob_file_drops_a_frame_whose_key_regresses() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Physically out of order: k2 precedes k1. Each frame is checksum-valid.
+    let records: Vec<(&[u8], &[u8])> = vec![(b"k0", b"v0"), (b"k2", b"v2"), (b"k1", b"v1")];
+    build_blob(&source, &fs, &records)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(
+        report.records_salvaged, 2,
+        "the order-regressing frame is dropped, not re-emitted: {report:?}",
+    );
+    let [dropped] = report.dropped.as_slice() else {
+        panic!(
+            "exactly the regressing frame drops, got {:?}",
+            report.dropped
+        );
+    };
+    assert!(
+        matches!(dropped.reason, BlobDropReason::Corrupt(_)),
+        "the drop is recorded as corruption: {:?}",
+        dropped.reason,
+    );
+
+    // The salvaged file is sorted, so it re-opens under the writer's contract.
+    let recovered = scan_blob(&dest, &fs)?;
+    assert_eq!(
+        recovered,
+        vec![
+            (b"k0".to_vec(), b"v0".to_vec()),
+            (b"k2".to_vec(), b"v2".to_vec())
+        ],
+        "only the in-order prefix survives, still sorted",
+    );
+    Ok(())
+}
+
+/// The blob-order guard must use the TREE comparator, not raw bytes: a blob file
+/// written by a reverse-comparator tree is in descending key order, which is
+/// perfectly valid there. Salvaging it under that comparator must keep every
+/// record; bytewise ordering would wrongly judge each record as regressing and
+/// drop healthy data.
+#[test]
+fn salvage_blob_file_keeps_reverse_ordered_records_under_a_reverse_comparator() -> crate::Result<()>
+{
+    struct ReverseComparator;
+    impl crate::comparator::UserComparator for ReverseComparator {
+        fn name(&self) -> &'static str {
+            "reverse-lexicographic-test"
+        }
+        fn compare(&self, a: &[u8], b: &[u8]) -> core::cmp::Ordering {
+            b.cmp(a)
+        }
+    }
+
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Descending key order: correct for a reverse-comparator tree.
+    let records: Vec<(&[u8], &[u8])> = vec![(b"k2", b"v2"), (b"k1", b"v1"), (b"k0", b"v0")];
+    build_blob(&source, &fs, &records)?;
+
+    let comparator: crate::comparator::SharedComparator = Arc::new(ReverseComparator);
+    let report = salvage_blob_file(&source, dest, &fs, 0, &comparator)?;
+    assert_eq!(
+        report.records_salvaged, 3,
+        "descending order is NOT regressing under a reverse comparator: {report:?}",
+    );
+    assert!(
+        report.dropped.is_empty(),
+        "no record is dropped as out-of-order: {report:?}",
+    );
+    Ok(())
+}
+
+/// `salvage_blob_file` must fsync the destination's PARENT DIRECTORY before
+/// returning a salvaged path: the writer syncs the blob file's bytes, but
+/// without the directory sync a power loss can discard the new directory entry
+/// even though the report says recovery succeeded (the SST salvage writer
+/// already syncs its parent directory). Fault-inject the directory fsync to
+/// prove it happens — a build that never syncs the directory never triggers the
+/// fault and wrongly reports the move durable.
+#[test]
+fn salvage_blob_file_syncs_the_destination_directory() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultInjector, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let out = dir.path().join("blobdest");
+    std::fs::create_dir_all(&out)?;
+    let dest = out.join("blob_salvaged");
+
+    let injector = Arc::new(FaultInjector::new());
+    let fs: Arc<dyn Fs> = Arc::new(FaultFs::with_injector(StdFs, Arc::clone(&injector)));
+
+    let records: Vec<(&[u8], &[u8])> = vec![(b"k0", b"v0"), (b"k1", b"v1")];
+    build_blob(&source, &fs, &records)?;
+
+    // Arm AFTER building, so only the salvage's destination-directory sync trips.
+    injector.arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other)).on_path("blobdest"),
+    );
+
+    let Err(err) = salvage_blob_file(&source, dest, &fs, 0, &default_comparator()) else {
+        panic!("the destination-directory fsync fault must surface");
+    };
+    // Assert the surfaced error is the INJECTED directory-sync fault, not some
+    // unrelated failure: a build that stopped syncing the directory would fail
+    // elsewhere (or not at all), and a loose "any error" check would not notice.
+    assert!(
+        err.to_string().contains("injected fault on SyncDirectory"),
+        "the salvage error must be the injected destination-directory sync fault, got {err:?}",
+    );
+    Ok(())
+}
+
+/// The TOCTOU variant of the pre-existing-destination guarantee: a file that
+/// appears at `dest` AFTER any existence probe but BEFORE the writer's
+/// `create_new` open (a concurrent worker winning the destination) must also
+/// survive the failed salvage. Ownership is decided by `create_new` alone —
+/// when it fails, this call created nothing and must remove nothing. The
+/// injected `Metadata` fault materializes the race window deterministically:
+/// the probe cannot see the file, yet `create_new` finds it.
+#[test]
+fn salvage_blob_file_keeps_a_racing_dest_created_after_the_existence_probe() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_dest");
+    let plain: Arc<dyn Fs> = Arc::new(StdFs);
+    build_blob(&source, &plain, &[(b"k0", b"v0")])?;
+
+    // The "racing" worker's file is already at dest, but any metadata probe of
+    // dest fails — exactly the window where the file lands between a stat and
+    // the `create_new` open.
+    std::fs::write(&dest, b"racing worker's blob")?;
+    let fault = FaultFs::new(StdFs);
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Metadata, Fault::Error(ErrorKind::NotFound)).on_path("blob_dest"),
+    );
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let result = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator());
+    assert!(
+        result.is_err(),
+        "the destination is taken, the salvage fails: {result:?}",
+    );
+    assert_eq!(
+        std::fs::read(&dest)?,
+        b"racing worker's blob",
+        "the racing worker's file survives the failed salvage",
+    );
+    Ok(())
+}
+
+/// A transient I/O failure on the verbatim REREAD must not drop the block:
+/// the first, recovery-aware read has already produced a verified decoded
+/// block, so the loader falls back to the re-encode path (`verbatim = None`)
+/// exactly like a checksum / parity mismatch on the re-read frame. Reserving
+/// `Err` for the initial verified read keeps one flaky pread from discarding
+/// a block that is provably recoverable.
+#[test]
+fn salvage_load_block_reencodes_when_the_verbatim_reread_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use crate::table::block::BlockType;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0..50u32 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Collect the first data block's handle BEFORE arming the fault (the
+    // open + index walk issue their own reads).
+    let table = open(source, &fs)?;
+    let Some(kh) = table.data_block_handles().find_map(Result::ok) else {
+        panic!("source has at least one data block");
+    };
+    let handle = *kh.as_ref();
+
+    // Within `salvage_load_block` the FIRST positional read is the verified
+    // recovery-aware load; the SECOND is the raw verbatim re-read. Fail
+    // exactly that second read, once.
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("source")
+            .skip(1)
+            .once(),
+    );
+    let result = table.salvage_load_block(&handle, BlockType::Data);
+    injector.clear();
+
+    let sb = match result {
+        Ok(sb) => sb,
+        Err(e) => panic!("a failed verbatim re-read falls back to re-encode, got Err({e:?})"),
+    };
+    assert!(
+        sb.verbatim.is_none(),
+        "the re-read was never verified, so the block must not be byte-copied",
+    );
+    assert!(
+        !sb.block.data.is_empty(),
+        "the verified first read's decoded payload is preserved for re-encoding",
+    );
+    Ok(())
+}
+
+/// `tli_structure_authenticated` must PROPAGATE a TRANSIENT I/O fault from
+/// opening / reading the index mirrors rather than fold it into `false` (an
+/// untrusted index). The salvage walk consults this to decide whether an indexed
+/// offset is a trusted block boundary; reading a flaky open as `false` degrades
+/// to physical-chain-only provenance and surrenders every block past the first
+/// header break — dropping healthy keys the intact TLI could anchor on retry. A
+/// single transient-kind (`Interrupted`) `Open` fault reproduces the flaky
+/// failure; the method must return the propagated I/O error.
+#[test]
+fn tli_structure_authenticated_propagates_a_transient_read_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0..50u32 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Open cleanly, THEN fault the dedicated open the authentication read issues
+    // with a TRANSIENT (`Interrupted`) kind.
+    let table = open(source, &fs)?;
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Interrupted))
+            .on_path("source")
+            .once(),
+    );
+    let result = table.tli_structure_authenticated();
+    injector.clear();
+    assert!(
+        matches!(result, Err(crate::Error::Io(_))),
+        "a transient failure authenticating the index structure must propagate, not be \
+         read as an untrusted index: {result:?}",
+    );
+    Ok(())
+}
+
+/// `tli_structure_authenticated` must DEGRADE a PERSISTENT I/O fault to `false`
+/// (an untrusted index) rather than propagate it. When one mirror is
+/// persistently unreadable (a bad sector) but the other mirror and the data
+/// section stay readable, propagating the error makes the `salvage_blocks`
+/// caller's `?` abort before its physical-chain fallback, recovering NONE of the
+/// intact data blocks. `false` lets the walk fall back to physical-chain
+/// provenance and recover the readable blocks.
+#[test]
+fn tli_structure_authenticated_degrades_a_persistent_read_failure() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?;
+    for i in 0..50u32 {
+        writer.write(iv(i))?;
+    }
+    assert!(writer.finish()?.is_some(), "source SST is non-empty");
+
+    // Open cleanly, THEN fault the authentication read's open with a PERSISTENT
+    // (`Other`/EIO) kind.
+    let table = open(source, &fs)?;
+    injector.arm(FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).on_path("source"));
+    let result = table.tli_structure_authenticated();
+    injector.clear();
+    assert!(
+        matches!(result, Ok(false)),
+        "a persistent authentication failure must degrade to an untrusted index so the \
+         salvage walk can still recover the readable data: {result:?}",
+    );
+    Ok(())
+}
+
+/// `delete_positions_verified` must PROPAGATE a transient I/O fault rather than
+/// fold it into `false` (an unpositionable mask). Under the default
+/// `allow_delete_resurrection == false` a `false` verdict aborts salvage, so a
+/// flaky block read during `repair_with_salvage` would drop the table from the
+/// rebuilt manifest even though a retry could recover it faithfully. A single
+/// `ReadAt` fault on the first positional read the walk issues reproduces the
+/// transient read; the method must return the propagated I/O error, not
+/// `Ok(false)`.
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_positions_verified_propagates_a_transient_block_read_failure() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Open cleanly (footer + block-index reads happen here), THEN fault the
+    // first positional read the verification walk issues with a TRANSIENT
+    // (`Interrupted`) kind.
+    let table = open(source, &fs)?;
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Interrupted))
+            .on_path("source")
+            .once(),
+    );
+    let result = table.delete_positions_verified();
+    injector.clear();
+    assert!(
+        matches!(result, Err(crate::Error::Io(_))),
+        "a transient read during delete-position validation must propagate, not be read \
+         as a persistent unpositionable mask: {result:?}",
+    );
+    Ok(())
+}
+
+/// `delete_positions_verified` must DEGRADE a PERSISTENT positional read failure
+/// to `Ok(false)` (an unpositionable mask), not propagate it: with
+/// `allow_delete_resurrection` a bad sector under one block still lets the caller
+/// re-emit the remaining readable rows unmasked, instead of aborting the whole
+/// salvage.
+#[cfg(feature = "columnar")]
+#[test]
+fn delete_positions_verified_degrades_a_persistent_block_read_failure() -> crate::Result<()> {
+    use crate::config::DeleteStrategy;
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let n = 64u32;
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .delete_strategy(DeleteStrategy::MergeOnRead);
+    for i in 0..n {
+        writer.write(iv(i))?;
+    }
+    for pos in [5u32, 20, 40] {
+        writer.delete_bitmap_mut().insert(pos);
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar+deletes SST is non-empty",
+    );
+
+    // Open cleanly, THEN fault the first positional read the verification walk
+    // issues with a PERSISTENT (`Other`/EIO) kind.
+    let table = open(source, &fs)?;
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("source")
+            .once(),
+    );
+    let result = table.delete_positions_verified();
+    injector.clear();
+    assert!(
+        matches!(result, Ok(false)),
+        "a persistent read during delete-position validation must degrade to an \
+         unpositionable mask so the resurrection opt-in can take effect: {result:?}",
+    );
+    Ok(())
+}
+
+/// `salvage_blob_file` must not delete a pre-existing file at `dest` when the
+/// destination cannot be created (the writer's `create_new` open fails because
+/// the path already exists): the error-path cleanup is only for a partial file
+/// THIS call created. Deleting a pre-existing destination would turn an
+/// argument mistake (a stale path collision, or `source == dest`) into data
+/// loss.
+#[test]
+fn salvage_blob_file_keeps_a_preexisting_dest_on_open_failure() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_dest");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    build_blob(&source, &fs, &[(b"k0", b"v0")])?;
+    std::fs::write(&dest, b"pre-existing destination bytes")?;
+
+    let result = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator());
+    assert!(
+        result.is_err(),
+        "an already-existing destination fails the salvage: {result:?}",
+    );
+    assert_eq!(
+        std::fs::read(&dest)?,
+        b"pre-existing destination bytes",
+        "a pre-existing destination file survives the failed salvage",
+    );
+    Ok(())
+}
+
+/// The salvaged blob file is COMPACTED: after a dropped record every later
+/// record shifts to a new offset, and existing SST `ValueHandle::offset`
+/// values point into the SOURCE. The report's `offset_remap` must map every
+/// salvaged record's source frame offset to its offset in the recovered file
+/// (and omit the dropped one), so a caller can re-target handles before
+/// swapping the file in.
+#[test]
+fn salvage_blob_file_reports_an_offset_remap_for_every_salvaged_record() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let records: Vec<(&[u8], &[u8])> = vec![
+        (b"k0", b"v0-payload"),
+        (b"k1", b"v1-payload"),
+        (b"k2", b"v2-payload"),
+        (b"k3", b"v3-payload"),
+    ];
+    build_blob(&source, &fs, &records)?;
+
+    // Source frame offsets, in order, from a clean pre-corruption scan.
+    let source_offsets: Vec<u64> = BlobScanner::new(&source, &*fs, 0)?
+        .filter_map(Result::ok)
+        .map(|e| e.offset)
+        .collect();
+    assert_eq!(source_offsets.len(), 4, "four source records");
+
+    // Corrupt the SECOND record's value bytes (a checksum break): the scanner
+    // re-syncs at the next magic. k2, reached by that byte scan through k1's
+    // damaged bytes, has an unprovable boundary; the taint is sticky, so the walk
+    // STOPS there and reports the surrendered tail (k2, k3) as ONE drop. So only
+    // record 0 (before the corruption) survives.
+    {
+        let Some(&second) = source_offsets.get(1) else {
+            panic!("second record offset");
+        };
+        // Past the frame header, inside key/value bytes.
+        let flip = usize::try_from(second).unwrap_or(0) + 45;
+        let mut bytes = std::fs::read(&source)?;
+        if let Some(b) = bytes.get_mut(flip) {
+            *b ^= 0xFF;
+        }
+        std::fs::write(&source, &bytes)?;
+    }
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(report.records_salvaged, 1, "{report:?}");
+    assert_eq!(
+        report.dropped.len(),
+        2,
+        "the corrupt record + the surrendered tail (recorded once) drop: {report:?}"
+    );
+
+    // The remap covers exactly the salvaged records, keyed by their SOURCE
+    // offsets, and its targets are the actual frame offsets in the recovered
+    // file (verified against a scan of the destination).
+    let dest_offsets: Vec<u64> = BlobScanner::new(&dest, &*fs, 0)?
+        .filter_map(Result::ok)
+        .map(|e| e.offset)
+        .collect();
+    let expected: Vec<(u64, u64)> = std::iter::once(&0usize)
+        .zip(&dest_offsets)
+        .map(|(&src_idx, &new)| {
+            (
+                source_offsets.get(src_idx).copied().unwrap_or(u64::MAX),
+                new,
+            )
+        })
+        .collect();
+    assert_eq!(
+        report.offset_remap, expected,
+        "the remap maps each surviving source frame to its compacted target",
+    );
+    // The dropped record's source offset is NOT in the map: its handle is lost.
+    let Some(&dropped_src) = source_offsets.get(1) else {
+        panic!("second record offset");
+    };
+    assert!(
+        report
+            .offset_remap
+            .iter()
+            .all(|(src, _)| *src != dropped_src),
+        "a dropped record has no remap target: {report:?}",
+    );
+    Ok(())
+}
+
+/// When a record write to the destination fails mid-salvage, `salvage_blob_file`
+/// must error AND remove the partial destination it created, so a retry / repair
+/// caller never finds a half-written blob file.
+#[test]
+fn salvage_blob_file_removes_the_partial_dest_when_a_write_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    let records: Vec<(&[u8], &[u8])> = vec![(b"k0", b"v0"), (b"k1", b"v1")];
+    build_blob(&source, &fs, &records)?;
+
+    // Fail every write to the destination file: the first recovered record's
+    // write-back errors.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other)).on_path("blob_salvaged"),
+    );
+
+    let result = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator());
+    assert!(
+        result.is_err(),
+        "a failed destination write must error the salvage",
+    );
+    assert!(
+        !std::path::Path::new(&dest).exists(),
+        "the partial destination is removed on a write failure",
+    );
+    Ok(())
+}
+
+#[test]
+fn salvage_blob_file_drops_a_corrupt_record_and_keeps_the_rest() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let records: Vec<(&[u8], &[u8])> = vec![
+        (b"k0", b"value-zero"),
+        (b"k1", b"value-one"),
+        (b"k2", b"value-two"),
+        (b"k3", b"value-three"),
+    ];
+    build_blob(&source, &fs, &records)?;
+
+    // Flip the last byte of the second record's value: the checksum (over
+    // key + value) fails, but the frame header (lengths, magic) stays intact, so
+    // the scanner reports a checksum mismatch and re-syncs at the next record.
+    let Some(second_frame_end) = BlobScanner::new(&source, &*fs, 0)?
+        .filter_map(Result::ok)
+        .nth(1)
+        .map(|e| e.frame_end)
+    else {
+        panic!("source blob must have at least two records");
+    };
+    let flip = usize::try_from(second_frame_end - 1).unwrap_or(0);
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(flip) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    // The corrupt k1 drops on its checksum, and the scanner then RESYNCS to the
+    // next magic. k2's frame is reached by that byte scan through k1's damaged
+    // bytes, so its boundary is UNPROVEN. The taint is sticky, so the walk STOPS at
+    // k2 and reports the whole surrendered tail (k2 and k3 chained past it) as ONE
+    // drop, rather than re-emitting a possibly-fabricated chain. Only k0, before
+    // the corruption, is provable.
+    assert_eq!(
+        report.dropped.len(),
+        2,
+        "the corrupt record + the surrendered tail (recorded once) drop: {report:?}"
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(BlobDropReason::ChecksumMismatch)
+        ),
+        "the corrupt record reports a checksum mismatch: {report:?}",
+    );
+    assert_eq!(
+        report
+            .dropped
+            .iter()
+            .filter(
+                |d| matches!(&d.reason, BlobDropReason::Corrupt(m) if m.contains("surrendered"))
+            )
+            .count(),
+        1,
+        "the surrendered tail after the resync is recorded ONCE: {report:?}",
+    );
+    assert_eq!(
+        report.records_salvaged, 1,
+        "only k0 is recovered; k1 (corrupt) and the surrendered tail (k2, k3) are not"
+    );
+
+    // The salvaged file holds only k0: k1 (corrupt) and the whole tainted tail
+    // (k2, k3) after the resync are absent.
+    let recovered = scan_blob(&dest, &fs)?;
+    let keys: Vec<Vec<u8>> = recovered.iter().map(|(k, _)| k.clone()).collect();
+    assert_eq!(
+        keys,
+        vec![b"k0".to_vec()],
+        "only the provable frame before the corruption survives",
+    );
+    Ok(())
+}
+
+/// A blob file where EVERY record is corrupt salvages nothing: the report
+/// carries only drops, `salvaged_path` is `None`, and the empty destination
+/// placeholder the writer created is removed (a repair caller would otherwise
+/// re-quarantine a stray zero-record blob file in its place).
+#[test]
+fn salvage_blob_file_removes_the_empty_dest_when_nothing_is_recoverable() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let records: Vec<(&[u8], &[u8])> = vec![(b"k0", b"value-zero"), (b"k1", b"value-one")];
+    build_blob(&source, &fs, &records)?;
+
+    // Flip the last value byte of BOTH records: each frame header stays
+    // intact, so the scanner reports one checksum mismatch per record and
+    // re-syncs — leaving zero salvageable records.
+    let frame_ends: Vec<u64> = BlobScanner::new(&source, &*fs, 0)?
+        .filter_map(Result::ok)
+        .map(|e| e.frame_end)
+        .collect();
+    assert_eq!(frame_ends.len(), 2, "source blob holds two records");
+    let mut bytes = std::fs::read(&source)?;
+    for end in frame_ends {
+        let flip = usize::try_from(end - 1).unwrap_or(0);
+        if let Some(b) = bytes.get_mut(flip) {
+            *b ^= 0xFF;
+        }
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(report.records_salvaged, 0, "{report:?}");
+    assert_eq!(report.dropped.len(), 2, "both records drop: {report:?}");
+    assert_eq!(
+        report.salvaged_path, None,
+        "nothing recoverable yields no salvaged path",
+    );
+    assert!(
+        fs.metadata(&dest).is_err(),
+        "the empty destination placeholder is removed",
+    );
+    Ok(())
+}
+
+/// A STRUCTURAL failure mid-walk (a record frame whose magic bytes are gone,
+/// not a checksum miss) terminates the blob walk: the scanner cannot re-sync
+/// past it, so the salvage records one `Corrupt` drop for the unreadable tail
+/// and keeps everything scanned before it.
+#[test]
+fn salvage_blob_file_stops_at_a_smashed_frame_and_keeps_the_prefix() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    let records: Vec<(&[u8], &[u8])> = vec![
+        (b"k0", b"value-zero"),
+        (b"k1", b"value-one"),
+        (b"k2", b"value-two"),
+    ];
+    build_blob(&source, &fs, &records)?;
+
+    // Smash the LAST record's frame magic (the file structure and trailer
+    // stay intact): the scanner reports it as a structural InvalidHeader it
+    // cannot re-sync from, unlike a checksum miss.
+    let Some(last_start) = BlobScanner::new(&source, &*fs, 0)?
+        .filter_map(Result::ok)
+        .nth(1)
+        .map(|e| e.frame_end)
+    else {
+        panic!("source blob must have at least two records");
+    };
+    let mut bytes = std::fs::read(&source)?;
+    let at = usize::try_from(last_start).unwrap_or(0);
+    let Some(magic) = bytes.get_mut(at..at + 4) else {
+        panic!("last record's frame magic within the file");
+    };
+    magic.copy_from_slice(b"????");
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(
+        report.records_salvaged, 2,
+        "the records before the smashed frame are recovered: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(BlobDropReason::Corrupt(_))
+        ),
+        "the truncated tail is recorded as a structural drop: {report:?}",
+    );
+    let recovered = scan_blob(&dest, &fs)?;
+    assert_eq!(recovered.len(), 2, "the salvaged copy holds the prefix");
+    Ok(())
+}
+
+/// A blob frame whose header CRC and data checksum are internally consistent
+/// but whose `key_len` is ZERO yields an Ok scanner entry with an empty key —
+/// which the blob writer's ingest asserts against. Salvage must route such a
+/// frame through the corrupt-record path (dropped, walk continues) instead of
+/// panicking in the writer and leaving a partial destination behind.
+#[test]
+fn salvage_blob_file_drops_an_empty_key_frame() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    build_blob(&source, &fs, &[(b"k", b"vvvv"), (b"k2", b"second")])?;
+
+    // Re-frame the FIRST record as `key_len = 0`: its key byte becomes the
+    // first value byte (the hashed key||value byte span is unchanged), with
+    // the header CRC and data checksum recomputed so the frame stays
+    // internally consistent. V4 frame layout from offset 0:
+    //   magic 4 | checksum 16 | seqno 8 | key_len 2 | real_val_len 4 |
+    //   on_disk_val_len 4 | header_crc 4 | key | value.
+    let mut bytes = std::fs::read(&source)?;
+    let seqno = {
+        let Some(b) = bytes.get(20..28) else {
+            panic!("seqno within the first frame");
+        };
+        u64::from_le_bytes(b.try_into().unwrap_or([0; 8]))
+    };
+    // header_crc = truncated xxh3 over (seqno, key_len, real_val_len,
+    // on_disk_val_len), matching the writer's framing.
+    let new_hcrc = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3::default();
+        hasher.update(&seqno.to_le_bytes());
+        hasher.update(&0u16.to_le_bytes());
+        hasher.update(&5u32.to_le_bytes());
+        hasher.update(&5u32.to_le_bytes());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "intentionally truncated to the 4-byte header CRC"
+        )]
+        {
+            hasher.digest() as u32
+        }
+    };
+    // data checksum = xxh3_128(key || value || header_crc_le); with the empty
+    // key the hashed span is the same "kvvvv" bytes plus the NEW header CRC.
+    let new_checksum = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3::default();
+        hasher.update(b"kvvvv");
+        hasher.update(&new_hcrc.to_le_bytes());
+        hasher.digest128()
+    };
+    let patch = |bytes: &mut Vec<u8>, range: core::ops::Range<usize>, val: &[u8]| {
+        let Some(slot) = bytes.get_mut(range) else {
+            panic!("patch range within the first frame");
+        };
+        slot.copy_from_slice(val);
+    };
+    patch(&mut bytes, 4..20, &new_checksum.to_le_bytes());
+    patch(&mut bytes, 28..30, &0u16.to_le_bytes());
+    patch(&mut bytes, 30..34, &5u32.to_le_bytes());
+    patch(&mut bytes, 34..38, &5u32.to_le_bytes());
+    patch(&mut bytes, 38..42, &new_hcrc.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "the empty-key frame drops as corrupt: {report:?}",
+    );
+    assert!(
+        matches!(
+            report.dropped.first().map(|d| &d.reason),
+            Some(BlobDropReason::Corrupt(_))
+        ),
+        "the drop reason names the malformed frame: {report:?}",
+    );
+    assert_eq!(
+        report.records_salvaged, 1,
+        "the record after the malformed frame is still recovered",
+    );
+    let recovered = scan_blob(&dest, &fs)?;
+    assert_eq!(
+        recovered,
+        vec![(b"k2".to_vec(), b"second".to_vec())],
+        "the salvaged copy holds exactly the healthy record",
+    );
+    Ok(())
+}
+
+/// A blob frame whose header CRC and data checksum are internally consistent
+/// but whose `real_val_len` field disagrees with the bytes actually stored
+/// (`on_disk_val_len`, an uncompressed source) is REJECTED by the live blob
+/// reader — salvage must not launder it: re-emitting through the writer would
+/// restamp the frame with a consistent length and count a record the live
+/// read path treats as corrupt as salvaged. It must drop through the
+/// corrupt-record path instead.
+#[test]
+fn salvage_blob_file_drops_a_frame_with_a_forged_value_length() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    build_blob(&source, &fs, &[(b"k", b"vvvv"), (b"k2", b"second")])?;
+
+    // Re-stamp the FIRST record's `real_val_len` (4 → 5) while the stored
+    // bytes stay 4 (`on_disk_val_len` unchanged), with the header CRC and
+    // data checksum recomputed so the frame stays internally consistent —
+    // exactly the shape the scanner accepts and `Reader::get` rejects.
+    // V4 frame layout from offset 0:
+    //   magic 4 | checksum 16 | seqno 8 | key_len 2 | real_val_len 4 |
+    //   on_disk_val_len 4 | header_crc 4 | key | value.
+    let mut bytes = std::fs::read(&source)?;
+    let seqno = {
+        let Some(b) = bytes.get(20..28) else {
+            panic!("seqno within the first frame");
+        };
+        u64::from_le_bytes(b.try_into().unwrap_or([0; 8]))
+    };
+    let new_hcrc = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3::default();
+        hasher.update(&seqno.to_le_bytes());
+        hasher.update(&1u16.to_le_bytes());
+        hasher.update(&5u32.to_le_bytes());
+        hasher.update(&4u32.to_le_bytes());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "intentionally truncated to the 4-byte header CRC"
+        )]
+        {
+            hasher.digest() as u32
+        }
+    };
+    let new_checksum = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3::default();
+        hasher.update(b"kvvvv");
+        hasher.update(&new_hcrc.to_le_bytes());
+        hasher.digest128()
+    };
+    let patch = |bytes: &mut Vec<u8>, range: core::ops::Range<usize>, val: &[u8]| {
+        let Some(slot) = bytes.get_mut(range) else {
+            panic!("patch range within the first frame");
+        };
+        slot.copy_from_slice(val);
+    };
+    patch(&mut bytes, 4..20, &new_checksum.to_le_bytes());
+    patch(&mut bytes, 30..34, &5u32.to_le_bytes());
+    patch(&mut bytes, 38..42, &new_hcrc.to_le_bytes());
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_blob_file(&source, dest.clone(), &fs, 0, &default_comparator())?;
+    assert_eq!(
+        report.dropped.len(),
+        1,
+        "the forged-length frame drops as corrupt: {report:?}",
+    );
+    assert_eq!(
+        report.records_salvaged, 1,
+        "the record after the malformed frame is still recovered",
+    );
+    let recovered = scan_blob(&dest, &fs)?;
+    assert_eq!(
+        recovered,
+        vec![(b"k2".to_vec(), b"second".to_vec())],
+        "the salvaged copy holds exactly the healthy record",
+    );
+    Ok(())
+}
+
+/// A compressed blob source is rejected (fail-closed): the scanner yields on-disk
+/// compressed bytes that this path cannot faithfully re-emit yet.
+#[cfg(feature = "lz4")]
+#[test]
+fn salvage_blob_file_rejects_a_compressed_source() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let source = dir.path().join("blob_source");
+    let dest = dir.path().join("blob_salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    {
+        let mut writer =
+            BlobWriter::new(&source, 0, 0, &*fs)?.use_compression(crate::CompressionType::Lz4);
+        writer.write(b"k0", 0, b"some compressible value aaaaaaaaaaaaaaaa")?;
+        writer.finish()?;
+    }
+
+    assert!(
+        matches!(
+            salvage_blob_file(&source, dest, &fs, 0, &default_comparator()),
+            Err(crate::Error::FeatureUnsupported(_)),
+        ),
+        "a compressed blob file must be rejected rather than mis-salvaged",
+    );
+    Ok(())
+}
+
+/// A columnar source carrying a per-field value sub-column salvages into a copy
+/// that KEEPS the sub-column (verbatim `ColumnBatch` re-emit), instead of
+/// collapsing it into a single value column via a row round-trip.
+#[cfg(feature = "columnar")]
+#[test]
+fn salvage_preserves_columnar_value_subcolumns() -> crate::Result<()> {
+    use crate::table::columnar::{Column, TypeTag, entries_to_column_batch};
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let cmp = default_comparator();
+
+    // Two columnar blocks whose value is a single fixed-4 sub-column (id 3),
+    // written verbatim through the ingest batch path (per-row seqno 0).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for block in 0..2u32 {
+        let entries: Vec<InternalValue> = (0..4u32)
+            .map(|i| {
+                let k = format!("k{:04}", block * 4 + i);
+                InternalValue::from_components(k.into_bytes(), b"x".to_vec(), 0, ValueType::Value)
+            })
+            .collect();
+        let mut batch = entries_to_column_batch(&entries)?;
+        batch.columns.pop();
+        let mut data = Vec::new();
+        for i in 0..4u32 {
+            data.extend_from_slice(&(block * 4 + i).to_le_bytes());
+        }
+        batch.columns.push(Column {
+            column_id: 3,
+            type_tag: TypeTag::Fixed(4),
+            validity: None,
+            data,
+        });
+        writer.write_columnar_batch(&batch, &cmp)?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "a healthy columnar SST drops nothing: {report:?}"
+    );
+    // No deletes + clean blocks: each columnar block is copied through verbatim,
+    // which is exactly why the per-field sub-columns survive byte-for-byte.
+    assert_eq!(
+        report.blocks_copied_verbatim, report.blocks_salvaged,
+        "clean columnar blocks are copied verbatim",
+    );
+
+    // Reopen and project sub-column 3 via the per-SST scan: it survives as a
+    // sub-column. A row round-trip would have collapsed it into the value column.
+    let recovered = open(dest, &fs)?;
+    assert!(
+        recovered.metadata.columnar,
+        "the recovered copy stays columnar"
+    );
+    let batches = recovered.columnar_scan(&[3], None)?;
+    let rows: u32 = batches.iter().map(|b| b.row_count).sum();
+    assert_eq!(rows, 8, "every row's sub-column is recovered");
+    assert!(
+        batches
+            .iter()
+            .all(|b| b.columns.iter().all(|c| c.column_id == 3)),
+        "the value sub-column (id 3) is preserved verbatim, not collapsed",
+    );
+    Ok(())
+}
+
+/// A columnar Page-ECC SST with a single-byte RS-recoverable fault in a data
+/// block (no deletes): salvage recovers the block from parity and **re-encodes**
+/// the healed batch rather than copying the faulty on-disk bytes verbatim, so the
+/// recovered copy carries clean bytes. The clean block around it is still copied
+/// verbatim.
+#[cfg(all(feature = "columnar", feature = "page_ecc"))]
+#[test]
+fn salvage_reencodes_an_ecc_recovered_columnar_block() -> crate::Result<()> {
+    use crate::table::block::{EccParams, Header};
+    use crate::table::columnar::entries_to_column_batch;
+
+    let dir = tempdir()?;
+    let source = dir.path().join("source");
+    let dest = dir.path().join("salvaged");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let cmp = default_comparator();
+
+    // Two columnar blocks under RS(4,2) parity, no deletes (so the no-deletes
+    // copy-through / recover path is taken, not the delete-masked one).
+    let mut writer = Writer::new(source.clone(), 0, 0, Arc::clone(&fs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_ecc(Some(EccParams::RS_4_2));
+    for block in 0..2u32 {
+        let entries: Vec<InternalValue> = (0..4u32)
+            .map(|i| {
+                let k = format!("k{:04}", block * 4 + i);
+                InternalValue::from_components(k.into_bytes(), b"x".to_vec(), 0, ValueType::Value)
+            })
+            .collect();
+        let batch = entries_to_column_batch(&entries)?;
+        writer.write_columnar_batch(&batch, &cmp)?;
+    }
+    assert!(
+        writer.finish()?.is_some(),
+        "source columnar SST is non-empty"
+    );
+
+    // Flip one byte of the first columnar data block (RS(4,2) recovers a single
+    // byte error).
+    let first_off = {
+        let table = open(source.clone(), &fs)?;
+        let Some(kh) = table.data_block_handles().find_map(Result::ok) else {
+            panic!("a non-empty SST has at least one data block");
+        };
+        usize::try_from(*kh.as_ref().offset()).unwrap_or(usize::MAX)
+    };
+    let pos = first_off + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&source)?;
+    if let Some(b) = bytes.get_mut(pos) {
+        *b ^= 0x80;
+    }
+    std::fs::write(&source, &bytes)?;
+
+    let report = salvage_sst(&source, dest.clone(), &fs)?;
+    assert!(
+        report.is_complete(),
+        "an RS-recoverable columnar block is healed, not dropped: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_salvaged, report.blocks_total,
+        "every block is recovered",
+    );
+    // The recovered block was re-encoded (verbatim:None), so fewer verbatim copies
+    // than salvaged blocks; the other (clean) block is copied verbatim.
+    assert!(
+        report.blocks_copied_verbatim < report.blocks_salvaged,
+        "the ECC-recovered columnar block is re-encoded, not copied verbatim: {report:?}",
+    );
+
+    let recovered = open(dest, &fs)?;
+    assert!(
+        recovered.metadata.columnar,
+        "the recovered copy stays columnar"
+    );
+    assert_eq!(recovered.metadata.item_count, 8, "every row is recovered");
     Ok(())
 }

--- a/src/scrub.rs
+++ b/src/scrub.rs
@@ -46,6 +46,8 @@ use crate::AbstractTree;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+pub(crate) mod heal_attest;
+
 /// One uncorrectable finding from a patrol scrub.
 ///
 /// Emitted when a block failed its checksum and Page-ECC parity could not
@@ -80,6 +82,22 @@ pub enum ScrubError {
         /// The underlying error, rendered as text.
         reason: String,
     },
+
+    /// An in-place heal rewrote this table's bytes, but its refreshed
+    /// full-file digest could not be persisted to the manifest (recomputing
+    /// the digest or installing the new version failed). The healed BYTES are
+    /// durable; the manifest may still carry a stale pre-heal digest, so a
+    /// later [`crate::verify::verify_integrity`] can flag the healed file as
+    /// corrupt until a re-run of the scrub (or a manifest rebuild) refreshes
+    /// it.
+    ChecksumRefreshFailed {
+        /// Table whose digest could not be refreshed.
+        table_id: crate::table::TableId,
+        /// On-disk path of the SST.
+        path: PathBuf,
+        /// The underlying error, rendered as text.
+        reason: String,
+    },
 }
 
 /// Aggregated result of a [`patrol_scrub`] run.
@@ -98,8 +116,15 @@ pub struct PatrolScrubReport {
     /// Distinct SSTs newly queued for a healing recompaction by this scrub
     /// (confirmed-persistent correction with `auto_heal` enabled). Zero when
     /// `auto_heal` is off (correction-on-read still happens, only the rewrite
-    /// scheduling is suppressed).
+    /// scheduling is suppressed), and zero in heal-in-place mode (the correction
+    /// is persisted directly, so no full-file rewrite is scheduled).
     pub ssts_scheduled_for_rewrite: usize,
+    /// Blocks whose Page-ECC correction was persisted **in place** — the
+    /// corrected bytes written back at the block's existing offset
+    /// (size-preserving), no full-file rewrite. Non-zero only when
+    /// [`PatrolScrubOptions::heal_in_place`] is set; it is the O(damage)
+    /// counterpart to [`ssts_scheduled_for_rewrite`](Self::ssts_scheduled_for_rewrite).
+    pub blocks_healed_in_place: usize,
     /// Blocks that failed their checksum and could NOT be recovered from parity
     /// (or were otherwise unreadable). These are real, unhealed corruption.
     pub uncorrectable_blocks: usize,
@@ -111,18 +136,26 @@ pub struct PatrolScrubReport {
 
 impl PatrolScrubReport {
     /// `true` when every block the scrub read was clean or successfully
-    /// corrected (no uncorrectable corruption was found).
+    /// corrected AND the sweep finished with no findings at all: no
+    /// uncorrectable corruption, no block-index walk that failed to
+    /// enumerate a table's blocks, and no manifest-digest refresh that
+    /// could not be persisted after an in-place heal. Any entry in
+    /// [`errors`](Self::errors) means the tree needs operator attention
+    /// even when every block that WAS read verified clean.
     #[must_use]
     pub fn is_ok(&self) -> bool {
-        self.uncorrectable_blocks == 0
+        self.uncorrectable_blocks == 0 && self.errors.is_empty()
     }
 
-    /// Folds a per-SST partial report into this accumulator.
-    fn merge(&mut self, other: Self) {
+    /// Folds a per-SST partial report into this accumulator. `pub(crate)` for
+    /// the heal path's read-only fallback (it folds a scrub report into the
+    /// heal report when the file cannot be opened read+write).
+    pub(crate) fn merge(&mut self, other: Self) {
         self.sst_files_scanned += other.sst_files_scanned;
         self.blocks_scanned += other.blocks_scanned;
         self.corrections_applied += other.corrections_applied;
         self.ssts_scheduled_for_rewrite += other.ssts_scheduled_for_rewrite;
+        self.blocks_healed_in_place += other.blocks_healed_in_place;
         self.uncorrectable_blocks += other.uncorrectable_blocks;
         self.errors.extend(other.errors);
     }
@@ -141,6 +174,15 @@ pub struct PatrolScrubOptions {
     /// the next, capping I/O pressure on a production box during a scrub.
     /// `None` (the default) runs at full speed.
     pub throttle: Option<std::time::Duration>,
+
+    /// Persist each Page-ECC correction **in place** rather than scheduling a
+    /// full-file healing rewrite: a corrected block's bytes are written back at
+    /// its existing offset (size-preserving), leaving every healthy block
+    /// untouched (O(damage), not O(file)). `false` (the default) keeps the
+    /// classic behaviour — correct on read and queue the SST for a clean rewrite
+    /// via [`HealHints`](crate::heal_hints::HealHints). Requires the `page_ecc`
+    /// feature; without it the flag is inert (there is no parity to heal from).
+    pub heal_in_place: bool,
 }
 
 impl Default for PatrolScrubOptions {
@@ -148,6 +190,7 @@ impl Default for PatrolScrubOptions {
         Self {
             parallelism: 1,
             throttle: None,
+            heal_in_place: false,
         }
     }
 }
@@ -164,6 +207,14 @@ impl PatrolScrubOptions {
     #[must_use]
     pub const fn throttle(mut self, delay: std::time::Duration) -> Self {
         self.throttle = Some(delay);
+        self
+    }
+
+    /// Enables persisting corrections in place (see
+    /// [`heal_in_place`](Self::heal_in_place)).
+    #[must_use]
+    pub const fn heal_in_place(mut self, enable: bool) -> Self {
+        self.heal_in_place = enable;
         self
     }
 }
@@ -220,7 +271,13 @@ impl PatrolScrubOptions {
 /// # }
 /// ```
 #[must_use]
-pub fn patrol_scrub(tree: &impl AbstractTree, options: &PatrolScrubOptions) -> PatrolScrubReport {
+// `Sync`: the parallel path shares `tree` with the scan workers so each can
+// reconcile its table's manifest digest inside the same checkpoint-exclusion
+// window as its heal scan (both tree types are `Sync`).
+pub fn patrol_scrub(
+    tree: &(impl AbstractTree + Sync),
+    options: &PatrolScrubOptions,
+) -> PatrolScrubReport {
     let version = tree.current_version();
     let tables: Vec<crate::table::Table> = version.iter_tables().cloned().collect();
 
@@ -230,7 +287,7 @@ pub fn patrol_scrub(tree: &impl AbstractTree, options: &PatrolScrubOptions) -> P
     if workers <= 1 {
         let mut report = PatrolScrubReport::default();
         for (idx, table) in tables.iter().enumerate() {
-            report.merge(table.scrub_data_blocks());
+            report.merge(scan_and_reconcile(tree, table, options));
             // Inter-SST pause only; skip the sleep after the final table so a
             // finished scrub returns promptly instead of idling one extra
             // throttle interval.
@@ -251,7 +308,7 @@ pub fn patrol_scrub(tree: &impl AbstractTree, options: &PatrolScrubOptions) -> P
                     let mut local = PatrolScrubReport::default();
                     let mut idx = cursor.fetch_add(1, Ordering::Relaxed);
                     while let Some(table) = tables.get(idx) {
-                        local.merge(table.scrub_data_blocks());
+                        local.merge(scan_and_reconcile(tree, table, options));
                         // Claim the next SST first; only pause if this worker
                         // still has another table, so no worker sleeps after its
                         // final SST.
@@ -282,6 +339,711 @@ pub fn patrol_scrub(tree: &impl AbstractTree, options: &PatrolScrubOptions) -> P
         report.merge(partial);
     }
     report
+}
+
+/// Scans one SST and, for a corruption-free heal scan, reconciles its
+/// manifest digest — all under ONE checkpoint-exclusion window: a checkpoint
+/// that slipped in between the heal's last write and the digest refresh
+/// would link the already-healed bytes while capturing the still-stale
+/// version digest, permanently desynchronizing the immutable checkpoint
+/// manifest from its own files. A table without an installed pause has no
+/// checkpoint machinery, so nothing can link it concurrently and the window
+/// is skipped; plain (non-heal) scrubs mutate nothing and never take it.
+fn scan_and_reconcile(
+    tree: &impl AbstractTree,
+    table: &crate::table::Table,
+    options: &PatrolScrubOptions,
+) -> PatrolScrubReport {
+    // Only a Page-ECC table can have had its bytes legitimately healed in
+    // place (this pass or an earlier one whose refresh failed), so only
+    // those get the digest reconciliation. On a table WITHOUT ECC a
+    // manifest digest mismatch is real evidence — an in-band alteration
+    // whose block checksums were re-stamped has NO other detector — and
+    // restamping would erase the only record of it; skipping also spares
+    // every ordinary SST the full-file digest read. The COMPILED feature
+    // gates it too: without `page_ecc` an ECC table falls back to the
+    // read-only scrub (nothing can have healed), so reconciling would burn
+    // a digest read only to fail closed on the walk's parity warning.
+    let heals =
+        cfg!(feature = "page_ecc") && options.heal_in_place && table.metadata.ecc_params.is_some();
+    // Serializes same-table heals for the WHOLE scan-to-reconcile span (not
+    // just the scan): with two overlapping heal patrols, A could compute a
+    // digest, B could heal a fresh fault and install its own, and A would
+    // then install the stale one. Also keeps the link-count probe honest
+    // (the probed handle is always the current live inode).
+    #[cfg(feature = "page_ecc")]
+    let heal_lock = heals.then(|| table.heal_lock_arc());
+    #[cfg(feature = "page_ecc")]
+    let _heal_exclusive = heal_lock.as_ref().map(|l| l.lock());
+    // The pause is installed on EVERY live table before it becomes visible: flush
+    // outputs via `register_tables`, compaction outputs via `install_merge` and the
+    // tight-space slice loop (both call `install_deletion_pause`). So for a healable
+    // (Page-ECC) table `deletion_pause.get()` is `Some`, and this heal enters the
+    // checkpoint mutation window rather than racing a concurrent checkpoint's
+    // hard-link. `None` (a table with no pause, e.g. a diagnostic reader) just
+    // skips the window.
+    let _mutation_window = heals
+        .then(|| {
+            table
+                .deletion_pause
+                .get()
+                .map(|p| p.enter_mutation_window())
+        })
+        .flatten();
+    // The CURRENT view of this table, resolved under the heal lock: a
+    // concurrent patrol may have refreshed the manifest — or a tight-space
+    // compaction may have installed a RESTRICTED same-id view — after this
+    // caller's table view was captured, and both the attribution probe and
+    // the reconciliation must judge against what the manifest says NOW.
+    // `None` when the table has already been compacted away; the captured
+    // view and its snapshot digest then stand in (nothing left to attribute
+    // against).
+    let current = tree
+        .current_version()
+        .iter_tables()
+        .find(|t| t.id() == table.id())
+        .cloned();
+    // When the current view's RESTRICTION differs from the captured one, the
+    // captured view is stale: its file region (and so its pre-heal digest)
+    // can never match the current manifest digest, which covers a different
+    // region. Scanning the stale view would trip the divergent-heal guard
+    // before the block walk and return a clean report with a known fault
+    // untouched. Scan the CURRENT view instead — the heal lock held above is
+    // SHARED across same-id views (`reopen_restricted` carries it forward),
+    // so the serialization still covers the substituted view.
+    let scan_table: &crate::table::Table = match &current {
+        Some(cur) if cur.restrict_lower_bound() != table.restrict_lower_bound() => cur,
+        _ => table,
+    };
+    let manifest_checksum = current
+        .as_ref()
+        .map_or_else(|| table.checksum(), crate::table::Table::checksum);
+    let (mut partial, heal_attributable) =
+        scan_one(scan_table, options, tree.sync_mode(), manifest_checksum);
+    if heals
+        && wants_checksum_refresh(&partial)
+        && let Some(finding) = refresh_healed_checksum(tree, scan_table, heal_attributable)
+    {
+        partial.errors.push(finding);
+    }
+    partial
+}
+
+/// Reconciles every table that still carries a pending `.heal-attest` sidecar,
+/// so a checkpoint about to snapshot the tree captures each table's REFRESHED
+/// digest rather than the stale pre-heal one (the sidecar is not copied into
+/// the checkpoint, so an unreconciled table would fail the immutable
+/// checkpoint's integrity check forever with no marker to reconcile).
+///
+/// Runs the same per-table scan-and-reconcile as a patrol, but only for the
+/// tables that actually have a pending attestation (the common case is none, so
+/// this is a cheap `exists` probe per table and no scan). Must be called BEFORE
+/// a checkpoint takes its link window: the reconcile acquires each table's
+/// mutation window, which the link window mutually excludes.
+///
+/// # Errors
+///
+/// Returns an error if a pending-heal table could NOT be reconciled (corruption
+/// remains, or the digest refresh failed): the caller must not snapshot a table
+/// whose on-disk bytes disagree with the digest it would record.
+#[cfg(feature = "page_ecc")]
+pub(crate) fn reconcile_pending_heals(tree: &impl AbstractTree) -> crate::Result<()> {
+    let options = PatrolScrubOptions::default().heal_in_place(true);
+    let version = tree.current_version();
+    // A sidecar-probe FAILURE aborts (fail-closed): mistaking an unreadable
+    // probe for "no pending heal" would let the snapshot capture a stale digest.
+    let mut pending: Vec<crate::table::Table> = Vec::new();
+    for table in version.iter_tables() {
+        if table.metadata.ecc_params.is_some()
+            && heal_attest::exists(&*table.fs, &table.path).map_err(crate::Error::Io)?
+        {
+            pending.push(table.clone());
+        }
+    }
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let mut report = PatrolScrubReport::default();
+    for table in &pending {
+        report.merge(scan_and_reconcile(tree, table, &options));
+    }
+    if report.is_ok() {
+        Ok(())
+    } else {
+        Err(crate::Error::from(std::io::Error::other(alloc::format!(
+            "checkpoint aborted: {} pending heal attestation(s) could not be reconciled \
+             ({} uncorrectable block(s), {} finding(s)); run a scrub and retry",
+            pending.len(),
+            report.uncorrectable_blocks,
+            report.errors.len(),
+        ))))
+    }
+}
+
+/// Abort a checkpoint if any table still carries a pending `.heal-attest`
+/// marker, when the marker cannot be reconciled at this point:
+///
+/// - On a build WITHOUT `page_ecc` (no ECC scan machinery), used BEFORE the
+///   link window in place of reconciliation.
+/// - On ANY build, used AFTER the link window is held: reconciliation there is
+///   impossible because it needs each table's mutation window, which the link
+///   window (the write half of the same lock) mutually excludes. This closes
+///   the residual race where a concurrent heal left a fresh marker between the
+///   pre-window reconcile and the link-window acquisition.
+///
+/// Either way, snapshotting a healed table under its stale pre-heal digest with
+/// no marker copied would produce an immutable checkpoint that fails integrity
+/// verification forever. The operator retries; the next attempt reconciles it.
+///
+/// # Errors
+///
+/// Returns an error if any table has a pending marker, or if a marker probe
+/// itself fails (fail-closed).
+#[cfg(feature = "std")]
+pub(crate) fn abort_checkpoint_if_pending_heals(
+    tree: &impl AbstractTree,
+    reason: &str,
+) -> crate::Result<()> {
+    let version = tree.current_version();
+    for table in version.iter_tables() {
+        if heal_attest::exists(&*table.fs, &table.path).map_err(crate::Error::Io)? {
+            // The marker may be OBSOLETE: a heal that refreshed the manifest
+            // digest but crashed (or whose best-effort unlink failed) before
+            // removing the sidecar leaves a marker whose file ALREADY matches the
+            // manifest. A build WITHOUT `page_ecc` never runs reconciliation to
+            // clear it, so an unconditional abort would wedge EVERY checkpoint
+            // forever. When the live-region digest already agrees with the
+            // manifest the heal completed and snapshotting under that digest is
+            // consistent: reclaim the stale marker and continue. This removal is
+            // safe at both call sites — the pre-window call is `page_ecc`-free
+            // (no concurrent heal can write a marker) and the post-window call
+            // holds the link window that excludes heals. A digest read failure
+            // falls through to the abort (fail-closed).
+            if let Ok(fresh) = table.live_region_checksum()
+                && fresh == table.checksum()
+            {
+                heal_attest::remove(&*table.fs, &table.path);
+                continue;
+            }
+            return Err(crate::Error::from(std::io::Error::other(alloc::format!(
+                "checkpoint aborted: table #{} has a pending heal attestation that cannot be \
+                 reconciled here ({reason}); retry the checkpoint",
+                table.id(),
+            ))));
+        }
+    }
+    Ok(())
+}
+
+/// Whether a per-SST HEAL scan warrants the manifest-digest reconciliation:
+/// the scan must have left the file free of known corruption (no
+/// uncorrectable blocks, no findings). Restamping a partially-healed file
+/// would compute the fresh digest over the still-corrupt bytes, making a
+/// later `verify_integrity` pass on an SST with known, unrepaired corruption.
+///
+/// Deliberately NOT gated on "this pass healed something": a refresh that
+/// failed on an earlier pass (or a crash between the heal's `sync_data` and
+/// the manifest update) leaves a stale digest that a later scan — which then
+/// reads only clean blocks — must still reconcile, or the mismatch survives
+/// forever. The reconciliation itself is a no-op when the digests already
+/// agree, so a clean scan of a healthy table costs one streaming read and no
+/// manifest write.
+fn wants_checksum_refresh(partial: &PatrolScrubReport) -> bool {
+    partial.uncorrectable_blocks == 0 && partial.errors.is_empty()
+}
+
+/// Reconciles a table's manifest digest with its on-disk bytes after a
+/// corruption-free heal scan: an in-place heal (this pass or an earlier one
+/// whose manifest update failed / was interrupted) may have left the digest
+/// captured at recovery stale, and a later verify (or repair) would flag the
+/// healed file against it. When the recomputed digest already matches the
+/// manifest, nothing is written. A failure is returned as a
+/// [`ScrubError::ChecksumRefreshFailed`] finding (the caller folds it into
+/// the report) — the healed bytes are durable either way, and the next heal
+/// scan retries the reconciliation.
+/// `heal_attributable` comes from the heal scan: `true` when the file's
+/// digest was probed right before the pass's first write-back and matched
+/// the manifest, so every byte the file now differs by is provably one of
+/// that pass's verified corrections. It is what lets a table carrying
+/// deletion metadata — which no semantic gate can authenticate — still be
+/// reconciled after a legitimate heal.
+fn refresh_healed_checksum(
+    tree: &impl AbstractTree,
+    table: &crate::table::Table,
+    heal_attributable: bool,
+) -> Option<ScrubError> {
+    let finding = |reason: String| {
+        log::warn!(
+            "failed to persist refreshed checksum for healed table #{}: {reason}",
+            table.id(),
+        );
+        Some(ScrubError::ChecksumRefreshFailed {
+            table_id: table.id(),
+            path: (*table.path).clone(),
+            reason,
+        })
+    };
+
+    // Restriction-aware: a tight-space RESTRICTED view digests only its live
+    // suffix (its punched prefix reads as zeros), matching the suffix digest the
+    // manifest records for it.
+    let fresh = match table.live_region_checksum() {
+        Ok(ck) => ck,
+        Err(e) => return finding(e.to_string()),
+    };
+    // Compare against the CURRENT manifest entry, not the caller's captured
+    // view: two concurrent heal patrols capture the same version before the
+    // per-table heal lock serializes them, so by the time the loser gets
+    // here the winner may have already installed a refreshed checksum. The
+    // captured view's stale snapshot would then flag an already-reconciled
+    // file as mismatched (and, on a table the semantic gates cannot clear
+    // without heal attribution, surface a spurious ChecksumRefreshFailed).
+    let binding = tree.current_version();
+    let Some(current_view) = binding.iter_tables().find(|t| t.id() == table.id()) else {
+        // Table already compacted away while the heal ran: the old file is
+        // on its way out, there is no manifest entry left to reconcile.
+        return None;
+    };
+    // A tight-space compaction can replace the captured view with a restricted
+    // same-id view (punching its prefix) while this heal runs, and it does NOT
+    // take the per-table heal lock. `fresh` was hashed over the CAPTURED view's
+    // live region, so installing it against a current view of a different
+    // restriction would record a digest the file can never match: a whole-file
+    // digest in a suffix-only manifest (or vice versa), permanently unreconcilable
+    // once the prefix is punched. If the current view's restriction no longer
+    // matches the captured one, abort: the current restricted view already carries
+    // the digest compaction installed for it, and the next patrol reconciles it
+    // under the correct restriction. Any pending marker is kept for that retry.
+    if current_view.restrict_lower_bound() != table.restrict_lower_bound() {
+        return None;
+    }
+    let current = current_view.checksum();
+    if fresh == current {
+        // Digest already agrees with the manifest: no version upgrade to
+        // install. A `.heal-attest` sidecar here is now OBSOLETE: a prior
+        // reconcile installed this digest but crashed (or its best-effort unlink
+        // transiently failed) before removing the marker. Leaving it makes every
+        // future checkpoint classify the table as pending and run a full heal
+        // scan before snapshotting, so reclaim it now. Best-effort: a missing
+        // sidecar (the common case) is a no-op.
+        heal_attest::remove(&*table.fs, &table.path);
+        return None;
+    }
+
+    // A mismatch is attributable to a heal either DIRECTLY (this pass wrote the
+    // corrections and probed a matching pre-heal digest) or via a COMPLETED
+    // attestation left by an earlier heal whose reconciliation crashed / failed.
+    // That attestation binds `post == current`, so it can ONLY re-authorize the
+    // exact bytes the heal produced — never an unrelated later forge. A marker
+    // that bound merely `pre == manifest` (the former in-progress marker) would
+    // authorize ANY structurally valid current bytes, so a crash after the
+    // marker but before any heal, followed by a checksum-restamped alteration to
+    // a non-authenticatable surface, could be legitimized; the heal now writes a
+    // post-bound completed marker UP FRONT instead, and a bare pre-only marker
+    // is ignored here. Every path still re-verifies the file structurally below
+    // before the digest is reconciled.
+    let attest_result = heal_attest::attests(
+        &*table.fs,
+        &table.path,
+        table.encryption.as_deref(),
+        table.id(),
+        fresh,
+        current,
+    );
+    let attributable =
+        heal_attributable || matches!(attest_result, heal_attest::AttestResult::Attests);
+    // A sidecar the probe could not read CONCLUSIVELY must never trigger marker
+    // removal in the unattributable branch below: it may be a
+    // transiently-unreadable VALID marker, and deleting it would strand the
+    // healed table under the stale digest forever. Only a conclusively absent /
+    // non-attesting marker is safe to clear.
+    let sidecar_inconclusive = matches!(attest_result, heal_attest::AttestResult::Inconclusive);
+    // Re-record the attestation before reconciling, binding the CURRENT manifest
+    // digest: this is the crash-recovery insurance for the install below. If it
+    // cannot be made durable, ABORT the reconcile rather than install a digest
+    // whose recovery marker did not land — a crash after the install begins would
+    // then strand the healed bytes under a mismatch a later patrol refuses to
+    // attribute. Fail closed on the durability-primitive failure; the next patrol
+    // retries once the write succeeds (any earlier up-front marker is kept for it).
+    if heal_attributable
+        && let Err(e) = heal_attest::write(
+            &*table.fs,
+            &table.path,
+            table.encryption.as_deref(),
+            table.id(),
+            current,
+            fresh,
+        )
+    {
+        return finding(alloc::format!(
+            "could not persist the reconcile attestation ({e}); the manifest digest \
+             was not refreshed"
+        ));
+    }
+
+    // A refusal drops the heal sidecar only when it PROVES the file is bad: an
+    // attestation refused for proven corruption must not survive to authorize an
+    // UNRELATED later mismatch (its `pre == manifest` binding does not expire on
+    // its own, and a corrupt file needs a compaction / repair rewrite, not a
+    // lingering marker). An INCONCLUSIVE refusal — a transient I/O read, or a
+    // walk that could only warn (unverifiable, not corrupt, bytes) — instead
+    // KEEPS the marker: the block was genuinely healed and the marker is its
+    // only durable attribution, so deleting it on a retryable error would strand
+    // the healed SST under the stale digest and every later clean patrol would
+    // reject the reconcile forever. The completed marker binds `post ==
+    // current`, so a kept marker can only ever re-authorize the SAME healed
+    // bytes on retry, never a new mismatch. The transient install failure at the
+    // very end keeps the marker for the same reason.
+    let refuse = |reason: String, remove_marker: bool| -> Option<ScrubError> {
+        if remove_marker {
+            heal_attest::remove(&*table.fs, &table.path);
+        }
+        finding(reason)
+    };
+    // A cross-check that fails with an I/O error is inconclusive (the read may
+    // succeed on retry), so it keeps the marker; every other error kind
+    // (structural / checksum / decode) proves corruption and removes it.
+    let definitive = |e: &crate::Error| !matches!(e, crate::Error::Io(_));
+
+    // AUTHORITATIVE content has no cross-check, so an UNATTRIBUTED mismatch
+    // (the pre-heal digest did NOT probe equal to the manifest, so the file's
+    // difference from the manifest is not provably this pass's verified
+    // corrections) must never be restamped over. Every table carries content
+    // no gate below can re-derive:
+    // - non-derivable meta scalars — `created_at` (a wall clock has no in-file
+    //   source; FIFO trusts it for TTL) and the per-KV footer descriptor (an
+    //   on/off flag). The field-for-field bounds check authenticates these
+    //   only against the RECOVERY-TIME copy, which an OFFLINE restamp before
+    //   open poisons, so it cannot arbitrate a re-stamp of them;
+    // - range_tombstones / delete_bitmap: nothing in-file re-derives which
+    //   rows or ranges were genuinely deleted;
+    // - VALUE bytes of a footer-less table: a value changed behind a
+    //   re-stamped block checksum decodes cleanly.
+    // The manifest's whole-file digest is the ONLY surviving record of the
+    // honest bytes for all three, so an unattributed mismatch fails closed
+    // REGARDLESS of footers. This is checked BEFORE the out-of-band walk and
+    // the semantic cross-checks below: an unattributed mismatch fails closed
+    // no matter what they find, so running them first only repeats a full-file
+    // verification every patrol pass until a compaction / repair rewrite
+    // installs a legitimized digest. The attributable path — the pre-heal
+    // digest matched the manifest, proving the file differs solely by this
+    // pass's corrections — falls through to the walk + gates and reconciles.
+    if !attributable {
+        // Name deletion metadata specifically — a reconcile that laundered a
+        // re-stamped range_tombstones / delete_bitmap would resurrect the rows
+        // it masked, the scariest of the three surfaces.
+        // This branch means the mismatch is NOT attributable to a heal, so no
+        // marker of this pass attests the current bytes: a conclusively
+        // absent / non-attesting marker is stale and clearing it is correct
+        // hygiene. But if the sidecar read was INCONCLUSIVE (a transient I/O /
+        // AEAD / malformed read), keep the marker: it may be a valid marker that
+        // reads cleanly on retry, and deleting it would strand the healed table.
+        let remove_marker = !sidecar_inconclusive;
+        match table.has_deletion_metadata() {
+            Ok(true) => {
+                return refuse(
+                    "digest mismatch not attributable to this pass's heal on a \
+                     table carrying deletion metadata (range tombstones / delete \
+                     bitmap), which no cross-check can authenticate; the manifest \
+                     digest was not refreshed"
+                        .into(),
+                    remove_marker,
+                );
+            }
+            Ok(false) => {}
+            Err(e) => return refuse(e.to_string(), remove_marker),
+        }
+        return refuse(
+            "digest mismatch not attributable to this pass's heal; the file's \
+             non-derivable content (meta scalars such as created_at and the \
+             per-KV footer descriptor, plus any footer-less value bytes) has no \
+             cross-check to authenticate it and the recovery-time copy may \
+             itself be a pre-open restamp; the manifest digest was not refreshed"
+                .into(),
+            remove_marker,
+        );
+    }
+
+    // The heal scan covered DATA blocks only, so a digest mismatch is not
+    // yet attributable to a heal: rot in a side section (filter, zone map,
+    // range tombstones, block layout) also moves the digest while leaving
+    // the scan clean. Walk EVERY section out-of-band before installing the
+    // fresh digest: restamping over unverified bytes would launder the
+    // corruption into the manifest and blind `verify_integrity` to it. The
+    // walk also cross-checks each block's role against its TOC section and
+    // compares the two FULLY-decoded meta mirrors, so a re-stamped
+    // internally-consistent forge (a relabeled block, a tail meta whose
+    // fields diverge from meta_mid) fails the refresh too. Fail closed on
+    // warnings as well: an unrecognized-ECC or parity-unverifiable walk
+    // skipped bytes, so the file is not provably clean.
+    // A restricted view's punched data-block prefix reads as zeros; walk only
+    // its live suffix. The punch-offset lookup is fallible (a volatile /
+    // partitioned index read), and falling back to `0` would walk the punched
+    // prefix — whose zero bytes surface as STRUCTURAL errors the definitive
+    // classifier below then treats as proven corruption, removing this pass's
+    // valid heal attestation while the manifest digest stays stale (later
+    // patrols can no longer attribute the healed bytes). Treat a lookup failure
+    // as INCONCLUSIVE instead: keep the marker for the next patrol to retry.
+    let data_start = match table.restrict_lower_bound() {
+        Some(bound) => match table.punch_offset_for(bound) {
+            Ok(offset) => offset,
+            Err(e) => {
+                return refuse(
+                    alloc::format!(
+                        "restricted-view punch-offset lookup failed ({e}); the manifest \
+                         digest was not refreshed"
+                    ),
+                    false,
+                );
+            }
+        },
+        None => 0,
+    };
+    let walk = crate::verify::verify_sst_file_with_context(
+        &*table.fs,
+        &table.path,
+        table.encryption.as_deref(),
+        Some(table.id()),
+        data_start,
+    );
+    if !walk.errors.is_empty() || !walk.warnings.is_empty() {
+        // A walk error is definitive only when it proves corruption. A transient
+        // read failure (`SstFileUnreadable` / `DataReadError`) may succeed on
+        // retry, and the warnings on their own (skipped, unverifiable-but-not-
+        // corrupt bytes) are inconclusive — both keep the marker so a genuine
+        // heal is not stranded by a flaky read or an unverifiable parity walk.
+        let walk_definitive = walk.errors.iter().any(|e| {
+            use crate::verify::BlockVerifyError as E;
+            !matches!(e, E::SstFileUnreadable { .. } | E::DataReadError { .. })
+        });
+        return refuse(
+            "digest mismatch with corruption outside the scanned data blocks; \
+             the manifest digest was not refreshed"
+                .into(),
+            walk_definitive,
+        );
+    }
+
+    // The walk verifies raw block checksums but never DECODES entries, so a
+    // stale per-KV footer behind a re-stamped block checksum still reads
+    // clean at the block level. Footer-bearing tables get the per-KV
+    // verification too before the digest is trusted (a table without
+    // footers makes this a no-op).
+    if let Err(e) = table.verify_kv_checksums() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a per-KV verification failure ({e}); the \
+             manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The `linked_blob_files` section carries no per-section checksum and
+    // the walk can only validate its SHAPE, so a flipped blob id passes it.
+    // Cross-check the recorded ids against the table's own indirection
+    // entries (a no-op without the section) before trusting the digest.
+    if let Err(e) = table.verify_blob_links() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a blob-link cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // Each TLI mirror verified independently clean above, but a forged tail
+    // that DECODES to a different handle list than the head passes every
+    // byte-level check — and the next recovery prefers the tail, silently
+    // hiding blocks. Compare the decoded mirrors before trusting the digest.
+    if let Err(e) = table.verify_tli_mirrors() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a TLI mirror comparison failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The seqno_bounds block is checksum-clean to the walk even when its
+    // payload was re-stamped to another structurally valid map, and
+    // scan_since_seqno trusts it to SKIP blocks. Cross-check every recorded
+    // range against the blocks' decoded entries (a no-op without the
+    // section) before trusting the digest.
+    if let Err(e) = table.verify_seqno_bounds() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a seqno-bounds cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The walk verifies only the outer frame, so a checksum-clean block whose
+    // trailer declares more entries than it decodes reads clean; full-decode
+    // every block and confirm the counts match before trusting the digest,
+    // or restamping would legitimize a silently-truncated tail.
+    if let Err(e) = table.verify_block_entry_counts() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a block entry-count mismatch ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The zone_map block is checksum-clean to the walk even when its payload
+    // was re-stamped to another structurally valid map, and a predicate scan
+    // trusts its min/max to SKIP blocks. Cross-check every recorded range
+    // against the blocks' decoded key ranges (a no-op without the section)
+    // before trusting the digest.
+    if let Err(e) = table.verify_zone_map() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a zone-map cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The locator block is checksum-clean to the walk even when re-stamped to
+    // resolve a key to a block other than its newest-version block, and
+    // point_read trusts its answer. Cross-check every key's mapping against
+    // its decoded newest-version block (a no-op without the section) before
+    // trusting the digest.
+    if let Err(e) = table.verify_locator() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a locator cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The filter block is checksum-clean to the walk even when its payload
+    // was re-stamped to another parseable filter, and check_bloom trusts it
+    // to SKIP point reads — a key made into a false negative silently
+    // disappears from every read. Probe every decoded key against the
+    // on-disk filter (a no-op without one) before trusting the digest.
+    if let Err(e) = table.verify_filter(tree.prefix_extractor().as_ref()) {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a filter cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // The block_layout block is checksum-clean to the walk even when a
+    // cumulative end was re-stamped to another structurally valid value, and
+    // the partial range-read path trusts it to bound decompression — a
+    // mis-mapped boundary silently omits keys. Cross-check every recorded
+    // boundary against the frames' actual inner blocks (a no-op without the
+    // section) before trusting the digest.
+    if let Err(e) = table.verify_block_layout() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a block-layout cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // A data block's embedded hash / binary index is checksum-clean to the
+    // walk even when a bucket was re-stamped to MARKER_FREE, yet point_read
+    // trusts it and returns None for the affected keys. Probe every decoded
+    // key through the full point-read path before trusting the digest.
+    if let Err(e) = table.verify_point_read_reachability() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a point-read reachability failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // Both meta mirrors re-stamped CONSISTENTLY pass the mirror comparison,
+    // yet run selection trusts the recorded key range to route reads AROUND
+    // this table — a narrowed range silently hides real keys and the range
+    // tombstones that mask older tables. Cross-check the recorded bounds
+    // against the decoded contents before trusting the digest.
+    if let Err(e) = table.verify_metadata_bounds() {
+        return refuse(
+            alloc::format!(
+                "digest mismatch with a metadata-bounds cross-check failure ({e}); \
+             the manifest digest was not refreshed"
+            ),
+            definitive(&e),
+        );
+    }
+
+    // Pass the captured view's restriction so the install, under its own lock,
+    // rejects the refresh if a compaction swapped the current view to a different
+    // restriction after the pre-window check below (closing that TOCTOU: `fresh`
+    // describes the captured region and must not be recorded against a view of a
+    // different restriction).
+    use crate::abstract_tree::ChecksumRefreshOutcome;
+    match tree.refresh_table_checksum(table.id(), fresh, table.restrict_lower_bound()) {
+        Ok(ChecksumRefreshOutcome::Refreshed) => {
+            // The manifest now holds a legitimate digest; the attestation that
+            // may have authorized this reconciliation has served its purpose.
+            heal_attest::remove(&*table.fs, &table.path);
+            None
+        }
+        // No-op install: the table was compacted away, or a restriction swap made
+        // the digest inapplicable to the current view. The manifest digest is
+        // unchanged, so KEEP the marker — the next patrol reconciles the current
+        // view through it rather than losing the only attribution.
+        Ok(ChecksumRefreshOutcome::Stale) => None,
+        // The install lock was held by a concurrent compaction. The healed
+        // bytes are durable while the manifest digest stays stale and the
+        // attestation stays pending: a clean report would mislead a later
+        // integrity check (mismatch) or a checkpoint (abort on the pending
+        // reconcile). Surface a finding; the kept marker lets the next patrol
+        // retry once the compaction releases the state.
+        Ok(ChecksumRefreshOutcome::Contended) => finding(
+            "the manifest install lock was held by a concurrent compaction; the \
+             healed bytes are durable but the manifest digest is stale until a \
+             later patrol reconciles the kept attestation"
+                .to_string(),
+        ),
+        Err(e) => finding(e.to_string()),
+    }
+}
+
+/// Scans one SST: heals corrections in place when
+/// [`heal_in_place`](PatrolScrubOptions::heal_in_place) is set (and `page_ecc` is
+/// built), otherwise runs the classic correct-on-read + schedule-rewrite scrub.
+/// The `bool` is the heal-attribution flag (see
+/// [`refresh_healed_checksum`]); always `false` on the read-only scrub path,
+/// which never writes.
+fn scan_one(
+    table: &crate::table::Table,
+    options: &PatrolScrubOptions,
+    sync_mode: crate::fs::SyncMode,
+    manifest_checksum: crate::Checksum,
+) -> (PatrolScrubReport, bool) {
+    // In-place heal only applies to SSTs written with Page-ECC parity — there is
+    // nothing to reconstruct without it. A table with no ECC still needs its
+    // integrity checked, so it takes the normal scrub path (which verifies each
+    // block's checksum and reports uncorrectable ones) rather than the heal path,
+    // whose per-block reconstruction is a no-op there.
+    #[cfg(feature = "page_ecc")]
+    if options.heal_in_place && table.metadata.ecc_params.is_some() {
+        return table.heal_data_blocks_in_place(sync_mode, manifest_checksum);
+    }
+    let _ = (options, sync_mode, manifest_checksum);
+    (table.scrub_data_blocks(), false)
 }
 
 #[cfg(test)]

--- a/src/scrub/ecc_tests.rs
+++ b/src/scrub/ecc_tests.rs
@@ -3,8 +3,11 @@
     reason = "tests assert on known-present values; a panic is the failure signal"
 )]
 // Target-conditional: `u64 as usize` on a block offset only narrows on
-// 32-bit pointer widths, so clippy does NOT fire on the 64-bit CI host;
-// `allow` (not `expect`, which would be unfulfilled there).
+// 32-bit pointer widths, so clippy does NOT fire on the 64-bit CI host.
+// This must stay `allow`, NOT `expect`: an `#[expect]` that never fires (as on
+// the 64-bit host) is itself a warning (`unfulfilled_lint_expectations`), so the
+// usual `#[expect]`-over-`#[allow]` preference does not apply to a lint that only
+// triggers on some targets.
 #![allow(
     clippy::cast_possible_truncation,
     reason = "in-file block offsets fit usize; only narrow on 32-bit targets"
@@ -48,6 +51,98 @@ fn write_ecc_sst(dir: &std::path::Path) -> (std::path::PathBuf, crate::table::Bl
         tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
     }
     tree.flush_active_memtable(2_000).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    let keyed = table
+        .block_index
+        .iter()
+        .next()
+        .expect("table has at least one data block")
+        .expect("block index entry decodes");
+    let handle = crate::table::BlockHandle::new(keyed.offset(), keyed.size());
+    ((*table.path).clone(), handle)
+}
+
+/// A SINGLE-data-block ECC SST, so the heal's positioned-read sequence is
+/// predictable for fault-injection tests: the up-front correction-prediction
+/// pass reads the block twice (scrub + re-read) and the write-back pass reads it
+/// twice more, in that order.
+fn write_single_block_ecc_sst(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, crate::table::BlockHandle) {
+    let tree = open_ecc_tree(dir);
+    for i in 0u64..4 {
+        tree.insert(format!("key-{i:03}"), format!("v{i:03}"), i);
+    }
+    tree.flush_active_memtable(4).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    let keyed = table
+        .block_index
+        .iter()
+        .next()
+        .expect("table has at least one data block")
+        .expect("block index entry decodes");
+    let handle = crate::table::BlockHandle::new(keyed.offset(), keyed.size());
+    ((*table.path).clone(), handle)
+}
+
+/// As [`write_ecc_sst`], but with per-KV checksum footers
+/// (`KvChecksumPolicy::AllLevels`). Footered tables keep the stale-digest
+/// reconcile available on a later clean pass (their value bytes re-derive
+/// authentication through the per-KV gate), so reconcile tests use this
+/// fixture.
+fn write_ecc_sst_footered(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, crate::table::BlockHandle) {
+    let tree = open_ecc_tree(dir);
+    tree.update_runtime_config(|c| {
+        c.kv_checksums = crate::runtime_config::KvChecksumPolicy::AllLevels;
+    })
+    .expect("enable kv checksums");
+    for i in 0u64..2_000 {
+        tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+    }
+    tree.flush_active_memtable(2_000).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    let keyed = table
+        .block_index
+        .iter()
+        .next()
+        .expect("table has at least one data block")
+        .expect("block index entry decodes");
+    let handle = crate::table::BlockHandle::new(keyed.offset(), keyed.size());
+    ((*table.path).clone(), handle)
+}
+
+/// As [`write_ecc_sst`], plus a range tombstone so the SST carries the
+/// `range_tombstones` section — the deletion metadata the digest
+/// reconciliation cannot semantically authenticate.
+fn write_ecc_sst_with_range_tombstone(
+    dir: &std::path::Path,
+) -> (std::path::PathBuf, crate::table::BlockHandle) {
+    let tree = open_ecc_tree(dir);
+    for i in 0u64..2_000 {
+        tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+    }
+    tree.remove_range("key-000100", "key-000200", 2_000);
+    tree.flush_active_memtable(2_100).expect("flush");
 
     let binding = tree.version_history.read().latest_version();
     let table = binding
@@ -202,5 +297,3818 @@ fn patrol_scrub_clean_ecc_tree_reports_no_corrections() -> crate::Result<()> {
     // Sanity: a clean read of a key still returns the right value.
     let got = tree.get(b"key-000000", MAX_SEQNO)?.expect("key present");
     assert_eq!(&*got, b"v000000");
+    Ok(())
+}
+
+#[test]
+fn patrol_scrub_heals_in_place_restoring_the_block_byte_for_byte() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Snapshot the healthy file, then flip one RS-correctable payload byte.
+    let original = std::fs::read(&sst_path)?;
+    let corrupt_pos = block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = original.clone();
+    let slot = bytes
+        .get_mut(corrupt_pos)
+        .expect("corrupt_pos in range for the SST bytes");
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+    assert_ne!(bytes, original, "the seeded fault changed the file");
+
+    // Heal in place: persist the correction at the block's offset, no full rewrite.
+    let tree = open_ecc_tree(dir.path());
+    let opts = PatrolScrubOptions::default().heal_in_place(true);
+    let report = patrol_scrub(&tree, &opts);
+
+    assert_eq!(
+        report.blocks_healed_in_place, 1,
+        "exactly the corrupted block is healed in place: {report:?}",
+    );
+    assert_eq!(report.corrections_applied, 1, "{report:?}");
+    assert_eq!(
+        report.ssts_scheduled_for_rewrite, 0,
+        "in-place heal schedules no full-file rewrite: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 0, "{report:?}");
+    assert!(report.is_ok(), "{report:?}");
+
+    // The heal reconstructs the ORIGINAL frame (RS-recovered data + recomputed
+    // parity == as-written bytes), so the file is byte-identical to before the
+    // fault: the correction was persisted, and no healthy block was touched.
+    let healed = std::fs::read(&sst_path)?;
+    assert_eq!(
+        healed, original,
+        "in-place heal restores the SST byte-for-byte (O(damage), nothing else moved)",
+    );
+
+    // A second pass finds nothing to heal — the on-disk bytes now read clean.
+    // Drop the first tree first: the directory lock is exclusive, so a second
+    // open of the same dir while it is alive would fail with `Locked`.
+    drop(tree);
+    let tree2 = open_ecc_tree(dir.path());
+    let report2 = patrol_scrub(&tree2, &PatrolScrubOptions::default().heal_in_place(true));
+    assert_eq!(
+        report2.blocks_healed_in_place, 0,
+        "nothing left to heal after a clean heal: {report2:?}",
+    );
+    assert_eq!(report2.corrections_applied, 0, "{report2:?}");
+    Ok(())
+}
+
+#[test]
+fn patrol_scrub_heal_in_place_leaves_an_uncorrectable_block_for_salvage() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Wreck the whole payload+parity (header intact): beyond the RS(8,2) budget.
+    let payload_start = block.offset().0 as usize + Header::MIN_LEN;
+    let payload_end = block.offset().0 as usize + block.size() as usize;
+    let mut bytes = std::fs::read(&sst_path)?;
+    for slot in bytes
+        .get_mut(payload_start..payload_end)
+        .expect("block payload range in bounds")
+    {
+        *slot ^= 0xFF;
+    }
+    std::fs::write(&sst_path, &bytes)?;
+    let corrupted = std::fs::read(&sst_path)?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "an uncorrectable block is not healed in place: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "the uncorrectable block is reported, not silently skipped: {report:?}",
+    );
+    assert!(
+        !report.is_ok(),
+        "uncorrectable corruption fails the heal pass"
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::UncorrectableBlock { .. })),
+        "the finding is an UncorrectableBlock: {report:?}",
+    );
+    // The heal must not have written anything for that block: it is left intact
+    // for block salvage (the new-file copy-through path).
+    let after = std::fs::read(&sst_path)?;
+    assert_eq!(
+        after, corrupted,
+        "an uncorrectable block is left untouched in place for salvage",
+    );
+    Ok(())
+}
+
+/// A table WITHOUT Page-ECC still has its integrity checked under
+/// `heal_in_place`: there is nothing to heal without parity, so it takes the
+/// checksum-verifying scrub path, and a corrupt block is reported uncorrectable
+/// rather than silently reported clean.
+#[test]
+fn patrol_scrub_heal_in_place_still_checks_a_non_ecc_table() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // Build a plain (no Page-ECC) SST, then drop the tree so the file can be
+    // corrupted and reopened with fresh caches.
+    let sst_path;
+    let block_off;
+    {
+        let crate::AnyTree::Standard(tree) = crate::Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()
+        .expect("open plain tree") else {
+            unreachable!("standard tree configured (no kv separation)");
+        };
+        for i in 0u64..2_000 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(2_000).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        let keyed = table
+            .block_index
+            .iter()
+            .next()
+            .expect("table has a data block")
+            .expect("index entry decodes");
+        sst_path = (*table.path).clone();
+        block_off = keyed.offset().0 as usize;
+    }
+
+    // Flip a payload byte of the first data block (no parity → uncorrectable).
+    let mut bytes = std::fs::read(&sst_path)?;
+    let slot = bytes
+        .get_mut(block_off + Header::MIN_LEN + 3)
+        .expect("corrupt position in range");
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+    .expect("reopen plain tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a non-ECC table has nothing to heal in place: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "a corrupt block in a non-ECC table is reported, not silently clean: {report:?}",
+    );
+    assert!(!report.is_ok(), "uncorrectable corruption fails the pass");
+    Ok(())
+}
+
+/// Bit rot confined to a block's PARITY trailer reads as Clean (the payload
+/// checksum passes and parity is only consulted on a payload mismatch), so
+/// without an explicit trailer check the heal pass would leave dead ECC on
+/// disk — a later payload fault could no longer be recovered. `heal_in_place`
+/// must verify each clean block's trailer against freshly computed parity and
+/// PERSIST a rebuilt trailer on a mismatch (the pass holds the read+write
+/// handle; the payload is untouched, so the rewrite is size-preserving).
+#[test]
+fn heal_in_place_restores_a_rotted_parity_trailer() -> crate::Result<()> {
+    use crate::coding::Decode;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Flip one byte INSIDE the first data block's parity trailer (right after
+    // its `data_length` payload): the payload checksum still verifies, so the
+    // block reads back Clean.
+    let mut bytes = std::fs::read(&sst_path)?;
+    let base = block.offset().0 as usize;
+    let Some(mut cursor) = bytes.get(base..) else {
+        panic!("first data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos = base + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    let original = *slot;
+    *slot = original ^ 0xFF;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Reopen (fresh caches + fds) and heal in place.
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted parity trailer is rebuilt and persisted: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 0, "{report:?}");
+    assert!(report.is_ok(), "a parity rebuild is a heal, not a finding");
+
+    // The on-disk byte is restored to its EXACT original value (not merely
+    // changed): the rebuilt parity is recomputed over the untouched payload,
+    // so anything but the original would be wrong parity persisted.
+    let healed = std::fs::read(&sst_path)?;
+    let Some(&now) = healed.get(trailer_pos) else {
+        panic!("parity trailer within the healed file");
+    };
+    assert_eq!(now, original, "the original parity byte was restored");
+    Ok(())
+}
+
+/// Opens an RS(8,2) Page-ECC tree at `dir` through the given filesystem
+/// (fault-injection variant of [`open_ecc_tree`]).
+fn open_ecc_tree_on(dir: &std::path::Path, fs: std::sync::Arc<dyn crate::fs::Fs>) -> crate::Tree {
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .with_shared_fs(fs)
+    .open()
+    .expect("open ecc tree on injected fs") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    tree
+}
+
+/// Flips one parity-trailer byte of `block` in the SST at `path`. Payload
+/// checksums stay clean, so only the heal pass (which verifies trailers)
+/// notices; a heal then rebuilds the trailer in place.
+fn corrupt_parity_trailer_byte(
+    path: &std::path::Path,
+    block: &crate::table::BlockHandle,
+) -> crate::Result<()> {
+    use crate::coding::Decode;
+
+    let mut bytes = std::fs::read(path)?;
+    let base = block.offset().0 as usize;
+    let Some(mut cursor) = bytes.get(base..) else {
+        panic!("data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos = base + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Rebuilds the manifest from whatever is on disk, recording the digest of
+/// the CURRENT (possibly rotted) bytes, and asserts exactly one table was
+/// admitted. This is how the reconcile tests seed a manifest digest that
+/// disagrees with the ORIGINAL bytes a later heal restores.
+fn rebuild_manifest_over_current_bytes(dir: &std::path::Path) -> crate::Result<()> {
+    let report = crate::Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+    assert_eq!(report.recovered, 1, "{report:?}");
+    Ok(())
+}
+
+/// Opens a FaultFs-backed ECC tree at `dir` with a ONE-SHOT `Open` fault
+/// armed on the manifest edit log ("edits"), so the first digest refresh
+/// fails while the heal itself (which only touches the SST under tables/)
+/// proceeds. Returns the tree and the injector for the caller to `clear()`.
+fn open_ecc_tree_with_failing_edit_log(
+    dir: &std::path::Path,
+) -> (crate::Tree, std::sync::Arc<crate::fs::FaultInjector>) {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir, std::sync::Arc::new(fault));
+    injector.arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other))
+            .on_path("edits")
+            .once(),
+    );
+    (tree, injector)
+}
+
+/// A failed raw re-read during the clean-block parity-trailer check is a
+/// finding, not a silent skip: the block's trailer could not be verified, so
+/// the heal pass reports it as uncorrectable and moves on (the remaining
+/// blocks still get their trailers checked).
+#[test]
+fn heal_in_place_reports_a_failed_parity_reread_as_uncorrectable() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (_sst_path, _block) = write_single_block_ecc_sst(dir.path());
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The single block is read twice in the up-front correction-prediction pass
+    // (scrub, then the raw frame re-read for the parity-trailer comparison) and
+    // twice again in the write-back pass. Skip the two prediction reads and the
+    // write-back scrub, then fail exactly the write-back parity re-read.
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(3)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.uncorrectable_blocks, 1,
+        "the unverifiable trailer is a finding: {report:?}",
+    );
+    assert!(
+        format!("{report:?}").contains("parity re-read failed"),
+        "the finding names the failed re-read: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "nothing was persisted for the failed block: {report:?}",
+    );
+    Ok(())
+}
+
+/// A parity-trailer rebuild whose WRITE fails is a finding: the rot stays on
+/// disk, so the heal must report the block as uncorrectable instead of
+/// counting a heal that never landed.
+#[test]
+fn heal_in_place_reports_a_failed_trailer_writeback_as_uncorrectable() -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte of the first data block (payload checksum
+    // still verifies, so the block scrubs Clean and the trailer check fires).
+    let mut bytes = std::fs::read(&sst_path)?;
+    let base = block.offset().0 as usize;
+    let Some(mut cursor) = bytes.get(base..) else {
+        panic!("first data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos = base + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    let rotted = *slot ^ 0xFF;
+    *slot = rotted;
+    std::fs::write(&sst_path, &bytes)?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The rot leaves the file differing from the (un-rebuilt) manifest, so this is
+    // the restorative heal path: the FIRST write to `tables/` is the crash-recovery
+    // marker sidecar, the SECOND is the trailer rebuild. Let the marker land, then
+    // fail the trailer write-back.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(1)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a write-back that failed is not counted as a heal: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 1, "{report:?}");
+    assert!(
+        format!("{report:?}").contains("in-place parity rebuild"),
+        "the finding names the failed rebuild: {report:?}",
+    );
+
+    // The rot is still on disk (nothing was silently half-written).
+    let after = std::fs::read(&sst_path)?;
+    assert_eq!(
+        after.get(trailer_pos).copied(),
+        Some(rotted),
+        "the rotted trailer byte is untouched after the failed write-back",
+    );
+    Ok(())
+}
+
+/// A write-back that FAILS must KEEP the in-progress marker, even though zero
+/// blocks were counted as healed. `write_all` reports no byte count on error, so
+/// a failure may have PARTIALLY written the block (or a full write's later sync
+/// failed while the bytes still reach storage): the file may already differ from
+/// the manifest digest, and dropping the marker would strand it with no
+/// attribution for a later refresh. Removal is reserved for the no-mutation case
+/// (a block that was never written — see the sibling uncorrectable test).
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_keeps_the_marker_when_a_write_back_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    // Rot a parity trailer (payload checksum still verifies, so the block scrubs
+    // Clean and the trailer-rebuild heal fires) and rebuild the manifest over
+    // the rotted bytes, so the pre-heal digest matches and the marker is written.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The FIRST write to `tables/` is the marker sidecar; the SECOND is the
+    // trailer rebuild. Skip the marker write so the marker lands, then fail the
+    // trailer write so zero blocks heal but a write WAS attempted.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(1)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a failed write-back heals no block: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1
+            && format!("{report:?}").contains("in-place parity rebuild"),
+        "the failed trailer write-back must be recorded, proving the write was \
+         attempted: {report:?}",
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the marker must be KEPT after a failed write-back — the file may already be \
+         partially modified, so a later patrol still needs the attribution",
+    );
+    Ok(())
+}
+
+/// The RESTORATIVE heal path (the current bytes already differ from the manifest
+/// digest, but healing restores exactly what the manifest describes) must ALSO
+/// persist its `.heal-attest` marker BEFORE the first write-back. Otherwise a
+/// crash after syncing some of several corrections leaves the file matching
+/// neither the manifest nor the healed digest, and with no marker a checkpoint
+/// hard-links those intermediate bytes under the stale manifest digest, producing
+/// a permanently inconsistent checkpoint. Rot a parity trailer but leave the
+/// manifest holding the ORIGINAL digest (so the heal is restorative, not
+/// attributable), fault the write-back after the marker lands, and assert the
+/// marker persists (#78).
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_keeps_the_marker_when_a_restorative_write_back_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    // Rot a parity trailer but DO NOT rebuild the manifest: the current bytes now
+    // differ from the manifest digest (pre-heal does NOT match), yet rebuilding the
+    // trailer restores exactly the original bytes the manifest still describes
+    // (predicted == manifest): the restorative path.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The FIRST write to `tables/` is the marker sidecar; the SECOND is the trailer
+    // rebuild. Let the marker land, then fail the write-back so the file may be
+    // partially modified with the marker still present.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(1)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a failed write-back heals no block: {report:?}",
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the restorative heal must persist its marker BEFORE the first write-back, so a \
+         crash cannot expose unattested intermediate bytes to a checkpoint hard-link",
+    );
+    Ok(())
+}
+
+/// The marker IS removed when no write was ever attempted: every candidate block
+/// is uncorrectable, so the file is untouched and the marker attests to a heal
+/// that never happened. Removing it prevents its unexpiring `pre == manifest`
+/// binding from later authorizing an unrelated digest mismatch.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_removes_the_marker_when_no_write_is_attempted() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    // Wreck the ENTIRE first data block (payload + parity trailer) BEYOND RS
+    // recovery so it scrubs uncorrectable and the heal reaches no write-back at
+    // all, then rebuild the manifest so the pre-heal digest matches and the
+    // marker is written up front.
+    let start = block.offset().0 as usize + Header::MIN_LEN;
+    let end = block.offset().0 as usize + block.size() as usize;
+    let mut bytes = std::fs::read(&sst_path)?;
+    for off in start..end {
+        if let Some(b) = bytes.get_mut(off) {
+            *b ^= 0xFF;
+        }
+    }
+    std::fs::write(&sst_path, &bytes)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(crate::fs::StdFs));
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "an uncorrectable block heals nothing: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "the uncorrectable block is recorded: {report:?}",
+    );
+    assert!(
+        !heal_attest_path(&sst_path).exists(),
+        "the marker must be removed when no write was attempted, so it cannot authorize a \
+         later unrelated mismatch",
+    );
+    Ok(())
+}
+
+/// A heal that lands its block but then hits a TRANSIENT read error during the
+/// out-of-band reconcile walk must KEEP the heal attestation. The block was
+/// genuinely healed and the marker is its only durable attribution; deleting it
+/// on an inconclusive (retryable) failure would strand the healed SST under the
+/// stale manifest digest, and every later clean patrol would then reject the
+/// reconcile forever. The marker is dropped only on PROVEN corruption.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_keeps_the_marker_when_the_reconcile_walk_read_fails_transiently()
+-> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+
+    // A SINGLE-data-block ECC SST: the heal scan then does exactly two SST reads
+    // (the block scrub, then the persist-side re-read), so the NEXT read is the
+    // reconcile walk — the read this test faults.
+    let (sst_path, block) = {
+        let tree = open_ecc_tree(dir.path());
+        for i in 0u64..4 {
+            tree.insert(format!("key-{i:03}"), format!("v{i:03}"), i);
+        }
+        tree.flush_active_memtable(4).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        let keyed = table
+            .block_index
+            .iter()
+            .next()
+            .expect("table has at least one data block")
+            .expect("block index entry decodes");
+        (
+            (*table.path).clone(),
+            crate::table::BlockHandle::new(keyed.offset(), keyed.size()),
+        )
+    };
+
+    // Rot the parity trailer (the payload stays checksum-clean, so the block
+    // scrubs Clean and the trailer-rebuild heal fires) and rebuild the manifest
+    // over the rotted bytes so the pre-heal digest matches and the marker lands.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The heal reads the block twice in the up-front correction-prediction pass
+    // (scrub + parity re-read) and twice more in the write-back pass, so the
+    // block's trailer rebuild lands after 4 positioned reads; every read after
+    // that belongs to the reconcile walk / semantic checks (the digest passes
+    // stream sequentially, not via ReadAt). Fail them all so the reconcile hits
+    // a transient read error, which must NOT delete the just-written
+    // attestation.
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(4),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 1,
+        "the trailer rebuild must land before the walk fault: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "the transient walk read must refuse the digest refresh: {report:?}",
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "a transient walk failure must KEEP the marker for retry, not strand the \
+         healed SST under the stale manifest digest",
+    );
+    Ok(())
+}
+
+/// A TRANSIENT read during the up-front correction-PREDICTION pass must
+/// PROPAGATE, not be folded into "no correction". Swallowing it would drop the
+/// block from the predicted offset set, so the write pass — gated on that set —
+/// would skip a correction it re-discovers on the healable block and report a
+/// clean pass with the fault still on disk. Fault ONLY the first positioned read
+/// (the prediction pass's initial block scrub); the write-pass reads then
+/// succeed, so the pre-fix `Err(_) => Ok(None)` silently skips the heal while the
+/// fixed code surfaces the transient read.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_propagates_a_transient_read_during_correction_prediction() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+
+    // A single-data-block ECC SST whose parity trailer is rotted (payload stays
+    // checksum-clean, so the block would heal via a trailer rebuild).
+    let (sst_path, block) = {
+        let tree = open_ecc_tree(dir.path());
+        for i in 0u64..4 {
+            tree.insert(format!("key-{i:03}"), format!("v{i:03}"), i);
+        }
+        tree.flush_active_memtable(4).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        let keyed = table
+            .block_index
+            .iter()
+            .next()
+            .expect("table has at least one data block")
+            .expect("block index entry decodes");
+        (
+            (*table.path).clone(),
+            crate::table::BlockHandle::new(keyed.offset(), keyed.size()),
+        )
+    };
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // Fault the FIRST positioned read — the prediction pass's initial block
+    // scrub — and let every later read succeed, so the write pass would find the
+    // block healable but never see its offset in the predicted set.
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    // The transient prediction read must SURFACE (an error / inconclusive pass),
+    // not vanish into a clean report that leaves the fault on disk.
+    assert!(
+        !report.is_ok(),
+        "a transient prediction read must surface as an error, not report a clean pass \
+         over the un-healed fault: {report:?}",
+    );
+    Ok(())
+}
+
+/// The reconcile must ABORT if it cannot persist the crash-recovery attestation:
+/// installing the refreshed digest while that marker's write failed would leave
+/// the healed bytes with no on-disk marker for a crash mid-install, and a later
+/// patrol would then refuse to attribute the mismatch. Fault the reconcile's
+/// attestation write (the SECOND sidecar write; the up-front one during the heal
+/// succeeds) and assert the refresh is refused with the marker kept for retry.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_refuses_the_refresh_when_the_reconcile_attestation_write_fails()
+-> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+
+    let (sst_path, block) = {
+        let tree = open_ecc_tree(dir.path());
+        for i in 0u64..4 {
+            tree.insert(format!("key-{i:03}"), format!("v{i:03}"), i);
+        }
+        tree.flush_active_memtable(4).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        let keyed = table
+            .block_index
+            .iter()
+            .next()
+            .expect("table has at least one data block")
+            .expect("block index entry decodes");
+        (
+            (*table.path).clone(),
+            crate::table::BlockHandle::new(keyed.offset(), keyed.size()),
+        )
+    };
+
+    // Attributable trailer-rebuild heal (payload stays checksum-clean).
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The heal writes the completed marker UP FRONT (first sidecar write); the
+    // reconcile re-writes it before installing (second sidecar write). Skip the
+    // first and fail the second so only the reconcile's attestation write fails.
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other))
+            .on_path(".heal-attest")
+            .skip(1)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 1,
+        "the trailer rebuild lands before the reconcile: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a failed reconcile attestation write must refuse the digest refresh, not \
+         install it without a durable marker: {report:?}",
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the marker is kept for the next patrol to retry the reconcile",
+    );
+    Ok(())
+}
+
+/// A tight-space RESTRICTED table's heal walk must SKIP the punched-out prefix:
+/// a block whose last key is below the restriction bound was reclaimed by a
+/// superseding output table, so reading its frame reports a spurious
+/// uncorrectable error that would suppress the digest refresh for a real
+/// correction in the live suffix. The walk must start at the bound.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_skips_blocks_below_the_restriction_bound() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, first_block) = write_ecc_sst(dir.path());
+
+    // Wreck the FIRST data block's payload beyond RS recovery (uncorrectable):
+    // it holds the lowest keys, so a bound above them puts it in the prefix.
+    let start = first_block.offset().0 as usize + Header::MIN_LEN;
+    let mut bytes = std::fs::read(&sst_path)?;
+    for off in start..start + 256 {
+        if let Some(b) = bytes.get_mut(off) {
+            *b ^= 0xFF;
+        }
+    }
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Re-open the table restricted to a bound well above the first block's keys,
+    // so the wrecked block sits in the (punched) prefix the walk must skip.
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(crate::fs::StdFs));
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    let restricted = table.reopen_restricted(crate::UserKey::from(b"key-001000".as_slice()))?;
+
+    let (report, _healed) =
+        restricted.heal_data_blocks_in_place(crate::fs::SyncMode::Full, restricted.checksum());
+    assert!(
+        report.errors.is_empty()
+            && report.uncorrectable_blocks == 0
+            && report.blocks_healed_in_place == 0,
+        "the wrecked block below the restriction bound must be skipped entirely, \
+         neither healed nor reported: {report:?}",
+    );
+    Ok(())
+}
+
+/// A heal whose manifest-digest refresh loses the compaction-state `try_lock`
+/// (a concurrent compaction is mid-install; blocking would invert the
+/// heal-lock / compaction-state order and deadlock) must NOT report a clean
+/// pass: the healed bytes are durable but the manifest digest stays stale and
+/// the attestation stays pending, so a later integrity check flags the mismatch
+/// and a checkpoint can abort despite the "clean" scrub. The contention must
+/// surface as a `ChecksumRefreshFailed` finding; the marker is kept for the
+/// next patrol to reconcile.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_reports_a_contended_checksum_refresh_as_a_finding() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_single_block_ecc_sst(dir.path());
+
+    // Attributable trailer-rebuild heal (payload stays checksum-clean): the
+    // manifest digest covers the CURRENT (rotted) bytes, so the heal changes
+    // them and the reconcile must install a refreshed digest.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(crate::fs::StdFs));
+    // Hold the compaction state across the scrub, as a long-running concurrent
+    // compaction would: the reconcile's `try_lock` then loses.
+    let _compaction_guard = tree.compaction_state.lock();
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert_eq!(
+        report.blocks_healed_in_place, 1,
+        "the heal itself lands; only the digest install is contended: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "install-lock contention must surface as a finding, not a clean pass: {report:?}",
+    );
+    assert!(!report.is_ok(), "{report:?}");
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the marker is kept for the next patrol to reconcile",
+    );
+    Ok(())
+}
+
+/// A patrol whose CAPTURED table view went stale — tight-space compaction
+/// installed a RESTRICTED same-id view (whose manifest digest covers only the
+/// live suffix) after the capture — must scan the CURRENT view, not the captured
+/// one. Scanning the captured whole-file view against the current suffix
+/// checksum makes the pre-heal digest probe fail unconditionally, so the
+/// divergent-heal guard returns a default CLEAN report before the block walk:
+/// the patrol claims `is_ok()` with zero blocks healed while the known
+/// correctable fault stays on disk.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_scans_the_current_view_when_the_captured_one_went_stale() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _first_block) = write_ecc_sst(dir.path());
+
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(crate::fs::StdFs));
+    // Capture the UNRESTRICTED view, as a patrol does before its scan.
+    let captured = {
+        let binding = tree.version_history.read().latest_version();
+        binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table")
+            .clone()
+    };
+
+    // A tight-space slice installs a RESTRICTED same-id view after the capture;
+    // `with_tight_slice` is the worker's install transform. The restricted
+    // view's manifest digest covers only the live suffix.
+    let restricted = captured.reopen_restricted(crate::UserKey::from(b"key-001000".as_slice()))?;
+    tree.version_history.write().upgrade_version(
+        &tree.config.path,
+        |current| {
+            let mut copy = current.clone();
+            let ctx = crate::version::TransformContext::new(tree.config.comparator.as_ref());
+            copy.version = copy.version.with_tight_slice(
+                &[(captured.id(), restricted.clone())],
+                &[],
+                &[],
+                vec![],
+                None,
+                0,
+                &ctx,
+            );
+            Ok(copy)
+        },
+        &tree.config.seqno,
+        &tree.config.visible_seqno,
+        &*tree.config.fs,
+        tree.runtime_config.load_full(),
+        tree.config.encryption.clone(),
+    )?;
+
+    // Rot one payload byte (RS-correctable) in the LAST data block — well above
+    // the restriction bound, squarely inside the live suffix the current view
+    // serves. The rot lands AFTER the restricted digest was captured, so the
+    // heal is plainly restorative for the current view.
+    let last_block = {
+        let mut last = None;
+        for handle in restricted.block_index.iter() {
+            let handle = handle?;
+            last = Some(crate::table::BlockHandle::new(
+                handle.offset(),
+                handle.size(),
+            ));
+        }
+        last.expect("table has data blocks")
+    };
+    let corrupt_pos = last_block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let Some(slot) = bytes.get_mut(corrupt_pos) else {
+        panic!("corrupt_pos in range for the SST bytes");
+    };
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Scan through the STALE captured view. The restriction mismatch must make
+    // the scan target the CURRENT view; a scan of the captured one would trip
+    // the divergent-heal guard and report clean with the fault untouched.
+    let report = super::scan_and_reconcile(
+        &tree,
+        &captured,
+        &PatrolScrubOptions::default().heal_in_place(true),
+    );
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the known correctable fault must be healed through the current view, \
+         not silently skipped by the divergent-heal guard: {report:?}",
+    );
+    assert!(report.is_ok(), "{report:?}");
+    Ok(())
+}
+
+/// A corrected block whose heal RE-READ fails (transient I/O on the second,
+/// persist-side read) is a finding: the correction cannot be written back, so
+/// the block is reported uncorrectable rather than silently skipped.
+#[test]
+fn heal_in_place_reports_a_failed_heal_reread_as_uncorrectable() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_single_block_ecc_sst(dir.path());
+
+    // Flip one payload byte of the block (RS-correctable).
+    let corrupt_pos = block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let Some(slot) = bytes.get_mut(corrupt_pos) else {
+        panic!("corrupt_pos in range for the SST bytes");
+    };
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // The corrupted first block is read twice in the up-front correction-
+    // prediction pass (scrub + `heal_frame` re-read) and twice in the write-back
+    // pass. Skip the two prediction reads and the write-back scrub, then fail the
+    // write-back `heal_frame` re-read.
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .skip(3)
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "nothing was persisted for the failed block: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 1, "{report:?}");
+    assert!(
+        format!("{report:?}").contains("heal re-read failed"),
+        "the finding names the failed heal re-read: {report:?}",
+    );
+    Ok(())
+}
+
+/// An in-place heal must not mutate an inode a checkpoint hard-links: the
+/// checkpoint's manifest recorded the digest of the bytes AT SNAPSHOT TIME,
+/// and rewriting the shared inode underneath it permanently desynchronizes
+/// the snapshot from its own manifest (only the LIVE tree's digest is
+/// reconciled). The heal must instead break the link (heal a private copy of
+/// the live file), leaving the checkpoint's inode byte-identical to what its
+/// manifest describes.
+#[test]
+fn heal_in_place_does_not_mutate_a_hard_linked_checkpoint_inode() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one payload byte (RS-correctable) BEFORE the snapshot: the
+    // checkpoint captures the rotted bytes, exactly what its manifest
+    // would describe.
+    let corrupt_pos = block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let slot = bytes.get_mut(corrupt_pos).expect("corrupt_pos in range");
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Checkpoint-style hard link to the (rotted) SST. A separate directory
+    // outside the tree keeps recovery from treating it as an orphan.
+    let cp_dir = tempfile::tempdir_in(dir.path().parent().expect("tempdir has a parent"))?;
+    let link_path = cp_dir.path().join("checkpoint.sst");
+    std::fs::hard_link(&sst_path, &link_path)?;
+    let snapshot = std::fs::read(&link_path)?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the live file's fault is healed: {report:?}",
+    );
+    assert!(report.is_ok(), "{report:?}");
+
+    // The LIVE path carries the healed bytes...
+    let live = std::fs::read(&sst_path)?;
+    assert_ne!(
+        live, snapshot,
+        "the live path must expose the healed bytes after the scrub",
+    );
+    // ...while the checkpoint's inode still holds exactly the snapshot the
+    // checkpoint manifest describes.
+    let checkpoint = std::fs::read(&link_path)?;
+    assert_eq!(
+        checkpoint, snapshot,
+        "the checkpoint's hard-linked inode must keep its snapshot bytes: \
+         healing through a shared inode desynchronizes the checkpoint from \
+         its own manifest digest",
+    );
+    Ok(())
+}
+
+/// After an unshare detaches the live path onto a new inode, the table's
+/// descriptor cache may still hold the OLD inode's fd: a later heal on the
+/// same open tree would then SCRUB the stale inode (clean) while its
+/// re-read and write-back use the live file — a recoverable fault on the
+/// live copy reads as an unexplained checksum mismatch and is reported
+/// uncorrectable without ever attempting ECC recovery. The unshare must
+/// invalidate the cached descriptor.
+#[test]
+fn heal_in_place_rebinds_the_descriptor_cache_after_an_unshare() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte so the FIRST heal actually WRITES (the
+    // unshare runs lazily, only before the first write-back), then
+    // hard-link the SST so that write takes the unshare path.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    let cp_dir = tempfile::tempdir_in(dir.path().parent().expect("tempdir has a parent"))?;
+    std::fs::hard_link(&sst_path, cp_dir.path().join("checkpoint.sst"))?;
+
+    let tree = open_ecc_tree(dir.path());
+
+    // Prime the descriptor cache with the ORIGINAL inode, then heal (the
+    // unshare renames a private copy over the live path).
+    assert!(tree.get("key-000000", crate::SeqNo::MAX)?.is_some());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(report.is_ok(), "the trailer rebuild succeeds: {report:?}");
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the first pass must write, so the unshare runs: {report:?}",
+    );
+
+    // A recoverable payload fault lands on the LIVE (post-rename) inode.
+    let corrupt_pos = block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let slot = bytes
+        .get_mut(corrupt_pos)
+        .expect("corrupt_pos in range for the SST bytes");
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // SECOND heal on the SAME open tree: the scrub must see the live inode's
+    // fault as ECC-recoverable, not scrub a stale cached fd clean and then
+    // report the live mismatch as uncorrectable.
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the live fault is ECC-recovered and healed in place: {report:?}",
+    );
+    assert!(report.is_ok(), "{report:?}");
+    Ok(())
+}
+
+/// The descriptor invalidation must happen as soon as the publish RENAME
+/// succeeds — even when the post-rename directory sync fails: the live path
+/// already points at the new inode, so bailing out before the invalidation
+/// leaves the cache pinned to the old checkpoint-linked inode, and a later
+/// heal (which sees one link on the new inode and does not unshare again)
+/// scrubs the stale inode while the live file rots.
+#[test]
+fn heal_in_place_rebinds_the_descriptor_cache_when_the_directory_sync_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte (the unshare only runs before the first
+    // write-back), then hard-link the SST so the FIRST heal takes the
+    // unshare path.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    let cp_dir = tempfile::tempdir_in(dir.path().parent().expect("tempdir has a parent"))?;
+    std::fs::hard_link(&sst_path, cp_dir.path().join("checkpoint.sst"))?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+
+    // Prime the descriptor cache with the ORIGINAL inode, then heal with the
+    // post-rename directory sync failing: the unshare errors out AFTER the
+    // rename has already replaced the live path.
+    assert!(tree.get("key-000000", crate::SeqNo::MAX)?.is_some());
+    injector.arm(
+        FaultRule::new(FaultOp::SyncDirectory, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(
+        !report.is_ok(),
+        "the failed unshare is a finding: {report:?}"
+    );
+
+    // A recoverable payload fault lands on the LIVE (post-rename) inode.
+    let corrupt_pos = block.offset().0 as usize + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let slot = bytes
+        .get_mut(corrupt_pos)
+        .expect("corrupt_pos in range for the SST bytes");
+    *slot ^= 0x80;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // SECOND heal on the SAME open tree: the scrub must see the live
+    // inode's fault as ECC-recoverable, not scrub the stale cached fd.
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the live fault is ECC-recovered and healed in place: {report:?}",
+    );
+    assert!(report.is_ok(), "{report:?}");
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a RENAMED section: a
+/// TOC whose `filter` entry was re-labelled to an unknown name (trailer
+/// checksum re-stamped) hides the section from every reader while each
+/// block inside still passes its byte-level checks — an unknown
+/// block-format section must FAIL the walk closed, or the restamp would
+/// legitimize an archive whose known sections silently vanished.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_renamed_section() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    // Open FIRST (lazy filters, so the missing `filter` section is not
+    // touched by the scan), then rename the section in the TOC.
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .filter_block_pinning_policy(crate::config::PinningPolicy::new([false]))
+    .open()
+    .expect("open ecc tree with lazy filters") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    crate::test_forge::forge_section_name(&sst_path, b"filter", b"filtex")?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "an unknown section name must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the renamed-section SST must keep failing verify_integrity: \
+         restamping its digest would legitimize the vanished section",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over DIVERGED metadata
+/// mirrors: a tail `meta` block whose payload was re-stamped to another
+/// internally-consistent value (a changed `compression#data`, ECC descriptor
+/// untouched) passes every byte-level check, and the in-memory table keeps
+/// serving reads from its previously loaded metadata — so only a FULL
+/// comparison of the decoded mirrors can catch it. Restamping would make
+/// `verify_integrity` accept a file whose next recovery prefers the altered
+/// tail and misreads every data block.
+#[test]
+fn heal_in_place_does_not_restamp_over_diverged_meta_mirrors() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    // Open FIRST: the live tree keeps serving reads from its previously
+    // loaded metadata, so the forge below is invisible to the data/KV scan.
+    let tree = open_ecc_tree(dir.path());
+
+    // Re-stamp the TAIL meta's data-block compression from the written
+    // None (tag 0, the default L0 policy) to Lz4 (tag 1) — same value
+    // length, fresh block checksum and parity, `meta_mid` untouched. Only
+    // the NEXT recovery would prefer the altered tail and misread every
+    // data block.
+    crate::test_forge::forge_tail_meta_value(&sst_path, b"compression#data", &[1])?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "diverged meta mirrors must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would mask a forge only the mirror comparison detects",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `zone_map`: a
+/// payload re-stamped to another structurally valid map (a changed max
+/// value, fresh block checksum + parity) passes every byte-level and framing
+/// check, yet a predicate scan trusts its min/max to SKIP blocks — a shrunk
+/// range silently omits matching rows. Only a cross-check against the blocks'
+/// decoded key ranges can catch it before the refresh legitimizes the forge.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_zone_map() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    // An ECC tree WITH the zone_map section (off by default).
+    let sst_path = {
+        let tree = open_ecc_tree(dir.path());
+        tree.update_runtime_config(|c| c.zone_map = true)?;
+        for i in 0u64..2_000 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(2_000).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (*table.path).clone()
+    };
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_flip_section_last_payload_byte(&sst_path, b"zone_map", Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged zone_map must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let predicate scans silently skip matching blocks",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over ALTERED deletion
+/// metadata: a `range_tombstones` payload changed to another value (fresh
+/// block checksum + parity) passes every byte-level, framing, and role
+/// check, and NO semantic gate can authenticate which ranges were genuinely
+/// deleted — the tombstones ARE the source of truth, there is nothing
+/// in-file to cross-check them against. Refreshing the digest would
+/// permanently legitimize the alteration: later reads either resurrect
+/// deleted data or hide previously live data. The refresh must fail closed
+/// unless the mismatch is provably attributable to this pass's own heal
+/// writes.
+#[test]
+fn heal_in_place_does_not_restamp_over_altered_range_tombstones() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_with_range_tombstone(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_flip_section_last_payload_byte(
+        &sst_path,
+        b"range_tombstones",
+        Some((8, 2)),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "altered range tombstones must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the alteration stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the altered SST must keep failing verify_integrity: restamping its \
+         digest would let reads resurrect deleted data or hide live data",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED VALUE in a
+/// footer-less (default) table: a value byte changed behind a re-stamped
+/// block checksum + parity decodes cleanly with the same keys, seqnos, and
+/// counts, so every derived-metadata cross-check passes — the manifest
+/// digest is the ONLY record of the original value bytes, and refreshing it
+/// without attribution to this pass's own heal writes would erase that
+/// record permanently.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_footerless_value() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_value_byte_in_first_data_block(&sst_path, Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged footer-less value must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would erase the only record of the original value bytes",
+    );
+    Ok(())
+}
+
+/// As [`write_ecc_sst_footered`], but with 256 KiB zstd data blocks over
+/// ~600 KiB of KV so at least one data block splits into >= 2 inner zstd
+/// blocks and the SST carries a `block_layout` section.
+fn write_ecc_zstd_multiblock_sst(dir: &std::path::Path) -> std::path::PathBuf {
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .data_block_size_policy(crate::config::BlockSizePolicy::all(256 * 1024))
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::Zstd(19),
+    ))
+    .open()
+    .expect("open ecc zstd tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    tree.update_runtime_config(|c| {
+        c.kv_checksums = crate::runtime_config::KvChecksumPolicy::AllLevels;
+    })
+    .expect("enable kv checksums");
+    for i in 0u64..20_000 {
+        tree.insert(format!("key-{i:012}"), format!("value-{i:08}-payload"), i);
+    }
+    tree.flush_active_memtable(20_000).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    assert!(
+        table.regions.block_layout.is_some(),
+        "the multi-inner-block fixture must carry a block_layout section",
+    );
+    (*table.path).clone()
+}
+
+/// Salvage must NOT byte-copy a MULTI-INNER block verbatim: its recorded
+/// `block_layout` is the very (checksum-consistent, unauthenticated) section a
+/// forge can corrupt to route an otherwise-readable zstd SST through salvage, so
+/// copying the block verbatim would re-emit the same untrusted inner boundaries
+/// and keep partial range reads omitting keys even though salvage reports
+/// success. The block re-encodes from the verified payload instead
+/// (`verbatim = None`); single-inner blocks (empty layout) still copy verbatim.
+#[test]
+fn salvage_load_block_re_encodes_a_multi_inner_block() -> crate::Result<()> {
+    use crate::table::BlockHandle;
+    use crate::table::block::BlockType;
+
+    let dir = tempfile::tempdir()?;
+    // Build a multi-inner-block zstd SST and keep the tree alive so its table
+    // handle stays valid for the salvage-load probe below.
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .data_block_size_policy(crate::config::BlockSizePolicy::all(256 * 1024))
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::Zstd(19),
+    ))
+    .open()
+    .expect("open ecc zstd tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    tree.update_runtime_config(|c| {
+        c.kv_checksums = crate::runtime_config::KvChecksumPolicy::AllLevels;
+    })
+    .expect("enable kv checksums");
+    for i in 0u64..20_000 {
+        tree.insert(format!("key-{i:012}"), format!("value-{i:08}-payload"), i);
+    }
+    tree.flush_active_memtable(20_000).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    let multi_inner_offsets = table.block_layout.offsets();
+    assert!(
+        !multi_inner_offsets.is_empty(),
+        "the fixture must carry at least one multi-inner-block frame",
+    );
+
+    // The data block recorded in the block_layout is multi-inner: salvage must
+    // re-encode it, not verbatim-copy its untrusted boundaries.
+    let multi = table
+        .block_index
+        .iter()
+        .filter_map(Result::ok)
+        .find(|kh| multi_inner_offsets.contains(&kh.offset().0))
+        .map(|kh| BlockHandle::new(kh.offset(), kh.size()))
+        .expect("a block index handle for the multi-inner offset");
+    let sb = table.salvage_load_block(&multi, BlockType::Data)?;
+    assert!(
+        sb.verbatim.is_none(),
+        "a multi-inner block must re-encode from the verified payload, not byte-copy its \
+         unauthenticated recorded layout",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `block_layout`:
+/// a middle cumulative end shifted to another structurally valid value
+/// (fresh block checksum + parity) passes every byte-level and framing
+/// check — no gate compares the recorded boundaries with the zstd frames'
+/// real inner-block layout — yet the partial range-read path trusts it to
+/// bound decompression, silently omitting keys from the mis-mapped span.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_block_layout() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = write_ecc_zstd_multiblock_sst(dir.path());
+
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .data_block_size_policy(crate::config::BlockSizePolicy::all(256 * 1024))
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::Zstd(19),
+    ))
+    .open()
+    .expect("reopen ecc zstd tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    crate::test_forge::forge_block_layout_shift_middle_end(&sst_path, Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged block_layout must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let partial range reads silently omit keys",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over TLI mirrors forged
+/// CONSISTENTLY: both copies re-encoded to the same truncated handle list
+/// (fresh checksums, parity, Index role) pass every byte-level check AND
+/// the decoded mirror comparison — the equality of two forged copies proves
+/// nothing. Only a structural check of the decoded handles against the
+/// physical data section (the writer emits data blocks back-to-back, so the
+/// handles must exactly TILE it) can catch the dropped handle before the
+/// next recovery loads the forged list and range scans silently lose the
+/// unreachable block. Footered fixture, so the forge is not pre-empted by
+/// the footer-less attribution rule.
+#[test]
+fn heal_in_place_does_not_restamp_over_consistently_forged_tli_mirrors() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Open FIRST (the live table already loaded its index), then forge.
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_tli_mirrors_truncated(
+        &sst_path,
+        0,
+        Some(crate::table::block::EccParams::try_new(8, 2)?),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "consistently forged TLI mirrors must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let the next recovery hide the dropped block",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over FORGED metadata KEY
+/// BOUNDS: both meta mirrors re-stamped CONSISTENTLY to a narrower
+/// `key#max` (fresh checksums and parity) pass every byte-level check and
+/// the full mirror comparison — only a cross-check of the recorded range
+/// against the decoded data keys can catch it. Restamping would make run
+/// selection trust the forged range and silently skip this table for real
+/// keys outside it. The fixture is footered, so the forge is not
+/// pre-empted by the footer-less attribution rule.
+#[test]
+fn heal_in_place_does_not_restamp_over_forged_meta_key_bounds() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    // Real keys run up to "key-001999"; narrow the recorded max below half
+    // the key space (same value length keeps the frame geometry).
+    crate::test_forge::forge_meta_value_both_mirrors(&sst_path, b"key#max", b"key-000999")?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "forged meta key bounds must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let run selection silently skip real keys",
+    );
+    Ok(())
+}
+
+/// Opens an RS(8,2) Page-ECC tree at `dir` whose data blocks are
+/// uncompressed and carry an embedded hash index — the layout
+/// `forge_hash_index_all_free` requires.
+fn open_ecc_hashed_tree(dir: &std::path::Path) -> crate::Tree {
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::None,
+    ))
+    .data_block_hash_ratio_policy(crate::config::HashRatioPolicy::all(2.0))
+    .open()
+    .expect("open ecc hashed tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    tree
+}
+
+/// A footered, uncompressed ECC SST whose data blocks carry an embedded
+/// HASH INDEX (non-zero `data_block_hash_ratio`), for the hash-index forge.
+fn write_ecc_sst_footered_hashed(dir: &std::path::Path) -> std::path::PathBuf {
+    let tree = open_ecc_hashed_tree(dir);
+    tree.update_runtime_config(|c| {
+        c.kv_checksums = crate::runtime_config::KvChecksumPolicy::AllLevels;
+    })
+    .expect("enable kv checksums");
+    for i in 0u64..2_000 {
+        tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+    }
+    tree.flush_active_memtable(2_000).expect("flush");
+
+    let binding = tree.version_history.read().latest_version();
+    let table = binding
+        .version
+        .iter_tables()
+        .next()
+        .expect("flush produced one table");
+    (*table.path).clone()
+}
+
+/// The digest reconciliation must not restamp over a FORGED embedded HASH
+/// INDEX: filling the first block's hash index with `MARKER_FREE` leaves
+/// every logical entry, per-KV footer, and the outer block checksum intact,
+/// so a sequential decode and the count / key / seqno gates all pass — yet
+/// after reopen `point_read` trusts the hash index and returns `None` for
+/// every existing key in that block. The indexes must be probed against the
+/// decoded keys before the digest is trusted.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_hash_index() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = write_ecc_sst_footered_hashed(dir.path());
+
+    let tree = open_ecc_hashed_tree(dir.path());
+    crate::test_forge::forge_hash_index_all_free(&sst_path, Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged hash index must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let point reads miss existing keys",
+    );
+    Ok(())
+}
+
+/// The reconcile gates must judge the bytes ON DISK, not the block cache:
+/// a block read before the forge leaves its pristine copy cached, and a
+/// gate that loads through the cache validates that stale original instead
+/// of the file being reconciled. Same forge as
+/// [`heal_in_place_does_not_restamp_over_a_forged_hash_index`], but with a
+/// point read FIRST so the pristine first data block is cached when the
+/// heal scan runs — the refresh must still be refused.
+#[test]
+fn heal_in_place_does_not_trust_cached_blocks_over_the_disk_bytes() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = write_ecc_sst_footered_hashed(dir.path());
+
+    let tree = open_ecc_hashed_tree(dir.path());
+    // Warm the block cache with the PRISTINE first data block (the key lives
+    // in it), then forge the on-disk hash index; the cached copy stays good.
+    assert!(
+        tree.get("key-000000", MAX_SEQNO)?.is_some(),
+        "pre-forge read warms the cache",
+    );
+    crate::test_forge::forge_hash_index_all_free(&sst_path, Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged hash index must refuse the digest refresh even when the \
+         pristine block is cached: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let point reads miss existing keys after the cache cools",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over FORGED metadata SEQUENCE
+/// bounds: on a footer-bearing table WITHOUT deletion metadata (no sentinel
+/// to complicate the bounds), both meta mirrors re-stamped with `seqno#min`
+/// raised while every data entry stays intact pass the mirror walk and all
+/// per-KV / key / count gates — yet after reopen a snapshot read whose
+/// threshold is at or below the forged minimum returns early at
+/// `Table::get`, silently missing older visible versions. The recorded
+/// bounds must be cross-checked against the decoded entries' real seqnos.
+#[test]
+fn heal_in_place_does_not_restamp_over_forged_meta_seqno_bounds() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Read the SST's real recorded max so the forged min stays <= max (a
+    // min > max would fail the meta load for a different reason).
+    let tree = open_ecc_tree(dir.path());
+    let recorded_max = {
+        let binding = tree.version_history.read().latest_version();
+        let table = binding.version.iter_tables().next().expect("one table");
+        table.get_highest_seqno()
+    };
+    // Raise seqno#min to the recorded max — every entry below it is now
+    // hidden from snapshots at or under the forged minimum.
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"seqno#min",
+        &recorded_max.to_le_bytes(),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "forged metadata seqno bounds must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let snapshot reads silently skip older visible versions",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `created_at`:
+/// both meta mirrors re-stamped with an OLDER timestamp (same 16-byte
+/// length, fresh checksums and parity) pass every byte-level check, the
+/// mirror comparison, and every content-derived gate — no cross-check can
+/// re-derive a wall-clock timestamp from the entries. Yet after reopen
+/// FIFO compaction trusts the recorded `created_at` for its TTL decision
+/// and can classify the live SST as expired, permanently dropping it. The
+/// disk-fresh meta must equal the recovery-time copy field for field
+/// before the digest is trusted.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_created_at() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Open FIRST so the live table keeps its recovery-time timestamp, then
+    // back-date the on-disk copy in both mirrors (u128 LE nanoseconds; the
+    // equal value length keeps the frame geometry).
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"created_at",
+        &1u128.to_le_bytes(),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged created_at must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let FIFO compaction drop the live SST as TTL-expired",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a `created_at` back-dated
+/// while the tree was CLOSED. The post-open forge above is caught by the
+/// field-for-field bounds check because the live table keeps the honest
+/// recovery-time copy; an OFFLINE restamp defeats that check by poisoning the
+/// recovery-time copy itself — recovery loads the forged `created_at`, so the
+/// disk-fresh copy equals it. The manifest's whole-file digest is then the
+/// only surviving record of the honest bytes, and the mismatch it produces is
+/// UNATTRIBUTABLE to any heal. Because no cross-check can re-derive a
+/// wall-clock timestamp, an unattributed mismatch must fail closed even on a
+/// footer-bearing table; otherwise the patrol would persist the forged digest
+/// and FIFO compaction would drop the live SST as TTL-expired.
+#[test]
+fn heal_in_place_rejects_a_created_at_restamped_before_open() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Back-date `created_at` in BOTH mirrors BEFORE the tree opens: recovery
+    // then loads the forgery into the live table's metadata.
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"created_at",
+        &1u128.to_le_bytes(),
+    )?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    // Pin the fail-closed reason, not just the error variant: another gate
+    // could raise ChecksumRefreshFailed for a different cause and keep this
+    // test green while the attribution gate goes uncovered.
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            ScrubError::ChecksumRefreshFailed { reason, .. }
+                if reason.contains("not attributable to this pass's heal")
+        )),
+        "an unattributed mismatch on a footer-bearing table must not reconcile a \
+         pre-open created_at restamp: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its digest \
+         would let FIFO compaction drop the live SST as TTL-expired",
+    );
+    Ok(())
+}
+
+/// A stale IN-PROGRESS heal marker must NOT authorize a reconcile. The
+/// in-progress marker binds only `pre == manifest`, not the healed bytes, so a
+/// crash after the marker was written but before any block was healed leaves it
+/// attesting a heal that never happened. If a checksum-restamped alteration to a
+/// non-authenticatable surface (here a pre-open `created_at` back-date, which
+/// poisons the recovery-time copy so no gate can catch it) then lands, the
+/// marker would legitimize it: the patrol refreshes the manifest over the forged
+/// bytes. Attribution must come only from this pass's heal or a COMPLETED marker
+/// (which binds `post == current`); a bare pre-only marker is ignored, so the
+/// mismatch stays unattributable and fails closed.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_in_place_ignores_a_stale_in_progress_marker() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Back-date `created_at` in BOTH mirrors before open, poisoning the
+    // recovery-time copy so the field-for-field gate cannot catch it — the
+    // mismatch is unattributable unless a marker authorizes it.
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"created_at",
+        &1u128.to_le_bytes(),
+    )?;
+
+    let tree = open_ecc_tree(dir.path());
+    // Manufacture a stale in-progress marker whose `pre` equals the manifest
+    // digest (the clean, pre-forge checksum the manifest still records), as a
+    // crash between the marker write and the first heal would leave.
+    let manifest_checksum = {
+        let binding = tree.version_history.read().latest_version();
+        binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table")
+            .checksum()
+    };
+    crate::scrub::heal_attest::write_in_progress(
+        &crate::fs::StdFs,
+        &sst_path,
+        None,
+        0,
+        manifest_checksum,
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            ScrubError::ChecksumRefreshFailed { reason, .. }
+                if reason.contains("not attributable to this pass's heal")
+        )),
+        "a stale in-progress marker must not make an unattributed mismatch \
+         attributable: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: a stale in-progress \
+         marker must not authorize restamping its digest",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED KV-footer
+/// DESCRIPTOR: both meta mirrors re-stamped with `descriptor#kv_checksum`
+/// set to off while the footer-bearing data blocks are left intact. The
+/// mirror walk accepts the matching copies, and the in-memory descriptor is
+/// still the recovery-time `Some(algo)` so `verify_kv_checksums` passes —
+/// yet after reopen the on-disk `None` descriptor stops footer stripping,
+/// so point reads misread footer bytes as the data-block trailer. The
+/// disk-fresh descriptor must be cross-checked against the recovery-time
+/// one before trusting the metadata.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_kv_checksum_descriptor() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    // Open FIRST so the live table keeps its recovery-time Some(algo), then
+    // forge the on-disk descriptor to off (byte 0) in both mirrors.
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_meta_value_both_mirrors(&sst_path, b"descriptor#kv_checksum", &[0])?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged kv-checksum descriptor must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let point reads misread footer bytes as the trailer",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED metadata BLOCK
+/// COUNT: both mirrors re-stamped consistently to a smaller
+/// `block_count#data` (fresh checksums and parity) pass every byte-level
+/// check and the mirror comparison, and the bounds gate's key/item checks
+/// stay clean (the blocks themselves are untouched) — yet `Table::scan`
+/// hands the recorded count to the compaction scanner, which stops after
+/// that many blocks: a rewrite silently drops every key in the omitted
+/// tail. Footered fixture, so the forge is not pre-empted by the
+/// footer-less attribution rule.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_data_block_count() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    // The fixture writes 9 data blocks; record 1 (little-endian u64, same
+    // value length keeps the frame geometry).
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"block_count#data",
+        &1u64.to_le_bytes(),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged data-block count must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let compaction scans silently drop the omitted blocks",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED TLI SEPARATOR
+/// key: both mirrors re-encoded with the first block's separator lowered to
+/// a truncated prefix stay equal, sorted, and section-tiling — yet after
+/// reopen the index binary search routes keys in `(forged_separator,
+/// real_last_key]` to the wrong block, so `point_read` misses existing
+/// keys. The in-memory point-read reachability gate does not catch this on
+/// the heal path (the live table keeps its correct recovery-time index), so
+/// the disk-fresh separator must be cross-checked against the addressed
+/// block's decoded final key.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_tli_separator() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_tli_mirrors_lower_first_separator(
+        &sst_path,
+        0,
+        Some(crate::table::block::EccParams::try_new(8, 2)?),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged TLI separator must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let point reads miss keys routed to the wrong block",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED TLI BINARY
+/// INDEX: both mirrors re-stamped with the last binary-index pointer
+/// redirected to the first restart head leave the sequential entry stream
+/// untouched, so mirror equality, section tiling, and every separator
+/// cross-check pass — yet after reopen the index binary search trusts the
+/// forged pointer and can start at the wrong restart head, silently
+/// missing keys on seeks. Each disk-fresh pointer must be validated
+/// against the sequentially derived restart heads.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_tli_binary_index() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst_footered(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_tli_binary_index_pointer(
+        &sst_path,
+        0,
+        Some(crate::table::block::EccParams::try_new(8, 2)?),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged TLI binary index must refuse the digest refresh: {report:?}",
+    );
+
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let index seeks start at the wrong restart head",
+    );
+    Ok(())
+}
+
+/// A LEGITIMATE heal on a tombstone-bearing table must still reconcile the
+/// manifest digest: attribution (the pre-write digest matched the manifest,
+/// so the file now differs by exactly this pass's verified corrections)
+/// proves the deletion metadata itself is untouched — the fail-closed rule
+/// for unattributable mismatches must not permanently flag every healed
+/// table that happens to carry range tombstones.
+#[test]
+fn heal_in_place_reconciles_a_tombstone_bearing_table_after_a_legit_heal() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_with_range_tombstone(dir.path());
+
+    // Rot one parity-trailer byte, then let a manifest rebuild record the
+    // digest of the ROTTED bytes: the heal restores the original trailer,
+    // so the reconciliation has a real mismatch to persist.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+    assert!(
+        report.is_ok(),
+        "an attributable heal reconciles the digest despite the deletion \
+         metadata: {report:?}",
+    );
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        integrity.is_ok(),
+        "the healed table verifies clean against the refreshed digest, got {:?}",
+        integrity.errors,
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `filter`: a
+/// payload altered to another parseable `BuRR` filter (fresh block checksum +
+/// parity) passes every byte-level, framing, and role check — the walk never
+/// probes the filter against the table's keys — yet `check_bloom` trusts it
+/// to SKIP point reads, so a key made into a false negative silently
+/// disappears from every read. Only a probe of each decoded key against the
+/// filter can catch it before the refresh legitimizes the forge.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_filter() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    let tree = open_ecc_tree(dir.path());
+    // The forge targets the section's FIRST filter block, which covers the
+    // table's lowest keys — make its first key the false negative.
+    crate::test_forge::forge_filter_false_negative(
+        &sst_path,
+        crate::hash::hash64(b"key-000000"),
+        Some((8, 2)),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged filter must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let point reads silently miss existing keys",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `seqno_bounds`
+/// map: a payload re-stamped to another structurally valid map (fresh block
+/// checksum + parity, `min <= max`, ascending offsets) passes every
+/// byte-level and framing check, yet `scan_since_seqno` trusts it to SKIP
+/// blocks — zeroed bounds silently omit a block's live entries from every
+/// CDC / incremental scan. Only a cross-check against the blocks' decoded
+/// entries can catch it before the refresh legitimizes the forge.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_seqno_bounds() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    // An ECC tree WITH the seqno_bounds section (off by default).
+    let sst_path = {
+        let tree = open_ecc_tree(dir.path());
+        tree.update_runtime_config(|c| c.seqno_in_index = true)?;
+        for i in 0u64..2_000 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(2_000).expect("flush");
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (*table.path).clone()
+    };
+
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_seqno_bounds_zeroed_entry(&sst_path, Some((8, 2)))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a forged seqno_bounds map must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would let scans silently skip live blocks",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a FORGED `tli_tail`: a
+/// tail mirror re-encoded to a truncated handle list is independently
+/// checksum-, parity-, and role-consistent, so the out-of-band walk reads it
+/// clean — yet `read_tli` prefers it on the next recovery, and the hidden
+/// block's keys silently vanish. Only a comparison of the two DECODED TLI
+/// mirrors can catch it before the digest refresh legitimizes the forge.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_forged_tli_tail() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    // Open FIRST (the live table already loaded its index), then forge.
+    let tree = open_ecc_tree(dir.path());
+    crate::test_forge::forge_tli_tail_truncated(
+        &sst_path,
+        0,
+        Some(crate::table::block::EccParams::try_new(8, 2)?),
+    )?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "diverged TLI mirrors must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged SST must keep failing verify_integrity: restamping its \
+         digest would hide a mirror only the decoded comparison detects",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a RELABELED section
+/// block: a checksum-clean block whose `block_type` was forged (a filter
+/// block re-stamped as Data) passes payload and parity verification, so
+/// only a section-vs-role cross-check in the out-of-band walk can catch
+/// it. Restamping would make `verify_integrity` accept an SST whose lazy
+/// filter load rejects the role at read time.
+#[test]
+fn heal_in_place_does_not_restamp_over_a_relabeled_section_block() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    // Relabel the FIRST filter block as Data and re-stamp its header: the
+    // payload and its checksum are untouched, so every byte-level check
+    // stays clean while the role no longer matches the section.
+    crate::test_forge::forge_section_block_role(
+        &sst_path,
+        b"filter",
+        crate::table::block::BlockType::Data,
+    )?;
+
+    // Reopen with LAZY filters (no pinning): the default policy pins the L0
+    // filter at open, which loads it and rejects the role before the scrub
+    // even runs — the dangerous variant is the lazy one, where nothing
+    // touches the filter until a point read long after the restamp.
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .filter_block_pinning_policy(crate::config::PinningPolicy::new([false]))
+    .open()
+    .expect("open ecc tree with lazy filters") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "the relabeled block must refuse the digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the forge stays visible.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the relabeled SST must keep failing verify_integrity: restamping \
+         its digest would mask a forge only the role cross-check detects",
+    );
+    Ok(())
+}
+
+/// A heal scan over a HEALTHY hard-linked SST must not detach it: the
+/// unshare exists to protect a checkpoint from in-place writes, and a scan
+/// that finds nothing to write has no reason to stream the whole file into
+/// a private copy. Detaching eagerly turns a heal patrol over a
+/// checkpointed database into O(database) writes and permanently doubles
+/// the disk usage of every linked SST, breaking the option's O(damage)
+/// contract.
+// Unix-gated for the `nlink` assertion (`std` exposes the NTFS count only
+// behind an unstable feature); the lazy-detach behaviour itself is
+// platform-independent.
+#[cfg(unix)]
+#[test]
+fn heal_in_place_keeps_a_healthy_sst_hard_linked() -> crate::Result<()> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    let cp_dir = tempfile::tempdir_in(dir.path().parent().expect("tempdir has a parent"))?;
+    std::fs::hard_link(&sst_path, cp_dir.path().join("checkpoint.sst"))?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(report.is_ok(), "{report:?}");
+    assert_eq!(report.blocks_healed_in_place, 0, "nothing to heal");
+
+    assert_eq!(
+        std::fs::metadata(&sst_path)?.nlink(),
+        2,
+        "a clean scan must leave the checkpoint link in place: detaching \
+         without a write to protect it from costs a full-file copy and \
+         doubles the SST's disk usage",
+    );
+    Ok(())
+}
+
+/// A failed link-count probe must FAIL CLOSED: the heal cannot prove the
+/// inode is exclusive, so it must take the unshare (copy) path as if the file
+/// were shared — and still heal the detached copy, not skip the table or
+/// write through the possibly-shared inode.
+#[test]
+fn heal_in_place_treats_an_unknown_link_count_as_shared() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+    injector.arm(
+        FaultRule::new(FaultOp::HardLinkCount, Fault::Error(ErrorKind::Other))
+            .on_path("tables")
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    // The heal proceeded through the copy path: the trailer rot is healed and
+    // nothing surfaced as a finding.
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "fail-closed still heals (through the detached copy): {report:?}",
+    );
+    assert!(report.is_ok(), "{report:?}");
+    Ok(())
+}
+
+/// A failed unshare must not leave its `*.healtmp` artifact behind: recovery
+/// parses every non-special file under `tables/` as a numeric table id, so a
+/// leftover temp copy makes the NEXT open of the whole tree fail
+/// `Unrecoverable` — a heal that could not proceed must degrade to a
+/// read-only scan, not brick the reopen path.
+#[test]
+fn heal_in_place_cleans_up_the_temp_copy_when_the_unshare_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte (so the heal has something to WRITE — the
+    // unshare only runs before the first write-back), then hard-link the
+    // rotted SST so the heal takes the unshare path.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    let cp_dir = tempfile::tempdir_in(dir.path().parent().expect("tempdir has a parent"))?;
+    std::fs::hard_link(&sst_path, cp_dir.path().join("checkpoint.sst"))?;
+
+    // Fail the pre-publish sync of the heal copy: the copy was already
+    // created and fully written by then.
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+    injector.arm(
+        FaultRule::new(FaultOp::SyncAll, Fault::Error(ErrorKind::Other))
+            .on_path("healtmp")
+            .once(),
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(
+        !report.is_ok(),
+        "the failed unshare is a finding: {report:?}"
+    );
+
+    // No temp artifact may survive the failure...
+    let leftovers: Vec<_> = std::fs::read_dir(sst_path.parent().expect("sst in tables dir"))?
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().contains("healtmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "a failed unshare must remove its temp copy: {leftovers:?}",
+    );
+
+    // ...and the tree must reopen: a heal failure must never brick recovery.
+    // The trailer rot is still on disk (the write was refused), so the
+    // integrity scan keeps flagging it.
+    drop(tree);
+    let tree = open_ecc_tree(dir.path());
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the refused heal leaves the rot in place and visible",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over corruption the heal scan
+/// never looked at: the scan covers DATA blocks only, so rot in a side
+/// section (filter, zone map, range tombstones) leaves the scan clean while
+/// the file digest disagrees with the manifest; blindly installing the fresh
+/// digest would make `verify_integrity` accept the corrupted file, masking
+/// the rot until the side section is lazily loaded.
+#[test]
+fn heal_in_place_does_not_restamp_over_side_section_rot() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _) = write_ecc_sst(dir.path());
+
+    // Rot a 64-byte run inside the FILTER section's payload (well past the
+    // RS(8,2) correction budget): the data blocks stay clean, but the
+    // out-of-band section walk (and any later filter load) flags it.
+    let (pos, len) = {
+        let mut f = std::fs::File::open(&sst_path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"filter") else {
+            panic!("the SST must carry a filter section");
+        };
+        (entry.pos(), entry.len())
+    };
+    assert!(len > 128, "filter section large enough to rot: {len}");
+    let start = usize::try_from(pos).expect("filter offset fits usize") + 40;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let Some(run) = bytes.get_mut(start..start + 64) else {
+        panic!("filter payload within the file");
+    };
+    for b in run {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Heal scan: every DATA block reads clean, yet the file digest now
+    // disagrees with the manifest (the filter byte changed).
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        !report.is_ok(),
+        "a digest mismatch the scan cannot attribute to a heal must be a \
+         finding, not silently restamped: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "the finding must be the refused digest refresh: {report:?}",
+    );
+    assert_eq!(
+        report.uncorrectable_blocks, 0,
+        "the data blocks themselves stay clean: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so the corruption stays
+    // visible to integrity scans instead of being laundered into a fresh
+    // manifest entry.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the corrupted file must keep failing verify_integrity: restamping \
+         its digest over unverified side sections would mask the rot",
+    );
+    Ok(())
+}
+
+/// Byte path of the heal attestation sidecar next to an SST.
+fn heal_attest_path(sst_path: &std::path::Path) -> std::path::PathBuf {
+    let mut name = sst_path.as_os_str().to_os_string();
+    name.push(".heal-attest");
+    std::path::PathBuf::from(name)
+}
+
+/// A manifest-digest refresh that FAILED (or a crash after the heal's
+/// `sync_data` but before the manifest update) leaves a stale digest. Because
+/// the heal writes a sidecar ATTESTATION before the reconciliation, a later
+/// clean heal-in-place scrub — which sees only clean blocks and cannot
+/// attribute the mismatch to any write of its own — reconciles the digest via
+/// that attestation instead of flagging the healed table as corrupt forever.
+/// (For an unencrypted table the attestation is plaintext; forging it needs the
+/// same directory write access that could re-stamp the SST directly, which is
+/// outside the on-disk-tamper model the digest gate defends.)
+#[test]
+fn heal_in_place_reconciles_a_crashed_refresh_via_the_attestation() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // FIRST heal pass: the trailer is rebuilt in place and an attestation is
+    // written, but the manifest refresh fails (injected fault on the edit-log
+    // open), leaving the stale digest AND the attestation on disk.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(report.blocks_healed_in_place >= 1, "{report:?}");
+    assert!(
+        !report.is_ok(),
+        "the failed refresh is a finding: {report:?}"
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the heal must leave an attestation for the crashed refresh",
+    );
+
+    // SECOND heal pass, fault gone: every block reads clean (nothing to heal),
+    // and the manifest still carries the rotted digest. The attestation proves
+    // the file is the healed version, so the mismatch is reconciled.
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.is_ok(),
+        "a crashed refresh must reconcile via the attestation on the next scrub: {report:?}",
+    );
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        integrity.is_ok(),
+        "the reconciled digest matches the healed file, got {:?}",
+        integrity.errors,
+    );
+    assert!(
+        !heal_attest_path(&sst_path).exists(),
+        "the attestation is consumed once its reconciliation lands",
+    );
+    Ok(())
+}
+
+/// A heal writes the completed attestation UP FRONT — before any block is
+/// healed — binding the deterministic post-heal digest, so a crash anywhere in
+/// the heal leaves that marker on disk. The next clean scrub reconciles via it:
+/// the marker binds `post == current`, so once the file reaches the healed
+/// state the mismatch is attributable and the structural gates re-verify before
+/// the digest is trusted. Without it the clean re-scan cannot attribute the
+/// mismatch and the stale digest is rejected forever.
+#[test]
+fn heal_in_place_reconciles_via_a_completed_marker() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // First heal pass with a failing edit-log: the blocks are healed and the
+    // completed attestation is written, but the manifest refresh fails.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(report.blocks_healed_in_place >= 1, "{report:?}");
+
+    // Model the crash window explicitly: the file is healed, and the completed
+    // marker binds the manifest's (stale) `pre` to the healed file's `post`.
+    let (table_id, manifest_digest) = {
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("the healed table is still in the manifest");
+        (table.id(), table.checksum())
+    };
+    let healed_digest = crate::Checksum::from_raw(crate::repair::compute_table_checksum(
+        &crate::fs::StdFs,
+        &sst_path,
+    )?);
+    std::fs::remove_file(heal_attest_path(&sst_path))?;
+    crate::scrub::heal_attest::write(
+        &crate::fs::StdFs,
+        &sst_path,
+        None,
+        table_id,
+        manifest_digest,
+        healed_digest,
+    )?;
+
+    // Second pass, fault gone: every block reads clean (nothing to heal), so the
+    // mismatch is attributable only via the completed marker.
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "the second pass must find every block clean, so ONLY the marker attributes the \
+         mismatch (a re-heal would make attribution direct and skip the marker path): {report:?}",
+    );
+    assert!(
+        report.is_ok(),
+        "a crash before the manifest refresh must reconcile via the completed \
+         marker on the next scrub: {report:?}",
+    );
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        integrity.is_ok(),
+        "the reconciled digest matches the healed file, got {:?}",
+        integrity.errors,
+    );
+    assert!(
+        !heal_attest_path(&sst_path).exists(),
+        "the marker is consumed once its reconciliation lands",
+    );
+    Ok(())
+}
+
+/// `attests_post` is the discriminator the heal path uses to decide a not-matched
+/// heal is NOT diverging: it matches only a COMPLETED marker recording exactly
+/// `post` for this table, regardless of the marker's `pre`. A wrong post or a
+/// wrong table id does not match, so a genuinely diverging heal is not mistaken
+/// for a safe restore-to-an-attested-digest.
+#[test]
+fn attests_post_matches_only_the_recorded_completed_post() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("t.sst");
+    std::fs::write(&path, b"x")?;
+
+    let pre = crate::Checksum::from_raw(0x1111);
+    let post = crate::Checksum::from_raw(0x2222);
+    crate::scrub::heal_attest::write(&crate::fs::StdFs, &path, None, 7, pre, post)?;
+
+    use crate::scrub::heal_attest::AttestResult;
+    // The recorded post matches for the right table, whatever the `pre` was.
+    assert!(matches!(
+        crate::scrub::heal_attest::attests_post(&crate::fs::StdFs, &path, None, 7, post),
+        AttestResult::Attests,
+    ));
+    // A different post does not match.
+    assert!(matches!(
+        crate::scrub::heal_attest::attests_post(
+            &crate::fs::StdFs,
+            &path,
+            None,
+            7,
+            crate::Checksum::from_raw(0x3333),
+        ),
+        AttestResult::Absent,
+    ));
+    // A different table id does not match.
+    assert!(matches!(
+        crate::scrub::heal_attest::attests_post(&crate::fs::StdFs, &path, None, 8, post),
+        AttestResult::Absent,
+    ));
+    Ok(())
+}
+
+/// A TRANSIENT read of the attestation sidecar must resolve to `Inconclusive`,
+/// never `Absent`. Collapsing it to "does not attest" (the old `bool` return)
+/// would make the diverging-heal check skip the heal, then let the reconcile
+/// reread the now-readable marker, find it no longer matches the current bytes,
+/// and delete a VALID marker — permanently stranding the healed table.
+#[test]
+fn attests_post_is_inconclusive_on_a_transient_sidecar_read() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+    use crate::scrub::heal_attest::AttestResult;
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("t.sst");
+    std::fs::write(&path, b"x")?;
+    let post = crate::Checksum::from_raw(0x2222);
+    crate::scrub::heal_attest::write(
+        &crate::fs::StdFs,
+        &path,
+        None,
+        7,
+        crate::Checksum::from_raw(0x1111),
+        post,
+    )?;
+
+    // Fault the sidecar OPEN with a transient (non-NotFound) error: `read_sidecar`
+    // maps that to `Inconclusive`, and `attests_post` must propagate it.
+    let fault = FaultFs::new(crate::fs::StdFs);
+    fault.injector().arm(
+        FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Interrupted)).on_path("heal-attest"),
+    );
+
+    assert!(
+        matches!(
+            crate::scrub::heal_attest::attests_post(&fault, &path, None, 7, post),
+            AttestResult::Inconclusive,
+        ),
+        "a transient sidecar read must be Inconclusive, not Absent",
+    );
+    Ok(())
+}
+
+/// Without a valid attestation, an unattributable stale digest STILL fails
+/// closed: the attestation is the only thing that lets a clean re-scan
+/// reconcile, so deleting it (modelling a crash before the attestation was
+/// written, or an offline restamp with no attestation at all) must restore the
+/// fail-closed behavior — nothing else distinguishes the mismatch from an
+/// offline restamp of the non-derivable meta scalars.
+#[test]
+fn heal_in_place_fails_closed_without_a_heal_attestation() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // First pass heals + attests, but the refresh fails.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(report.blocks_healed_in_place >= 1, "{report:?}");
+
+    // Remove the attestation before the retry: the mismatch is now
+    // unattributable with no evidence of a legitimate heal.
+    std::fs::remove_file(heal_attest_path(&sst_path))?;
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            ScrubError::ChecksumRefreshFailed { reason, .. }
+                if reason.contains("not attributable to this pass's heal")
+        )),
+        "without an attestation the stale digest must fail closed: {report:?}",
+    );
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the unattested stale digest keeps flagging, got {:?}",
+        integrity.errors,
+    );
+    Ok(())
+}
+
+/// A transiently-unreadable sidecar must NOT be treated as an absent marker on
+/// the unattributable re-scan path: deleting it on a retryable read error would
+/// strand the healed table under the stale digest forever. The read is
+/// INCONCLUSIVE, so the reconcile fails closed (no digest refresh) but KEEPS the
+/// marker for the next pass to retry.
+#[test]
+fn reconcile_keeps_the_marker_when_the_sidecar_read_is_inconclusive() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // First pass heals + writes the attestation, but the manifest refresh fails,
+    // leaving the marker on disk for a later pass to reconcile.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(report.blocks_healed_in_place >= 1, "{report:?}");
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the heal left a marker"
+    );
+
+    // Second pass: the block is clean, so the mismatch is attributable only via
+    // the marker, but its read fails transiently (an open error, not not-found).
+    // That is inconclusive, not absent, so the marker must survive.
+    injector
+        .arm(FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).on_path(".heal-attest"));
+    let _ = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "an inconclusive sidecar read must keep the marker, not delete it",
+    );
+    Ok(())
+}
+
+/// A `.heal-attest` sidecar whose SST is absent from the recovered manifest is
+/// an orphan: its table was retired (compacted away, its numeric file unlinked)
+/// while the attestation lingered. Recovery must SWEEP the orphan rather than
+/// skip it forever — an attestation can only ever reconcile a table that still
+/// exists, so a leaked sidecar is dead weight that every future recovery scan
+/// re-processes. A LIVE table's pending attestation must still be preserved.
+#[test]
+fn recovery_sweeps_an_orphaned_heal_attestation_but_keeps_a_live_one() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, _block) = write_ecc_sst(dir.path());
+    let tables_dir = sst_path.parent().expect("the SST lives in a tables folder");
+
+    // An orphan sidecar for a table id that is NOT in the manifest.
+    let orphan = tables_dir.join("99999.heal-attest");
+    std::fs::write(&orphan, b"orphaned attestation")?;
+    // A pending attestation for the LIVE SST (its id IS in the manifest).
+    let live = heal_attest_path(&sst_path);
+    std::fs::write(&live, b"live attestation")?;
+
+    // Reopen: recovery scans the tables folder and reconciles sidecars.
+    let _tree = open_ecc_tree(dir.path());
+
+    assert!(
+        !orphan.exists(),
+        "recovery must sweep a sidecar whose table id is absent from the manifest",
+    );
+    assert!(
+        live.exists(),
+        "recovery must preserve a live table's pending attestation",
+    );
+    Ok(())
+}
+
+/// A prior reconciliation may have installed the refreshed checksum but crashed
+/// (or its best-effort sidecar unlink transiently failed) before removing the
+/// `.heal-attest` marker. The next reconciliation then finds the on-disk digest
+/// already matches the manifest and must RECLAIM the now-obsolete marker:
+/// leaving it makes every future checkpoint classify the table as pending and
+/// run a full heal scan before snapshotting.
+#[test]
+fn reconcile_reclaims_an_obsolete_marker_when_the_digest_already_matches() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // A clean ECC table: its on-disk digest already matches the manifest.
+    let (sst_path, _block) = write_ecc_sst(dir.path());
+
+    // Plant a leftover sidecar, modelling a prior reconcile that installed the
+    // digest but did not manage to remove its marker.
+    let marker = heal_attest_path(&sst_path);
+    std::fs::write(&marker, b"obsolete marker")?;
+    assert!(marker.exists());
+
+    // A heal-in-place patrol scrub: the table is clean, so the reconcile takes
+    // the `fresh == current` branch, which must reclaim the obsolete marker.
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.is_ok(),
+        "a clean ECC table scrubs cleanly: {report:?}"
+    );
+
+    assert!(
+        !marker.exists(),
+        "an obsolete marker must be reclaimed once the digest already matches the manifest",
+    );
+    Ok(())
+}
+
+/// The checkpoint-time guard `abort_checkpoint_if_pending_heals` must not wedge
+/// on an OBSOLETE marker: a prior reconcile installed the refreshed digest but
+/// crashed before removing the sidecar, so the file ALREADY matches the
+/// manifest. A build WITHOUT `page_ecc` never runs reconciliation to clear it,
+/// so an unconditional abort would fail EVERY checkpoint forever. When the
+/// live-region digest already agrees with the manifest the guard reclaims the
+/// stale marker and proceeds; a genuine pending heal (a digest that does NOT
+/// match) still aborts.
+#[test]
+fn abort_checkpoint_ignores_an_obsolete_marker_but_aborts_on_a_stale_digest() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // A clean ECC table: its on-disk digest already matches the manifest.
+    let (sst_path, _block) = write_ecc_sst(dir.path());
+    let marker = heal_attest_path(&sst_path);
+
+    // Case 1: an obsolete leftover marker (a crash between the digest refresh
+    // and the marker unlink). The guard must proceed and reclaim it.
+    std::fs::write(&marker, b"obsolete marker")?;
+    let tree = open_ecc_tree(dir.path());
+    crate::scrub::abort_checkpoint_if_pending_heals(&tree, "obsolete-marker case")?;
+    assert!(
+        !marker.exists(),
+        "an obsolete marker matching the manifest must be reclaimed, not wedge the checkpoint",
+    );
+
+    // Case 2: a genuine pending heal — the on-disk digest no longer matches the
+    // manifest. Flip an interior data byte (length and trailer intact) so the
+    // streamed digest diverges while the in-memory manifest entry is unchanged.
+    std::fs::write(&marker, b"pending marker")?;
+    let mut bytes = std::fs::read(&sst_path)?;
+    if let Some(b) = bytes.get_mut(64) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst_path, &bytes)?;
+    let err = crate::scrub::abort_checkpoint_if_pending_heals(&tree, "stale-digest case")
+        .expect_err("a pending heal whose digest does not match the manifest must abort");
+    assert!(
+        matches!(err, crate::Error::Io(_)),
+        "the abort is surfaced as an Io error, got {err:?}",
+    );
+    assert!(
+        marker.exists(),
+        "a genuine pending marker is kept for the next reconciliation",
+    );
+    Ok(())
+}
+
+/// A checkpoint must not hold the link window's write half while its flush
+/// blocks on `compaction_state`: with Page ECC that closes a three-way cycle —
+/// a tight-space compaction holds `compaction_state` while waiting for a
+/// table's heal lock, and a heal patrol holds that heal lock while waiting for
+/// the link window's read half. Orchestrates all three parties (the test
+/// thread stands in for the compaction, holding `compaction_state` and then
+/// wanting the heal lock) and asserts every one completes; pre-fix the trio
+/// deadlocks and the test hangs into the harness timeout.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn checkpoint_flush_does_not_deadlock_with_patrol_and_compaction() -> crate::Result<()> {
+    use crate::AbstractTree;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let dir = tempfile::tempdir()?;
+    write_ecc_sst(dir.path());
+    let tree = Arc::new(open_ecc_tree_on(dir.path(), Arc::new(crate::fs::StdFs)));
+
+    // Data in the active memtable, so the checkpoint's flush genuinely
+    // installs a version (an empty flush never reaches `compaction_state`).
+    tree.insert("pending-row", "v", 5_000);
+
+    let table = {
+        let binding = tree.version_history.read().latest_version();
+        binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table")
+            .clone()
+    };
+
+    // Party 1 (this thread, standing in for a mid-install compaction): hold
+    // `compaction_state` for the whole orchestration.
+    let state_guard = tree.compaction_state.lock();
+
+    // Party 2: the checkpoint. Its flush blocks on `compaction_state` (held
+    // above). Pre-fix it blocked there while HOLDING the link window's write
+    // half; the fix flushes before taking the window.
+    let checkpoint = {
+        let tree = Arc::clone(&tree);
+        let dst = dir.path().join("checkpoint");
+        std::thread::spawn(move || tree.create_checkpoint(&dst))
+    };
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Party 3: a heal patrol. It takes the table's heal lock and then enters
+    // the mutation window (the link window's read half) — pre-fix it blocked
+    // there while holding the heal lock.
+    let patrol = {
+        let tree = Arc::clone(&tree);
+        std::thread::spawn(move || {
+            patrol_scrub(&*tree, &PatrolScrubOptions::default().heal_in_place(true))
+        })
+    };
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Party 1 now wants the heal lock, exactly like the tight-space slice loop
+    // does while holding `compaction_state`. Pre-fix: the patrol holds it and
+    // waits for the link window the checkpoint holds while the checkpoint
+    // waits for our `compaction_state` — the cycle hangs all three.
+    drop(table.heal_lock_arc().lock());
+    drop(state_guard);
+
+    let report = patrol.join().expect("patrol thread must not panic");
+    assert!(report.is_ok(), "{report:?}");
+    checkpoint
+        .join()
+        .expect("checkpoint thread must not panic")?;
+    Ok(())
+}
+
+/// A checkpoint taken while a table carries a PENDING heal attestation (healed
+/// bytes on disk, the live version still recording the pre-heal digest, and the
+/// `.heal-attest` sidecar which the checkpoint does NOT copy) must not capture
+/// that stale digest: the immutable checkpoint would fail integrity
+/// verification forever with no marker to reconcile. The checkpoint reconciles
+/// pending heals BEFORE snapshotting, so the captured version is self-consistent
+/// (healed bytes under a refreshed digest).
+#[cfg(feature = "page_ecc")]
+#[test]
+fn checkpoint_reconciles_a_pending_heal_before_snapshotting() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // Heal with a failing edit-log: the blocks are healed and the attestation
+    // is written, but the manifest refresh fails, leaving a PENDING heal.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+    assert!(report.blocks_healed_in_place >= 1, "{report:?}");
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "the failed refresh must leave a pending attestation",
+    );
+
+    // Snapshot while the heal is still pending.
+    let dst = dir.path().join("checkpoint");
+    tree.create_checkpoint(&dst)?;
+
+    // The immutable checkpoint must verify clean: reconciling the pending heal
+    // before the snapshot means the captured digest matches the linked (healed)
+    // bytes (pre-fix it captured the stale pre-heal digest and failed forever).
+    let checkpoint = open_ecc_tree(&dst);
+    let integrity = crate::verify::verify_integrity(&checkpoint);
+    assert!(
+        integrity.is_ok(),
+        "the checkpoint must not capture a table's stale pre-heal digest, got {:?}",
+        integrity.errors,
+    );
+    Ok(())
+}
+
+/// A real-on-disk [`Fs`](crate::fs::Fs) (over `StdFs`) whose `exists` probe
+/// FAILS for any `.heal-attest` sidecar, modelling a stat error on the
+/// attestation probe. Every other operation delegates to `StdFs`.
+mod exists_fail_fs {
+    use crate::fs::{Fs, FsDirEntry, FsFile, FsMetadata, FsOpenOptions, StdFs};
+    use crate::io;
+    use std::path::Path;
+
+    pub(super) struct ExistsFailFs;
+
+    impl Fs for ExistsFailFs {
+        fn open(&self, path: &Path, opts: &FsOpenOptions) -> io::Result<Box<dyn FsFile>> {
+            StdFs.open(path, opts)
+        }
+        fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.create_dir_all(path)
+        }
+        fn read_dir(&self, path: &Path) -> io::Result<Vec<FsDirEntry>> {
+            StdFs.read_dir(path)
+        }
+        fn remove_file(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_file(path)
+        }
+        fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+            StdFs.remove_dir_all(path)
+        }
+        fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+            StdFs.rename(from, to)
+        }
+        fn metadata(&self, path: &Path) -> io::Result<FsMetadata> {
+            StdFs.metadata(path)
+        }
+        fn sync_directory(&self, path: &Path) -> io::Result<()> {
+            StdFs.sync_directory(path)
+        }
+        fn exists(&self, path: &Path) -> io::Result<bool> {
+            if path.to_string_lossy().ends_with(".heal-attest") {
+                return Err(io::Error::other("injected attestation probe failure"));
+            }
+            StdFs.exists(path)
+        }
+        fn backend_id(&self) -> Option<u64> {
+            StdFs.backend_id()
+        }
+        fn volume_id(&self, path: &Path) -> Option<u64> {
+            StdFs.volume_id(path)
+        }
+    }
+}
+
+/// The checkpoint's pending-heal reconciliation probes each ECC table for a
+/// `.heal-attest` sidecar. If that probe FAILS (an I/O error, not a clean
+/// absent), treating it as "no pending heal" would let the checkpoint snapshot
+/// the table's bytes under a possibly-stale digest with no marker to reconcile.
+/// The probe must fail CLOSED: a probe error aborts the reconciliation, which
+/// the checkpoint propagates (aborting the snapshot). Drives
+/// [`reconcile_pending_heals`] directly — the exact step the checkpoint runs
+/// before its link window — so the fault needs only the probe, not the
+/// checkpoint's full filesystem surface.
+#[test]
+fn reconcile_pending_heals_aborts_when_the_attestation_probe_fails() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // A plain ECC table (no corruption needed): the reconcile still probes it
+    // for a pending sidecar, and that probe is what fails here.
+    let _ = write_ecc_sst_footered(dir.path());
+
+    let tree = open_ecc_tree_on(
+        dir.path(),
+        std::sync::Arc::new(exists_fail_fs::ExistsFailFs),
+    );
+
+    let result = crate::scrub::reconcile_pending_heals(&tree);
+    assert!(
+        result.is_err(),
+        "a failed attestation probe must abort the reconciliation, not silently \
+         skip the table (pre-fix the probe error was swallowed as 'no pending heal'): \
+         {result:?}",
+    );
+    Ok(())
+}
+
+/// The attributable heal path (the manifest digest matches the CURRENT pre-heal
+/// bytes) is about to change bytes the manifest still matches, so its
+/// crash-recovery attestation MUST be durable BEFORE the first block is mutated.
+/// If the attestation cannot be persisted, the heal must ABORT (not proceed and
+/// only log), because a crash after a corrected block syncs but before the
+/// manifest refresh would leave healed bytes under the stale digest with no
+/// marker, which fail-closed reconciliation rejects forever, permanently
+/// stranding a table that was reconcilable a moment earlier. Leaving the block
+/// corrupt keeps the table reconcilable; the next patrol retries.
+#[test]
+fn heal_in_place_aborts_when_the_attestation_cannot_be_persisted() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+
+    // Seed the ATTRIBUTABLE reconcile scenario: rot a parity byte, then rebuild
+    // the manifest over the rotted bytes so the manifest digest == the current
+    // (pre-heal) file. `pre_heal_digest_matches` is then true and the heal would
+    // change bytes the manifest currently matches (the only path that writes a
+    // crash-recovery marker).
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+    let before = std::fs::read(&sst_path)?;
+
+    // Fault every open of the attestation sidecar so it can never be persisted.
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+    injector
+        .arm(FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).on_path(".heal-attest"));
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    // The heal aborted: no block was mutated, so the file is byte-for-byte what
+    // it was before the pass (pre-fix the heal proceeds and rewrites the block).
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "the heal must not mutate any block when its attestation cannot be persisted: {report:?}",
+    );
+    let after = std::fs::read(&sst_path)?;
+    assert_eq!(
+        after, before,
+        "the corrupt block must stay untouched so the table stays reconcilable",
+    );
+    // The skipped heal is surfaced as a finding, not silently swallowed.
+    assert!(
+        !report.is_ok(),
+        "aborting the heal must surface a finding: {report:?}",
+    );
+    // A failed attestation write must not leave a partial marker behind.
+    assert!(
+        !heal_attest_path(&sst_path).exists(),
+        "no partial attestation marker after a failed write",
+    );
+    Ok(())
+}
+
+/// The checkpoint's pre-window reconciliation only scans ECC tables, so a
+/// pending `.heal-attest` marker it cannot consume (here: one on a non-ECC
+/// table) whose digest is STALE — healed bytes not yet reconciled — must still
+/// be caught by the post-link-window fail-closed guard rather than snapshot the
+/// table under that stale digest with no marker. Models the residual race where
+/// a genuine pending heal survives the pre-window reconcile. (A marker whose
+/// digest already matches the manifest is obsolete and does NOT abort; see
+/// [`abort_checkpoint_ignores_an_obsolete_marker_but_aborts_on_a_stale_digest`].)
+#[test]
+fn checkpoint_aborts_when_a_pending_marker_survives_the_pre_window_reconcile() -> crate::Result<()>
+{
+    use crate::AbstractTree;
+
+    let dir = tempfile::tempdir()?;
+    // A plain (non-ECC) tree: the pre-window reconcile scans only ECC tables,
+    // so a marker planted here survives to the post-link-window guard.
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()?
+    else {
+        unreachable!("standard tree configured");
+    };
+    for i in 0u64..4 {
+        tree.insert(format!("key-{i:03}"), format!("v{i:03}"), i);
+    }
+    tree.flush_active_memtable(4)?;
+    let sst_path = {
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (*table.path).clone()
+    };
+
+    // Make the on-disk digest diverge from the manifest so the surviving marker
+    // models a GENUINE pending heal (healed bytes the reconcile has not caught
+    // up to), the case the post-window guard must abort on. Flip an interior
+    // byte (length and trailer intact); the manifest still records the pre-flip
+    // digest.
+    let mut bytes = std::fs::read(&sst_path)?;
+    if let Some(b) = bytes.get_mut(50) {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&sst_path, &bytes)?;
+    // Plant a pending marker the ECC-only pre-window reconcile will not consume.
+    std::fs::write(heal_attest_path(&sst_path), b"pending marker")?;
+
+    let dst = dir.path().join("checkpoint");
+    let result = tree.create_checkpoint(&dst);
+    assert!(
+        result.is_err(),
+        "a pending marker with a stale digest the pre-window reconcile cannot consume must \
+         abort the checkpoint at the post-link-window guard: {result:?}",
+    );
+    Ok(())
+}
+
+/// The pre-heal digest probe (`live_region_checksum`, a SEQUENTIAL full-file
+/// read) can fail transiently. Converting that I/O error into an ordinary
+/// "digest does not match the manifest" would let the heal proceed writing
+/// corrections with NO completed attestation: if the manifest legitimately
+/// describes the degraded pre-heal bytes (a rebuild over a correctable fault),
+/// the healed digest then differs from the manifest and reconciliation rejects
+/// it forever with no marker. The probe failure must ABORT the heal before the
+/// first write, exactly like a digest-prediction / attestation-persistence
+/// failure. Faults only the sequential `Read` (the digest probe); block loads
+/// use `read_at`, so the correctable fault is still discovered.
+#[test]
+fn heal_in_place_aborts_when_the_pre_heal_digest_probe_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst_footered(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+    let before = std::fs::read(&sst_path)?;
+
+    // Fail the sequential digest read only (block loads use read_at).
+    let fault = FaultFs::new(crate::fs::StdFs);
+    let injector = fault.injector();
+    let tree = open_ecc_tree_on(dir.path(), std::sync::Arc::new(fault));
+    injector.arm(FaultRule::new(FaultOp::Read, Fault::Error(ErrorKind::Other)).on_path("tables"));
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a failed pre-heal digest probe must abort before any block is mutated: {report:?}",
+    );
+    let after = std::fs::read(&sst_path)?;
+    assert_eq!(
+        after, before,
+        "the corrupt block must stay untouched so the table stays reconcilable",
+    );
+    assert!(
+        !report.is_ok(),
+        "aborting the heal must surface a finding: {report:?}",
+    );
+    Ok(())
+}
+
+/// An in-place heal that changes the SST's bytes must REFRESH the manifest's
+/// full-file checksum. The heal itself restores the block's original bytes
+/// (whose digest usually matches the manifest), but a table admitted by a
+/// MANIFEST REBUILD while its parity was already rotted carries the digest of
+/// the ROTTED bytes — a later heal then restores the original parity and
+/// `verify_integrity` flags the freshly healed table as corrupt against the
+/// stale digest, durably, on every scan.
+#[test]
+fn heal_in_place_refreshes_the_manifest_checksum() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte, then let a manifest rebuild admit the
+    // table with the digest of the ROTTED bytes (parity-only rot grades
+    // degraded-but-readable, so the rebuild keeps the file as-is).
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // Heal the trailer in place: the file's bytes return to their ORIGINAL
+    // state, which no longer matches the rotted digest the rebuilt manifest
+    // recorded.
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+
+    // Without a manifest-checksum refresh, every later integrity scan flags
+    // the freshly healed (fully verifiable) table as corrupt.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        integrity.is_ok(),
+        "a healed table must verify clean against a refreshed manifest \
+         checksum, got {:?}",
+        integrity.errors,
+    );
+
+    // The refreshed checksum survives a reopen (persisted, not just patched
+    // in memory).
+    drop(tree);
+    let tree = open_ecc_tree(dir.path());
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        integrity.is_ok(),
+        "the refreshed checksum is durable across reopen, got {:?}",
+        integrity.errors,
+    );
+    Ok(())
+}
+
+/// A reconciliation whose captured Table VIEW predates another patrol's
+/// successful digest refresh must treat the already-reconciled file as
+/// clean: the view's checksum snapshot is stale, but the CURRENT manifest
+/// entry and the file agree, so there is nothing left to reconcile. Two
+/// concurrent heal patrols hit exactly this interleaving — both capture
+/// the same version before the per-table heal lock serializes them — and
+/// on a footer-less table the loser has no attributable correction, so
+/// the stale comparison surfaced as a spurious `ChecksumRefreshFailed`
+/// on a healthy, already-reconciled table.
+#[test]
+fn checksum_refresh_is_idempotent_against_a_stale_table_view() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // Footer-less on purpose: without heal attribution the fail-closed
+    // authoritative-content rule turns the stale mismatch into a finding.
+    let (sst_path, block) = write_ecc_sst(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let tree = open_ecc_tree(dir.path());
+    // Capture the table view BEFORE the heal, like a concurrently started
+    // second patrol would.
+    let stale_view = {
+        let binding = tree.version_history.read().latest_version();
+        binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("one table")
+            .clone()
+    };
+
+    // First patrol: heals the trailer in place and installs the refreshed
+    // digest into the manifest.
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+    assert!(report.is_ok(), "the first patrol reconciles: {report:?}");
+
+    // Second patrol's reconcile step, still holding the pre-heal view: the
+    // current manifest and the file already agree, so it must be a no-op.
+    let finding = refresh_healed_checksum(&tree, &stale_view, false);
+    assert!(
+        finding.is_none(),
+        "an already-reconciled file must not be reported: {finding:?}",
+    );
+    Ok(())
+}
+
+/// A PINNED file descriptor (a tree opened without an FD cache) cannot be
+/// retargeted at the private copy the hard-link unshare produces: after
+/// the copy + rename this Table would keep reading the DEAD inode forever
+/// — reads, scrub probes, and digest checks all resolve through the
+/// pinned handle while the manifest and live path refer to the healed
+/// copy. The heal must REFUSE the detach instead: the blocked write-backs
+/// surface as findings and every checkpoint link stays byte-identical to
+/// what its manifest describes.
+#[test]
+fn heal_in_place_refuses_to_detach_under_a_pinned_descriptor() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // A second hard link stands in for a checkpoint's snapshot.
+    let link = dir.path().join("checkpoint-link");
+    std::fs::hard_link(&sst_path, &link)?;
+
+    // No descriptor table: every Table pins one FD at recover time.
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .use_descriptor_table(None)
+    .open()
+    .expect("open pinned ecc tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    // The refused detach specifically: an UncorrectableBlock finding whose
+    // reason names the unshare refusal, not any unrelated failure.
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            ScrubError::UncorrectableBlock { reason, .. }
+                if reason.starts_with("unshare hard-linked SST for heal: ")
+        )),
+        "a refused detach must surface as an unshare finding: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "no block may be healed when the detach is refused: {report:?}",
+    );
+    assert_eq!(
+        std::fs::read(&sst_path)?,
+        std::fs::read(&link)?,
+        "the live path must stay byte-identical to its checkpoint link (no detach)",
+    );
+    Ok(())
+}
+
+/// The pre-write ATTRIBUTION probe must compare against the CURRENT
+/// manifest digest, not the caller's captured view: a reconciliation
+/// running with a view captured before the manifest was re-recorded
+/// (here: a manifest rebuilt over freshly rotted bytes after an earlier
+/// heal already refreshed it) sees a stale checksum, marks a legitimate
+/// heal unattributable, and the fail-closed rule then refuses to refresh
+/// a footer-less table forever — even though the file's pre-write digest
+/// matched the manifest exactly.
+#[test]
+fn heal_attribution_compares_against_the_current_manifest_digest() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    // Footer-less: without attribution the fail-closed rule turns the
+    // refusal into a permanent ChecksumRefreshFailed.
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Heal cycle one: rot, record the rotted digest, heal + refresh.
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+    let stale_view = {
+        let tree = open_ecc_tree(dir.path());
+        let stale = {
+            let binding = tree.version_history.read().latest_version();
+            binding
+                .version
+                .iter_tables()
+                .next()
+                .expect("one table")
+                .clone()
+        };
+        let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+        assert!(report.is_ok(), "the first heal reconciles: {report:?}");
+        stale
+    };
+
+    // Rot a SECOND fault — in a DIFFERENT block, so the rotted digest
+    // differs from the first cycle's — and re-record the manifest over the
+    // rotted bytes: the CURRENT manifest matches the file while the
+    // captured view still carries the digest recorded before the first
+    // heal.
+    let second_block = {
+        let keyed = stale_view
+            .block_index
+            .iter()
+            .nth(1)
+            .expect("the fixture writes several data blocks")
+            .expect("block index entry decodes");
+        crate::table::BlockHandle::new(keyed.offset(), keyed.size())
+    };
+    corrupt_parity_trailer_byte(&sst_path, &second_block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    let tree = open_ecc_tree(dir.path());
+    let report = scan_and_reconcile(
+        &tree,
+        &stale_view,
+        &PatrolScrubOptions::default().heal_in_place(true),
+    );
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the second fault is rebuilt in place: {report:?}",
+    );
+    assert!(
+        report.is_ok(),
+        "a heal whose pre-write digest matches the CURRENT manifest is \
+         attributable and must reconcile: {report:?}",
+    );
+    Ok(())
+}
+
+/// A manifest-digest refresh that FAILS after an in-place heal must surface in
+/// the scrub report, not vanish into a log line: the heal already rewrote the
+/// SST's bytes, so with the refresh lost a manifest that carried a stale
+/// (pre-heal) digest keeps flagging the healed file as corrupt on every later
+/// `verify_integrity` — while the patrol report claims a clean heal.
+#[test]
+fn heal_in_place_reports_a_failed_checksum_refresh() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, block) = write_ecc_sst(dir.path());
+
+    // Rot one parity-trailer byte, then let a manifest rebuild record the
+    // digest of the ROTTED bytes, so the heal's reconciliation actually has
+    // a mismatch to persist (against a manifest that already holds the
+    // correct digest the reconciliation is a no-op and never touches the
+    // edit log).
+    corrupt_parity_trailer_byte(&sst_path, &block)?;
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // Fail the manifest edit-log open the refresh performs; the heal itself
+    // touches only the SST under tables/.
+    let (tree, injector) = open_ecc_tree_with_failing_edit_log(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    injector.clear();
+
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a failed manifest-digest refresh must be a scrub finding, not a \
+         swallowed log line: {report:?}",
+    );
+    // The public status must fail too: a caller following `is_ok()` would
+    // otherwise treat the scrub as clean while the manifest keeps a stale
+    // digest that flags the healed SST on every later integrity scan.
+    assert!(
+        !report.is_ok(),
+        "a scrub whose findings include a failed checksum refresh is not ok",
+    );
+    Ok(())
+}
+
+/// A heal pass that fixes one block while ANOTHER block in the same SST stays
+/// uncorrectable must NOT refresh the manifest's full-file checksum: the
+/// refreshed digest would be computed over the current bytes — including the
+/// still-corrupt block — so a later `verify_integrity` would pass on an SST
+/// with known, unrepaired corruption. The digest may only be restamped once
+/// the file is fully healed.
+#[test]
+fn heal_in_place_skips_the_checksum_refresh_while_corruption_remains() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let (sst_path, first) = write_ecc_sst(dir.path());
+
+    // The SECOND data block, to wreck beyond the RS budget.
+    let second = {
+        let tree = open_ecc_tree(dir.path());
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("one table recovered");
+        let mut it = table.block_index.iter();
+        let _ = it.next().expect("first block").expect("decodes");
+        let keyed = it.next().expect("second block").expect("decodes");
+        crate::table::BlockHandle::new(keyed.offset(), keyed.size())
+    };
+
+    // Block 1: rot one parity-trailer byte (heal-in-place rebuilds it).
+    corrupt_parity_trailer_byte(&sst_path, &first)?;
+
+    // Block 2: wreck the whole payload+parity (uncorrectable, left for salvage).
+    let mut bytes = std::fs::read(&sst_path)?;
+    let payload_start = second.offset().0 as usize + Header::MIN_LEN;
+    let payload_end = second.offset().0 as usize + second.size() as usize;
+    for slot in bytes
+        .get_mut(payload_start..payload_end)
+        .expect("second block payload range in bounds")
+    {
+        *slot ^= 0xFF;
+    }
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Manifest rebuild records the digest of the CORRUPT bytes.
+    rebuild_manifest_over_current_bytes(dir.path())?;
+
+    // Heal pass: block 1's trailer is rebuilt, block 2 stays uncorrectable.
+    let tree = open_ecc_tree(dir.path());
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report.blocks_healed_in_place >= 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "the wrecked block is reported uncorrectable: {report:?}",
+    );
+
+    // The digest must NOT have been restamped over the still-corrupt bytes:
+    // the file no longer matches ANY trustworthy digest, and the integrity
+    // scan must keep flagging it until the corruption is actually repaired.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "an SST with a known uncorrectable block must keep failing \
+         verify_integrity — restamping its manifest checksum would mask the \
+         corruption",
+    );
+    Ok(())
+}
+
+/// A clean encrypted, columnar, Page-ECC SST heals in place with no findings.
+/// Its data blocks are sealed as
+/// [`BlockType::Columnar`](crate::table::block::BlockType::Columnar) and
+/// encrypted through the AAD block path; the heal read must decrypt, decompress,
+/// and verify them without reporting a healthy block as uncorrectable. (The AAD
+/// block-type byte is reconstructed from the on-disk frame, not the caller's
+/// block-type argument, so the heal read decrypts correctly regardless of the
+/// argument — this guards that the whole encrypted-columnar heal path stays
+/// clean.)
+#[cfg(all(feature = "columnar", feature = "encryption", zstd_any))]
+#[test]
+fn heal_in_place_leaves_a_clean_encrypted_columnar_sst_with_no_findings() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let enc: std::sync::Arc<dyn crate::encryption::EncryptionProvider> =
+        std::sync::Arc::new(crate::Aes256GcmProvider::new(&[0x51; 32]));
+    let crate::AnyTree::Standard(tree) = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .with_encryption(Some(enc))
+    .open()
+    .expect("open encrypted ecc tree") else {
+        unreachable!("standard tree configured (no kv separation)");
+    };
+    // Columnar layout: the flush transposes the memtable into
+    // `BlockType::Columnar` data blocks (encrypted through the tree's provider).
+    tree.update_runtime_config(|cfg| cfg.columnar = true)?;
+
+    for i in 0u64..2_000 {
+        tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+    }
+    tree.flush_active_memtable(2_000).expect("flush");
+
+    // Precondition: the flush produced an encrypted columnar SST (columnar
+    // layout + ECC parity + an encryption provider), so the heal read exercises
+    // the AAD block path over `BlockType::Columnar` blocks.
+    {
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        assert!(table.metadata.columnar, "the SST is columnar");
+        assert!(table.metadata.ecc_params.is_some(), "the SST carries ECC");
+        assert!(table.encryption.is_some(), "the SST is encrypted");
+    }
+
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+
+    assert!(
+        report.blocks_scanned >= 1,
+        "the columnar SST has at least one data block to scrub: {report:?}",
+    );
+    assert_eq!(
+        report.uncorrectable_blocks, 0,
+        "a clean encrypted columnar block must decrypt and verify cleanly, \
+         not be reported uncorrectable: {report:?}",
+    );
+    assert!(
+        report.is_ok(),
+        "a clean encrypted columnar SST heals with no findings: {report:?}",
+    );
+    Ok(())
+}
+
+/// A `{id}.heal-attest` sidecar left in `tables/` by a crashed heal refresh
+/// must NOT break the next `Tree::open`: the table-folder scan skips it (it is
+/// never a table file) instead of parsing its name as a `TableId` and returning
+/// `Unrecoverable`. Deleting it here would forfeit the crashed-refresh recovery,
+/// so the scan leaves it for the next scrub to consume.
+#[test]
+fn tree_open_skips_a_lingering_heal_attestation() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = {
+        let crate::AnyTree::Standard(tree) = crate::Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?
+        else {
+            unreachable!("standard tree configured");
+        };
+        for i in 0u64..50 {
+            tree.insert(format!("k{i:04}"), b"v", i);
+        }
+        tree.flush_active_memtable(50)?;
+        let binding = tree.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+
+    // A crashed refresh leaves this sidecar next to the SST.
+    std::fs::write(heal_attest_path(&sst_path), b"pending attestation")?;
+
+    // Reopen: the sidecar must be skipped, not parsed as a table id.
+    let reopened = crate::Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open();
+    assert!(
+        reopened.is_ok(),
+        "a lingering heal-attest sidecar must not break open: {:?}",
+        reopened.err(),
+    );
+    assert!(
+        heal_attest_path(&sst_path).exists(),
+        "open must leave the pending attestation for the next scrub to consume",
+    );
     Ok(())
 }

--- a/src/scrub/heal_attest.rs
+++ b/src/scrub/heal_attest.rs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026-present, Structured World Foundation
+
+//! Sidecar heal-attestation lockfile.
+//!
+//! An in-place ECC heal writes and syncs corrected bytes, then
+//! [`refresh_healed_checksum`](super::refresh_healed_checksum) reconciles the
+//! manifest digest. If the process crashes (or the refresh fails) BETWEEN the
+//! block write-back and the manifest update, the next scrub reads a CLEAN file:
+//! nothing is written that pass, so the heal is not attributable, and the
+//! fail-closed digest gate would reject the stale manifest digest FOREVER —
+//! `verify` / repair keep reporting the healed table as corrupt until a full
+//! rewrite installs a legitimate digest.
+//!
+//! This sidecar bridges that window. Before the reconciliation, the heal writes
+//! `(table_id, pre_heal_digest, post_heal_digest)` next to the SST and syncs it;
+//! after a successful refresh it is removed. A later scrub trusts it ONLY when
+//! the file now hashes to `post_heal_digest` AND the manifest still holds
+//! `pre_heal_digest` — i.e. the file is exactly the recorded healed version and
+//! nothing else moved the manifest since.
+//!
+//! # Threat model
+//!
+//! For an ENCRYPTED table the payload is AEAD-sealed with the table's provider,
+//! so an offline attacker without the key cannot forge an attestation that
+//! `decrypt` accepts — the security boundary the digest gate defends stays
+//! intact. For an UNENCRYPTED table the sidecar is plaintext: forging it needs
+//! the same directory write access that could re-stamp the SST (or the manifest)
+//! directly, which is outside the on-disk-tamper model, so the plaintext form is
+//! sufficient there.
+
+use crate::Checksum;
+use crate::encryption::EncryptionProvider;
+use crate::fs::{Fs, FsOpenOptions};
+use alloc::vec::Vec;
+use std::path::{Path, PathBuf};
+
+/// A COMPLETED attestation: the heal finished and its exact `(pre, post)`
+/// digests are recorded, so a reconcile only trusts the file that hashes to
+/// `post`.
+const KIND_COMPLETED: u8 = 0;
+/// An IN-PROGRESS marker: a legacy pre-only kind that bound only `pre ==
+/// manifest`, not the healed bytes. The heal now records a completed marker with
+/// the deterministic post-heal digest UP FRONT instead, so this kind is never
+/// written in production; [`attests`] rejects it (it is not [`KIND_COMPLETED`]),
+/// which is what stops a bare pre-only marker from authorizing an unrelated
+/// forge. Retained only so the tests can forge one and prove it is ignored.
+#[cfg(test)]
+const KIND_IN_PROGRESS: u8 = 1;
+
+/// Serialized payload length: `kind` (u8) + `table_id` (u64) + pre digest (u128)
+/// + post digest (u128).
+const ATTEST_LEN: usize = 1 + 8 + 16 + 16;
+
+/// The attestation sits next to the SST with a `.heal-attest` suffix APPENDED
+/// (not a replaced extension), so it never collides with the SST's own name.
+fn attest_path(table_path: &Path) -> PathBuf {
+    let mut name = table_path.as_os_str().to_os_string();
+    name.push(".heal-attest");
+    PathBuf::from(name)
+}
+
+/// The staging path the sidecar is written + synced to before an atomic rename
+/// onto [`attest_path`]. A crash between the temp write and the rename leaves
+/// this behind; tree recovery sweeps `{id}.heal-attest.tmp` (it is disposable:
+/// either the live sidecar it would have replaced still bridges the crash
+/// window, or the heal is simply re-run).
+fn attest_tmp_path(table_path: &Path) -> PathBuf {
+    let mut name = attest_path(table_path).into_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
+fn serialize(kind: u8, table_id: u64, pre: u128, post: u128) -> Vec<u8> {
+    let mut out = Vec::with_capacity(ATTEST_LEN);
+    out.push(kind);
+    out.extend_from_slice(&table_id.to_le_bytes());
+    out.extend_from_slice(&pre.to_le_bytes());
+    out.extend_from_slice(&post.to_le_bytes());
+    out
+}
+
+fn deserialize(plain: &[u8]) -> Option<(u8, u64, u128, u128)> {
+    let kind = *plain.first()?;
+    let id = u64::from_le_bytes(plain.get(1..9)?.try_into().ok()?);
+    let pre = u128::from_le_bytes(plain.get(9..25)?.try_into().ok()?);
+    let post = u128::from_le_bytes(plain.get(25..41)?.try_into().ok()?);
+    Some((kind, id, pre, post))
+}
+
+/// Seals `plain` (AEAD for a keyed table, else plaintext) and publishes it as
+/// the sidecar next to `table_path` through a synced temp + atomic rename.
+///
+/// The temp is written, flushed, and fsynced in full, THEN atomically renamed
+/// onto the live sidecar path. A mid-write or sync failure therefore leaves the
+/// partial bytes in the temp (removed best-effort) and never touches the live
+/// sidecar: an already-durable in-progress marker survives a failed completed
+/// write, instead of being truncated in place and destroyed, which would leave
+/// a healed SST with a stale manifest digest and no valid attestation, forever
+/// unreconcilable.
+///
+/// The temp is ALWAYS fully synced with `sync_all`, regardless of
+/// [`Config::sync_mode`](crate::Config): the attestation is a crash-recovery
+/// anchor (recovery reconciles a healed table's digest through it), so it must be
+/// durable before the rename even when the tree runs at a relaxed sync mode.
+fn write_sidecar(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    plain: &[u8],
+) -> crate::Result<()> {
+    let content = match encryption {
+        Some(enc) => enc.encrypt(plain)?,
+        None => plain.to_vec(),
+    };
+    let path = attest_path(table_path);
+    let tmp = attest_tmp_path(table_path);
+    let publish = (|| -> crate::Result<()> {
+        let mut file = fs.open(
+            &tmp,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        file.write_all(&content)?;
+        file.flush()?;
+        file.sync_all()?;
+        drop(file);
+        // Atomic replace: the live sidecar is either the old marker or the fully
+        // written new one, never a truncated in-between.
+        fs.rename(&tmp, &path)?;
+        if let Some(parent) = path.parent() {
+            fs.sync_directory(parent)?;
+        }
+        Ok(())
+    })();
+    if publish.is_err() {
+        // The rename did not land, so the live sidecar is untouched; drop the
+        // partial temp (a crash that skips this is swept by tree recovery).
+        let _ = fs.remove_file(&tmp);
+    }
+    publish
+}
+
+/// Outcome of reading the sidecar. Distinguishes a CONCLUSIVELY absent sidecar
+/// from one that could not be read: a caller deciding whether to DELETE the
+/// marker must not treat an unreadable / undecryptable / malformed sidecar as
+/// "absent", because that could be a transiently-unreadable VALID marker whose
+/// deletion would strand a healed table under a stale digest forever.
+enum SidecarRead {
+    /// Decoded `(kind, id, pre, post)`.
+    Present(u8, u64, u128, u128),
+    /// Conclusively absent (the file does not exist).
+    Missing,
+    /// Present but not conclusively readable (an open error other than
+    /// not-found, a read error, an AEAD rejection, or a malformed payload).
+    /// Retryable.
+    Inconclusive,
+}
+
+/// Reads and opens the sidecar. See [`SidecarRead`] for the missing-vs-
+/// inconclusive distinction the removal decision relies on.
+fn read_sidecar(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+) -> SidecarRead {
+    let path = attest_path(table_path);
+    let mut file = match fs.open(&path, &FsOpenOptions::new().read(true)) {
+        Ok(file) => file,
+        Err(e) if e.kind() == crate::io::ErrorKind::NotFound => return SidecarRead::Missing,
+        Err(_) => return SidecarRead::Inconclusive,
+    };
+    // Bound the read: a valid sidecar is exactly `ATTEST_LEN` bytes (plaintext)
+    // or `ATTEST_LEN + max AEAD overhead` (encrypted). Reject anything larger
+    // BEFORE reading it, so a corrupt / attacker-replaced sidecar cannot force an
+    // allocation of its full (attacker-controlled) length, and a valid record
+    // padded with a long garbage tail cannot be laundered past `deserialize`.
+    let max_len =
+        ATTEST_LEN as u64 + u64::from(encryption.map_or(0, EncryptionProvider::max_overhead));
+    match file.metadata() {
+        Ok(meta) if meta.len > max_len => return SidecarRead::Inconclusive,
+        Ok(_) => {}
+        Err(_) => return SidecarRead::Inconclusive,
+    }
+    let mut content = Vec::new();
+    // Cap the reader at the same bound as the metadata probe, so the allocation
+    // limit holds even if the file grew after the probe (a concurrent writer, or a
+    // backend whose metadata disagrees with its data). Reading `max_len + 1` bytes
+    // lets an over-long payload surface as Inconclusive below.
+    if std::io::Read::read_to_end(
+        &mut std::io::Read::take(&mut file, max_len.saturating_add(1)),
+        &mut content,
+    )
+    .is_err()
+    {
+        return SidecarRead::Inconclusive;
+    }
+    if content.len() as u64 > max_len {
+        return SidecarRead::Inconclusive;
+    }
+    let plain = match encryption {
+        // A tampered or wrong-key sidecar fails the AEAD open: inconclusive, not
+        // absent, so never delete a marker on this basis.
+        Some(enc) => match enc.decrypt(&content) {
+            Ok(plain) => plain,
+            Err(_) => return SidecarRead::Inconclusive,
+        },
+        None => content,
+    };
+    match deserialize(&plain) {
+        Some((kind, id, pre, post)) => SidecarRead::Present(kind, id, pre, post),
+        None => SidecarRead::Inconclusive,
+    }
+}
+
+/// Whether an attestation attests the current bytes, is absent, or could not be
+/// read. See [`attests`].
+pub enum AttestResult {
+    /// A completed marker binds exactly `(pre == manifest, post == current)`
+    /// for this table: the stale manifest digest is safe to reconcile.
+    Attests,
+    /// No attesting marker: conclusively missing, or present but binding
+    /// different values / a non-completed kind. Safe to clear.
+    Absent,
+    /// The sidecar could not be read conclusively. Retryable: the caller must
+    /// NOT delete the marker on this basis (it may be a valid marker).
+    Inconclusive,
+}
+
+/// Forges a legacy IN-PROGRESS marker (pre-only). Test-only: production never
+/// writes this kind — the heal records a completed marker with the post-heal
+/// digest up front. The tests use it to prove [`attests`] ignores a bare
+/// pre-only marker, so it can never authorize an unrelated forge.
+///
+/// # Errors
+///
+/// Propagates the AEAD seal error and any write / sync I/O error.
+#[cfg(test)]
+pub fn write_in_progress(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    pre: Checksum,
+) -> crate::Result<()> {
+    let plain = serialize(KIND_IN_PROGRESS, table_id, pre.into_u128(), 0);
+    write_sidecar(fs, table_path, encryption, &plain)
+}
+
+/// Whether a marker is a legacy IN-PROGRESS (pre-only) attestation. Test-only:
+/// production attribution consults [`attests`] alone, which requires
+/// [`KIND_COMPLETED`], so a pre-only marker is never trusted.
+#[cfg(test)]
+pub(super) fn attests_in_progress(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    manifest: Checksum,
+) -> bool {
+    match read_sidecar(fs, table_path, encryption) {
+        SidecarRead::Present(kind, id, pre, _post) => {
+            kind == KIND_IN_PROGRESS && id == table_id && pre == manifest.into_u128()
+        }
+        SidecarRead::Missing | SidecarRead::Inconclusive => false,
+    }
+}
+
+/// Writes and syncs a heal attestation next to `table_path`.
+///
+/// # Errors
+///
+/// Propagates the AEAD seal error (encrypted tables) and any I/O error from the
+/// write / sync. The caller must FAIL CLOSED on such an error: the heal /
+/// reconciliation must not proceed, `refresh_healed_checksum` returns
+/// `ScrubError::ChecksumRefreshFailed` without updating the manifest digest, and
+/// the `.heal-attest` sidecar is left in place for the next scrub to retry. A
+/// silently-dropped attestation would let a crash mid-refresh strand a stale
+/// digest with no marker to reconcile it.
+pub fn write(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    pre: Checksum,
+    post: Checksum,
+) -> crate::Result<()> {
+    let plain = serialize(KIND_COMPLETED, table_id, pre.into_u128(), post.into_u128());
+    write_sidecar(fs, table_path, encryption, &plain)
+}
+
+/// Whether a valid attestation proves the CURRENT file (hashing to `current`)
+/// is the healed version recorded against the manifest's `manifest` digest.
+///
+/// [`AttestResult::Attests`] means the stale manifest digest is safe to
+/// reconcile to `current`. [`AttestResult::Absent`] means no marker attests
+/// these values (conclusively missing, wrong id, wrong digests, or a
+/// non-completed kind), safe to clear. [`AttestResult::Inconclusive`] means
+/// the sidecar could not be read (I/O / AEAD / malformed): the caller must keep
+/// the marker, since it may be a transiently-unreadable valid one.
+pub(super) fn attests(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    current: Checksum,
+    manifest: Checksum,
+) -> AttestResult {
+    match read_sidecar(fs, table_path, encryption) {
+        SidecarRead::Present(kind, id, pre, post) => {
+            if kind == KIND_COMPLETED
+                && id == table_id
+                && post == current.into_u128()
+                && pre == manifest.into_u128()
+            {
+                AttestResult::Attests
+            } else {
+                AttestResult::Absent
+            }
+        }
+        SidecarRead::Missing => AttestResult::Absent,
+        SidecarRead::Inconclusive => AttestResult::Inconclusive,
+    }
+}
+
+/// Whether a COMPLETED marker beside `table_path` already attests `post` as the
+/// healed digest for `table_id` (regardless of its recorded `pre`). Lets the
+/// heal path recognize that re-healing a not-matched file back to an
+/// already-attested `post` is safe — the existing marker still reconciles it —
+/// so such a heal need not be skipped as "diverging".
+///
+/// Tri-state so a TRANSIENT sidecar read (`Inconclusive`) is never collapsed to
+/// "does not attest": a caller that skipped the heal on that basis would leave
+/// the file diverged from the marker's `post`, and the reconcile that follows
+/// would reread the now-readable marker, find it no longer matches the current
+/// bytes, and delete it — stranding the table with neither attribution nor
+/// marker. On `Inconclusive` the caller must preserve the marker and retry.
+pub fn attests_post(
+    fs: &dyn Fs,
+    table_path: &Path,
+    encryption: Option<&dyn EncryptionProvider>,
+    table_id: u64,
+    post: Checksum,
+) -> AttestResult {
+    match read_sidecar(fs, table_path, encryption) {
+        SidecarRead::Present(kind, id, _pre, marker_post)
+            if kind == KIND_COMPLETED && id == table_id && marker_post == post.into_u128() =>
+        {
+            AttestResult::Attests
+        }
+        SidecarRead::Present(..) | SidecarRead::Missing => AttestResult::Absent,
+        SidecarRead::Inconclusive => AttestResult::Inconclusive,
+    }
+}
+
+/// Removes the attestation (best-effort), syncing the parent so the removal is
+/// durable — an un-synced unlink can resurrect the sidecar after a power loss,
+/// where it would otherwise linger in `tables/` across opens. Called both when a
+/// reconciliation it authorized has installed a legitimate digest AND when a
+/// marker must be invalidated (a heal that touched no block, or a refused
+/// reconciliation), so a stale marker never authorizes an unrelated later
+/// mismatch.
+pub fn remove(fs: &dyn Fs, table_path: &Path) {
+    let path = attest_path(table_path);
+    if fs.remove_file(&path).is_ok()
+        && let Some(parent) = path.parent()
+    {
+        let _ = fs.sync_directory(parent);
+    }
+}
+
+/// Whether a pending attestation sidecar exists for `table_path`. A probe
+/// FAILURE propagates as an error (fail-closed): a caller that reconciles
+/// pending heals before a checkpoint must abort rather than mistake an
+/// unreadable probe for "no pending heal" and snapshot a stale digest.
+///
+/// # Errors
+///
+/// Propagates the underlying [`Fs::exists`] error.
+pub fn exists(fs: &dyn Fs, table_path: &Path) -> crate::io::Result<bool> {
+    fs.exists(&attest_path(table_path))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/scrub/heal_attest/tests.rs
+++ b/src/scrub/heal_attest/tests.rs
@@ -1,0 +1,349 @@
+#![expect(clippy::unwrap_used, reason = "test asserts on known-present values")]
+
+use super::{AttestResult, attest_path, attests, attests_post, remove, write, write_in_progress};
+use crate::Checksum;
+use crate::fs::{Fs, StdFs};
+use std::sync::Arc;
+
+fn ck(v: u128) -> Checksum {
+    Checksum::from_raw(v)
+}
+
+#[test]
+fn attests_roundtrips_a_plaintext_attestation() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    // Trusted only when file digest == post, manifest == pre, and the id matches.
+    assert!(
+        matches!(
+            attests(&*fs, &path, None, 7, ck(200), ck(100)),
+            AttestResult::Attests
+        ),
+        "a matching attestation is trusted",
+    );
+}
+
+#[test]
+fn attests_rejects_a_mismatched_digest_or_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    // A present-but-mismatched marker is conclusively non-attesting (Absent),
+    // not inconclusive: the sidecar read cleanly, its values just do not match.
+    // Wrong current (file) digest: the file is not the attested healed version.
+    assert!(matches!(
+        attests(&*fs, &path, None, 7, ck(999), ck(100)),
+        AttestResult::Absent
+    ));
+    // Wrong manifest digest: something else moved the manifest since the heal.
+    assert!(matches!(
+        attests(&*fs, &path, None, 7, ck(200), ck(999)),
+        AttestResult::Absent
+    ));
+    // Wrong table id.
+    assert!(matches!(
+        attests(&*fs, &path, None, 8, ck(200), ck(100)),
+        AttestResult::Absent
+    ));
+}
+
+#[test]
+fn attests_returns_absent_without_a_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A conclusively absent sidecar (no file) is Absent, safe to clear.
+    assert!(matches!(
+        attests(&*fs, &path, None, 7, ck(200), ck(100)),
+        AttestResult::Absent
+    ));
+}
+
+#[test]
+fn attests_rejects_a_truncated_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    // Drop a trailing byte so the plaintext payload is shorter than the fixed
+    // 40-byte record: `deserialize`'s `get(..)?` bound must reject it (the
+    // encrypted tamper test never reaches this path — AEAD fails first).
+    let ap = attest_path(&path);
+    let bytes = std::fs::read(&ap).unwrap();
+    let Some(short) = bytes.get(..bytes.len() - 1) else {
+        panic!("the written sidecar is non-empty");
+    };
+    std::fs::write(&ap, short).unwrap();
+    // A malformed (truncated) sidecar is INCONCLUSIVE, not Absent: it does not
+    // attest (so the digest is not reconciled), but it must not be treated as a
+    // clean absence that would license deleting a possibly-recoverable marker.
+    assert!(
+        matches!(
+            attests(&*fs, &path, None, 7, ck(200), ck(100)),
+            AttestResult::Inconclusive
+        ),
+        "a short attestation is inconclusive, not attesting",
+    );
+}
+
+#[test]
+fn attests_rejects_an_oversized_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A valid completed marker followed by a large garbage tail. This is
+    // FAIL-FIRST for the pre-read bound: `deserialize` reads its fields with
+    // `get(1..9)` / `get(9..25)` / `get(25..41)`, which accept ANY buffer of at
+    // least the record length and ignore trailing bytes, so without the bound
+    // `read_sidecar` slurps the whole (attacker-controlled) tail, `deserialize`
+    // accepts the leading record, and the padded file is trusted as a marker.
+    // The tail is sized far past `ATTEST_LEN + max overhead` to stand in for the
+    // memory-exhaustion vector the bound closes.
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    let ap = attest_path(&path);
+    let mut bytes = std::fs::read(&ap).unwrap();
+    bytes.extend(std::iter::repeat_n(0u8, 1 << 20));
+    std::fs::write(&ap, &bytes).unwrap();
+
+    // An oversized sidecar is INCONCLUSIVE (rejected before the read), never a
+    // trusted marker: a valid plaintext record is exactly the fixed length, so
+    // extra bytes mean the file is not a marker this build wrote.
+    assert!(
+        matches!(
+            attests(&*fs, &path, None, 7, ck(200), ck(100)),
+            AttestResult::Inconclusive
+        ),
+        "an oversized attestation is inconclusive, not attesting",
+    );
+}
+
+#[test]
+fn attests_is_inconclusive_when_the_sidecar_metadata_read_fails() {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    // Fault the sidecar's metadata probe (the size bound the read-side enforces):
+    // a metadata failure must be fail-closed INCONCLUSIVE, never a clean read
+    // that could authorize deleting a possibly-valid marker.
+    injector.arm(
+        FaultRule::new(FaultOp::Metadata, Fault::Error(ErrorKind::Other)).on_path(".heal-attest"),
+    );
+    assert!(
+        matches!(
+            attests(&*fs, &path, None, 7, ck(200), ck(100)),
+            AttestResult::Inconclusive
+        ),
+        "a metadata probe failure is inconclusive, not attesting",
+    );
+}
+
+/// `attests_post` matches on the recorded POST digest (and id) alone, ignoring the
+/// recorded PRE: a marker written with any pre attests as long as the post equals
+/// the file's current digest.
+#[test]
+fn attests_post_attests_on_a_matching_post_regardless_of_pre() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // Written with pre=100; `attests_post` never looks at pre.
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    assert!(
+        matches!(
+            attests_post(&*fs, &path, None, 7, ck(200)),
+            AttestResult::Attests
+        ),
+        "a matching post attests independent of the recorded pre",
+    );
+}
+
+/// A present marker whose post (or id) does not match, and an absent marker, are
+/// both conclusively non-attesting: `Absent`, safe to clear.
+#[test]
+fn attests_post_returns_absent_on_a_nonmatching_post_or_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    // Wrong post: the file is not the attested healed version.
+    assert!(matches!(
+        attests_post(&*fs, &path, None, 7, ck(999)),
+        AttestResult::Absent
+    ));
+    // Wrong id: the marker belongs to another table identity.
+    assert!(matches!(
+        attests_post(&*fs, &path, None, 8, ck(200)),
+        AttestResult::Absent
+    ));
+    // No marker at all.
+    remove(&*fs, &path);
+    assert!(matches!(
+        attests_post(&*fs, &path, None, 7, ck(200)),
+        AttestResult::Absent
+    ));
+}
+
+/// A metadata-probe failure on the marker is fail-closed `Inconclusive`: the
+/// caller must preserve the marker and retry, never mistake it for a clean
+/// non-attesting read.
+#[test]
+fn attests_post_is_inconclusive_when_the_metadata_read_fails() {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    injector.arm(
+        FaultRule::new(FaultOp::Metadata, Fault::Error(ErrorKind::Other)).on_path(".heal-attest"),
+    );
+    assert!(
+        matches!(
+            attests_post(&*fs, &path, None, 7, ck(200)),
+            AttestResult::Inconclusive
+        ),
+        "a metadata probe failure is inconclusive, not non-attesting",
+    );
+}
+
+#[test]
+fn attests_rejects_a_legacy_in_progress_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    // A pre-only (in-progress) marker with the CORRECT table id and pre-digest:
+    // only its `kind` differs from a completed marker. It must never authorize a
+    // reconcile, so `attests` rejects it through the Absent branch (a bare
+    // pre-only marker is safe to clear, it does not bind a post-heal digest).
+    write_in_progress(&*fs, &path, None, 7, ck(100)).unwrap();
+    assert!(
+        matches!(
+            attests(&*fs, &path, None, 7, ck(200), ck(100)),
+            AttestResult::Absent
+        ),
+        "a legacy in-progress marker is non-attesting (Absent)",
+    );
+}
+
+#[test]
+fn remove_deletes_the_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+
+    write(&*fs, &path, None, 7, ck(100), ck(200)).unwrap();
+    assert!(attest_path(&path).exists());
+    remove(&*fs, &path);
+    assert!(!attest_path(&path).exists());
+}
+
+/// A completed-attestation write that FAILS must leave an already-durable
+/// in-progress marker intact. The completed sidecar publishes through a temp +
+/// atomic rename, so a mid-write failure never touches the live sidecar; the
+/// in-progress marker survives to bridge the crash window. Without this the
+/// completed write truncates the marker in place before failing, destroying it
+/// and leaving the healed SST with a stale manifest digest and no valid
+/// attestation, permanently unreconcilable.
+#[test]
+fn a_failed_completed_write_preserves_the_in_progress_marker() {
+    use super::{attests_in_progress, write_in_progress};
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+
+    // A durable in-progress marker exists (file hashes to the manifest `pre`).
+    write_in_progress(&*fs, &path, None, 7, ck(100)).unwrap();
+    assert!(
+        attests_in_progress(&*fs, &path, None, 7, ck(100)),
+        "the in-progress marker is written and durable",
+    );
+
+    // Now the completed write fails mid-write (its temp sidecar write faults).
+    injector.arm(
+        FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other)).on_path(".heal-attest"),
+    );
+    assert!(
+        write(&*fs, &path, None, 7, ck(100), ck(200)).is_err(),
+        "the faulted completed-attestation write must fail",
+    );
+
+    // The in-progress marker must still be intact: the failed completed write
+    // never truncated the live sidecar.
+    assert!(
+        attests_in_progress(&*fs, &path, None, 7, ck(100)),
+        "a failed completed write must leave the in-progress marker intact",
+    );
+}
+
+/// The encrypted attestation is AEAD-sealed: a tampered ciphertext or a wrong
+/// key fails the open, so an offline attacker without the key cannot forge one.
+#[cfg(feature = "encryption")]
+#[test]
+fn attests_rejects_a_tampered_or_wrong_key_encrypted_sidecar() {
+    use crate::encryption::Aes256GcmProvider;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("7");
+    let fs: Arc<dyn Fs> = Arc::new(StdFs);
+    let enc = Aes256GcmProvider::new(&[7u8; 32]);
+
+    // A valid sealed attestation is trusted.
+    write(&*fs, &path, Some(&enc), 7, ck(100), ck(200)).unwrap();
+    assert!(matches!(
+        attests(&*fs, &path, Some(&enc), 7, ck(200), ck(100)),
+        AttestResult::Attests
+    ));
+
+    // A flipped ciphertext byte fails the AEAD open: inconclusive (an AEAD
+    // rejection is not treated as a clean absence that licenses deletion).
+    let ap = attest_path(&path);
+    let mut bytes = std::fs::read(&ap).unwrap();
+    if let Some(b) = bytes.last_mut() {
+        *b ^= 0xFF;
+    }
+    std::fs::write(&ap, &bytes).unwrap();
+    assert!(
+        matches!(
+            attests(&*fs, &path, Some(&enc), 7, ck(200), ck(100)),
+            AttestResult::Inconclusive
+        ),
+        "a tampered encrypted attestation is inconclusive, not attesting",
+    );
+
+    // A sidecar sealed under a DIFFERENT key fails the open too: inconclusive.
+    write(&*fs, &path, Some(&enc), 7, ck(100), ck(200)).unwrap();
+    let wrong = Aes256GcmProvider::new(&[9u8; 32]);
+    assert!(
+        matches!(
+            attests(&*fs, &path, Some(&wrong), 7, ck(200), ck(100)),
+            AttestResult::Inconclusive
+        ),
+        "an attestation sealed under a different key is inconclusive",
+    );
+}

--- a/src/scrub/tests.rs
+++ b/src/scrub/tests.rs
@@ -23,6 +23,7 @@ fn report_merge_sums_every_counter_and_concatenates_errors() {
         blocks_scanned: 10,
         corrections_applied: 2,
         ssts_scheduled_for_rewrite: 1,
+        blocks_healed_in_place: 4,
         uncorrectable_blocks: 0,
         errors: vec![],
     };
@@ -31,6 +32,7 @@ fn report_merge_sums_every_counter_and_concatenates_errors() {
         blocks_scanned: 5,
         corrections_applied: 1,
         ssts_scheduled_for_rewrite: 1,
+        blocks_healed_in_place: 3,
         uncorrectable_blocks: 3,
         errors: vec![ScrubError::UncorrectableBlock {
             table_id: 7,
@@ -43,18 +45,35 @@ fn report_merge_sums_every_counter_and_concatenates_errors() {
     assert_eq!(acc.blocks_scanned, 15);
     assert_eq!(acc.corrections_applied, 3);
     assert_eq!(acc.ssts_scheduled_for_rewrite, 2);
+    assert_eq!(acc.blocks_healed_in_place, 7);
     assert_eq!(acc.uncorrectable_blocks, 3);
     assert_eq!(acc.errors.len(), 1);
 }
 
 #[test]
-fn report_is_ok_only_when_no_uncorrectable_blocks() {
+fn report_is_ok_only_when_no_uncorrectable_blocks_and_no_errors() {
     let mut report = PatrolScrubReport::default();
     assert!(report.is_ok(), "a fresh empty report is ok");
     report.corrections_applied = 5;
     assert!(report.is_ok(), "corrected blocks do not make a scrub fail");
     report.uncorrectable_blocks = 1;
     assert!(!report.is_ok(), "an uncorrectable block fails the scrub");
+
+    // A recorded error alone (zero uncorrectable blocks) also fails the scrub: a
+    // verification or I/O error left the scrub unable to vouch for the data, so
+    // `is_ok` must require BOTH conditions, not just the uncorrectable count.
+    let mut with_error = PatrolScrubReport::default();
+    with_error.errors.push(ScrubError::UncorrectableBlock {
+        table_id: 7,
+        path: "/x".into(),
+        block_offset: 42,
+        reason: "boom".into(),
+    });
+    assert_eq!(with_error.uncorrectable_blocks, 0);
+    assert!(
+        !with_error.is_ok(),
+        "a recorded error fails the scrub even with zero uncorrectable blocks",
+    );
 }
 
 #[test]
@@ -100,6 +119,54 @@ fn patrol_scrub_empty_tree_scans_nothing() {
     assert!(report.is_ok());
 }
 
+/// A patrol reconcile calls `refresh_table_checksum` while holding a table's
+/// heal lock; a concurrent tight-space compaction holds `compaction_state` and
+/// then acquires that heal lock. Blocking on `compaction_state` here would
+/// invert the lock order (`heal_lock` -> `compaction_state` on the patrol path
+/// vs `compaction_state` -> `heal_lock` on the compaction path) and deadlock.
+/// The refresh must instead SKIP — reporting the skip as
+/// [`ChecksumRefreshOutcome::Contended`], distinct from a benign no-op — when
+/// `compaction_state` is contended.
+///
+/// Deterministic without threads: `parking_lot`'s non-reentrant `try_lock` fails
+/// even for the holding thread, so a blocking `lock()` would self-deadlock this
+/// very test (a hang), and the `try_lock` skip returns `Contended`.
+///
+/// [`ChecksumRefreshOutcome::Contended`]: crate::abstract_tree::ChecksumRefreshOutcome::Contended
+#[test]
+fn refresh_table_checksum_skips_when_compaction_state_is_contended() {
+    use crate::abstract_tree::ChecksumRefreshOutcome;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let AnyTree::Standard(tree) = standard_tree(dir.path()) else {
+        unreachable!("standard tree configured");
+    };
+    // Flush a real table so the refresh has a genuine (id, checksum) to look
+    // up: an `Ok(false)` is then attributable specifically to the try_lock
+    // contention skip, not to a missing-table early return that also yields
+    // `Ok(false)`.
+    tree.insert("k", "v", 0);
+    tree.flush_active_memtable(1).expect("flush");
+    let (id, checksum) = {
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (table.id(), table.checksum())
+    };
+
+    let held = tree.compaction_state.lock();
+    let result = tree.refresh_table_checksum(id, checksum, None);
+    drop(held);
+    assert!(
+        matches!(result, Ok(ChecksumRefreshOutcome::Contended)),
+        "refresh must skip (not block) when compaction_state is contended, and \
+         report the skip as Contended — the table exists, so a Stale here would \
+         mask the contention as a benign no-op: {result:?}",
+    );
+}
+
 #[test]
 fn patrol_scrub_parallel_over_many_ssts_visits_every_file() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -123,4 +190,316 @@ fn patrol_scrub_parallel_over_many_ssts_visits_every_file() {
     assert_eq!(report.sst_files_scanned, 4, "every SST scrubbed once");
     assert!(report.blocks_scanned >= 4);
     assert!(report.is_ok());
+}
+
+/// Opens an uncompressed RS(8,2) Page-ECC tree whose flushed SSTs carry
+/// per-KV checksum footers. ECC because only Page-ECC tables get the
+/// heal-mode digest reconciliation these tests exercise.
+#[cfg(feature = "page_ecc")]
+fn open_kv_checked_tree(dir: &std::path::Path) -> crate::Result<crate::Tree> {
+    use crate::runtime_config::{EccScheme, KvChecksumPolicy};
+
+    let AnyTree::Standard(tree) = Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::None,
+    ))
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .open()?
+    else {
+        unreachable!("standard tree configured");
+    };
+    tree.update_runtime_config(|c| c.kv_checksums = KvChecksumPolicy::AllLevels)?;
+    Ok(tree)
+}
+
+/// Opens (or reopens) a KV-separated RS(8,2) Page-ECC tree at `dir`.
+#[cfg(feature = "page_ecc")]
+fn open_blob_ecc_tree(dir: &std::path::Path) -> crate::Result<crate::BlobTree> {
+    use crate::runtime_config::EccScheme;
+
+    let AnyTree::Blob(tree) = Config::new(
+        dir,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .open()?
+    else {
+        unreachable!("kv separation configured");
+    };
+    Ok(tree)
+}
+
+/// Builds a KV-separated RS(8,2) Page-ECC tree at `dir` with ten large
+/// values (blob-file indirections plus a `linked_blob_files` section) and
+/// returns the flushed SST's path. Reopen with [`open_blob_ecc_tree`].
+#[cfg(feature = "page_ecc")]
+fn build_blob_ecc_sst(dir: &std::path::Path) -> crate::Result<std::path::PathBuf> {
+    let tree = open_blob_ecc_tree(dir)?;
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10)?;
+    let binding = tree.index.version_history.read().latest_version();
+    let Some(table) = binding.version.iter_tables().next() else {
+        panic!("flush produced one table");
+    };
+    Ok((*table.path).clone())
+}
+
+/// Byte offset of the `linked_blob_files` SFA section in the SST at `path`
+/// (the record layout after the u32 count is: `id u64 | len u64 | bytes u64
+/// | on_disk_bytes u64`).
+#[cfg(feature = "page_ecc")]
+fn linked_blob_files_offset(path: &std::path::Path) -> crate::Result<usize> {
+    let mut f = std::fs::File::open(path)?;
+    let reader = crate::sfa::Reader::from_reader(&mut f)?;
+    let Some(entry) = reader
+        .toc()
+        .iter()
+        .find(|e| e.name() == b"linked_blob_files")
+    else {
+        return Err(crate::Error::InvalidHeader(
+            "SST is missing its linked_blob_files section",
+        ));
+    };
+    usize::try_from(entry.pos())
+        .map_err(|_| crate::Error::InvalidHeader("linked_blob_files offset exceeds usize"))
+}
+
+/// The blob-link cross-check must compare the COMPLETE accounting records,
+/// not just the id set: a record whose `bytes` counter rotted (ids intact)
+/// feeds `Version::with_dropped` fragmentation math, and a forged total can
+/// make `BlobFile::is_dead` prune a blob another table still references.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_scrub_does_not_restamp_over_forged_blob_link_accounting() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = build_blob_ecc_sst(dir.path())?;
+
+    // Flip one byte inside the first record's `bytes` counter: every id
+    // stays intact, the shape stays valid.
+    let pos = linked_blob_files_offset(&sst_path)?;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let Some(slot) = bytes.get_mut(pos + 4 + 16) else {
+        panic!("first record's bytes counter within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&sst_path, &bytes)?;
+
+    let tree = open_blob_ecc_tree(dir.path())?;
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "forged blob-link accounting must refuse the digest refresh: {report:?}",
+    );
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged accounting must keep failing verify_integrity",
+    );
+    Ok(())
+}
+
+/// A heal-mode scrub must NEVER reconcile the digest of a table WITHOUT
+/// Page-ECC: nothing can have legitimately healed its bytes in place, so a
+/// manifest-level digest mismatch on such a table is real evidence — an
+/// in-band alteration whose block checksums were re-stamped has NO other
+/// detector (no parity, no footers), and restamping the manifest digest
+/// would erase the only record of it. It also spares every ordinary SST
+/// the full-file digest read.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_scrub_does_not_reconcile_a_non_ecc_table() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = {
+        let AnyTree::Standard(tree) = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(crate::config::CompressionPolicy::all(
+            crate::CompressionType::None,
+        ))
+        .open()?
+        else {
+            unreachable!("standard tree configured");
+        };
+        for i in 0u64..500 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(500)?;
+        let binding = tree.version_history.read().latest_version();
+        let Some(table) = binding.version.iter_tables().next() else {
+            panic!("flush produced one table");
+        };
+        (*table.path).clone()
+    };
+
+    // In-band alteration with a re-stamped block checksum: every frame reads
+    // internally valid, only the manifest digest disagrees.
+    crate::test_forge::forge_restamped_data_block(&sst_path)?;
+
+    let AnyTree::Standard(tree) = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(crate::config::CompressionPolicy::all(
+        crate::CompressionType::None,
+    ))
+    .open()?
+    else {
+        unreachable!("standard tree configured");
+    };
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    // The reconciliation must be SKIPPED, not attempted-and-failed: a
+    // ChecksumRefreshFailed finding here would mean the non-ECC gate in the
+    // scan regressed even if the digest itself survived.
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "a non-ECC table must skip the digest reconciliation entirely, not \
+         attempt and fail it: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest: on a non-ECC table it is the
+    // ONLY detector of a re-stamped in-band alteration.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "a non-ECC table's digest mismatch must survive a heal scrub: \
+         restamping it would erase the only record of the alteration",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a `linked_blob_files`
+/// record whose blob id rotted WITHOUT changing the section's shape: the
+/// section carries no per-section checksum, so a flipped id byte passes the
+/// walk's structural validation — only deriving the id set from the table's
+/// own indirection entries can catch it. Restamping would hide a live blob
+/// from GC or point relocation at a nonexistent one.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_scrub_does_not_restamp_over_a_forged_blob_link_id() -> crate::Result<()> {
+    // A KV-separated Page-ECC tree: large values go to a blob file, the SST
+    // carries indirections plus a linked_blob_files section (ECC because
+    // only Page-ECC tables get the heal-mode digest reconciliation).
+    let dir = tempfile::tempdir()?;
+    let sst_path = build_blob_ecc_sst(dir.path())?;
+
+    // Flip one byte INSIDE the first record's blob_file_id: the count and
+    // section length stay valid, so the shape check passes.
+    let pos = linked_blob_files_offset(&sst_path)?;
+    let mut bytes = std::fs::read(&sst_path)?;
+    let Some(slot) = bytes.get_mut(pos + 4) else {
+        panic!("first blob id within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&sst_path, &bytes)?;
+
+    // Heal scan: data blocks read clean, the section is structurally valid,
+    // yet the file digest disagrees with the manifest.
+    let tree = open_blob_ecc_tree(dir.path())?;
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        !report.is_ok(),
+        "a digest mismatch over a forged blob-link id must be a finding, \
+         not silently restamped: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "the finding must be the refused digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so integrity scans keep
+    // flagging the forged file.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged file must keep failing verify_integrity: restamping its \
+         digest over an unverifiable blob-link list would mask the forgery",
+    );
+    Ok(())
+}
+
+/// The digest reconciliation must not restamp over a STALE per-KV footer
+/// hidden behind a re-stamped block checksum: neither the heal scan nor the
+/// out-of-band section walk decodes entries, so only the per-KV verification
+/// can catch it — without it, `verify_integrity` starts accepting a file
+/// that `verify_kv_checksums` still rejects.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_scrub_does_not_restamp_over_a_stale_kv_footer() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let sst_path = {
+        let tree = open_kv_checked_tree(dir.path())?;
+        for i in 0u64..500 {
+            tree.insert(format!("key-{i:06}"), format!("v{i:06}"), i);
+        }
+        tree.flush_active_memtable(500)?;
+        let binding = tree.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (*table.path).clone()
+    };
+
+    crate::test_forge::forge_stale_kv_footer(&sst_path)?;
+
+    // Heal scan: block checksums read clean (re-stamped), yet the file
+    // digest disagrees with the manifest.
+    let tree = open_kv_checked_tree(dir.path())?;
+    assert!(
+        crate::verify::verify_kv_checksums(&tree).is_err(),
+        "the forged footer must be detectable by per-KV verification",
+    );
+    let report = patrol_scrub(&tree, &PatrolScrubOptions::default().heal_in_place(true));
+    assert!(
+        !report.is_ok(),
+        "a digest mismatch over a stale per-KV footer must be a finding, \
+         not silently restamped: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, ScrubError::ChecksumRefreshFailed { .. })),
+        "the finding must be the refused digest refresh: {report:?}",
+    );
+
+    // The manifest keeps the ORIGINAL digest, so integrity scans keep
+    // flagging the forged file.
+    let integrity = crate::verify::verify_integrity(&tree);
+    assert!(
+        !integrity.is_ok(),
+        "the forged file must keep failing verify_integrity: restamping its \
+         digest over an unverified per-KV footer would mask the corruption",
+    );
+    Ok(())
 }

--- a/src/sfa/reader.rs
+++ b/src/sfa/reader.rs
@@ -14,6 +14,7 @@ use std::io::{BufReader, Read, Seek};
 /// Archive reader
 pub struct Reader {
     toc: Toc,
+    toc_pos: u64,
 }
 
 impl Reader {
@@ -35,7 +36,10 @@ impl Reader {
             trailer.toc_len,
             trailer.toc_checksum,
         )?;
-        Ok(Self { toc })
+        Ok(Self {
+            toc,
+            toc_pos: trailer.toc_pos,
+        })
     }
 
     /// Creates a new [`Reader`] from a reader.
@@ -51,12 +55,24 @@ impl Reader {
             trailer.toc_len,
             trailer.toc_checksum,
         )?;
-        Ok(Self { toc })
+        Ok(Self {
+            toc,
+            toc_pos: trailer.toc_pos,
+        })
     }
 
     /// Lists the table of contents.
     #[must_use]
     pub fn toc(&self) -> &Toc {
         &self.toc
+    }
+
+    /// File offset where the TOC begins — the end of the last section's
+    /// payload region. The writer emits sections strictly back-to-back, so
+    /// the named entries must exactly tile `[0, toc_pos())`; a verifier uses
+    /// this bound to detect an omitted (re-stamped-away) TOC entry.
+    #[must_use]
+    pub fn toc_pos(&self) -> u64 {
+        self.toc_pos
     }
 }

--- a/src/table/block/decoder.rs
+++ b/src/table/block/decoder.rs
@@ -217,6 +217,29 @@ pub struct DecoderMeta {
     cached_entries_end: usize,
 }
 
+// Test-only: the binary-index forge patches pointer bytes in place and needs
+// the trailer-derived layout; production readers go through the decoder.
+#[cfg(test)]
+impl DecoderMeta {
+    /// Byte offset of the binary index within the block payload.
+    #[must_use]
+    pub(crate) fn binary_index_offset(&self) -> u32 {
+        self.binary_index_offset
+    }
+
+    /// Number of binary-index pointers (one per restart head).
+    #[must_use]
+    pub(crate) fn binary_index_len(&self) -> u32 {
+        self.binary_index_len
+    }
+
+    /// Width of one binary-index pointer in bytes (2 or 4).
+    #[must_use]
+    pub(crate) fn binary_index_step_size(&self) -> u8 {
+        self.binary_index_step_size
+    }
+}
+
 impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Parsed> {
     #[must_use]
     pub fn restart_interval(&self) -> u8 {
@@ -550,6 +573,63 @@ impl<'a, Item: Decodable<Parsed>, Parsed: ParsedItem<Item>> Decoder<'a, Item, Pa
     /// [`Self::get_binary_index_reader`]).
     pub(crate) fn cached_binary_index_reader(&self) -> Option<BinaryIndexReader<'_>> {
         self.get_binary_index_reader()
+    }
+
+    /// Validates the block's BINARY INDEX against the sequentially derived
+    /// restart heads: pointer `i` must hold the byte offset of restart head
+    /// `i`, and the pointer count must match the head count. The sequential
+    /// decode never reads the pointers, so a forged pointer is invisible to
+    /// every entry-level cross-check while the seek path trusts it and can
+    /// start at the wrong restart head, silently missing keys. A block
+    /// without a binary index has nothing to authenticate (seeks fall back
+    /// to sequential scanning).
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the pointer list disagrees with
+    /// the restart heads; [`crate::Error::InvalidTrailer`] when the trailer
+    /// is malformed.
+    #[cfg_attr(
+        not(feature = "std"),
+        allow(
+            // Deliberately `allow`, not `expect`: the delegating data/index-block
+            // callers keep this live under some alloc-only feature combinations,
+            // so an `expect(dead_code)` would be an unfulfilled-expectation
+            // warning there. `allow` is the config-agnostic suppression.
+            dead_code,
+            reason = "reconcile-gate check; the verify/scrub consumers are std-gated"
+        )
+    )]
+    pub(crate) fn verify_binary_index(block: &'a Block) -> crate::Result<()> {
+        let probe = Self::try_new(block)?;
+        let Some(reader) = probe.get_binary_index_reader() else {
+            return Ok(());
+        };
+        let mut scan = Self::try_new(block)?;
+        let mut heads: Vec<usize> = Vec::new();
+        loop {
+            let is_restart = scan.lo_scanner.remaining_in_interval == 0;
+            let head = scan.lo_scanner.offset;
+            if scan.next().is_none() {
+                break;
+            }
+            if is_restart {
+                heads.push(head);
+            }
+        }
+        if reader.len() != heads.len() {
+            return Err(crate::Error::InvalidHeader(
+                "binary index pointer count disagrees with the block's restart heads",
+            ));
+        }
+        for (idx, head) in heads.iter().enumerate() {
+            if reader.get(idx) != *head {
+                return Err(crate::Error::InvalidHeader(
+                    "a binary index pointer disagrees with its restart head",
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Hash index reader built from the trailer metadata cached at

--- a/src/table/block/mod.rs
+++ b/src/table/block/mod.rs
@@ -96,6 +96,25 @@ pub(crate) fn expected_parity_len(data_length: u32, params: EccParams) -> u32 {
     shard_bytes.saturating_mul(parity_shards)
 }
 
+/// [`expected_parity_len`], rejecting a trailer above the payload hard cap
+/// ([`MAX_DECOMPRESSION_SIZE`]). A legitimately-written block never exceeds it —
+/// the writer enforces the same bound before emitting the trailer — so a larger
+/// DERIVED length means a forged / corrupt ECC descriptor amplifying the payload
+/// (e.g. a high-parity shard scheme with `saturating_mul` reaching gigabytes).
+/// Rejecting here, immediately after deriving the length and BEFORE any
+/// allocation or trailer read, is the read side of the writer's cap and mirrors
+/// the out-of-band verifier's `DoS` guard.
+fn checked_ecc_length(data_length: u32, params: EccParams) -> crate::Result<u32> {
+    let ecc_length = expected_parity_len(data_length, params);
+    if ecc_length > MAX_DECOMPRESSION_SIZE {
+        return Err(crate::Error::DecompressedSizeTooLarge {
+            declared: u64::from(ecc_length),
+            limit: u64::from(MAX_DECOMPRESSION_SIZE),
+        });
+    }
+    Ok(ecc_length)
+}
+
 /// Whether the on-disk block carries a Reed-Solomon parity trailer.
 ///
 /// Source of truth depends on the block type:
@@ -692,7 +711,7 @@ impl Block {
 
             #[cfg(feature = "lz4")]
             CompressionType::Lz4 => {
-                compressed_buf = Some(lz4_flex::compress(data));
+                compressed_buf = Some(lz4_flex::block::compress(data));
             }
 
             #[cfg(zstd_any)]
@@ -811,6 +830,20 @@ impl Block {
         // compiler folds it out.
         #[cfg(feature = "page_ecc")]
         let parity_buf: Option<Vec<u8>> = if let Some(ecc_params) = transform.ecc_params() {
+            // Reject a trailer above the payload hard cap BEFORE encoding it:
+            // the out-of-band verifier bounds trailers at this cap (its DoS
+            // guard against forged descriptors), so emitting a larger one
+            // would create an SST the verifier falsely flags as corrupt. No
+            // sane scheme/block combination reaches this — it takes a
+            // high-amplification shard layout (e.g. RS(1,255)) on a huge
+            // block — so the write fails loudly instead of producing an
+            // unverifiable file.
+            if expected_parity_len(payload_len, ecc_params) > MAX_DECOMPRESSION_SIZE {
+                return Err(crate::Error::FeatureUnsupported(
+                    "ecc parity trailer above the verifier's hard cap: the configured shard \
+                     scheme amplifies this block's payload past 256 MiB of parity",
+                ));
+            }
             // SEC-DED emits one check byte per 8-byte word; shard schemes emit a
             // Reed-Solomon / XOR trailer. Both produce a parity buffer the
             // reader re-sizes from `data_length` via `expected_parity_len`.
@@ -919,7 +952,7 @@ impl Block {
         // is `expected_parity_len(data_length)` (the RS(4, 2) scheme is
         // deterministic), otherwise none.
         let ecc_length = if block_has_parity(&header, transform) {
-            expected_parity_len(header.data_length, block_ecc_params(&header, transform))
+            checked_ecc_length(header.data_length, block_ecc_params(&header, transform))?
         } else {
             0
         };
@@ -981,7 +1014,7 @@ impl Block {
                     let mut builder =
                         unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    let bytes_written = lz4_flex::decompress_into(&decrypted, &mut builder)
+                    let bytes_written = lz4_flex::block::decompress_into(&decrypted, &mut builder)
                         .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != header.uncompressed_length as usize {
@@ -1093,7 +1126,7 @@ impl Block {
                     let mut builder =
                         unsafe { Slice::builder_unzeroed(header.uncompressed_length as usize) };
 
-                    let bytes_written = lz4_flex::decompress_into(&raw_data, &mut builder)
+                    let bytes_written = lz4_flex::block::decompress_into(&raw_data, &mut builder)
                         .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != header.uncompressed_length as usize {
@@ -1299,17 +1332,22 @@ impl Block {
             // length, when recognized, is derived from `data_length` + scheme.
             let has_ecc = block_has_parity(&parsed_header, transform);
             let ecc_length = if has_ecc {
-                expected_parity_len(
+                checked_ecc_length(
                     parsed_header.data_length,
                     block_ecc_params(&parsed_header, transform),
-                )
+                )?
             } else {
                 0
             };
 
-            // Clamp-to-zero: a block truncated before its header ends has no
-            // payload, which `classify_block_trailer` then flags as a mismatch.
-            let actual_payload_plus_ecc = block_size.saturating_sub(header_len);
+            // The header was decoded from these `block_size` bytes above, so
+            // `block_size >= header_len` holds and this cannot underflow.
+            // `checked_sub` on this recovery path surfaces any future decode
+            // regression loudly instead of clamping to a 0-payload that a
+            // truncated block could sneak through the trailer check as clean.
+            let actual_payload_plus_ecc = block_size
+                .checked_sub(header_len)
+                .ok_or(crate::Error::InvalidHeader("Block"))?;
             let actual_data_len = parsed_header.data_length as usize;
             let ecc_status = classify_block_trailer(
                 has_ecc,
@@ -1415,8 +1453,9 @@ impl Block {
                         Slice::builder_unzeroed(parsed_header.uncompressed_length as usize)
                     };
 
-                    let bytes_written = lz4_flex::decompress_into(&decrypted, &mut decompressed)
-                        .map_err(|_| crate::Error::Decompress(compression))?;
+                    let bytes_written =
+                        lz4_flex::block::decompress_into(&decrypted, &mut decompressed)
+                            .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != parsed_header.uncompressed_length as usize {
                         return Err(crate::Error::Decompress(compression));
@@ -1486,17 +1525,23 @@ impl Block {
             // payload). See the encrypted branch + `classify_block_trailer`.
             let has_ecc = block_has_parity(&parsed_header, transform);
             let ecc_length = if has_ecc {
-                expected_parity_len(
+                checked_ecc_length(
                     parsed_header.data_length,
                     block_ecc_params(&parsed_header, transform),
-                )
+                )?
             } else {
                 0
             };
 
-            // Clamp-to-zero: a buffer shorter than the header carries no payload,
-            // which the trailer classification then flags as a mismatch.
-            let actual_payload_plus_ecc = buf.len().saturating_sub(header_len);
+            // The header was decoded from `buf` above, so `buf.len() >=
+            // header_len` holds and this cannot underflow. `checked_sub` on this
+            // recovery path surfaces any future decode regression loudly instead
+            // of clamping to a 0-payload the trailer check could accept as a
+            // clean empty block.
+            let actual_payload_plus_ecc = buf
+                .len()
+                .checked_sub(header_len)
+                .ok_or(crate::Error::InvalidHeader("Block"))?;
             let actual_data_len = parsed_header.data_length as usize;
             let ecc_status = classify_block_trailer(
                 has_ecc,
@@ -1582,7 +1627,7 @@ impl Block {
                     };
 
                     let bytes_written =
-                        lz4_flex::decompress_into(compressed_data, &mut decompressed)
+                        lz4_flex::block::decompress_into(compressed_data, &mut decompressed)
                             .map_err(|_| crate::Error::Decompress(compression))?;
 
                     if bytes_written != parsed_header.uncompressed_length as usize {
@@ -1652,6 +1697,163 @@ impl Block {
         Ok((Self { header, data }, ecc_status, recovery))
     }
 
+    /// In-place autoheal primitive: read this block's on-disk frame and, if its
+    /// checksum fails but Page-ECC recovers it, return the CORRECTED frame bytes
+    /// to write back at the same offset.
+    ///
+    /// The returned frame is `header ++ recovered_data ++ freshly-recomputed
+    /// parity` and is byte-length-identical to the on-disk block (RS / SEC-DED
+    /// reconstruct the original `data_length` payload, and the parity length is a
+    /// deterministic function of it), so it can be written in place without
+    /// shifting any later block. Returns `Ok(None)` when the block reads clean (no
+    /// heal needed) or carries no recognized parity (nothing to reconstruct from);
+    /// `Err` when the checksum fails and parity cannot recover it (uncorrectable)
+    /// or the block is unreadable.
+    ///
+    /// Works purely at the framed-bytes level: the checksum and parity cover the
+    /// on-disk (post-compression, post-encryption) data bytes, so no decompress /
+    /// decrypt is needed — `transform` is consulted only for the parity scheme.
+    #[cfg(feature = "page_ecc")]
+    pub(crate) fn heal_frame(
+        file: &dyn FsFile,
+        handle: BlockHandle,
+        transform: &BlockTransform<'_>,
+    ) -> crate::Result<Option<(alloc::vec::Vec<u8>, EccRecoveryKind)>> {
+        let block_size = handle.size() as usize;
+        if block_size < Header::MIN_LEN {
+            return Err(crate::Error::InvalidHeader("Block"));
+        }
+        // Pre-allocation sanity cap on `handle.size()` (mirrors
+        // `from_file_with_recovery`): reject an absurd on-disk size from a corrupt
+        // handle before allocating the read buffer. Bound = max payload
+        // (+ encryption overhead) + its parity + the largest header.
+        let enc_overhead = transform
+            .encryption()
+            .map_or(0u64, |e| u64::from(e.max_overhead()));
+        let max_payload = u64::from(MAX_DECOMPRESSION_SIZE) + enc_overhead;
+        let max_ecc_overhead = match transform.ecc_params() {
+            Some(params) => {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "max_payload is MAX_DECOMPRESSION_SIZE (+ enc overhead), well below u32::MAX"
+                )]
+                let max_payload_u32 = max_payload.min(u64::from(u32::MAX)) as u32;
+                u64::from(expected_parity_len(max_payload_u32, params))
+            }
+            None => 0,
+        };
+        let max_on_disk_size = max_payload + max_ecc_overhead + Header::MAX_LEN as u64;
+        if u64::from(handle.size()) > max_on_disk_size {
+            return Err(crate::Error::DecompressedSizeTooLarge {
+                declared: u64::from(handle.size()),
+                limit: max_on_disk_size,
+            });
+        }
+        let mut buf = alloc::vec![0u8; block_size];
+        let n = file.read_at(&mut buf, *handle.offset())?;
+        if n != block_size {
+            return Err(crate::Error::Io(crate::io::Error::new(
+                crate::io::ErrorKind::UnexpectedEof,
+                "heal_frame: short block read",
+            )));
+        }
+        let header = Header::decode_from(&mut &buf[..])?;
+        let header_len = Header::header_len(header.block_type);
+        // Heal targets blocks under a recognized parity scheme; without one there
+        // is nothing to reconstruct from (a checksum-only block that fails is
+        // salvage's job, not in-place heal's).
+        let has_ecc = block_has_parity(&header, transform);
+        if !has_ecc {
+            return Ok(None);
+        }
+        let ecc_params = block_ecc_params(&header, transform);
+        let ecc_length = checked_ecc_length(header.data_length, ecc_params)?;
+        // Validate the on-disk trailer the same way the read path does before ever
+        // treating the block as clean: the post-header bytes must be exactly
+        // `data_length + ecc_length`. Extra trailing bytes (an over-sized / malformed
+        // block) are rejected rather than silently reported clean, matching
+        // `from_file_with_recovery`.
+        let actual_data_len = usize::try_from(header.data_length)
+            .map_err(|_| crate::Error::InvalidHeader("Block"))?;
+        // The header was decoded from these `block_size` bytes above, so
+        // `block_size >= header_len` holds and this cannot underflow.
+        // `checked_sub` on this recovery path surfaces any future decode
+        // regression loudly instead of clamping to a 0-payload that a truncated
+        // block could sneak through the trailer check as a clean read.
+        let actual_payload_plus_ecc = block_size
+            .checked_sub(header_len)
+            .ok_or(crate::Error::InvalidHeader("Block"))?;
+        classify_block_trailer(
+            has_ecc,
+            actual_payload_plus_ecc,
+            actual_data_len,
+            ecc_length,
+            &handle,
+        )?;
+        // `read_payload_and_verify` consumes exactly `data_length + ecc_length`
+        // bytes from a cursor over the post-header bytes, returning the (recovered)
+        // data and whether a correction was applied.
+        let post_header = buf
+            .get(header_len..)
+            .ok_or(crate::Error::InvalidHeader("Block"))?;
+        let mut cursor = crate::io::Cursor::new(post_header);
+        let (data, recovery) = Self::read_payload_and_verify(
+            &mut cursor,
+            header.data_length,
+            ecc_length,
+            header.checksum,
+            ecc_params,
+        )?;
+        let Some(kind) = recovery else {
+            // Clean read: nothing to persist. NOTE this is a FRAME-level clean
+            // (header + payload checksum + trailer verified), not a full decode —
+            // a header-only fault such as a bad `uncompressed_length` is not caught
+            // here. A caller that needs full-integrity detection must pair this
+            // with a decoding read; the in-place heal
+            // (`Table::heal_data_blocks_in_place`) verifies each block via the scrub
+            // read path first and only uses `heal_frame` to fetch the corrected
+            // bytes for a block that read path already flagged as recovered.
+            //
+            // A PARITY-ONLY fault (payload + payload checksum intact, ECC trailer
+            // rotted) is deliberately NOT this function's job: the read path reads
+            // it as clean, so `heal_frame` is never called for it. That case is
+            // repaired earlier in `heal_data_blocks_in_place` by
+            // `Table::raw_block_parity_delta`, which recomputes the parity over the
+            // verified payload and rewrites the trailer when it diverges (proven by
+            // `heal_in_place_restores_a_rotted_parity_trailer`). So a clean frame
+            // reaching here has an intact trailer already — returning `None` leaves
+            // no damaged parity on disk.
+            return Ok(None);
+        };
+        // Recompute the parity over the corrected data so the rewritten frame is
+        // canonical regardless of whether the fault hit a data or a parity shard.
+        let parity = if matches!(ecc_params, EccParams::Secded) {
+            crate::secded::encode_block_parity(&data)
+        } else {
+            let (data_shards, parity_shards) = ecc_params.as_shards();
+            crate::ecc::encode_parity(&data, data_shards, parity_shards)?
+        };
+        let header_bytes = buf
+            .get(..header_len)
+            .ok_or(crate::Error::InvalidHeader("Block"))?;
+        let mut frame = alloc::vec::Vec::with_capacity(header_len + data.len() + parity.len());
+        frame.extend_from_slice(header_bytes);
+        frame.extend_from_slice(&data);
+        frame.extend_from_slice(&parity);
+        // An in-place heal overwrites the block at its existing offset, so the
+        // rebuilt frame MUST be byte-length-identical to the original — a shorter
+        // or longer frame would corrupt the following block. Enforce at runtime
+        // (not just `debug_assert`): the recovered payload / recomputed parity are
+        // deterministic, so a mismatch means the header disagrees with the on-disk
+        // layout; refuse rather than write a wrong-length block in release builds.
+        if frame.len() != block_size {
+            return Err(crate::Error::InvalidHeader(
+                "in-place heal: rebuilt frame length differs from the on-disk block",
+            ));
+        }
+        Ok(Some((frame, kind)))
+    }
+
     /// Reads a data block's verified COMPRESSED payload (the zstd frame) WITHOUT
     /// decompressing it, for partial / lazy decode. Returns the header, the
     /// compressed-frame bytes (checksum-verified; ECC-recovered if a recognized
@@ -1713,17 +1915,22 @@ impl Block {
 
         let has_ecc = block_has_parity(&parsed_header, transform);
         let ecc_length = if has_ecc {
-            expected_parity_len(
+            checked_ecc_length(
                 parsed_header.data_length,
                 block_ecc_params(&parsed_header, transform),
-            )
+            )?
         } else {
             0
         };
 
-        // Clamp-to-zero: a buffer shorter than the header carries no payload,
-        // which the trailer classification then flags as a mismatch.
-        let actual_payload_plus_ecc = buf.len().saturating_sub(header_len);
+        // The header was decoded from `buf` above, so `buf.len() >= header_len`
+        // holds and this cannot underflow. `checked_sub` on this recovery path
+        // surfaces any future decode regression loudly instead of clamping to a
+        // 0-payload the trailer check could accept as a clean empty block.
+        let actual_payload_plus_ecc = buf
+            .len()
+            .checked_sub(header_len)
+            .ok_or(crate::Error::InvalidHeader("Block"))?;
         let actual_data_len = parsed_header.data_length as usize;
         let _ecc_status = classify_block_trailer(
             has_ecc,

--- a/src/table/block/tests.rs
+++ b/src/table/block/tests.rs
@@ -440,7 +440,7 @@ fn lz4_corrupted_uncompressed_length_triggers_decompress_error() {
     let payload: &[u8] = b"hello world";
 
     // Compress with lz4 using the block format
-    let compressed = lz4_flex::compress(payload);
+    let compressed = lz4_flex::block::compress(payload);
 
     // Build a header with corrupted uncompressed_length (1 byte too large)
     let data_length = compressed.len() as u32;
@@ -1849,6 +1849,100 @@ mod page_ecc {
             &BlockTransform::PlainEcc(EccParams::RS_4_2),
         )?;
         assert_eq!(&*block.data, PAYLOAD);
+        Ok(())
+    }
+
+    /// `heal_frame` validates the on-disk trailer before treating a block as
+    /// clean: a handle whose size claims more bytes than `header + data + parity`
+    /// (extra trailing bytes) is rejected — matching the normal read path — rather
+    /// than silently reported clean and left un-healed.
+    #[test]
+    fn heal_frame_with_extra_trailing_bytes_is_rejected() -> crate::Result<()> {
+        let transform = BlockTransform::PlainEcc(EccParams::RS_4_2);
+        let tmp = super::write_block_to_tempfile(
+            PAYLOAD,
+            BlockIdentity::for_test(0, BlockType::Data),
+            &transform,
+        )?;
+        let path = tmp.dir.path().join("block");
+
+        // Append trailing bytes and claim them in the handle: the block still
+        // reads back clean, but its declared size now exceeds header + data +
+        // parity.
+        let mut bytes = std::fs::read(&path)?;
+        let real_size = bytes.len();
+        bytes.extend_from_slice(&[0u8; 16]);
+        std::fs::write(&path, &bytes)?;
+
+        let oversized_size = u32::try_from(real_size + 16)
+            .map_err(|e| crate::Error::Io(crate::io::Error::other(e.to_string())))?;
+        let oversized = BlockHandle::new(tmp.handle.offset(), oversized_size);
+        let file = std::fs::File::open(&path)?;
+        let err = Block::heal_frame(&file, oversized, &transform)
+            .expect_err("an over-sized block (extra trailing bytes) must be rejected");
+        assert!(
+            matches!(err, crate::Error::InvalidHeader("Block")),
+            "the trailer-length check rejects the extra bytes as InvalidHeader, got {err:?}",
+        );
+        Ok(())
+    }
+
+    /// `heal_frame` on a block with no recognized parity has nothing to
+    /// reconstruct, so it returns `Ok(None)` (heal is a no-op; a checksum-only
+    /// block that fails is salvage's job).
+    #[test]
+    fn heal_frame_without_parity_returns_none() -> crate::Result<()> {
+        let tmp = super::write_block_to_tempfile(
+            PAYLOAD,
+            BlockIdentity::for_test(0, BlockType::Data),
+            &BlockTransform::PLAIN,
+        )?;
+        assert!(
+            Block::heal_frame(&tmp.file, tmp.handle, &BlockTransform::PLAIN)?.is_none(),
+            "a block without parity is a heal no-op",
+        );
+        Ok(())
+    }
+
+    /// `heal_frame` rejects an absurd on-disk size (a corrupt handle) before
+    /// allocating the read buffer, the same cap the read path applies.
+    #[test]
+    fn heal_frame_with_an_oversized_handle_is_rejected() -> crate::Result<()> {
+        let transform = BlockTransform::PlainEcc(EccParams::RS_4_2);
+        let tmp = super::write_block_to_tempfile(
+            PAYLOAD,
+            BlockIdentity::for_test(0, BlockType::Data),
+            &transform,
+        )?;
+        let oversized = BlockHandle::new(tmp.handle.offset(), u32::MAX);
+        let err = Block::heal_frame(&tmp.file, oversized, &transform)
+            .expect_err("oversized handle must be rejected");
+        assert!(
+            matches!(err, crate::Error::DecompressedSizeTooLarge { .. }),
+            "expected DecompressedSizeTooLarge, got {err:?}",
+        );
+        Ok(())
+    }
+
+    /// `heal_frame` errors when the handle claims more bytes than the file holds
+    /// (a truncated block), rather than acting on a short read.
+    #[test]
+    fn heal_frame_with_a_short_read_errors() -> crate::Result<()> {
+        let transform = BlockTransform::PlainEcc(EccParams::RS_4_2);
+        let tmp = super::write_block_to_tempfile(
+            PAYLOAD,
+            BlockIdentity::for_test(0, BlockType::Data),
+            &transform,
+        )?;
+        // Claim 4 KiB more than the file actually contains: within the size cap,
+        // but the read cannot fill the buffer.
+        let short = BlockHandle::new(tmp.handle.offset(), tmp.handle.size() + 4096);
+        let err = Block::heal_frame(&tmp.file, short, &transform)
+            .expect_err("a handle past EOF must error, not act on a short read");
+        assert!(
+            matches!(&err, crate::Error::Io(e) if e.kind() == crate::io::ErrorKind::UnexpectedEof),
+            "a handle past EOF must surface an UnexpectedEof short-read error, got {err:?}",
+        );
         Ok(())
     }
 

--- a/src/table/block_layout.rs
+++ b/src/table/block_layout.rs
@@ -140,6 +140,23 @@ impl BlockLayoutMap {
         self.entries.len()
     }
 
+    /// Whether the map records no blocks at all.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Number of recorded entries at or above `from_offset`: the LIVE entries
+    /// of a tight-space restricted view (its `[0, from_offset)` blocks are
+    /// punched, so their layout entries describe dead frames). `from_offset ==
+    /// 0` yields [`len`](Self::len).
+    #[cfg(feature = "std")]
+    pub fn live_len(&self, from_offset: u64) -> usize {
+        self.entries
+            .iter()
+            .filter(|(off, _)| *off >= from_offset)
+            .count()
+    }
+
     /// Recorded block offsets, ascending. Test-only enumeration helper.
     /// Its sole caller is the zstd large-block roundtrip test, so it is gated
     /// to that feature to stay dead-code-clean in every other test build.

--- a/src/table/columnar.rs
+++ b/src/table/columnar.rs
@@ -58,6 +58,7 @@
 //!   segment that carries the column returns it. Mixed old/new segments thus
 //!   coexist with no migration step.
 
+use crate::table::zone_map::ColumnStats;
 use crate::{Error, Result, Slice, ValueType, key::InternalKey, value::InternalValue};
 use alloc::vec::Vec;
 
@@ -449,6 +450,63 @@ impl ColumnBatch {
             .sum()
     }
 
+    /// Per-column zone-map statistics for this block: one [`ColumnStats`] entry
+    /// per [`TypeTag::Bytes`] column, in column order.
+    ///
+    /// A `Bytes` column's comparable encoding is its raw value bytes, so `min` /
+    /// `max` are the byte-wise minimum / maximum over the column's non-null rows
+    /// (an all-null column records an empty range and its null count).
+    /// Fixed-width columns are omitted: their comparable encoding is not yet
+    /// defined (they are not row-filterable either), and recording a raw-byte
+    /// min / max could mis-order them and let a block-skip drop matching rows.
+    /// Omitting them keeps
+    /// [`can_skip_block`](super::columnar_predicate::ColumnRangePredicate::can_skip_block)
+    /// conservative for those columns (no entry means the block is never
+    /// skipped on them).
+    ///
+    /// The table writer records these for every columnar block, and
+    /// `verify_zone_map` re-derives them from the decoded block to authenticate
+    /// the recorded section, so the two computations must stay identical.
+    #[must_use]
+    pub(crate) fn zone_stats(&self) -> Vec<ColumnStats> {
+        let rows = self.row_count;
+        let mut stats = Vec::new();
+        for col in &self.columns {
+            let TypeTag::Bytes = col.type_tag else {
+                continue;
+            };
+            let mut min: Option<&[u8]> = None;
+            let mut max: Option<&[u8]> = None;
+            // Bounded by `rows` (a u32), so the count never overflows.
+            let mut null_count: u32 = 0;
+            for i in 0..rows {
+                if !column_row_valid(col, i) {
+                    null_count += 1;
+                    continue;
+                }
+                let Ok(value) = bytes_column_row(&col.data, rows, i) else {
+                    continue;
+                };
+                if min.is_none_or(|m| value < m) {
+                    min = Some(value);
+                }
+                if max.is_none_or(|m| value > m) {
+                    max = Some(value);
+                }
+            }
+            stats.push(ColumnStats {
+                column_id: u32::from(col.column_id),
+                type_tag: TypeTag::Bytes.to_wire().0,
+                codec_id: 0,
+                null_count,
+                row_count: rows,
+                min: min.unwrap_or(&[]).to_vec(),
+                max: max.unwrap_or(&[]).to_vec(),
+            });
+        }
+        stats
+    }
+
     /// Appends `other`'s rows after this batch's, in place, so a sequence of
     /// small ingest batches can accumulate into one rowgroup before a block is
     /// written. The two batches must share the same columns (id + type) in the
@@ -757,6 +815,19 @@ fn build_bytes_column<'a>(rows: impl Iterator<Item = &'a [u8]>) -> Result<Vec<u8
     }
     offsets.extend_from_slice(&payload);
     Ok(offsets)
+}
+
+/// Whether row `i` of `col` is valid (non-null): a column with no validity
+/// bitmap has every row valid; otherwise a set bit (LSB-first) means valid.
+fn column_row_valid(col: &Column, i: u32) -> bool {
+    match &col.validity {
+        None => true,
+        Some(bits) => {
+            let idx = i as usize;
+            bits.get(idx / 8)
+                .is_some_and(|byte| byte & (1u8 << (idx % 8)) != 0)
+        }
+    }
 }
 
 /// Reads row `i` of a [`TypeTag::Bytes`] column body (offset table + payload),

--- a/src/table/columnar/tests.rs
+++ b/src/table/columnar/tests.rs
@@ -917,3 +917,68 @@ fn column_batch_match_entries_rejects_a_zero_row_block() {
         "expected an empty-block InvalidHeader, got {err:?}",
     );
 }
+
+#[test]
+fn zone_stats_records_per_bytes_column_ranges_and_omits_fixed_columns() {
+    // A columnar block's zone map must carry one entry PER Bytes column (the
+    // user-key column AND the value column), each with the raw-byte min / max
+    // over its rows — not just a single synthetic key-range column. The fixed
+    // seqno and value-type columns have no comparable encoding and are omitted,
+    // so a block-skip over them stays conservative.
+    let batch = entries_to_column_batch(&[
+        entry(b"alpha", 3, ValueType::Value, b"mval"),
+        entry(b"gamma", 2, ValueType::Value, b"aval"),
+        entry(b"omega", 1, ValueType::Value, b"zval"),
+    ])
+    .expect("three-row batch");
+
+    let stats = batch.zone_stats();
+
+    // Exactly the two Bytes columns (user key = 0, value = 3), in column order;
+    // the fixed seqno (1) and value-type (2) columns are absent.
+    let ids: Vec<u32> = stats.iter().map(|s| s.column_id).collect();
+    assert_eq!(
+        ids,
+        vec![u32::from(COL_USER_KEY), u32::from(COL_VALUE)],
+        "only the Bytes columns get a zone-map entry, in column order",
+    );
+
+    let key_stat = &stats[0];
+    assert_eq!(
+        key_stat.min, b"alpha",
+        "user-key min is the first sorted key"
+    );
+    assert_eq!(
+        key_stat.max, b"omega",
+        "user-key max is the last sorted key"
+    );
+    assert_eq!(key_stat.row_count, 3);
+    assert_eq!(key_stat.null_count, 0);
+    // Bytes wire tag (see `TypeTag::to_wire`).
+    assert_eq!(key_stat.type_tag, 1);
+
+    let val_stat = &stats[1];
+    assert_eq!(
+        val_stat.min, b"aval",
+        "value min is the byte-wise minimum value, independent of key order",
+    );
+    assert_eq!(
+        val_stat.max, b"zval",
+        "value max is the byte-wise maximum value",
+    );
+    assert_eq!(val_stat.row_count, 3);
+    assert_eq!(val_stat.null_count, 0);
+
+    // The value column's range enables a non-key block-skip: a predicate whose
+    // value band is entirely below the block minimum proves the block holds no
+    // match, which the old single-column (key-only) map could never do.
+    let below = crate::table::columnar_predicate::ColumnRangePredicate {
+        column_id: COL_VALUE,
+        lower: None,
+        upper: Some(b"aaaa".to_vec()),
+    };
+    assert!(
+        below.can_skip_block(&stats),
+        "a value-column predicate below the block's value range skips the block",
+    );
+}

--- a/src/table/columnar_predicate.rs
+++ b/src/table/columnar_predicate.rs
@@ -165,11 +165,14 @@ fn filter_column(col: &Column, rows: usize, mask: &[bool], kept: usize) -> Colum
                 // leaving a missing offset and malformed framing.
                 let value = bytes_row(&col.data, rows, row).unwrap_or(&[]);
                 payload.extend_from_slice(value);
-                // The kept payload is a subset of the original, whose offsets
-                // already fit u32. The caps only guard the unreachable overflow
-                // and keep the offsets monotonically non-decreasing.
+                // `col` is an already-decoded column, so its per-row lengths and
+                // their running total both fit u32 by construction (that is how
+                // the offset table was parsed). The kept payload is a SUBSET of
+                // that original, so `acc` stays within the original total and can
+                // never exceed u32::MAX — plain arithmetic, no cap to hide a
+                // corrupt overrun and no error channel to surface one on.
                 let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
-                acc = acc.saturating_add(len);
+                acc += len;
                 offsets.extend_from_slice(&acc.to_le_bytes());
             }
             offsets.extend_from_slice(&payload);
@@ -217,25 +220,45 @@ fn compact_validity(bits: &[u8], mask: &[bool], kept: usize) -> Vec<u8> {
 /// newest-wins dedup. An out-of-range index contributes an empty (`Bytes`) or
 /// zero-filled (`Fixed`) cell rather than panicking, so a malformed index can
 /// never desync a column's framing from the output row count.
-#[must_use]
-pub(crate) fn take_rows(batch: &ColumnBatch, indices: &[u32]) -> ColumnBatch {
+pub(crate) fn take_rows(batch: &ColumnBatch, indices: &[u32]) -> crate::Result<ColumnBatch> {
     let rows = batch.row_count as usize;
     let columns = batch
         .columns
         .iter()
         .map(|c| take_column(c, rows, indices))
-        .collect();
+        .collect::<crate::Result<_>>()?;
     // `indices.len()` is the output row count; it fits u32 because every index
     // addresses a row of a single block, whose count is itself a u32.
     let row_count = u32::try_from(indices.len()).unwrap_or(u32::MAX);
-    ColumnBatch { row_count, columns }
+    Ok(ColumnBatch { row_count, columns })
 }
 
 /// Gathers one column to the rows listed in `indices` (in that order),
 /// rebuilding its framing (fixed chunks copied, `Bytes` offset table + payload
 /// repacked) and its validity bitmap. Sibling of [`filter_column`] for the
 /// index-driven [`take_rows`] gather.
-fn take_column(col: &Column, rows: usize, indices: &[u32]) -> Column {
+/// Advances the running `Bytes` offset accumulator by one gathered value's
+/// length, returning the new offset. Unlike the mask-driven `filter_column`, a
+/// gather may REPEAT an index (any index list is permitted), so the emitted
+/// payload is not a subset of the original and the running u32 offset can exceed
+/// the original total. A saturating accumulator would peg the offsets at
+/// `u32::MAX` while the payload kept growing, desyncing the offset table from the
+/// payload (later rows mis-sliced on read); instead this returns
+/// [`crate::Error::DecompressedSizeTooLarge`] when either a single value's length
+/// or the accumulated total would exceed the u32 offset-table capacity.
+fn advance_bytes_offset(acc: u32, value_len: usize) -> crate::Result<u32> {
+    let len = u32::try_from(value_len).map_err(|_| crate::Error::DecompressedSizeTooLarge {
+        declared: value_len as u64,
+        limit: u64::from(u32::MAX),
+    })?;
+    acc.checked_add(len)
+        .ok_or_else(|| crate::Error::DecompressedSizeTooLarge {
+            declared: u64::from(acc) + u64::from(len),
+            limit: u64::from(u32::MAX),
+        })
+}
+
+fn take_column(col: &Column, rows: usize, indices: &[u32]) -> crate::Result<Column> {
     let data = match col.type_tag {
         TypeTag::Fixed(width) => {
             let width = width as usize;
@@ -264,9 +287,11 @@ fn take_column(col: &Column, rows: usize, indices: &[u32]) -> Column {
                 // A missing cell degrades to empty (one offset still written), so
                 // the offset table stays in lockstep with the output row count.
                 let value = bytes_row(&col.data, rows, i as usize).unwrap_or(&[]);
+                // Advance the offset accumulator BEFORE appending the value, so a
+                // genuinely oversized gather is a clean error rather than a
+                // silently corrupt batch (see `advance_bytes_offset`).
+                acc = advance_bytes_offset(acc, value.len())?;
                 payload.extend_from_slice(value);
-                let len = u32::try_from(value.len()).unwrap_or(u32::MAX);
-                acc = acc.saturating_add(len);
                 offsets.extend_from_slice(&acc.to_le_bytes());
             }
             offsets.extend_from_slice(&payload);
@@ -277,12 +302,12 @@ fn take_column(col: &Column, rows: usize, indices: &[u32]) -> Column {
         .validity
         .as_ref()
         .map(|bits| take_validity(bits, indices));
-    Column {
+    Ok(Column {
         column_id: col.column_id,
         type_tag: col.type_tag,
         validity,
         data,
-    }
+    })
 }
 
 /// Rebuilds a validity bitmap for the rows listed in `indices`, preserving each

--- a/src/table/columnar_predicate/tests.rs
+++ b/src/table/columnar_predicate/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     Column, ColumnBatch, ColumnRangePredicate, ColumnStats, TypeTag, byte_eq_mask, byte_eq_scalar,
-    filter_batch,
+    filter_batch, take_rows,
 };
 use crate::table::columnar::{column_batch_to_entries, entries_to_column_batch};
 use crate::{Slice, ValueType, key::InternalKey, value::InternalValue};
@@ -209,4 +209,57 @@ fn filter_batch_compacts_fixed_data_and_validity() {
     assert_eq!(col.data, vec![10, 30], "fixed data keeps rows 0 and 2");
     // Both kept rows were valid, compacted to the low two bits.
     assert_eq!(col.validity, Some(vec![0b0000_0011]));
+}
+
+#[test]
+fn take_rows_repeats_a_bytes_value_and_keeps_offsets_monotonic() {
+    // A gather may list the same index more than once. The Bytes value must be
+    // emitted once per occurrence and the offset table stay monotonic — the
+    // accumulator adds each repeat's length (checked, so a genuinely oversized
+    // gather errors cleanly rather than wrapping the u32 table into a desynced
+    // frame; a normal gather like this one never approaches the limit).
+    let batch = entries_to_column_batch(&[
+        entry(b"k0", 3, b"aaa"),
+        entry(b"k1", 2, b"bb"),
+        entry(b"k2", 1, b"c"),
+    ])
+    .expect("transpose");
+
+    // Gather rows [0, 0, 2]: row 0 ("aaa") twice, then row 2 ("c").
+    let taken = take_rows(&batch, &[0, 0, 2]).expect("gather within the u32 offset limit");
+    assert_eq!(taken.row_count, 3);
+
+    let entries = column_batch_to_entries(&taken).expect("transpose back");
+    let values: Vec<&[u8]> = entries.iter().map(|e| e.value.as_ref()).collect();
+    assert_eq!(
+        values,
+        vec![&b"aaa"[..], &b"aaa"[..], &b"c"[..]],
+        "the repeated index emits its value each time, framed by a monotonic offset table",
+    );
+}
+
+/// The `Bytes` offset accumulator's overflow guard, exercised WITHOUT
+/// materializing a multi-GiB payload: the arithmetic is driven directly at the
+/// u32 boundary.
+#[test]
+fn advance_bytes_offset_rejects_a_u32_offset_overflow() {
+    // A repeated gather can push the accumulated total past u32::MAX; the
+    // `checked_add` guard rejects it (a tiny `value_len`, nothing allocated).
+    assert!(matches!(
+        super::advance_bytes_offset(u32::MAX - 3, 10),
+        Err(crate::Error::DecompressedSizeTooLarge { .. }),
+    ));
+    // A single value longer than u32::MAX trips the `u32::try_from` guard. Only
+    // reachable where usize is wider than u32 (64-bit); on a 32-bit target usize
+    // IS u32, so a length can never exceed it.
+    #[cfg(target_pointer_width = "64")]
+    assert!(matches!(
+        super::advance_bytes_offset(0, (u32::MAX as usize) + 1),
+        Err(crate::Error::DecompressedSizeTooLarge { .. }),
+    ));
+    // A normal advance within the u32 ceiling succeeds.
+    assert_eq!(
+        super::advance_bytes_offset(100, 50).expect("within the u32 offset ceiling"),
+        150,
+    );
 }

--- a/src/table/data_block/mod.rs
+++ b/src/table/data_block/mod.rs
@@ -697,6 +697,25 @@ impl DataBlock {
         }
     }
 
+    /// Test-only: the `(offset, len)` span of the embedded hash index within
+    /// this block's (footer-stripped) `inner.data`, or `None` when the block
+    /// carries no hash index. Used by the forgery helpers to corrupt the
+    /// hash index in place.
+    #[cfg(test)]
+    pub(crate) fn hash_index_span(&self) -> Option<(usize, usize)> {
+        use core::mem::size_of;
+
+        let trailer = Trailer::new(&self.inner);
+        let offset = size_of::<u8>() + size_of::<u8>() + size_of::<u32>() + size_of::<u32>();
+        let mut reader = trailer.as_slice().get(offset..)?;
+        let hash_index_len = reader.read_u32::<LittleEndian>().ok()?;
+        let hash_index_offset = reader.read_u32::<LittleEndian>().ok()?;
+        if hash_index_len == 0 {
+            return None;
+        }
+        Some((hash_index_offset as usize, hash_index_len as usize))
+    }
+
     /// Returns the number of hash buckets.
     #[must_use]
     pub fn hash_bucket_count(&self) -> Option<usize> {
@@ -961,6 +980,45 @@ impl DataBlock {
             Decoder::<InternalValue, DataBlockParsedItem>::new(&self.inner),
             comparator,
         )
+    }
+
+    /// The user key of the block's FIRST (lowest) entry, or `None` when the block
+    /// decodes to no entries. Repair uses it to derive a resurrection-mode
+    /// restriction that keeps the whole first readable (straddling) block.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a block-decode failure from [`try_iter`](Self::try_iter).
+    #[cfg(feature = "std")]
+    pub(crate) fn first_user_key(
+        &self,
+        comparator: crate::comparator::SharedComparator,
+    ) -> crate::Result<Option<crate::UserKey>> {
+        match self.try_iter(comparator)?.next() {
+            Some(item) => Ok(Some(item.materialize(&self.inner.data).key.user_key)),
+            None => Ok(None),
+        }
+    }
+
+    /// Validates the binary index against the sequentially derived restart
+    /// heads (see [`Decoder::verify_binary_index`]): the sequential decode
+    /// never reads the pointers, so a forged pointer passes every
+    /// entry-level cross-check while seeks trust it and can start at the
+    /// wrong restart head.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when a pointer disagrees with its
+    /// restart head; [`crate::Error::InvalidTrailer`] on a malformed trailer.
+    #[cfg_attr(
+        not(feature = "std"),
+        allow(
+            dead_code,
+            reason = "reconcile-gate check; the verify/scrub consumers are std-gated"
+        )
+    )]
+    pub(crate) fn verify_binary_index(&self) -> crate::Result<()> {
+        Decoder::<InternalValue, DataBlockParsedItem>::verify_binary_index(&self.inner)
     }
 
     /// Returns the binary index length (number of pointers).

--- a/src/table/filter/block.rs
+++ b/src/table/filter/block.rs
@@ -38,6 +38,17 @@ impl FilterBlock {
     pub fn size(&self) -> usize {
         self.0.size()
     }
+
+    /// Whether the decoded payload is the empty "no filter installed" sentinel
+    /// (see [`maybe_contains_hash`](Self::maybe_contains_hash)). The read path
+    /// treats this permissively, but a verifier deciding whether to trust the
+    /// bytes must distinguish it from a real filter — a present-but-empty full
+    /// filter on a table with keys is anomalous (the writer omits the section
+    /// rather than emitting an empty one).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.data.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/src/table/index_block/mod.rs
+++ b/src/table/index_block/mod.rs
@@ -147,6 +147,27 @@ impl IndexBlock {
         )
     }
 
+    /// Validates the binary index against the sequentially derived restart
+    /// heads (see [`Decoder::verify_binary_index`]): the sequential decode
+    /// never reads the pointers, so a forged pointer passes every
+    /// entry-level cross-check while index seeks trust it and can start at
+    /// the wrong restart head.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when a pointer disagrees with its
+    /// restart head; [`crate::Error::InvalidTrailer`] on a malformed trailer.
+    #[cfg_attr(
+        not(feature = "std"),
+        allow(
+            dead_code,
+            reason = "reconcile-gate check; the verify/scrub consumers are std-gated"
+        )
+    )]
+    pub(crate) fn verify_binary_index(&self) -> crate::Result<()> {
+        Decoder::<KeyedBlockHandle, IndexBlockParsedItem>::verify_binary_index(&self.inner)
+    }
+
     /// Parses the block trailer once and returns the reusable
     /// [`DecoderMeta`], so repeated lookups can build decoders via
     /// [`Self::iter_with_meta`] without re-parsing.

--- a/src/table/inner.rs
+++ b/src/table/inner.rs
@@ -160,6 +160,28 @@ pub struct Inner {
     /// masking, instead of recomputing the cumulative row counts per read.
     pub(crate) delete_block_starts: Option<alloc::sync::Arc<crate::HashMap<u64, u32>>>,
 
+    /// Whether a SALVAGE-MODE open degraded this segment's delete masking: its
+    /// `delete_bitmap` section exists but was unreadable (so the bitmap was
+    /// reset to empty) or readable-but-unpositionable (its zone map was
+    /// unreadable, so it was ignored). Reads then show every row live,
+    /// resurrecting positionally-deleted rows — the salvage walk consults this
+    /// to fail closed unless the caller explicitly opted into that
+    /// degradation. Always `false` on a normal (non-salvage) open, which fails
+    /// instead of degrading.
+    pub(crate) delete_bitmap_degraded: bool,
+
+    /// Whether a SALVAGE-MODE open degraded a REBUILDABLE side section
+    /// (filter / `filter_tli`, seqno bounds, zone map, locator) because its
+    /// block did not decode as the claimed type. Salvage re-derives every such
+    /// section from the recovered entries, so a section that is present but does
+    /// not decode may be a `range_tombstones` / `delete_bitmap` relabeled to a
+    /// rebuildable name and re-roled — which salvage would discard, resurrecting
+    /// the suppressed rows. The salvage walk consults this to fail closed when
+    /// the table exposes no deletion metadata. Purely STRUCTURAL (each decode
+    /// reads its own section's bytes, independent of the data blocks), so a
+    /// corrupt DATA block does not trip it.
+    pub(crate) rebuildable_section_degraded: bool,
+
     /// Retrieval-ribbon locator, loaded on open from the optional `locator`
     /// section. `Some` only when the table was written with a locator policy
     /// enabled; lets a point read resolve a key to its data block in O(1),
@@ -212,6 +234,27 @@ pub struct Inner {
     // pin `Inner` to std, matching `deletion_pause`. The hint set itself is
     // `no_std` + alloc (see `crate::heal_hints`).
     pub(crate) heal_hints: once_cell::race::OnceBox<Arc<crate::heal_hints::HealHints>>,
+
+    /// Serializes concurrent in-place heal passes of THIS table, held by the
+    /// patrol scrub across the WHOLE scan-to-reconcile span. Two overlapping
+    /// heals race in two ways without it: through the link-count probe (one
+    /// detaches the live path onto a private copy, leaving the other's
+    /// already-open handle on the OLD inode — whose count then reads 1 even
+    /// though only checkpoint links remain, so that heal would write through
+    /// the snapshot), and through the digest reconciliation (A computes a
+    /// digest, B heals a fresh fault and installs its own, A installs the
+    /// stale one).
+    // std+page_ecc: only the heal-mode patrol scrub takes it; `parking_lot`
+    // (not `spin`) because a heal pass is a long blocking operation.
+    //
+    // Held behind a shared `Arc` inside an `OnceBox` so it serializes by STABLE
+    // table identity, not by this replaceable `Inner`: tight-space compaction
+    // re-opens a table as a DISTINCT `Inner` (a different physical view of the
+    // same file), and `reopen_restricted` propagates this lock into it so two
+    // patrols cannot heal + reconcile the same SST concurrently. Lazily created
+    // on first heal for an ordinary table (the tree does not install it).
+    #[cfg(all(feature = "std", feature = "page_ecc"))]
+    pub(crate) heal_lock: once_cell::race::OnceBox<Arc<parking_lot::Mutex<()>>>,
 }
 
 impl Inner {
@@ -228,6 +271,24 @@ impl Drop for Inner {
 
         if self.is_deleted.load(core::sync::atomic::Ordering::Acquire) {
             log::trace!("Cleanup deleted table {global_id:?} at {:?}", self.path);
+
+            // Reclaim any pending `.heal-attest` sidecar: a retired table can
+            // never be reconciled, so its attestation is dead weight. Done here
+            // (before the deferred / background unlink paths return) so every
+            // deletion route reclaims it. Best-effort: a missing sidecar (the
+            // common case) is a no-op, and the recovery scan sweeps any straggler.
+            #[cfg(feature = "std")]
+            crate::scrub::heal_attest::remove(&*self.fs, &self.path);
+
+            // Reclaim any `.restrict-bound` sidecar the same way: a retired table's
+            // tight-space restriction bound is dead weight, and left behind it would
+            // linger as an orphan (swept by the recovery scan, but a leak until
+            // then). Best-effort; done before the deferred / background unlink paths
+            // return so every deletion route reclaims it. A concurrent checkpoint has
+            // already linked its OWN copy of the sidecar, so removing this original is
+            // safe even on the deferred-deletion (checkpoint-active) branch below.
+            #[cfg(feature = "std")]
+            crate::restrict_bound::remove(&*self.fs, &self.path, crate::fs::SyncMode::Normal);
 
             // Move the accessor and block index out so all file handles
             // (including clones held by the block index) are closed before
@@ -314,11 +375,25 @@ impl Drop for Inner {
             // span punch would zero a section the SST needs. The block index
             // yields only data-block handles, so iterating it punches exactly the
             // reclaimable data and never an index / filter / footer region.
+            //
+            // Punch TOP-DOWN (highest reclaimable block first) and STOP at the
+            // first failure. This keeps the resulting hole pattern CLASSIFIABLE
+            // for a sidecar-less manifest repair: any failure (or crash) leaves
+            // intact blocks strictly BELOW the zeroed ones — the irregular
+            // signature repair fails closed on — while a fully successful pass
+            // leaves the clean zeroed prefix the classical geometry bound is
+            // sound for. Bottom-up with continue-past-failures could instead
+            // leave intact-but-consumed blocks ABOVE a clean zeroed prefix,
+            // indistinguishable from a live suffix, and a sidecar-less repair
+            // would then restrict to a bound that resurrects their superseded
+            // rows. Stopping reclaims less space on a failure, but reclaim is
+            // best-effort; classification soundness is not.
             let off = self
                 .punch_on_drop
                 .load(core::sync::atomic::Ordering::Acquire);
             if off != u64::MAX {
                 use crate::table::block_index::BlockIndex;
+                let mut reclaimable: alloc::vec::Vec<(u64, u32)> = alloc::vec::Vec::new();
                 for handle in self.block_index.iter() {
                     // Log why reclaim stopped instead of silently swallowing the
                     // block-index read error (this is an integrity-sensitive path).
@@ -329,19 +404,22 @@ impl Drop for Inner {
                                 "Failed to iterate block index while punching table {global_id:?} at {:?}: {e:?}",
                                 self.path,
                             );
-                            break;
+                            return;
                         }
                     };
                     let block_off = handle.offset().0;
-                    if block_off < off
-                        && let Err(e) =
-                            self.fs
-                                .punch_hole(&self.path, block_off, u64::from(handle.size()))
-                    {
+                    if block_off < off {
+                        reclaimable.push((block_off, handle.size()));
+                    }
+                }
+                for (block_off, size) in reclaimable.into_iter().rev() {
+                    if let Err(e) = self.fs.punch_hole(&self.path, block_off, u64::from(size)) {
                         log::warn!(
-                            "Failed to punch tight-space data block at {block_off} of table {global_id:?} at {:?}: {e:?}",
+                            "Failed to punch tight-space data block at {block_off} of table {global_id:?} at {:?}; \
+                             stopping the reclaim to keep the hole pattern classifiable: {e:?}",
                             self.path,
                         );
+                        break;
                     }
                 }
             }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -34,7 +34,12 @@ impl From<u128> for Timestamp {
     }
 }
 
-#[derive(Debug)]
+// `PartialEq`: the out-of-band verifier compares the two decoded meta
+// mirrors: a tail re-stamped to another internally-consistent payload is
+// detectable only by disagreeing with `meta_mid`. `Clone` lets that verifier
+// compare an ECC-masked copy ([`Self::without_ecc`]) without consuming the
+// original.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedMeta {
     pub id: TableId,
     pub created_at: Timestamp,
@@ -51,6 +56,30 @@ pub struct ParsedMeta {
     pub file_size: u64,
     pub item_count: u64,
     pub tombstone_count: u64,
+
+    /// Number of RANGE tombstones the writer emitted into the
+    /// `range_tombstones` section. Distinct from `tombstone_count` (point
+    /// deletes). Salvage cross-checks it against the parsed section: a `> 0`
+    /// count with no readable section means the section was hidden (renamed /
+    /// re-roled), so salvaging would resurrect the rows it masked.
+    pub range_tombstone_count: u64,
+
+    /// Number of positions in this table's `delete_bitmap` section, or `None`
+    /// for tables written before this field existed. The section is optional
+    /// (omitted when empty), so this authenticated count lets a reader detect a
+    /// re-stamped TOC that hid a non-empty bitmap (renamed it, or replaced it
+    /// with another valid optional section): a `Some(n)` with `n > 0` and no
+    /// readable delete-bitmap section is a forgery that would resurrect every
+    /// positionally-deleted row.
+    pub delete_bitmap_len: Option<u64>,
+
+    /// XXH3-128 of the delete-bitmap section's encoded bytes, binding its
+    /// CONTENTS (not just its cardinality) into the meta. `None` on tables
+    /// written before this field. A count-only cross-check would accept an
+    /// equal-cardinality checksum-valid substitution that, during manifest repair
+    /// (no original whole-file digest), resurrects deleted rows / drops live ones.
+    pub delete_bitmap_hash: Option<u128>,
+
     pub weak_tombstone_count: u64,
     pub weak_tombstone_reclaimable: u64,
 
@@ -114,11 +143,27 @@ pub struct ParsedMeta {
     /// path (the restart heads sit every `data_block_restart_interval` entries).
     pub data_block_restart_interval: u8,
 
+    /// Restart interval the index blocks were encoded with. Not consumed on
+    /// the read path (index blocks decode without it), but persisted so a
+    /// layout-mirroring rewrite (salvage) reproduces the source's index
+    /// encoding instead of the writer default.
+    pub index_block_restart_interval: u8,
+
     /// Whether this SST's data blocks are column-organized (PAX) rather than
     /// row-major. Read from the optional `descriptor#columnar` property;
     /// defaults to `false` for SSTs written without it (row-major). The reader
     /// reconstructs row entries from a columnar block on load.
     pub columnar: bool,
+
+    /// Bulk-ingest provenance from the optional `descriptor#bulk_ingested`
+    /// property: `Some(true)` = bulk-ingested (every entry at LOCAL seqno 0, MVCC
+    /// ordering carried by a manifest-only `global_seqno`), `Some(false)` = a
+    /// normal flush / compaction table (offset 0), `None` = the key is ABSENT, a
+    /// legacy SST of UNKNOWN provenance. Manifest repair fails closed on
+    /// `Some(true)` and treats `None` as ambiguous (a legacy table may itself
+    /// have been bulk-ingested), since it cannot reconstruct the offset from the
+    /// SST alone.
+    pub bulk_ingested: Option<bool>,
 }
 
 macro_rules! read_u8 {
@@ -190,6 +235,24 @@ fn validated_restart_interval_index(restart_interval: u8) -> crate::Result<u8> {
 }
 
 impl ParsedMeta {
+    /// Returns `self` with the ECC-descriptor fields normalized to their
+    /// "no scheme" values (`page_ecc = false`, `ecc_params = None`,
+    /// `ecc_unrecognized = false`).
+    ///
+    /// The out-of-band mirror comparison uses this so two `meta` / `meta_mid`
+    /// copies diverge only on a NON-ECC field: an ECC-descriptor-only difference
+    /// (a lone unrecognized sibling, or a descriptor-only forge) is arbitrated
+    /// separately and must not by itself condemn a healthy table, while a change
+    /// to a correctness field like `created_at` still surfaces even when it hides
+    /// behind an unrecognized descriptor.
+    #[cfg(feature = "std")]
+    pub(crate) fn without_ecc(mut self) -> Self {
+        self.page_ecc = false;
+        self.ecc_params = None;
+        self.ecc_unrecognized = false;
+        self
+    }
+
     #[expect(clippy::too_many_lines)]
     pub fn load_with_handle(
         file: &dyn FsFile,
@@ -270,7 +333,7 @@ impl ParsedMeta {
             }
         }
 
-        let _index_block_restart_interval =
+        let index_block_restart_interval =
             validated_restart_interval_index(read_u8!(block, b"restart_interval#index", &cmp))?;
         // Data-block restart interval: needed to rebuild a positional restart
         // index when partial-decoding a block (lazy read path).
@@ -284,6 +347,20 @@ impl ParsedMeta {
             None => false,
             Some(v) => match v.value.as_ref() {
                 [b] => *b != 0,
+                _ => return Err(crate::Error::InvalidHeader("TableMeta")),
+            },
+        };
+
+        // Optional bulk-ingest provenance. `None` = the key is ABSENT: a legacy
+        // SST (written before the flag existed) whose provenance is UNKNOWN, so
+        // manifest repair must treat it as AMBIGUOUS (it may be a legacy
+        // bulk-ingested table that stored local seqno 0 under a manifest-only
+        // offset). `Some(true/false)` = a newer SST that authoritatively records
+        // whether it was bulk-ingested. One byte, non-zero meaning ingested.
+        let bulk_ingested = match block.point_read(b"descriptor#bulk_ingested", SeqNo::MAX, &cmp)? {
+            None => None,
+            Some(v) => match v.value.as_ref() {
+                [b] => Some(*b != 0),
                 _ => return Err(crate::Error::InvalidHeader("TableMeta")),
             },
         };
@@ -303,6 +380,7 @@ impl ParsedMeta {
         }
         let item_count = read_u64!(block, b"item_count", &cmp);
         let tombstone_count = read_u64!(block, b"tombstone_count", &cmp);
+        let range_tombstone_count = read_u64!(block, b"range_tombstone_count", &cmp);
         let data_block_count = read_u64!(block, b"block_count#data", &cmp);
         let index_block_count = read_u64!(block, b"block_count#index", &cmp);
         let _filter_block_count = read_u64!(block, b"block_count#filter", &cmp);
@@ -442,8 +520,27 @@ impl ParsedMeta {
                 None => Ok(None),
             }
         };
+        // Present-but-wrong-width is corrupt meta, so require exactly 16 bytes.
+        let read_opt_u128 = |key: &[u8]| -> crate::Result<Option<u128>> {
+            match block.point_read(key, SeqNo::MAX, &cmp)? {
+                Some(item) => {
+                    let bytes = <[u8; 16]>::try_from(&item.value[..])
+                        .map_err(|_| crate::Error::InvalidHeader("TableMeta"))?;
+                    Ok(Some(u128::from_le_bytes(bytes)))
+                }
+                None => Ok(None),
+            }
+        };
         let sum_user_key_bytes = read_opt_u64(b"key_bytes#sum")?;
         let sum_value_bytes = read_opt_u64(b"value_bytes#sum")?;
+        // Intentionally OPTIONAL, not a required `read_u64!`: tables written
+        // before this field carry no key and must still decode (`None`). It also
+        // does not need to be mandatory for the forgery cross-check — the whole
+        // meta block is verified field-for-field against the recovery-time copy
+        // and the mirror, so a stripped or forged key fails meta integrity long
+        // before the `delete_bitmap_len` cross-check would run.
+        let delete_bitmap_len = read_opt_u64(b"descriptor#delete_bitmap_len")?;
+        let delete_bitmap_hash = read_opt_u128(b"descriptor#delete_bitmap_hash")?;
 
         Ok(Self {
             id,
@@ -456,6 +553,9 @@ impl ParsedMeta {
             file_size,
             item_count,
             tombstone_count,
+            range_tombstone_count,
+            delete_bitmap_len,
+            delete_bitmap_hash,
             weak_tombstone_count,
             weak_tombstone_reclaimable,
             sum_user_key_bytes,
@@ -467,7 +567,9 @@ impl ParsedMeta {
             ecc_params,
             ecc_unrecognized,
             data_block_restart_interval,
+            index_block_restart_interval,
             columnar,
+            bulk_ingested,
         })
     }
 }

--- a/src/table/meta.rs
+++ b/src/table/meta.rs
@@ -55,6 +55,15 @@ pub struct ParsedMeta {
     pub(super) highest_kv_seqno: SeqNo,
     pub file_size: u64,
     pub item_count: u64,
+
+    /// Number of DISTINCT user keys the writer counted (the `key_count` meta
+    /// key), or `None` for tables written before this field was persisted.
+    /// Together with [`Self::item_count`] it proves key uniqueness:
+    /// `key_count == item_count` means no key carries more than one version,
+    /// so a scan can skip per-key newest-visible dedup. `None` is conservative
+    /// (duplicate versions assumed).
+    pub key_count: Option<u64>,
+
     pub tombstone_count: u64,
 
     /// Number of RANGE tombstones the writer emitted into the
@@ -541,6 +550,7 @@ impl ParsedMeta {
         // before the `delete_bitmap_len` cross-check would run.
         let delete_bitmap_len = read_opt_u64(b"descriptor#delete_bitmap_len")?;
         let delete_bitmap_hash = read_opt_u128(b"descriptor#delete_bitmap_hash")?;
+        let key_count = read_opt_u64(b"key_count")?;
 
         Ok(Self {
             id,
@@ -552,6 +562,7 @@ impl ParsedMeta {
             highest_kv_seqno,
             file_size,
             item_count,
+            key_count,
             tombstone_count,
             range_tombstone_count,
             delete_bitmap_len,

--- a/src/table/meta/tests.rs
+++ b/src/table/meta/tests.rs
@@ -456,3 +456,90 @@ fn load_with_handle_missing_page_ecc_descriptor_returns_err() {
         "expected InvalidHeader(\"TableMeta\"), got {result:?}",
     );
 }
+
+/// Returns [`valid_meta_items`] with `extra` inserted / replacing its key,
+/// kept lexicographically sorted (the meta block is point-read by key, so it
+/// must stay ordered). Lets a corruption test add an OPTIONAL descriptor key
+/// (absent from `valid_meta_items` for backward compatibility) at a bad width.
+fn meta_items_with(extra: InternalValue) -> Vec<InternalValue> {
+    let mut items: Vec<_> = valid_meta_items()
+        .into_iter()
+        .filter(|iv| iv.key.user_key != extra.key.user_key)
+        .collect();
+    items.push(extra);
+    items.sort_by(|a, b| a.key.user_key.cmp(&b.key.user_key));
+    items
+}
+
+/// A one-byte `descriptor#bulk_ingested` parses as the provenance flag.
+#[test]
+fn load_with_handle_bulk_ingested_byte_parses_as_flag() {
+    let parsed =
+        load_meta_from_items(&meta_items_with(meta("descriptor#bulk_ingested", &[1u8]))).unwrap();
+    assert_eq!(parsed.bulk_ingested, Some(true));
+    let parsed =
+        load_meta_from_items(&meta_items_with(meta("descriptor#bulk_ingested", &[0u8]))).unwrap();
+    assert_eq!(parsed.bulk_ingested, Some(false));
+    // Absent (legacy) parses as unknown.
+    assert_eq!(
+        load_meta_from_items(&valid_meta_items())
+            .unwrap()
+            .bulk_ingested,
+        None
+    );
+}
+
+/// A `descriptor#bulk_ingested` value that is not exactly one byte is corrupt
+/// meta, not silently truncatable.
+#[test]
+fn load_with_handle_bulk_ingested_wrong_width_returns_err() {
+    let result = load_meta_from_items(&meta_items_with(meta(
+        "descriptor#bulk_ingested",
+        &[1u8, 2],
+    )));
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+        "expected InvalidHeader(\"TableMeta\"), got {result:?}",
+    );
+}
+
+/// A `range_tombstone_count` that is not exactly eight bytes is corrupt meta.
+#[test]
+fn load_with_handle_range_tombstone_count_wrong_width_returns_err() {
+    let result = load_meta_from_items(&meta_items_with(meta(
+        "range_tombstone_count",
+        &[1u8, 2, 3],
+    )));
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+        "expected InvalidHeader(\"TableMeta\"), got {result:?}",
+    );
+}
+
+/// A present `descriptor#delete_bitmap_len` that is not exactly eight bytes is
+/// corrupt meta (the field is optional, but present-but-wrong-width is not).
+#[test]
+fn load_with_handle_delete_bitmap_len_wrong_width_returns_err() {
+    let result = load_meta_from_items(&meta_items_with(meta(
+        "descriptor#delete_bitmap_len",
+        &[1u8],
+    )));
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+        "expected InvalidHeader(\"TableMeta\"), got {result:?}",
+    );
+}
+
+/// A present `descriptor#delete_bitmap_hash` that is not exactly sixteen bytes
+/// is corrupt meta.
+#[test]
+fn load_with_handle_delete_bitmap_hash_wrong_width_returns_err() {
+    let result = load_meta_from_items(&meta_items_with(meta(
+        "descriptor#delete_bitmap_hash",
+        &[1u8, 2, 3],
+    )));
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("TableMeta"))),
+        "expected InvalidHeader(\"TableMeta\"), got {result:?}",
+    );
+}

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -30,7 +30,10 @@ pub mod util;
 pub mod writer;
 pub(crate) mod zone_map;
 
-#[cfg(test)]
+// std-gated like the sibling test modules: the tests drive real files through
+// `StdFs` and the std-only `restrict_bound` sidecar API, so a no-std test
+// build must skip the whole module.
+#[cfg(all(test, feature = "std"))]
 #[allow(
     clippy::unwrap_used,
     clippy::indexing_slicing,
@@ -92,6 +95,50 @@ pub(crate) type BlockTaskPlan = (
     Vec<(BlockHandle, Vec<usize>)>,
 );
 
+/// How [`Table::recover_inner`] treats degraded sidecars and the metadata id
+/// cross-check.
+#[derive(Clone, Copy)]
+pub(crate) enum RecoveryMode {
+    /// Live-tree open: a corrupt delete-bitmap / unreadable zone map fails
+    /// closed, and the caller's durable id (manifest entry / file name) is
+    /// cross-checked against the meta payload (with MID-mirror fallback on a
+    /// bad TAIL copy).
+    Live,
+    /// Salvage open: a corrupt delete-bitmap / missing zone map degrades
+    /// instead of failing, so a damaged sidecar still opens. For an
+    /// UNENCRYPTED source the id cross-check uses `expected_id`: `Some` when
+    /// the caller knows the durable id out-of-band (repair — from the SST
+    /// file name), so a forged TAIL id falls back to the intact MID mirror
+    /// instead of poisoning the recovered copy's identity; `None` for a
+    /// standalone recovery reader, where the source's own stored id IS the
+    /// identity to recover under. An ENCRYPTED open always cross-checks the
+    /// caller's id — the meta block's AAD binds it regardless.
+    Salvage {
+        /// The durable table id known out-of-band, or `None` when the
+        /// source's stored id is authoritative.
+        expected_id: Option<TableId>,
+        /// Load the MID meta mirror FIRST (tail as fallback), inverting the
+        /// default tail-first order. Set by the salvage arbitration when the
+        /// two mirrors decode to DIVERGENT contents: neither copy can be
+        /// proven genuine, so salvage attempts both orders and keeps the
+        /// attempt that recovers more.
+        prefer_mid_meta: bool,
+    },
+}
+
+/// Cached outcome of the heal's lazy hard-link probe/detach (see
+/// [`Table::ensure_unshared_for_write`]): the probe and copy run at most
+/// once per scan, and only when a write-back is actually needed.
+#[cfg(feature = "page_ecc")]
+enum UnshareState {
+    /// No write attempted yet: the link count has not been probed.
+    Unprobed,
+    /// The handle is safe to write through (exclusive, or already detached).
+    Ready,
+    /// The unshare failed; every write is refused with this reason.
+    Failed(alloc::string::String),
+}
+
 /// A disk segment (a.k.a. `Table`, `SSTable`, `SST`, `sorted string table`) that is located on disk
 ///
 /// A table is an immutable list of key-value pairs, split into compressed blocks.
@@ -112,6 +159,13 @@ pub struct Table(
     /// (not the shared `Arc<Inner>`) so an older snapshot keeps its own
     /// unrestricted view of the same physical SST. `None` on the common path.
     Option<UserKey>,
+    /// Refreshed full-file checksum: when `Some`, an in-place heal changed the
+    /// file's bytes AFTER it was recovered, and this digest supersedes the one
+    /// captured at recovery. Carried on the wrapper (like the restriction) so
+    /// the version diff sees the change and persists it to the manifest, while
+    /// older snapshots keep the digest they were recovered under. `None` on
+    /// the common path.
+    Option<Checksum>,
 );
 
 impl core::ops::Deref for Table {
@@ -195,6 +249,49 @@ fn apply_global_seqno(local: SeqNo, global: SeqNo) -> SeqNo {
     })
 }
 
+/// Result of [`Table::salvage_load_block`]: the decoded block plus, when it read
+/// back cleanly, its raw on-disk bytes for a verbatim copy.
+pub(crate) struct SalvageBlock {
+    /// The decoded (decompressed / decrypted / ECC-healed) block: the source of
+    /// the per-row entries the salvage walk accounts and, on the re-encode path,
+    /// re-serializes.
+    pub block: Block,
+    /// `Some((raw_on_disk_bytes, header, inner_layout))` when the block read back
+    /// cleanly (no ECC recovery): the walk byte-copies these verbatim. `None` when
+    /// ECC recovery healed the block, so the faulty on-disk bytes must not be
+    /// propagated and the caller re-encodes the healed payload instead.
+    pub verbatim: Option<VerbatimCopy>,
+}
+
+/// Raw on-disk frame captured for a verbatim block copy:
+/// `(raw_on_disk_bytes, header, inner_layout)`. See [`SalvageBlock::verbatim`].
+pub(crate) type VerbatimCopy = (
+    alloc::vec::Vec<u8>,
+    crate::table::block::Header,
+    alloc::vec::Vec<u32>,
+);
+
+/// Outcome of [`Table::derive_restriction_bound`] — the CONSERVATIVE
+/// punch-geometry classification for a punched SST whose exact
+/// `.restrict-bound` sidecar is not trustworthy.
+#[cfg(feature = "std")]
+pub(crate) enum DerivedRestriction {
+    /// The zeroed blocks form a CLEAN prefix (a fully successful punch):
+    /// restrict to this bound — the first readable block's end key — and no
+    /// superseded key resurrects, at the cost of at most that one straddling
+    /// block's live suffix.
+    Bound(UserKey),
+    /// Every data block reads as zeros: no live data survives the punch; the
+    /// caller excludes the table.
+    NoLiveData,
+    /// A readable block sits BELOW a zeroed one — positive evidence of failed
+    /// `punch_hole` calls, after which no geometry bound can separate
+    /// intact-but-consumed blocks from live ones. The caller sets the table
+    /// aside (resurrection mode derives greedily instead, accepting the
+    /// re-exposure by contract).
+    IrregularPunch,
+}
+
 impl Table {
     #[must_use]
     pub fn global_seqno(&self) -> SeqNo {
@@ -266,6 +363,17 @@ impl Table {
             // Parse the buffer
             let mut reader = &buf[..];
             let len = reader.read_u32::<LE>()?;
+            // Bound the declared record count by the bytes that remain BEFORE
+            // reserving: each record is 4 u64s (32 bytes), so a corrupt or
+            // forged count header (e.g. u32::MAX) must fail as invalid data
+            // here rather than trigger a multi-GB Vec pre-allocation (which
+            // aborts the process on allocators that don't overcommit).
+            const RECORD_SIZE: usize = 4 * core::mem::size_of::<u64>();
+            if len as usize > reader.len() / RECORD_SIZE {
+                return Err(crate::Error::InvalidHeader(
+                    "linked_blob_files: declared record count exceeds section size",
+                ));
+            }
             let mut blob_files = Vec::with_capacity(len as usize);
 
             for _ in 0..len {
@@ -339,6 +447,45 @@ impl Table {
         self.delete_bitmap.as_ref()
     }
 
+    /// Whether this segment was written WITH a positional delete bitmap (it
+    /// carries a `delete_bitmap` section), independent of whether that bitmap is
+    /// currently loaded. This stays `true` even when a salvage-mode open degraded
+    /// a corrupt bitmap to empty, so the salvage walk can tell "no deletes ever"
+    /// apart from "deletes whose bitmap was lost" — and must NOT byte-copy a block
+    /// of the latter verbatim (which would resurrect positionally-deleted rows
+    /// the recovered copy no longer masks).
+    ///
+    /// `pub(crate)` for the salvage walk ([`crate::salvage`]); only the columnar
+    /// copy-through path consults it, so it is gated to that feature.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn has_delete_bitmap_section(&self) -> bool {
+        self.regions.delete_bitmap.is_some()
+    }
+
+    /// Whether the loaded delete-bitmap's CONTENTS match the meta-recorded
+    /// `descriptor#delete_bitmap_hash` (and length). The section's own block
+    /// checksum only proves the bytes are self-consistent; an equal-cardinality
+    /// substitution (a different, checksum-valid bitmap) passes both that and the
+    /// positional cross-check, yet masks the WRONG rows. Salvage has no original
+    /// whole-file digest to compare against, so it MUST authenticate the contents
+    /// before masking. A present section with a missing hash (a table written
+    /// before the field) cannot be authenticated → `false` (fail closed). A table
+    /// with no delete-bitmap section has nothing to authenticate → `true`.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn delete_bitmap_authenticated(&self) -> bool {
+        if !self.has_delete_bitmap_section() {
+            return true;
+        }
+        match self.metadata.delete_bitmap_hash {
+            Some(recorded) => {
+                let bitmap = self.delete_bitmap();
+                crate::hash::hash128(&bitmap.encode()) == recorded
+                    && self.metadata.delete_bitmap_len == Some(bitmap.len())
+            }
+            None => false,
+        }
+    }
+
     /// Whether this segment carries a parallel `zone_map` section, i.e. it was
     /// written with the zone-map policy on and held at least one data block.
     /// The section powers predicate-based block-skip; absence means scans read
@@ -347,6 +494,16 @@ impl Table {
     #[must_use]
     pub fn has_zone_map(&self) -> bool {
         self.regions.zone_map.is_some()
+    }
+
+    /// Whether this segment carries a parallel `seqno_bounds` section. Unlike
+    /// the loaded map (best-effort at recover time — an unreadable section
+    /// degrades it to empty), this reflects actual SECTION presence, so a
+    /// source with rotted bounds still salvages into a copy WITH the section
+    /// (the writer re-derives the ranges from the re-emitted entries).
+    #[must_use]
+    pub fn has_seqno_bounds(&self) -> bool {
+        self.regions.seqno_bounds.is_some()
     }
 
     /// The fraction of this segment's rows masked by its positional
@@ -404,6 +561,136 @@ impl Table {
             #[cfg(feature = "metrics")]
             &self.metrics,
         )
+    }
+
+    /// Loads a data-carrying block STRAIGHT FROM THE FILE, bypassing the
+    /// block cache in both directions, for the semantic reconcile gates: a
+    /// block read before an on-disk alteration leaves its pristine copy
+    /// cached, and a gate served that stale original would judge bytes
+    /// other than the ones the digest refresh is about to trust. Reuses the
+    /// cached file descriptor but never consults or populates the block
+    /// cache (the cold verification blocks must not evict the live working
+    /// set either). Decodes under the table's data-block codec context, so
+    /// it fits every gate that walks `block_index` (Data or Columnar role).
+    // Compiled under no_std alongside its `verify_kv_checksums` consumer,
+    // which is itself dead there (the verify/scrub caller is std-gated).
+    #[cfg_attr(
+        not(feature = "std"),
+        allow(
+            dead_code,
+            reason = "gate-only loader; the verify/scrub consumers are std-gated"
+        )
+    )]
+    fn load_block_from_disk(
+        &self,
+        handle: &BlockHandle,
+        block_type: BlockType,
+    ) -> crate::Result<Block> {
+        let (fd, _cache_event) = self
+            .file_accessor
+            .get_or_open_table(&self.global_id(), &self.path)?;
+        let transform = crate::table::util::build_block_transform(
+            self.metadata.data_block_compression,
+            self.encryption.as_deref(),
+            self.metadata.ecc_params,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        let block = Block::from_file(
+            fd.as_ref(),
+            *handle,
+            crate::table::block::BlockIdentity {
+                table_id: self.metadata.id,
+                block_type,
+                dict_id: self.metadata.data_block_compression.dict_id(),
+                window_log: 0,
+            },
+            &transform,
+        )?;
+        // Swap-defence role check, mirroring `load_block`.
+        if block.header.block_type != block_type {
+            return Err(crate::Error::InvalidTag((
+                "BlockType",
+                block.header.block_type.into(),
+            )));
+        }
+        Ok(block)
+    }
+
+    /// Frames the block starting at `offset` by reading its HEADER straight
+    /// from the file: the on-disk span is header + payload + parity trailer
+    /// (SST blocks carry no `block_flags` byte, so the trailer is sized from
+    /// the per-SST descriptor scheme). The writer emits blocks back-to-back,
+    /// making the physical tiling ground truth: the salvage gap walk frames
+    /// index-omitted bytes with this, and the TLI mirror gate compares each
+    /// decoded handle against the frame its header derives. A header that
+    /// fails to decode, or a span leaving `section_end`, means the bytes are
+    /// not frameable as a block.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] on an undecodable header or an
+    /// out-of-section span; any I/O error from the read.
+    #[cfg(feature = "std")]
+    pub(crate) fn probe_block_handle_at(
+        &self,
+        offset: u64,
+        section_end: u64,
+    ) -> crate::Result<BlockHandle> {
+        let file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        self.probe_block_handle_in(&*file, offset, section_end)
+    }
+
+    /// As [`probe_block_handle_at`] but reads through an ALREADY-OPEN handle, so
+    /// a caller scanning many offsets (the salvage resync loop, which steps one
+    /// byte at a time because block starts are not aligned) pays a single
+    /// `open` instead of one per probed offset.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] on an undecodable header or an
+    /// out-of-section span; any I/O error from the read.
+    #[cfg(feature = "std")]
+    pub(crate) fn probe_block_handle_in(
+        &self,
+        file: &dyn crate::fs::FsFile,
+        offset: u64,
+        section_end: u64,
+    ) -> crate::Result<BlockHandle> {
+        use crate::coding::Decode;
+        use crate::table::block::Header;
+
+        // Positional read of the largest possible header (block_flags-bearing
+        // types are one byte longer than the SST minimum); a short read only
+        // matters if it cuts into the bytes `decode_from` actually consumes.
+        let mut buf = [0u8; Header::MAX_LEN];
+        let got = file.read_at(&mut buf, offset)?;
+        let mut cursor = buf.get(..got).ok_or(crate::Error::InvalidHeader(
+            "block header read out of bounds",
+        ))?;
+        let header = Header::decode_from(&mut cursor)?;
+        let header_len = Header::header_len(header.block_type) as u64;
+        let parity_len = self.metadata.ecc_params.map_or(0, |scheme| {
+            u64::from(crate::table::block::expected_parity_len(
+                header.data_length,
+                scheme,
+            ))
+        });
+        let total = header_len
+            .checked_add(u64::from(header.data_length))
+            .and_then(|t| t.checked_add(parity_len))
+            .ok_or(crate::Error::InvalidHeader("block span overflows the file"))?;
+        let end = offset
+            .checked_add(total)
+            .ok_or(crate::Error::InvalidHeader("block span overflows the file"))?;
+        if end > section_end {
+            return Err(crate::Error::InvalidHeader(
+                "block extends past its section",
+            ));
+        }
+        let size = u32::try_from(total)
+            .map_err(|_| crate::Error::InvalidHeader("block span exceeds the block size limit"))?;
+        Ok(BlockHandle::new(BlockOffset(offset), size))
     }
 
     /// Loads (and, for columnar SSTs, reconstructs + delete-masks) a data block.
@@ -472,6 +759,419 @@ impl Table {
             // No materialized deletes (or, unreachably, an unmapped block):
             // reconstruct the whole block.
             None => DataBlock::from_columnar_block(&block.data, restart).map(Some),
+        }
+    }
+
+    /// Loads a columnar data block as a delete-masked
+    /// [`ColumnBatch`](crate::table::columnar::ColumnBatch), preserving its
+    /// per-field value sub-columns (and per-row seqnos) instead of reconstructing
+    /// rows. Salvage re-emits the result verbatim so a recovered columnar SST
+    /// keeps its sub-columns and MVCC versions; `Ok(None)` when the positional
+    /// delete-bitmap removes every row of the block.
+    ///
+    /// `pub(crate)` for the salvage walk ([`crate::salvage`]).
+    #[cfg(feature = "columnar")]
+    pub(crate) fn load_columnar_block_masked(
+        &self,
+        handle: &BlockHandle,
+    ) -> crate::Result<Option<crate::table::columnar::ColumnBatch>> {
+        let block = self.load_block(
+            handle,
+            BlockType::Columnar,
+            self.metadata.data_block_compression,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        let batch = crate::table::columnar::ColumnBatch::decode(&block.data)?;
+        // A real writer never emits an empty data block (the ingest path skips
+        // the write entirely), so a checksum-clean ZERO-ROW batch is malformed
+        // input. Reject it here rather than return it as "live": the writer
+        // primitives emit nothing for an empty batch, and a caller counting it
+        // as recovered would misreport an unrecovered block as salvaged.
+        if batch.row_count == 0 {
+            return Err(crate::Error::InvalidHeader("columnar: zero-row data block"));
+        }
+        let Some(start) = self
+            .delete_block_starts
+            .as_ref()
+            .and_then(|starts| starts.get(&handle.offset().0))
+            .copied()
+        else {
+            // No materialized deletes: the whole block is live.
+            return Ok(Some(batch));
+        };
+        // Drop positionally-deleted rows: this block's rows occupy global
+        // positions `[start, start + row_count)` in write order. A corrupt zone
+        // map can make `start` large enough that `start + i` overflows the u32
+        // row-position space and wraps back to the start of the bitmap, masking
+        // unrelated rows. Fail closed on overflow: the salvage walk drops and
+        // re-emits this block as corrupt rather than applying deletes at wrong
+        // positions.
+        let keep: alloc::vec::Vec<bool> = (0..batch.row_count)
+            .map(|i| {
+                let pos = start.checked_add(i).ok_or(crate::Error::InvalidHeader(
+                    "columnar delete position overflow",
+                ))?;
+                Ok(!self.delete_bitmap.contains(pos))
+            })
+            .collect::<crate::Result<_>>()?;
+        let masked = crate::table::columnar_predicate::filter_batch(&batch, &keep);
+        if masked.row_count == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(masked))
+        }
+    }
+
+    /// Cross-checks the positional delete mask against the ACTUAL per-block
+    /// row counts. `delete_block_starts` is derived from the zone map, and a
+    /// zone map that decodes but carries wrong counts (a checksum-repatched
+    /// tamper) shifts every later block's claimed start — the mask would then
+    /// delete the WRONG rows, silently. Walks the data blocks in index order
+    /// and requires each block's claimed start to equal the running sum of
+    /// actual decoded row counts. An UNREADABLE block fails the verification
+    /// outright: its actual count is unknowable, and trusting the zone map's
+    /// claim for it would let a repatched count on exactly that block shift
+    /// every later mask undetected. Trivially `true` when the segment has no
+    /// materialized deletes.
+    ///
+    /// `pub(crate)` for the salvage walk ([`crate::salvage`]), which must not
+    /// mask against unverified positions.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a transient [`crate::Error::Io`] from an index / block read.
+    /// `Ok(false)` is reserved for a STRUCTURAL failure (a reordered index, a
+    /// count mismatch, an undecodable or zero-row block): folding a flaky read
+    /// into `false` would classify a retryable fault as a persistent
+    /// unpositionable mask, and — with the default `allow_delete_resurrection ==
+    /// false` — abort salvage, letting `repair_with_salvage` rebuild the manifest
+    /// WITHOUT a table a retry could have recovered faithfully.
+    #[cfg(feature = "columnar")]
+    pub(crate) fn delete_positions_verified(&self) -> crate::Result<bool> {
+        let Some(starts) = self.delete_block_starts.as_deref() else {
+            // No materialized deletes: there is nothing to position.
+            return Ok(true);
+        };
+        let mut cumulative: u32 = 0;
+        // Anchor the walk to PHYSICAL block order. `delete_block_starts` is built
+        // by walking this same index, so a forged TLI that REORDERS the handles
+        // rebuilds the starts in that reordered sequence and self-validates
+        // against them, yet the bitmap positions were assigned in the writer's
+        // physical block order, so the salvage walk (which sorts blocks by
+        // offset) would mask against the wrong starts. Requiring strictly
+        // increasing offsets rejects the reorder: a genuine index is always in
+        // offset order (the writer emits blocks back-to-back).
+        let mut prev_offset: Option<u64> = None;
+        for keyed in self.block_index.iter() {
+            let keyed = match keyed {
+                Ok(keyed) => keyed,
+                // Only a TRANSIENT read propagates (a retry could verify the
+                // mask); a PERSISTENT index failure makes every later position
+                // unverifiable, so degrade to an unpositionable mask (`Ok(false)`)
+                // and let the caller's resurrection opt-in decide.
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                Err(_) => return Ok(false),
+            };
+            let offset = keyed.offset().0;
+            if prev_offset.is_some_and(|prev| offset <= prev) {
+                // Out-of-order (or duplicate) offset: the index was reordered, so
+                // the physical positions cannot be trusted.
+                return Ok(false);
+            }
+            prev_offset = Some(offset);
+            if starts.get(&offset) != Some(&cumulative) {
+                return Ok(false);
+            }
+            let handle = BlockHandle::new(keyed.offset(), keyed.size());
+            let block = match self.load_block(
+                &handle,
+                BlockType::Columnar,
+                self.metadata.data_block_compression,
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+            ) {
+                Ok(block) => block,
+                // Only a TRANSIENT read propagates; a PERSISTENT load failure
+                // leaves the block's actual count unknowable, so every later
+                // position is unverifiable — degrade to an unpositionable mask
+                // (`Ok(false)`) rather than trust the (potentially tampered)
+                // zone-map claim for it, and let the resurrection opt-in decide.
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                Err(_) => return Ok(false),
+            };
+            // FULLY decode the batch rather than trusting the leading LE u32
+            // row count: a checksum-repatched tamper can keep those four bytes
+            // intact while breaking the column framing. The salvage walk would
+            // drop such a block as undecodable — but its ACTUAL row count is
+            // then just as unknowable as an unreadable block's, so accepting
+            // the claimed count here would let the mask land on unproven
+            // positions for every later block. Fail closed on any decode
+            // failure.
+            let Ok(batch) = crate::table::columnar::ColumnBatch::decode(&block.data) else {
+                // A decode failure is STRUCTURAL (the salvage walk drops such a
+                // block), so its actual count is unknowable — fail closed.
+                return Ok(false);
+            };
+            // A ZERO-ROW batch is malformed input (a real writer never emits
+            // an empty block) and the salvage walk DROPS it — so accepting it
+            // here (a tampered zone map can claim 0 for exactly that block,
+            // keeping the chain self-consistent) would verify positions the
+            // bitmap was never built against for every later block. Reject
+            // it like the rest of the salvage pipeline does.
+            if batch.row_count == 0 {
+                return Ok(false);
+            }
+            let advance = batch.row_count;
+            // `wrapping_add` matches how the open path builds the starts map,
+            // so the comparison chain stays consistent (the salvage read mask
+            // separately rejects positions that would overflow).
+            cumulative = cumulative.wrapping_add(advance);
+        }
+        Ok(true)
+    }
+
+    /// Salvage helper: load one data block recovery-aware and, when it reads back
+    /// cleanly, also capture its raw on-disk bytes for a verbatim copy.
+    ///
+    /// Bypasses the block cache so the returned recovery status reflects THIS read
+    /// of the medium (a cached block hides whether the on-disk bytes needed ECC
+    /// repair). On a clean read ([`verbatim`](SalvageBlock::verbatim) is `Some`),
+    /// the salvage walk byte-copies the raw bytes into the recovered SST instead of
+    /// decoding + re-encoding the block; on an ECC-recovered read (`None`) the
+    /// faulty on-disk bytes must not be propagated, so the caller re-encodes the
+    /// healed payload in [`block`](SalvageBlock::block) instead.
+    ///
+    /// `pub(crate)` for the salvage walk ([`crate::salvage`]).
+    pub(crate) fn salvage_load_block(
+        &self,
+        handle: &BlockHandle,
+        block_type: BlockType,
+    ) -> crate::Result<SalvageBlock> {
+        let table_id = self.global_id();
+        let (fd, _) = self
+            .file_accessor
+            .get_or_open_table(&table_id, &self.path)?;
+        let transform = crate::table::util::build_block_transform(
+            self.metadata.data_block_compression,
+            self.encryption.as_deref(),
+            self.metadata.ecc_params,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        )?;
+        let (block, status, recovery) = crate::table::block::Block::from_file_with_recovery(
+            fd.as_ref(),
+            *handle,
+            crate::table::block::BlockIdentity {
+                table_id: table_id.table_id(),
+                block_type,
+                dict_id: self.metadata.data_block_compression.dict_id(),
+                window_log: 0,
+            },
+            &transform,
+        )?;
+        // A wrong block type means a swapped / corrupt index entry pointed us at
+        // the wrong bytes; surface it rather than salvage the wrong block.
+        if block.header.block_type != block_type {
+            return Err(crate::Error::InvalidTag((
+                "BlockType",
+                block.header.block_type.into(),
+            )));
+        }
+        // A table whose ECC descriptor this build cannot interpret still reads
+        // cleanly (`EccStatus::Unrecognized`, `recovery.is_none()`), but its raw
+        // bytes carry an opaque parity trailer the salvage writer's mirrored ECC
+        // (`ecc_params = None`) does not account for. A verbatim copy of those
+        // bytes would fail the writer's on-disk-size check and abort the whole
+        // salvage, so force the re-encode path (which emits a trailer-free block
+        // from the decoded payload) for such tables. The same applies to a
+        // RECOGNIZED scheme on a build without `page_ecc`: the salvage writer
+        // mirrors ECC as `None` there (it cannot emit parity), so raw bytes
+        // with a trailer must be re-encoded trailer-free, not byte-copied.
+        let ecc_verbatim_ok = cfg!(feature = "page_ecc") || self.metadata.ecc_params.is_none();
+        // Clean read: capture the raw on-disk bytes (and inner layout) for a
+        // verbatim copy. A second pread of a cold block costs far less than the
+        // re-compression the copy avoids.
+        //
+        // `Err` from this function is reserved for the initial VERIFIED read:
+        // by this point that read has already produced a recoverable decoded
+        // block, so ANY failure of the re-read — a transient I/O error or a
+        // corrupt header, same as a checksum / parity mismatch below — must
+        // not drop the block; it just disqualifies the byte-copy and falls
+        // back to re-encoding the verified payload (`verbatim = None`).
+        let capture_verbatim = || -> Option<VerbatimCopy> {
+            use crate::coding::Decode;
+            let raw =
+                crate::file::read_exact(fd.as_ref(), *handle.offset(), handle.size() as usize)
+                    .ok()?;
+            let header = crate::table::block::Header::decode_from(&mut &raw[..]).ok()?;
+            let layout = self.inner_block_layout(handle.offset().0);
+            // A recorded MULTI-INNER layout is the untrusted `block_layout`
+            // section itself: a checksum-consistent forge of it routes an
+            // otherwise-readable zstd SST through salvage, and copying the block
+            // verbatim would re-emit the same unauthenticated inner boundaries,
+            // so partial range reads keep omitting keys even though salvage
+            // reports success. Disqualify verbatim for such blocks; the re-encode
+            // path below rebuilds the frame from the verified decoded payload and
+            // records a fresh, self-consistent layout. Single-inner blocks (the
+            // common case, empty layout) are unaffected.
+            if !layout.is_empty() {
+                return None;
+            }
+            // The bytes COPIED are this second read, not the verified first
+            // one, so validate this exact frame before marking it
+            // verbatim-safe (a transient fault or concurrent mutation between
+            // the reads must not persist unchecked bytes):
+            // - the re-read header must equal the verified read's header;
+            // - the re-read payload must hash to the header's stored checksum
+            //   (the checksum covers the on-disk payload bytes uniformly —
+            //   pre-decrypt, pre-decompress);
+            // - for an ECC table, the parity trailer must match freshly
+            //   computed parity (a clean payload checksum never validates the
+            //   trailer — parity is only consulted on a mismatch — so bit rot
+            //   confined to the trailer otherwise reads as a clean block).
+            // Any mismatch falls back to the re-encode path, which emits the
+            // VERIFIED first read's decoded payload with fresh framing.
+            let header_len = crate::table::block::Header::header_len(header.block_type);
+            // checked_add: a forged/rotted data_length can overflow the
+            // payload-end sum on 32-bit targets; overflow = not verbatim-safe.
+            let payload_checksum_ok = header_len
+                .checked_add(header.data_length as usize)
+                .and_then(|payload_end| raw.get(header_len..payload_end))
+                .is_some_and(|payload| {
+                    crate::hash::hash128(payload) == header.checksum.into_u128()
+                });
+            (header == block.header
+                && payload_checksum_ok
+                && self.raw_block_parity_verifies(&raw, &header))
+            .then(|| (raw.to_vec(), header, layout))
+        };
+        // The PER-BLOCK status must be Ok too: `EccStatus::Unrecognized` means
+        // the frame carried trailing bytes the transform could not attribute
+        // (e.g. an over-sized forged index handle leaking the next section's
+        // bytes into the read) — the payload verified, but the raw frame is
+        // longer than the header's on-disk size and a verbatim copy would be
+        // rejected by the writer, dropping a recoverable block. Re-encode the
+        // verified payload instead.
+        let verbatim = if recovery.is_none()
+            && status == crate::table::block::EccStatus::Ok
+            && !self.metadata.ecc_unrecognized
+            && ecc_verbatim_ok
+        {
+            capture_verbatim()
+        } else {
+            None
+        };
+        Ok(SalvageBlock { block, verbatim })
+    }
+
+    /// Whether `raw`'s parity trailer matches freshly computed parity over its
+    /// payload — the verbatim-copy eligibility check for a block of an
+    /// ECC-carrying table (see [`Self::salvage_load_block`]). Trivially `true`
+    /// for a table without a recognized ECC scheme; a build without `page_ecc`
+    /// never reaches this for an ECC table (the caller's gate already routes
+    /// those to the re-encode path).
+    #[cfg_attr(
+        not(feature = "page_ecc"),
+        expect(
+            clippy::unused_self,
+            reason = "without page_ecc the caller's gate excludes ECC tables, so there is no parity to check"
+        )
+    )]
+    fn raw_block_parity_verifies(&self, raw: &[u8], header: &crate::table::block::Header) -> bool {
+        #[cfg(feature = "page_ecc")]
+        {
+            matches!(self.raw_block_parity_delta(raw, header), Ok(None))
+        }
+        #[cfg(not(feature = "page_ecc"))]
+        {
+            let _ = (raw, header);
+            true
+        }
+    }
+
+    /// Compares `raw`'s parity trailer against freshly computed parity over
+    /// its payload. `Ok(None)` — the trailer matches (or the table carries no
+    /// recognized ECC scheme); `Ok(Some(fresh))` — MISMATCH, `fresh` is the
+    /// parity the trailer should hold (the in-place heal persists it);
+    /// `Err(())` — the frame is inconsistent or the encoder rejected the
+    /// shape, so the trailer is unverifiable.
+    #[cfg(feature = "page_ecc")]
+    fn raw_block_parity_delta(
+        &self,
+        raw: &[u8],
+        header: &crate::table::block::Header,
+    ) -> Result<Option<alloc::vec::Vec<u8>>, ()> {
+        let Some(params) = self.metadata.ecc_params else {
+            return Ok(None);
+        };
+        let header_len = crate::table::block::Header::header_len(header.block_type);
+        // Checked: `data_length` comes from a re-read header, so a forged
+        // value must fail as "unverifiable", never wrap (32-bit `usize`).
+        let Some(payload_end) = header_len.checked_add(header.data_length as usize) else {
+            return Err(());
+        };
+        // Treat any frame inconsistency as "unverifiable" rather than panicking.
+        let (Some(payload), Some(trailer)) =
+            (raw.get(header_len..payload_end), raw.get(payload_end..))
+        else {
+            return Err(());
+        };
+        let fresh = match params {
+            crate::table::block::EccParams::Secded => crate::secded::encode_block_parity(payload),
+            crate::table::block::EccParams::Shard { .. } => {
+                let (ds, ps) = params.as_shards();
+                match crate::ecc::encode_parity(payload, ds, ps) {
+                    Ok(p) => p,
+                    Err(_) => return Err(()),
+                }
+            }
+        };
+        // The heal writes `fresh` back AT the trailer's offset, so the frame
+        // must hold EXACTLY that many trailer bytes: a shorter (or longer)
+        // on-disk trailer means the frame is malformed, and "healing" it
+        // would write past the frame's end into the next block's bytes,
+        // breaking the size-preserving heal contract. Unverifiable, not
+        // healable.
+        if trailer.len() != fresh.len() {
+            return Err(());
+        }
+        if trailer == fresh {
+            Ok(None)
+        } else {
+            Ok(Some(fresh))
+        }
+    }
+
+    /// The inner-zstd block layout (cumulative decompressed end offsets) for the
+    /// data block at `offset`, or empty when the block has a single inner block
+    /// (the common case) — and always, on a build without zstd, where data blocks
+    /// never split. Salvage's verbatim copy passes this through so a multi-inner
+    /// block keeps its layout at its new file offset (the offsets are
+    /// decompressed-space and block-relative, so they stay valid after the move).
+    #[cfg_attr(
+        not(feature = "zstd"),
+        expect(
+            clippy::unused_self,
+            reason = "the layout lookup is zstd-only; without zstd no data block splits, so the layout is always empty and `self` is unused"
+        )
+    )]
+    fn inner_block_layout(&self, offset: u64) -> alloc::vec::Vec<u32> {
+        #[cfg(feature = "zstd")]
+        {
+            self.block_layout
+                .ends_for(offset)
+                .map(<[u32]>::to_vec)
+                .unwrap_or_default()
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            let _ = offset;
+            alloc::vec::Vec::new()
         }
     }
 
@@ -552,6 +1252,20 @@ impl Table {
         self.metadata.file_size
     }
 
+    /// The on-disk ROLE of this table's data blocks: a columnar segment's
+    /// writer seals them as [`BlockType::Columnar`], a row-major one as
+    /// [`BlockType::Data`]. Scrub / heal walks pass this as the expected type
+    /// so the per-block role check (swap-defence against a misdirected index
+    /// entry) matches what the writer actually emitted.
+    #[cfg(feature = "std")]
+    fn data_block_role(&self) -> BlockType {
+        if self.metadata.columnar {
+            BlockType::Columnar
+        } else {
+            BlockType::Data
+        }
+    }
+
     /// Patrol-scrubs every data block of this table: a cache-bypassing read that
     /// runs the Page-ECC verify+correct path, recording a heal hint (when
     /// `auto_heal` is on) on a confirmed-persistent correction.
@@ -592,6 +1306,15 @@ impl Table {
                 }
             };
 
+            // Tight-space restriction: skip a block whose last key is below the
+            // bound: it sits in the punched-out prefix a superseding output
+            // table now owns, so scrubbing its reclaimed bytes would report
+            // spurious corruption for a restricted view (see `Table::range`).
+            if let Some(bound) = &self.1
+                && self.comparator.compare(keyed.end_key(), bound) == core::cmp::Ordering::Less
+            {
+                continue;
+            }
             let block_offset = keyed.offset().0;
             let handle = BlockHandle::new(keyed.offset(), keyed.size());
             report.blocks_scanned += 1;
@@ -601,7 +1324,7 @@ impl Table {
                 &self.path,
                 &self.file_accessor,
                 &handle,
-                BlockType::Data,
+                self.data_block_role(),
                 self.metadata.data_block_compression,
                 self.encryption.as_deref(),
                 self.metadata.ecc_params,
@@ -641,6 +1364,1191 @@ impl Table {
         report
     }
 
+    /// Ensures the heal's handle may be WRITTEN through: probes the link
+    /// count on first use and detaches a multiply-linked inode onto a
+    /// private copy via [`Self::unshare_for_heal`]. The outcome is cached in
+    /// `state`, so the probe and copy run at most once per scan and only
+    /// when a write is actually needed (a clean scan never detaches a
+    /// checkpoint link). A failed link-count query is treated as shared
+    /// (fail closed) — the copy path is safe either way.
+    ///
+    /// # Errors
+    ///
+    /// The unshare failure reason when the write must NOT happen (the inode
+    /// may still be shared); repeated calls keep returning it.
+    #[cfg(feature = "page_ecc")]
+    fn ensure_unshared_for_write(
+        &self,
+        file: &mut Box<dyn crate::fs::FsFile>,
+        state: &mut UnshareState,
+        sync_mode: crate::fs::SyncMode,
+    ) -> Result<(), alloc::string::String> {
+        match state {
+            UnshareState::Ready => Ok(()),
+            UnshareState::Failed(reason) => Err(reason.clone()),
+            UnshareState::Unprobed => {
+                let shared = match file.hard_link_count() {
+                    Ok(n) => n > 1,
+                    Err(e) => {
+                        log::warn!(
+                            "in-place heal: link-count query failed for table {} at {}: {e}; \
+                             assuming the inode is shared",
+                            self.id(),
+                            self.path.display(),
+                        );
+                        true
+                    }
+                };
+                if shared {
+                    // A pinned FD (no descriptor cache) is bound to its
+                    // inode for the table's lifetime: after the unshare's
+                    // copy + rename, every later read, scrub probe, and
+                    // digest check would keep resolving the DEAD inode
+                    // while the manifest points at the healed live path.
+                    // Refuse the detach — the blocked write-backs surface
+                    // as findings and every link stays byte-identical.
+                    if !self.file_accessor.can_retarget() {
+                        let reason = alloc::string::String::from(
+                            "the inode is multiply linked and the pinned file \
+                             descriptor cannot be retargeted at a detached copy; \
+                             refusing the in-place write",
+                        );
+                        *state = UnshareState::Failed(reason.clone());
+                        return Err(reason);
+                    }
+                    match self.unshare_for_heal(file.as_ref(), sync_mode) {
+                        Ok(fresh) => *file = fresh,
+                        Err(reason) => {
+                            *state = UnshareState::Failed(reason.clone());
+                            return Err(reason);
+                        }
+                    }
+                }
+                *state = UnshareState::Ready;
+                Ok(())
+            }
+        }
+    }
+
+    /// Detaches this table's live path from a multiply-linked inode so an
+    /// in-place heal can write without touching the other links (checkpoint
+    /// snapshots): streams the file into a sibling `*.healtmp-{n}` copy, syncs
+    /// it, and atomically renames it over the live path. The returned handle
+    /// is the copy's (still valid after the rename), open read+write.
+    ///
+    /// The temp name carries a process-wide sequence number so two concurrent
+    /// heal scans of the same table can never remove or rename each other's
+    /// in-progress copy (cross-process exclusion comes from the directory
+    /// lock). Every pre-rename failure removes the copy before returning —
+    /// recovery refuses to open a tree whose `tables/` holds a file it cannot
+    /// parse as a table id, so an abandoned artifact must never outlive the
+    /// heal (recovery still sweeps `*.healtmp-*` left by a hard crash).
+    #[cfg(feature = "page_ecc")]
+    pub(crate) fn unshare_for_heal(
+        &self,
+        source: &dyn crate::fs::FsFile,
+        sync_mode: crate::fs::SyncMode,
+    ) -> Result<Box<dyn crate::fs::FsFile>, alloc::string::String> {
+        use std::io::{Seek, SeekFrom, Write};
+
+        static HEAL_TMP_SEQ: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+        let len = source
+            .metadata()
+            .map_err(|e| alloc::format!("metadata: {e}"))?
+            .len;
+
+        // A tight-space-restricted view has reclaimed the DATA blocks below its
+        // frontier, but NOT the whole `[0, punch)` span: live index / filter blocks
+        // are interleaved among those data blocks (partitioned index / filter) and
+        // the reopen path reads them, so `Inner::drop` punches each data block
+        // INDIVIDUALLY and leaves the metadata blocks intact. Reproduce that exact
+        // hole pattern in the heal copy — copy the live blocks, leave the reclaimed
+        // data-block extents as holes — instead of materializing the zeros (which
+        // would re-allocate the reclaimed space, an ENOSPC risk on the near-full disk
+        // tight-space runs on) OR zeroing the whole prefix (which would corrupt the
+        // interleaved metadata). `punch` is `0` for a normal (unrestricted) table, so
+        // its copy is byte-for-byte as before.
+        let punch = self
+            .punch_offset()
+            .map_err(|e| alloc::format!("punch offset: {e}"))?;
+        let sparse = punch > 0 && self.fs.capabilities(&self.path).punch_hole;
+        let seq = HEAL_TMP_SEQ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        let tmp_path = self.path.with_extension(alloc::format!("healtmp-{seq}"));
+        let mut tmp = self
+            .fs
+            .open(
+                &tmp_path,
+                &FsOpenOptions::new().read(true).write(true).create_new(true),
+            )
+            .map_err(|e| alloc::format!("create heal copy: {e}"))?;
+
+        // Any failure past this point must take the copy with it (see above).
+        let mut copy = || -> Result<(), alloc::string::String> {
+            // The reclaimed DATA-block extents below the frontier — exactly what
+            // tight-space punched (via `Inner::drop`). The block index yields ONLY
+            // data-block handles, so live index / filter blocks interleaved below the
+            // frontier are NOT in this set and stay in the copied complement.
+            let mut holes: alloc::vec::Vec<(u64, u64)> = alloc::vec::Vec::new();
+            if sparse {
+                use crate::table::block_index::BlockIndex;
+                for handle in self.block_index.iter() {
+                    let handle = handle.map_err(|e| alloc::format!("block index iter: {e}"))?;
+                    let block_off = handle.offset().0;
+                    if block_off < punch {
+                        holes.push((block_off, u64::from(handle.size())));
+                    }
+                }
+                holes.sort_unstable();
+                // Establish the full size so the un-written data-block extents stay
+                // sparse holes.
+                tmp.set_len(len)
+                    .map_err(|e| alloc::format!("set heal copy length: {e}"))?;
+            }
+
+            // Live ranges to stream = the complement of the data-block holes across
+            // `[0, len)`. With no holes (a normal table) this is the whole file.
+            let mut live: alloc::vec::Vec<(u64, u64)> = alloc::vec::Vec::new();
+            let mut cursor = 0u64;
+            for &(h_off, h_len) in &holes {
+                if h_off > cursor {
+                    live.push((cursor, h_off));
+                }
+                cursor = cursor.max(h_off + h_len);
+            }
+            if cursor < len {
+                live.push((cursor, len));
+            }
+
+            let mut buf = alloc::vec![0u8; 1 << 20];
+            for &(start, end) in &live {
+                tmp.seek(SeekFrom::Start(start))
+                    .map_err(|e| alloc::format!("seek heal copy to {start}: {e}"))?;
+                let mut off = start;
+                while off < end {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "the u64 min() is taken first, so the value is bounded by buf.len()"
+                    )]
+                    let want = (end - off).min(buf.len() as u64) as usize;
+                    let Some(chunk) = buf.get_mut(..want) else {
+                        return Err(alloc::string::String::from("chunk within buffer"));
+                    };
+                    let n = source
+                        .read_at(chunk, off)
+                        .map_err(|e| alloc::format!("read source at {off}: {e}"))?;
+                    if n < want {
+                        // Fill-or-EOF contract: a short read here means the file
+                        // shrank underneath us — abort rather than install a
+                        // truncated copy.
+                        return Err(alloc::format!(
+                            "short read at {off}: got {n} of {want} bytes"
+                        ));
+                    }
+                    tmp.write_all(chunk)
+                        .map_err(|e| alloc::format!("write heal copy at {off}: {e}"))?;
+                    off += want as u64;
+                }
+            }
+            // Deallocate the data-block holes even where `set_len` zero-allocated, so
+            // the reclaimed space is not silently re-consumed by the heal copy.
+            for &(h_off, h_len) in &holes {
+                self.fs
+                    .punch_hole(&tmp_path, h_off, h_len)
+                    .map_err(|e| alloc::format!("punch heal copy data block at {h_off}: {e}"))?;
+            }
+            // sync_all, not sync_data: the copy is a NEW file, its size must
+            // be durable before the rename publishes it. Mode-aware: the
+            // caller selected the tree's durability (Normal skips the macOS
+            // F_FULLFSYNC hardware barrier, same as the flush path).
+            tmp.sync_all_with(sync_mode)
+                .map_err(|e| alloc::format!("sync heal copy: {e}"))?;
+            self.fs
+                .rename(&tmp_path, &self.path)
+                .map_err(|e| alloc::format!("rename heal copy into place: {e}"))
+        };
+        if let Err(reason) = copy() {
+            if let Err(e) = self.fs.remove_file(&tmp_path) {
+                log::warn!(
+                    "failed to remove abandoned heal copy {}: {e}",
+                    tmp_path.display(),
+                );
+            }
+            return Err(reason);
+        }
+        // The rename has replaced the live path, so the descriptor cache now
+        // holds the OLD inode's fd: a later heal (or read) resolving through
+        // it would scrub the detached inode while writes target the live one,
+        // misreporting a live-only fault as an unexplained (uncorrectable)
+        // mismatch. Drop the stale entry IMMEDIATELY — before the durability
+        // sync below, whose failure must not leave the cache pinned to the
+        // dead inode — so the next access reopens the live path.
+        self.file_accessor.remove_for_table(&self.global_id());
+        if let Some(parent) = self.path.parent() {
+            self.fs
+                .sync_directory_with(parent, sync_mode)
+                .map_err(|e| alloc::format!("sync directory after rename: {e}"))?;
+        }
+        // The handle survives the rename (same inode, now the live path).
+        Ok(tmp)
+    }
+
+    /// In-place ECC autoheal: like [`Self::scrub_data_blocks`], but PERSISTS each
+    /// correction by writing the corrected block back at its existing offset
+    /// (size-preserving) instead of scheduling a full-file healing rewrite.
+    /// Healthy blocks are never rewritten, so the cost is O(damage), not O(file).
+    ///
+    /// Opens the SST read+write through the tree's `Fs` (bypassing the block
+    /// cache, like scrub), and for each data block that fails its checksum but
+    /// Page-ECC recovers it, writes back `header ++ recovered_data ++ recomputed
+    /// parity` and `sync_data`s it before moving on, so a crash mid-heal leaves
+    /// the block in its prior, still-RS-correctable state. Uncorrectable /
+    /// unreadable blocks are recorded as findings and left for block salvage.
+    ///
+    /// HARD-LINK SAFE by unsharing: checkpoints hard-link SSTs, and a
+    /// checkpoint's manifest records the digest of the bytes AT SNAPSHOT TIME,
+    /// which the checkpoint (immutable by design) can never reconcile the way
+    /// the live tree does. Writing through a shared inode would therefore
+    /// desynchronize the snapshot from its own manifest whenever the recorded
+    /// digest is not the original file's (a manifest rebuilt over rotted
+    /// bytes). Right before the FIRST write-back (lazily — a clean scan of a
+    /// linked healthy table performs zero writes and keeps the checkpoint's
+    /// disk sharing), the link count is probed and a multiply-linked live
+    /// path is detached onto a private copy (copy + atomic rename), which is
+    /// then healed, leaving every other link byte-identical to what its
+    /// manifest describes. Cached read-only descriptors may keep serving the
+    /// old inode until they are reopened; its bytes are unchanged, so reads
+    /// stay correct (ECC-corrected on the fly as before).
+    ///
+    /// Returns the scrub report plus an ATTRIBUTION flag: `true` when the
+    /// file's digest was computed right before this pass's FIRST write and it
+    /// matched the manifest digest — every byte the file now differs from
+    /// the manifest state by is provably one of this pass's verified
+    /// corrections. The digest reconciliation uses it to decide whether a
+    /// post-heal mismatch may cover sections that cannot be semantically
+    /// authenticated (deletion metadata). `false` whenever nothing was
+    /// written, the pre-write digest could not be computed, or it already
+    /// disagreed with the manifest.
+    ///
+    /// `pub(crate)` for [`crate::scrub::patrol_scrub`] (heal-in-place enabled).
+    /// `sync_mode` is the tree's configured durability
+    /// ([`Config::sync_mode`](crate::config::Config::sync_mode)): every
+    /// write-back, the unshare copy, and the post-rename directory sync
+    /// honor it, so a patrol with many corrections does not pay a macOS
+    /// `F_FULLFSYNC` hardware barrier per block when the caller selected
+    /// [`SyncMode::Normal`](crate::fs::SyncMode::Normal).
+    ///
+    /// `manifest_checksum` is the table's CURRENT manifest digest, read by
+    /// the caller under the per-table heal lock: a concurrent patrol may
+    /// have refreshed the manifest after this view was captured, and the
+    /// attribution probe must compare against what the manifest says NOW.
+    #[cfg(feature = "page_ecc")]
+    pub(crate) fn heal_data_blocks_in_place(
+        &self,
+        sync_mode: crate::fs::SyncMode,
+        manifest_checksum: Checksum,
+    ) -> (crate::scrub::PatrolScrubReport, bool) {
+        use crate::scrub::{PatrolScrubReport, ScrubError};
+        use std::io::{Seek, SeekFrom, Write};
+
+        let mut report = PatrolScrubReport {
+            sst_files_scanned: 1,
+            ..PatrolScrubReport::default()
+        };
+        // Whether any write-back was ATTEMPTED. A write_all that errors after a
+        // partial write, or a full write whose sync then fails, may already have
+        // changed the on-disk bytes even though `blocks_healed_in_place` stays 0,
+        // so the marker (the only attribution for a later digest refresh) must be
+        // KEPT in that case; it is removed only when no mutation ever began.
+        let mut write_attempted = false;
+
+        // NEITHER exclusion is taken here — both are held by the patrol
+        // scrub across this scan AND the digest reconciliation that follows
+        // it, because re-acquiring either inside would deadlock:
+        // - the per-table `heal_lock` (a Mutex) serializes same-table heals
+        //   for the whole scan-to-reconcile span, so one patrol cannot
+        //   install a digest computed before another patrol's heal;
+        // - the `DeletionPause` mutation window excludes a checkpoint's link
+        //   pass for the same span, so a checkpoint cannot link healed bytes
+        //   under a stale digest.
+
+        // A single read+write handle for both the recovery read and the
+        // write-back, opened directly (not via the read-only descriptor cache) so
+        // the heal sees the medium and can mutate it.
+        let mut file = match self
+            .fs
+            .open(&self.path, &FsOpenOptions::new().read(true).write(true))
+        {
+            Ok(f) => f,
+            Err(e) => {
+                // Cannot persist corrections (a read-only replica, restrictive
+                // permissions) — but the table must still get its integrity
+                // CHECKED. Record the failed open, then fall back to the
+                // read-only scrub so corruption still surfaces instead of
+                // returning a healthy-looking report with zero blocks scanned.
+                report.errors.push(ScrubError::BlockIndexUnreadable {
+                    table_id: self.id(),
+                    path: self.path.to_path_buf(),
+                    reason: alloc::format!("open read+write for heal: {e}"),
+                });
+                report.merge(self.scrub_data_blocks());
+                // Both passes stamped this SST as scanned; it is one file.
+                report.sst_files_scanned = 1;
+                return (report, false);
+            }
+        };
+
+        // A multiply-linked inode (a checkpoint shares it) must not be healed
+        // through — but detaching costs a full-file copy and permanently
+        // ends the checkpoint's disk sharing, so it happens LAZILY: the link
+        // count is probed (and a shared inode detached onto a private copy)
+        // only right before the FIRST write-back. A clean scan of a linked
+        // healthy table therefore stays O(damage) = zero writes. The probe
+        // stays honest under the caller's mutation window: a checkpoint
+        // cannot link this SST anywhere inside the scan-to-write span.
+        let mut unshare_state = UnshareState::Unprobed;
+
+        let transform = match crate::table::util::build_block_transform(
+            self.metadata.data_block_compression,
+            self.encryption.as_deref(),
+            self.metadata.ecc_params,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                report.errors.push(ScrubError::BlockIndexUnreadable {
+                    table_id: self.id(),
+                    path: self.path.to_path_buf(),
+                    reason: alloc::format!("build transform for heal: {e:?}"),
+                });
+                return (report, false);
+            }
+        };
+
+        // Attribution + crash-recovery marker, computed UP FRONT while the file
+        // still holds its pre-heal bytes. The heal is deterministic, so the
+        // digest of the file with every correction applied is known before any
+        // write lands: bind THAT into the attestation (not just `pre ==
+        // manifest`), so a marker a crash leaves behind can only ever
+        // re-authorize the exact healed bytes, never an unrelated later forge.
+        // A clean scan (no corrections) writes nothing. `pre_heal_matched`
+        // still drives the returned attribution flag and the zero-heal marker
+        // cleanup below; the per-block correction is recomputed identically in
+        // the write loop (both call `heal_correction_for_block`).
+        // A restricted view predicts (and later digests) only its live suffix;
+        // its corrections all lie there, and the punched prefix is not hashed.
+        // A transient failure resolving that bound must ABORT, not fall back to
+        // offset 0: predicting (and attesting) over the WHOLE physical file while
+        // the manifest and reconciliation hash only the suffix would, after a
+        // crash mid-heal, leave a completed marker whose digest can never match
+        // the suffix — permanently stranding the healed table.
+        let heal_start = match self.restrict_lower_bound() {
+            Some(bound) => match self.punch_offset_for(bound) {
+                Ok(off) => off,
+                Err(e) => {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!(
+                            "could not resolve the restricted heal start; heal skipped to \
+                             keep the table reconcilable: {e:?}"
+                        ),
+                    });
+                    return (report, false);
+                }
+            },
+            None => 0,
+        };
+        // Predict the post-heal digest AND the exact set of offsets the heal
+        // will touch, streaming so a broadly damaged table does not materialize
+        // every corrected frame at once. The write loop below applies ONLY these
+        // offsets, so a fault appearing after this pass is never healed under a
+        // digest that did not attest it.
+        let (predicted_digest, predicted_offsets) =
+            match self.predict_heal_digest_and_offsets(file.as_ref(), &transform, heal_start) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!(
+                            "could not predict the post-heal digest; heal skipped to keep the \
+                             table reconcilable: {e:?}"
+                        ),
+                    });
+                    return (report, false);
+                }
+            };
+        // The pre-heal digest probe result: `None` when there is nothing to
+        // heal; otherwise `Some(matched)` where `matched` says whether the
+        // current bytes still match the manifest (the ATTRIBUTABLE path). A
+        // probe FAILURE aborts before the first write: writing corrections with
+        // no completed marker can permanently strand a table whose manifest
+        // legitimately described the pre-heal bytes.
+        let pre_heal_matched: Option<bool> = if predicted_offsets.is_empty() {
+            None
+        } else {
+            let matched = match self.pre_heal_digest_matches(manifest_checksum) {
+                Ok(matched) => matched,
+                Err(e) => {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!(
+                            "pre-heal digest probe failed; heal skipped to keep the \
+                             table reconcilable: {e:?}"
+                        ),
+                    });
+                    return (report, false);
+                }
+            };
+            if matched {
+                // ATTRIBUTABLE path: the heal is about to change bytes the
+                // manifest digest still matches, so the crash-recovery marker
+                // MUST be durable BEFORE the first mutation. If the post-heal
+                // digest cannot be predicted, or the attestation cannot be
+                // persisted, do NOT heal: a crash after a corrected block syncs
+                // but before the in-process manifest refresh would leave healed
+                // bytes under the stale digest with no marker, and fail-closed
+                // reconciliation rejects that mismatch forever, permanently
+                // stranding a table that was reconcilable a moment earlier.
+                // Leaving the block corrupt keeps the table reconcilable; the
+                // next patrol retries once the marker can be written. (A
+                // non-crash run also reconciles directly, but the marker is the
+                // ONLY thing that survives a crash, so its durability gates the
+                // mutation.)
+                if let Err(e) = crate::scrub::heal_attest::write(
+                    &*self.fs,
+                    &self.path,
+                    self.encryption.as_deref(),
+                    self.id(),
+                    manifest_checksum,
+                    Checksum::from_raw(predicted_digest),
+                ) {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!(
+                            "could not persist the heal attestation; heal skipped to keep the \
+                             table reconcilable: {e}"
+                        ),
+                    });
+                    return (report, false);
+                }
+                Some(true)
+            } else {
+                // NOT-matched pre-heal: the current bytes already differ from the
+                // manifest digest. If the predicted heal RESTORES the manifest
+                // digest (the common restorative case: a rotted file healing back to
+                // exactly what the manifest describes), the write window STILL needs
+                // a durable marker BEFORE the first mutation. A crash after syncing
+                // SOME of several corrections leaves the file matching neither the
+                // manifest nor the predicted digest; with no marker a checkpoint
+                // hard-links those intermediate bytes under the stale manifest
+                // digest, producing a permanently inconsistent checkpoint. The
+                // marker records `(manifest, predicted)` (here equal), so a reconcile
+                // trusts the file only once it hashes to the restored digest. (The
+                // DIVERGING sub-case, predicted != manifest, is gated separately
+                // below against an EXISTING completed marker via `attests_post`.)
+                if Checksum::from_raw(predicted_digest) == manifest_checksum
+                    && let Err(e) = crate::scrub::heal_attest::write(
+                        &*self.fs,
+                        &self.path,
+                        self.encryption.as_deref(),
+                        self.id(),
+                        manifest_checksum,
+                        Checksum::from_raw(predicted_digest),
+                    )
+                {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!(
+                            "could not persist the restorative heal attestation; heal \
+                             skipped to keep the table reconcilable: {e}"
+                        ),
+                    });
+                    return (report, false);
+                }
+                Some(false)
+            }
+        };
+
+        // A DIVERGING heal on a stale-manifest file must NOT proceed: when the
+        // current bytes do not match the manifest AND the predicted post-heal
+        // digest would not match it either, the file is drifting away from the
+        // manifest (e.g. a prior heal crashed after writing its completed
+        // attestation but before refreshing the manifest, then a fresh fault
+        // appeared). Writing these corrections would move the bytes off any
+        // existing attestation's `post` digest with no chaining marker, so the
+        // reconcile that runs right after this returns could not attribute the
+        // result and would strip the marker — leaving future scrubs and
+        // checkpoints unable to reconcile the table. Leave it untouched (fail
+        // closed): the reconcile still reconciles an existing marker against the
+        // manifest, and a later patrol heals the fault once the bytes line up.
+        //
+        // A not-matched file whose predicted heal RESTORES the manifest digest
+        // (a plain rotted file healing back to what the manifest describes), or
+        // restores a digest an existing COMPLETED marker already attests (a fresh
+        // fault on the just-healed bytes, which that marker still reconciles), is
+        // NOT diverging, so it proceeds. `None` (nothing to heal) is unaffected.
+        if pre_heal_matched == Some(false)
+            && Checksum::from_raw(predicted_digest) != manifest_checksum
+        {
+            use crate::scrub::heal_attest::AttestResult;
+            match crate::scrub::heal_attest::attests_post(
+                &*self.fs,
+                &self.path,
+                self.encryption.as_deref(),
+                self.id(),
+                Checksum::from_raw(predicted_digest),
+            ) {
+                // An existing COMPLETED marker already attests the predicted post:
+                // the heal restores an attested digest, not a divergence — proceed.
+                AttestResult::Attests => {}
+                // No attesting marker: healing would drift the file off any
+                // marker's post with no chaining attribution, so the reconcile
+                // could not attribute it and would strip the marker. Fail closed.
+                AttestResult::Absent => return (report, false),
+                // The attestation probe hit a TRANSIENT read. Collapsing that to
+                // "does not attest" (the old behavior) would skip the heal, leaving
+                // the file diverged from a marker that MAY attest the predicted
+                // post; the reconcile then rereads the now-readable marker, finds
+                // it no longer matches the current bytes, and deletes it — stranding
+                // the table. Record a finding so the report is non-clean (a
+                // checkpoint's `reconcile_pending_heals` then aborts instead of
+                // removing) and skip; the next patrol retries once the probe reads
+                // cleanly and the marker's verdict is conclusive.
+                AttestResult::Inconclusive => {
+                    report.errors.push(ScrubError::ChecksumRefreshFailed {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: "heal attestation probe was inconclusive (transient read); heal \
+                                 skipped to preserve the existing marker for the next patrol"
+                            .to_string(),
+                    });
+                    return (report, false);
+                }
+            }
+        }
+
+        for entry in self.block_index.iter() {
+            let keyed = match entry {
+                Ok(h) => h,
+                Err(e) => {
+                    // A structural index error means later offsets can't be
+                    // trusted — stop this table, record it.
+                    report.errors.push(ScrubError::BlockIndexUnreadable {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        reason: alloc::format!("{e:?}"),
+                    });
+                    break;
+                }
+            };
+            // Tight-space restriction: a block whose last key is below the bound
+            // sits in the punched-out (reclaimed) prefix that a superseding
+            // output table now owns. Its bytes are gone, so reading it reports a
+            // spurious uncorrectable error that would suppress the digest refresh
+            // for a real correction in the LIVE suffix. Skip it: the read path
+            // clamps scans the same way (see `Table::range`).
+            if let Some(bound) = &self.1
+                && self.comparator.compare(keyed.end_key(), bound) == core::cmp::Ordering::Less
+            {
+                continue;
+            }
+            let block_offset = keyed.offset().0;
+            let handle = BlockHandle::new(keyed.offset(), keyed.size());
+            report.blocks_scanned += 1;
+
+            // Verify the block through the SAME full read the scrub path uses
+            // (checksum + decode + ECC recovery), not just a bare frame check.
+            // This detects a checksum-clean-but-undecodable block (e.g. a corrupt
+            // `uncompressed_length`) and a corrupt block in a non-ECC segment,
+            // reporting it as uncorrectable instead of silently clean. `heal_hints
+            // = None`: this path persists the correction IN PLACE, so it must not
+            // also queue a full-file healing rewrite. The metric is recorded inside
+            // `scrub_block`.
+            let outcome = crate::table::util::scrub_block(
+                self.global_id(),
+                &self.path,
+                &self.file_accessor,
+                &handle,
+                self.data_block_role(),
+                self.metadata.data_block_compression,
+                self.encryption.as_deref(),
+                self.metadata.ecc_params,
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+                None,
+                #[cfg(feature = "metrics")]
+                &self.metrics,
+            );
+            match outcome {
+                // Verified clean: nothing to persist.
+                // Verified clean — but a clean PAYLOAD checksum never
+                // validates the parity trailer (parity is only consulted on a
+                // mismatch), so rot confined to the trailer would silently
+                // leave dead ECC on disk: a later payload fault in this block
+                // could no longer be recovered. This pass holds the read+write
+                // handle and the payload is untouched, so a size-preserving
+                // trailer rebuild is exactly the heal it exists to perform.
+                Ok(crate::table::util::BlockScrubOutcome::Clean) => {
+                    let raw = match crate::file::read_exact(
+                        file.as_ref(),
+                        block_offset,
+                        keyed.size() as usize,
+                    ) {
+                        Ok(raw) => raw,
+                        Err(e) => {
+                            report.uncorrectable_blocks += 1;
+                            report.errors.push(ScrubError::UncorrectableBlock {
+                                table_id: self.id(),
+                                path: self.path.to_path_buf(),
+                                block_offset,
+                                reason: alloc::format!(
+                                    "in-place heal: parity re-read failed: {e:?}"
+                                ),
+                            });
+                            continue;
+                        }
+                    };
+                    use crate::coding::Decode;
+                    let Ok(raw_header) = crate::table::block::Header::decode_from(&mut &raw[..])
+                    else {
+                        // The scrub just read this frame cleanly; a header that
+                        // no longer decodes is an inconsistency worth surfacing.
+                        report.uncorrectable_blocks += 1;
+                        report.errors.push(ScrubError::UncorrectableBlock {
+                            table_id: self.id(),
+                            path: self.path.to_path_buf(),
+                            block_offset,
+                            reason: alloc::string::String::from(
+                                "in-place heal: block scrubbed clean but its header no \
+                                 longer decodes",
+                            ),
+                        });
+                        continue;
+                    };
+                    // The bytes examined below are this SECOND read, not the
+                    // frame the scrub just verified: a transient fault or
+                    // fresh rot between the reads would otherwise feed the
+                    // parity comparison an unverified payload, and the
+                    // rebuild arm would PERSIST parity computed over those
+                    // corrupt bytes — turning a recoverable block into one
+                    // whose ECC agrees with the corruption. Verify the
+                    // re-read header's ROLE and its payload against the
+                    // header checksum first; a mismatch is surfaced, never
+                    // acted on.
+                    if raw_header.block_type != self.data_block_role() {
+                        report.uncorrectable_blocks += 1;
+                        report.errors.push(ScrubError::UncorrectableBlock {
+                            table_id: self.id(),
+                            path: self.path.to_path_buf(),
+                            block_offset,
+                            reason: alloc::string::String::from(
+                                "in-place heal: block scrubbed clean but its re-read \
+                                 header carries a different block role",
+                            ),
+                        });
+                        continue;
+                    }
+                    let header_len = crate::table::block::Header::header_len(raw_header.block_type);
+                    // checked_add: a forged/rotted data_length can overflow
+                    // the payload-end sum on 32-bit targets; overflow is an
+                    // uncorrectable finding, not a panic.
+                    let payload_ok = header_len
+                        .checked_add(raw_header.data_length as usize)
+                        .and_then(|payload_end| raw.get(header_len..payload_end))
+                        .is_some_and(|payload| {
+                            crate::hash::hash128(payload) == raw_header.checksum.into_u128()
+                        });
+                    if !payload_ok {
+                        report.uncorrectable_blocks += 1;
+                        report.errors.push(ScrubError::UncorrectableBlock {
+                            table_id: self.id(),
+                            path: self.path.to_path_buf(),
+                            block_offset,
+                            reason: alloc::string::String::from(
+                                "in-place heal: block scrubbed clean but its re-read \
+                                 payload does not match its checksum",
+                            ),
+                        });
+                        continue;
+                    }
+                    match self.raw_block_parity_delta(&raw, &raw_header) {
+                        // Trailer matches (or no ECC): nothing to persist.
+                        Ok(None) => {}
+                        // Trailer rot: persist the freshly computed parity at
+                        // its on-disk position (header + payload unchanged).
+                        Ok(Some(fresh)) => {
+                            let trailer_offset = block_offset
+                                + crate::table::block::Header::header_len(raw_header.block_type)
+                                    as u64
+                                + u64::from(raw_header.data_length);
+                            // Apply ONLY corrections the prediction pass attested.
+                            // A trailer rebuild that appears now but was not
+                            // predicted (fresh rot between the two reads) is left
+                            // as-is: healing it would put bytes on disk the
+                            // marker's digest never covered, and a later
+                            // checkpoint would snapshot them under the stale
+                            // digest. It stays RS-correctable for the next patrol.
+                            if !predicted_offsets.contains(&trailer_offset) {
+                                continue;
+                            }
+                            // Attribution + the crash-recovery marker were
+                            // captured UP FRONT (before this loop), so nothing is
+                            // done here. First write: make sure no checkpoint link
+                            // shares the inode (lazy detach).
+                            if let Err(reason) = self.ensure_unshared_for_write(
+                                &mut file,
+                                &mut unshare_state,
+                                sync_mode,
+                            ) {
+                                report.uncorrectable_blocks += 1;
+                                report.errors.push(ScrubError::UncorrectableBlock {
+                                    table_id: self.id(),
+                                    path: self.path.to_path_buf(),
+                                    block_offset,
+                                    reason: alloc::format!(
+                                        "unshare hard-linked SST for heal: {reason}"
+                                    ),
+                                });
+                                continue;
+                            }
+                            let write_back = file
+                                .seek(SeekFrom::Start(trailer_offset))
+                                .and_then(|_| file.write_all(&fresh));
+                            // The write_all may have written some bytes even if it
+                            // then errored; mark the file as possibly mutated so a
+                            // later failure does not drop the attestation.
+                            write_attempted = true;
+                            let durable = match write_back {
+                                Ok(()) => file
+                                    .sync_data_with(sync_mode)
+                                    .map_err(|e| alloc::format!("sync: {e}")),
+                                Err(e) => Err(alloc::format!("write: {e}")),
+                            };
+                            if let Err(reason) = durable {
+                                report.uncorrectable_blocks += 1;
+                                report.errors.push(ScrubError::UncorrectableBlock {
+                                    table_id: self.id(),
+                                    path: self.path.to_path_buf(),
+                                    block_offset,
+                                    reason: alloc::format!("in-place parity rebuild {reason}"),
+                                });
+                                continue;
+                            }
+                            report.blocks_healed_in_place += 1;
+                        }
+                        Err(()) => {
+                            report.uncorrectable_blocks += 1;
+                            report.errors.push(ScrubError::UncorrectableBlock {
+                                table_id: self.id(),
+                                path: self.path.to_path_buf(),
+                                block_offset,
+                                reason: alloc::string::String::from(
+                                    "in-place heal: parity trailer unverifiable on a \
+                                     checksum-clean block",
+                                ),
+                            });
+                        }
+                    }
+                }
+                // Recovered from parity: persist the corrected frame in place.
+                Ok(crate::table::util::BlockScrubOutcome::Corrected { .. }) => {
+                    // Apply ONLY corrections the prediction pass attested. A block
+                    // that recovers now but was not in the predicted set (a fault
+                    // that appeared after the prediction) is left corrupt: writing
+                    // it would heal bytes the marker's digest never covered, so a
+                    // later checkpoint could snapshot them under the stale digest.
+                    // It stays RS-correctable, so the next patrol retries.
+                    if !predicted_offsets.contains(&block_offset) {
+                        continue;
+                    }
+                    let frame = match crate::table::block::Block::heal_frame(
+                        file.as_ref(),
+                        handle,
+                        &transform,
+                    ) {
+                        Ok(Some((frame, _kind))) => frame,
+                        // The scrub read corrected a fault but the confirming
+                        // re-read is already clean: a TRANSIENT fault the first
+                        // read hit and the re-read did not. This mirrors the
+                        // schedule path (`maybe_record_persistent_heal`), which
+                        // treats a clean confirmation re-read as transient and
+                        // does not act — there is nothing on disk to persist.
+                        Ok(None) => {
+                            log::debug!(
+                                "in-place heal: transient correction on block at offset \
+                                 {block_offset} in table {} at {}; re-read clean, nothing to \
+                                 persist",
+                                self.id(),
+                                self.path.display(),
+                            );
+                            continue;
+                        }
+                        // A real read/decode error on the re-read: surface it
+                        // rather than silently skip the write-back.
+                        Err(e) => {
+                            report.uncorrectable_blocks += 1;
+                            report.errors.push(ScrubError::UncorrectableBlock {
+                                table_id: self.id(),
+                                path: self.path.to_path_buf(),
+                                block_offset,
+                                reason: alloc::format!(
+                                    "in-place heal: block scrubbed as corrected but the heal \
+                                     re-read failed: {e:?}"
+                                ),
+                            });
+                            continue;
+                        }
+                    };
+                    // Attribution + the crash-recovery marker were captured UP
+                    // FRONT (before this loop). First write: make sure no
+                    // checkpoint link shares the inode (lazy detach).
+                    if let Err(reason) =
+                        self.ensure_unshared_for_write(&mut file, &mut unshare_state, sync_mode)
+                    {
+                        report.uncorrectable_blocks += 1;
+                        report.errors.push(ScrubError::UncorrectableBlock {
+                            table_id: self.id(),
+                            path: self.path.to_path_buf(),
+                            block_offset,
+                            reason: alloc::format!("unshare hard-linked SST for heal: {reason}"),
+                        });
+                        continue;
+                    }
+                    // Seek + write (std::io) and sync (crate::io) carry different
+                    // error types, so each is handled separately; both render to
+                    // text for the finding. `sync_data` (not `sync_all`): the file
+                    // size is unchanged, so only the data needs flushing, and it
+                    // must land before the next block so a crash leaves the block
+                    // in its prior, still-RS-correctable state.
+                    let write_back = file
+                        .seek(SeekFrom::Start(block_offset))
+                        .and_then(|_| file.write_all(&frame));
+                    // The write_all may have written some bytes even if it then
+                    // errored (a partial write); mark the file as possibly mutated
+                    // so a later failure does not drop the attestation.
+                    write_attempted = true;
+                    let durable = match write_back {
+                        Ok(()) => file
+                            .sync_data_with(sync_mode)
+                            .map_err(|e| alloc::format!("sync: {e}")),
+                        Err(e) => Err(alloc::format!("write: {e}")),
+                    };
+                    if let Err(reason) = durable {
+                        report.uncorrectable_blocks += 1;
+                        log::error!(
+                            "in-place heal: write-back failed for block at offset \
+                             {block_offset} in table {} at {}: {reason}",
+                            self.id(),
+                            self.path.display(),
+                        );
+                        report.errors.push(ScrubError::UncorrectableBlock {
+                            table_id: self.id(),
+                            path: self.path.to_path_buf(),
+                            block_offset,
+                            reason: alloc::format!("in-place heal {reason}"),
+                        });
+                        continue;
+                    }
+                    report.corrections_applied += 1;
+                    report.blocks_healed_in_place += 1;
+                }
+                Err(e) => {
+                    report.uncorrectable_blocks += 1;
+                    log::error!(
+                        "in-place heal: uncorrectable block at offset {block_offset} in table \
+                         {} at {}: {e:?}",
+                        self.id(),
+                        self.path.display(),
+                    );
+                    report.errors.push(ScrubError::UncorrectableBlock {
+                        table_id: self.id(),
+                        path: self.path.to_path_buf(),
+                        block_offset,
+                        reason: alloc::format!("{e:?}"),
+                    });
+                }
+            }
+        }
+
+        // The in-progress marker is written speculatively before the first
+        // block write; if NO block was actually healed (every candidate turned
+        // out uncorrectable) AND no write was ever attempted, the file is
+        // unchanged and the marker attests to a heal that never happened. Remove
+        // it so it cannot later authorize an unrelated digest mismatch (its
+        // `pre == manifest` binding does not expire on its own). But when a
+        // write WAS attempted and then failed (a partial write, or a full write
+        // whose sync failed), the on-disk bytes may already differ from the
+        // manifest digest: KEEP the marker so a later patrol can still attribute
+        // and refresh the altered table rather than stranding it.
+        let healed = pre_heal_matched == Some(true);
+        if healed && report.blocks_healed_in_place == 0 && !write_attempted {
+            crate::scrub::heal_attest::remove(&*self.fs, &self.path);
+        }
+
+        (report, healed)
+    }
+
+    /// The correction the in-place heal would apply to one data block, computed
+    /// WITHOUT writing. [`Self::predict_heal_digest_and_offsets`] calls this to
+    /// PREDICT the post-heal digest and the offsets to touch; the write loop in
+    /// [`Self::heal_data_blocks_in_place`] performs the same decision inline and
+    /// applies it. The heal is deterministic (RS recovery / parity rebuild over
+    /// the same pre-heal bytes), so the prediction and the later application
+    /// are byte-identical. This MIRRORS the write loop's arms; a drift only
+    /// weakens crash recovery (a predicted digest that no longer matches the
+    /// applied bytes fails the marker CLOSED, never authorizing wrong bytes),
+    /// it is never a correctness hazard.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a TRANSIENT read failure (the confirming block / frame re-read)
+    /// rather than mapping it to "no correction": a swallowed read would omit the
+    /// block from the prediction's offset set, and the write loop's gate would then
+    /// skip a correction it re-discovers, reporting a clean pass over known damage.
+    #[cfg(feature = "page_ecc")]
+    fn heal_correction_for_block(
+        &self,
+        file: &dyn crate::fs::FsFile,
+        keyed: &KeyedBlockHandle,
+        transform: &crate::table::block::BlockTransform<'_>,
+    ) -> crate::Result<Option<(u64, alloc::vec::Vec<u8>)>> {
+        use crate::coding::Decode;
+        let block_offset = keyed.offset().0;
+        let handle = BlockHandle::new(keyed.offset(), keyed.size());
+        let outcome = crate::table::util::scrub_block(
+            self.global_id(),
+            &self.path,
+            &self.file_accessor,
+            &handle,
+            self.data_block_role(),
+            self.metadata.data_block_compression,
+            self.encryption.as_deref(),
+            self.metadata.ecc_params,
+            #[cfg(zstd_any)]
+            self.zstd_dictionary.as_deref(),
+            None,
+            #[cfg(feature = "metrics")]
+            &self.metrics,
+        );
+        match outcome {
+            Ok(crate::table::util::BlockScrubOutcome::Clean) => {
+                // A clean-payload block still needs a parity-trailer rebuild if its
+                // trailer rotted. The confirming re-read PROPAGATES on a transient
+                // failure (see the doc), but a decode / structural inconsistency
+                // leaves the bytes unchanged (`Ok(None)`), matching the write loop's
+                // report-and-skip.
+                let raw = crate::file::read_exact(file, block_offset, keyed.size() as usize)?;
+                let Ok(raw_header) = crate::table::block::Header::decode_from(&mut &raw[..]) else {
+                    return Ok(None);
+                };
+                if raw_header.block_type != self.data_block_role() {
+                    return Ok(None);
+                }
+                let header_len = crate::table::block::Header::header_len(raw_header.block_type);
+                let payload_ok = header_len
+                    .checked_add(raw_header.data_length as usize)
+                    .and_then(|payload_end| raw.get(header_len..payload_end))
+                    .is_some_and(|payload| {
+                        crate::hash::hash128(payload) == raw_header.checksum.into_u128()
+                    });
+                if !payload_ok {
+                    return Ok(None);
+                }
+                match self.raw_block_parity_delta(&raw, &raw_header) {
+                    Ok(Some(fresh)) => {
+                        let trailer_offset = block_offset
+                            + crate::table::block::Header::header_len(raw_header.block_type) as u64
+                            + u64::from(raw_header.data_length);
+                        Ok(Some((trailer_offset, fresh)))
+                    }
+                    // Trailer matches (no ECC / already fresh) or is
+                    // unverifiable: nothing to persist.
+                    Ok(None) | Err(()) => Ok(None),
+                }
+            }
+            Ok(crate::table::util::BlockScrubOutcome::Corrected { .. }) => {
+                match crate::table::block::Block::heal_frame(file, handle, transform) {
+                    Ok(Some((frame, _kind))) => Ok(Some((block_offset, frame))),
+                    // A confirming re-read that is now clean: a transient fault the
+                    // first read hit and this one did not, so nothing to persist.
+                    Ok(None) => Ok(None),
+                    // A real read / decode error on the confirming read PROPAGATES:
+                    // mapping it to "no correction" would let the write loop's gate
+                    // skip a correction it re-discovers and report a clean pass.
+                    Err(e) => Err(e),
+                }
+            }
+            // A TRANSIENT read (Io) during this prediction PROPAGATES: swallowing
+            // it drops the block from the predicted offset set, so the write pass
+            // would skip a correction it re-discovers on an ECC-correctable block
+            // and report a clean pass over the fault still on disk. An
+            // UNCORRECTABLE / structural failure leaves the bytes as they are (the
+            // scrub already recorded the finding and the write pass re-surfaces
+            // it), so there is no correction to predict.
+            Err(e @ crate::Error::Io(_)) => Err(e),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Read-only pass predicting the post-heal whole-file digest AND the set of
+    /// write offsets the heal will touch, WITHOUT materializing every corrected
+    /// frame. The predicted digest is streamed: each correction (see
+    /// [`Self::heal_correction_for_block`]) is spliced into a running hash and
+    /// then DROPPED, so a broadly damaged multi-gigabyte table costs only one
+    /// correction frame of heap at a time instead of the whole repaired file.
+    ///
+    /// The returned offset set is what the write loop gates on: it applies ONLY
+    /// corrections whose offset was predicted here, so a fault that appears
+    /// AFTER this pass (transient rot, a byte flipped between the two reads) is
+    /// left unwritten rather than healed under a digest that never attested it.
+    ///
+    /// The streamed digest is byte-identical to
+    /// [`crate::repair::compute_table_checksum_with_overrides`] fed the same
+    /// corrections: the file is hashed from `heal_start` to EOF with each
+    /// size-preserving correction substituted at its offset. Corrections are
+    /// non-overlapping and strictly increasing (block index order; one
+    /// correction per block, within that block), so a single forward pass with a
+    /// discard-the-replaced-bytes cursor reproduces exactly that byte stream.
+    /// Skips a restricted view's punched prefix exactly as the write loop does.
+    ///
+    /// # Errors
+    ///
+    /// Any I/O error opening or streaming the file.
+    #[cfg(feature = "page_ecc")]
+    fn predict_heal_digest_and_offsets(
+        &self,
+        file: &dyn crate::fs::FsFile,
+        transform: &crate::table::block::BlockTransform<'_>,
+        heal_start: u64,
+    ) -> crate::Result<(u128, crate::HashSet<u64>)> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        let mut offsets = crate::HashSet::default();
+        // A dedicated sequential reader for the digest stream: it walks forward
+        // from `heal_start` while `file` still serves the per-block scrub reads.
+        let mut rdr = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        rdr.seek(SeekFrom::Start(heal_start))?;
+        let mut buf = alloc::vec![0u8; 256 * 1024];
+        // Absolute file position the sequential reader has consumed up to.
+        let mut pos = heal_start;
+
+        // Reads exactly `count` bytes from `rdr`, hashing them when `hash` is set
+        // and discarding them (the region a correction replaces) otherwise.
+        let consume = |rdr: &mut alloc::boxed::Box<dyn crate::fs::FsFile>,
+                       hasher: &mut xxhash_rust::xxh3::Xxh3Default,
+                       buf: &mut [u8],
+                       mut count: u64,
+                       hash: bool|
+         -> crate::Result<()> {
+            while count > 0 {
+                let want = usize::try_from(count.min(buf.len() as u64)).unwrap_or(buf.len());
+                let Some(window) = buf.get_mut(..want) else {
+                    break;
+                };
+                rdr.read_exact(window)?;
+                if hash {
+                    hasher.update(window);
+                }
+                count -= want as u64;
+            }
+            Ok(())
+        };
+
+        for entry in self.block_index.iter() {
+            // Propagate a transient index-read failure rather than `break`: a
+            // truncated prediction would return a digest and an offset set that
+            // omit every later block, and the write loop's `predicted_offsets`
+            // guard would then silently skip any correctable fault it finds there,
+            // reporting a clean heal while leaving known damage on disk. Aborting
+            // makes the patrol report the failed pass and retry.
+            let keyed = entry?;
+            if let Some(bound) = &self.1
+                && self.comparator.compare(keyed.end_key(), bound) == core::cmp::Ordering::Less
+            {
+                continue;
+            }
+            let Some((write_offset, bytes)) =
+                self.heal_correction_for_block(file, &keyed, transform)?
+            else {
+                continue;
+            };
+            // Corrections are strictly increasing and non-overlapping; a
+            // regression would mean overlapping splices, so bail rather than
+            // underflow the gap.
+            let Some(gap) = write_offset.checked_sub(pos) else {
+                break;
+            };
+            consume(&mut rdr, &mut hasher, &mut buf, gap, true)?;
+            hasher.update(&bytes);
+            let replaced = bytes.len() as u64;
+            consume(&mut rdr, &mut hasher, &mut buf, replaced, false)?;
+            pos = write_offset + replaced;
+            offsets.insert(write_offset);
+            // `bytes` is dropped here: only its offset is retained.
+        }
+
+        // Hash the untouched tail from the last correction to EOF.
+        loop {
+            let n = rdr.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            let Some(window) = buf.get(..n) else { break };
+            hasher.update(window);
+        }
+
+        Ok((hasher.digest128(), offsets))
+    }
+
+    /// Whether the file's CURRENT digest equals `manifest_checksum` — the
+    /// attribution probe [`Self::heal_data_blocks_in_place`] takes right
+    /// before its first write-back. The caller supplies the CURRENT
+    /// manifest digest (read under the per-table heal lock), not this
+    /// view's snapshot: a concurrent patrol may have refreshed the manifest
+    /// after this view was captured, and comparing against the stale
+    /// snapshot would mark a legitimate heal unattributable.
+    ///
+    /// # Errors
+    ///
+    /// A failed digest read PROPAGATES rather than grading `false`: the caller
+    /// must abort the heal on a probe failure, because proceeding would write
+    /// corrections with no completed attestation, and if the manifest
+    /// legitimately described the pre-heal bytes the healed digest would then be
+    /// permanently unreconcilable.
+    #[cfg(feature = "page_ecc")]
+    fn pre_heal_digest_matches(&self, manifest_checksum: Checksum) -> crate::Result<bool> {
+        // Restriction-aware: a restricted view's manifest digest covers only its
+        // live suffix, so probe the same region.
+        Ok(self.live_region_checksum()? == manifest_checksum)
+    }
+
+    /// Whether the ON-DISK file carries deletion metadata the digest
+    /// reconciliation cannot semantically authenticate: a `range_tombstones`
+    /// or `delete_bitmap` section. These are AUTHORITATIVE — nothing in-file
+    /// can re-derive which rows or ranges were genuinely deleted — so unlike
+    /// the derived sections (zone map, seqno bounds, locator, filter) a
+    /// re-stamped payload has no cross-check. Read from the file's TOC, not
+    /// the recover-time regions, for the same distrust-of-memory reason as
+    /// the other gates.
+    ///
+    /// # Errors
+    ///
+    /// Any I/O / decode error from reading the SFA trailer.
+    #[cfg(feature = "std")]
+    pub(crate) fn has_deletion_metadata(&self) -> crate::Result<bool> {
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        Ok(regions.range_tombstones.is_some() || regions.delete_bitmap.is_some())
+    }
+
     /// Scrub: verifies the per-KV checksum footer of every data block in this
     /// table, decoding each block and recomputing each entry's logical-content
     /// digest.
@@ -678,18 +2586,21 @@ impl Table {
 
         // Descriptor declares this SST footer-bearing, and an SST is
         // homogeneous — every data block carries a footer under `expected_algo`.
+        // A restricted view's punched prefix blocks are dead and read as zeros,
+        // so skip them (only the live suffix is footer-verified).
+        let punch = self.punch_offset()?;
         for handle in self.block_index.iter() {
             let handle = handle?;
             let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
             // Load the RAW block (footer intact) — do NOT route through
-            // `load_data_block`, which strips the footer via `from_loaded`.
-            let block = self.load_block(
-                &block_handle,
-                BlockType::Data,
-                self.metadata.data_block_compression,
-                #[cfg(zstd_any)]
-                self.zstd_dictionary.as_deref(),
-            )?;
+            // `load_data_block`, which strips the footer via `from_loaded` —
+            // and DISK-FRESH: a pristine copy cached before an on-disk
+            // re-stamp would otherwise pass this gate for a file whose
+            // stale footer no longer matches its altered value bytes.
+            let block = self.load_block_from_disk(&block_handle, BlockType::Data)?;
             DataBlock::verify_kv_checked(
                 &block.data,
                 block.header,
@@ -698,6 +2609,2124 @@ impl Table {
             )?;
         }
         Ok(())
+    }
+
+    /// Cross-checks the recorded `linked_blob_files` section against the
+    /// COMPLETE accounting derived from this table's indirection entries
+    /// (per blob id: reference count, logical bytes, on-disk bytes). The
+    /// section carries NO per-section checksum, so structurally valid rot —
+    /// a flipped id byte OR a flipped counter byte — is invisible to the
+    /// out-of-band walk; the entries themselves are the only integrity
+    /// source, and the counters feed fragmentation math (a forged total can
+    /// make a blob file look dead while another table still references it).
+    /// Duplicate records for one id are rejected too. A no-op (`Ok`) for
+    /// tables without the section.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the recorded records disagree
+    /// with the derived ones; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_blob_links(&self) -> crate::Result<()> {
+        use crate::coding::Decode;
+        use alloc::collections::BTreeMap;
+
+        // A restricted view's punched prefix is unscannable, so its derived
+        // accounting can only cover the LIVE SUFFIX; the recorded section
+        // aggregates the WHOLE table. An EXACT match is therefore impossible, but
+        // skipping the check entirely lets a same-size bit flip in the
+        // (checksum-less) section drop or forge a blob id the readable suffix
+        // still addresses, after which blob GC can retire a file the suffix points
+        // into. So a restricted view runs a CONTAINMENT check instead (see the
+        // final comparison below): every id/count the suffix derives must be
+        // COVERED BY the recorded aggregate. (This is orthogonal to the
+        // heal-attribution the unrestricted exact check also provides: an in-place
+        // heal rewrites DATA blocks only, never `linked_blob_files`.)
+        let restricted = self.restrict_lower_bound().is_some();
+
+        // Derive the indirection accounting FIRST, even when the section is
+        // absent: a table that still carries `ValueHandle` indirections but
+        // advertises no `linked_blob_files` section must NOT pass. Blob GC
+        // consults `list_blob_file_references()` to decide whether other tables
+        // reference a blob, so an accepted table with hidden indirections lets
+        // GC rewrite / drop a blob file this table still points into.
+        // (len, bytes, on_disk_bytes) per blob id, accumulated exactly the
+        // way the writer folds them from indirections.
+        let mut derived: BTreeMap<crate::vlog::BlobFileId, (usize, u64, u64)> = BTreeMap::new();
+        {
+            let mut accumulate = |kv: InternalValue| -> crate::Result<()> {
+                if kv.key.value_type == crate::ValueType::Indirection {
+                    let mut cursor = &kv.value[..];
+                    let ind = crate::blob_tree::handle::BlobIndirection::decode_from(&mut cursor)?;
+                    let slot = derived.entry(ind.vhandle.blob_file_id).or_insert((0, 0, 0));
+                    slot.0 += 1;
+                    slot.1 += u64::from(ind.size);
+                    slot.2 += u64::from(ind.vhandle.on_disk_size);
+                }
+                Ok(())
+            };
+            // A restricted view's `[0, punch)` prefix is hole-punched and reads as
+            // zeros: `range` raises its lower bound to the restriction so it never
+            // loads a punched block, whereas `scan` walks every physical block from
+            // offset 0 (and would fail decoding a zeroed one). Derive from the live
+            // region accordingly; the restricted derive covers only the live suffix.
+            if restricted {
+                for kv in self.range(..) {
+                    accumulate(kv?)?;
+                }
+            } else {
+                for kv in self.scan()? {
+                    accumulate(kv?)?;
+                }
+            }
+        }
+        let Some(recorded) = self.list_blob_file_references()? else {
+            // No section is valid ONLY for a table with no indirections; a
+            // non-empty derived map with no recorded section is a dropped /
+            // renamed section hiding live blob references.
+            if !derived.is_empty() {
+                return Err(crate::Error::InvalidHeader(
+                    "table carries indirection entries but no linked_blob_files section",
+                ));
+            }
+            return Ok(());
+        };
+        // The writer OMITS the linked_blob_files section when there are no blob
+        // references, so a PRESENT but empty (zero-count) section is a forgery,
+        // not a legitimate no-op: e.g. a delete_bitmap replaced by a four-byte
+        // zero-count linked_blob_files. Both `derived` and `recorded_map` would
+        // then be empty and the equality check below would pass, keeping the
+        // table after its deletion metadata vanished. Reject it here.
+        if recorded.is_empty() {
+            return Err(crate::Error::InvalidHeader(
+                "linked_blob_files section is present but records no blob references",
+            ));
+        }
+        let mut recorded_map: BTreeMap<crate::vlog::BlobFileId, (usize, u64, u64)> =
+            BTreeMap::new();
+        for link in &recorded {
+            if recorded_map
+                .insert(
+                    link.blob_file_id,
+                    (link.len, link.bytes, link.on_disk_bytes),
+                )
+                .is_some()
+            {
+                return Err(crate::Error::InvalidHeader(
+                    "linked_blob_files carries duplicate records for one blob id",
+                ));
+            }
+        }
+        if restricted {
+            // Containment: the recorded aggregate covers the WHOLE table, so each
+            // id the live suffix references must appear with a count/byte total at
+            // least as large as the suffix's own. A suffix-referenced id missing
+            // from the section, or recorded below the suffix's derived total,
+            // means the section dropped or under-counted a live reference — reject
+            // so blob GC cannot retire a file the suffix still addresses.
+            for (id, derived_counts) in &derived {
+                match recorded_map.get(id) {
+                    Some(rec)
+                        if rec.0 >= derived_counts.0
+                            && rec.1 >= derived_counts.1
+                            && rec.2 >= derived_counts.2 => {}
+                    _ => {
+                        return Err(crate::Error::InvalidHeader(
+                            "linked_blob_files omits or under-counts a blob id the \
+                             restricted suffix still references",
+                        ));
+                    }
+                }
+            }
+            return Ok(());
+        }
+        if derived != recorded_map {
+            return Err(crate::Error::InvalidHeader(
+                "linked_blob_files disagrees with the table's indirection entries",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Compares the two DECODED TLI mirrors (head `tli` vs `tli_tail`) and
+    /// validates the decoded handle list against the PHYSICAL section
+    /// layout. Each copy is independently checksum- (and parity-)consistent,
+    /// so a forged tail that encodes a DIFFERENT handle list passes every
+    /// byte-level check — and BOTH mirrors forged to the SAME list pass the
+    /// equality comparison too, since two forged copies prove nothing about
+    /// the data blocks. The writer emits blocks strictly back-to-back, so
+    /// the decoded handles must exactly TILE their section: in full-index
+    /// mode the handles tile the `data` section; in partitioned mode the TLI
+    /// handles tile the `index` section and the partitions' concatenated
+    /// data handles tile the `data` section. An omitted, redirected, or
+    /// duplicated handle leaves a gap or an overlap.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the decoded mirrors differ or
+    /// the handle list does not tile the physical sections; any I/O / decode
+    /// error while loading either copy (an unreadable mirror is equally
+    /// untrustworthy for the callers' restamp / keep decisions).
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_tli_mirrors(&self) -> crate::Result<()> {
+        self.verify_tli_mirrors_inner(true)
+    }
+
+    /// Whether the index STRUCTURE alone authenticates its offsets as original
+    /// block boundaries: the mirrors agree, the binary-index pointers verify,
+    /// the partition separators are consistent, and the handles TILE their
+    /// section. This is the block-boundary provenance the salvage walk needs to
+    /// trust an indexed offset without re-reading each (possibly corrupt) data
+    /// block — [`verify_tli_mirrors`](Self::verify_tli_mirrors) additionally
+    /// frames and decodes every data block, which a bit-rotted-but-index-intact
+    /// table (the salvage case) would fail spuriously.
+    ///
+    /// # Errors
+    ///
+    /// Propagates only a TRANSIENT [`crate::Error::Io`] from opening / reading
+    /// the index mirrors: folding a flaky read into `false` would make the
+    /// salvage walk fall back to physical-chain provenance and surrender every
+    /// block past the first header break, dropping otherwise healthy keys the
+    /// intact TLI could have anchored on retry. `Ok(false)` covers a STRUCTURAL
+    /// authentication failure (mirrors disagree, pointers do not verify, handles
+    /// do not tile) AND a PERSISTENT read failure of one mirror: both mean the
+    /// index cannot be trusted here, so the walk should fall back to the readable
+    /// data section rather than abort and recover nothing.
+    #[cfg(feature = "std")]
+    pub(crate) fn tli_structure_authenticated(&self) -> crate::Result<bool> {
+        match self.verify_tli_mirrors_inner(false) {
+            Ok(()) => Ok(true),
+            // Only a TRANSIENT read propagates (so the salvage walk aborts for a
+            // retry rather than surrendering an intact index to a flaky read). A
+            // PERSISTENT mirror failure (a bad-sector `UnexpectedEof` on one
+            // mirror while the other and the data section stay readable) is
+            // untrusted input, not a reason to abort: fold it into `false` so the
+            // walk falls back to physical-chain provenance and still recovers the
+            // readable data blocks.
+            Err(crate::Error::Io(e)) if e.kind().is_transient() => Err(crate::Error::Io(e)),
+            Err(_) => Ok(false),
+        }
+    }
+
+    /// Shared body. `frame_blocks` additionally frames and decodes each
+    /// addressed DATA block (the full integrity check the scrub reconcile
+    /// wants); with it `false` only the index structure is authenticated, for
+    /// the salvage walk that runs over corrupt data blocks by design.
+    #[cfg(feature = "std")]
+    fn verify_tli_mirrors_inner(&self, frame_blocks: bool) -> crate::Result<()> {
+        use crate::table::block::ParsedItem as _;
+
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        let head = Self::read_tli_at(
+            &*file,
+            regions.tli,
+            self.metadata.id,
+            self.metadata.index_block_compression,
+            self.encryption.as_deref(),
+            self.metadata.ecc_params,
+        )?;
+        if let Some(tail_handle) = regions.tli_tail {
+            let tail = Self::read_tli_at(
+                &*file,
+                tail_handle,
+                self.metadata.id,
+                self.metadata.index_block_compression,
+                self.encryption.as_deref(),
+                self.metadata.ecc_params,
+            )?;
+            if head.as_slice() != tail.as_slice() {
+                return Err(crate::Error::InvalidHeader(
+                    "tli_tail decodes to a different handle list than the head tli",
+                ));
+            }
+        }
+
+        // Structural coverage: the decoded handles must tile their section.
+        let data_section = trailer
+            .toc()
+            .section(b"data")
+            .ok_or(crate::Error::InvalidHeader("data section missing"))?;
+        head.try_iter(self.comparator.clone())?;
+        // The sequential walk below never reads the BINARY INDEX pointers,
+        // so a pointer redirected to another restart head passes mirror
+        // equality, tiling, and every separator check — yet the seek path
+        // trusts it after reopen. Authenticate the pointers against the
+        // sequentially derived restart heads.
+        head.verify_binary_index()?;
+        let keyed: alloc::vec::Vec<KeyedBlockHandle> = head
+            .iter(self.comparator.clone())
+            .map(|i| i.materialize(head.as_slice()))
+            .collect();
+        let handles: alloc::vec::Vec<BlockHandle> = keyed.iter().map(|k| *k.as_ref()).collect();
+        if let Some(index_handle) = regions.index {
+            // Partitioned: the TLI addresses index partitions inside the
+            // `index` section; the partitions address the data blocks.
+            let index_section = trailer
+                .toc()
+                .section(b"index")
+                .ok_or(crate::Error::InvalidHeader("index section missing"))?;
+            let _ = index_handle;
+            if !Self::frames_tile_section(&handles, index_section.pos(), index_section.len()) {
+                return Err(crate::Error::InvalidHeader(
+                    "tli handles do not tile the index section",
+                ));
+            }
+            self.verify_handles_frame_blocks(&handles, index_section.pos(), index_section.len())?;
+            let mut data_handles = alloc::vec::Vec::new();
+            for top in &keyed {
+                let part = Self::read_tli_at(
+                    &*file,
+                    *top.as_ref(),
+                    self.metadata.id,
+                    self.metadata.index_block_compression,
+                    self.encryption.as_deref(),
+                    self.metadata.ecc_params,
+                )?;
+                part.try_iter(self.comparator.clone())?;
+                // Same pointer authentication as the TLI above: a partition
+                // seek trusts its binary index too.
+                part.verify_binary_index()?;
+                let part_keyed: alloc::vec::Vec<KeyedBlockHandle> = part
+                    .iter(self.comparator.clone())
+                    .map(|i| i.materialize(part.as_slice()))
+                    .collect();
+                if frame_blocks {
+                    let punch = self.punch_offset()?;
+                    for k in &part_keyed {
+                        // Punched prefix blocks of a restricted view decode to
+                        // zeros; skip their separator cross-check (they are dead).
+                        if k.offset().0 < punch {
+                            continue;
+                        }
+                        self.verify_separator_matches_block(k)?;
+                    }
+                }
+                // The TLI's top-level SEPARATOR for this partition must equal the
+                // partition's LAST data-block separator. `frames_tile_section`
+                // and the per-block separator checks ignore the top-level keys,
+                // so a re-stamped partition boundary (in both mirrors) passes
+                // them all — yet `TwoLevelBlockIndex::forward_reader` seeks by the
+                // top-level separator and would route reads to the wrong
+                // partition, skipping the keys the real partition holds.
+                let Some(part_last) = part_keyed.last() else {
+                    return Err(crate::Error::InvalidHeader(
+                        "tli addresses an index partition that decodes to zero entries",
+                    ));
+                };
+                if self
+                    .comparator
+                    .compare(top.end_key().as_ref(), part_last.end_key().as_ref())
+                    != core::cmp::Ordering::Equal
+                {
+                    return Err(crate::Error::InvalidHeader(
+                        "tli separator disagrees with its partition's last separator",
+                    ));
+                }
+                data_handles.extend(part_keyed.iter().map(|k| *k.as_ref()));
+            }
+            if !Self::frames_tile_section(&data_handles, data_section.pos(), data_section.len()) {
+                return Err(crate::Error::InvalidHeader(
+                    "index partitions' data handles do not tile the data section",
+                ));
+            }
+            if frame_blocks {
+                self.verify_handles_frame_blocks(
+                    &data_handles,
+                    data_section.pos(),
+                    data_section.len(),
+                )?;
+            }
+        } else {
+            if !Self::frames_tile_section(&handles, data_section.pos(), data_section.len()) {
+                return Err(crate::Error::InvalidHeader(
+                    "tli data handles do not tile the data section",
+                ));
+            }
+            if frame_blocks {
+                self.verify_handles_frame_blocks(&handles, data_section.pos(), data_section.len())?;
+                let punch = self.punch_offset()?;
+                for k in &keyed {
+                    // Punched prefix blocks of a restricted view decode to zeros;
+                    // skip their separator cross-check (they are dead).
+                    if k.offset().0 < punch {
+                        continue;
+                    }
+                    self.verify_separator_matches_block(k)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Confirms a leaf index entry's SEPARATOR (its `end_key`) equals the
+    /// addressed data block's actual decoded last key. A forged separator
+    /// re-stamped to another still-sorted value passes the mirror comparison
+    /// and section tiling (both ignore the keys), yet the index binary
+    /// search routes keys in `(forged_separator, real_last_key]` to the wrong
+    /// block — `point_read` then misses existing keys. The in-memory
+    /// reachability probe does not catch this on the heal path (the live
+    /// table keeps its correct recovery-time index), so the disk-fresh
+    /// separator must be checked against the block's decoded final key here.
+    #[cfg(feature = "std")]
+    fn verify_separator_matches_block(&self, keyed: &KeyedBlockHandle) -> crate::Result<()> {
+        let block_handle = BlockHandle::new(keyed.offset(), keyed.size());
+        let entries = self.decode_block_entries(&block_handle)?;
+        let Some(last) = entries.last() else {
+            return Err(crate::Error::InvalidHeader(
+                "tli separator addresses a data block that decodes to zero entries",
+            ));
+        };
+        if self
+            .comparator
+            .compare(keyed.end_key().as_ref(), last.key.user_key.as_ref())
+            != core::cmp::Ordering::Equal
+        {
+            return Err(crate::Error::InvalidHeader(
+                "tli separator does not match the addressed block's decoded last key",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Requires every handle's SIZE to equal the physical frame its block's
+    /// on-disk header derives (header + payload + parity). The cumulative
+    /// tiling check cannot tell ONE handle spanning several back-to-back
+    /// blocks from the real per-block layout: the spanned frame still
+    /// decodes its FIRST payload (the tail reads as an unrecognized trailer
+    /// on a non-ECC block), so the separator cross-check passes too — yet
+    /// every later physical block is unreachable through the index and
+    /// reads silently miss its keys.
+    #[cfg(feature = "std")]
+    fn verify_handles_frame_blocks(
+        &self,
+        handles: &[BlockHandle],
+        pos: u64,
+        len: u64,
+    ) -> crate::Result<()> {
+        // checked, not saturating: a re-stamped TOC could overflow `pos + len`,
+        // and a saturated `u64::MAX` bound would then accept a forged oversized
+        // handle instead of rejecting the corrupt section.
+        let section_end = pos
+            .checked_add(len)
+            .ok_or(crate::Error::InvalidHeader("data section length overflows"))?;
+        // A restricted view's punched prefix blocks read as zeros, so their
+        // physical frame can no longer be probed. They tile the section by
+        // length (punch preserves file size) but are dead, so skip framing
+        // them. Index-section handles sit above the (data-section) punch
+        // offset and are never skipped.
+        let punch = self.punch_offset()?;
+        for handle in handles {
+            if handle.offset().0 < punch {
+                continue;
+            }
+            let probed = self.probe_block_handle_at(handle.offset().0, section_end)?;
+            if probed.size() != handle.size() {
+                return Err(crate::Error::InvalidHeader(
+                    "an index handle's size disagrees with its block's physical frame",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether `handles`, in order, exactly tile `[pos, pos + len)`: the
+    /// first starts at `pos`, each next starts where the previous ended, and
+    /// the last ends at `pos + len`. The writer emits blocks back-to-back,
+    /// so any omitted, redirected, or duplicated handle breaks the tiling.
+    #[cfg(feature = "std")]
+    fn frames_tile_section(handles: &[BlockHandle], pos: u64, len: u64) -> bool {
+        let mut at = pos;
+        for handle in handles {
+            if handle.offset().0 != at {
+                return false;
+            }
+            at = match at.checked_add(u64::from(handle.size())) {
+                Some(v) => v,
+                None => return false,
+            };
+        }
+        pos.checked_add(len) == Some(at)
+    }
+
+    /// Cross-checks the recorded `seqno_bounds` section against the ACTUAL
+    /// per-block seqno ranges derived from decoding every data block's
+    /// entries. The section's block is checksum-clean to the out-of-band
+    /// walk even when its PAYLOAD was re-stamped to another structurally
+    /// valid map, and `scan_since_seqno` trusts it to SKIP blocks — a forged
+    /// range silently omits a block's live entries from every CDC /
+    /// incremental scan. Every recorded block must exist, every data block
+    /// must be recorded, and each recorded range must equal the decoded one.
+    /// A no-op for tables without the section.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the recorded map disagrees with
+    /// the decoded entries; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_seqno_bounds(&self) -> crate::Result<()> {
+        use crate::table::block::ParsedItem as _;
+
+        // Re-read the section FROM DISK: the in-memory map was loaded at
+        // recover time, so an on-disk re-stamp after the open (the very
+        // forge this check exists for) would be invisible to it. Unlike the
+        // best-effort recover load, an unreadable section here is an error —
+        // the callers are deciding whether to trust the file's bytes.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        let Some(sb_handle) = regions.seqno_bounds else {
+            return Ok(());
+        };
+        let seqno_bounds = {
+            let block = Block::from_file(
+                &*file,
+                sb_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: self.metadata.id,
+                    block_type: BlockType::SeqnoBounds,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::SeqnoBounds {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)?
+        };
+        // No early return on an empty map: a PRESENT-but-empty section on a
+        // table with data blocks is a forgery (every writer emits one entry per
+        // block). The per-block loop below rejects it — the first block's
+        // `bounds_for` returns `None` — while a genuinely empty table (no data
+        // blocks) still passes, since the loop runs zero times and `checked`
+        // equals the empty map's length.
+        // Skip a restricted view's punched (dead) prefix blocks; count only the
+        // LIVE seqno_bounds entries below so the cross-check covers the suffix.
+        let punch = self.punch_offset()?;
+        let mut checked = 0usize;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            let Some(recorded) = seqno_bounds.bounds_for(block_handle.offset().0) else {
+                return Err(crate::Error::InvalidHeader(
+                    "seqno_bounds is missing a data block's entry",
+                ));
+            };
+            let derived = {
+                #[cfg(feature = "columnar")]
+                if self.metadata.columnar {
+                    let block = self.load_block_from_disk(&block_handle, BlockType::Columnar)?;
+                    let batch = crate::table::columnar::ColumnBatch::decode(&block.data)?;
+                    let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+                    let mut seqnos = entries.iter().map(|e| e.key.seqno);
+                    let Some(first) = seqnos.next() else {
+                        return Err(crate::Error::InvalidHeader(
+                            "columnar data block decodes to zero rows",
+                        ));
+                    };
+                    Some(seqnos.fold((first, first), |(lo, hi), s| (lo.min(s), hi.max(s))))
+                } else {
+                    None
+                }
+                #[cfg(not(feature = "columnar"))]
+                None::<(SeqNo, SeqNo)>
+            };
+            let derived = if let Some(d) = derived {
+                d
+            } else {
+                let block = self.load_block_from_disk(&block_handle, BlockType::Data)?;
+                let data_block =
+                    DataBlock::from_loaded(block, self.metadata.kv_checksum_algo.is_some())?;
+                let mut seqnos = data_block
+                    .try_iter(self.comparator.clone())?
+                    .map(|p| p.seqno());
+                let Some(first) = seqnos.next() else {
+                    return Err(crate::Error::InvalidHeader(
+                        "row data block decodes to zero entries",
+                    ));
+                };
+                seqnos.fold((first, first), |(lo, hi), s| (lo.min(s), hi.max(s)))
+            };
+            if derived != recorded {
+                return Err(crate::Error::InvalidHeader(
+                    "seqno_bounds disagrees with the block's decoded entries",
+                ));
+            }
+            checked = checked
+                .checked_add(1)
+                .ok_or(crate::Error::InvalidHeader("seqno_bounds"))?;
+        }
+        // Every recorded entry matched some walked block (offsets are unique
+        // on both sides), so equal counts mean the map records EXACTLY the
+        // table's blocks — a forged extra entry cannot hide among them.
+        if checked != seqno_bounds.live_len(punch) {
+            return Err(crate::Error::InvalidHeader(
+                "seqno_bounds carries entries for blocks the index does not hold",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Fully DECODES every data block and checks its entry count against the
+    /// trailer's declared item count. The out-of-band walk verifies only the
+    /// outer frame, and `verify_kv_checksums` is a no-op for a footer-less
+    /// SST, so a checksum- and parity-consistent block with a valid prefix
+    /// followed by a malformed entry is otherwise graded clean: the entry
+    /// decoder turns a mid-stream parse failure into an ordinary end of
+    /// iteration, so a later scan silently omits the malformed tail. Decoding
+    /// to fewer (or more) entries than the trailer declares is corruption.
+    /// Covers both row-major and columnar blocks.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when a block decodes to a different
+    /// entry count than its trailer declares; any I/O / decode error from the
+    /// full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_block_entry_counts(&self) -> crate::Result<()> {
+        // A restricted view's punched prefix blocks are dead (read as zeros);
+        // only its live suffix blocks are entry-count-verified.
+        let punch = self.punch_offset()?;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            #[cfg(feature = "columnar")]
+            if self.metadata.columnar {
+                let block = self.load_block_from_disk(&block_handle, BlockType::Columnar)?;
+                // `column_batch_to_entries` fully materializes the rows, so a
+                // malformed batch fails here rather than truncating silently.
+                let batch = crate::table::columnar::ColumnBatch::decode(&block.data)?;
+                let entries = crate::table::columnar::column_batch_to_entries(&batch)?;
+                if entries.len() != batch.row_count as usize {
+                    return Err(crate::Error::InvalidHeader(
+                        "columnar block decodes to fewer rows than its batch declares",
+                    ));
+                }
+                continue;
+            }
+            let block = self.load_block_from_disk(&block_handle, BlockType::Data)?;
+            let data_block =
+                DataBlock::from_loaded(block, self.metadata.kv_checksum_algo.is_some())?;
+            let declared = data_block.len();
+            let decoded = data_block.try_iter(self.comparator.clone())?.count();
+            if decoded != declared {
+                return Err(crate::Error::InvalidHeader(
+                    "data block decodes to fewer entries than its trailer declares",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Cross-checks the recorded `zone_map` section against the ACTUAL
+    /// per-block statistics derived from decoding every data block. The
+    /// section's block is checksum-clean to the out-of-band walk even when
+    /// its PAYLOAD was re-stamped to another structurally valid map, and
+    /// `columnar_scan` trusts its min/max to SKIP blocks — a forged range
+    /// silently omits matching rows. A row block records one synthetic column
+    /// (whole-block key range + row count); a columnar block records one entry
+    /// per stored column, re-derived from the decoded batch. Every block must
+    /// be recorded and its recorded stats must equal the decoded ones. A no-op
+    /// for tables without the section.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the recorded map disagrees with
+    /// the decoded blocks; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_zone_map(&self) -> crate::Result<()> {
+        // Re-read the section FROM DISK: the in-memory map is best-effort at
+        // recover time, so an on-disk re-stamp after the open is invisible to
+        // it. An unreadable section is an error here (the caller is deciding
+        // whether to trust the file's bytes), unlike the best-effort load.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        let Some(zm_handle) = regions.zone_map else {
+            return Ok(());
+        };
+        let zone_map = {
+            let block = Block::from_file(
+                &*file,
+                zm_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: self.metadata.id,
+                    block_type: BlockType::ZoneMap,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::ZoneMap {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            crate::table::zone_map::ZoneMap::decode(&block.data)?
+        };
+        // The writer emits one zone-map entry per data block whenever the
+        // section exists, so a PRESENT-but-empty map on a table with data blocks
+        // is a forgery — e.g. a delete_bitmap relabeled and re-roled to an empty
+        // zone_map, which drops the deletion metadata while every semantic gate
+        // (tiling, block role, parsed deletion state) still passes. Reject it,
+        // as the other rebuildable-section checks do.
+        if zone_map.is_empty() {
+            if self.block_index.iter().next().is_some() {
+                return Err(crate::Error::InvalidHeader(
+                    "zone_map section is present but empty on a table with data blocks",
+                ));
+            }
+            return Ok(());
+        }
+        // A restricted view's punched prefix blocks are DEAD (never read), and
+        // the zone_map still carries their entries (the file is punched, not
+        // rewritten). Skip those blocks and count only the LIVE zone_map entries
+        // below, so the cross-check authenticates exactly the suffix.
+        let punch = self.punch_offset()?;
+        let mut checked = 0usize;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            let Some(recorded) = zone_map.columns_for(block_handle.offset().0) else {
+                return Err(crate::Error::InvalidHeader(
+                    "zone_map is missing a data block's entry",
+                ));
+            };
+            // Authenticate the recorded entry against the block's ACTUAL decoded
+            // statistics. A columnar block records one entry per stored column,
+            // re-derived here by the SAME function the writer used, so any
+            // divergence (a re-stamped range, an added / dropped column, a
+            // flipped id) is a forgery. A row block records a single synthetic
+            // whole-block key range (checked in `verify_row_block_zone_entry`).
+            #[cfg(feature = "columnar")]
+            if self.metadata.columnar {
+                let block = self.load_block_from_disk(&block_handle, BlockType::Columnar)?;
+                let batch = crate::table::columnar::ColumnBatch::decode(&block.data)?;
+                if batch.row_count == 0 {
+                    return Err(crate::Error::InvalidHeader(
+                        "columnar data block decodes to zero rows",
+                    ));
+                }
+                if recorded != batch.zone_stats().as_slice() {
+                    return Err(crate::Error::InvalidHeader(
+                        "zone_map disagrees with the columnar block's per-column statistics",
+                    ));
+                }
+            } else {
+                self.verify_row_block_zone_entry(recorded, &block_handle)?;
+            }
+            #[cfg(not(feature = "columnar"))]
+            self.verify_row_block_zone_entry(recorded, &block_handle)?;
+
+            checked = checked
+                .checked_add(1)
+                .ok_or(crate::Error::InvalidHeader("zone_map"))?;
+        }
+        if checked != zone_map.live_len(punch) {
+            return Err(crate::Error::InvalidHeader(
+                "zone_map carries entries for blocks the index does not hold",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Cross-checks a ROW data block's recorded zone-map entry: it must be
+    /// exactly one synthetic whole-block column (`column_id == 0`, zero type /
+    /// codec / null fields) whose `min` / `max` / `row_count` equal the block's
+    /// decoded key range and row count.
+    ///
+    /// Authenticates the column's IDENTITY, not just its key bounds. A
+    /// re-stamped map that keeps the checked min / max / `row_count` but changes
+    /// the id to a consumer value-column id would let
+    /// [`ColumnRangePredicate::can_skip_block`](crate::table::columnar_predicate::ColumnRangePredicate::can_skip_block)
+    /// read those key bounds as value-column statistics and skip blocks holding
+    /// matching rows. Split out of [`Self::verify_zone_map`] so the columnar
+    /// path can authenticate its per-column entry instead.
+    #[cfg(feature = "std")]
+    fn verify_row_block_zone_entry(
+        &self,
+        recorded: &[crate::table::zone_map::ColumnStats],
+        block_handle: &BlockHandle,
+    ) -> crate::Result<()> {
+        let [col] = recorded else {
+            return Err(crate::Error::InvalidHeader(
+                "zone_map block does not carry exactly one synthetic column",
+            ));
+        };
+        if col.column_id != 0 || col.type_tag != 0 || col.codec_id != 0 || col.null_count != 0 {
+            return Err(crate::Error::InvalidHeader(
+                "zone_map synthetic column identity disagrees with the \
+                 writer's whole-block column (id / type / codec / null)",
+            ));
+        }
+        let (min_key, max_key, rows) = self.zone_stats_from_row_block(block_handle)?;
+        if col.min != min_key || col.max != max_key || col.row_count as usize != rows {
+            return Err(crate::Error::InvalidHeader(
+                "zone_map disagrees with the block's decoded key range or row count",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Derives `(min_user_key, max_user_key, row_count)` from a decoded ROW
+    /// data block, for the [`Self::verify_zone_map`] cross-check.
+    #[cfg(feature = "std")]
+    fn zone_stats_from_row_block(
+        &self,
+        block_handle: &BlockHandle,
+    ) -> crate::Result<(Vec<u8>, Vec<u8>, usize)> {
+        use crate::table::block::ParsedItem as _;
+        let block = self.load_block_from_disk(block_handle, BlockType::Data)?;
+        let data_block = DataBlock::from_loaded(block, self.metadata.kv_checksum_algo.is_some())?;
+        let entries: Vec<_> = data_block
+            .try_iter(self.comparator.clone())?
+            .map(|p| p.materialize(data_block.as_slice()))
+            .collect();
+        let (Some(first), Some(last)) = (entries.first(), entries.last()) else {
+            return Err(crate::Error::InvalidHeader(
+                "row data block decodes to zero entries",
+            ));
+        };
+        Ok((
+            first.key.user_key.to_vec(),
+            last.key.user_key.to_vec(),
+            entries.len(),
+        ))
+    }
+
+    /// Publishes this table's tight-space restriction lower bound to its
+    /// `.restrict-bound` sidecar, so manifest repair recovers the exact bound
+    /// WITHOUT the SST itself being mutated (which would invalidate the whole-file
+    /// checksum the manifest still holds for it). MUST be called STRICTLY AFTER the
+    /// slice's version install commits and BEFORE the prefix is hole-punched: the
+    /// post-commit ordering makes a sidecar on disk always denote a committed
+    /// restriction (so repair honors it without a commit protocol), and writing it
+    /// before the punch gives every punched input a recoverable exact bound. The
+    /// atomic `temp + rename` write leaves the sidecar fully present or absent
+    /// across a crash, beside an untouched SST.
+    ///
+    /// # Errors
+    ///
+    /// Propagates encryption / filesystem failures from the atomic sidecar write.
+    #[cfg(feature = "std")]
+    pub(crate) fn write_restrict_sidecar(
+        &self,
+        bound: &[u8],
+        sync_mode: crate::fs::SyncMode,
+    ) -> crate::Result<()> {
+        crate::restrict_bound::write(
+            &*self.fs,
+            &self.path,
+            self.encryption.as_deref(),
+            self.metadata.id,
+            bound,
+            sync_mode,
+        )
+    }
+
+    /// Reads one data block's RAW on-disk bytes through `file` and reports
+    /// whether they are all zero — the signature of a hole-punched (reclaimed)
+    /// block. A short all-zero prefix alone is NOT proof (a corrupt block could
+    /// begin with zeros), so a zero opening window falls through to a full-extent
+    /// read; a nonzero window proves the block intact without reading the rest
+    /// (a real block's header and first entry bytes are never all zero).
+    ///
+    /// # Errors
+    ///
+    /// Propagates the positioned read failure.
+    #[cfg(feature = "std")]
+    fn block_is_zeroed_in(
+        file: &dyn crate::fs::FsFile,
+        block_handle: &BlockHandle,
+    ) -> crate::Result<bool> {
+        const WINDOW: usize = 64;
+        let size = block_handle.size() as usize;
+        let window = size.min(WINDOW);
+        let head = crate::file::read_exact(file, block_handle.offset().0, window)?;
+        if head.iter().any(|&b| b != 0) {
+            return Ok(false);
+        }
+        if size <= window {
+            return Ok(true);
+        }
+        let bytes = crate::file::read_exact(file, block_handle.offset().0, size)?;
+        Ok(bytes.iter().all(|&b| b == 0))
+    }
+
+    /// Whether ANY of this table's data blocks is hole-punched (reads as zeros).
+    /// This is the punch test for the case where the sidecar bound itself could
+    /// not be read: a zeroed data block means the SST genuinely lost data to a
+    /// punch (bound lost → derive one from the geometry), while a fully intact
+    /// data section means an unpunched file. EVERY block is inspected, not just
+    /// the first: the punch-on-drop reclaim continues past an individual
+    /// `punch_hole` failure, so a partially-punched SST can keep its first block
+    /// intact while later prefix blocks are zeroed — a first-block-only probe
+    /// would misread that file as unpunched and recover it unrestricted, routing
+    /// later reads into the zeroed blocks.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a block-index or positioned-read failure.
+    #[cfg(feature = "std")]
+    pub(crate) fn has_punched_data_block(&self) -> crate::Result<bool> {
+        let file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            if Self::block_is_zeroed_in(&*file, &BlockHandle::new(handle.offset(), handle.size()))?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// The conservative restriction bound derived from the PHYSICAL punch alone,
+    /// for a punched SST whose exact `.restrict-bound` sidecar is not trustworthy
+    /// (lost / corrupt / unbacked) and whose manifest restriction is also gone.
+    ///
+    /// Walks the data blocks in key order and classifies the punch geometry.
+    ///
+    /// A CLEAN zeroed prefix (every zeroed block precedes every readable one,
+    /// starting at the first data block — the pattern a fully successful
+    /// punch-on-drop reclaim leaves) yields
+    /// [`DerivedRestriction::Bound`]: the END key of the first readable block.
+    /// Restricting to that key drops the punched prefix AND the first readable
+    /// block, which may STRADDLE the true (mid-block) bound: since the end key
+    /// is that block's maximum, it is at or above the true bound, so every
+    /// served key is live and NO superseded key is resurrected. The cost is at
+    /// most that one block's live suffix, which is exactly the trade the
+    /// resurrection flag governs; the resurrection path keeps the whole
+    /// readable region instead.
+    ///
+    /// An IRREGULAR pattern — any readable block BELOW a zeroed one — is
+    /// positive evidence that individual `punch_hole` calls failed mid-reclaim
+    /// (the reclaim logs and continues per block). Then ANY readable block may
+    /// equally be an intact-but-consumed block whose punch also failed, and no
+    /// geometry bound can separate consumed from live: anchoring anywhere
+    /// either resurrects superseded rows or discards live ones. That is
+    /// [`DerivedRestriction::IrregularPunch`] — the caller sets the table
+    /// aside (the resurrection path, which accepts re-exposure by contract,
+    /// still derives greedily instead). The punch-on-drop reclaim punches
+    /// top-down and stops at its first failure precisely so any failure lands
+    /// in the DETECTABLE irregular class; the only invisible case is a reclaim
+    /// whose very first punch failed (no hole at all — zero evidence), which
+    /// reads as an unpunched table here.
+    ///
+    /// [`DerivedRestriction::NoLiveData`] when EVERY block reads as zeros: no
+    /// live data survives the punch, so the caller excludes the table (no
+    /// recoverable live data to lose).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a block-index or positioned-read failure.
+    #[cfg(feature = "std")]
+    pub(crate) fn derive_restriction_bound(&self) -> crate::Result<DerivedRestriction> {
+        let file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let mut candidate: Option<UserKey> = None;
+        let mut seen_readable = false;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            if Self::block_is_zeroed_in(&*file, &BlockHandle::new(handle.offset(), handle.size()))?
+            {
+                if seen_readable {
+                    return Ok(DerivedRestriction::IrregularPunch);
+                }
+            } else {
+                seen_readable = true;
+                if candidate.is_none() {
+                    candidate = Some(handle.end_key().clone());
+                }
+            }
+        }
+        Ok(match candidate {
+            Some(bound) => DerivedRestriction::Bound(bound),
+            None => DerivedRestriction::NoLiveData,
+        })
+    }
+
+    /// The GREEDY counterpart of [`derive_restriction_bound`](Self::derive_restriction_bound)
+    /// for RESURRECTION mode: returns the FIRST (lowest) key of the first
+    /// readable block after the LAST zeroed one, so restricting to it keeps the
+    /// WHOLE straddling block — resurrecting its sub-bound keys — while still
+    /// excluding every punched (zeroed) block below it. Returning the punched
+    /// table UNRESTRICTED instead would route a read to a zeroed,
+    /// physically-missing block and fail after a supposedly successful repair;
+    /// anchoring before the last zeroed block (a partial punch can leave intact
+    /// blocks interleaved with zeroed ones) would do the same. Wholly-empty
+    /// readable blocks (e.g. a columnar block fully masked by its delete bitmap)
+    /// are skipped. `None` when no readable non-empty block follows the last
+    /// zeroed one.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a block-index, positioned-read, or block-decode failure.
+    #[cfg(feature = "std")]
+    pub(crate) fn derive_resurrection_bound(&self) -> crate::Result<Option<UserKey>> {
+        let file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let mut candidate: Option<UserKey> = None;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let bh = BlockHandle::new(handle.offset(), handle.size());
+            if Self::block_is_zeroed_in(&*file, &bh)? {
+                candidate = None;
+                continue;
+            }
+            if candidate.is_none()
+                && let Some(db) = self.load_data_block(&bh)?
+                && let Some(first) = db.first_user_key(self.comparator.clone())?
+            {
+                candidate = Some(first);
+            }
+        }
+        Ok(candidate)
+    }
+
+    /// Cross-checks the recorded `locator` section against the ACTUAL
+    /// key → newest-version-block mapping derived from decoding every data
+    /// block. A checksum- and parity-consistent forged locator is accepted by
+    /// the out-of-band walk on its block role alone, but `point_read_inner`
+    /// trusts its answer and reads the addressed block directly: a locator
+    /// redirected from a key's newest-version block to a LATER block holding
+    /// an OLDER version returns that stale value without falling back to the
+    /// sorted index. A correctly-built locator answers every in-table key
+    /// with the block holding its newest version (the FIRST block covering
+    /// it, since blocks are sorted by key then descending seqno), so any key
+    /// whose locator answer points at a different block is corruption. A
+    /// no-op for tables without the section.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when a key's locator answer disagrees
+    /// with its decoded newest-version block; any I/O / decode error from the
+    /// full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_locator(&self) -> crate::Result<()> {
+        // Re-read the section FROM DISK and pair it with the ordinal → handle
+        // map (the writer's block_id order == index order), mirroring the open
+        // path. An unreadable section is an error here (the caller is deciding
+        // whether to trust the bytes), unlike the best-effort open load.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        let Some(loc_handle) = regions.locator else {
+            return Ok(());
+        };
+        let block = Block::from_file(
+            &*file,
+            loc_handle,
+            crate::table::block::BlockIdentity {
+                table_id: self.metadata.id,
+                block_type: BlockType::Locator,
+                dict_id: 0,
+                window_log: 0,
+            },
+            &{
+                let t = match self.encryption.as_deref() {
+                    Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                    None => crate::table::block::BlockTransform::PLAIN,
+                };
+                if let Some(ecc) = self.metadata.ecc_params {
+                    t.with_ecc(ecc)
+                } else {
+                    t
+                }
+            },
+        )?;
+        if block.header.block_type != BlockType::Locator {
+            return Err(crate::Error::InvalidTag((
+                "BlockType",
+                block.header.block_type.into(),
+            )));
+        }
+        let blocks: Vec<BlockHandle> = self
+            .block_index
+            .iter()
+            .map(|r| r.map(|kbh| *kbh.as_ref()))
+            .collect::<crate::Result<Vec<_>>>()?;
+        let locator = crate::table::locator::LoadedLocator::new(block.data, blocks);
+
+        // Walk blocks in index (block_id) order; the FIRST time a user key
+        // appears is its newest version, so that block is the locator's
+        // expected answer. `seen` dedups across blocks (a key's older
+        // versions in later blocks must not overwrite the expectation).
+        let mut seen: crate::HashSet<Vec<u8>> = crate::HashSet::default();
+        // A restricted view's punched prefix blocks are dead; skip them. Their
+        // keys are superseded, so a suffix key's newest version is in the suffix,
+        // and reads never consult the locator's prefix answers.
+        let punch = self.punch_offset()?;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            // Load the disk-fresh row block once so a `Restart` / `Entry`
+            // slot hint can be probed against it below. Columnar blocks carry
+            // no in-block slot semantics (rows are reconstructed on load), so
+            // there the locator is per-block and only the block-id is checked.
+            #[cfg(feature = "columnar")]
+            let row_block = if self.metadata.columnar {
+                None
+            } else {
+                Some(DataBlock::from_loaded(
+                    self.load_block_from_disk(&block_handle, BlockType::Data)?,
+                    self.metadata.kv_checksum_algo.is_some(),
+                )?)
+            };
+            #[cfg(not(feature = "columnar"))]
+            let row_block = Some(DataBlock::from_loaded(
+                self.load_block_from_disk(&block_handle, BlockType::Data)?,
+                self.metadata.kv_checksum_algo.is_some(),
+            )?);
+            // Reuse the already-loaded row block for row tables (its entries
+            // are what `decode_block_entries` would re-decode); only the
+            // columnar path needs the separate reconstruction decode.
+            use crate::table::block::ParsedItem as _;
+            let entries: Vec<InternalValue> = match row_block.as_ref() {
+                Some(block) => block
+                    .try_iter(self.comparator.clone())?
+                    .map(|p| p.materialize(block.as_slice()))
+                    .collect(),
+                None => self.decode_block_entries(&block_handle)?,
+            };
+            for entry in entries {
+                let user_key = entry.key.user_key.to_vec();
+                if !seen.insert(user_key.clone()) {
+                    continue;
+                }
+                let key_hash = crate::hash::hash64(&user_key);
+                // The writer OMITS the locator section when it cannot build one
+                // and otherwise encodes EVERY unique key, so a present locator
+                // that gives NO answer for a decoded key is a forgery — e.g. a
+                // delete_bitmap relabeled/re-roled to a locator that resolves
+                // nothing. The read path falls back to the sorted index on a
+                // miss, but a verifier deciding whether to trust the bytes must
+                // treat the unanswered key as corrupt (otherwise the relabel
+                // records no degradation and the deleted rows come back live).
+                let Some((located, hint)) = locator.locate_block(key_hash)? else {
+                    return Err(crate::Error::InvalidHeader(
+                        "locator gives no answer for a decoded key it should resolve",
+                    ));
+                };
+                if located.offset() != block_handle.offset() {
+                    return Err(crate::Error::InvalidHeader(
+                        "locator resolves a key to a block other than its newest-version block",
+                    ));
+                }
+                // A `Restart` / `Entry` slot hint sends `point_read_at_slot`
+                // straight to that in-block position: a checksum-clean
+                // locator can keep the right block id yet redirect the slot
+                // to a later restart interval holding an OLDER version of a
+                // multi-version key, and the read returns the stale value
+                // without falling back to the sorted index. Probe the hint
+                // and require the NEWEST version (the first decoded entry for
+                // the key, which is `entry` here since `located` == this
+                // block). A `None` hint (per-block precision) has no slot to
+                // validate.
+                if let (Some((slot, is_entry)), Some(block)) = (hint, row_block.as_ref()) {
+                    let found = block.point_read_at_slot(
+                        slot,
+                        is_entry,
+                        user_key.as_ref(),
+                        crate::seqno::MAX_SEQNO,
+                        &self.comparator,
+                    )?;
+                    let disagrees = match &found {
+                        Some(v) => {
+                            v.key.seqno != entry.key.seqno
+                                || v.key.value_type != entry.key.value_type
+                                || v.value != entry.value
+                        }
+                        None => true,
+                    };
+                    if disagrees {
+                        return Err(crate::Error::InvalidHeader(
+                            "locator slot hint does not resolve a key's newest version",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Confirms every decoded key is RETRIEVABLE through its own block's
+    /// in-block indexes, judged on the DISK-FRESH bytes. A data block's
+    /// embedded HASH INDEX is checksum-clean to the out-of-band walk even
+    /// when a bucket was re-stamped to `MARKER_FREE`: the sequential decode
+    /// gates still see every entry, but `point_read` trusts the index and
+    /// returns `None` for the affected keys. Each block is re-read from the
+    /// file and probed through ITS OWN `point_read` — the table-level probe
+    /// this replaces went through the recovery-time in-memory index and the
+    /// block cache, so a pristine cached copy masked the on-disk forge.
+    /// Filter, locator, and TLI misdirection have their own disk-fresh
+    /// gates (`verify_filter`, `verify_locator`, `verify_tli_mirrors`).
+    /// Columnar blocks carry no in-block key index (rows are reconstructed
+    /// on load), so they have nothing to probe.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when a decoded key is not retrievable
+    /// from its block; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_point_read_reachability(&self) -> crate::Result<()> {
+        use crate::table::block::ParsedItem as _;
+        // Columnar blocks carry no in-block key index to probe, but the GLOBAL
+        // internal-key sort order (user key ASC, then seqno DESC per key) is still
+        // an invariant the read path relies on: `column_batch_match_entries`
+        // binary-searches the key column assuming it is sorted, so a
+        // checksum-restamped block with reordered keys — which every other
+        // columnar check (count / zone-bound comparisons) tolerates — would make
+        // point reads miss a key or return a stale version. Enforce the order over
+        // the live suffix (the punched prefix is dead); there is no point_read to
+        // run, so this is the only order gate for a columnar table.
+        #[cfg(feature = "columnar")]
+        if self.metadata.columnar {
+            let punch = self.punch_offset()?;
+            let mut prev_internal: Option<(UserKey, SeqNo)> = None;
+            for handle in self.block_index.iter() {
+                let handle = handle?;
+                let block_handle = BlockHandle::new(handle.offset(), handle.size());
+                if block_handle.offset().0 < punch {
+                    continue;
+                }
+                for entry in self.decode_block_entries(&block_handle)? {
+                    if let Some((pk, ps)) = &prev_internal {
+                        let out_of_order = match self.comparator.compare(&entry.key.user_key, pk) {
+                            core::cmp::Ordering::Greater => false,
+                            core::cmp::Ordering::Less => true,
+                            core::cmp::Ordering::Equal => entry.key.seqno >= *ps,
+                        };
+                        if out_of_order {
+                            return Err(crate::Error::InvalidHeader(
+                                "columnar entries are out of order (a user key decreased, or an \
+                                 equal key's seqno did not strictly decrease) across the walk",
+                            ));
+                        }
+                    }
+                    prev_internal = Some((entry.key.user_key.clone(), entry.key.seqno));
+                }
+            }
+            return Ok(());
+        }
+        // The internal-key sort order (user key ASC, then seqno DESC per key) is
+        // a GLOBAL invariant across the whole table, not just within a block.
+        // Carry the last decoded internal key ACROSS block boundaries so a
+        // checksum-restamped later block cannot raise the seqno of a key that
+        // also ends the preceding block: both blocks would decode and probe
+        // cleanly on their own, yet after reopen the index seeks the first block
+        // and a later compaction could persist the stale (lower-seqno) version.
+        // A restricted view's punched prefix blocks are dead; skip them. The
+        // global sort order still holds across the LIVE suffix, so `prev_internal`
+        // simply starts at the first live block.
+        let punch = self.punch_offset()?;
+        let mut prev_internal: Option<(UserKey, SeqNo)> = None;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            let block = self.load_block_from_disk(&block_handle, BlockType::Data)?;
+            let data_block =
+                DataBlock::from_loaded(block, self.metadata.kv_checksum_algo.is_some())?;
+            // A block whose keys all resolve through its HASH index never
+            // exercises the binary index in the probes below, yet range
+            // seeks still trust it — authenticate the pointers directly.
+            data_block.verify_binary_index()?;
+            let entries: Vec<InternalValue> = data_block
+                .try_iter(self.comparator.clone())?
+                .map(|p| p.materialize(data_block.as_slice()))
+                .collect();
+            // A key's versions are adjacent within the block (sorted by key
+            // then descending seqno), so the FIRST occurrence is the newest
+            // and one probe per distinct key suffices.
+            let mut prev_key: Option<UserKey> = None;
+            for entry in entries {
+                // Enforce the global sort order on EVERY entry (before the
+                // per-key dedup below), tracking the previous entry across block
+                // boundaries: the user key must strictly increase, or (for the
+                // same user key) the seqno must strictly decrease.
+                if let Some((pk, ps)) = &prev_internal {
+                    let out_of_order = match self.comparator.compare(&entry.key.user_key, pk) {
+                        core::cmp::Ordering::Greater => false,
+                        core::cmp::Ordering::Less => true,
+                        core::cmp::Ordering::Equal => entry.key.seqno >= *ps,
+                    };
+                    if out_of_order {
+                        return Err(crate::Error::InvalidHeader(
+                            "data-block entries are out of order (a user key decreased, or an \
+                             equal key's seqno did not strictly decrease) across the walk",
+                        ));
+                    }
+                }
+                prev_internal = Some((entry.key.user_key.clone(), entry.key.seqno));
+
+                if prev_key.as_ref() == Some(&entry.key.user_key) {
+                    continue;
+                }
+                // Require the probe to return the NEWEST version, not merely
+                // SOME version. A key spanning restart intervals has a
+                // conflict-marked hash bucket; re-stamping that bucket to a
+                // later interval holding an OLDER version still yields
+                // `Some`, so an `is_none` check would pass — yet point reads
+                // after reopen would return the stale value. Match the
+                // decoded newest entry's seqno, value type, and bytes.
+                let found = data_block.point_read(
+                    entry.key.user_key.as_ref(),
+                    crate::seqno::MAX_SEQNO,
+                    &self.comparator,
+                )?;
+                let disagrees = match &found {
+                    Some(v) => {
+                        v.key.seqno != entry.key.seqno
+                            || v.key.value_type != entry.key.value_type
+                            || v.value != entry.value
+                    }
+                    None => true,
+                };
+                if disagrees {
+                    return Err(crate::Error::InvalidHeader(
+                        "a decoded key's point_read does not return its newest version \
+                         (an in-block index disagrees with the entries)",
+                    ));
+                }
+                prev_key = Some(entry.key.user_key);
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether the salvage-mode open degraded a REBUILDABLE side section
+    /// (filter / `filter_tli`, seqno bounds, zone map, locator) because its
+    /// block did not decode as the claimed type — see
+    /// [`Inner::rebuildable_section_degraded`](crate::table::inner::Inner). Used
+    /// by salvage to fail closed on a table whose degraded section may be a
+    /// relabeled deletion it would otherwise discard and resurrect.
+    ///
+    /// `std`-gated because its only consumer is the salvage path (`std`-only).
+    #[cfg(feature = "std")]
+    pub(crate) fn salvage_degraded_a_rebuildable_section(&self) -> bool {
+        self.rebuildable_section_degraded
+    }
+
+    /// Probes every decoded data key against the on-disk `filter` section:
+    /// each key the table holds must be reported as POSSIBLY PRESENT. A
+    /// checksum- and parity-consistent forged filter is accepted by the
+    /// out-of-band walk on its framing and role alone — the walk never
+    /// probes it — but `check_bloom` trusts it to SKIP point reads, so a key
+    /// made into a false negative silently disappears from every read. A
+    /// false positive is unprovable (it is the filter's normal error mode),
+    /// but a false NEGATIVE on an existing key is corruption by
+    /// construction. A no-op for tables without a filter.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the filter reports an existing
+    /// key as definitely absent; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_filter(
+        &self,
+        prefix_extractor: Option<&alloc::sync::Arc<dyn crate::prefix::PrefixExtractor>>,
+    ) -> crate::Result<()> {
+        // Re-read the filter FROM DISK: the open path PINS the filter (or
+        // its partition index) in memory at recover time, so an on-disk
+        // re-stamp after the open (the very forge this check exists for)
+        // would be invisible to `check_bloom`. An unreadable filter is an
+        // error here (the caller is deciding whether to trust the bytes),
+        // unlike the read path's permissive empty-payload sentinel.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        if regions.filter.is_none() && regions.filter_tli.is_none() {
+            return Ok(());
+        }
+        let filter_transform = {
+            let t = match self.encryption.as_deref() {
+                Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                None => crate::table::block::BlockTransform::PLAIN,
+            };
+            if let Some(ecc) = self.metadata.ecc_params {
+                t.with_ecc(ecc)
+            } else {
+                t
+            }
+        };
+        let load_filter_block =
+            |handle: BlockHandle| -> crate::Result<crate::table::filter::block::FilterBlock> {
+                let block = Block::from_file(
+                    &*file,
+                    handle,
+                    crate::table::block::BlockIdentity {
+                        table_id: self.metadata.id,
+                        block_type: BlockType::Filter,
+                        dict_id: 0,
+                        window_log: 0,
+                    },
+                    &filter_transform,
+                )?;
+                if block.header.block_type != BlockType::Filter {
+                    return Err(crate::Error::InvalidTag((
+                        "BlockType",
+                        block.header.block_type.into(),
+                    )));
+                }
+                Ok(crate::table::filter::block::FilterBlock::new(block))
+            };
+
+        // Partitioned mode: the partition index maps a key to its filter
+        // block. Loaded from disk for the same reason as the filter itself.
+        let filter_index = if let Some(idx_handle) = regions.filter_tli {
+            let block = Block::from_file(
+                &*file,
+                idx_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: self.metadata.id,
+                    block_type: BlockType::Index,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = crate::table::block::BlockTransform::from_parts(
+                        self.metadata.index_block_compression,
+                        self.encryption.as_deref(),
+                        #[cfg(zstd_any)]
+                        None,
+                    )?;
+                    if let Some(ecc) = self.metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::Index {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            let idx = IndexBlock::new(block);
+            idx.try_iter(self.comparator.clone())?;
+            Some(idx)
+        } else {
+            None
+        };
+        let full_filter = if filter_index.is_none() {
+            regions.filter.map(load_filter_block).transpose()?
+        } else {
+            None
+        };
+        // A present full filter whose payload decodes to the empty "no filter"
+        // sentinel is a forgery on a table with data blocks: the writer omits
+        // the section entirely when filtering is disabled, so it never emits a
+        // present-but-empty full filter. Left unrejected, the read-path probe
+        // below reports Ok(true) for EVERY key (the permissive empty sentinel),
+        // so a delete_bitmap renamed and re-roled to an empty filter passes the
+        // whole check, the SST is kept, and reopening resurrects the rows the
+        // hidden bitmap deleted.
+        if let Some(filter) = &full_filter
+            && filter.is_empty()
+            && self.block_index.iter().next().is_some()
+        {
+            return Err(crate::Error::InvalidHeader(
+                "filter section is present but empty on a table with data blocks",
+            ));
+        }
+
+        // Partition blocks are shared by many keys; memoize by file offset so
+        // the probe loop reads each partition once.
+        let mut partitions: alloc::collections::BTreeMap<
+            u64,
+            crate::table::filter::block::FilterBlock,
+        > = alloc::collections::BTreeMap::new();
+
+        // A restricted view's punched prefix blocks decode to zeros; skip them.
+        // Their keys are superseded, so the live filter is only obligated to
+        // report the suffix keys present.
+        let punch = self.punch_offset()?;
+        let mut prev_key: Option<Vec<u8>> = None;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            let entries = self.decode_block_entries(&block_handle)?;
+            for entry in entries {
+                // Blocks are sorted by key then descending seqno, so a key's
+                // older versions are always adjacent — one probe per key.
+                if prev_key.as_deref() == Some(entry.key.user_key.as_ref()) {
+                    continue;
+                }
+                let user_key = entry.key.user_key.to_vec();
+                let key_hash = crate::hash::hash64(&user_key);
+                let maybe_present = if let Some(idx) = &filter_index {
+                    let mut iter = idx.iter(self.comparator.clone());
+                    iter.seek(&user_key, crate::seqno::MAX_SEQNO);
+                    let Some(part_handle) = iter.next() else {
+                        // A key past the last partition is a definite miss on
+                        // the read path — a false negative by construction.
+                        return Err(crate::Error::InvalidHeader(
+                            "filter partition index does not cover an existing key",
+                        ));
+                    };
+                    let part_handle = part_handle.materialize(idx.as_slice()).into_inner();
+                    let filter = match partitions.entry(part_handle.offset().0) {
+                        alloc::collections::btree_map::Entry::Occupied(e) => e.into_mut(),
+                        alloc::collections::btree_map::Entry::Vacant(e) => {
+                            e.insert(load_filter_block(part_handle)?)
+                        }
+                    };
+                    // The partition index only addresses partitions the writer
+                    // filled with keys, so a partition that decodes to the empty
+                    // "no filter" sentinel yet is sought for an existing key is a
+                    // forgery (a delete_bitmap relabeled to an empty filter
+                    // partition under a re-stamped filter_tli). Left unrejected,
+                    // the probe below reports Ok(true) permissively for every
+                    // key and the relabel passes as a filter-less table.
+                    if filter.is_empty() {
+                        return Err(crate::Error::InvalidHeader(
+                            "filter partition is present but empty for an existing key",
+                        ));
+                    }
+                    filter.maybe_contains_hash(key_hash)?
+                } else if let Some(filter) = &full_filter {
+                    filter.maybe_contains_hash(key_hash)?
+                } else {
+                    true
+                };
+                if !maybe_present {
+                    return Err(crate::Error::InvalidHeader(
+                        "filter reports an existing key as definitely absent",
+                    ));
+                }
+                // A full filter also indexes every PREFIX the extractor
+                // emits for a key, and `maybe_contains_prefix` trusts it to
+                // SKIP whole tables on a prefix scan. A filter rebuilt from
+                // complete-key hashes alone (a salvage without the extractor)
+                // passes the key probe above yet turns every prefix into a
+                // false negative — the table silently vanishes from prefix
+                // scans. Probe each emitted prefix hash too. Partitioned
+                // filters stay conservative (their prefix probe is
+                // deliberately best-effort), so this runs only for a full
+                // filter with a configured extractor.
+                if let (Some(filter), Some(extractor)) = (&full_filter, prefix_extractor) {
+                    for prefix in extractor.prefixes(&user_key) {
+                        let prefix_hash = crate::hash::hash64(prefix);
+                        if !filter.maybe_contains_hash(prefix_hash)? {
+                            return Err(crate::Error::InvalidHeader(
+                                "filter reports an existing key's prefix as definitely absent",
+                            ));
+                        }
+                    }
+                }
+                prev_key = Some(user_key);
+            }
+        }
+        Ok(())
+    }
+
+    /// Cross-checks the recorded metadata BOUNDS against the table's decoded
+    /// contents. Both meta mirrors re-stamped CONSISTENTLY (fresh checksums
+    /// and parity) pass every byte-level check and the mirror comparison,
+    /// yet run selection trusts `key#min`/`key#max` to route reads AROUND
+    /// this table — a narrowed range silently hides real keys (and the range
+    /// tombstones that mask older tables). Checks, against the ON-DISK meta:
+    /// - the recorded key range COVERS the decoded first/last data keys and
+    ///   every recorded range tombstone's bounds (covers, not equals: the
+    ///   writer legitimately widens the range over tombstone-only spans);
+    /// - the recorded `item_count` equals the decoded entry count (the
+    ///   tombstone sentinel is an on-disk entry counted on both sides);
+    /// - the recorded `data_block_count` equals the indexed block count
+    ///   ([`Table::scan`] hands it to the compaction scanner, which stops
+    ///   after that many blocks — a smaller forge drops the tail);
+    /// - the disk-fresh per-KV footer descriptor matches the recovery-time
+    ///   one (a re-stamped `None` would misread footer bytes as the trailer
+    ///   after reopen);
+    /// - for tables WITHOUT a range-tombstone sentinel, the recorded
+    ///   `seqno#min` is at or below the decoded minimum and `seqno#kv_max`
+    ///   is at or above the decoded maximum (a raised min / lowered max
+    ///   hides visible versions from snapshot reads). RT-bearing tables skip
+    ///   this: the writer records the KV range EXCLUDING the sentinel's
+    ///   synthetic RT-derived seqno, so the decoded range legitimately
+    ///   differs — and those tables are already gated by the fail-closed
+    ///   deletion-metadata attribution rule.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the recorded bounds disagree
+    /// with the decoded contents; any I/O / decode error from the full scan.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_metadata_bounds(&self) -> crate::Result<()> {
+        // Re-read the meta FROM DISK: the in-memory copy was parsed at
+        // recover time, so an on-disk re-stamp after the open (the very
+        // forge this check exists for) would be invisible to it.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        // Tail-first with MID fallback, mirroring recovery: the next open
+        // trusts the same copy, and a table living off its intact MID mirror
+        // (unreadable forged tail) must be judged by THAT copy's bounds.
+        let meta = match crate::table::meta::ParsedMeta::load_with_handle(
+            &*file,
+            &regions.metadata,
+            Some(self.metadata.id),
+            self.encryption.as_deref(),
+        ) {
+            Ok(meta) => meta,
+            Err(tail_err) => {
+                let Some(mid_handle) = regions.metadata_mid else {
+                    return Err(tail_err);
+                };
+                crate::table::meta::ParsedMeta::load_with_handle(
+                    &*file,
+                    &mid_handle,
+                    Some(self.metadata.id),
+                    self.encryption.as_deref(),
+                )?
+            }
+        };
+
+        // Nothing on the heal path legitimately rewrites the meta sections,
+        // so the disk-fresh copy must equal the recovery-time one FIELD FOR
+        // FIELD. A single-field comparison is not enough: any descriptor
+        // re-stamped consistently in both mirrors passes the mirror walk,
+        // and fields no gate can re-derive from the entries stay
+        // authoritative-only — `descriptor#kv_checksum` flipped to `None`
+        // makes every reader misread footer bytes as the block trailer
+        // after reopen, and a back-dated `created_at` lets FIFO compaction
+        // drop the live SST as TTL-expired. The recovery-time copy is
+        // trustworthy (the blocks decoded under it at open), so any
+        // disk-fresh divergence is a post-open re-stamp.
+        if meta != self.metadata {
+            return Err(crate::Error::InvalidHeader(
+                "disk-fresh meta disagrees with the recovery-time copy",
+            ));
+        }
+
+        // Load the range tombstones UP FRONT: the synthetic sentinel an RT-ONLY
+        // table records is derived from them and must be EXCLUDED from the KV
+        // seqno bounds below (its seqno is RT-derived and lies outside the
+        // recorded KV range), and the same list feeds the key-range coverage
+        // check further down.
+        let tombstones = if let Some(rt_handle) = regions.range_tombstones {
+            let block = Block::from_file(
+                &*file,
+                rt_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: self.metadata.id,
+                    block_type: BlockType::RangeTombstone,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::RangeTombstone {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            Some(Self::decode_range_tombstones(
+                &block,
+                self.comparator.as_ref(),
+            )?)
+        } else {
+            None
+        };
+        // The `(start, seqno)` of the synthetic sentinel entry (a weak tombstone
+        // at the (seqno, start)-minimal tombstone), or `None` when the table is
+        // not RT-only. Excluded ONCE from the decoded KV seqno bounds below.
+        //
+        // Only an RT-ONLY table (no real KV items) carries a synthetic sentinel,
+        // written SOLELY to give an otherwise KV-empty range-tombstone table one
+        // index entry (the writer's `finish`), so its `item_count` is exactly 1.
+        // Gate on that — NOT on a seqno comparison against `highest_kv_seqno`: the
+        // sentinel exclusion feeds the seqno-bounds check below, and
+        // `highest_kv_seqno` is precisely the field that check validates, so using
+        // it to identify the sentinel is circular — an attacker who lowers a
+        // re-stamped `highest_kv_seqno` below a REAL weak tombstone would make it
+        // look synthetic, exclude it, and slip the forged bound past. `item_count`
+        // is instead cross-checked against the DECODED entry count below, so a
+        // forged `item_count == 1` on a multi-entry table is rejected there; a
+        // genuine single-real-KV table whose sole weak tombstone matches the
+        // RT-minimal `(key, seqno)` is unreachable (the covering RT would have to
+        // start at that sole key and end past it, exceeding the one-key range the
+        // coverage check enforces, and an empty point tombstone is rejected at
+        // decode), so this never wrongly excludes a real entry.
+        let sentinel = tombstones
+            .as_deref()
+            .filter(|_| meta.item_count == 1)
+            .and_then(crate::range_tombstone::RangeTombstone::sentinel)
+            .map(|(k, s)| (k.clone(), s));
+        let mut sentinel_excluded = false;
+
+        // A restricted (tight-space) view's `[0, punch)` prefix blocks are
+        // punched to zeros: the index still LISTS them (so counting index
+        // entries yields the whole-table block count, which `meta` records),
+        // but they no longer DECODE. Count every block toward `data_block_count`
+        // without decoding, and aggregate entries / keys / seqnos over the live
+        // suffix only. `meta.item_count` describes the whole table, so its
+        // exact-equality check relaxes to a subset check for a restricted view.
+        let punch = self.punch_offset()?;
+        let restricted = self.restrict_lower_bound().is_some();
+        let mut count: u64 = 0;
+        let mut block_count: u64 = 0;
+        let mut first_key: Option<UserKey> = None;
+        let mut last_key: Option<UserKey> = None;
+        let mut seqno_lo: Option<SeqNo> = None;
+        let mut seqno_hi: Option<SeqNo> = None;
+        for handle in self.block_index.iter() {
+            let handle = handle?;
+            let block_handle = BlockHandle::new(handle.offset(), handle.size());
+            block_count = block_count
+                .checked_add(1)
+                .ok_or(crate::Error::InvalidHeader("meta bounds"))?;
+            if block_handle.offset().0 < punch {
+                continue;
+            }
+            let entries = self.decode_block_entries(&block_handle)?;
+            count = count
+                .checked_add(entries.len() as u64)
+                .ok_or(crate::Error::InvalidHeader("meta bounds"))?;
+            if first_key.is_none() {
+                first_key = entries.first().map(|e| e.key.user_key.clone());
+            }
+            if let Some(last) = entries.last() {
+                last_key = Some(last.key.user_key.clone());
+            }
+            for entry in &entries {
+                // Exclude the synthetic RT sentinel (once): its RT-derived seqno
+                // is deliberately outside the recorded KV range, so folding it in
+                // would break the KV seqno-bound cross-check for an RT-only table.
+                if !sentinel_excluded
+                    && let Some((sentinel_key, sentinel_seqno)) = &sentinel
+                    && entry.key.seqno == *sentinel_seqno
+                    && entry.key.value_type == crate::ValueType::WeakTombstone
+                    && entry.key.user_key.as_ref() == sentinel_key.as_ref()
+                {
+                    sentinel_excluded = true;
+                    continue;
+                }
+                let s = entry.key.seqno;
+                seqno_lo = Some(seqno_lo.map_or(s, |lo| lo.min(s)));
+                seqno_hi = Some(seqno_hi.map_or(s, |hi| hi.max(s)));
+            }
+        }
+        if restricted {
+            // The live suffix is a subset of the whole table `meta` describes;
+            // it must not decode to MORE entries than the recorded whole-table
+            // count (that would be a grafted-in forge, not a punched prefix).
+            if count > meta.item_count {
+                return Err(crate::Error::InvalidHeader(
+                    "restricted view decodes to more entries than meta item_count",
+                ));
+            }
+        } else if count != meta.item_count {
+            return Err(crate::Error::InvalidHeader(
+                "meta item_count disagrees with the decoded entry count",
+            ));
+        }
+
+        // Seqno bounds route snapshot visibility: `get_for_key_cmp` skips this
+        // table when the query snapshot is at or below the recorded minimum,
+        // and treats it as fully visible above the recorded maximum. Both
+        // meta mirrors re-stamped with `seqno#min` raised (or `seqno#kv_max`
+        // lowered) pass every other gate yet silently hide older / newer
+        // visible versions after reopen. Cross-check against the decoded seqnos.
+        // The synthetic RT sentinel was already excluded above (its RT-derived
+        // seqno lies outside the recorded KV range), so this runs for RT-bearing
+        // tables too: an RT-ONLY table's sole entry drops out, leaving no bounds
+        // to check, while an RT+KV table's real entries are checked. A recorded
+        // minimum ABOVE the real minimum, or a recorded KV maximum BELOW the
+        // real maximum, is corruption.
+        if let (Some(lo), Some(hi)) = (seqno_lo, seqno_hi) {
+            if meta.seqnos.0 > lo {
+                return Err(crate::Error::InvalidHeader(
+                    "meta seqno#min is above the decoded minimum seqno",
+                ));
+            }
+            if meta.highest_kv_seqno < hi {
+                return Err(crate::Error::InvalidHeader(
+                    "meta seqno#kv_max is below the decoded maximum seqno",
+                ));
+            }
+        }
+        // `Table::scan` hands the recorded count to the compaction scanner,
+        // which stops after that many blocks: a count re-stamped SMALLER
+        // silently drops every key in the omitted tail from rewrites.
+        if block_count != meta.data_block_count {
+            return Err(crate::Error::InvalidHeader(
+                "meta data_block_count disagrees with the indexed block count",
+            ));
+        }
+        let cmp = &self.comparator;
+        let covers = |key: &[u8]| {
+            cmp.compare(meta.key_range.min().as_ref(), key) != core::cmp::Ordering::Greater
+                && cmp.compare(meta.key_range.max().as_ref(), key) != core::cmp::Ordering::Less
+        };
+        if let (Some(first), Some(last)) = (&first_key, &last_key)
+            && !(covers(first.as_ref()) && covers(last.as_ref()))
+        {
+            return Err(crate::Error::InvalidHeader(
+                "meta key range does not cover the decoded data keys",
+            ));
+        }
+
+        // The decoded tombstone count must match the recorded
+        // `range_tombstone_count`. A re-stamped RT block that decodes to a
+        // SUBSET, or a dropped section, passes the coverage check below for its
+        // surviving entries while the missing ranges no longer mask lower-level
+        // data — reads then resurrect the keys those tombstones deleted. The
+        // count lives in the meta block (already cross-checked field-for-field
+        // against the recovery-time copy above), so it is the trustworthy side.
+        let decoded_rt_count = tombstones.as_ref().map_or(0, alloc::vec::Vec::len) as u64;
+        if decoded_rt_count != meta.range_tombstone_count {
+            return Err(crate::Error::InvalidHeader(
+                "range_tombstones count disagrees with the recorded range_tombstone_count",
+            ));
+        }
+
+        // The recorded positional-delete count must match the readable
+        // delete_bitmap section EXACTLY, in both directions. The section is
+        // OPTIONAL (the writer omits it, and records the count as 0, precisely
+        // when the bitmap is empty), so its effective length is its decoded
+        // length when present and 0 when absent. A re-stamped TOC can break the
+        // agreement either way:
+        //   - a `> 0` count with the section RENAMED away (or REPLACED by
+        //     another valid optional section, e.g. a full filter that passes
+        //     every probe) leaves the table reporting no deletion, resurrecting
+        //     every positionally-deleted row;
+        //   - a `0` count with a live non-empty section GRAFTED on (the
+        //     no-delete count is genuine, but a bitmap from another table is
+        //     spliced in) makes reads apply that mask and drop live rows.
+        // Comparing effective length to the recorded count catches both, like
+        // the range-tombstone count check above. The count lives in the meta
+        // block (already cross-checked field-for-field against the recovery-time
+        // copy above and against the mirror), so it is the trustworthy side.
+        // `None` is an older table without the field: nothing to cross-check.
+        // Columnar-only: the bitmap is a columnar-layout section.
+        #[cfg(feature = "columnar")]
+        if let Some(recorded) = meta.delete_bitmap_len {
+            let effective = if self.has_delete_bitmap_section() {
+                self.delete_bitmap().len()
+            } else {
+                0
+            };
+            if effective != recorded {
+                return Err(crate::Error::InvalidHeader(
+                    "delete_bitmap count disagrees with the recorded \
+                     descriptor#delete_bitmap_len (the section was hidden, \
+                     replaced, or grafted on)",
+                ));
+            }
+        }
+        // Authenticate the delete-bitmap CONTENTS, not just its cardinality: the
+        // count check above accepts an equal-cardinality checksum-valid bitmap
+        // substituted for the real one, which — during manifest repair, with no
+        // original whole-file digest to compare against — would resurrect the
+        // originally-deleted rows and drop different live ones. The meta-bound
+        // hash of the section's encoded bytes catches any content substitution;
+        // the meta block is itself checksum- and mirror-verified, so a forger
+        // cannot restamp the hash without failing meta integrity. Re-encoding the
+        // decoded bitmap is byte-identical to the on-disk section (the container
+        // kind and its contents round-trip verbatim), so it matches the writer's
+        // hash.
+        //
+        // This gate runs ONLY during repair / heal reconciliation, never on an
+        // ordinary read (which the manifest's whole-file digest already
+        // protects). Those paths have no original digest, so a PRESENT bitmap
+        // section MUST carry a content hash to be authenticated here: a table
+        // written before this field (`None`) cannot be authenticated, so it fails
+        // closed rather than accepting a possibly-substituted equal-cardinality
+        // mask. Ordinary reads of such an older table are unaffected.
+        #[cfg(feature = "columnar")]
+        if self.has_delete_bitmap_section() {
+            match meta.delete_bitmap_hash {
+                Some(recorded_hash) => {
+                    let actual_hash = crate::hash::hash128(&self.delete_bitmap().encode());
+                    if actual_hash != recorded_hash {
+                        return Err(crate::Error::InvalidHeader(
+                            "delete_bitmap contents disagree with the recorded \
+                             descriptor#delete_bitmap_hash (an equal-cardinality bitmap \
+                             was substituted)",
+                        ));
+                    }
+                }
+                None => {
+                    return Err(crate::Error::InvalidHeader(
+                        "delete_bitmap section present without a \
+                         descriptor#delete_bitmap_hash; its contents cannot be \
+                         authenticated during repair / heal",
+                    ));
+                }
+            }
+        }
+        // Range tombstones mask entries in OLDER tables during reads and
+        // merges, so a key range narrowed below a tombstone's extent routes
+        // reads around this table and resurrects the data it deletes. Reuse the
+        // list loaded up front (for the sentinel derivation) rather than
+        // re-reading the block.
+        if let Some(tombstones) = &tombstones {
+            for rt in tombstones {
+                if !(covers(rt.start.as_ref()) && covers(rt.end.as_ref())) {
+                    return Err(crate::Error::InvalidHeader(
+                        "meta key range does not cover a recorded range tombstone",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Cross-checks the recorded `block_layout` section against the ACTUAL
+    /// inner-block boundaries of each zstd data frame, derived by stepwise
+    /// partial decodes. The section's block is checksum-clean to the walk
+    /// even when a cumulative end was re-stamped to another structurally
+    /// valid value, and the partial range-read path trusts it to bound
+    /// decompression — a mis-mapped boundary silently omits keys from the
+    /// affected span. Every recorded entry must belong to a real data block,
+    /// its ends must be strictly increasing, each prefix decode must land
+    /// exactly on its recorded boundary, and the final end must exhaust the
+    /// frame. A no-op for tables without the section, for encrypted tables
+    /// (the lazy path never engages there — the plaintext frame requires a
+    /// whole-block decrypt), and on builds without zstd.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::InvalidHeader`] when the recorded layout disagrees
+    /// with the frames; any I/O / decode error from the frame reads.
+    #[cfg(feature = "std")]
+    pub(crate) fn verify_block_layout(&self) -> crate::Result<()> {
+        // The section-presence + EMPTINESS check runs on EVERY build (including
+        // non-zstd, where the per-frame cross-check below is compiled out): a
+        // relabeled delete_bitmap→empty block_layout drops the deletion metadata
+        // regardless of zstd, so the forgery must be caught either way.
+        //
+        // Re-read the section FROM DISK: the in-memory map was loaded at recover
+        // time, so an on-disk re-stamp after the open (the very forge this check
+        // exists for) would be invisible to it.
+        let mut file = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
+        let trailer = crate::sfa::Reader::from_reader(&mut file)?;
+        let regions = regions::ParsedRegions::parse_from_toc(trailer.toc())?;
+        let Some(bl_handle) = regions.block_layout else {
+            return Ok(());
+        };
+        // Decode the map with an encryption-aware transform: on an encrypted
+        // table the section is AEAD-sealed, so both the emptiness check below
+        // AND catching a relabeled delete_bitmap (its AAD binds the block type,
+        // so decoding it as a BlockLayout fails the AEAD open) need the provider.
+        let map = {
+            let block = Block::from_file(
+                &*file,
+                bl_handle,
+                crate::table::block::BlockIdentity {
+                    table_id: self.metadata.id,
+                    block_type: BlockType::BlockLayout,
+                    dict_id: 0,
+                    window_log: 0,
+                },
+                &{
+                    let t = match self.encryption.as_deref() {
+                        Some(enc) => crate::table::block::BlockTransform::Encrypted(enc),
+                        None => crate::table::block::BlockTransform::PLAIN,
+                    };
+                    if let Some(ecc) = self.metadata.ecc_params {
+                        t.with_ecc(ecc)
+                    } else {
+                        t
+                    }
+                },
+            )?;
+            if block.header.block_type != BlockType::BlockLayout {
+                return Err(crate::Error::InvalidTag((
+                    "BlockType",
+                    block.header.block_type.into(),
+                )));
+            }
+            crate::table::block_layout::BlockLayoutMap::decode(&block.data)?
+        };
+        // The writer emits the block_layout section ONLY when it has at least
+        // one multi-inner-block frame to record, so a PRESENT-but-empty map on a
+        // table with data blocks is a forgery — e.g. a delete_bitmap renamed and
+        // re-roled to an empty block_layout, which drops the deletion metadata
+        // and resurrects positionally-deleted rows. (The per-block loop below
+        // cannot catch it: a block absent from the map is skipped, so an empty
+        // map trivially "agrees" with every block.)
+        if map.is_empty() {
+            if self.block_index.iter().next().is_some() {
+                return Err(crate::Error::InvalidHeader(
+                    "block_layout section is present but empty on a table with data blocks",
+                ));
+            }
+            return Ok(());
+        }
+        // The per-frame cross-check decodes whole zstd DATA frames: it needs
+        // zstd (the lazy partial-decode path) and cannot run on an encrypted
+        // table (the plaintext frame requires a whole-block decrypt the lazy
+        // path never performs). The emptiness forgery above is already rejected
+        // on every build, so a non-zstd / encrypted table stops here.
+        #[cfg(feature = "zstd")]
+        {
+            if self.encryption.is_some() {
+                return Ok(());
+            }
+            const ERR: crate::Error =
+                crate::Error::InvalidHeader("block_layout disagrees with the frames' inner blocks");
+
+            let transform = crate::table::util::build_block_transform(
+                self.metadata.data_block_compression,
+                None,
+                self.metadata.ecc_params,
+                #[cfg(zstd_any)]
+                self.zstd_dictionary.as_deref(),
+            )?;
+            // A restricted view's punched prefix frames read as zeros and cannot
+            // be frame-decoded; the map still records them (it is not rewritten
+            // on reopen), so cross-check `recorded_seen` against the LIVE map
+            // entries (offset >= punch) below instead of the whole map length.
+            let punch = self.punch_offset()?;
+            let mut recorded_seen = 0usize;
+            for handle in self.block_index.iter() {
+                let handle = handle?;
+                let block_handle = BlockHandle::new(handle.offset(), handle.size());
+                if block_handle.offset().0 < punch {
+                    continue;
+                }
+                let Some(ends) = map.ends_for(block_handle.offset().0) else {
+                    continue;
+                };
+                recorded_seen = recorded_seen
+                    .checked_add(1)
+                    .ok_or(crate::Error::InvalidHeader("block_layout"))?;
+                if !ends.iter().zip(ends.iter().skip(1)).all(|(a, b)| a < b) {
+                    return Err(ERR);
+                }
+                let (header, frame, _recovery) =
+                    Block::read_data_frame(&*file, block_handle, &transform)?;
+                if ends.last() != Some(&header.uncompressed_length) {
+                    return Err(ERR);
+                }
+                // Stepwise COLD prefix decodes: each recorded boundary must
+                // be exactly where the frame's k-th inner block ends. The
+                // per-block quadratic cost is bounded by the handful of
+                // inner blocks a data block splits into.
+                let mut src = std::io::Cursor::new(frame.as_ref());
+                let mut decoder = structured_zstd::decoding::FrameDecoder::new();
+                for (idx, &end) in ends.iter().enumerate() {
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "inner-block index is bounded by ends.len(), well within u32"
+                    )]
+                    let end_block = (idx + 1) as u32;
+                    src.set_position(0);
+                    // A zstd reset / decode failure on a checksum-clean frame is
+                    // DETERMINISTIC codec corruption (a forge that kept the block
+                    // checksum but broke the inner framing), NOT transient I/O:
+                    // map it to the structural `ERR` so repair's is_corruption
+                    // gate routes the table through salvage (which drops / re-
+                    // encodes the block) instead of aborting for a retry that can
+                    // never succeed. `Error::Io` stays reserved for real fs reads
+                    // (the frame read above still propagates its own I/O).
+                    decoder.reset(&mut src).map_err(|_| ERR)?;
+                    let pd = decoder
+                        .decode_blocks_partial(&mut src, 0, end_block, None, false)
+                        .map_err(|_| ERR)?;
+                    if pd.stopped_at.is_some()
+                        || pd.blocks_decoded != end_block
+                        || pd.data.len() != end as usize
+                    {
+                        return Err(ERR);
+                    }
+                    // The final recorded end must EXHAUST the frame: extra
+                    // unrecorded inner blocks would hide data past the map.
+                    if idx + 1 == ends.len() && !pd.frame_finished {
+                        return Err(ERR);
+                    }
+                }
+            }
+            // Every recorded LIVE entry matched a walked block (offsets are
+            // unique on both sides), so equal counts mean the map records ONLY
+            // the table's blocks. A restricted view compares against the live
+            // map entries; the punched prefix's entries are legitimately present.
+            if recorded_seen != map.live_len(punch) {
+                return Err(crate::Error::InvalidHeader(
+                    "block_layout carries entries for blocks the index does not hold",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Decodes one data block's entries (row or columnar) into
+    /// [`InternalValue`]s, for the semantic cross-check gates. Reads the
+    /// block DISK-FRESH ([`Self::load_block_from_disk`]): the gates judge
+    /// the file being reconciled, and a pristine copy cached before an
+    /// on-disk alteration must not stand in for the altered bytes.
+    #[cfg(feature = "std")]
+    fn decode_block_entries(
+        &self,
+        block_handle: &BlockHandle,
+    ) -> crate::Result<Vec<InternalValue>> {
+        use crate::table::block::ParsedItem as _;
+        #[cfg(feature = "columnar")]
+        if self.metadata.columnar {
+            let block = self.load_block_from_disk(block_handle, BlockType::Columnar)?;
+            let batch = crate::table::columnar::ColumnBatch::decode(&block.data)?;
+            return crate::table::columnar::column_batch_to_entries(&batch);
+        }
+        let block = self.load_block_from_disk(block_handle, BlockType::Data)?;
+        let data_block = DataBlock::from_loaded(block, self.metadata.kv_checksum_algo.is_some())?;
+        Ok(data_block
+            .try_iter(self.comparator.clone())?
+            .map(|p| p.materialize(data_block.as_slice()))
+            .collect())
     }
 
     /// Loads the filter block (if any) and checks the bloom filter.
@@ -2349,18 +6378,18 @@ impl Table {
             comparator,
             #[cfg(feature = "metrics")]
             metrics,
-            false,
+            RecoveryMode::Live,
         )
     }
 
-    /// Recovers a table, optionally in **salvage mode** (`salvage = true`).
+    /// Recovers a table, optionally in **salvage mode** (see [`RecoveryMode`]).
     ///
     /// In salvage mode a corrupt or truncated delete-bitmap degrades to empty
     /// ("all rows live, pending recompaction") and a delete-bitmap with an
     /// unreadable zone map is ignored rather than erroring, so a columnar
     /// segment with a damaged sidecar still opens and its data blocks can be
-    /// recovered. Normal recovery (`salvage = false`) fails closed on both, to
-    /// avoid resurrecting deleted rows. Used by [`crate::salvage`].
+    /// recovered. Normal recovery ([`RecoveryMode::Live`]) fails closed on
+    /// both, to avoid resurrecting deleted rows. Used by [`crate::salvage`].
     #[expect(
         clippy::too_many_arguments,
         clippy::too_many_lines,
@@ -2381,11 +6410,13 @@ impl Table {
         #[cfg(zstd_any)] zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
         comparator: SharedComparator,
         #[cfg(feature = "metrics")] metrics: Arc<Metrics>,
-        salvage: bool,
+        mode: RecoveryMode,
     ) -> crate::Result<Self> {
         use core::sync::atomic::AtomicBool;
         use meta::ParsedMeta;
         use regions::ParsedRegions;
+
+        let salvage = matches!(mode, RecoveryMode::Salvage { .. });
 
         log::debug!("Recovering table from file {}", file_path.display());
         let mut file = fs.open(&file_path, &FsOpenOptions::new().read(true))?;
@@ -2400,55 +6431,92 @@ impl Table {
         let regions = ParsedRegions::parse_from_toc(trailer.toc())?;
 
         log::trace!("Reading meta block, with meta_ptr={:?}", regions.metadata);
+        // The expected-id cross-check rejects a swapped / wrong-id file in a
+        // LIVE tree, where the manifest / file name is the durable identity.
+        // A salvage open with a caller-known id (repair — from the file name)
+        // keeps the check so a forged TAIL id falls back to the MID mirror; a
+        // STANDALONE salvage reader has no out-of-band id, so the SOURCE's
+        // own stored id is the identity and the check is skipped (None). An
+        // ENCRYPTED open always passes the caller's id — the meta block's AAD
+        // binds it, so decryption itself requires the right id.
+        let expected_id = match mode {
+            RecoveryMode::Live => Some(table_id),
+            RecoveryMode::Salvage { expected_id, .. } => {
+                if encryption.is_some() {
+                    Some(table_id)
+                } else {
+                    expected_id
+                }
+            }
+        };
+        // Salvage arbitration may invert the mirror order (see
+        // `RecoveryMode::Salvage::prefer_mid_meta`); live opens always load
+        // tail-first.
+        let prefer_mid_meta = matches!(
+            mode,
+            RecoveryMode::Salvage {
+                prefer_mid_meta: true,
+                ..
+            }
+        );
         // TAIL first (authoritative copy by convention; physically
         // identical content to MID — same `file_size`, same
         // `created_at`, same KV map — the only difference is which
         // SFA section is loaded). On any decode/decrypt/checksum
-        // failure fall back to the MID copy if present.
+        // failure fall back to the MID copy if present. Under salvage
+        // arbitration (`prefer_mid_meta`) the order is inverted: MID
+        // first, tail as the fallback.
+        let (first_handle, first_name, second, second_name) =
+            if prefer_mid_meta && let Some(mid_handle) = regions.metadata_mid {
+                (mid_handle, "MID", Some(regions.metadata), "TAIL")
+            } else {
+                (regions.metadata, "TAIL", regions.metadata_mid, "MID")
+            };
         let metadata = match ParsedMeta::load_with_handle(
             &*file,
-            &regions.metadata,
-            Some(table_id),
+            &first_handle,
+            expected_id,
             encryption.as_deref(),
         ) {
             Ok(m) => m,
-            Err(tail_err) => {
-                if let Some(mid_handle) = regions.metadata_mid {
+            Err(first_err) => {
+                if let Some(second_handle) = second {
                     log::warn!(
-                        "TAIL meta block unreadable for {} ({tail_err}); falling back to MID copy",
+                        "{first_name} meta block unreadable for {} ({first_err}); \
+                         falling back to {second_name} copy",
                         file_path.display(),
                     );
                     // Match the PR contract: when BOTH copies fail,
-                    // surface the original TAIL error (callers care
-                    // about the authoritative copy's failure mode).
-                    // The MID failure goes to the log so it's not
-                    // silently dropped from diagnostics.
+                    // surface the FIRST error (callers care about the
+                    // preferred copy's failure mode). The fallback
+                    // failure goes to the log so it's not silently
+                    // dropped from diagnostics.
                     // MID and TAIL are byte-identical: same `file_size`
                     // (= `*self.meta.file_pos`, only bumped inside
                     // `spill_block`, unchanged between the two writes),
                     // same `created_at` (snapshotted once in
-                    // `finish()`), same KV map. MID payload is usable
+                    // `finish()`), same KV map. Either payload is usable
                     // directly — no sentinel patching, no
                     // `std::fs::metadata` (which would also bypass the
                     // pluggable `Fs` backend).
                     match ParsedMeta::load_with_handle(
                         &*file,
-                        &mid_handle,
-                        Some(table_id),
+                        &second_handle,
+                        expected_id,
                         encryption.as_deref(),
                     ) {
-                        Ok(mid) => mid,
-                        Err(mid_err) => {
+                        Ok(m) => m,
+                        Err(second_err) => {
                             log::warn!(
-                                "MID meta block also unreadable for {}: {mid_err}; \
-                                 returning original TAIL error",
+                                "{second_name} meta block also unreadable for {}: {second_err}; \
+                                 returning original {first_name} error",
                                 file_path.display(),
                             );
-                            return Err(tail_err);
+                            return Err(first_err);
                         }
                     }
                 } else {
-                    return Err(tail_err);
+                    return Err(first_err);
                 }
             }
         };
@@ -2542,50 +6610,101 @@ impl Table {
             })
         };
 
+        // Set when the salvage-mode open DEGRADES a rebuildable side section
+        // (filter / filter_tli, seqno bounds, zone map, locator) because its
+        // block did not decode as the claimed type. Salvage re-derives every
+        // such section from the recovered entries, so a section that is present
+        // but does not decode may be a `range_tombstones` / `delete_bitmap`
+        // relabeled to a rebuildable name and re-roled — which salvage would
+        // discard, resurrecting the suppressed rows. This is a purely
+        // STRUCTURAL signal (each decode reads its own section's bytes,
+        // independent of the data blocks), so a corrupt DATA block does not
+        // trip it. `block_layout` is excluded: it fails the open outright, so a
+        // relabel to it is quarantined by the failed recovery rather than
+        // salvaged.
+        let mut rebuildable_section_degraded = false;
+
         let pinned_filter_index = if let Some(filter_tli_handle) = regions.filter_tli {
-            let block = Block::from_file(
-                file_handle.as_ref(),
-                filter_tli_handle,
-                crate::table::block::BlockIdentity {
-                    table_id: metadata.id,
-                    block_type: BlockType::Index,
-                    dict_id: 0,
-                    window_log: 0,
-                },
-                &{
-                    // Filter TLI is an Index (SST) block: no block_flags byte,
-                    // so ECC presence comes from the per-SST descriptor.
-                    let t = crate::table::block::BlockTransform::from_parts(
-                        metadata.index_block_compression,
-                        encryption.as_deref(),
-                        #[cfg(zstd_any)]
-                        None,
-                    )?;
-                    if let Some(ecc) = metadata.ecc_params {
-                        t.with_ecc(ecc)
-                    } else {
-                        t
-                    }
-                },
-            )?;
-            if block.header.block_type != BlockType::Index {
-                return Err(crate::Error::InvalidTag((
-                    "BlockType",
-                    block.header.block_type.into(),
-                )));
+            let load = || -> crate::Result<IndexBlock> {
+                let block = Block::from_file(
+                    file_handle.as_ref(),
+                    filter_tli_handle,
+                    crate::table::block::BlockIdentity {
+                        table_id: metadata.id,
+                        block_type: BlockType::Index,
+                        dict_id: 0,
+                        window_log: 0,
+                    },
+                    &{
+                        // Filter TLI is an Index (SST) block: no block_flags byte,
+                        // so ECC presence comes from the per-SST descriptor.
+                        let t = crate::table::block::BlockTransform::from_parts(
+                            metadata.index_block_compression,
+                            encryption.as_deref(),
+                            #[cfg(zstd_any)]
+                            None,
+                        )?;
+                        if let Some(ecc) = metadata.ecc_params {
+                            t.with_ecc(ecc)
+                        } else {
+                            t
+                        }
+                    },
+                )?;
+                if block.header.block_type != BlockType::Index {
+                    return Err(crate::Error::InvalidTag((
+                        "BlockType",
+                        block.header.block_type.into(),
+                    )));
+                }
+                let idx = IndexBlock::new(block);
+                // Validate filter index trailer eagerly (same as FullBlockIndex::new)
+                // so later iter() calls cannot panic on malformed blocks.
+                idx.try_iter(comparator.clone())?;
+                Ok(idx)
+            };
+            match load() {
+                Ok(idx) => Some(idx),
+                // Only a TRANSIENT read propagates so repair retries; a PERSISTENT
+                // I/O failure (bad sector, truncation) degrades under salvage like
+                // the seqno-bounds / zone-map / delete-bitmap / locator loaders —
+                // turning a one-shot failure into a permanent drop of the whole
+                // (recoverable) table would be wrong.
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                // Salvage never consults the source's filter — the
+                // destination writer rebuilds it from the recovered keys —
+                // so a STRUCTURALLY or PERSISTENTLY unreadable filter index must not
+                // cost the recoverable data (a live open still fails closed).
+                Err(e) if salvage => {
+                    log::warn!(
+                        "filter index for table {:?} is unreadable ({e}); salvaging \
+                         without it (the recovered copy re-derives its filter)",
+                        metadata.id
+                    );
+                    rebuildable_section_degraded = true;
+                    None
+                }
+                Err(e) => return Err(e),
             }
-            let idx = IndexBlock::new(block);
-            // Validate filter index trailer eagerly (same as FullBlockIndex::new)
-            // so later iter() calls cannot panic on malformed blocks.
-            idx.try_iter(comparator.clone())?;
-            Some(idx)
         } else {
             None
         };
 
         // TODO: FilterBlock newtype
-        let pinned_filter_block = if pinned_filter_index.is_none() && pin_filter {
-            regions
+        //
+        // In SALVAGE mode the source filter is never PINNED (the destination
+        // rebuilds it from the recovered keys), but a present full filter must
+        // still be PROBED even when `pin_filter` is false: a delete_bitmap
+        // renamed and re-roled to a `filter` (an empty sentinel, or a
+        // checksum/parity-valid but structurally broken BuRR payload) launders
+        // the deletion metadata. Loading and parsing it here trips the
+        // rebuildable-section degradation, which the salvage guard turns into a
+        // fail-closed quarantine. A live open (pin_filter, not salvage) keeps
+        // its exact prior behaviour.
+        let pinned_filter_block = if pinned_filter_index.is_none() && (pin_filter || salvage) {
+            let loaded = regions
                 .filter
                 .map(|filter_handle| {
                     log::debug!(
@@ -2631,7 +6750,63 @@ impl Table {
 
                     Ok::<_, crate::Error>(FilterBlock::new(block))
                 })
-                .transpose()?
+                .transpose();
+            match loaded {
+                Ok(Some(filter)) => {
+                    // A present full filter that decodes to the empty sentinel,
+                    // or whose BuRR payload does not parse, is not something the
+                    // writer ever emits (it omits the section when filtering is
+                    // disabled). In salvage mode treat it as a degraded
+                    // rebuildable section so a relabeled delete_bitmap cannot
+                    // pass as a filter-less table and resurrect deleted rows.
+                    if salvage && (filter.is_empty() || filter.maybe_contains_hash(0).is_err()) {
+                        log::warn!(
+                            "filter block for table {:?} is empty or unparsable; salvaging \
+                             as a degraded rebuildable section",
+                            metadata.id
+                        );
+                        rebuildable_section_degraded = true;
+                    }
+                    // Never PIN in salvage (the destination rebuilds the
+                    // filter); a live open with pin_filter keeps it.
+                    if pin_filter { Some(filter) } else { None }
+                }
+                Ok(None) => None,
+                // An InvalidTag here is STRUCTURAL, not corruption: the block
+                // loaded and verified its own PAYLOAD checksum, it is just the
+                // WRONG role. `Header::checksum` covers the payload, not the
+                // header, so a `block_type` byte that flips to another valid SST
+                // discriminant does NOT fail that checksum — it reaches this
+                // role check exactly like a TOC rename (a delete_bitmap renamed
+                // to `filter` without re-roling its header). Both are a valid
+                // block of the wrong name (the relabel signature), so degrade
+                // like the empty / unparsable payload above and fail closed.
+                //
+                // Any OTHER load failure (payload checksum / AEAD) is GENUINE
+                // bit-rot: a re-stamped relabel produces a checksum-VALID block,
+                // so a broken payload checksum is real corruption, rebuilt from
+                // the recovered keys. A delete-free table with a bit-rotted
+                // filter must auto-repair, not quarantine, so salvaging
+                // continues without degrading.
+                Err(e) if salvage => {
+                    if matches!(e, crate::Error::InvalidTag(_)) {
+                        log::warn!(
+                            "filter block for table {:?} has the wrong role ({e}); salvaging \
+                             as a degraded rebuildable section",
+                            metadata.id
+                        );
+                        rebuildable_section_degraded = true;
+                    } else {
+                        log::warn!(
+                            "filter block for table {:?} is unreadable ({e}); salvaging \
+                             without it (the recovered copy re-derives its filter)",
+                            metadata.id
+                        );
+                    }
+                    None
+                }
+                Err(e) => return Err(e),
+            }
         } else {
             None
         };
@@ -2770,13 +6945,25 @@ impl Table {
                 }
                 crate::table::seqno_bounds::SeqnoBoundsMap::decode(&block.data)
             };
-            load().unwrap_or_else(|e| {
-                log::warn!(
-                    "seqno-bounds section for table {:?} is unreadable ({e}); disabling seqno block-skip",
-                    metadata.id
-                );
-                crate::table::seqno_bounds::SeqnoBoundsMap::default()
-            })
+            match load() {
+                Ok(m) => m,
+                // Only a TRANSIENT read propagates so repair retries; a PERSISTENT
+                // failure (bad sector, truncation) degrades this rebuildable,
+                // derived section to an empty map (seqno block-skip disabled)
+                // rather than failing the whole open — turning an optimization's
+                // bit-rot into a hard availability loss would be wrong.
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                Err(e) => {
+                    log::warn!(
+                        "seqno-bounds section for table {:?} is unreadable ({e}); disabling seqno block-skip",
+                        metadata.id
+                    );
+                    rebuildable_section_degraded = true;
+                    crate::table::seqno_bounds::SeqnoBoundsMap::default()
+                }
+            }
         } else {
             crate::table::seqno_bounds::SeqnoBoundsMap::default()
         };
@@ -2822,13 +7009,23 @@ impl Table {
                 }
                 crate::table::zone_map::ZoneMap::decode(&block.data)
             };
-            load().unwrap_or_else(|e| {
-                log::warn!(
-                    "zone-map section for table {:?} is unreadable ({e}); disabling block-skip",
-                    metadata.id
-                );
-                crate::table::zone_map::ZoneMap::default()
-            })
+            match load() {
+                Ok(m) => m,
+                // Only a TRANSIENT read propagates so repair retries; a PERSISTENT
+                // failure degrades this rebuildable, derived section to an empty
+                // map (block-skip disabled) rather than failing the whole open.
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                Err(e) => {
+                    log::warn!(
+                        "zone-map section for table {:?} is unreadable ({e}); disabling block-skip",
+                        metadata.id
+                    );
+                    rebuildable_section_degraded = true;
+                    crate::table::zone_map::ZoneMap::default()
+                }
+            }
         } else {
             crate::table::zone_map::ZoneMap::default()
         };
@@ -2839,6 +7036,7 @@ impl Table {
         // resurrect deleted rows, so normal recovery propagates the error and
         // fails. In salvage mode it degrades to empty ("all rows live, pending
         // recompaction") so the segment's data is still recoverable.
+        let mut delete_bitmap_degraded = false;
         let mut delete_bitmap = if let Some(db_handle) = regions.delete_bitmap {
             let load = || -> crate::Result<crate::table::delete_bitmap::DeleteBitmap> {
                 let block = Block::from_file(
@@ -2872,11 +7070,22 @@ impl Table {
             };
             match load() {
                 Ok(db) => db,
+                // A TRANSIENT read propagates so repair retries: degrading the
+                // delete mask to "all rows live" on a one-shot fault would
+                // resurrect deleted rows in the rebuilt table. A PERSISTENT read
+                // failure in salvage mode instead falls through to the
+                // degradation branch below, where the caller's
+                // `allow_delete_resurrection` opt-in is honored downstream (a
+                // non-salvage open still fails closed via the final arm).
+                Err(crate::Error::Io(e)) if e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
                 Err(e) if salvage => {
                     log::warn!(
                         "delete-bitmap for table {:?} is unreadable ({e}); salvaging all rows as live",
                         metadata.id
                     );
+                    delete_bitmap_degraded = true;
                     crate::table::delete_bitmap::DeleteBitmap::default()
                 }
                 Err(e) => return Err(e),
@@ -2898,6 +7107,7 @@ impl Table {
                     "salvage: delete-bitmap for table {:?} has no readable zone map; ignoring it (all rows live)",
                     metadata.id
                 );
+                delete_bitmap_degraded = true;
                 delete_bitmap = crate::table::delete_bitmap::DeleteBitmap::default();
             } else {
                 return Err(crate::Error::InvalidHeader(
@@ -2940,8 +7150,9 @@ impl Table {
         // which isolates a corrupt sub-index partition to its own keys — so
         // enabling the locator by default does NOT widen the blast radius of a
         // partitioned-index corruption from "one partition" back to "whole SST".
-        let locator_index = regions.locator.and_then(|loc_handle| {
-            let block = Block::from_file(
+        let locator_block = match regions.locator {
+            None => None,
+            Some(loc_handle) => match Block::from_file(
                 file_handle.as_ref(),
                 loc_handle,
                 crate::table::block::BlockIdentity {
@@ -2961,16 +7172,34 @@ impl Table {
                         t
                     }
                 },
-            )
-            .inspect_err(|e| {
-                log::warn!("retrieval-ribbon locator disabled: section load failed: {e:?}");
-            })
-            .ok()?;
+            ) {
+                Ok(block) => Some(block),
+                // A TRANSIENT locator read during salvage must PROPAGATE, not
+                // degrade: `rebuildable_section_degraded` makes `salvage_attempt`
+                // read a delete-free table as possibly hiding deletion metadata and
+                // fail the whole SST (`FeatureUnsupported`), quarantining an
+                // otherwise-salvageable table instead of retrying the retryable
+                // read. Mirrors the zone-map / seqno-bounds / delete-bitmap loaders.
+                // A non-salvage open keeps the best-effort accelerator behavior
+                // (degrade to the sorted-index path), so a flaky read there never
+                // fails the open.
+                Err(crate::Error::Io(e)) if salvage && e.kind().is_transient() => {
+                    return Err(crate::Error::Io(e));
+                }
+                Err(e) => {
+                    log::warn!("retrieval-ribbon locator disabled: section load failed: {e:?}");
+                    rebuildable_section_degraded = true;
+                    None
+                }
+            },
+        };
+        let locator_index = locator_block.and_then(|block| {
             if block.header.block_type != BlockType::Locator {
                 log::warn!(
                     "retrieval-ribbon locator disabled: unexpected block type {:?}",
                     block.header.block_type
                 );
+                rebuildable_section_degraded = true;
                 return None;
             }
             let blocks: Vec<BlockHandle> = block_index
@@ -3035,6 +7264,8 @@ impl Table {
                 zone_map,
                 delete_bitmap,
                 delete_block_starts,
+                delete_bitmap_degraded,
+                rebuildable_section_degraded,
                 locator_index,
                 encryption,
 
@@ -3047,7 +7278,11 @@ impl Table {
                 background_deleter: once_cell::race::OnceBox::new(),
 
                 heal_hints: once_cell::race::OnceBox::new(),
+
+                #[cfg(all(feature = "std", feature = "page_ecc"))]
+                heal_lock: once_cell::race::OnceBox::new(),
             }),
+            None,
             None,
         ))
     }
@@ -3082,7 +7317,7 @@ impl Table {
     /// durably installed.
     #[must_use]
     pub(crate) fn with_restriction(&self, lower: UserKey) -> Self {
-        Self(self.0.clone(), Some(lower))
+        Self(self.0.clone(), Some(lower), self.2)
     }
 
     /// Re-opens this table as a DISTINCT [`Inner`](inner::Inner) (its own file
@@ -3096,20 +7331,37 @@ impl Table {
     /// Opens with its own file handle (no shared descriptor table) so the old
     /// view's handle lifecycle stays fully separate.
     ///
+    /// The suffix digest captured here must stay consistent with what the caller
+    /// installs in the manifest, so the caller MUST hold this table's
+    /// [`heal_lock_arc`](Self::heal_lock_arc) across BOTH this call and the
+    /// version edit that installs the returned view. Without it a concurrent
+    /// patrol heal could refresh a suffix block between the capture and the
+    /// install, binding the restricted manifest to a pre-heal digest that the
+    /// post-restriction patrol can neither match nor re-attribute (its
+    /// attestation binds whole-file, not suffix, digests).
+    ///
     /// # Errors
     ///
     /// Propagates any error from re-opening the SST file.
-    #[cfg_attr(
-        not(feature = "std"),
-        allow(
-            dead_code,
-            reason = "tight-space relocation view; its compaction consumer is std-gated, so unused under no_std"
-        )
-    )]
+    // std-only: computes the suffix digest via `crate::repair` (file I/O) and is
+    // reached only from tight-space compaction, which is itself std-gated.
+    #[cfg(feature = "std")]
     pub(crate) fn reopen_restricted(&self, lower: UserKey) -> crate::Result<Self> {
+        // The restricted view's digest is the LIVE SUFFIX only: its
+        // `[0, punch_offset)` prefix is hole-punched right after this view is
+        // installed, so a whole-file digest (what `self.checksum()` holds) would
+        // never match the punched file. Compute the suffix digest over the
+        // CURRENT bytes NOW, while the file is still whole — the suffix is
+        // untouched by the punch, and reading it fresh also folds in any in-place
+        // heal that refreshed this table (so a tight-space swap installs the
+        // healed suffix digest, never a stale pre-heal one).
+        let punch_offset = self.punch_offset_for(&lower)?;
+        let restricted_checksum = crate::Checksum::from_raw(
+            crate::repair::compute_table_checksum_from(&*self.fs, &self.path, punch_offset)?,
+        );
         let reopened = Self::recover(
             (*self.path).clone(),
-            self.checksum,
+            restricted_checksum,
             self.global_seqno,
             self.tree_id,
             self.metadata.id,
@@ -3125,6 +7377,17 @@ impl Table {
             #[cfg(feature = "metrics")]
             self.metrics.clone(),
         )?;
+        // The reopened `Inner` is DISTINCT from this one, so it starts without
+        // the tree-installed shared gates. Carry them forward, or the restricted
+        // view would lose them: without the checkpoint deletion pause a
+        // checkpoint could link healed bytes under a stale digest, and without
+        // the shared heal lock two patrols could heal + reconcile the same SST
+        // concurrently and leave a clean file mismatched with the manifest.
+        if let Some(pause) = self.0.deletion_pause.get() {
+            reopened.install_deletion_pause(Arc::clone(pause));
+        }
+        #[cfg(all(feature = "std", feature = "page_ecc"))]
+        reopened.install_heal_lock(self.heal_lock_arc());
         Ok(reopened.with_restriction(lower))
     }
 
@@ -3173,12 +7436,75 @@ impl Table {
         Ok(data_end)
     }
 
+    /// Byte offset of this view's first LIVE data block: `0` for a normal table,
+    /// or the punch offset for a tight-space RESTRICTED view (its `[0, offset)`
+    /// data blocks are hole-punched and read as zeros). A data block or section
+    /// entry at a lower offset is DEAD (superseded, never read), so the
+    /// disk-fresh verification gates skip it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a restricted view's punch-offset lookup failure instead of
+    /// grading it `0`: falling back to `0` would make the verification gates walk
+    /// the hole-punched prefix (which reads as zeros), report its blocks as
+    /// structural corruption, and — on the heal reconcile path — strip a valid
+    /// heal attestation for what is really a transient partitioned-index read.
+    /// Propagating keeps a transient failure inconclusive (the marker survives for
+    /// the next patrol). A normal (unrestricted) table never calls the fallible
+    /// lookup, so it always returns `Ok(0)`.
+    pub(crate) fn punch_offset(&self) -> crate::Result<u64> {
+        match self.restrict_lower_bound() {
+            Some(bound) => self.punch_offset_for(bound),
+            None => Ok(0),
+        }
+    }
+
+    /// The whole-file digest for a normal table, or the LIVE-SUFFIX digest for a
+    /// tight-space RESTRICTED view: its `[0, punch_offset)` prefix is hole-
+    /// punched once a superseding output table owns those keys, so hashing the
+    /// whole physical file would fold the punched (zeroed) prefix into the
+    /// digest and never match the manifest. Digesting only `[punch_offset, end)`
+    /// keeps the checksum stable across the punch, and it is what
+    /// [`reopen_restricted`](Self::reopen_restricted) records and what
+    /// verification / heal reconciliation must recompute for a restricted view.
+    #[cfg(feature = "std")]
+    pub(crate) fn live_region_checksum(&self) -> crate::Result<Checksum> {
+        let start = match self.restrict_lower_bound() {
+            Some(bound) => self.punch_offset_for(bound)?,
+            None => 0,
+        };
+        crate::repair::compute_table_checksum_from(&*self.fs, &self.path, start)
+            .map(Checksum::from_raw)
+    }
+
     /// Installs the tree-wide deletion pause used by checkpoints.
     ///
     /// Idempotent: a second call is a no-op. Called by the owning tree
     /// after recovery and after compaction registers freshly-built tables.
     pub(crate) fn install_deletion_pause(&self, pause: Arc<crate::deletion_pause::DeletionPause>) {
         let _ = self.0.deletion_pause.set(Box::new(pause));
+    }
+
+    /// The shared heal-serialization lock for this table, lazily created on
+    /// first use. Held by the patrol scrub across the whole scan-to-reconcile
+    /// span so two overlapping heals cannot race the link-count probe or the
+    /// digest reconciliation. Shared by STABLE table identity:
+    /// [`reopen_restricted`](Self::reopen_restricted) propagates it into the
+    /// distinct `Inner` it creates.
+    #[cfg(all(feature = "std", feature = "page_ecc"))]
+    pub(crate) fn heal_lock_arc(&self) -> Arc<parking_lot::Mutex<()>> {
+        Arc::clone(
+            self.0
+                .heal_lock
+                .get_or_init(|| Box::new(Arc::new(parking_lot::Mutex::new(())))),
+        )
+    }
+
+    /// Installs a shared heal lock, so a re-opened view serializes heals against
+    /// the original. Idempotent: a second call is a no-op.
+    #[cfg(all(feature = "std", feature = "page_ecc"))]
+    pub(crate) fn install_heal_lock(&self, lock: Arc<parking_lot::Mutex<()>>) {
+        let _ = self.0.heal_lock.set(Box::new(lock));
     }
 
     /// Installs the tree-wide background file deleter.
@@ -3204,7 +7530,18 @@ impl Table {
 
     #[must_use]
     pub fn checksum(&self) -> Checksum {
-        self.0.checksum
+        // The refreshed digest (an in-place heal changed the bytes after
+        // recovery) supersedes the one captured at recovery.
+        self.2.unwrap_or(self.0.checksum)
+    }
+
+    /// A view of this table whose full-file checksum is `checksum`: an
+    /// in-place heal changed the file's bytes, and installing this view into
+    /// a new version makes the diff persist the refreshed digest to the
+    /// manifest (see [`crate::Version::with_refreshed_table_checksum`]).
+    #[must_use]
+    pub(crate) fn with_refreshed_checksum(&self, checksum: Checksum) -> Self {
+        Self(self.0.clone(), self.1.clone(), Some(checksum))
     }
 
     /// Read `len` bytes from the cursor position with checked arithmetic.
@@ -3524,6 +7861,18 @@ impl Table {
     #[must_use]
     pub fn get_highest_seqno(&self) -> SeqNo {
         self.metadata.seqnos.1 + self.global_seqno()
+    }
+
+    /// The highest LOCAL (on-disk, pre-`global_seqno`) sequence number of any
+    /// entry, `0` for an empty table. Unlike [`get_highest_seqno`], it does NOT
+    /// add the offset. Manifest repair uses it as the LEGACY bulk-ingest
+    /// signature: a table of unknown provenance whose entries all sit at local
+    /// seqno 0 may itself be a legacy bulk-ingested table.
+    ///
+    /// [`get_highest_seqno`]: Self::get_highest_seqno
+    #[must_use]
+    pub(crate) fn max_local_seqno(&self) -> SeqNo {
+        self.metadata.seqnos.1
     }
 
     /// Returns the highest sequence number from KV entries only,

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -5908,10 +5908,47 @@ impl Table {
         // blocks in key (= write) order, the same order the writer assigned row
         // positions, so `row_base` is each block's first global row position.
         let has_deletes = !self.delete_bitmap.is_empty();
+        // Row count of a block that is stepped over without decoding, from its
+        // zone-map entry. A punched block CANNOT be decoded (it reads as
+        // zeros), so the zone map is the only source; without it every later
+        // row's positional delete mapping would silently shift — fail loudly
+        // instead.
+        let skipped_rows = |offset| {
+            self.zone_map
+                .columns_for(offset)
+                .and_then(|stats| stats.first())
+                .map(|s| s.row_count)
+                .ok_or(crate::Error::InvalidHeader(
+                    "columnar_scan: skipped block has no zone-map row count while positional deletes are present",
+                ))
+        };
+        // Tight-space restriction: data blocks wholly below the bound are
+        // hole-punched (they read as zeros), so they are stepped over, never
+        // decoded — the same key-based clamp the row-oriented scans apply.
+        // The first live block may STRADDLE the bound (the punch is
+        // block-aligned, the bound is a key), so its sub-bound rows are
+        // masked below.
+        let restrict = self.restrict_lower_bound();
+        let mut first_live_block = restrict.is_some();
         let mut row_base: u32 = 0;
         let mut out = Vec::new();
         for keyed in self.block_index.iter() {
             let keyed = keyed?;
+            if let Some(bound) = restrict
+                && self.comparator.compare(keyed.end_key(), bound.as_ref())
+                    == core::cmp::Ordering::Less
+            {
+                // The whole block precedes the bound: superseded (and normally
+                // punched) — skip it, keeping the position cursor aligned.
+                if has_deletes {
+                    row_base = row_base.wrapping_add(skipped_rows(*keyed.offset())?);
+                }
+                continue;
+            }
+            // Only the FIRST block at or past the bound can straddle it: keys
+            // ascend across blocks, so every later block is entirely live.
+            let straddles_bound = first_live_block;
+            first_live_block = false;
             // Zone-map block skip: prove the block is out of range and never
             // load it. A missing entry is conservative (cannot skip).
             if let Some(pred) = predicate
@@ -5922,15 +5959,42 @@ impl Table {
                 // (from its zone-map stats) so later blocks still map to the
                 // right delete positions. Skipped rows are predicate-excluded, so
                 // whether they are deleted does not affect the output.
-                if has_deletes && let Some(first) = stats.first() {
-                    row_base = row_base.wrapping_add(first.row_count);
+                if has_deletes {
+                    row_base = row_base.wrapping_add(skipped_rows(*keyed.offset())?);
                 }
                 continue;
             }
             let handle = BlockHandle::new(keyed.offset(), keyed.size());
             let batch = self.load_columnar_block_projected(&handle, &decode_projection)?;
             let row_count = batch.row_count;
-            let mut batch = if predicate.is_some() || has_deletes {
+            // Sub-bound row mask for the straddling block, from its key column
+            // decoded separately (one extra cached block read for at most one
+            // block per scan) so the main projection stays untouched.
+            let bound_mask: Option<Vec<bool>> = match restrict {
+                Some(bound) if straddles_bound => {
+                    use crate::table::columnar::{COL_USER_KEY, bytes_column_row};
+                    let keyed_batch =
+                        self.load_columnar_block_projected(&handle, &[COL_USER_KEY])?;
+                    let key_col = keyed_batch
+                        .columns
+                        .iter()
+                        .find(|c| c.column_id == COL_USER_KEY)
+                        .ok_or(crate::Error::InvalidHeader(
+                            "columnar_scan: straddling block is missing the key column",
+                        ))?;
+                    let mut mask = Vec::with_capacity(row_count as usize);
+                    for row in 0..row_count {
+                        let key = bytes_column_row(&key_col.data, row_count, row)?;
+                        mask.push(
+                            self.comparator.compare(key, bound.as_ref())
+                                != core::cmp::Ordering::Less,
+                        );
+                    }
+                    Some(mask)
+                }
+                _ => None,
+            };
+            let mut batch = if predicate.is_some() || has_deletes || bound_mask.is_some() {
                 let mut keep = match predicate {
                     Some(pred) => pred.matching_rows(&batch),
                     None => alloc::vec![true; row_count as usize],
@@ -5942,6 +6006,13 @@ impl Table {
                             *k = false;
                         }
                         pos = pos.wrapping_add(1);
+                    }
+                }
+                if let Some(mask) = &bound_mask {
+                    for (k, live) in keep.iter_mut().zip(mask) {
+                        if !live {
+                            *k = false;
+                        }
                     }
                 }
                 crate::table::columnar_predicate::filter_batch(&batch, &keep)

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -261,6 +261,10 @@ pub(crate) struct SalvageBlock {
     /// ECC recovery healed the block, so the faulty on-disk bytes must not be
     /// propagated and the caller re-encodes the healed payload instead.
     pub verbatim: Option<VerbatimCopy>,
+    /// Whether ECC recovery had to heal the block to read it. Kept separate
+    /// from `verbatim` (which is also `None` for verbatim-ineligible clean
+    /// reads) so the walk's live progress counts genuine heals only.
+    pub ecc_recovered: bool,
 }
 
 /// Raw on-disk frame captured for a verbatim block copy:
@@ -1066,7 +1070,11 @@ impl Table {
         } else {
             None
         };
-        Ok(SalvageBlock { block, verbatim })
+        Ok(SalvageBlock {
+            block,
+            verbatim,
+            ecc_recovered: recovery.is_some(),
+        })
     }
 
     /// Whether `raw`'s parity trailer matches freshly computed parity over its

--- a/src/table/multi_writer.rs
+++ b/src/table/multi_writer.rs
@@ -119,6 +119,11 @@ pub struct MultiWriter {
     /// flush / compaction uniformly writes columnar (or row-major) data blocks.
     use_columnar: bool,
 
+    /// Preserved across writer rotation so every successor [`Writer`] of one
+    /// bulk ingest is uniformly flagged bulk-ingested (see
+    /// [`Writer::use_bulk_ingested`]).
+    bulk_ingested: bool,
+
     /// Delete strategy applied to every successor [`Writer`], preserved across
     /// rotation. Under copy-on-write the writers persist no delete-bitmap; under
     /// merge-on-read / adaptive a populated bitmap is written.
@@ -205,6 +210,7 @@ impl MultiWriter {
             use_seqno_in_index: false,
             use_zone_map: false,
             use_columnar: false,
+            bulk_ingested: false,
             delete_strategy: crate::config::DeleteStrategy::default(),
             disable_cow_on_sst: false,
             locator_entry: crate::config::LocatorPolicyEntry::None,
@@ -579,6 +585,19 @@ impl MultiWriter {
         self
     }
 
+    /// Marks every table in this run as bulk-ingested (re-applied to each rotated
+    /// successor), so manifest repair can recognize their manifest-only
+    /// `global_seqno` dependence. See [`Writer::use_bulk_ingested`].
+    #[must_use]
+    pub(crate) fn use_bulk_ingested(mut self, bulk_ingested: bool) -> Self {
+        self.bulk_ingested = bulk_ingested;
+        // A multi-writer only produces flush / compaction / ingest output, whose
+        // provenance is always KNOWN — never the unknown (`None`) case that only
+        // salvage's mirror path yields.
+        self.writer = self.writer.use_bulk_ingested(Some(bulk_ingested));
+        self
+    }
+
     /// Sets the delete strategy for this and every rotated successor writer.
     #[must_use]
     pub fn delete_strategy(mut self, strategy: crate::config::DeleteStrategy) -> Self {
@@ -653,6 +672,7 @@ impl MultiWriter {
         new_writer = new_writer.use_seqno_in_index(self.use_seqno_in_index);
         new_writer = new_writer.use_zone_map(self.use_zone_map);
         new_writer = new_writer.use_columnar(self.use_columnar);
+        new_writer = new_writer.use_bulk_ingested(Some(self.bulk_ingested));
         new_writer = new_writer.delete_strategy(self.delete_strategy);
         new_writer = new_writer.use_disable_cow(self.disable_cow_on_sst);
         new_writer = new_writer.use_locator(self.locator_entry);

--- a/src/table/relocate.rs
+++ b/src/table/relocate.rs
@@ -74,10 +74,11 @@ impl Table {
         let mut src = self.fs.open(&self.path, &FsOpenOptions::new().read(true))?;
         let reader = crate::sfa::Reader::from_reader(&mut src)?;
 
-        // Re-encode the meta KV block with the new id. The block is loaded TAIL
-        // (`meta`) since MID and TAIL carry identical content; the same patched
-        // payload is written to both sections below.
-        let meta_payload = self.repoint_meta_block(&*src, new_table_id)?;
+        // Re-encode the meta KV block with the new id AND the new delete-bitmap
+        // descriptors. The block is loaded TAIL (`meta`) since MID and TAIL carry
+        // identical content; the same patched payload is written to both sections
+        // below.
+        let meta_payload = self.repoint_meta_block(&*src, new_table_id, delete_bitmap)?;
 
         let out = out_fs.open(new_path, &FsOpenOptions::new().write(true).create_new(true))?;
 
@@ -97,6 +98,13 @@ impl Table {
             };
             for entry in reader.toc().iter() {
                 let name = entry.name();
+                if name == b"delete_bitmap" {
+                    // The relocated table's delete bitmap is injected fresh below;
+                    // copying the source section too would leave two `delete_bitmap`
+                    // entries in the TOC, so section lookup could reject the SST or
+                    // select the stale copy while the metadata describes the new one.
+                    continue;
+                }
                 writer.start(name)?;
                 if name == b"meta_mid" || name == b"meta" {
                     // Re-encoded copy (new id), not the source bytes. Non-encrypted
@@ -152,13 +160,20 @@ impl Table {
     }
 
     /// Loads this segment's meta KV block, replaces the `table_id` entry's value
-    /// with `new_table_id`, and re-encodes the payload (uncompressed, ready for a
-    /// [`BlockType::Meta`] write). Every other meta field is preserved byte-exact,
-    /// so fields the parsed view does not expose still round-trip.
+    /// with `new_table_id` AND the two `descriptor#delete_bitmap_*` entries with
+    /// values describing `delete_bitmap` (the NEW positional bitmap this
+    /// relocation appends), then re-encodes the payload (uncompressed, ready for a
+    /// [`BlockType::Meta`] write). Every other meta field is preserved byte-exact.
+    ///
+    /// Without patching the delete-bitmap descriptors, the copied values would
+    /// still describe the SOURCE's (absent / different) bitmap, so
+    /// `verify_metadata_bounds` would flag the healthy relocated table during
+    /// `repair_with_salvage`, refuse to re-emit it, and quarantine it.
     fn repoint_meta_block(
         &self,
         src: &dyn FsFile,
         new_table_id: TableId,
+        delete_bitmap: &DeleteBitmap,
     ) -> crate::Result<Vec<u8>> {
         // Non-encrypted precondition (checked by the caller): PLAIN transform.
         let block = Block::from_file(
@@ -176,21 +191,63 @@ impl Table {
         // Meta keys are lexicographic, so the default comparator orders them.
         let cmp = crate::comparator::default_comparator();
         let mut entries: Vec<InternalValue> = block
-            .iter(cmp)
+            .iter(cmp.clone())
             .map(|item| item.materialize(block.as_slice()))
             .collect();
 
-        let mut patched = false;
+        // New delete-bitmap descriptor values (same key, same fixed width, so the
+        // in-place value swap preserves the meta block's sorted key order).
+        let db_len_bytes = delete_bitmap.len().to_le_bytes();
+        let db_hash_bytes = crate::hash::hash128(&delete_bitmap.encode()).to_le_bytes();
+        let (mut id_patched, mut len_patched, mut hash_patched) = (false, false, false);
         for entry in &mut entries {
-            if entry.key.user_key.as_ref() == b"table_id" {
-                entry.value = UserValue::from(&new_table_id.to_le_bytes()[..]);
-                patched = true;
+            match entry.key.user_key.as_ref() {
+                b"table_id" => {
+                    entry.value = UserValue::from(&new_table_id.to_le_bytes()[..]);
+                    id_patched = true;
+                }
+                b"descriptor#delete_bitmap_len" => {
+                    entry.value = UserValue::from(&db_len_bytes[..]);
+                    len_patched = true;
+                }
+                b"descriptor#delete_bitmap_hash" => {
+                    entry.value = UserValue::from(&db_hash_bytes[..]);
+                    hash_patched = true;
+                }
+                _ => {}
             }
         }
-        if !patched {
+        if !id_patched {
             return Err(crate::Error::InvalidHeader(
                 "relocate: meta block missing table_id",
             ));
+        }
+        // A LEGACY columnar source predates `descriptor#delete_bitmap_len` /
+        // `descriptor#delete_bitmap_hash` (the current writer always records both,
+        // as `0` when it holds no bitmap). Failing here would permanently block a
+        // single-input merge-on-read compaction that materializes range-tombstone
+        // deletes on such a table (the planner has already chosen the relocation
+        // fast path, with no copy-on-write fallback), so INSTEAD insert the
+        // descriptors describing the appended bitmap. The meta block requires
+        // sorted keys, so re-sort after inserting.
+        if !len_patched {
+            entries.push(InternalValue::from_components(
+                b"descriptor#delete_bitmap_len".to_vec(),
+                &db_len_bytes[..],
+                0,
+                crate::ValueType::Value,
+            ));
+        }
+        if !hash_patched {
+            entries.push(InternalValue::from_components(
+                b"descriptor#delete_bitmap_hash".to_vec(),
+                &db_hash_bytes[..],
+                0,
+                crate::ValueType::Value,
+            ));
+        }
+        if !(len_patched && hash_patched) {
+            entries.sort_by(|a, b| cmp.compare(a.key.user_key.as_ref(), b.key.user_key.as_ref()));
         }
 
         // Same encode parameters the writer uses for the meta block

--- a/src/table/relocate/tests.rs
+++ b/src/table/relocate/tests.rs
@@ -90,6 +90,49 @@ fn relocate_reuses_blocks_and_masks_deleted_rows() -> crate::Result<()> {
     Ok(())
 }
 
+/// A merge-on-read relocated columnar SST appends a NEW delete bitmap, so its
+/// re-encoded meta must describe THAT bitmap: `verify_metadata_bounds` (the
+/// repair-time forgery cross-check) authenticates `descriptor#delete_bitmap_len`
+/// and `descriptor#delete_bitmap_hash` against the on-disk section. If the
+/// relocation copied the source's (absent-bitmap) descriptors verbatim, the
+/// check would flag the healthy table and `repair_with_salvage` would quarantine
+/// it. The descriptors must be repointed to the appended bitmap.
+#[cfg(feature = "columnar")]
+#[test]
+fn relocated_mor_table_passes_metadata_bounds_cross_check() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let src_path = dir.path().join("src");
+    let out_path = dir.path().join("out");
+
+    let n = 96u32;
+    let mut writer = Writer::new(src_path.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0..n {
+        writer.write(InternalValue::from_components(
+            format!("k{i:04}").into_bytes(),
+            b"val",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    let (_, src_checksum) = writer.finish()?.expect("source table written");
+    let source = recover_at(&src_path, src_checksum, 0)?;
+
+    let mut bitmap = DeleteBitmap::new();
+    for &row in &[4u32, 7, 40, 95] {
+        bitmap.insert(row);
+    }
+    let out_checksum =
+        source.relocate_columnar_with_deletes(&out_path, &StdFs, 1, &bitmap, SyncMode::Normal)?;
+    let relocated = recover_at(&out_path, out_checksum, 1)?;
+
+    // The re-encoded meta describes the appended bitmap, so the forgery
+    // cross-check accepts the healthy relocated table.
+    relocated.verify_metadata_bounds()?;
+    Ok(())
+}
+
 #[test]
 fn relocate_rejects_row_major_segment() -> crate::Result<()> {
     let dir = tempfile::tempdir()?;
@@ -116,5 +159,69 @@ fn relocate_rejects_row_major_segment() -> crate::Result<()> {
         matches!(err, crate::Error::FeatureUnsupported(_)),
         "row-major segment must be rejected, got {err:?}",
     );
+    Ok(())
+}
+
+/// A merge-on-read relocated columnar SST keeps its PHYSICAL rows (the
+/// delete bitmap only masks them) and copies the source `linked_blob_files`
+/// accounting verbatim — so the blob-link cross-check must derive its
+/// accounting from the UNMASKED physical rows. Deriving from the masked
+/// view marks a healthy relocated table corrupt, and repair-with-salvage
+/// would then quarantine it (its retained range tombstones make it
+/// unsalvageable).
+#[cfg(feature = "columnar")]
+#[test]
+fn relocated_mor_table_passes_the_blob_link_cross_check() -> crate::Result<()> {
+    use crate::blob_tree::handle::BlobIndirection;
+    use crate::coding::Encode;
+    use crate::vlog::ValueHandle;
+
+    let dir = tempfile::tempdir()?;
+    let src_path = dir.path().join("src");
+    let out_path = dir.path().join("out");
+
+    // A columnar segment whose every row is a blob indirection into file 5,
+    // with the blob-link accounting the writer derives from those rows.
+    let n = 8u32;
+    let mut writer = Writer::new(src_path.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    let mut bytes_sum = 0u64;
+    let mut on_disk_sum = 0u64;
+    for i in 0..n {
+        let ind = BlobIndirection {
+            vhandle: ValueHandle {
+                blob_file_id: 5,
+                offset: u64::from(i) * 100,
+                on_disk_size: 40,
+            },
+            size: 80,
+        };
+        bytes_sum += u64::from(ind.size);
+        on_disk_sum += u64::from(ind.vhandle.on_disk_size);
+        let mut val = alloc::vec::Vec::new();
+        ind.encode_into(&mut val)?;
+        writer.write(InternalValue::from_components(
+            format!("k{i:04}").into_bytes(),
+            val,
+            1,
+            crate::ValueType::Indirection,
+        ))?;
+    }
+    writer.link_blob_file(5, n as usize, bytes_sum, on_disk_sum);
+    let (_, src_checksum) = writer.finish()?.expect("source table written");
+    let source = recover_at(&src_path, src_checksum, 0)?;
+
+    // Relocate with one indirection row MASKED: the physical rows (and the
+    // copied accounting) still include it.
+    let mut bitmap = DeleteBitmap::new();
+    bitmap.insert(3);
+    let out_checksum =
+        source.relocate_columnar_with_deletes(&out_path, &StdFs, 1, &bitmap, SyncMode::Normal)?;
+    let relocated = recover_at(&out_path, out_checksum, 1)?;
+
+    relocated
+        .verify_blob_links()
+        .expect("a healthy relocated MoR table passes the blob-link cross-check");
     Ok(())
 }

--- a/src/table/seqno_bounds.rs
+++ b/src/table/seqno_bounds.rs
@@ -164,6 +164,18 @@ impl SeqnoBoundsMap {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
+
+    /// Number of recorded entries at or above `from_offset`: the LIVE entries
+    /// of a tight-space restricted view (its `[0, from_offset)` blocks are
+    /// punched, so their entries are dead). `from_offset == 0` yields
+    /// [`len`](Self::len).
+    #[must_use]
+    pub fn live_len(&self, from_offset: u64) -> usize {
+        self.entries
+            .iter()
+            .filter(|(off, _)| *off >= from_offset)
+            .count()
+    }
 }
 
 #[cfg(test)]

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -541,7 +541,7 @@ fn block_layout_section_roundtrips_for_large_zstd_blocks() {
         "large multi-inner-block table must carry a block_layout section",
     );
     assert!(
-        table.block_layout.len() >= 1,
+        !table.block_layout.is_empty(),
         "at least one data block must have a recorded inner-block layout",
     );
     // Every recorded entry must have strictly increasing cumulative ends whose
@@ -752,6 +752,343 @@ fn reopen_restricted_yields_a_distinct_clamped_view() -> crate::Result<()> {
             Ok(())
         },
         None,
+        Some(|x| x),
+    )
+}
+
+/// A restricted view must still cross-check its `linked_blob_files` section: the
+/// section carries no checksum, so a same-size rot that under-counts (or drops) a
+/// blob id the READABLE SUFFIX still references passes the block walk, and blob GC
+/// could then retire a file the suffix addresses. The whole-table aggregate can't
+/// be matched exactly once the prefix is punched, but every id/count the suffix
+/// derives must be COVERED BY the recorded aggregate. Here id 9 (referenced by the
+/// suffix key `key00009`) is recorded with a too-small byte total, so both the
+/// unrestricted exact check and the restricted containment check must reject it.
+#[cfg(feature = "std")]
+#[test]
+fn verify_blob_links_rejects_an_undercounted_suffix_id_on_a_restricted_view() -> crate::Result<()> {
+    use crate::blob_tree::handle::BlobIndirection;
+    use crate::cache::Cache;
+    use crate::coding::Encode;
+    use crate::table::Writer;
+    use crate::vlog::ValueHandle;
+    use crate::{InternalValue, ValueType};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("0");
+
+    // Ten indirections (ids 0..10), each 1000 logical / 500 on-disk bytes. The
+    // recorded section matches every id EXCEPT id 9, whose byte total is forged
+    // small — the bit-flip a checksum-less section cannot otherwise catch.
+    let checksum = {
+        let mut w = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?.use_data_block_size(128);
+        for i in 0u64..10 {
+            let value = BlobIndirection {
+                size: 1000,
+                vhandle: ValueHandle {
+                    blob_file_id: i,
+                    on_disk_size: 500,
+                    offset: 0,
+                },
+            }
+            .encode_into_vec();
+            w.write(InternalValue::from_components(
+                format!("key{i:05}").into_bytes(),
+                value,
+                i + 1,
+                ValueType::Indirection,
+            ))?;
+        }
+        for i in 0u64..10 {
+            let bytes = if i == 9 { 1 } else { 1000 };
+            w.link_blob_file(i, 1, bytes, 500);
+        }
+        w.finish()?.expect("the SST is non-empty").1
+    };
+
+    let recover = || -> crate::Result<Table> {
+        Table::recover(
+            file.clone(),
+            checksum,
+            0,
+            0,
+            0,
+            Arc::new(Cache::with_capacity_bytes(1_000_000)),
+            Some(Arc::new(DescriptorTable::new(10))),
+            Arc::new(StdFs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            Arc::new(crate::metrics::Metrics::default()),
+        )
+    };
+
+    // Baseline: the unrestricted exact check already rejects the bad section.
+    assert!(
+        recover()?.verify_blob_links().is_err(),
+        "the unrestricted exact check must reject the under-counted id",
+    );
+
+    // The restricted view clamped to key00005 still references id 9 in its live
+    // suffix, so the containment check must reject the under-count too.
+    let restricted = recover()?.reopen_restricted(crate::UserKey::from(&b"key00005"[..]))?;
+    assert!(
+        restricted.verify_blob_links().is_err(),
+        "the restricted containment check must reject a suffix id the section under-counts",
+    );
+    Ok(())
+}
+
+/// `reopen_restricted` creates a DISTINCT `Inner` for the same table, so it must
+/// PROPAGATE the tree-installed shared gates onto it: the checkpoint deletion
+/// pause and the heal lock. Without them a restricted view skips the checkpoint
+/// mutation window (a checkpoint could link healed bytes under a stale digest)
+/// and serializes heals against a different lock (two patrols could heal +
+/// reconcile the same SST concurrently and leave a clean file mismatched with
+/// the manifest).
+#[cfg(all(feature = "std", feature = "page_ecc"))]
+#[test]
+fn reopen_restricted_propagates_the_shared_heal_and_deletion_gates() -> crate::Result<()> {
+    let items = [
+        crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"b", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"c", b"v", 0, crate::ValueType::Value),
+    ];
+
+    test_with_table(
+        &items,
+        |table| {
+            let pause = crate::deletion_pause::DeletionPause::new_shared();
+            table.install_deletion_pause(std::sync::Arc::clone(&pause));
+            let lock = table.heal_lock_arc();
+
+            let restricted = table.reopen_restricted(crate::UserKey::from(&b"b"[..]))?;
+
+            let restricted_pause = restricted
+                .0
+                .deletion_pause
+                .get()
+                .expect("the deletion pause is propagated");
+            assert!(
+                std::sync::Arc::ptr_eq(restricted_pause, &pause),
+                "the restricted view shares the ORIGINAL deletion pause",
+            );
+            assert!(
+                std::sync::Arc::ptr_eq(&restricted.heal_lock_arc(), &lock),
+                "the restricted view shares the ORIGINAL heal lock",
+            );
+            Ok(())
+        },
+        None,
+        Some(|x| x),
+    )
+}
+
+/// `raw_block_parity_delta` must reject a frame whose on-disk trailer length
+/// differs from the freshly computed parity: returning `Ok(Some(fresh))` for
+/// a short trailer would make the in-place heal write MORE bytes than the
+/// frame holds at that offset — past the block's end, into the next block's
+/// bytes — violating the size-preserving heal contract. A length mismatch is
+/// an unverifiable frame, not a healable one.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn raw_block_parity_delta_rejects_a_trailer_length_mismatch() -> crate::Result<()> {
+    use crate::coding::Decode;
+
+    let items = [
+        crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"b", b"v", 0, crate::ValueType::Value),
+    ];
+
+    test_with_table(
+        &items,
+        |table| {
+            let keyed = table
+                .data_block_handles()
+                .next()
+                .expect("a data block")
+                .expect("index entry decodes");
+            let handle = keyed.as_ref();
+            let file = std::fs::read(&*table.path)?;
+            let start = usize::try_from(handle.offset().0).unwrap_or(usize::MAX);
+            let Some(raw) = file.get(start..start + handle.size() as usize) else {
+                panic!("block frame within the file");
+            };
+            let header = crate::table::block::Header::decode_from(&mut &raw[..])?;
+
+            // Sanity: the intact frame's trailer verifies (no delta).
+            assert!(
+                matches!(table.raw_block_parity_delta(raw, &header), Ok(None)),
+                "the intact frame's parity trailer matches",
+            );
+
+            // A frame one byte SHORT of its trailer must be unverifiable —
+            // not a mismatch whose full-length rebuild the heal would write
+            // past the frame's end.
+            let Some(short) = raw.get(..raw.len() - 1) else {
+                panic!("frame is non-empty");
+            };
+            assert!(
+                table.raw_block_parity_delta(short, &header).is_err(),
+                "a trailer-length mismatch must be unverifiable, not healable",
+            );
+
+            Ok(())
+        },
+        None,
+        Some(|w: Writer| {
+            let Ok(params) = crate::table::block::EccParams::try_new(8, 2) else {
+                panic!("RS(8,2) params are valid");
+            };
+            w.use_ecc(Some(params))
+        }),
+    )
+}
+
+/// `scrub_block` must reject a block whose decoded ROLE differs from the
+/// caller's expected type, mirroring `load_block`'s swap-defence: an index
+/// entry misdirected at another (checksum-valid) block of a different role
+/// passes its payload checksum, so without the role check the scrub reports
+/// "clean" for a handle that no longer points at a data block at all.
+#[test]
+fn scrub_block_rejects_a_block_of_the_wrong_role() -> crate::Result<()> {
+    let items = [
+        crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"b", b"v", 0, crate::ValueType::Value),
+    ];
+
+    test_with_table(
+        &items,
+        |table| {
+            // The TLI block is a valid, checksum-clean block of role Index —
+            // exactly what a misdirected data-block handle would land on.
+            let outcome = crate::table::util::scrub_block(
+                table.global_id(),
+                &table.path,
+                &table.file_accessor,
+                &table.regions.tli,
+                crate::table::block::BlockType::Data,
+                table.metadata.data_block_compression,
+                table.encryption.as_deref(),
+                table.metadata.ecc_params,
+                #[cfg(zstd_any)]
+                table.zstd_dictionary.as_deref(),
+                None,
+                #[cfg(feature = "metrics")]
+                &table.metrics,
+            );
+            assert!(
+                matches!(outcome, Err(crate::Error::InvalidTag(("BlockType", _))),),
+                "a checksum-clean block of the WRONG role must fail the \
+                 role check specifically (not scrub clean, and not fail for \
+                 an unrelated reason): {outcome:?}",
+            );
+            Ok(())
+        },
+        None,
+        Some(|x| x),
+    )
+}
+
+/// A frame read through an OVER-SIZED (forged) index handle decodes cleanly —
+/// the payload checksum covers only `data_length` bytes, and the trailing
+/// garbage classifies as an unrecognized ECC trailer (`EccStatus::Unrecognized`)
+/// — but its raw bytes must NOT be marked verbatim-copy-safe: the salvage
+/// writer rejects the overlong frame against the header's on-disk size and the
+/// walk would drop a block whose payload actually verified. The load must fall
+/// back to the re-encode path (`verbatim = None`) instead.
+#[test]
+fn salvage_load_block_reencodes_an_over_read_frame() -> crate::Result<()> {
+    let items = [
+        crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"b", b"v", 0, crate::ValueType::Value),
+    ];
+
+    test_with_table(
+        &items,
+        |table| {
+            let keyed = table
+                .data_block_handles()
+                .next()
+                .expect("a data block")
+                .expect("index entry decodes");
+            let handle = keyed.as_ref();
+
+            // Sanity: through the TRUE handle the block is verbatim-copy-safe.
+            let clean = table.salvage_load_block(handle, crate::table::block::BlockType::Data)?;
+            assert!(clean.verbatim.is_some(), "a clean read is verbatim-safe");
+
+            // Forged handle: 8 bytes of the following section leak into the
+            // frame (the index section follows the data blocks, so the file
+            // has bytes there).
+            let over = crate::table::BlockHandle::new(handle.offset(), handle.size() + 8);
+            let sb = table.salvage_load_block(&over, crate::table::block::BlockType::Data)?;
+            assert!(
+                sb.verbatim.is_none(),
+                "an over-read frame with an opaque trailer must fall back to \
+                 the re-encode path, not offer its overlong raw bytes for a \
+                 verbatim copy",
+            );
+
+            Ok(())
+        },
+        None,
+        Some(|x| x),
+    )
+}
+
+/// `reopen_restricted` must carry a REFRESHED full-file checksum (set by an
+/// in-place heal after recovery) into the reopened view: recovering the fresh
+/// `Inner` with the stale pre-heal digest would reinstall that stale digest
+/// into the manifest when a tight-space compaction swaps the restricted view
+/// in, making later integrity scans flag the healed file as corrupt again.
+#[test]
+fn reopen_restricted_carries_the_live_suffix_digest() -> crate::Result<()> {
+    let items = [
+        crate::InternalValue::from_components(b"a", b"v", 0, crate::ValueType::Value),
+        crate::InternalValue::from_components(b"b", b"v", 0, crate::ValueType::Value),
+    ];
+
+    test_with_table(
+        &items,
+        |table| {
+            // The restricted view's manifest digest must cover only its LIVE
+            // SUFFIX `[punch_offset, end)`, not the whole file: the prefix is
+            // hole-punched after install, so a whole-file digest would never
+            // match the punched file. It is computed fresh from the current
+            // bytes (so any heal is folded in).
+            let restricted = table.reopen_restricted(crate::UserKey::from(&b"b"[..]))?;
+            let punch = table.punch_offset_for(b"b")?;
+            let expected = crate::Checksum::from_raw(crate::repair::compute_table_checksum_from(
+                &crate::fs::StdFs,
+                &table.path,
+                punch,
+            )?);
+            assert_eq!(
+                restricted.checksum(),
+                expected,
+                "the restricted view reports its live-suffix digest",
+            );
+            // `rotate_every == Some(1)` puts "b" in a later data block, so the
+            // punch offset is strictly positive and the suffix digest is
+            // genuinely exercised (not the degenerate whole-file case).
+            assert!(
+                punch > 0,
+                "reopening at a later block punches a real prefix"
+            );
+            assert_ne!(
+                restricted.checksum(),
+                table.checksum(),
+                "a non-zero punch offset makes the suffix digest differ from \
+                 the whole-file digest",
+            );
+            Ok(())
+        },
+        Some(1),
         Some(|x| x),
     )
 }
@@ -2805,6 +3142,444 @@ fn load_block_records_heal_hint_on_persistent_ecc_correction() -> crate::Result<
     Ok(())
 }
 
+/// Writes a small-block ECC SST of `n` entries under `scheme` through `fs`,
+/// returning its checksum. Shared by the in-place heal tests.
+#[cfg(feature = "page_ecc")]
+fn build_ecc_sst_for_heal(
+    file: &std::path::Path,
+    fs: Arc<dyn crate::fs::Fs>,
+    scheme: crate::table::block::EccParams,
+    n: u32,
+) -> crate::Checksum {
+    #[expect(
+        clippy::expect_used,
+        reason = "test setup; a panic is the failure signal"
+    )]
+    let mut writer = Writer::new(file.to_path_buf(), 0, 0, fs)
+        .expect("open writer")
+        .use_data_block_size(256)
+        .use_ecc(Some(scheme));
+    for i in 0..n {
+        #[expect(clippy::expect_used, reason = "test setup")]
+        writer
+            .write(InternalValue::from_components(
+                format!("key{i:05}").into_bytes(),
+                b"value-payload-bytes".to_vec(),
+                u64::from(i) + 1,
+                crate::ValueType::Value,
+            ))
+            .expect("write");
+    }
+    #[expect(clippy::expect_used, reason = "finish() returns Some after writes")]
+    let (_, checksum) = writer.finish().expect("finish").expect("non-empty");
+    checksum
+}
+
+/// Recovers a `Table` for `file` through `fs` with fresh caches.
+#[cfg(feature = "page_ecc")]
+#[expect(
+    clippy::expect_used,
+    reason = "test setup; a panic is the failure signal"
+)]
+fn recover_table_on(
+    file: &std::path::Path,
+    checksum: crate::Checksum,
+    fs: Arc<dyn crate::fs::Fs>,
+) -> Table {
+    Table::recover(
+        file.to_path_buf(),
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(crate::Cache::with_capacity_bytes(10_000_000)),
+        Some(Arc::new(crate::descriptor_table::DescriptorTable::new(10))),
+        fs,
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(crate::metrics::Metrics::default()),
+    )
+    .expect("recover table")
+}
+
+/// The first data block's file offset in `table`.
+#[cfg(feature = "page_ecc")]
+fn first_data_block_offset(table: &Table) -> u64 {
+    use crate::table::block_index::BlockIndex as _;
+    let Some(keyed) = table.block_index.iter().find_map(Result::ok) else {
+        panic!("a non-empty SST has at least one data block");
+    };
+    keyed.offset().0
+}
+
+/// A single-bit fault in a Page-ECC data block is healed in place AND the file
+/// is restored byte-for-byte (RS / SEC-DED reconstruct the original payload, the
+/// parity is recomputed deterministically). Exercises the SEC-DED branch of the
+/// heal primitive.
+#[cfg(feature = "page_ecc")]
+#[test]
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "in-file block offset fits usize; only narrows on 32-bit targets"
+)]
+fn heal_data_blocks_in_place_restores_a_secded_block_byte_for_byte() -> crate::Result<()> {
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(crate::fs::StdFs);
+    let checksum = build_ecc_sst_for_heal(&file, Arc::clone(&fs), EccParams::Secded, 200);
+
+    let original = std::fs::read(&file)?;
+    let first_off =
+        first_data_block_offset(&recover_table_on(&file, checksum, Arc::clone(&fs))) as usize;
+
+    // Flip a single bit in the first data block's payload — SEC-DED corrects one
+    // bit flip per word.
+    let pos = first_off + Header::MIN_LEN + 3;
+    let mut bytes = original.clone();
+    if let Some(b) = bytes.get_mut(pos) {
+        *b ^= 0x01;
+    }
+    std::fs::write(&file, &bytes)?;
+    assert_ne!(bytes, original, "the seeded fault changed the file");
+
+    let table = recover_table_on(&file, checksum, Arc::clone(&fs));
+    let (report, attributable) =
+        table.heal_data_blocks_in_place(crate::fs::SyncMode::Full, table.checksum());
+    assert_eq!(report.blocks_healed_in_place, 1, "{report:?}");
+    assert_eq!(report.uncorrectable_blocks, 0, "{report:?}");
+    // The manifest digest is the HEALTHY file's, but the seeded fault changed
+    // the bytes before the heal ran: the pre-heal digest cannot match, so the
+    // mismatch is NOT attributable to this pass's writes.
+    assert!(
+        !attributable,
+        "a pre-heal digest differing from the manifest must not attribute",
+    );
+
+    let healed = std::fs::read(&file)?;
+    assert_eq!(
+        healed, original,
+        "SEC-DED in-place heal restores the block byte-for-byte",
+    );
+    Ok(())
+}
+
+/// The heal reports ATTRIBUTION (`true`) when the file's digest right before
+/// its first write-back matches the manifest digest: parity-trailer rot with
+/// the manifest digest recomputed over the ROTTED bytes (the shape a manifest
+/// rebuild leaves behind) makes the post-heal mismatch provably the heal's
+/// own work — the flag that lets the digest reconciliation restamp tables
+/// whose authoritative content (deletion metadata, footer-less values) has
+/// no semantic cross-check.
+#[cfg(feature = "page_ecc")]
+#[test]
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "in-file block offset fits usize; only narrows on 32-bit targets"
+)]
+fn heal_data_blocks_in_place_attributes_a_matching_pre_heal_digest() -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(crate::fs::StdFs);
+    let healthy = build_ecc_sst_for_heal(&file, Arc::clone(&fs), EccParams::RS_4_2, 200);
+    let first_off =
+        first_data_block_offset(&recover_table_on(&file, healthy, Arc::clone(&fs))) as usize;
+
+    // Rot one parity-trailer byte of the first data block: the payload stays
+    // checksum-clean, only the heal's trailer verification notices.
+    let mut bytes = std::fs::read(&file)?;
+    let Some(mut cursor) = bytes.get(first_off..) else {
+        panic!("first data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos =
+        first_off + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&file, &bytes)?;
+
+    // The manifest digest covers the ROTTED bytes (a manifest rebuild admits
+    // the degraded-but-readable file as-is), so the pre-heal probe matches.
+    let rotted = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &file)?);
+    let table = recover_table_on(&file, rotted, Arc::clone(&fs));
+    let (report, attributable) =
+        table.heal_data_blocks_in_place(crate::fs::SyncMode::Full, table.checksum());
+    assert_eq!(
+        report.blocks_healed_in_place, 1,
+        "the rotted trailer is rebuilt in place: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 0, "{report:?}");
+    assert!(
+        attributable,
+        "a pre-heal digest matching the manifest attributes the mismatch to \
+         this pass's own verified corrections",
+    );
+    Ok(())
+}
+
+/// The streaming heal-digest prediction must be byte-identical to materializing
+/// every correction and splicing it through
+/// `compute_table_checksum_with_overrides`. The streaming path exists to bound
+/// heap on broadly damaged tables (it never holds more than one corrected frame
+/// at a time); this guards that the memory win did not change the predicted
+/// digest, which the crash-recovery marker binds. The OOM failure mode itself
+/// is not directly testable (it needs a multi-gigabyte damaged table).
+#[cfg(feature = "page_ecc")]
+#[test]
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "in-file block offset fits usize; only narrows on 32-bit targets"
+)]
+fn predict_heal_streams_the_same_digest_as_materializing_corrections() -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+    let healthy = build_ecc_sst_for_heal(&file, Arc::clone(&fs), EccParams::RS_4_2, 200);
+    let first_off =
+        first_data_block_offset(&recover_table_on(&file, healthy, Arc::clone(&fs))) as usize;
+
+    // Rot the first block's parity trailer → exactly one correction to splice.
+    let mut bytes = std::fs::read(&file)?;
+    let Some(mut cursor) = bytes.get(first_off..) else {
+        panic!("first data block within the file");
+    };
+    let header = Header::decode_from(&mut cursor)?;
+    let trailer_pos =
+        first_off + Header::header_len(header.block_type) + header.data_length as usize;
+    let Some(slot) = bytes.get_mut(trailer_pos) else {
+        panic!("parity trailer within the file");
+    };
+    *slot ^= 0xFF;
+    std::fs::write(&file, &bytes)?;
+
+    let rotted = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &file)?);
+    let table = recover_table_on(&file, rotted, Arc::clone(&fs));
+
+    let transform = crate::table::util::build_block_transform(
+        table.metadata.data_block_compression,
+        table.encryption.as_deref(),
+        table.metadata.ecc_params,
+        #[cfg(zstd_any)]
+        table.zstd_dictionary.as_deref(),
+    )?;
+    let fh = fs.open(&file, &crate::fs::FsOpenOptions::new().read(true))?;
+
+    // Streamed prediction (one frame of heap at a time).
+    let (streamed, offsets) = table.predict_heal_digest_and_offsets(fh.as_ref(), &transform, 0)?;
+
+    // Materialized reference: gather every correction and splice them all at once.
+    let mut corrections: Vec<(u64, Vec<u8>)> = Vec::new();
+    for entry in table.block_index.iter() {
+        let keyed = entry?;
+        if let Some(c) = table.heal_correction_for_block(fh.as_ref(), &keyed, &transform)? {
+            corrections.push(c);
+        }
+    }
+    let materialized =
+        crate::repair::compute_table_checksum_with_overrides(&*fs, &file, 0, &corrections)?;
+
+    assert_eq!(
+        streamed, materialized,
+        "the streamed digest must equal the materialized-overrides digest",
+    );
+    assert_eq!(
+        offsets.len(),
+        corrections.len(),
+        "one predicted offset per correction: {corrections:?}",
+    );
+    for (off, _) in &corrections {
+        assert!(
+            offsets.contains(off),
+            "every correction offset ({off}) is in the predicted set",
+        );
+    }
+    // Sanity: the rot did produce exactly the one trailer correction.
+    assert_eq!(corrections.len(), 1, "exactly one block was rotted");
+    Ok(())
+}
+
+/// When the corrected block's write-back fails (a failing `Fs`), the heal does
+/// not count it as healed and records it as an uncorrectable finding so it is
+/// left for block salvage rather than silently lost.
+#[cfg(feature = "page_ecc")]
+#[test]
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "in-file block offset fits usize; only narrows on 32-bit targets"
+)]
+fn heal_data_blocks_in_place_reports_a_block_whose_write_back_fails() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, StdFs};
+    use crate::io::ErrorKind;
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let checksum = build_ecc_sst_for_heal(&file, Arc::clone(&fs), EccParams::RS_4_2, 200);
+
+    let first_off =
+        first_data_block_offset(&recover_table_on(&file, checksum, Arc::clone(&fs))) as usize;
+
+    // RS-recoverable single-byte fault: the read recovers it (so heal returns a
+    // corrected frame), then the write-back is what fails.
+    let pos = first_off + Header::MIN_LEN + 3;
+    let mut bytes = std::fs::read(&file)?;
+    if let Some(b) = bytes.get_mut(pos) {
+        *b ^= 0x80;
+    }
+    std::fs::write(&file, &bytes)?;
+
+    // The rot leaves the file differing from the (healthy) manifest checksum, so
+    // this is the restorative heal path: its FIRST write is the crash-recovery
+    // marker sidecar. Skip that write so the marker lands, then fail every
+    // subsequent write, so the heal reads + recovers the block and its write-back
+    // is what errors.
+    injector.arm(FaultRule::new(FaultOp::Write, Fault::Error(ErrorKind::Other)).skip(1));
+
+    let table = recover_table_on(&file, checksum, fs);
+    let (report, _) = table.heal_data_blocks_in_place(crate::fs::SyncMode::Full, table.checksum());
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "a failed write-back heals nothing: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "the failed write-back is reported, not silently dropped: {report:?}",
+    );
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, crate::scrub::ScrubError::UncorrectableBlock { .. })),
+        "the finding is an UncorrectableBlock: {report:?}",
+    );
+    Ok(())
+}
+
+/// A non-ECC SST carries no parity, so an in-place heal finds nothing to
+/// reconstruct: every block reads back as "no recognized parity", nothing is
+/// written, and no block is reported as healed or uncorrectable.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_data_blocks_in_place_is_a_noop_on_a_non_ecc_sst() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(crate::fs::StdFs);
+    // No ECC (no `use_ecc`): blocks carry no parity trailer.
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::clone(&fs))?.use_data_block_size(256);
+    for i in 0..200u32 {
+        writer.write(InternalValue::from_components(
+            format!("key{i:05}").into_bytes(),
+            b"value-payload-bytes".to_vec(),
+            u64::from(i) + 1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    let Some((_, checksum)) = writer.finish()? else {
+        panic!("non-empty SST");
+    };
+
+    let table = recover_table_on(&file, checksum, fs);
+    let (report, _) = table.heal_data_blocks_in_place(crate::fs::SyncMode::Full, table.checksum());
+    assert!(
+        report.blocks_scanned > 0,
+        "the walk inspected blocks: {report:?}"
+    );
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "no parity means nothing to heal: {report:?}",
+    );
+    assert_eq!(report.uncorrectable_blocks, 0, "{report:?}");
+    assert!(report.errors.is_empty(), "{report:?}");
+    Ok(())
+}
+
+/// If the read+write handle for the heal cannot even be opened (a read-only
+/// replica, restrictive permissions, a failing `Fs`), the pass must NOT return
+/// a silent healthy report with zero blocks scanned: it records the failed
+/// open AND falls back to the read-only scrub, so the table's integrity is
+/// still checked and real corruption still surfaces.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn heal_data_blocks_in_place_reports_when_the_file_cannot_be_opened() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule, StdFs};
+    use crate::io::ErrorKind;
+    use crate::table::block::{EccParams, Header};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let checksum = build_ecc_sst_for_heal(&file, Arc::clone(&fs), EccParams::RS_4_2, 200);
+    let table = recover_table_on(&file, checksum, Arc::clone(&fs));
+
+    // Wreck the first data block's whole payload (header intact, far beyond
+    // the RS(4,2) budget) so the read-only fallback has real corruption to
+    // find and report.
+    {
+        use crate::table::block_index::BlockIndex as _;
+        let Some(keyed) = table.block_index.iter().find_map(Result::ok) else {
+            panic!("the SST has at least one data block");
+        };
+        let base = usize::try_from(keyed.offset().0).unwrap_or(usize::MAX);
+        let mut bytes = std::fs::read(&file)?;
+        let Some(payload) = bytes.get_mut(base + Header::MIN_LEN..base + keyed.size() as usize)
+        else {
+            panic!("block payload range within the file");
+        };
+        for b in payload {
+            *b ^= 0xFF;
+        }
+        std::fs::write(&file, &bytes)?;
+    }
+
+    // Fail exactly the heal's read+write open (the first open after arming);
+    // the read-only fallback may reopen freely afterwards.
+    injector.arm(FaultRule::new(FaultOp::Open, Fault::Error(ErrorKind::Other)).once());
+
+    let (report, _) = table.heal_data_blocks_in_place(crate::fs::SyncMode::Full, table.checksum());
+    assert!(
+        report.blocks_scanned >= 1,
+        "the read-only fallback still scans the table: {report:?}",
+    );
+    assert_eq!(
+        report.blocks_healed_in_place, 0,
+        "nothing is healed without a writable file: {report:?}",
+    );
+    assert!(
+        report.uncorrectable_blocks >= 1,
+        "the fallback scrub reports the seeded corruption: {report:?}",
+    );
+    assert!(!report.is_ok(), "corruption fails the pass: {report:?}");
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| matches!(e, crate::scrub::ScrubError::BlockIndexUnreadable { .. })),
+        "the failed read+write open is still reported: {report:?}",
+    );
+    Ok(())
+}
+
 /// End-to-end corruption test: tamper on-disk `seqno#kv_max` so it exceeds
 /// `seqno#max`, then verify that `ParsedMeta::load_with_handle` rejects the
 /// file with an `InvalidData` error.
@@ -3893,6 +4668,44 @@ fn recover_test_table_with_id(
     )
 }
 
+/// A retired table reclaims its `.restrict-bound` sidecar on drop, so a
+/// tight-space-restricted SST that is later compacted away does not leak an
+/// orphan sidecar beside its deleted file (the recovery scan would eventually
+/// sweep it, but leaving it is a leak until then).
+#[test]
+fn dropping_a_deleted_table_removes_its_restrict_bound_sidecar() -> crate::Result<()> {
+    use crate::fs::Fs;
+
+    let dir = tempdir()?;
+    let file = dir.path().join("0");
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?;
+    writer.write(crate::InternalValue::from_components(
+        b"k",
+        b"v",
+        1,
+        crate::ValueType::Value,
+    ))?;
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    // Publish a restrict-bound sidecar beside the SST, as a tight-space slice would.
+    let fs = StdFs;
+    crate::restrict_bound::write(&fs, &file, None, 0, b"k", crate::fs::SyncMode::Normal)?;
+    let sidecar = crate::restrict_bound::sidecar_path(&file);
+    assert!(fs.exists(&sidecar)?, "sidecar present before retirement");
+
+    // Retire the table and drop its last handle.
+    let table = recover_test_table(&file, checksum)?;
+    table.mark_as_deleted();
+    drop(table);
+
+    assert!(
+        !fs.exists(&sidecar)?,
+        "retiring the table must reclaim its restrict-bound sidecar, not leak it",
+    );
+    Ok(())
+}
+
 #[test]
 fn delete_bitmap_section_round_trips() -> crate::Result<()> {
     let dir = tempdir()?;
@@ -3955,6 +4768,73 @@ fn delete_bitmap_section_absent_when_no_deletes() -> crate::Result<()> {
         "no delete-bitmap section when the segment has no deletes"
     );
     assert!(table.delete_bitmap().is_empty());
+    Ok(())
+}
+
+/// A columnar table's zone map records one entry PER stored column (the
+/// user-key column AND the value column), each with its own range, and the
+/// verifier re-derives them from the decoded blocks so the honest table passes
+/// its forgery cross-check. Regression: the writer once stamped a single
+/// synthetic key-range column for every columnar block, hiding the non-key
+/// columns from `can_skip_block` pushdown.
+#[cfg(feature = "columnar")]
+#[test]
+fn columnar_zone_map_records_per_column_stats_and_round_trips() -> crate::Result<()> {
+    use crate::table::columnar::{COL_USER_KEY, COL_VALUE};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    // Distinct keys AND distinct values so the user-key and value columns have
+    // genuinely different ranges: a single synthetic key-range column could not
+    // describe the value column.
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true);
+    for i in 0..32u32 {
+        let key = format!("k{i:04}").into_bytes();
+        let value = format!("v{i:04}").into_bytes();
+        writer.write(crate::InternalValue::from_components(
+            key,
+            value,
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    assert!(table.metadata.columnar, "written as a columnar table");
+    assert!(!table.zone_map.is_empty(), "zone map populated");
+
+    // Every data block records BOTH the user-key column (0) and the value
+    // column (3), each with its own range — not a single synthetic column.
+    let mut saw_value_column = false;
+    for handle in table.block_index.iter() {
+        let handle = handle?;
+        let stats = table
+            .zone_map
+            .columns_for(handle.offset().0)
+            .expect("every data block has a zone-map entry");
+        let ids: Vec<u32> = stats.iter().map(|s| s.column_id).collect();
+        assert!(
+            ids.contains(&u32::from(COL_USER_KEY)),
+            "the user-key column is recorded, got ids {ids:?}",
+        );
+        if let Some(v) = stats.iter().find(|s| s.column_id == u32::from(COL_VALUE)) {
+            saw_value_column = true;
+            assert!(v.min <= v.max, "the value column's range is ordered");
+            assert!(!v.min.is_empty(), "the value column carries a real range");
+        }
+    }
+    assert!(
+        saw_value_column,
+        "at least one block records the non-key value column's stats",
+    );
+
+    // The writer's per-column map and the verifier's re-derivation agree, so the
+    // forgery cross-check accepts the honest table.
+    table.verify_zone_map()?;
     Ok(())
 }
 
@@ -4361,6 +5241,79 @@ fn write_columnar_batch_accounts_tombstones_seqno_bounds_and_restart_locator() -
     Ok(())
 }
 
+/// `verify_locator` must reject a locator re-stamped to resolve a key to a
+/// block OTHER than the one holding its newest version: every byte-level
+/// check reads clean, but `point_read_inner` trusts the answer and can return
+/// a stale value from the mispointed block without falling back to the index.
+/// An intact locator passes; a redirected one fails.
+#[test]
+fn verify_locator_rejects_a_redirected_key_mapping() -> crate::Result<()> {
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::table::locator::{LocatorSpec, build_locator_section};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("t");
+
+    // Small blocks so several data blocks (several block_ids) exist.
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_data_block_size(128)
+        .use_locator(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Block,
+            block_id_bits: None,
+            slot_bits: None,
+        });
+    for i in 0u64..200 {
+        writer.write(crate::InternalValue::from_components(
+            format!("key-{i:04}").into_bytes(),
+            format!("v{i:04}").into_bytes(),
+            i + 1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    // Intact locator verifies clean.
+    table.verify_locator()?;
+
+    // Rebuild the SAME ribbon (same key set, same widths → byte-identical
+    // length) but redirect the FIRST key to a DIFFERENT block ordinal.
+    let mut triples: Vec<(u64, u64, u64)> = Vec::new();
+    let block_count = table.block_index.iter().count() as u64;
+    assert!(block_count >= 2, "need multiple blocks to redirect between");
+    let mut seen = crate::HashSet::default();
+    for (ordinal, handle) in table.block_index.iter().enumerate() {
+        let handle = handle?;
+        let block_handle = crate::table::BlockHandle::new(handle.offset(), handle.size());
+        let entries = table.decode_block_entries(&block_handle)?;
+        for e in entries {
+            let uk = e.key.user_key.to_vec();
+            if seen.insert(uk.clone()) {
+                triples.push((crate::hash::hash64(&uk), ordinal as u64, 0));
+            }
+        }
+    }
+    // Redirect the first key to a different existing block.
+    let orig = triples[0].1;
+    triples[0].1 = if orig == 0 { block_count - 1 } else { 0 };
+    let spec = LocatorSpec {
+        precision: LocatorPrecision::Block,
+        block_id_bits: None,
+        slot_bits: None,
+    };
+    let forged = build_locator_section(&triples, spec).expect("forged section builds");
+
+    crate::test_forge::forge_replace_section_payload(&file, b"locator", &forged, None)?;
+
+    let table = recover_test_table(&file, checksum)?;
+    let result = table.verify_locator();
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader(_))),
+        "a redirected locator must be rejected, got {result:?}",
+    );
+    Ok(())
+}
+
 #[cfg(feature = "columnar")]
 #[test]
 fn write_columnar_batch_on_an_empty_batch_writes_no_block() -> crate::Result<()> {
@@ -4414,6 +5367,222 @@ fn write_columnar_batch_on_an_empty_batch_writes_no_block() -> crate::Result<()>
     assert!(
         writer.finish()?.is_none(),
         "an empty batch must not produce an SST",
+    );
+    Ok(())
+}
+
+/// A TRANSIENT locator-section read during a SALVAGE open must PROPAGATE, not
+/// degrade the section to `None`. The degradation sets `rebuildable_section_degraded`,
+/// which makes `salvage_attempt` read a delete-free table as possibly hiding
+/// deletion metadata and fail the whole SST (`FeatureUnsupported`), quarantining an
+/// otherwise-salvageable table instead of retrying the retryable read. A non-salvage
+/// open keeps the best-effort accelerator behavior (degrade to the sorted-index
+/// path), so this only applies in salvage mode (#80).
+#[test]
+fn recover_salvage_propagates_a_transient_locator_read() -> crate::Result<()> {
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let sst = dir.path().join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_data_block_size(128)
+            .use_locator(LocatorPolicyEntry::Enabled {
+                precision: LocatorPrecision::Entry,
+                block_id_bits: None,
+                slot_bits: None,
+            });
+        for i in 0..256u32 {
+            w.write(crate::InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                crate::ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Resolve the locator section's byte offset from a clean (Live) open.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &sst)?);
+    let loc_offset = {
+        let live = Table::recover(
+            sst.clone(),
+            checksum,
+            0,
+            0,
+            0,
+            Arc::new(Cache::with_capacity_bytes(1 << 20)),
+            Some(Arc::new(DescriptorTable::new(8))),
+            Arc::clone(&fs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            Arc::new(Metrics::default()),
+        )?;
+        live.regions
+            .locator
+            .expect("the multi-block SST carries a locator section")
+            .offset()
+            .0
+    };
+
+    // Fault ONLY the positioned read at the locator offset, once, with a genuine
+    // transient kind.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Interrupted))
+            .at_offset(loc_offset)
+            .once(),
+    );
+    let faulted: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let result = Table::recover_inner(
+        sst,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(DescriptorTable::new(8))),
+        Arc::clone(&faulted),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(Metrics::default()),
+        RecoveryMode::Salvage {
+            expected_id: None,
+            prefer_mid_meta: false,
+        },
+    );
+    injector.clear();
+
+    assert!(
+        matches!(&result, Err(crate::Error::Io(e)) if e.kind() == ErrorKind::Interrupted),
+        "a transient locator read in salvage mode must propagate (not degrade to a \
+         section-degraded open that later fails as FeatureUnsupported): {result:?}",
+    );
+    Ok(())
+}
+
+/// A PERSISTENT (non-retryable) filter-index read during a SALVAGE open must
+/// DEGRADE the rebuildable section, not propagate — the destination writer
+/// re-derives the filter from the recovered keys, so a bad sector under the
+/// partitioned filter's top-level index must not cost the whole recoverable
+/// table. Only a TRANSIENT read propagates (repair retries). Mirrors the
+/// seqno-bounds / zone-map / delete-bitmap / locator loaders.
+#[test]
+fn recover_salvage_degrades_a_persistent_filter_index_read() -> crate::Result<()> {
+    use crate::fs::{Fault, FaultFs, FaultOp, FaultRule};
+    use crate::io::ErrorKind;
+
+    let dir = tempdir()?;
+    let sst = dir.path().join("0");
+    let fs: Arc<dyn crate::fs::Fs> = Arc::new(StdFs);
+    {
+        let mut w = Writer::new(sst.clone(), 0, 0, Arc::clone(&fs))?
+            .use_data_block_size(128)
+            .use_partitioned_filter();
+        for i in 0..256u32 {
+            w.write(crate::InternalValue::from_components(
+                format!("k{i:05}").into_bytes(),
+                format!("v{i}").into_bytes(),
+                u64::from(i) + 1,
+                crate::ValueType::Value,
+            ))?;
+        }
+        assert!(w.finish()?.is_some(), "the SST is non-empty");
+    }
+
+    // Resolve the partitioned filter's top-level-index (`filter_tli`) byte offset
+    // from a clean (Live) open.
+    let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum(&*fs, &sst)?);
+    let tli_offset = {
+        let live = Table::recover(
+            sst.clone(),
+            checksum,
+            0,
+            0,
+            0,
+            Arc::new(Cache::with_capacity_bytes(1 << 20)),
+            Some(Arc::new(DescriptorTable::new(8))),
+            Arc::clone(&fs),
+            false,
+            false,
+            None,
+            #[cfg(zstd_any)]
+            None,
+            crate::comparator::default_comparator(),
+            #[cfg(feature = "metrics")]
+            Arc::new(Metrics::default()),
+        )?;
+        live.regions
+            .filter_tli
+            .expect("the partitioned-filter SST carries a filter_tli section")
+            .offset()
+            .0
+    };
+
+    // Fault the positioned read at the filter-index offset with a PERSISTENT
+    // (non-retryable) kind.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    injector.arm(
+        FaultRule::new(FaultOp::ReadAt, Fault::Error(ErrorKind::Other))
+            .at_offset(tli_offset)
+            .once(),
+    );
+    let faulted: Arc<dyn crate::fs::Fs> = Arc::new(fault);
+
+    let result = Table::recover_inner(
+        sst,
+        checksum,
+        0,
+        0,
+        0,
+        Arc::new(Cache::with_capacity_bytes(1 << 20)),
+        Some(Arc::new(DescriptorTable::new(8))),
+        Arc::clone(&faulted),
+        false,
+        false,
+        None,
+        #[cfg(zstd_any)]
+        None,
+        crate::comparator::default_comparator(),
+        #[cfg(feature = "metrics")]
+        Arc::new(Metrics::default()),
+        RecoveryMode::Salvage {
+            expected_id: None,
+            prefer_mid_meta: false,
+        },
+    );
+    injector.clear();
+
+    let recovered = match result {
+        Ok(table) => table,
+        Err(e) => panic!(
+            "a persistent filter-index read in salvage mode must degrade the rebuildable \
+             section and recover the table, not propagate and quarantine it: {e:?}",
+        ),
+    };
+    // A bare success would also pass if the injected fault never fired; the
+    // degradation flag proves the faulted filter-index load was actually
+    // routed through the salvage degrade arm.
+    assert!(
+        recovered.salvage_degraded_a_rebuildable_section(),
+        "the recovered table must report the degraded rebuildable section",
     );
     Ok(())
 }

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -4891,6 +4891,100 @@ fn delete_bitmap_masks_rows_in_columnar_scan() -> crate::Result<()> {
     Ok(())
 }
 
+/// A tight-space-restricted columnar SST has its consumed prefix hole-punched
+/// (those data blocks read as zeros). The columnar scan must skip the punched
+/// blocks instead of decoding them, mask the straddling block's sub-bound rows,
+/// and keep positional delete-bitmap mapping intact across the skipped blocks.
+#[cfg(feature = "columnar")]
+#[test]
+#[expect(clippy::unwrap_used)]
+fn restricted_columnar_scan_skips_punched_prefix_and_masks_sub_bound_rows() -> crate::Result<()> {
+    use crate::table::columnar::{
+        COL_SEQNO, COL_USER_KEY, COL_VALUE, COL_VALUE_TYPE, column_batch_to_entries,
+    };
+    use std::io::{Seek, SeekFrom, Write as _};
+
+    let dir = tempdir()?;
+    let file = dir.path().join("table");
+
+    let n = 256u32;
+    let keys: Vec<Vec<u8>> = (0..n).map(|i| format!("k{i:04}").into_bytes()).collect();
+    // One deleted row inside the (to-be-punched) prefix, one in the live
+    // suffix: the live one only masks correctly if the scan advances the
+    // positional row base across the skipped punched blocks.
+    let deleted_punched = 1u32;
+    let deleted_live = 250u32;
+
+    let mut writer = Writer::new(file.clone(), 0, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_zone_map(true)
+        .use_data_block_size(256);
+    for key in &keys {
+        writer.write(crate::InternalValue::from_components(
+            key.as_slice(),
+            b"v",
+            1,
+            crate::ValueType::Value,
+        ))?;
+    }
+    writer.delete_bitmap_mut().insert(deleted_punched);
+    writer.delete_bitmap_mut().insert(deleted_live);
+    let (_, checksum) = writer.finish()?.expect("table written");
+
+    let table = recover_test_table(&file, checksum)?;
+    let handles: Vec<_> = table
+        .block_index
+        .iter()
+        .collect::<crate::Result<Vec<_>>>()?;
+    assert!(handles.len() >= 3, "need several blocks to punch a prefix");
+
+    // Bound = two keys past the first block's end, so exactly one block is
+    // punched and the first live block STRADDLES the bound (one sub-bound row).
+    let first_end = handles[0].end_key().to_vec();
+    let j = keys.iter().position(|k| *k == first_end).unwrap();
+    let bound_idx = j + 2;
+    assert!(
+        bound_idx < deleted_live as usize,
+        "the live deleted row must stay above the bound"
+    );
+    let bound = crate::UserKey::from(keys[bound_idx].as_slice());
+
+    let punch_off = table.punch_offset_for(&bound)?;
+    assert_eq!(
+        punch_off,
+        handles[1].offset().0,
+        "exactly the first block is below the bound"
+    );
+
+    let restricted = table.with_restriction(bound);
+
+    // Simulate the tight-space hole punch: the consumed prefix reads as zeros.
+    let mut f = std::fs::OpenOptions::new().write(true).open(&file)?;
+    f.seek(SeekFrom::Start(0))?;
+    f.write_all(&vec![0u8; usize::try_from(punch_off).unwrap()])?;
+    f.sync_all()?;
+
+    let batches =
+        restricted.columnar_scan(&[COL_USER_KEY, COL_SEQNO, COL_VALUE_TYPE, COL_VALUE], None)?;
+    let mut got: Vec<Vec<u8>> = Vec::new();
+    for batch in &batches {
+        for entry in column_batch_to_entries(batch)? {
+            got.push(entry.key.user_key.to_vec());
+        }
+    }
+
+    let expected: Vec<Vec<u8>> = (bound_idx..n as usize)
+        .filter(|&i| i != deleted_live as usize)
+        .map(|i| keys[i].clone())
+        .collect();
+    assert_eq!(
+        got, expected,
+        "scan must start at the bound, mask the straddling block's sub-bound \
+         rows, and keep delete positions aligned across the punched prefix"
+    );
+    Ok(())
+}
+
 #[test]
 fn copy_on_write_strategy_suppresses_the_delete_bitmap_section() -> crate::Result<()> {
     let dir = tempdir()?;

--- a/src/table/util.rs
+++ b/src/table/util.rs
@@ -433,6 +433,16 @@ pub(crate) enum BlockScrubOutcome {
 /// Returns the [`BlockScrubOutcome`], or `Err` when the block is uncorrectable
 /// (checksum failed and parity could not recover it) or unreadable; the caller
 /// records that as an uncorrectable finding rather than silently skipping it.
+///
+/// Scope: FRAME integrity only — checksum, decompress, decrypt, ECC. The
+/// block body (restart trailer, entry framing, value-type tags) is
+/// deliberately NOT decoded here: a scrub is a lightweight bit-rot patrol,
+/// and any body-level fault in a checksum-clean block is (a) not producible
+/// by media corruption (the checksum covers the payload) and (b) the domain
+/// of callers that fully decode and validate block bodies (e.g. the salvage
+/// walk's row materialization). [`crate::verify::verify_sst_file`] is likewise
+/// a frame-level verifier. Both the plain patrol scrub and the in-place heal
+/// share exactly this depth.
 #[cfg(feature = "std")]
 #[expect(
     clippy::too_many_arguments,
@@ -459,7 +469,7 @@ pub(crate) fn scrub_block(
         #[cfg(zstd_any)]
         zstd_dict,
     )?;
-    let (_block, ecc_status, recovery) = Block::from_file_with_recovery(
+    let (block, ecc_status, recovery) = Block::from_file_with_recovery(
         fd.as_ref(),
         *handle,
         crate::table::block::BlockIdentity {
@@ -470,6 +480,15 @@ pub(crate) fn scrub_block(
         },
         &transform,
     )?;
+    // Role check, mirroring `load_block`'s swap-defence: an index entry
+    // misdirected at another (checksum-valid) block of a different role must
+    // surface as an uncorrectable finding, not scrub clean.
+    if block.header.block_type != block_type {
+        return Err(crate::Error::InvalidTag((
+            "BlockType",
+            block.header.block_type.into(),
+        )));
+    }
 
     Ok(match ecc_status {
         crate::table::block::EccStatus::Corrected => {

--- a/src/table/writer/mod.rs
+++ b/src/table/writer/mod.rs
@@ -58,6 +58,17 @@ struct HandleMeta {
     zone_block_min: Option<UserKey>,
 }
 
+/// The [`Writer::register_written_block`] inputs computed once by
+/// [`Writer::account_direct_block`] and shared by the columnar-ingest block path
+/// and the verbatim copy-through salvage path.
+struct DirectBlockInputs {
+    last_key: UserKey,
+    last_seqno: crate::SeqNo,
+    seqno_bounds: Option<(u64, u64)>,
+    item_count: usize,
+    zone_block_min: Option<UserKey>,
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug, core::hash::Hash)]
 pub struct LinkedFile {
     pub blob_file_id: BlobFileId,
@@ -120,6 +131,14 @@ pub struct Writer {
     prev_pos: (BlockOffset, BlockOffset),
 
     current_key: Option<UserKey>,
+
+    /// Seqno of the LAST entry written (any path — row `write()` or a direct
+    /// block), tracked alongside `current_key` so a direct block that begins
+    /// with the SAME user key can be validated against the internal order
+    /// `(user_key asc, seqno desc)` across the block boundary
+    /// ([`Self::validate_direct_block_order`]). `None` only before the first
+    /// entry.
+    current_key_seqno: Option<crate::SeqNo>,
 
     bloom_policy: BloomConstructionPolicy,
 
@@ -249,6 +268,22 @@ pub struct Writer {
     /// the first key is added.
     use_columnar: bool,
 
+    /// Whether this SST is written by the bulk-ingest path, which stores every
+    /// entry at LOCAL seqno 0 and relies on a manifest-only `global_seqno` for
+    /// its effective MVCC ordering. Persisted as `descriptor#bulk_ingested` so
+    /// manifest repair can tell such a table apart from a normal flush whose
+    /// entries merely happen to sit at seqno 0 (a fresh tree's first batch),
+    /// whose offset genuinely is 0.
+    ///
+    /// Three-state: `Some(true)` bulk-ingested, `Some(false)` authoritatively a
+    /// normal flush / compaction, `None` UNKNOWN. `None` omits the on-disk key
+    /// entirely (matching a legacy SST written before the descriptor existed) so
+    /// that salvaging a legacy table via [`Self::mirror_from`] preserves the
+    /// unknown provenance instead of falsely stamping "not ingested" — which
+    /// would let repair install it with `global_seqno` 0 and corrupt MVCC.
+    /// Default `Some(false)`.
+    bulk_ingested: Option<bool>,
+
     /// Pre-trained zstd dictionary for dictionary compression
     #[cfg(zstd_any)]
     zstd_dictionary: Option<Arc<crate::compression::ZstdDictionary>>,
@@ -298,10 +333,28 @@ impl Writer {
         let path = std::path::absolute(path)?;
 
         let file = fs.open(&path, &FsOpenOptions::new().write(true).create_new(true))?;
+        // From here the file exists and is OURS (`create_new` proved it), so
+        // this constructor owns cleanup: an init failure below must not leak a
+        // partial file, and a CALLER must never remove `path` on a constructor
+        // error — an open failure above created nothing, so caller-side
+        // cleanup would race a concurrent creator and delete a file it does
+        // not own.
         let writer = BufWriter::with_capacity(u16::MAX.into(), file);
         let writer = ChecksummedWriter::new(writer);
         let mut writer = crate::sfa::Writer::from_writer(writer);
-        writer.start("data")?;
+        if let Err(e) = writer.start("data") {
+            drop(writer);
+            // Best-effort cleanup of the partial file we just created; log a
+            // failure (it can make the next create_new(true) retry fail) rather
+            // than discard it, matching the blob-file writer.
+            if let Err(remove_err) = fs.remove_file(&path) {
+                log::warn!(
+                    "failed to remove partial table file {} after a writer-init error: {remove_err}",
+                    path.display(),
+                );
+            }
+            return Err(e.into());
+        }
 
         Ok(Self {
             fs,
@@ -353,6 +406,7 @@ impl Writer {
             chunk_size: 0,
 
             current_key: None,
+            current_key_seqno: None,
 
             bloom_policy: BloomConstructionPolicy::default(),
 
@@ -372,6 +426,7 @@ impl Writer {
             use_seqno_in_index: false,
             use_zone_map: false,
             use_columnar: false,
+            bulk_ingested: Some(false),
 
             #[cfg(zstd_any)]
             zstd_dictionary: None,
@@ -626,6 +681,92 @@ impl Writer {
         self
     }
 
+    /// Seeds this writer with the persisted block-layout settings of an existing
+    /// table's [`ParsedMeta`](crate::table::meta::ParsedMeta), so a rewrite (e.g.
+    /// salvage) reproduces the source's layout instead of falling back to writer
+    /// defaults: data + index block compression, ECC scheme, data-block restart
+    /// interval, columnar layout (with its zone map), and the per-KV checksum
+    /// footer algorithm.
+    ///
+    /// Only settings the source actually carries are mirrored. Layout choices
+    /// that are not persisted in metadata (partitioned filter / index, bloom
+    /// policy, hash ratio, locator, prefix extractor) fall back to writer
+    /// defaults and are not restored here. Must be called before the first key,
+    /// like the individual `use_*` setters it delegates to.
+    ///
+    /// `has_zone_map` is the source's ACTUAL zone-map presence (a section, not
+    /// a metadata property — the caller reads it off the open table): a row SST
+    /// written with the zone-map policy keeps its zone map, and a columnar SST
+    /// without one does not gain one. `has_seqno_bounds` is likewise the
+    /// source's actual `seqno_bounds` SECTION presence (`Table::has_seqno_bounds`,
+    /// `regions.seqno_bounds.is_some()`), NOT whether the best-effort loaded map
+    /// happens to be non-empty — so a source whose section is present but
+    /// unreadable still salvages into a copy that carries one (the writer
+    /// re-derives the ranges from the re-emitted entries).
+    #[must_use]
+    pub(crate) fn mirror_from(
+        self,
+        meta: &crate::table::meta::ParsedMeta,
+        has_zone_map: bool,
+        has_seqno_bounds: bool,
+    ) -> Self {
+        // Mirror ECC only when this build can actually emit parity. Without the
+        // `page_ecc` feature `with_ecc()` is the identity (no trailer is ever
+        // written), but a `Some` here would still size every registered block
+        // handle with phantom parity bytes (`on_disk_size_with`), so the
+        // re-emitted table would reopen with handles that over-read into the
+        // following blocks. Matches the metadata writer's effective-ECC logic,
+        // which likewise resolves to "off" on such builds.
+        let effective_ecc = if cfg!(feature = "page_ecc") {
+            meta.ecc_params
+        } else {
+            None
+        };
+        // A restart interval MUST be > 0 (the setters assert it). A forged or
+        // corrupt source meta can carry 0; salvage must not panic on it, so a
+        // zero falls back to this writer's own default instead of the setter's
+        // assertion.
+        let data_restart_interval = if meta.data_block_restart_interval > 0 {
+            meta.data_block_restart_interval
+        } else {
+            self.data_block_restart_interval
+        };
+        let index_restart_interval = if meta.index_block_restart_interval > 0 {
+            meta.index_block_restart_interval
+        } else {
+            self.index_block_restart_interval
+        };
+        let writer = self
+            .use_data_block_compression(meta.data_block_compression)
+            .use_index_block_compression(meta.index_block_compression)
+            .use_ecc(effective_ecc)
+            .use_data_block_restart_interval(data_restart_interval)
+            .use_index_block_restart_interval(index_restart_interval)
+            // A columnar source re-emits as columnar (the writer transposes the
+            // recovered rows back into PAX blocks), rather than degrading to a
+            // row-major copy.
+            .use_columnar(meta.columnar)
+            // A bulk-ingested source stays flagged so a salvaged / re-emitted
+            // copy is still recognized by manifest repair as relying on a
+            // manifest-only global_seqno offset. A legacy source of unknown
+            // provenance (`None`) re-emits unflagged (we do not guess).
+            .use_bulk_ingested(meta.bulk_ingested)
+            .use_zone_map(has_zone_map)
+            // A source with a seqno_bounds section keeps its seqno-scoped
+            // block-skip: the writer re-derives the per-block ranges from
+            // the re-emitted entries (never copies the source's map).
+            .use_seqno_in_index(has_seqno_bounds);
+        // Re-emit per-KV checksum footers under the source's algorithm when it
+        // carried them (an SST is footer-homogeneous, so `AllLevels` reproduces
+        // the same per-block footer state).
+        match meta.kv_checksum_algo {
+            Some(algo) => {
+                writer.use_kv_checksums(crate::runtime_config::KvChecksumPolicy::AllLevels, algo)
+            }
+            None => writer,
+        }
+    }
+
     /// Convenience wiring: resolves the tree's `Config::page_ecc` flag +
     /// the configured `EccScheme` into the per-block [`EccParams`] and
     /// applies it via [`Self::use_ecc`]. `page_ecc == false` (or a
@@ -732,6 +873,19 @@ impl Writer {
         // persisted `descriptor#columnar` never advertises a layout the blocks
         // do not have (which would misroute the reader's block identity).
         self.use_columnar = columnar && cfg!(feature = "columnar");
+        self
+    }
+
+    /// Sets the bulk-ingest provenance (see [`Self::bulk_ingested`] field), so
+    /// the persisted `descriptor#bulk_ingested` lets manifest repair distinguish
+    /// a bulk-ingested table from a normal flush whose entries merely sit at
+    /// seqno 0. `None` omits the key (unknown provenance, preserving a legacy
+    /// SST's absence through salvage). Must be set before the first key is
+    /// written.
+    #[must_use]
+    pub(crate) fn use_bulk_ingested(mut self, bulk_ingested: Option<bool>) -> Self {
+        self.assert_not_started("use_bulk_ingested");
+        self.bulk_ingested = bulk_ingested;
         self
     }
 
@@ -878,6 +1032,7 @@ impl Writer {
         self.chunk_size += user_key.len() + value_len;
         self.chunk.push(item);
         self.previous_item = Some((user_key, value_type));
+        self.current_key_seqno = Some(seqno);
 
         if self.chunk_size >= self.data_block_size as usize {
             self.spill_block()?;
@@ -1050,6 +1205,7 @@ impl Writer {
             seqno_bounds,
             item_count,
             zone_block_min,
+            None, // row block: register synthesizes the whole-block key range
         )?;
 
         // IMPORTANT: Clear chunk after everything else
@@ -1127,6 +1283,12 @@ impl Writer {
         )?;
         let layout = core::mem::take(&mut prepared.layout);
         let header = prepared.write_to(&mut self.file_writer)?;
+        // Per-column zone-map stats for this columnar block, derived once from
+        // the batch. Gated on the zone-map policy exactly like the row-block
+        // synthetic entry (`zone_block_min` is `Some` iff the policy is on), so
+        // a zone-map-off table writes no zone-map section. `verify_zone_map`
+        // re-derives these from the decoded block to authenticate the section.
+        let columnar_columns = zone_block_min.as_ref().map(|_| batch.zone_stats());
         self.register_written_block(
             header,
             layout,
@@ -1135,6 +1297,7 @@ impl Writer {
             seqno_bounds,
             item_count,
             zone_block_min,
+            columnar_columns,
         )
     }
 
@@ -1193,6 +1356,43 @@ impl Writer {
         batch: &crate::table::columnar::ColumnBatch,
         comparator: &crate::SharedComparator,
     ) -> crate::Result<Option<crate::UserKey>> {
+        self.write_columnar_block_inner(batch, comparator, true)
+    }
+
+    /// Writes a pre-built [`ColumnBatch`](crate::table::columnar::ColumnBatch) as a
+    /// single columnar block, storing its value sub-columns AND its per-row seqnos
+    /// **verbatim** — unlike [`Self::write_columnar_batch`], which is the
+    /// bulk-ingest path and requires seqno `0` (assigned at finish). Salvage uses
+    /// this to re-emit a recovered columnar block under its original sequence
+    /// numbers, so the recovered copy keeps both its per-field sub-columns and its
+    /// MVCC versions. The table must be written with `global_seqno` `0` so the
+    /// stored seqnos are the effective ones.
+    ///
+    /// Returns the batch's last user key (or `None` for an empty batch).
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::write_columnar_batch`], except a non-zero per-row seqno is
+    /// accepted (it is stored as the row's sequence number).
+    #[cfg(feature = "columnar")]
+    pub(crate) fn write_columnar_block_verbatim(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+        comparator: &crate::SharedComparator,
+    ) -> crate::Result<Option<crate::UserKey>> {
+        self.write_columnar_block_inner(batch, comparator, false)
+    }
+
+    /// Shared body for the two columnar-block writers. `require_zero_seqno`
+    /// enforces the bulk-ingest contract (every row seqno `0`); the verbatim
+    /// salvage path passes `false` to store the batch's own seqnos.
+    #[cfg(feature = "columnar")]
+    fn write_columnar_block_inner(
+        &mut self,
+        batch: &crate::table::columnar::ColumnBatch,
+        comparator: &crate::SharedComparator,
+        require_zero_seqno: bool,
+    ) -> crate::Result<Option<crate::UserKey>> {
         // A columnar batch only makes sense (and only reads back correctly) when
         // the table is marked columnar; reject a row-mode writer rather than
         // writing a columnar block under a row descriptor.
@@ -1205,111 +1405,51 @@ impl Writer {
         // The framed values feed the shape accounting; the block stores the
         // consumer's sub-columns (not a re-transpose).
         let entries = crate::table::columnar::column_batch_to_entries(batch)?;
-        let Some(last) = entries.last() else {
-            return Ok(None); // empty batch: no block
-        };
 
         // Ingest contract. Unsorted keys would corrupt the sorted block index /
         // zone map; a non-zero seqno would read back shifted by the table's
         // assigned sequence number. Reject both before writing anything.
-        if entries.iter().any(|e| e.key.seqno != 0) {
+        if require_zero_seqno && entries.iter().any(|e| e.key.seqno != 0) {
             return Err(crate::Error::FeatureUnsupported(
                 "columnar batch ingest requires every row seqno to be 0 (the ingestion assigns the sequence number)",
             ));
         }
-        let mut prev = self.current_key.as_ref();
-        for e in &entries {
-            if let Some(p) = prev
-                && comparator.compare(p.as_ref(), e.key.user_key.as_ref())
-                    != core::cmp::Ordering::Less
-            {
-                return Err(crate::Error::InvalidHeader(
-                    "columnar batch ingest requires strictly increasing keys",
-                ));
-            }
-            prev = Some(&e.key.user_key);
-        }
-        let last_key = last.key.user_key.clone();
-        let last_seqno = last.key.seqno;
-        let item_count = entries.len();
-        let seqno_bounds = self.use_seqno_in_index.then(|| {
-            entries.iter().fold((u64::MAX, u64::MIN), |(mn, mx), e| {
-                (mn.min(e.key.seqno), mx.max(e.key.seqno))
-            })
-        });
-        let zone_block_min = self
-            .use_zone_map
-            .then(|| entries.first().map(|e| e.key.user_key.clone()))
-            .flatten();
-
-        // Flush any row chunk buffered by prior `write()` calls before this
-        // direct block, so its block (and locator ordinal) is registered first
-        // and the sorted block / index order is preserved. The validation above
-        // ran first, so an invalid batch never forces a spill. A no-op when the
-        // chunk is empty (the columnar-only ingest path).
-        self.spill_block()?;
-
-        // Per-row shape / seqno / key accounting, mirroring `write()` minus the
-        // chunk push (the direct columnar block holds all rows already). The
-        // locator records each new key's position within this single block, the
-        // same as the flush path does for a transposed columnar block.
-        for (row, e) in entries.iter().enumerate() {
-            let user_key = &e.key.user_key;
-            self.meta.sum_user_key_bytes += user_key.len() as u64;
-            self.meta.sum_value_bytes += e.value.len() as u64;
-            if e.is_tombstone() {
-                self.meta.tombstone_count += 1;
-            }
-            if e.key.value_type == ValueType::WeakTombstone {
-                self.meta.weak_tombstone_count += 1;
-            }
-            if e.key.value_type == ValueType::Value
-                && let Some((prev_key, prev_type)) = &self.previous_item
-                && prev_type == &ValueType::WeakTombstone
-                && prev_key.as_ref() == user_key.as_ref()
-            {
-                self.meta.weak_tombstone_reclaimable_count += 1;
-            }
-            if Some(user_key) != self.current_key.as_ref() {
-                self.meta.key_count += 1;
-                self.current_key = Some(user_key.clone());
-                if self.bloom_policy.is_active() {
-                    self.filter_writer.register_key(user_key)?;
-                }
-                if let Some(spec) = self.locator {
-                    // `row` is this key's item index within the forming columnar
-                    // block; `locator_block_id` is the block's ordinal.
-                    let pos = row as u64;
-                    let slot = match spec.precision {
-                        crate::config::LocatorPrecision::Block => 0,
-                        crate::config::LocatorPrecision::Restart => {
-                            pos / u64::from(self.data_block_restart_interval)
-                        }
-                        crate::config::LocatorPrecision::Entry => pos,
-                    };
-                    self.locators.push((
-                        crate::hash::hash64(user_key),
-                        self.locator_block_id,
-                        slot,
+        // Bulk columnar ingest (`require_zero_seqno`) is a load of strictly-unique,
+        // ascending keys. The verbatim salvage re-emit path (`require_zero_seqno ==
+        // false`) can carry repeated user keys across MVCC versions of one key, so
+        // it must NOT enforce strict uniqueness — but the block must still be in
+        // valid INTERNAL-key order (`account_direct_block` trusts it): salvage
+        // feeds this path with entries decoded from an untrusted block, and an
+        // unvalidated out-of-order block would register a wrong last-key in the
+        // index. Check within the batch and against the writer's prior key before
+        // any state mutation.
+        if require_zero_seqno {
+            let mut prev = self.current_key.as_ref();
+            for e in &entries {
+                if let Some(p) = prev
+                    && comparator.compare(p.as_ref(), e.key.user_key.as_ref())
+                        != core::cmp::Ordering::Less
+                {
+                    return Err(crate::Error::InvalidHeader(
+                        "columnar batch ingest requires strictly increasing keys",
                     ));
                 }
+                prev = Some(&e.key.user_key);
             }
-            if self.meta.first_key.is_none() {
-                self.meta.first_key = Some(user_key.clone());
-            }
-            self.previous_item = Some((user_key.clone(), e.key.value_type));
-            self.meta.lowest_seqno = self.meta.lowest_seqno.min(e.key.seqno);
-            self.meta.highest_seqno = self.meta.highest_seqno.max(e.key.seqno);
-            self.meta.highest_kv_seqno = self.meta.highest_kv_seqno.max(e.key.seqno);
+        } else {
+            self.validate_direct_block_order(&entries, comparator)?;
         }
+        let Some(inputs) = self.account_direct_block(&entries)? else {
+            return Ok(None); // empty batch: no block
+        };
 
         self.encode_columnar_batch_block(
             batch,
-            last_key.clone(),
-            last_seqno,
-            seqno_bounds,
-            item_count,
-            zone_block_min,
+            inputs.last_key.clone(),
+            inputs.last_seqno,
+            inputs.seqno_bounds,
+            inputs.item_count,
+            inputs.zone_block_min,
         )?;
         // This block's keys were recorded with the current locator ordinal;
         // advance it so a following batch's keys belong to the next block (the
@@ -1317,7 +1457,7 @@ impl Writer {
         if self.locator.is_some() {
             self.locator_block_id += 1;
         }
-        Ok(Some(last_key))
+        Ok(Some(inputs.last_key))
     }
 
     /// Encodes `chunk` into `buf`, returning the `block_flags` bits the transform
@@ -1370,6 +1510,7 @@ impl Writer {
         seqno_bounds: Option<(u64, u64)>,
         item_count: usize,
         zone_block_min: Option<UserKey>,
+        columnar_columns: Option<Vec<crate::table::zone_map::ColumnStats>>,
     ) -> crate::Result<()> {
         self.meta.uncompressed_size += u64::from(header.uncompressed_length);
 
@@ -1399,21 +1540,33 @@ impl Writer {
                 .push((self.meta.file_pos, (seqno_min, seqno_max)));
         }
         // Zone-map entry for this block (parallel section keyed by file offset,
-        // like seqno_bounds). A row block records one synthetic column with the
-        // block's key range; the row count never approaches `u32::MAX` (a data
-        // block holds at most a few thousand entries), so the cap is defensive.
+        // like seqno_bounds). A columnar block records one entry per stored
+        // column (`columnar_columns`, pre-derived from the batch); a row block
+        // records one synthetic column with the block's key range. The row count
+        // never approaches `u32::MAX` (a data block holds at most a few thousand
+        // entries), so the cap is defensive. `zone_block_min` is `Some` exactly
+        // when the zone-map policy is on, gating both variants alike.
         if let Some(min_key) = zone_block_min {
-            let row_count = u32::try_from(item_count).unwrap_or(u32::MAX);
-            let columns = alloc::vec![crate::table::zone_map::ColumnStats {
-                column_id: 0,
-                type_tag: 0,
-                codec_id: 0,
-                null_count: 0,
-                row_count,
-                min: min_key.to_vec(),
-                max: last_key.to_vec(),
-            }];
-            self.zone_map_section.push((self.meta.file_pos, columns));
+            let columns = if let Some(cols) = columnar_columns {
+                cols
+            } else {
+                let row_count = u32::try_from(item_count).unwrap_or(u32::MAX);
+                alloc::vec![crate::table::zone_map::ColumnStats {
+                    column_id: 0,
+                    type_tag: 0,
+                    codec_id: 0,
+                    null_count: 0,
+                    row_count,
+                    min: min_key.to_vec(),
+                    max: last_key.to_vec(),
+                }]
+            };
+            // A valid columnar batch always has at least the user-key column, so
+            // this is non-empty in practice; guard defensively so an empty stats
+            // vector never registers a column-less zone-map entry.
+            if !columns.is_empty() {
+                self.zone_map_section.push((self.meta.file_pos, columns));
+            }
         }
         self.index_writer.register_data_block(handle)?;
 
@@ -1425,6 +1578,260 @@ impl Writer {
         self.prev_pos.1 += u64::from(bytes_written);
 
         self.meta.last_key = Some(last_key);
+        Ok(())
+    }
+
+    /// Validates key order against prior writes, flushes any pending row chunk to
+    /// keep block order, and folds the per-row shape / seqno / filter / locator
+    /// accounting for a block written *directly* (not via the row chunk) —
+    /// returning the inputs [`Self::register_written_block`] needs. Shared by the
+    /// columnar-ingest block path and the verbatim copy-through salvage path so the
+    /// bookkeeping has a single source of truth. Does NOT write or register the
+    /// block: the caller emits it (encode, or a verbatim byte-copy). Returns `None`
+    /// for an empty entry set (no block).
+    ///
+    /// `entries` must already be in valid block order. Equal user keys are
+    /// permitted (a recovered data block can carry several MVCC versions of one
+    /// key); the columnar-ingest contract of strictly-unique keys is enforced by
+    /// the caller ([`Self::write_columnar_block_inner`]), not here.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing the pending row chunk or registering a filter
+    /// key fails.
+    fn account_direct_block(
+        &mut self,
+        entries: &[InternalValue],
+    ) -> crate::Result<Option<DirectBlockInputs>> {
+        let Some(last) = entries.last() else {
+            return Ok(None);
+        };
+        let last_key = last.key.user_key.clone();
+        let last_seqno = last.key.seqno;
+        let item_count = entries.len();
+        let seqno_bounds = self.use_seqno_in_index.then(|| {
+            entries.iter().fold((u64::MAX, u64::MIN), |(mn, mx), e| {
+                (mn.min(e.key.seqno), mx.max(e.key.seqno))
+            })
+        });
+        let zone_block_min = self
+            .use_zone_map
+            .then(|| entries.first().map(|e| e.key.user_key.clone()))
+            .flatten();
+
+        // Flush any row chunk buffered by prior `write()` calls before this
+        // direct block, so its block (and locator ordinal) is registered first
+        // and the sorted block / index order is preserved. The validation above
+        // ran first, so an invalid batch never forces a spill. A no-op when the
+        // chunk is empty (the columnar-only ingest / salvage path).
+        self.spill_block()?;
+
+        // Drain any blocks still being compressed on worker threads BEFORE the
+        // direct block appends its raw bytes: a direct write lands at the current
+        // file position, so a submitted-but-unwritten parallel block would
+        // otherwise be written at an overlapping offset and register a wrong
+        // handle. `spill_block` only drains down to the parallel cap, so an
+        // explicit full drain is required here (a no-op without parallel
+        // compression, mirroring the finish path).
+        #[cfg(feature = "std")]
+        while self.parallel.as_ref().map_or(0, BlockCompressor::pending) > 0 {
+            self.drain_one_parallel()?;
+        }
+
+        // Per-row shape / seqno / key accounting, mirroring `write()` minus the
+        // chunk push (the direct block holds all rows already). The locator
+        // records each new key's position within this single block, the same as
+        // the flush path does for a transposed columnar block.
+        for (row, e) in entries.iter().enumerate() {
+            let user_key = &e.key.user_key;
+            self.meta.sum_user_key_bytes += user_key.len() as u64;
+            self.meta.sum_value_bytes += e.value.len() as u64;
+            if e.is_tombstone() {
+                self.meta.tombstone_count += 1;
+            }
+            if e.key.value_type == ValueType::WeakTombstone {
+                self.meta.weak_tombstone_count += 1;
+            }
+            if e.key.value_type == ValueType::Value
+                && let Some((prev_key, prev_type)) = &self.previous_item
+                && prev_type == &ValueType::WeakTombstone
+                && prev_key.as_ref() == user_key.as_ref()
+            {
+                self.meta.weak_tombstone_reclaimable_count += 1;
+            }
+            if Some(user_key) != self.current_key.as_ref() {
+                self.meta.key_count += 1;
+                self.current_key = Some(user_key.clone());
+                if self.bloom_policy.is_active() {
+                    self.filter_writer.register_key(user_key)?;
+                }
+                if let Some(spec) = self.locator {
+                    // `row` is this key's item index within the forming block;
+                    // `locator_block_id` is the block's ordinal.
+                    let pos = row as u64;
+                    let slot = match spec.precision {
+                        crate::config::LocatorPrecision::Block => 0,
+                        crate::config::LocatorPrecision::Restart => {
+                            pos / u64::from(self.data_block_restart_interval)
+                        }
+                        crate::config::LocatorPrecision::Entry => pos,
+                    };
+                    self.locators.push((
+                        crate::hash::hash64(user_key),
+                        self.locator_block_id,
+                        slot,
+                    ));
+                }
+            }
+            if self.meta.first_key.is_none() {
+                self.meta.first_key = Some(user_key.clone());
+            }
+            self.previous_item = Some((user_key.clone(), e.key.value_type));
+            self.current_key_seqno = Some(e.key.seqno);
+            self.meta.lowest_seqno = self.meta.lowest_seqno.min(e.key.seqno);
+            self.meta.highest_seqno = self.meta.highest_seqno.max(e.key.seqno);
+            self.meta.highest_kv_seqno = self.meta.highest_kv_seqno.max(e.key.seqno);
+        }
+
+        Ok(Some(DirectBlockInputs {
+            last_key,
+            last_seqno,
+            seqno_bounds,
+            item_count,
+            zone_block_min,
+        }))
+    }
+
+    /// Appends a data block to the output by copying its raw on-disk bytes
+    /// **verbatim** — no decode + re-encode + re-compress + re-ECC — while folding
+    /// the same per-row accounting a freshly-encoded block gets. Salvage uses this
+    /// to fast-path blocks that read back cleanly (checksum passed without ECC
+    /// recovery): the original framing, compression, encryption, ECC parity, and
+    /// (for a columnar block) the PAX sub-columns / zone map are preserved
+    /// bit-for-bit at the block's new file offset.
+    ///
+    /// `raw` MUST be the exact `header.on_disk_size_with(self.ecc)` bytes the
+    /// source wrote for this block (header + payload + ECC trailer); `layout` is
+    /// its inner-zstd block layout (empty for a single-inner block). The inner
+    /// layout offsets are decompressed-space and block-relative, so they stay
+    /// valid at the new file offset. `entries` are the block's decoded rows, used
+    /// only for filter / key-count / seqno / zone accounting — never
+    /// re-serialized. The writer's ECC scheme must match the one the source block
+    /// was written under (the salvage path mirrors it), or the recorded block size
+    /// diverges from the copied bytes.
+    ///
+    /// Returns the block's last user key (or `None` for an empty entry set).
+    /// `entries` may contain repeated user keys (MVCC versions of one key); they
+    /// are accounted, not re-ordered, and the raw block already holds them in
+    /// valid order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `raw`'s length disagrees with the header's on-disk size
+    /// under this writer's ECC scheme, if the entries are out of internal-key
+    /// order ([`Self::validate_direct_block_order`]), or the write fails.
+    pub(crate) fn append_verbatim_data_block(
+        &mut self,
+        raw: &[u8],
+        header: crate::table::block::Header,
+        layout: alloc::vec::Vec<u32>,
+        entries: &[InternalValue],
+        // Per-column zone-map stats for a COLUMNAR block being copied verbatim
+        // (`Some`, pre-derived from its decoded `ColumnBatch`); `None` for a row
+        // block, where `register_written_block` synthesizes the whole-block key
+        // range. A columnar block copied with `None` would record the row-block
+        // synthetic column-0 stat, which `verify_zone_map` then rejects on the
+        // columnar table.
+        columnar_columns: Option<Vec<crate::table::zone_map::ColumnStats>>,
+        comparator: &crate::SharedComparator,
+    ) -> crate::Result<Option<crate::UserKey>> {
+        // The copied bytes ARE the block; their length must equal what the index
+        // entry will record (`register_written_block` sizes the handle and advances
+        // `file_pos` by `header.on_disk_size_with(self.ecc)`). A mismatch means the
+        // writer's ECC scheme was not mirrored from the source — refuse rather than
+        // record a handle that over- or under-reads on reopen.
+        let expected = header.on_disk_size_with(self.ecc) as usize;
+        if raw.len() != expected {
+            return Err(crate::Error::InvalidHeader(
+                "verbatim block copy: raw length disagrees with the header on-disk size",
+            ));
+        }
+        // The entries come from an UNTRUSTED (possibly tampered,
+        // checksum-repatched) block; `account_direct_block` trusts their order,
+        // so validate it before any state mutation.
+        self.validate_direct_block_order(entries, comparator)?;
+        let Some(inputs) = self.account_direct_block(entries)? else {
+            return Ok(None);
+        };
+        {
+            #[cfg(not(feature = "std"))]
+            use crate::io::Write;
+            #[cfg(feature = "std")]
+            use std::io::Write;
+            // Append straight into the active data region, exactly where
+            // `Block::write_to` would have written a freshly-encoded block's bytes.
+            self.file_writer.write_all(raw)?;
+        }
+        self.register_written_block(
+            header,
+            layout,
+            inputs.last_key.clone(),
+            inputs.last_seqno,
+            inputs.seqno_bounds,
+            inputs.item_count,
+            inputs.zone_block_min,
+            columnar_columns,
+        )?;
+        if self.locator.is_some() {
+            self.locator_block_id += 1;
+        }
+        Ok(Some(inputs.last_key))
+    }
+
+    /// Validates a direct (verbatim / re-emitted) block's entries against the
+    /// internal-key ordering invariant BEFORE any writer state mutates: user
+    /// keys non-decreasing (duplicate user keys are MVCC versions and are
+    /// allowed, unlike bulk ingest), equal user keys carry strictly decreasing
+    /// seqnos, and the block must not sort before the previously written key.
+    /// The salvage walk feeds these paths with entries decoded from untrusted
+    /// (possibly tampered, checksum-repatched) blocks; emitting an out-of-order
+    /// block would register a wrong last-key in the index and corrupt binary
+    /// search / scan order in the recovered SST. `pub(crate)` so the salvage
+    /// walk can also pre-validate its row-by-row re-emit path.
+    pub(crate) fn validate_direct_block_order(
+        &self,
+        entries: &[InternalValue],
+        comparator: &crate::SharedComparator,
+    ) -> crate::Result<()> {
+        let err = || crate::Error::InvalidHeader("direct block entries out of internal-key order");
+        if let (Some(prev), Some(first)) = (self.current_key.as_ref(), entries.first()) {
+            match comparator.compare(prev.as_ref(), first.key.user_key.as_ref()) {
+                core::cmp::Ordering::Greater => return Err(err()),
+                // The same user key spans the block boundary: its versions
+                // must keep strictly decreasing seqnos across the edge, just
+                // like the in-block window check below. An untracked prior
+                // seqno cannot happen once a key was written (both write
+                // paths record it), so treat it as a violation, not a pass.
+                core::cmp::Ordering::Equal
+                    if self
+                        .current_key_seqno
+                        .is_none_or(|prev_seqno| first.key.seqno >= prev_seqno) =>
+                {
+                    return Err(err());
+                }
+                _ => {}
+            }
+        }
+        for pair in entries.windows(2) {
+            let (Some(a), Some(b)) = (pair.first(), pair.get(1)) else {
+                continue;
+            };
+            match comparator.compare(a.key.user_key.as_ref(), b.key.user_key.as_ref()) {
+                core::cmp::Ordering::Less => {}
+                core::cmp::Ordering::Equal if a.key.seqno > b.key.seqno => {}
+                _ => return Err(err()),
+            }
+        }
         Ok(())
     }
 
@@ -1479,6 +1886,7 @@ impl Writer {
             meta.seqno_bounds,
             meta.item_count,
             meta.zone_block_min,
+            None, // parallel pipeline handles row (Data) blocks only
         )
     }
 
@@ -1516,8 +1924,6 @@ impl Writer {
             // Compute the coverage of all range tombstones.
             let mut min_start: Option<UserKey> = None;
             let mut max_end: Option<UserKey> = None;
-            let mut sentinel_start: Option<UserKey> = None;
-            let mut sentinel_seqno: Option<crate::SeqNo> = None;
             for rt in &self.range_tombstones {
                 match &min_start {
                     None => min_start = Some(rt.start.clone()),
@@ -1529,22 +1935,15 @@ impl Writer {
                     Some(cur_max) if rt.end > *cur_max => max_end = Some(rt.end.clone()),
                     _ => {}
                 }
-
-                match (sentinel_seqno, &sentinel_start) {
-                    (None, _) => {
-                        sentinel_seqno = Some(rt.seqno);
-                        sentinel_start = Some(rt.start.clone());
-                    }
-                    (Some(cur_seqno), Some(cur_start))
-                        if rt.seqno < cur_seqno
-                            || (rt.seqno == cur_seqno && rt.start < *cur_start) =>
-                    {
-                        sentinel_seqno = Some(rt.seqno);
-                        sentinel_start = Some(rt.start.clone());
-                    }
-                    _ => {}
-                }
             }
+            // The sentinel uses the (seqno, start)-minimal tombstone's start and
+            // seqno. Shared with the verify path so both agree on which entry is
+            // the synthetic sentinel (excluded from the recorded KV seqno range).
+            let (sentinel_start, sentinel_seqno) =
+                match crate::range_tombstone::RangeTombstone::sentinel(&self.range_tombstones) {
+                    Some((start, seqno)) => (Some(start.clone()), Some(seqno)),
+                    None => (None, None),
+                };
 
             if let (Some(start), Some(end), Some(sentinel_key), Some(sentinel_seqno)) =
                 (min_start, max_end, sentinel_start, sentinel_seqno)
@@ -1702,8 +2101,17 @@ impl Writer {
         // Write the optional positional delete-bitmap section (only when the
         // segment has materialized deletes AND the strategy keeps a bitmap;
         // copy-on-write drops rows instead). Applied as a row mask at scan time;
-        // absent otherwise, so a read without deletes pays nothing.
-        if !self.delete_bitmap.is_empty() && self.delete_strategy.writes_bitmap() {
+        // absent otherwise, so a read without deletes pays nothing. Compute the
+        // decision ONCE: the recorded `delete_bitmap_len` below must reflect the
+        // exact same predicate as the section actually written here, or the
+        // reader's "count > 0 requires a section" cross-check would misfire.
+        let writes_delete_bitmap =
+            !self.delete_bitmap.is_empty() && self.delete_strategy.writes_bitmap();
+        // Encode ONCE and reuse the bytes for both the section content and the
+        // `delete_bitmap_hash` below, so the persisted hash provably covers the
+        // exact bytes written (and the encode does not run twice per finish).
+        let delete_bitmap_bytes = writes_delete_bitmap.then(|| self.delete_bitmap.encode());
+        if writes_delete_bitmap {
             // Co-write invariant: the positional mask resolves each block's start
             // row from the zone map, and recovery rejects a delete-bitmap SST that
             // lacks one. Fail here at the write site (a clear misconfiguration)
@@ -1716,7 +2124,7 @@ impl Writer {
             self.file_writer.start("delete_bitmap")?;
             self.block_buffer.clear();
             self.block_buffer
-                .extend_from_slice(&self.delete_bitmap.encode());
+                .extend_from_slice(delete_bitmap_bytes.as_deref().unwrap_or_default());
             Block::write_into(
                 &mut self.file_writer,
                 &self.block_buffer,
@@ -1902,7 +2310,32 @@ impl Writer {
             index_block_restart_interval: self.index_block_restart_interval,
             initial_level: self.initial_level,
             use_columnar: self.use_columnar,
+            bulk_ingested: self.bulk_ingested,
             range_tombstone_count,
+            // Record the count that corresponds to the delete_bitmap section
+            // ACTUALLY written above, via the single `writes_delete_bitmap`
+            // decision. A strategy that keeps no bitmap (or a compaction that
+            // applied its deletes, leaving the bitmap empty) writes no section
+            // and records 0, so the reader's "count > 0 requires a section"
+            // cross-check never fires on a legitimate table.
+            delete_bitmap_len: if writes_delete_bitmap {
+                self.delete_bitmap.len()
+            } else {
+                0
+            },
+            // Bind the delete-bitmap CONTENTS, not just its count, into the meta:
+            // an equal-cardinality but checksum-valid bitmap substituted for the
+            // real one would otherwise pass the count cross-check and, during
+            // manifest repair (no original whole-file digest to compare against),
+            // silently resurrect deleted rows / drop live ones. The hash is over
+            // the exact encoded bytes written to the section above; the meta block
+            // is itself checksum- and mirror-protected, so this authenticates the
+            // section content transitively.
+            delete_bitmap_hash: if writes_delete_bitmap {
+                crate::hash::hash128(delete_bitmap_bytes.as_deref().unwrap_or_default())
+            } else {
+                0
+            },
             created_at_nanos,
         };
 
@@ -2121,7 +2554,21 @@ struct MetaSectionParams<'a> {
     index_block_restart_interval: u8,
     initial_level: u8,
     use_columnar: bool,
+    /// Bulk-ingest provenance: `Some(_)` writes `descriptor#bulk_ingested`,
+    /// `None` omits it (unknown provenance, preserving a legacy SST's absence).
+    bulk_ingested: Option<bool>,
     range_tombstone_count: u64,
+    /// Number of positions in this table's delete bitmap. Recorded so a reader
+    /// can AUTHENTICATE the bitmap's presence: the section itself is optional
+    /// (omitted when empty), so without this count a re-stamped TOC could hide a
+    /// non-empty `delete_bitmap` (rename it away, or replace it with another
+    /// valid optional section) and resurrect every positionally-deleted row. A
+    /// `> 0` count with no readable delete-bitmap section is then a forgery.
+    delete_bitmap_len: u64,
+    /// XXH3-128 of the delete-bitmap section's encoded bytes (0 when no section
+    /// is written), binding its CONTENTS into the meta so an equal-cardinality
+    /// substitution cannot pass the count-only cross-check.
+    delete_bitmap_hash: u128,
     /// `created_at` snapshot taken once in `finish()`. Both MID and
     /// TAIL writes consume this same value; generating it inside
     /// `write_meta_section` per call would stamp the two copies with
@@ -2231,7 +2678,7 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
     };
 
     let meta = meta_kv;
-    let meta_items = [
+    let mut meta_items = vec![
         meta("block_count#data", &p.data_block_count.to_le_bytes()),
         meta(
             "block_count#filter",
@@ -2261,6 +2708,18 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         // homogeneous SST, so the read path learns the layout from the
         // descriptor instead of inspecting a block header.
         meta("descriptor#columnar", &[u8::from(p.use_columnar)]),
+        // Authenticated positional-delete count: the `delete_bitmap` section is
+        // optional (omitted when empty), so this count lets a reader detect a
+        // re-stamped TOC that hid a non-empty bitmap. A `> 0` count with no
+        // readable bitmap section is a forgery that would resurrect deleted rows.
+        meta(
+            "descriptor#delete_bitmap_hash",
+            &p.delete_bitmap_hash.to_le_bytes(),
+        ),
+        meta(
+            "descriptor#delete_bitmap_len",
+            &p.delete_bitmap_len.to_le_bytes(),
+        ),
         // Per-SST transform descriptor: per-KV-footer presence + algorithm
         // as one byte (0 = no footer, else 1 + algo wire tag). Lets the
         // reader know the whole table's footer state without inspecting any
@@ -2317,11 +2776,20 @@ fn write_meta_section<W: crate::io::Write + crate::io::Seek>(
         ),
     ];
 
-    #[cfg(debug_assertions)]
-    {
-        let is_sorted = meta_items.iter().is_sorted_by_key(|kv| &kv.key);
-        assert!(is_sorted, "meta items not sorted correctly");
+    // Per-SST provenance: whether this table was bulk-ingested (every entry at
+    // local seqno 0, relying on a manifest-only global_seqno offset). Emitted
+    // ONLY when the provenance is KNOWN — a `None` (legacy SST, or one salvaged
+    // from a legacy source) omits the key so manifest repair reads it as unknown
+    // and applies its seqno heuristic, rather than a stamped "not ingested" that
+    // would wrongly keep a bulk-ingested table with global_seqno 0. Inserted out
+    // of order, then the whole list is sorted below.
+    if let Some(flag) = p.bulk_ingested {
+        meta_items.push(meta("descriptor#bulk_ingested", &[u8::from(flag)]));
     }
+
+    // The data-block encoder requires sorted keys; the entry above may be out of
+    // position (and future optional entries likewise), so sort rather than assert.
+    meta_items.sort_by(|a, b| a.key.cmp(&b.key));
 
     block_buffer.clear();
     DataBlock::encode_into(block_buffer, &meta_items, 1, 0.0)?;

--- a/src/table/writer/tests.rs
+++ b/src/table/writer/tests.rs
@@ -71,6 +71,40 @@ fn table_writer_count() -> crate::Result<()> {
     Ok(())
 }
 
+/// A shard scheme whose parity trailer for a block would exceed the payload
+/// hard cap (256 MiB) must be rejected at WRITE time: the out-of-band
+/// verifier bounds the trailer at that cap before reserving its buffer, so a
+/// writer that could emit a larger one would produce an SST the verifier
+/// falsely flags as corrupt. Rejecting the write keeps the cap an invariant —
+/// every SST in existence stays within the verifier's supported envelope.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn writer_rejects_a_block_whose_parity_exceeds_the_hard_cap() -> crate::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("1");
+    // RS(1,255): every payload byte amplified 255x into parity. Keep the
+    // payload JUST above the 256 MiB cap (1_100_000 × 255 ≈ 268 MiB) so a
+    // regression of the pre-encoding guard allocates barely past the cap
+    // instead of half a gigabyte destabilizing CI.
+    let mut writer = Writer::new(path, 1, 0, Arc::new(StdFs))?
+        .use_ecc(Some(crate::table::block::EccParams::try_new(1, 255)?));
+    let write_result = writer.write(InternalValue::from_components(
+        b"k".as_slice(),
+        vec![0xABu8; 1_100_000],
+        0,
+        ValueType::Value,
+    ));
+    let result = match write_result {
+        Ok(()) => writer.finish().map(|_| ()),
+        Err(e) => Err(e),
+    };
+    assert!(
+        matches!(result, Err(crate::Error::FeatureUnsupported(_))),
+        "an over-cap parity trailer must fail the write loudly, got {result:?}",
+    );
+    Ok(())
+}
+
 #[test]
 #[should_panic(expected = "index block restart interval must be greater than zero")]
 fn writer_rejects_zero_index_block_restart_interval() {
@@ -208,4 +242,206 @@ fn writer_rejects_partitioned_filter_switch_after_write() {
         panic!("write should succeed: {e}");
     }
     let _writer = writer.use_partitioned_filter();
+}
+
+/// A block re-emitted through the verbatim columnar path can hold several MVCC
+/// versions of one user key (same key, descending seqno). Unlike bulk ingest,
+/// that path must NOT reject equal user keys — only strictly-unique keys are an
+/// ingest contract. Regression for the verbatim salvage re-emit path.
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_block_verbatim_accepts_mvcc_duplicate_keys() -> crate::Result<()> {
+    use crate::comparator::default_comparator;
+    use crate::table::columnar::entries_to_column_batch;
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("1");
+    let cmp = default_comparator();
+    let mut writer = Writer::new(path, 1, 0, Arc::new(StdFs))?.use_columnar(true);
+
+    // Two MVCC versions of "dup" (valid block order: user key ascending, seqno
+    // descending within a key) — NOT strictly unique.
+    let entries = alloc::vec![
+        InternalValue::from_components(b"dup".to_vec(), b"v3".to_vec(), 3, ValueType::Value),
+        InternalValue::from_components(b"dup".to_vec(), b"v1".to_vec(), 1, ValueType::Value),
+    ];
+    let batch = entries_to_column_batch(&entries)?;
+    writer.write_columnar_block_verbatim(&batch, &cmp)?;
+    assert!(
+        writer.finish()?.is_some(),
+        "the verbatim block writes and finishes"
+    );
+    Ok(())
+}
+
+/// When the same user key spans two consecutive direct blocks, the boundary
+/// must keep the internal order `(user_key asc, seqno desc)`: a second block
+/// whose FIRST version of the shared key carries a seqno >= the previous
+/// block's LAST version is a tampered / malformed block and must be rejected,
+/// exactly like an in-block inversion. A correctly descending boundary still
+/// passes.
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_block_verbatim_rejects_an_equal_key_boundary_seqno_inversion() -> crate::Result<()>
+{
+    use crate::comparator::default_comparator;
+    use crate::table::columnar::entries_to_column_batch;
+
+    let dir = tempfile::tempdir()?;
+    let cmp = default_comparator();
+
+    // Inverted boundary: block 1 ends with ("dup", 5); block 2 begins with
+    // ("dup", 6) — a NEWER version sorting after an older one.
+    let mut writer = Writer::new(dir.path().join("inv"), 1, 0, Arc::new(StdFs))?.use_columnar(true);
+    let first = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"dup".to_vec(),
+        b"v5".to_vec(),
+        5,
+        ValueType::Value,
+    )])?;
+    writer.write_columnar_block_verbatim(&first, &cmp)?;
+    let inverted = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"dup".to_vec(),
+        b"v6".to_vec(),
+        6,
+        ValueType::Value,
+    )])?;
+    assert!(
+        writer
+            .write_columnar_block_verbatim(&inverted, &cmp)
+            .is_err(),
+        "an equal-key boundary whose seqno does not decrease is rejected",
+    );
+
+    // Valid boundary: the shared key's versions keep strictly decreasing
+    // across the block edge.
+    let mut ok_writer =
+        Writer::new(dir.path().join("ok"), 1, 0, Arc::new(StdFs))?.use_columnar(true);
+    let first = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"dup".to_vec(),
+        b"v5".to_vec(),
+        5,
+        ValueType::Value,
+    )])?;
+    ok_writer.write_columnar_block_verbatim(&first, &cmp)?;
+    let descending = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"dup".to_vec(),
+        b"v3".to_vec(),
+        3,
+        ValueType::Value,
+    )])?;
+    ok_writer.write_columnar_block_verbatim(&descending, &cmp)?;
+    assert!(
+        ok_writer.finish()?.is_some(),
+        "a correctly descending equal-key boundary still writes and finishes",
+    );
+    Ok(())
+}
+
+/// The columnar bulk-ingest contract is enforced by `write_columnar_batch`:
+/// a row-mode writer, a non-zero per-row seqno, or non-increasing keys are each
+/// rejected before any block is written.
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_batch_enforces_the_ingest_contract() -> crate::Result<()> {
+    use crate::comparator::default_comparator;
+    use crate::table::columnar::entries_to_column_batch;
+
+    let dir = tempfile::tempdir()?;
+    let cmp = default_comparator();
+    let good = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"a".to_vec(),
+        b"v".to_vec(),
+        0,
+        ValueType::Value,
+    )])?;
+
+    // 1. Row-mode writer (no `use_columnar`) rejects a columnar batch.
+    let mut row_writer = Writer::new(dir.path().join("row"), 1, 0, Arc::new(StdFs))?;
+    assert!(
+        row_writer.write_columnar_batch(&good, &cmp).is_err(),
+        "a columnar batch on a row-mode writer is rejected",
+    );
+
+    // 2. A non-zero per-row seqno is rejected (ingest assigns the seqno).
+    let mut w2 = Writer::new(dir.path().join("s"), 1, 0, Arc::new(StdFs))?.use_columnar(true);
+    let nonzero = entries_to_column_batch(&alloc::vec![InternalValue::from_components(
+        b"a".to_vec(),
+        b"v".to_vec(),
+        7,
+        ValueType::Value,
+    )])?;
+    assert!(
+        w2.write_columnar_batch(&nonzero, &cmp).is_err(),
+        "a non-zero per-row seqno is rejected on bulk ingest",
+    );
+
+    // 3. Non-increasing keys within the batch are rejected.
+    let mut w3 = Writer::new(dir.path().join("k"), 1, 0, Arc::new(StdFs))?.use_columnar(true);
+    let unsorted = entries_to_column_batch(&alloc::vec![
+        InternalValue::from_components(b"b".to_vec(), b"v".to_vec(), 0, ValueType::Value),
+        InternalValue::from_components(b"a".to_vec(), b"v".to_vec(), 0, ValueType::Value),
+    ])?;
+    assert!(
+        w3.write_columnar_batch(&unsorted, &cmp).is_err(),
+        "non-increasing keys are rejected on bulk ingest",
+    );
+    Ok(())
+}
+
+/// Columnar bulk ingest with an `Entry`-precision locator records a per-key
+/// locator slot for every distinct key (the per-entry-index arm of the direct
+/// block accounting).
+#[cfg(feature = "columnar")]
+#[test]
+fn write_columnar_batch_records_entry_precision_locator() -> crate::Result<()> {
+    use crate::comparator::default_comparator;
+    use crate::config::{LocatorPolicyEntry, LocatorPrecision};
+    use crate::table::columnar::entries_to_column_batch;
+
+    let dir = tempfile::tempdir()?;
+    let cmp = default_comparator();
+    let mut writer = Writer::new(dir.path().join("1"), 1, 0, Arc::new(StdFs))?
+        .use_columnar(true)
+        .use_locator(LocatorPolicyEntry::Enabled {
+            precision: LocatorPrecision::Entry,
+            block_id_bits: None,
+            slot_bits: None,
+        });
+    let entries: alloc::vec::Vec<InternalValue> = (0..8u32)
+        .map(|i| {
+            InternalValue::from_components(
+                format!("key{i:03}").into_bytes(),
+                b"v".to_vec(),
+                0,
+                ValueType::Value,
+            )
+        })
+        .collect();
+    let batch = entries_to_column_batch(&entries)?;
+    writer.write_columnar_batch(&batch, &cmp)?;
+
+    // Validate the recorded locator slots, not just that finish() succeeds. All
+    // eight keys land in the single direct block (ordinal 0), and Entry
+    // precision records each key's row index as its slot, so the accumulated
+    // triples are exactly `(hash64(key), 0, row)`.
+    assert_eq!(
+        writer.locators.len(),
+        entries.len(),
+        "one locator slot per distinct key",
+    );
+    for (row, recorded) in writer.locators.iter().enumerate() {
+        let key = format!("key{row:03}");
+        assert_eq!(
+            *recorded,
+            (crate::hash::hash64(key.as_bytes()), 0, row as u64),
+            "key at row {row} maps to (hash, direct block 0, slot == row index)",
+        );
+    }
+
+    assert!(
+        writer.finish()?.is_some(),
+        "the columnar SST with an entry-precision locator finishes",
+    );
+    Ok(())
 }

--- a/src/table/zone_map.rs
+++ b/src/table/zone_map.rs
@@ -253,6 +253,27 @@ impl ZoneMap {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
+
+    /// Number of recorded entries at or above `from_offset`: the LIVE entries
+    /// of a tight-space restricted view (its `[0, from_offset)` blocks are
+    /// punched, so their stats describe dead blocks). `from_offset == 0` yields
+    /// [`len`](Self::len).
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn live_len(&self, from_offset: u64) -> usize {
+        self.entries
+            .iter()
+            .filter(|(off, _)| *off >= from_offset)
+            .count()
+    }
+
+    /// Test-only: the raw `(offset, columns)` entries, for forges that
+    /// re-encode the section with a record removed or altered.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn entries(&self) -> &[(u64, Vec<ColumnStats>)] {
+        &self.entries
+    }
 }
 
 /// Forward cursor over a [`ZoneMap`], optimized for ascending-offset block

--- a/src/test_forge.rs
+++ b/src/test_forge.rs
@@ -1,0 +1,2598 @@
+//! Shared on-disk forgery helpers for corruption tests.
+//!
+//! These deliberately construct byte patterns a healthy writer never emits
+//! (stale footers behind re-stamped checksums), so integrity tests can prove
+//! the read/repair paths fail closed. Test-only: never compiled into the
+//! production library.
+
+#![expect(
+    clippy::expect_used,
+    reason = "test helpers assert on known-present values; a panic is the failure signal"
+)]
+
+/// Forges a STALE per-KV footer behind a RE-STAMPED block checksum in the
+/// first data block of the SST at `path`: flips one digest byte inside the
+/// footer's checksum array, then recomputes the block header checksum over
+/// the altered payload. Block-level verification then reads clean while
+/// per-KV verification still detects the mismatch.
+///
+/// The SST must be uncompressed (the payload is patched in place) and
+/// footer-bearing (written under `KvChecksumPolicy::AllLevels`).
+// `pub` (not `pub(crate)`): the module itself is `pub(crate)`, so the item
+// stays crate-internal either way and clippy::redundant_pub_crate fires on
+// the doubled restriction.
+pub fn forge_stale_kv_footer(path: &std::path::Path) -> crate::Result<()> {
+    use crate::table::block::kv_checksum::FOOTER_TAIL_LEN;
+    // The LAST byte of the digest array, just before the fixed algo+count
+    // tail — the footer stays structurally intact.
+    flip_and_restamp_first_data_block(path, FOOTER_TAIL_LEN + 1)
+}
+
+/// Flips the LAST payload byte of the first data block and re-stamps the
+/// block header checksum: the frame reads internally valid while its bytes
+/// no longer match what the manifest digest was computed over. For an
+/// uncompressed, footer-less SST this models an in-band alteration only the
+/// manifest-level digest can catch.
+pub fn forge_restamped_data_block(path: &std::path::Path) -> crate::Result<()> {
+    flip_and_restamp_first_data_block(path, 1)
+}
+
+/// RENAMES a TOC section to a DUPLICATE recognized name and re-stamps the
+/// renamed section's block header ROLE plus the trailer's TOC checksum: the
+/// section entries still tile perfectly and both names pass the
+/// recognized-role walk, yet the reader's name lookup (`Toc::section`)
+/// returns the FIRST match, so the renamed section is hidden — e.g.
+/// `range_tombstones` renamed to a second `data` vanishes and its deleted
+/// range resurrects. The block header at the section's offset is re-encoded
+/// under `to_role` (a fresh header checksum; both must be SST block types so
+/// the header length is unchanged and the payload / parity stay valid), so
+/// the only remaining trace is the duplicate name. `from` and `to` may
+/// differ in length (the TOC is rebuilt). The payload is untouched, so its
+/// parity trailer still verifies.
+pub fn forge_duplicate_section_name(
+    path: &std::path::Path,
+    from: &[u8],
+    to: &[u8],
+    to_role: crate::table::block::BlockType,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+
+    // Locate the section's block offset so its header role can be re-stamped.
+    let section_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == from) else {
+            panic!("the SST must carry the section to rename");
+        };
+        usize::try_from(entry.pos()).expect("section offset fits usize")
+    };
+    // Re-encode the block header under the new role (SST block types have no
+    // block_flags byte and equal header length, so the frame geometry and
+    // the payload / parity trailer are untouched).
+    {
+        let Some(block) = bytes.get(section_off..) else {
+            panic!("section block within the file");
+        };
+        let mut cursor = block;
+        let header = Header::decode_from(&mut cursor)?;
+        let header_len = Header::header_len(header.block_type);
+        assert_eq!(
+            header_len,
+            Header::header_len(to_role),
+            "the rerole must keep the header length so the geometry holds",
+        );
+        let new_header = Header {
+            block_type: to_role,
+            ..header
+        };
+        let mut hdr_bytes = Vec::with_capacity(header_len);
+        new_header.encode_into(&mut hdr_bytes)?;
+        let Some(dst) = bytes.get_mut(section_off..section_off + header_len) else {
+            panic!("section header within the file");
+        };
+        dst.copy_from_slice(&hdr_bytes);
+    }
+
+    // Rebuild the TOC with the renamed entry (name length may change).
+    let toc = bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region");
+    assert_eq!(toc.get(..4), Some(&b"TOC!"[..]), "TOC magic");
+    // The splice below rebuilds the file as prefix + new TOC + trailer, so
+    // any bytes between the TOC's end and the trailer would be silently
+    // dropped; the writer emits them adjacent today — fail loudly if that
+    // layout ever changes instead of producing a truncated fixture.
+    assert_eq!(
+        toc_pos + toc_len,
+        trailer_start,
+        "the TOC must sit directly before the trailer",
+    );
+    let count = u32::from_le_bytes(toc.get(4..8).expect("count").try_into().expect("4 bytes"));
+    let mut new_toc = Vec::with_capacity(toc.len());
+    new_toc.extend_from_slice(toc.get(..8).expect("TOC header"));
+    let mut at = 8usize;
+    let mut renamed = false;
+    for _ in 0..count {
+        let pos = toc.get(at..at + 16).expect("pos+len");
+        at += 16;
+        let name_len = usize::from(u16::from_le_bytes(
+            toc.get(at..at + 2)
+                .expect("name_len")
+                .try_into()
+                .expect("2 bytes"),
+        ));
+        at += 2;
+        let entry_name = toc.get(at..at + name_len).expect("name");
+        at += name_len;
+        new_toc.extend_from_slice(pos);
+        if entry_name == from {
+            renamed = true;
+            new_toc.extend_from_slice(
+                &u16::try_from(to.len())
+                    .expect("name fits u16")
+                    .to_le_bytes(),
+            );
+            new_toc.extend_from_slice(to);
+        } else {
+            new_toc.extend_from_slice(&u16::try_from(name_len).expect("fits u16").to_le_bytes());
+            new_toc.extend_from_slice(entry_name);
+        }
+    }
+    assert!(renamed, "section name present in the TOC");
+
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(&new_toc);
+        hasher.digest128()
+    };
+    let mut out = Vec::with_capacity(toc_pos + new_toc.len() + TRAILER_SIZE);
+    out.extend_from_slice(bytes.get(..toc_pos).expect("pre-TOC prefix"));
+    out.extend_from_slice(&new_toc);
+    out.extend_from_slice(
+        bytes
+            .get(trailer_start..trailer_start + 4 + 1 + 1)
+            .expect("trailer head"),
+    );
+    out.extend_from_slice(&fresh.to_le_bytes());
+    out.extend_from_slice(
+        &u64::try_from(toc_pos)
+            .expect("toc_pos fits u64")
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(
+        &u64::try_from(new_toc.len())
+            .expect("TOC length fits u64")
+            .to_le_bytes(),
+    );
+    std::fs::write(path, &out)?;
+    Ok(())
+}
+
+/// Overwrites the on-disk `len` field of the named SFA TOC section with
+/// `new_len` and re-stamps the TOC trailer checksum. The section catalogue then
+/// advertises a bogus length (e.g. `u64::MAX`, whose `pos + len` overflows)
+/// while every other structure stays intact and every byte-level check passes.
+/// Used to prove the salvage physical walk rejects a data section whose end
+/// overflows / runs past the TOC instead of tiling to that forged upper bound
+/// (which would make the byte-at-a-time resync scan every offset to the bound).
+///
+/// A `len` change does not move the entry, so the TOC and every later section
+/// stay byte-for-byte in place; only the eight length bytes and the trailer
+/// digest change.
+pub fn forge_section_len(path: &std::path::Path, name: &[u8], new_len: u64) -> crate::Result<()> {
+    let mut bytes = std::fs::read(path)?;
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+
+    // Walk the TOC entries to find the target's len-field byte offset. Each
+    // entry is pos (u64 LE) + len (u64 LE) + name_len (u16 LE) + name, so the
+    // len field is the second u64 of the entry's 16-byte pos+len prefix.
+    let toc = bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region");
+    assert_eq!(toc.get(..4), Some(&b"TOC!"[..]), "TOC magic");
+    let count = u32::from_le_bytes(toc.get(4..8).expect("count").try_into().expect("4 bytes"));
+    let mut at = 8usize;
+    let mut len_field_off: Option<usize> = None;
+    for _ in 0..count {
+        let entry_off = at;
+        at += 16;
+        let name_len = usize::from(u16::from_le_bytes(
+            toc.get(at..at + 2)
+                .expect("name_len")
+                .try_into()
+                .expect("2 bytes"),
+        ));
+        at += 2;
+        let entry_name = toc.get(at..at + name_len).expect("name");
+        at += name_len;
+        if entry_name == name {
+            len_field_off = Some(toc_pos + entry_off + 8);
+        }
+    }
+    let Some(len_off) = len_field_off else {
+        panic!(
+            "section {:?} present in the TOC",
+            core::str::from_utf8(name)
+        );
+    };
+    bytes
+        .get_mut(len_off..len_off + 8)
+        .expect("len field within file")
+        .copy_from_slice(&new_len.to_le_bytes());
+
+    // Re-stamp the trailer digest (xxh3-128 over the mutated TOC bytes only).
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region"));
+        hasher.digest128()
+    };
+    let ck_off = trailer_start + 4 + 1 + 1;
+    bytes
+        .get_mut(ck_off..ck_off + 16)
+        .expect("trailer checksum")
+        .copy_from_slice(&fresh.to_le_bytes());
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// RENAMES an SFA TOC section (same-length name) and re-stamps the trailer's
+/// TOC checksum: the archive stays internally consistent while a section the
+/// verifier knows disappears behind an unrecognized name — the shape only a
+/// fail-closed unknown-section check can catch (every block inside still
+/// passes its own byte-level checks).
+pub fn forge_section_name(path: &std::path::Path, from: &[u8], to: &[u8]) -> crate::Result<()> {
+    assert_eq!(from.len(), to.len(), "the rename must keep the name length");
+
+    let mut bytes = std::fs::read(path)?;
+    // SFA trailer layout (fixed size, at the very end of the file):
+    // magic "SFA!" | version u8 | checksum_type u8 | toc_checksum u128 LE |
+    // toc_pos u64 LE | toc_len u64 LE.
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+
+    {
+        let Some(toc) = bytes.get_mut(toc_pos..toc_pos + toc_len) else {
+            panic!("TOC region within the file");
+        };
+        // Walk the parsed TOC entries instead of searching raw bytes: a raw
+        // window search on `b"filter"` would also match inside the
+        // `filter_tli` entry's name. Layout: "TOC!" | count u32 LE | entries
+        // (pos u64 | len u64 | name_len u16 | name).
+        let count = u32::from_le_bytes(
+            toc.get(4..8)
+                .expect("count prefix")
+                .try_into()
+                .expect("4 bytes"),
+        );
+        let mut at = 8usize;
+        let mut name_at = None;
+        for _ in 0..count {
+            let name_len = usize::from(u16::from_le_bytes(
+                toc.get(at + 16..at + 18)
+                    .expect("name_len")
+                    .try_into()
+                    .expect("2 bytes"),
+            ));
+            let entry_name = toc.get(at + 18..at + 18 + name_len).expect("name");
+            if entry_name == from {
+                name_at = Some(at + 18);
+                break;
+            }
+            at += 18 + name_len;
+        }
+        let Some(name_at) = name_at else {
+            panic!("section name present in the TOC");
+        };
+        let Some(dst) = toc.get_mut(name_at..name_at + to.len()) else {
+            panic!("section name within the TOC");
+        };
+        dst.copy_from_slice(to);
+    }
+
+    let Some(toc) = bytes.get(toc_pos..toc_pos + toc_len) else {
+        panic!("TOC region within the file");
+    };
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(toc);
+        hasher.digest128()
+    };
+    let Some(dst) = bytes.get_mut(trailer_start + 4 + 1 + 1..trailer_start + 4 + 1 + 1 + 16) else {
+        panic!("toc_checksum within the trailer");
+    };
+    dst.copy_from_slice(&fresh.to_le_bytes());
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// OMITS an SFA TOC entry entirely and re-stamps the trailer's TOC checksum
+/// and length: the archive stays internally consistent while a whole section
+/// vanishes from every reader's sight (its bytes are still in the file, but
+/// nothing references them) — the shape only a TOC coverage check can catch,
+/// since every remaining block still passes its own byte-level checks.
+pub fn forge_section_omitted(path: &std::path::Path, name: &[u8]) -> crate::Result<()> {
+    let bytes = std::fs::read(path)?;
+    // SFA trailer layout (fixed size, at the very end of the file):
+    // magic "SFA!" | version u8 | checksum_type u8 | toc_checksum u128 LE |
+    // toc_pos u64 LE | toc_len u64 LE.
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+
+    // Parse the TOC: "TOC!" magic | count u32 LE | entries
+    // (pos u64 | len u64 | name_len u16 | name).
+    let toc = bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region");
+    assert_eq!(toc.get(..4), Some(&b"TOC!"[..]), "TOC magic");
+    let count = u32::from_le_bytes(toc.get(4..8).expect("count").try_into().expect("4 bytes"));
+    let mut new_toc = Vec::with_capacity(toc.len());
+    new_toc.extend_from_slice(b"TOC!");
+    new_toc.extend_from_slice(&count.checked_sub(1).expect("TOC has entries").to_le_bytes());
+    let mut at = 8usize;
+    let mut omitted = false;
+    for _ in 0..count {
+        let entry_start = at;
+        at += 16;
+        let name_len = usize::from(u16::from_le_bytes(
+            toc.get(at..at + 2)
+                .expect("name_len")
+                .try_into()
+                .expect("2 bytes"),
+        ));
+        at += 2;
+        let entry_name = toc.get(at..at + name_len).expect("name");
+        at += name_len;
+        if entry_name == name {
+            omitted = true;
+        } else {
+            new_toc.extend_from_slice(toc.get(entry_start..at).expect("entry"));
+        }
+    }
+    assert!(omitted, "section name present in the TOC");
+
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(&new_toc);
+        hasher.digest128()
+    };
+    let mut out = Vec::with_capacity(toc_pos + new_toc.len() + TRAILER_SIZE);
+    out.extend_from_slice(bytes.get(..toc_pos).expect("pre-TOC prefix"));
+    out.extend_from_slice(&new_toc);
+    out.extend_from_slice(
+        bytes
+            .get(trailer_start..trailer_start + 4 + 1 + 1)
+            .expect("trailer head"),
+    );
+    out.extend_from_slice(&fresh.to_le_bytes());
+    out.extend_from_slice(
+        &u64::try_from(toc_pos)
+            .expect("toc_pos fits u64")
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(
+        &u64::try_from(new_toc.len())
+            .expect("TOC length fits u64")
+            .to_le_bytes(),
+    );
+    std::fs::write(path, &out)?;
+    Ok(())
+}
+
+/// REPLACES the value of `key` inside the TAIL `meta` block's payload with
+/// `forged_value` (same length), then re-stamps the block checksum and (on a
+/// parity-bearing build) recomputes the RS(4,2) trailer: the tail mirror
+/// stays internally consistent in every byte-level check while its DECODED
+/// metadata now disagrees with the intact `meta_mid` mirror — the shape only
+/// a full mirror comparison can catch. The key must be present verbatim
+/// (meta blocks use restart interval 1) with a one-byte length prefix
+/// matching `forged_value.len()`.
+pub fn forge_tail_meta_value(
+    path: &std::path::Path,
+    key: &[u8],
+    forged_value: &[u8],
+) -> crate::Result<()> {
+    forge_meta_value_in_section(path, b"meta", key, forged_value)
+}
+
+/// As [`forge_tail_meta_value`], but applied to BOTH meta mirrors (`meta`
+/// and `meta_mid`) so the copies stay CONSISTENT with each other: the mirror
+/// comparison passes and only a cross-check of the decoded field against the
+/// table's actual data can catch the forge.
+pub fn forge_meta_value_both_mirrors(
+    path: &std::path::Path,
+    key: &[u8],
+    forged_value: &[u8],
+) -> crate::Result<()> {
+    forge_meta_value_in_section(path, b"meta", key, forged_value)?;
+    forge_meta_value_in_section(path, b"meta_mid", key, forged_value)
+}
+
+/// Shared body of the meta-value forges: patches `key`'s value inside the
+/// named meta section's payload and re-stamps the block checksum plus, on a
+/// parity-bearing build, the fixed RS(4,2) trailer.
+fn forge_meta_value_in_section(
+    path: &std::path::Path,
+    section: &[u8],
+    key: &[u8],
+    forged_value: &[u8],
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == section) else {
+            panic!("the SST must carry the requested meta section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).expect("meta offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("meta block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("meta payload within the file");
+        };
+        let Some(key_pos) = payload.windows(key.len()).position(|w| w == key) else {
+            panic!("meta key present verbatim (restart interval 1)");
+        };
+        // Entry layout after the key bytes: value length (LEB128, one byte
+        // for these small values), then the value itself.
+        let val_at = key_pos + key.len();
+        assert_eq!(
+            payload.get(val_at).copied(),
+            u8::try_from(forged_value.len()).ok(),
+            "the forged value must keep the original length",
+        );
+        let Some(value) = payload.get_mut(val_at + 1..val_at + 1 + forged_value.len()) else {
+            panic!("meta value within the payload");
+        };
+        value.copy_from_slice(forged_value);
+    }
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("meta payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("meta header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    // A parity-bearing meta frame (self-describing blocks always use the
+    // fixed RS(4,2) layout) must have its trailer recomputed over the forged
+    // payload, or the walk would flag the forge ITSELF as parity rot.
+    #[cfg(feature = "page_ecc")]
+    {
+        let payload_end = payload_range.end;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("meta section length fits usize");
+        };
+        let frame_end = block_off + section_len;
+        if frame_end > payload_end {
+            let Some(payload) = bytes.get(payload_range) else {
+                panic!("meta payload within the file");
+            };
+            let parity = crate::ecc::encode_parity(payload, 4, 2)?;
+            assert_eq!(
+                frame_end - payload_end,
+                parity.len(),
+                "the meta frame's trailer length matches the fixed RS(4,2) layout",
+            );
+            let Some(dst) = bytes.get_mut(payload_end..frame_end) else {
+                panic!("meta parity trailer within the file");
+            };
+            dst.copy_from_slice(&parity);
+        }
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = section_len;
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// INFLATES the trailer `item_count` of the first data block by one and
+/// re-stamps the block header checksum: the block stays checksum-clean but
+/// iterating it yields FEWER entries than the trailer declares, modelling a
+/// truncated / partially-decodable entry region that a count cross-check
+/// must catch (the entry decoder turns a mid-stream parse failure into an
+/// ordinary end of iteration). The SST must be uncompressed, and must carry
+/// NO parity trailer: this helper re-stamps only the header checksum (unlike
+/// [`forge_tail_meta_value`]), so a parity-bearing block would additionally
+/// read as parity rot rather than as a clean-but-under-decoding block.
+pub fn forge_inflated_item_count(path: &std::path::Path) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let block_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"data") else {
+            panic!("the SST must carry a data section");
+        };
+        usize::try_from(entry.pos()).expect("data offset fits usize")
+    };
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("data block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+
+    // The item count is the LAST u32 of the block payload (the trailer's
+    // final field).
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("data payload within the file");
+        };
+        let count_at = payload.len() - core::mem::size_of::<u32>();
+        let Some(count_le) = payload.get_mut(count_at..) else {
+            panic!("item count within the payload");
+        };
+        let count = u32::from_le_bytes(count_le.try_into().expect("4 bytes"));
+        count_le.copy_from_slice(&(count + 1).to_le_bytes());
+    }
+
+    let Some(payload) = bytes.get(payload_range) else {
+        panic!("data payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("data header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// RELABELS the first block of the named SFA section to `forged` and
+/// re-encodes its header (fresh header CRC, payload and its checksum
+/// untouched): the block stays checksum-clean while its ROLE no longer
+/// matches the section that holds it, modelling a re-stamped `block_type`
+/// forge that only a section-vs-role cross-check can catch. The forged
+/// type must have the same header length as the original (all SST block
+/// types without `block_flags` do).
+pub fn forge_section_block_role(
+    path: &std::path::Path,
+    section: &[u8],
+    forged: crate::table::block::BlockType,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let block_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == section) else {
+            panic!("the SST must carry the targeted section");
+        };
+        usize::try_from(entry.pos()).expect("section offset fits usize")
+    };
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("section block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    assert_eq!(
+        header_len,
+        Header::header_len(forged),
+        "the forged role must keep the header length so the relabel is in place",
+    );
+
+    let new_header = Header {
+        block_type: forged,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("section header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Flips the LAST byte of a named section's PAYLOAD and re-stamps the block
+/// checksum (plus, for a parity-bearing SST, the descriptor-scheme parity
+/// trailer). The section stays structurally valid and every byte-level check
+/// reads clean while its decoded content now disagrees with the blocks it
+/// summarizes — the shape only a content cross-check can catch. For the
+/// `zone_map` section the last payload byte is the last byte of the final
+/// block's `max` value, so this narrows/changes a recorded key range.
+/// `shards` is the SST's descriptor scheme (`None` for a parity-less table).
+pub fn forge_flip_section_last_payload_byte(
+    path: &std::path::Path,
+    section: &[u8],
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == section) else {
+            panic!("the SST must carry the targeted section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("section block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("section payload within the file");
+        };
+        let last = payload.len() - 1;
+        let Some(slot) = payload.get_mut(last) else {
+            panic!("payload is non-empty");
+        };
+        *slot ^= 0xFF;
+    }
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("section payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("section header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("section length fits usize");
+        };
+        let frame_end = block_off + section_len;
+        if frame_end > payload_end {
+            let Some(payload) = bytes.get(payload_range) else {
+                panic!("section payload within the file");
+            };
+            let parity =
+                crate::ecc::encode_parity(payload, data_shards.into(), parity_shards.into())?;
+            assert_eq!(
+                frame_end - payload_end,
+                parity.len(),
+                "the frame's trailer length matches the descriptor scheme",
+            );
+            let Some(dst) = bytes.get_mut(payload_end..frame_end) else {
+                panic!("parity trailer within the file");
+            };
+            dst.copy_from_slice(&parity);
+        }
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = (section_len, shards);
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Overwrites a named block-format section's PAYLOAD with `new_payload` (which
+/// MUST be the same length as the existing payload, so the frame geometry is
+/// unchanged) and re-stamps the block checksum plus, for a parity-bearing SST,
+/// the descriptor-scheme parity trailer. Models a re-stamped section whose
+/// content was swapped for another structurally valid payload — every
+/// byte-level check reads clean while the decoded content disagrees with the
+/// blocks it describes. `shards` is the SST's descriptor scheme (`None` for a
+/// parity-less table).
+pub fn forge_replace_section_payload(
+    path: &std::path::Path,
+    section: &[u8],
+    new_payload: &[u8],
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == section) else {
+            panic!("the SST must carry the targeted section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("section block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    assert_eq!(
+        payload_range.len(),
+        new_payload.len(),
+        "the replacement payload must keep the frame geometry",
+    );
+    {
+        let Some(dst) = bytes.get_mut(payload_range.clone()) else {
+            panic!("section payload within the file");
+        };
+        dst.copy_from_slice(new_payload);
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(new_payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("section header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("section length fits usize");
+        };
+        let frame_end = block_off + section_len;
+        if frame_end > payload_end {
+            let parity =
+                crate::ecc::encode_parity(new_payload, data_shards.into(), parity_shards.into())?;
+            assert_eq!(
+                frame_end - payload_end,
+                parity.len(),
+                "the frame's trailer length matches the descriptor scheme",
+            );
+            let Some(dst) = bytes.get_mut(payload_end..frame_end) else {
+                panic!("parity trailer within the file");
+            };
+            dst.copy_from_slice(&parity);
+        }
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = (section_len, shards);
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Forges a VALUE inside the first data block of a footer-less, uncompressed
+/// SST: searches for a payload byte whose flip leaves the block fully
+/// decodable with the SAME keys, seqnos, and entry count while at least one
+/// VALUE differs, then re-stamps the block checksum plus, for a
+/// parity-bearing SST, the block's parity trailer. Every byte-level check
+/// and every derived-metadata cross-check (keys, counts, layout) reads clean
+/// — the manifest digest is the only remaining record of the original value
+/// bytes. `shards` is the SST's descriptor scheme (`None` for a parity-less
+/// table).
+pub fn forge_value_byte_in_first_data_block(
+    path: &std::path::Path,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::{Header, ParsedItem as _};
+
+    let mut bytes = std::fs::read(path)?;
+    let block_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"data") else {
+            panic!("the SST must carry a data section");
+        };
+        usize::try_from(entry.pos()).expect("data offset fits usize")
+    };
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("data block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("data payload within the file");
+    };
+
+    // Decode entries from a candidate payload; None when it fails to decode.
+    let decode = |payload: &[u8]| -> Option<alloc::vec::Vec<crate::InternalValue>> {
+        let block = crate::table::Block {
+            header: Header {
+                checksum: crate::Checksum::from_raw(crate::hash::hash128(payload)),
+                ..header
+            },
+            data: crate::Slice::from(payload.to_vec()),
+        };
+        let data_block = crate::table::DataBlock::from_loaded(block, false).ok()?;
+        let data = data_block.inner.data.clone();
+        let iter = data_block
+            .try_iter(crate::comparator::default_comparator())
+            .ok()?;
+        Some(iter.map(|p| p.materialize(&data)).collect())
+    };
+    let Some(baseline) = decode(payload) else {
+        panic!("the healthy first data block decodes");
+    };
+
+    // Search for a flip that changes ONLY a value: same count, same keys,
+    // same seqnos and value types, at least one differing value.
+    let mut candidate = payload.to_vec();
+    let flipped_at = (0..candidate.len()).find(|&i| {
+        let Some(slot) = candidate.get_mut(i) else {
+            return false;
+        };
+        *slot ^= 0xFF;
+        let ok = decode(&candidate).is_some_and(|entries| {
+            entries.len() == baseline.len()
+                && entries
+                    .iter()
+                    .zip(&baseline)
+                    .all(|(a, b)| a.key == b.key && a.value.len() == b.value.len())
+                && entries
+                    .iter()
+                    .zip(&baseline)
+                    .any(|(a, b)| a.value != b.value)
+        });
+        if !ok {
+            let Some(slot) = candidate.get_mut(i) else {
+                return false;
+            };
+            *slot ^= 0xFF;
+        }
+        ok
+    });
+    assert!(
+        flipped_at.is_some(),
+        "some payload byte flip must alter only a value while the block stays decodable",
+    );
+    {
+        let Some(dst) = bytes.get_mut(payload_range.clone()) else {
+            panic!("data payload within the file");
+        };
+        dst.copy_from_slice(&candidate);
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(&candidate));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("data header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    // Re-stamp THIS block's parity trailer (the data section holds more
+    // blocks after it, each with its own frame).
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let parity =
+            crate::ecc::encode_parity(&candidate, data_shards.into(), parity_shards.into())?;
+        let Some(dst) = bytes.get_mut(payload_end..payload_end + parity.len()) else {
+            panic!("parity trailer within the file");
+        };
+        dst.copy_from_slice(&parity);
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = shards;
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Forges the `block_layout` section by SHIFTING a MIDDLE cumulative end of
+/// the first recorded entry down to the midpoint of its neighbors, then
+/// re-stamps the block checksum plus, for a parity-bearing SST, the parity
+/// trailer. The map stays structurally valid (strictly ascending offsets,
+/// inner count >= 2, final end untouched) and every byte-level check reads
+/// clean, while the recorded boundary now disagrees with the zstd frame's
+/// real inner-block layout — the shape only a decode-derived cross-check
+/// can catch. `shards` is the SST's descriptor scheme (`None` for a
+/// parity-less table).
+pub fn forge_block_layout_shift_middle_end(
+    path: &std::path::Path,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::Decode;
+    use crate::table::block::Header;
+
+    let bytes = std::fs::read(path)?;
+    let pos = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"block_layout") else {
+            panic!("the SST must carry a block_layout section");
+        };
+        entry.pos()
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("section block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let Some(payload) =
+        bytes.get(block_off + header_len..block_off + header_len + header.data_length as usize)
+    else {
+        panic!("section payload within the file");
+    };
+
+    // Wire layout: [count u32] then per entry [offset u64 | inner u32 |
+    // inner x end u32]. Patch the FIRST entry's second-to-last end.
+    let read_u32 = |at: usize| {
+        u32::from_le_bytes(
+            payload
+                .get(at..at + 4)
+                .expect("u32 within the payload")
+                .try_into()
+                .expect("4 bytes"),
+        )
+    };
+    assert!(read_u32(0) >= 1, "the map records at least one block");
+    let inner = read_u32(12) as usize;
+    assert!(inner >= 2, "a recorded block has at least two inner blocks");
+    let target_at = 16 + (inner - 2) * 4;
+    let prev = if inner >= 3 {
+        read_u32(target_at - 4)
+    } else {
+        0
+    };
+    let current = read_u32(target_at);
+    assert!(
+        current > prev + 1,
+        "the target boundary must leave room for a shifted midpoint",
+    );
+    let shifted = prev + (current - prev) / 2;
+
+    let mut candidate = payload.to_vec();
+    let Some(dst) = candidate.get_mut(target_at..target_at + 4) else {
+        panic!("target end within the payload");
+    };
+    dst.copy_from_slice(&shifted.to_le_bytes());
+    forge_replace_section_payload(path, b"block_layout", &candidate, shards)
+}
+
+/// Fills the first data block's embedded HASH INDEX with `MARKER_FREE` and
+/// re-stamps the block header checksum plus, for a parity-bearing SST, the
+/// block's parity trailer. Every logical entry, per-KV footer, and the outer
+/// block checksum stay valid, so a sequential decode and the count / key /
+/// seqno gates all pass — yet `point_read` trusts the hash index and returns
+/// `None` for every existing key. The SST must be uncompressed and
+/// unencrypted (the hash index is patched in place through the on-disk
+/// payload), its blocks must carry a hash index (a non-zero
+/// `data_block_hash_ratio`) AND per-KV checksum footers — the block is
+/// re-parsed with `has_kv_footer = true` unconditionally, so a footer-less
+/// block would misread its trailer. `shards` is the SST's descriptor
+/// scheme (`None` for a parity-less table).
+pub fn forge_hash_index_all_free(
+    path: &std::path::Path,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::table::block::hash_index::MARKER_FREE;
+    patch_first_data_block_hash_index(path, shards, |region| region.fill(MARKER_FREE))
+}
+
+/// Re-stamps the FIRST data block's hash-index bucket for `key` (a
+/// CONFLICT marker for a key spanning restart intervals) to `binary_index_pos`,
+/// so `point_read` follows the forged bucket straight to that restart head
+/// instead of the sequential scan — returning an OLDER version of a
+/// multi-version key while the sequential decode still sees the newest.
+/// Every logical entry and the per-KV footer stay valid; only a
+/// newest-version cross-check of the point-read result can catch it. Same
+/// preconditions as [`forge_hash_index_all_free`].
+pub fn forge_hash_index_bucket(
+    path: &std::path::Path,
+    key: &[u8],
+    binary_index_pos: u8,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::table::block::hash_index::MARKER_CONFLICT;
+    patch_first_data_block_hash_index(path, shards, |region| {
+        // One byte per bucket, so the region length is the bucket count; the
+        // modulo keeps the result below it, hence within usize.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "hash % region.len() < region.len() <= usize::MAX"
+        )]
+        let bucket = (crate::hash::hash64(key) % region.len() as u64) as usize;
+        let Some(slot) = region.get_mut(bucket) else {
+            panic!("bucket within the hash index");
+        };
+        assert_eq!(
+            *slot, MARKER_CONFLICT,
+            "the target key's bucket must be a conflict marker (spans restart intervals)",
+        );
+        *slot = binary_index_pos;
+    })
+}
+
+/// Shared machinery for the hash-index forges: locates the FIRST data
+/// block's embedded hash index, hands its on-disk bytes to `patch`, and
+/// re-stamps the block header checksum plus (for a parity-bearing SST) the
+/// block's parity trailer. The SST must be uncompressed, unencrypted, carry
+/// a hash index, and carry per-KV footers (the block is re-parsed with
+/// `has_kv_footer = true`). `shards` is the descriptor scheme (`None` when
+/// parity-less).
+fn patch_first_data_block_hash_index(
+    path: &std::path::Path,
+    shards: Option<(u8, u8)>,
+    patch: impl FnOnce(&mut [u8]),
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::{Block, Header};
+    use crate::table::{DataBlock, block::BlockType};
+
+    let mut bytes = std::fs::read(path)?;
+    let block_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"data") else {
+            panic!("the SST must carry a data section");
+        };
+        usize::try_from(entry.pos()).expect("data offset fits usize")
+    };
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("data block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("data payload within the file");
+    };
+
+    // Locate the hash index within the footer-stripped inner block. For an
+    // uncompressed block the inner data is a prefix of the on-disk payload,
+    // so the inner offset maps straight through.
+    let (hi_offset, hi_len) = {
+        let loaded = Block {
+            header: Header {
+                block_type: BlockType::Data,
+                ..header
+            },
+            data: crate::Slice::from(payload.to_vec()),
+        };
+        let data_block = DataBlock::from_loaded(loaded, true)?;
+        data_block
+            .hash_index_span()
+            .expect("the block must carry a hash index")
+    };
+    {
+        let start = payload_range.start + hi_offset;
+        let Some(region) = bytes.get_mut(start..start + hi_len) else {
+            panic!("hash index within the payload");
+        };
+        patch(region);
+    }
+
+    // Re-stamp the block header checksum over the altered payload.
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("data payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("data header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let parity = crate::ecc::encode_parity(
+            bytes.get(payload_range).expect("payload"),
+            data_shards.into(),
+            parity_shards.into(),
+        )?;
+        let Some(dst) = bytes.get_mut(payload_end..payload_end + parity.len()) else {
+            panic!("parity trailer within the file");
+        };
+        dst.copy_from_slice(&parity);
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = shards;
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Forges the `filter` section so that the key hashing to `target_hash`
+/// becomes a FALSE NEGATIVE: searches for a single payload byte whose flip
+/// makes the (still parseable) `BuRR` filter report the hash as definitely
+/// absent, then re-stamps the block checksum plus, for a parity-bearing SST,
+/// the block's parity trailer. Every byte-level and framing check reads
+/// clean while a point read for that key is silently skipped — the shape
+/// only a probe of the filter against the blocks' decoded keys can catch.
+///
+/// Operates on the FIRST filter block of the section (in partitioned mode
+/// that is the partition covering the lowest keys, so pass the hash of the
+/// table's first key). The table must be unencrypted (the payload is probed
+/// as plaintext). `shards` is the SST's descriptor scheme (`None` for a
+/// parity-less table).
+pub fn forge_filter_false_negative(
+    path: &std::path::Path,
+    target_hash: u64,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+    use crate::table::filter::ribbon::burr::contains_hash_from_bytes;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"filter") else {
+            panic!("the SST must carry a filter section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("section block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("section payload within the file");
+    };
+    assert!(
+        matches!(contains_hash_from_bytes(payload, target_hash), Ok(true)),
+        "the target key must be present in the healthy filter",
+    );
+    // Search for one byte whose flip turns the target hash into a false
+    // negative while the filter still PARSES (a parse failure would be an
+    // unreadable filter, not the silent-skip shape this forge models).
+    let mut candidate = payload.to_vec();
+    let flipped_at = (0..candidate.len()).find(|&i| {
+        let Some(slot) = candidate.get_mut(i) else {
+            return false;
+        };
+        *slot ^= 0xFF;
+        let miss = matches!(contains_hash_from_bytes(&candidate, target_hash), Ok(false));
+        if !miss {
+            let Some(slot) = candidate.get_mut(i) else {
+                return false;
+            };
+            *slot ^= 0xFF;
+        }
+        miss
+    });
+    assert!(
+        flipped_at.is_some(),
+        "some payload byte flip must produce a parseable false-negative filter",
+    );
+    {
+        let Some(dst) = bytes.get_mut(payload_range.clone()) else {
+            panic!("section payload within the file");
+        };
+        dst.copy_from_slice(&candidate);
+    }
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(&candidate));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("section header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    // Re-stamp THIS block's parity trailer only (the section may hold more
+    // partition blocks after it, each with its own frame).
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let parity =
+            crate::ecc::encode_parity(&candidate, data_shards.into(), parity_shards.into())?;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("section length fits usize");
+        };
+        assert!(
+            payload_end + parity.len() <= block_off + section_len,
+            "the parity trailer stays within the section",
+        );
+        let Some(dst) = bytes.get_mut(payload_end..payload_end + parity.len()) else {
+            panic!("parity trailer within the file");
+        };
+        dst.copy_from_slice(&parity);
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = (section_len, shards);
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// ZEROES the LAST entry's `[seqno_min, seqno_max]` inside the
+/// `seqno_bounds` section's payload and re-stamps the block checksum (plus,
+/// for a parity-bearing SST, the descriptor-scheme parity trailer): the map
+/// stays structurally valid (`min <= max`, offsets untouched) and every
+/// byte-level check reads clean, while `scan_since_seqno` now SKIPS the
+/// block for any window above zero — the shape only a cross-check against
+/// the block's actually-decoded entries can catch. `shards` is the SST's
+/// descriptor scheme (`None` for a parity-less table).
+pub fn forge_seqno_bounds_zeroed_entry(
+    path: &std::path::Path,
+    shards: Option<(u8, u8)>,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let (pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"seqno_bounds") else {
+            panic!("the SST must carry a seqno_bounds section");
+        };
+        (entry.pos(), entry.len())
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("seqno_bounds block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("seqno_bounds payload within the file");
+        };
+        // Wire layout: [count u32 LE] then count x [offset u64 | min u64 | max u64].
+        let count = u32::from_le_bytes(
+            payload
+                .get(..4)
+                .expect("count prefix")
+                .try_into()
+                .expect("4 bytes"),
+        ) as usize;
+        assert!(count >= 1, "the map records at least one block");
+        let min_at = 4 + (count - 1) * 24 + 8;
+        let Some(minmax) = payload.get_mut(min_at..min_at + 16) else {
+            panic!("last entry's bounds within the payload");
+        };
+        minmax.fill(0);
+    }
+    let Some(payload) = bytes.get(payload_range.clone()) else {
+        panic!("seqno_bounds payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("seqno_bounds header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+
+    // Recompute the descriptor-scheme parity trailer over the forged payload
+    // so a parity-bearing SST reads clean rather than as parity rot.
+    #[cfg(feature = "page_ecc")]
+    if let Some((data_shards, parity_shards)) = shards {
+        let payload_end = payload_range.end;
+        let Ok(section_len) = usize::try_from(section_len) else {
+            panic!("section length fits usize");
+        };
+        let frame_end = block_off + section_len;
+        if frame_end > payload_end {
+            let Some(payload) = bytes.get(payload_range) else {
+                panic!("seqno_bounds payload within the file");
+            };
+            let parity =
+                crate::ecc::encode_parity(payload, data_shards.into(), parity_shards.into())?;
+            assert_eq!(
+                frame_end - payload_end,
+                parity.len(),
+                "the frame's trailer length matches the descriptor scheme",
+            );
+            let Some(dst) = bytes.get_mut(payload_end..frame_end) else {
+                panic!("parity trailer within the file");
+            };
+            dst.copy_from_slice(&parity);
+        }
+    }
+    #[cfg(not(feature = "page_ecc"))]
+    let _ = (section_len, shards);
+
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// REPLACES the `seqno_bounds` section with a valid, checksum-consistent block
+/// encoding an EMPTY map (a bare `count = 0`), shifting the following sections
+/// and re-stamping the TOC + trailer. Models the "rename an unused section to
+/// `seqno_bounds` and re-stamp it empty" forge: every byte-level check reads
+/// clean, yet the map records bounds for zero blocks even though the table
+/// still holds data blocks. The SST must be PLAIN (no compression / encryption
+/// / parity on the section) so the forged frame matches the reader's transform.
+pub fn forge_seqno_bounds_empty(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let mut payload = Vec::new();
+    crate::table::seqno_bounds::encode_seqno_bounds(&mut payload, &[])?;
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::SeqnoBounds,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &BlockTransform::PLAIN)?;
+    replace_section_frame(path, b"seqno_bounds", &forged)
+}
+
+/// REPLACES the `block_layout` section with a valid, checksum-consistent block
+/// encoding an EMPTY map, shifting the following sections and re-stamping the
+/// TOC + trailer. Models the "rename a `delete_bitmap` to an empty `block_layout`"
+/// forge: every byte-level check reads clean, yet the map records boundaries for
+/// zero blocks even though the table carries multi-inner-block frames. Pass the
+/// table's encryption provider for a keyed SST (the forged block is AEAD-sealed
+/// under the `block_layout` block type so the verifier decodes it), or `None`
+/// for a plaintext SST; the section carries no compression / parity either way.
+pub fn forge_block_layout_empty(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let mut payload = Vec::new();
+    crate::table::block_layout::encode_block_layouts(&mut payload, &[]);
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::BlockLayout,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let transform = match encryption {
+        Some(enc) => BlockTransform::Encrypted(enc),
+        None => BlockTransform::PLAIN,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &transform)?;
+    replace_section_frame(path, b"block_layout", &forged)
+}
+
+/// REPLACES the `zone_map` section with a valid, checksum-consistent `ZoneMap`
+/// block encoding an EMPTY map (zero entries), re-stamping the TOC + trailer.
+/// Models a `delete_bitmap` relabeled and re-roled to an empty `zone_map`: every
+/// byte-level check reads clean, yet the map records stats for zero blocks even
+/// though the table carries data. The SST must be PLAIN (no compression /
+/// encryption / parity on the section block).
+pub fn forge_zone_map_empty(path: &std::path::Path, table_id: crate::TableId) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let mut payload = Vec::new();
+    crate::table::zone_map::encode_zone_map(&mut payload, &[])?;
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::ZoneMap,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &BlockTransform::PLAIN)?;
+    replace_section_frame(path, b"zone_map", &forged)
+}
+
+/// REPLACES the `delete_bitmap` section with a valid, checksum-consistent
+/// `DeleteBitmap` block that decodes to an EMPTY bitmap, re-stamping the TOC +
+/// trailer. The writer only emits the section when the bitmap is NON-empty, so
+/// a present-but-empty bitmap is a checksum-consistent corruption: it keeps the
+/// section visible (so the concealment guards stay exempt) while carrying no
+/// positions, which would let a masked salvage re-emit every deleted row live.
+/// The SST must be PLAIN (no encryption / parity on the section block).
+pub fn forge_delete_bitmap_empty(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let payload = crate::table::delete_bitmap::DeleteBitmap::new().encode();
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::DeleteBitmap,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &BlockTransform::PLAIN)?;
+    replace_section_frame(path, b"delete_bitmap", &forged)
+}
+
+/// REPLACES the `delete_bitmap` section with a valid, checksum-consistent
+/// `DeleteBitmap` built from `positions`, re-stamping the TOC + trailer. With the
+/// SAME number of positions in the same chunk as the original it keeps the
+/// encoded length (and cardinality) identical — passing the count-only
+/// cross-check — while its CONTENTS differ, modelling an equal-cardinality
+/// substitution that resurrects different rows. The SST must be PLAIN.
+pub fn forge_delete_bitmap_substitute(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    positions: &[u32],
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let mut bitmap = crate::table::delete_bitmap::DeleteBitmap::new();
+    for &pos in positions {
+        bitmap.insert(pos);
+    }
+    let payload = bitmap.encode();
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::DeleteBitmap,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &BlockTransform::PLAIN)?;
+    replace_section_frame(path, b"delete_bitmap", &forged)
+}
+
+/// REPLACES the `filter` section with a valid, checksum-consistent Filter block
+/// carrying an EMPTY payload (the "no filter installed" sentinel), re-stamping
+/// the TOC + trailer. Models a `delete_bitmap` renamed and re-roled to an empty
+/// full `filter`: the read-path probe reports `Ok(true)` for every key on an
+/// empty payload, so the relabel would launder the deletion metadata unnoticed.
+/// The SST must be PLAIN (no encryption / parity on the section block).
+pub fn forge_filter_empty(path: &std::path::Path, table_id: crate::TableId) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::Filter,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &[], identity, &BlockTransform::PLAIN)?;
+    replace_section_frame(path, b"filter", &forged)
+}
+
+/// Empties the FIRST filter partition block IN PLACE: re-stamps its header to
+/// `data_length = 0` with the empty-payload checksum and a fresh header
+/// checksum, leaving the original bytes (and the block's on-disk size / the
+/// `filter_tli` handle) untouched, so the loader frames the same span but reads
+/// a zero-length ("no filter" sentinel) payload. Models a `filter_tli` that
+/// addresses an empty partition (a relabeled `delete_bitmap`): the read-path probe
+/// answers `Ok(true)` for every key it covers. The SST must be PLAIN and
+/// parity-less (the partition block carries no compression / encryption / ECC).
+pub fn forge_filter_first_partition_empty(path: &std::path::Path) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let pos = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"filter") else {
+            panic!("the SST must carry a filter section");
+        };
+        entry.pos()
+    };
+    let block_off = usize::try_from(pos).expect("section offset fits usize");
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("filter partition block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    // Empty payload sentinel: zero length, checksum over no bytes.
+    let new_header = Header {
+        data_length: 0,
+        uncompressed_length: 0,
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(&[])),
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("filter partition header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Re-stamps the data block header at `block_off` so its `data_length` spans
+/// all the way to `forged_end_off` (which must land on a LATER block boundary),
+/// leaving the ORIGINAL payload checksum untouched. The header's own integrity
+/// checksum is recomputed, so a header-only frame accepts the forged size — but
+/// the payload it now claims fails its checksum, so a full block LOAD rejects
+/// it. This models a checksum-valid FAKE header inside corrupt bytes whose
+/// oversized span hides the real blocks after it: a physical salvage walk that
+/// advanced by the framed size (before loading) would skip every block up to
+/// `forged_end_off`. The SST must be unencrypted with a parity-less data
+/// section (the span is computed as `header_len + data_length`).
+pub fn forge_data_block_oversized_header(
+    path: &std::path::Path,
+    block_off: u64,
+    forged_end_off: u64,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    let at = usize::try_from(block_off).expect("block offset fits usize");
+    let end = usize::try_from(forged_end_off).expect("forged end offset fits usize");
+    let Some(block) = bytes.get(at..) else {
+        panic!("the data block header at {at} lies within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let forged_len = end
+        .checked_sub(at + header_len)
+        .expect("forged end offset lies past the block header");
+    let forged_data_length = u32::try_from(forged_len).expect("forged data_length fits u32");
+    // Keep the original `checksum` (data checksum over the SMALL real payload)
+    // so the enlarged payload fails to load; only `data_length` grows.
+    let new_header = Header {
+        data_length: forged_data_length,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(at..at + header_len) else {
+        panic!("the data block header at {at} lies within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// REPLACES the `tli_tail` mirror with a re-encoded index block whose LAST
+/// handle was dropped, shifting the following `meta` section and re-stamping
+/// the TOC + trailer: every byte-level check (checksum, parity, role) stays
+/// clean while the tail mirror now DECODES to a different handle list than
+/// the intact head `tli` — the shape only a decoded mirror comparison can
+/// catch. `read_tli` prefers the tail on the next recovery, so the forged
+/// mirror silently hides the last data block's keys. The SST must be
+/// unencrypted and its index uncompressed; `ecc` is the table's descriptor
+/// scheme (`None` for a parity-less SST) so the forged block carries valid
+/// parity where the original did.
+pub fn forge_tli_tail_truncated(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    let forged = truncated_tli_frame(path, table_id, ecc)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// As [`forge_tli_tail_truncated`], but applied to BOTH mirrors (`tli` and
+/// `tli_tail`) so the copies stay CONSISTENT with each other: the decoded
+/// mirror comparison passes and only a structural check of the handle list
+/// against the physical data section can catch the dropped handle.
+pub fn forge_tli_mirrors_truncated(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    let forged = truncated_tli_frame(path, table_id, ecc)?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Re-encodes BOTH TLI mirrors (`tli`, `tli_tail`) after LOWERING the first
+/// block's separator (end) key to a truncated prefix of itself: still
+/// strictly below the next block's separator, so the handle list stays
+/// sorted, the mirrors stay equal, and the section tiling holds — but the
+/// separator no longer matches the addressed block's real last key. After
+/// reopen the index binary search routes keys in `(forged_separator,
+/// real_last_key]` to the WRONG block, so `point_read` returns `None` for
+/// existing keys. Only a cross-check of each separator against the
+/// addressed block's decoded final key can catch it. The SST must be
+/// unencrypted, its index uncompressed, and carry >= 2 data blocks.
+pub fn forge_tli_mirrors_lower_first_separator(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    let forged = rebuilt_tli_frame(path, table_id, ecc, |handles| {
+        use crate::table::KeyedBlockHandle;
+        let first = handles.first().expect("at least two handles");
+        let key = first.end_key().as_ref();
+        assert!(key.len() >= 2, "separator key long enough to truncate");
+        // A one-byte-shorter prefix is lexicographically smaller than the
+        // original and still smaller than the next block's separator.
+        let lowered = crate::UserKey::from(key.get(..key.len() - 1).expect("prefix"));
+        let rebuilt = KeyedBlockHandle::new(lowered, first.seqno(), *first.as_ref());
+        if let Some(slot) = handles.get_mut(0) {
+            *slot = rebuilt;
+        }
+    })?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Re-stamps the LAST binary-index pointer of BOTH TLI mirrors (`tli`,
+/// `tli_tail`) to the FIRST pointer's value, then re-encodes each frame
+/// (fresh checksum, role, and, under `ecc`, parity). The entry stream is
+/// untouched, so a sequential decode still yields every correct separator
+/// and handle — mirror equality, section tiling, and the separator
+/// cross-checks all pass — yet the index binary search trusts the forged
+/// pointer and can land on the wrong restart head, silently missing keys
+/// on seeks after reopen. Only a comparison of each pointer against the
+/// sequentially derived restart heads can catch it. The SST must be
+/// unencrypted, its index uncompressed, and carry >= 2 data blocks.
+pub fn forge_tli_binary_index_pointer(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    use crate::table::block::Block;
+
+    let (identity, transform, index) = tli_forge_frame(path, table_id, ecc)?;
+    let (mut payload, bi_offset, bi_len, step) = {
+        // Locate the binary index from the trailer metadata.
+        let meta = index.decoder_meta().expect("tli trailer parses");
+        (
+            index.as_slice().to_vec(),
+            usize::try_from(meta.binary_index_offset()).expect("offset fits usize"),
+            usize::try_from(meta.binary_index_len()).expect("len fits usize"),
+            usize::from(meta.binary_index_step_size()),
+        )
+    };
+    assert!(
+        bi_len >= 2,
+        "the forge needs at least two pointers so first != last",
+    );
+    let first: Vec<u8> = payload
+        .get(bi_offset..bi_offset + step)
+        .expect("first pointer within the payload")
+        .to_vec();
+    let last_at = bi_offset + (bi_len - 1) * step;
+    payload
+        .get_mut(last_at..last_at + step)
+        .expect("last pointer within the payload")
+        .copy_from_slice(&first);
+
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &transform)?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Rebuilds the `locator` section from `entries` (`(key_hash, block_id,
+/// slot)` triples under `Restart` precision) and re-frames it (fresh
+/// checksum, `Locator` role, no ECC / encryption). The caller passes the
+/// source's HONEST triples with one key's slot redirected to a later
+/// restart interval: the block id stays correct so the block-id gate
+/// passes, yet `point_read_at_slot` starts at the wrong interval and
+/// returns an older version. The SST must be unencrypted, non-ECC,
+/// already carry a `locator` section, AND have been written with
+/// `Restart` precision — the helper hardcodes `Restart` and does not read
+/// the source's precision byte, so forging an `Entry` / `Block`-precision
+/// SST would silently change its slot semantics. `table_id` is the SST's
+/// id (0 for a standalone Writer fixture).
+pub fn forge_locator_slots(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    entries: &[(u64, u64, u64)],
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+
+    let spec = crate::table::locator::LocatorSpec {
+        precision: crate::config::LocatorPrecision::Restart,
+        block_id_bits: None,
+        slot_bits: None,
+    };
+    let Some(section) = crate::table::locator::build_locator_section(entries, spec) else {
+        panic!("the forged locator entries must build a section");
+    };
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::Locator,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let transform = crate::table::block::BlockTransform::PLAIN;
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &section, identity, &transform)?;
+    replace_section_frame(path, b"locator", &forged)
+}
+
+/// Re-encodes the `zone_map` section WITHOUT its LAST block entry (fresh
+/// checksum, `ZoneMap` role): paired with a TLI forge hiding the same
+/// trailing block, the positioning chain over the remaining indexed
+/// blocks stays self-consistent — the omitted block is invisible to every
+/// index-driven check and only a physical data-section walk can find it.
+/// The SST must be unencrypted, non-ECC, and carry a zone map with >= 2
+/// entries.
+pub fn forge_zone_map_drop_last_entry(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+    use crate::table::{BlockHandle, BlockOffset};
+
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::ZoneMap,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let transform = crate::table::block::BlockTransform::from_parts(
+        crate::CompressionType::None,
+        None,
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    let (pos, len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"zone_map") else {
+            panic!("the SST must carry a zone_map section");
+        };
+        (
+            usize::try_from(entry.pos()).expect("pos fits usize"),
+            usize::try_from(entry.len()).expect("len fits usize"),
+        )
+    };
+    let blocks: Vec<(BlockOffset, Vec<crate::table::zone_map::ColumnStats>)> = {
+        let file = crate::fs::Fs::open(
+            &crate::fs::StdFs,
+            path,
+            &crate::fs::FsOpenOptions::new().read(true),
+        )?;
+        let block = Block::from_file(
+            &*file,
+            BlockHandle::new(
+                BlockOffset(u64::try_from(pos).expect("pos fits u64")),
+                u32::try_from(len).expect("section fits u32"),
+            ),
+            identity,
+            &transform,
+        )?;
+        let map = crate::table::zone_map::ZoneMap::decode(&block.data)?;
+        let entries = map.entries();
+        assert!(
+            entries.len() >= 2,
+            "dropping the last entry must leave a non-empty map",
+        );
+        entries
+            .get(..entries.len() - 1)
+            .expect("all but the last entry")
+            .iter()
+            .map(|(off, cols)| (BlockOffset(*off), cols.clone()))
+            .collect()
+    };
+
+    let mut payload = Vec::new();
+    crate::table::zone_map::encode_zone_map(&mut payload, &blocks)?;
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &transform)?;
+    replace_section_frame(path, b"zone_map", &forged)
+}
+
+/// Re-stamps the `zone_map` so the FIRST data block's synthetic column carries
+/// a NON-ZERO `column_id` (a consumer value-column id) while its min / max / row
+/// count stay intact. Models a checksum-restamped zone map that repurposes the
+/// whole-block key statistic as a value-column statistic: the key-bounds check
+/// still passes, but `ColumnRangePredicate::can_skip_block` would then read
+/// those key bounds as value-column stats and skip blocks holding matching
+/// rows. The SST must be uncompressed and unencrypted.
+pub fn forge_zone_map_column_id(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+    use crate::table::{BlockHandle, BlockOffset};
+
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::ZoneMap,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let transform = crate::table::block::BlockTransform::from_parts(
+        crate::CompressionType::None,
+        None,
+        #[cfg(zstd_any)]
+        None,
+    )?;
+
+    let (pos, len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"zone_map") else {
+            panic!("the SST must carry a zone_map section");
+        };
+        (
+            usize::try_from(entry.pos()).expect("pos fits usize"),
+            usize::try_from(entry.len()).expect("len fits usize"),
+        )
+    };
+    let mut blocks: Vec<(BlockOffset, Vec<crate::table::zone_map::ColumnStats>)> = {
+        let file = crate::fs::Fs::open(
+            &crate::fs::StdFs,
+            path,
+            &crate::fs::FsOpenOptions::new().read(true),
+        )?;
+        let block = Block::from_file(
+            &*file,
+            BlockHandle::new(
+                BlockOffset(u64::try_from(pos).expect("pos fits u64")),
+                u32::try_from(len).expect("section fits u32"),
+            ),
+            identity,
+            &transform,
+        )?;
+        let map = crate::table::zone_map::ZoneMap::decode(&block.data)?;
+        map.entries()
+            .iter()
+            .map(|(off, cols)| (BlockOffset(*off), cols.clone()))
+            .collect()
+    };
+    let Some((_off, cols)) = blocks.first_mut() else {
+        panic!("the zone_map carries at least one block entry");
+    };
+    let Some(col) = cols.first_mut() else {
+        panic!("the block entry carries its synthetic column");
+    };
+    assert_eq!(
+        col.column_id, 0,
+        "the writer stamps a zero synthetic column id",
+    );
+    col.column_id = 7;
+
+    let mut payload = Vec::new();
+    crate::table::zone_map::encode_zone_map(&mut payload, &blocks)?;
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &transform)?;
+    replace_section_frame(path, b"zone_map", &forged)
+}
+
+/// Shared preamble of the TLI forges: the Index identity, the uncompressed
+/// (optionally ECC) transform, and the DECODED `tli_tail` mirror. Every TLI
+/// forge must agree on these — a drift between copies would silently write
+/// an unreadable frame instead of the intended corruption. The SST must be
+/// unencrypted and its index uncompressed.
+fn tli_forge_frame(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<(
+    crate::table::block::BlockIdentity,
+    crate::table::block::BlockTransform<'static>,
+    crate::table::IndexBlock,
+)> {
+    use crate::table::block::{Block, BlockIdentity, BlockType};
+    use crate::table::{BlockHandle, BlockOffset, IndexBlock};
+
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::Index,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let transform = {
+        let t = crate::table::block::BlockTransform::from_parts(
+            crate::CompressionType::None,
+            None,
+            #[cfg(zstd_any)]
+            None,
+        )?;
+        if let Some(ecc) = ecc {
+            t.with_ecc(ecc)
+        } else {
+            t
+        }
+    };
+
+    let (tail_pos, tail_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"tli_tail") else {
+            panic!("the SST must carry a tli_tail mirror");
+        };
+        (
+            usize::try_from(entry.pos()).expect("pos fits usize"),
+            usize::try_from(entry.len()).expect("len fits usize"),
+        )
+    };
+    let file = crate::fs::Fs::open(
+        &crate::fs::StdFs,
+        path,
+        &crate::fs::FsOpenOptions::new().read(true),
+    )?;
+    let block = Block::from_file(
+        &*file,
+        BlockHandle::new(
+            BlockOffset(u64::try_from(tail_pos).expect("pos fits u64")),
+            u32::try_from(tail_len).expect("tail section fits u32"),
+        ),
+        identity,
+        &transform,
+    )?;
+    Ok((identity, transform, IndexBlock::new(block)))
+}
+
+/// Re-encodes BOTH TLI mirrors (`tli`, `tli_tail`) with an INTERIOR handle
+/// removed (the middle of the list), so the hidden block sits between two
+/// indexed neighbours rather than at the section tail. The mirrors stay
+/// equal and every remaining handle is intact — only a physical tiling
+/// cross-check can notice the interior gap. The SST must be unencrypted,
+/// its index uncompressed, and carry >= 3 data blocks.
+pub fn forge_tli_mirrors_drop_interior(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    let forged = rebuilt_tli_frame(path, table_id, ecc, |handles| {
+        assert!(
+            handles.len() >= 3,
+            "an interior drop needs a handle strictly between two neighbours",
+        );
+        handles.remove(handles.len() / 2);
+    })?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Re-encodes BOTH TLI mirrors (`tli`, `tli_tail`) as a SINGLE handle that
+/// starts at the first block and spans the ENTIRE summed size, keeping the
+/// first block's separator. Cumulative tiling accepts it (one span covers
+/// the section), the mirrors stay equal, and the separator matches the
+/// spanned frame's decoded content (only the FIRST payload decodes; the
+/// rest reads as an unrecognized trailer on a non-ECC block) — yet every
+/// later physical block is unreachable through the index. Only a
+/// per-handle comparison against the physical block frame can catch it.
+/// The SST must be unencrypted, non-ECC, its index uncompressed, and
+/// carry >= 2 data blocks.
+pub fn forge_tli_mirrors_span_single_handle(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    let forged = rebuilt_tli_frame(path, table_id, None, |handles| {
+        use crate::table::{BlockHandle, KeyedBlockHandle};
+        // With a single handle the "spanning" replacement would be
+        // byte-identical to the original — a silent no-op fixture instead
+        // of the intended corruption.
+        assert!(
+            handles.len() >= 2,
+            "spanning a single handle needs at least two handles to hide",
+        );
+        let total: u32 = handles.iter().map(|h| h.as_ref().size()).sum();
+        let Some(first) = handles.first() else {
+            panic!("the source carries data blocks");
+        };
+        let spanning = KeyedBlockHandle::new(
+            first.end_key().clone(),
+            first.seqno(),
+            BlockHandle::new(first.as_ref().offset(), total),
+        );
+        *handles = vec![spanning];
+    })?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Re-encodes BOTH TLI mirrors with an EXTRA handle whose offset sits far
+/// beyond any data section (as a checksum-repatched index could declare). The
+/// real handles stay intact; the appended one sorts last, so a salvage gap walk
+/// that probes up to a handle's offset without bounding it to the section end
+/// would scan the whole space between the section and that offset (an unbounded
+/// hang, and later SST sections read as candidate data frames). The SST must be
+/// unencrypted and its index uncompressed, and carry >= 2 data blocks.
+pub fn forge_tli_mirrors_offset_beyond_section(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    let forged = rebuilt_tli_frame(path, table_id, None, |handles| {
+        use crate::table::{BlockHandle, KeyedBlockHandle};
+        let Some(last) = handles.last().cloned() else {
+            panic!("the source carries data blocks");
+        };
+        let beyond = KeyedBlockHandle::new(
+            last.end_key().clone(),
+            last.seqno(),
+            BlockHandle::new(
+                crate::table::block::BlockOffset(u64::MAX / 2),
+                last.as_ref().size(),
+            ),
+        );
+        handles.push(beyond);
+    })?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Re-encodes BOTH TLI mirrors (`tli`, `tli_tail`) with the FIRST TWO
+/// handles SWAPPED: every handle is still present and intact, the mirrors
+/// stay equal, and the section is still fully covered — but the list is no
+/// longer in offset (key) order. A physical tiling pass that trusts the
+/// stored order double-covers the out-of-place block (once via the gap
+/// probe, once via the handle) unless it re-sorts and skips covered spans.
+/// The SST must be unencrypted, its index uncompressed, and carry >= 2
+/// data blocks.
+pub fn forge_tli_mirrors_swap_first_two(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<()> {
+    let forged = rebuilt_tli_frame(path, table_id, ecc, |handles| {
+        handles.swap(0, 1);
+    })?;
+    replace_section_frame(path, b"tli", &forged)?;
+    replace_section_frame(path, b"tli_tail", &forged)
+}
+
+/// Decodes the `tli_tail` mirror's handle list, drops the LAST handle, and
+/// returns the re-encoded Index frame (checksum-, role-, and, under `ecc`,
+/// parity-consistent). The SST must be unencrypted and its index
+/// uncompressed.
+fn truncated_tli_frame(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+) -> crate::Result<Vec<u8>> {
+    rebuilt_tli_frame(path, table_id, ecc, |handles| {
+        handles.pop();
+    })
+}
+
+/// Decodes the `tli_tail` mirror's handle list, applies `mutate`, and returns
+/// the re-encoded Index frame (checksum-, role-, and, under `ecc`,
+/// parity-consistent). The SST must be unencrypted and its index
+/// uncompressed, and the mutated list must stay DECODABLE (the delta
+/// encoding does not require sorted input — the reorder forge relies on
+/// that to model an out-of-order forged index).
+fn rebuilt_tli_frame(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+    ecc: Option<crate::table::block::EccParams>,
+    mutate: impl FnOnce(&mut Vec<crate::table::KeyedBlockHandle>),
+) -> crate::Result<Vec<u8>> {
+    use crate::table::block::Block;
+    use crate::table::{IndexBlock, KeyedBlockHandle};
+
+    let (identity, transform, index) = tli_forge_frame(path, table_id, ecc)?;
+    let mut handles: Vec<KeyedBlockHandle> = {
+        use crate::table::block::ParsedItem as _;
+        let mut out = Vec::new();
+        for item in index.iter(crate::comparator::default_comparator()) {
+            out.push(item.materialize(index.as_slice()));
+        }
+        out
+    };
+    assert!(
+        handles.len() >= 2,
+        "the forge needs at least two handles so the mutation leaves a valid index",
+    );
+
+    mutate(&mut handles);
+
+    let payload = IndexBlock::encode_into_vec(&handles)?;
+    let mut forged = Vec::new();
+    Block::write_into(&mut forged, &payload, identity, &transform)?;
+    Ok(forged)
+}
+
+/// Replaces the named single-block section's bytes with `forged`, shifting
+/// every later section, patching the TOC's length + positions, and
+/// re-stamping the trailer. The rebuilt archive stays internally consistent
+/// in every byte-level check.
+fn replace_section_frame(
+    path: &std::path::Path,
+    section: &[u8],
+    forged: &[u8],
+) -> crate::Result<()> {
+    let bytes = std::fs::read(path)?;
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let (section_pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == section) else {
+            panic!("the SST must carry the section to replace");
+        };
+        (
+            usize::try_from(entry.pos()).expect("pos fits usize"),
+            usize::try_from(entry.len()).expect("len fits usize"),
+        )
+    };
+
+    // Rebuild the file: splice the forged frame in, shift the trailing
+    // sections, fix the TOC's length + shifted positions, re-stamp the
+    // trailer.
+    let delta = i64::try_from(forged.len()).expect("forged block fits i64")
+        - i64::try_from(section_len).expect("section fits i64");
+    let mut out = Vec::with_capacity(bytes.len());
+    out.extend_from_slice(bytes.get(..section_pos).expect("pre-section prefix"));
+    out.extend_from_slice(forged);
+    out.extend_from_slice(
+        bytes
+            .get(section_pos + section_len..toc_pos)
+            .expect("post-section sections"),
+    );
+    let new_toc_pos = out.len();
+
+    // Rebuild the TOC from the old one, patching lengths/positions.
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+    let toc = bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region");
+    assert_eq!(toc.get(..4), Some(&b"TOC!"[..]), "TOC magic");
+    let count = u32::from_le_bytes(toc.get(4..8).expect("count").try_into().expect("4 bytes"));
+    let mut new_toc = Vec::with_capacity(toc.len());
+    new_toc.extend_from_slice(toc.get(..8).expect("TOC header"));
+    let mut at = 8usize;
+    for _ in 0..count {
+        let pos = read_u64(toc, at);
+        let len = read_u64(toc, at + 8);
+        let name_len = usize::from(u16::from_le_bytes(
+            toc.get(at + 16..at + 18)
+                .expect("name_len")
+                .try_into()
+                .expect("2 bytes"),
+        ));
+        let name = toc.get(at + 18..at + 18 + name_len).expect("name");
+        let (new_pos, new_len) = if name == section {
+            (pos, forged.len() as u64)
+        } else if pos > section_pos as u64 {
+            (
+                pos.checked_add_signed(delta).expect("shifted pos fits u64"),
+                len,
+            )
+        } else {
+            (pos, len)
+        };
+        new_toc.extend_from_slice(&new_pos.to_le_bytes());
+        new_toc.extend_from_slice(&new_len.to_le_bytes());
+        new_toc.extend_from_slice(toc.get(at + 16..at + 18 + name_len).expect("name field"));
+        at += 18 + name_len;
+    }
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(&new_toc);
+        hasher.digest128()
+    };
+    out.extend_from_slice(&new_toc);
+    out.extend_from_slice(
+        bytes
+            .get(trailer_start..trailer_start + 4 + 1 + 1)
+            .expect("trailer head"),
+    );
+    out.extend_from_slice(&fresh.to_le_bytes());
+    out.extend_from_slice(
+        &u64::try_from(new_toc_pos)
+            .expect("toc_pos fits u64")
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(
+        &u64::try_from(new_toc.len())
+            .expect("TOC length fits u64")
+            .to_le_bytes(),
+    );
+    std::fs::write(path, &out)?;
+    Ok(())
+}
+
+/// RENAMES the `from` section to `to` in the TOC and REPLACES its bytes with
+/// `new_payload`, shifting the trailing sections and re-stamping the TOC +
+/// trailer. Models a raw-section relabel (a `delete_bitmap` replaced by a
+/// zero-count `linked_blob_files`, or re-roled to an empty `block_layout`): the
+/// catalogue stays uniquely named and tiled, every byte-level check reads clean,
+/// yet the deletion metadata is gone. `to` may differ in length from `from`.
+pub fn forge_rename_and_replace_section(
+    path: &std::path::Path,
+    from: &[u8],
+    to: &[u8],
+    new_payload: &[u8],
+) -> crate::Result<()> {
+    let bytes = std::fs::read(path)?;
+    const TRAILER_SIZE: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    let trailer_start = bytes.len() - TRAILER_SIZE;
+    let read_u64 = |bytes: &[u8], at: usize| {
+        let Some(b) = bytes.get(at..at + 8) else {
+            panic!("u64 field within the trailer");
+        };
+        u64::from_le_bytes(b.try_into().expect("8 bytes"))
+    };
+    let toc_pos = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16))
+        .expect("toc_pos fits usize");
+    let (section_pos, section_len) = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == from) else {
+            panic!("the SST must carry the section to rename");
+        };
+        (
+            usize::try_from(entry.pos()).expect("pos fits usize"),
+            usize::try_from(entry.len()).expect("len fits usize"),
+        )
+    };
+
+    let delta = i64::try_from(new_payload.len()).expect("payload fits i64")
+        - i64::try_from(section_len).expect("section fits i64");
+    let mut out = Vec::with_capacity(bytes.len());
+    out.extend_from_slice(bytes.get(..section_pos).expect("pre-section prefix"));
+    out.extend_from_slice(new_payload);
+    out.extend_from_slice(
+        bytes
+            .get(section_pos + section_len..toc_pos)
+            .expect("post-section sections"),
+    );
+    let new_toc_pos = out.len();
+
+    let toc_len = usize::try_from(read_u64(&bytes, trailer_start + 4 + 1 + 1 + 16 + 8))
+        .expect("toc_len fits usize");
+    let toc = bytes.get(toc_pos..toc_pos + toc_len).expect("TOC region");
+    assert_eq!(toc.get(..4), Some(&b"TOC!"[..]), "TOC magic");
+    assert_eq!(
+        toc_pos + toc_len,
+        trailer_start,
+        "the TOC must sit directly before the trailer; the splice above drops any gap",
+    );
+    let count = u32::from_le_bytes(toc.get(4..8).expect("count").try_into().expect("4 bytes"));
+    let mut new_toc = Vec::with_capacity(toc.len());
+    new_toc.extend_from_slice(b"TOC!");
+    new_toc.extend_from_slice(&count.to_le_bytes());
+    let mut at = 8usize;
+    for _ in 0..count {
+        let pos = read_u64(toc, at);
+        let len = read_u64(toc, at + 8);
+        let name_len = usize::from(u16::from_le_bytes(
+            toc.get(at + 16..at + 18)
+                .expect("name_len")
+                .try_into()
+                .expect("2 bytes"),
+        ));
+        let name = toc.get(at + 18..at + 18 + name_len).expect("name");
+        if name == from {
+            new_toc.extend_from_slice(&pos.to_le_bytes());
+            new_toc.extend_from_slice(&(new_payload.len() as u64).to_le_bytes());
+            new_toc.extend_from_slice(
+                &u16::try_from(to.len())
+                    .expect("name fits u16")
+                    .to_le_bytes(),
+            );
+            new_toc.extend_from_slice(to);
+        } else {
+            let new_pos = if pos > section_pos as u64 {
+                pos.checked_add_signed(delta).expect("shifted pos fits u64")
+            } else {
+                pos
+            };
+            new_toc.extend_from_slice(&new_pos.to_le_bytes());
+            new_toc.extend_from_slice(&len.to_le_bytes());
+            new_toc.extend_from_slice(toc.get(at + 16..at + 18 + name_len).expect("name field"));
+        }
+        at += 18 + name_len;
+    }
+    let fresh = {
+        let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
+        hasher.update(&new_toc);
+        hasher.digest128()
+    };
+    out.extend_from_slice(&new_toc);
+    out.extend_from_slice(
+        bytes
+            .get(trailer_start..trailer_start + 4 + 1 + 1)
+            .expect("trailer head"),
+    );
+    out.extend_from_slice(&fresh.to_le_bytes());
+    out.extend_from_slice(
+        &u64::try_from(new_toc_pos)
+            .expect("toc_pos fits u64")
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(
+        &u64::try_from(new_toc.len())
+            .expect("TOC len fits u64")
+            .to_le_bytes(),
+    );
+    std::fs::write(path, &out)?;
+    Ok(())
+}
+
+/// Renames the `delete_bitmap` section to `block_layout` and replaces its block
+/// with a valid EMPTY `BlockLayout` block. The writer only emits a real
+/// `block_layout` section for multi-inner-block (zstd) frames, so this
+/// synthesises the present-but-empty forgery on builds where it cannot occur
+/// naturally (non-zstd) to exercise the build-independent emptiness check. The
+/// SST must be PLAIN and parity-less: the replacement block is framed with
+/// `BlockTransform::PLAIN`, so an encrypted source would fail the AEAD open and
+/// an ECC source would read as a missing parity trailer, in both cases before
+/// the emptiness check runs.
+#[cfg(not(feature = "zstd"))]
+pub fn forge_delete_bitmap_as_empty_block_layout(
+    path: &std::path::Path,
+    table_id: crate::TableId,
+) -> crate::Result<()> {
+    use crate::table::block::{Block, BlockIdentity, BlockTransform, BlockType};
+
+    let mut payload = Vec::new();
+    crate::table::block_layout::encode_block_layouts(&mut payload, &[]);
+    let identity = BlockIdentity {
+        table_id,
+        block_type: BlockType::BlockLayout,
+        dict_id: 0,
+        window_log: 0,
+    };
+    let mut frame = Vec::new();
+    Block::write_into(&mut frame, &payload, identity, &BlockTransform::PLAIN)?;
+    forge_rename_and_replace_section(path, b"delete_bitmap", b"block_layout", &frame)
+}
+
+/// Shared core: flips `payload[len - flip_from_end]` of the FIRST data
+/// block of the SST at `path`, then recomputes the block header checksum
+/// over the altered payload so block-level verification reads clean.
+fn flip_and_restamp_first_data_block(
+    path: &std::path::Path,
+    flip_from_end: usize,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    let mut bytes = std::fs::read(path)?;
+    // The data section is the first SFA section, so the first data block
+    // starts at its position.
+    let block_off = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = match crate::sfa::Reader::from_reader(&mut f) {
+            Ok(r) => r,
+            Err(e) => panic!("reading the SFA trailer failed: {e:?}"),
+        };
+        let Some(entry) = reader.toc().iter().find(|e| e.name() == b"data") else {
+            panic!("the SST must carry a data section");
+        };
+        usize::try_from(entry.pos()).expect("data offset fits usize")
+    };
+    let Some(block) = bytes.get(block_off..) else {
+        panic!("data block within the file");
+    };
+    let mut cursor = block;
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+
+    {
+        let Some(payload) = bytes.get_mut(payload_range.clone()) else {
+            panic!("data payload within the file");
+        };
+        let flip_at = payload.len() - flip_from_end;
+        let Some(slot) = payload.get_mut(flip_at) else {
+            panic!("flip offset within the payload");
+        };
+        *slot ^= 0xFF;
+    }
+
+    // Re-stamp the block header checksum over the altered payload so the
+    // block-level walk reads clean. Fail loudly on a bad range: silently
+    // hashing an empty slice would leave the block failing the ORDINARY
+    // checksum walk, proving nothing about the stale-footer path.
+    let Some(payload) = bytes.get(payload_range) else {
+        panic!("data payload within the file");
+    };
+    let new_checksum = crate::Checksum::from_raw(crate::hash::hash128(payload));
+    let new_header = Header {
+        checksum: new_checksum,
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    let Some(hdr_dst) = bytes.get_mut(block_off..block_off + header_len) else {
+        panic!("data header within the file");
+    };
+    hdr_dst.copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// Raises the seqno of the FIRST entry of the data block at `block_off` from a
+/// 1-byte varint value to `new_seqno` (also `< 128`, so the varint width is
+/// unchanged and nothing shifts), then re-stamps the block header checksum. The
+/// row entry layout is `[value_type u8][seqno varint][...]`, so the seqno is the
+/// byte immediately after the header + the value-type byte. Models a
+/// checksum-restamped later block whose boundary key's seqno was raised.
+/// The SST must be uncompressed, unencrypted, footer-less, and parity-less: this
+/// helper edits the raw payload and re-stamps only the block-header checksum, so
+/// it neither decrypts/re-encrypts the payload nor regenerates any Page-ECC
+/// parity trailer.
+pub fn forge_raise_data_block_first_seqno(
+    path: &std::path::Path,
+    block_off: usize,
+    new_seqno: u8,
+) -> crate::Result<()> {
+    use crate::coding::{Decode, Encode};
+    use crate::table::block::Header;
+
+    assert!(
+        new_seqno < 0x80,
+        "the raised seqno must stay a 1-byte varint"
+    );
+    let mut bytes = std::fs::read(path)?;
+    let mut cursor = bytes.get(block_off..).expect("block within the file");
+    let header = Header::decode_from(&mut cursor)?;
+    let header_len = Header::header_len(header.block_type);
+    let payload_range =
+        block_off + header_len..block_off + header_len + header.data_length as usize;
+    // payload[0] = value_type, payload[1] = the seqno varint (1 byte for < 128).
+    let seqno_at = block_off + header_len + 1;
+    let old = *bytes.get(seqno_at).expect("seqno byte within the payload");
+    assert!(
+        old < 0x80,
+        "the original seqno must be a 1-byte varint, got {old:#x}"
+    );
+    if let Some(slot) = bytes.get_mut(seqno_at) {
+        *slot = new_seqno;
+    }
+    let payload = bytes.get(payload_range).expect("payload within the file");
+    let new_header = Header {
+        checksum: crate::Checksum::from_raw(crate::hash::hash128(payload)),
+        ..header
+    };
+    let mut hdr_bytes = Vec::with_capacity(header_len);
+    new_header.encode_into(&mut hdr_bytes)?;
+    bytes
+        .get_mut(block_off..block_off + header_len)
+        .expect("header within the file")
+        .copy_from_slice(&hdr_bytes);
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}

--- a/src/tree/columnar_scan.rs
+++ b/src/tree/columnar_scan.rs
@@ -465,7 +465,7 @@ impl ColumnarScan {
             kept.push(i);
         }
 
-        let mut merged = take_rows(&combined, &kept);
+        let mut merged = take_rows(&combined, &kept)?;
 
         // Apply the row predicate AFTER newest-version dedup: each surviving row is
         // now the newest visible version of its key, so a key whose newest version

--- a/src/tree/columnar_scan.rs
+++ b/src/tree/columnar_scan.rs
@@ -21,10 +21,13 @@
 //! overlap:
 //!
 //! - A **singleton** group (a segment whose key range overlaps no other) whose
-//!   rows are all visible streams its
+//!   rows are all visible AND provably one-version-per-key (the writer's
+//!   distinct-key count equals its row count) streams its
 //!   [`Table::columnar_scan`](crate::Table::columnar_scan) batches verbatim —
 //!   zero-copy column-skip, no key decode, no row gather. A singleton the
-//!   snapshot straddles gets a per-row seqno mask first.
+//!   snapshot straddles gets a per-row seqno mask first, and one that can hold
+//!   several versions of a key (an overwritten key in a flush / compaction
+//!   product) additionally gets per-key newest-visible dedup.
 //! - An **overlapping** group is row-merged: the projection is augmented with the
 //!   intrinsic key + seqno columns, each segment's rows are visibility-masked and
 //!   tagged with their effective seqno, the union is sorted by `(key asc,
@@ -66,6 +69,12 @@ struct Segment {
     global: SeqNo,
     /// Whether every row is visible at the snapshot, or visibility is per-row.
     visibility: SeqnoVisibility,
+    /// Whether this segment can physically hold several MVCC versions of one
+    /// key (a flush / compaction product with an overwritten key). Proven
+    /// unique only when the writer's distinct-key count equals the row count;
+    /// legacy tables without the count are conservatively assumed to carry
+    /// duplicates. Gates the singleton path's per-key newest-visible dedup.
+    may_dup: bool,
 }
 
 /// One key-disjoint group of segments: either a single segment (streamed
@@ -141,11 +150,16 @@ impl Tree {
                 ));
             }
             let key_range = &table.metadata.key_range;
+            let may_dup = table
+                .metadata
+                .key_count
+                .is_none_or(|k| k != table.metadata.item_count);
             segments.push(Segment {
                 min: key_range.min().clone(),
                 max: key_range.max().clone(),
                 global: table.global_seqno(),
                 visibility,
+                may_dup,
                 table: table.clone(),
             });
         }
@@ -240,6 +254,9 @@ impl ColumnarScan {
     /// (when the snapshot straddles the segment) or outside the requested range
     /// (when the segment only partially overlaps it).
     fn process_singleton(&self, seg: &Segment) -> crate::Result<Vec<ColumnBatch>> {
+        if seg.may_dup {
+            return self.process_singleton_dedup(seg);
+        }
         let range_filter = !self.range_is_full();
         if seg.visibility == SeqnoVisibility::All && !range_filter {
             let mut out = seg
@@ -326,6 +343,128 @@ impl ColumnarScan {
             }
             if range_filter && !key_projected {
                 visible.columns.retain(|c| c.column_id != COL_USER_KEY);
+            }
+            if visible.row_count > 0 {
+                out.push(visible);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Singleton whose segment can physically hold several MVCC versions of one
+    /// key (`Segment::may_dup`): every version is a physical row, so the scan
+    /// must keep only the newest VISIBLE version per key instead of streaming
+    /// the segment verbatim. Rows are stored in internal-key order (key
+    /// ascending, seqno descending within a key), so within each key run the
+    /// invisible too-new versions come first and the first visible row is the
+    /// newest visible version; a run can span batch boundaries, so the last
+    /// kept key carries across batches. The predicate runs AFTER dedup
+    /// (mirroring [`Self::merge_group`]): a key whose newest version fails the
+    /// predicate is dropped, never served from an older matching version —
+    /// which also rules out predicate-driven zone-map block-skip here.
+    fn process_singleton_dedup(&self, seg: &Segment) -> crate::Result<Vec<ColumnBatch>> {
+        // Decode the columns the dedup needs even when the caller did not
+        // project them (dropped again at the end): the key column always, the
+        // seqno column when the snapshot straddles the segment, the predicate
+        // column for the after-dedup filter.
+        let key_projected = self.projection.contains(&COL_USER_KEY);
+        let seqno_projected = self.projection.contains(&COL_SEQNO);
+        let partial = seg.visibility == SeqnoVisibility::Partial;
+        let mut augmented = self.projection.clone();
+        if !key_projected {
+            augmented.push(COL_USER_KEY);
+        }
+        if partial && !seqno_projected {
+            augmented.push(COL_SEQNO);
+        }
+        let predicate_col = self.predicate.as_ref().map(|p| p.column_id);
+        let predicate_col_projected = predicate_col.is_some_and(|c| self.projection.contains(&c));
+        if let Some(pc) = predicate_col
+            && !augmented.contains(&pc)
+        {
+            augmented.push(pc);
+        }
+
+        // Visible iff `local < threshold` (the snapshot in this segment's local
+        // seqno space); `Partial` guarantees the subtraction is in range.
+        let threshold = self.seqno.saturating_sub(seg.global);
+        let range_filter = !self.range_is_full();
+        let cmp = self.comparator.as_ref();
+
+        let mut out = Vec::new();
+        // The user key of the last key run whose newest visible version was
+        // already emitted (or deliberately dropped by the range filter) —
+        // owned, because a run can span batch boundaries.
+        let mut last_key: Option<alloc::vec::Vec<u8>> = None;
+        for batch in seg.table.columnar_scan(&augmented, None)? {
+            if batch.row_count == 0 {
+                continue;
+            }
+            let key_col = batch
+                .columns
+                .iter()
+                .find(|c| c.column_id == COL_USER_KEY)
+                .ok_or(Error::InvalidHeader(
+                    "columnar_scan: dedup batch missing the key column",
+                ))?;
+            let seqno_col = if partial {
+                Some(
+                    batch
+                        .columns
+                        .iter()
+                        .find(|c| c.column_id == COL_SEQNO)
+                        .ok_or(Error::InvalidHeader(
+                            "columnar_scan: dedup batch missing the seqno column",
+                        ))?,
+                )
+            } else {
+                None
+            };
+
+            let mut mask = Vec::with_capacity(batch.row_count as usize);
+            for row in 0..batch.row_count {
+                let visible = match seqno_col {
+                    Some(seqno_col) => fixed_u64_row(&seqno_col.data, row)? < threshold,
+                    None => true,
+                };
+                if !visible {
+                    mask.push(false);
+                    continue;
+                }
+                let key = bytes_column_row(&key_col.data, batch.row_count, row)?;
+                if last_key
+                    .as_deref()
+                    .is_some_and(|p| cmp.compare(p, key) == core::cmp::Ordering::Equal)
+                {
+                    // A later visible version of an already-decided key run —
+                    // shadowed by the newest visible version above it.
+                    mask.push(false);
+                    continue;
+                }
+                // First visible row of a new key run = the newest visible
+                // version. Deciding the run here (even when the range filter
+                // drops the row) also drops its older versions above.
+                last_key = Some(key.to_vec());
+                mask.push(!range_filter || key_in_bounds(key, &self.lo, &self.hi, cmp));
+            }
+
+            let mut visible = filter_batch(&batch, &mask);
+            // The predicate runs on the deduped survivors only (see doc).
+            if let Some(pred) = self.predicate.as_ref() {
+                let pred_mask = pred.matching_rows(&visible);
+                visible = filter_batch(&visible, &pred_mask);
+            }
+            // Match the singleton contract: yield exactly the projected columns.
+            if !key_projected {
+                visible.columns.retain(|c| c.column_id != COL_USER_KEY);
+            }
+            if !seqno_projected {
+                visible.columns.retain(|c| c.column_id != COL_SEQNO);
+            }
+            if let Some(pc) = predicate_col
+                && !predicate_col_projected
+            {
+                visible.columns.retain(|c| c.column_id != pc);
             }
             if visible.row_count > 0 {
                 out.push(visible);

--- a/src/tree/ingest.rs
+++ b/src/tree/ingest.rs
@@ -154,6 +154,11 @@ impl<'a> Ingestion<'a> {
         // tables are columnar too (a row ingest is transposed at spill, a
         // columnar batch is stored directly via `write_columnar_batch`).
         writer = writer.use_columnar(rc.columnar);
+        // Flag every ingested SST: its entries are written at local seqno 0 and
+        // rely on the `global_seqno` allocated at commit, so manifest repair must
+        // recognize the manifest-only offset (and fail closed when it is lost)
+        // rather than mistake the table for a normal flush at seqno 0.
+        writer = writer.use_bulk_ingested(true);
         writer = writer.use_disable_cow_on_sst(rc.disable_cow_on_sst_files);
         writer = writer.use_kv_checksums(rc.kv_checksums, rc.kv_checksum_algo);
         writer = writer.use_locator(tree.config.locator_policy.get(INITIAL_CANONICAL_LEVEL));

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -413,6 +413,84 @@ impl AbstractTree for Tree {
         self.version_history.read().latest_version().version
     }
 
+    #[cfg(feature = "std")]
+    fn refresh_table_checksum(
+        &self,
+        table_id: TableId,
+        checksum: crate::checksum::Checksum,
+        expected_restriction: Option<&crate::UserKey>,
+    ) -> crate::Result<crate::abstract_tree::ChecksumRefreshOutcome> {
+        use crate::abstract_tree::ChecksumRefreshOutcome;
+        // Same lock order as flush / compaction version installs: compaction
+        // state first, then the version history write lock. But the caller (the
+        // patrol reconcile) holds this table's HEAL LOCK across this call, and a
+        // concurrent tight-space compaction acquires that heal lock WHILE holding
+        // `compaction_state`. Blocking on `compaction_state` here would invert the
+        // order (heal_lock -> compaction_state on this path vs
+        // compaction_state -> heal_lock on the compaction path) and deadlock
+        // permanently. `try_lock` instead: a failed acquire means a compaction is
+        // mid-install, so skip this refresh — but report the skip as CONTENDED,
+        // not as a benign no-op: the healed bytes are durable while the manifest
+        // digest stays stale, so a "clean" report would mislead a later
+        // integrity check / checkpoint. The caller keeps the attestation and
+        // surfaces a finding; the next patrol retries once the compaction
+        // releases the state.
+        let Some(mut _compaction_state) = self.compaction_state.try_lock() else {
+            return Ok(ChecksumRefreshOutcome::Contended);
+        };
+        let mut version_lock = self.version_history.write();
+
+        // Under the install lock, resolve the CURRENT view of this table and
+        // reject the refresh if either it is gone (compacted away — nothing to
+        // refresh) or its restriction no longer matches the one `checksum` was
+        // computed for. A tight-space compaction can swap the captured view for a
+        // restricted same-id view (punching its prefix) between the caller's read
+        // and this lock; installing the caller's digest against a different
+        // restriction would record one the punched file can never match. Skipping
+        // leaves the current view's own (compaction-installed) digest in place for
+        // the next patrol to reconcile.
+        let restriction_matches = version_lock
+            .latest_version()
+            .version
+            .iter_tables()
+            .find(|t| t.id() == table_id)
+            .is_some_and(|t| t.restrict_lower_bound() == expected_restriction);
+        if !restriction_matches {
+            // No-op: the manifest digest is unchanged, so the caller must keep the
+            // attestation for the next patrol.
+            return Ok(ChecksumRefreshOutcome::Stale);
+        }
+
+        version_lock
+            .upgrade_version(
+                &self.config.path,
+                |current| {
+                    let mut copy = current.clone();
+                    if let Some(next) = copy
+                        .version
+                        .with_refreshed_table_checksum(table_id, checksum)
+                    {
+                        copy.version = next;
+                    }
+                    Ok(copy)
+                },
+                &self.config.seqno,
+                &self.config.visible_seqno,
+                &*self.config.fs,
+                self.0.runtime_config.load_full(),
+                self.0.config.encryption.clone(),
+            )
+            .map(|()| ChecksumRefreshOutcome::Refreshed)
+    }
+
+    fn sync_mode(&self) -> crate::fs::SyncMode {
+        self.config.sync_mode
+    }
+
+    fn prefix_extractor(&self) -> Option<alloc::sync::Arc<dyn crate::prefix::PrefixExtractor>> {
+        self.config.prefix_extractor.clone()
+    }
+
     fn storage_stats(&self) -> crate::Result<crate::StorageStats> {
         // One version snapshot reused for the footprint and the full-compaction
         // estimate below: a second `current_version()` could race a concurrent
@@ -3246,7 +3324,9 @@ impl Tree {
             log::error!(
                 "It looks like you are trying to open a V1 database - the database needs a manual migration, however a migration tool is not provided, as V1 is extremely outdated."
             );
-            return Err(crate::Error::InvalidVersion(FormatVersion::V1.into()));
+            // Literal discriminant: V1 is a retired format and FormatVersion
+            // carries no legacy variants (V5-only contract).
+            return Err(crate::Error::InvalidVersion(1));
         }
 
         // Decide between recovery and fresh creation atomically by attempting
@@ -3793,8 +3873,14 @@ impl Tree {
             )?;
             let manifest = Manifest::decode_from(&mut archive_reader)?;
 
-            if !matches!(manifest.version, FormatVersion::V5) {
-                return Err(crate::Error::InvalidVersion(manifest.version.into()));
+            // V5 is the only variant `FormatVersion` can decode to (the
+            // engine reads exactly one on-disk format, no legacy paths), so
+            // a pre-V5 manifest already failed decode_from with
+            // InvalidVersion. This match stays as the explicit gate the
+            // format contract documents — and as the compile-time hook that
+            // forces a review of the open path when a new variant is added.
+            match manifest.version {
+                FormatVersion::V5 => {}
             }
 
             let supplied_name = config.comparator.name();
@@ -4026,6 +4112,12 @@ impl Tree {
 
         let cnt = table_map.len();
 
+        // Immutable snapshot of every table id the manifest knows. `table_map`
+        // is drained as tables are recovered below, so it cannot answer "is this
+        // id live?" order-independently; this set can. Used to sweep an orphaned
+        // `.heal-attest` sidecar whose SST was retired.
+        let manifest_ids: crate::HashSet<TableId> = table_map.keys().copied().collect();
+
         log::debug!("Recovering {cnt} tables from {}", tree_path.display());
 
         let progress_mod = match cnt {
@@ -4079,6 +4171,113 @@ impl Tree {
                         "Skipping unexpected directory in tables folder: {}",
                         table_file_path.display()
                     );
+                    continue;
+                }
+
+                // An in-place heal detaches a hard-linked SST through a
+                // `{id}.healtmp-{n}` copy that is renamed over the live path;
+                // a hard crash between its creation and the rename leaves the
+                // artifact behind. It is never referenced by any manifest, so
+                // sweep it instead of failing the id parse below. Only the
+                // EXACT artifact shape (numeric id, numeric sequence) is owned
+                // cleanup state — a foreign name that merely contains
+                // `.healtmp` (an operator backup like `0.healtmp.backup`) must
+                // fall through to the id parse and fail recovery unharmed,
+                // never be deleted.
+                if let Some((id_part, seq_part)) = table_file_name.split_once(".healtmp-")
+                    && id_part.parse::<TableId>().is_ok()
+                    && seq_part.parse::<u64>().is_ok()
+                {
+                    log::warn!(
+                        "Removing abandoned heal copy: {}",
+                        table_file_path.display()
+                    );
+                    Self::sweep_artifact(folder_fs.as_ref(), &table_file_path)?;
+                    continue;
+                }
+
+                // A `{id}.heal-attest.tmp` is a crashed sidecar-publish temp: the
+                // attestation was written + synced to this temp for an atomic
+                // rename onto `{id}.heal-attest`, but the process died before the
+                // rename. It is disposable: either the live sidecar it would have
+                // replaced still bridges the crash window, or the heal is re-run,
+                // so sweep it like the healtmp copies. Checked BEFORE the
+                // `.heal-attest` skip because that suffix is a prefix of this one.
+                if table_file_name
+                    .strip_suffix(".heal-attest.tmp")
+                    .is_some_and(|id| id.parse::<TableId>().is_ok())
+                {
+                    log::warn!(
+                        "Removing abandoned heal-attest temp: {}",
+                        table_file_path.display()
+                    );
+                    Self::sweep_artifact(folder_fs.as_ref(), &table_file_path)?;
+                    continue;
+                }
+
+                // A `{id}.heal-attest` sidecar records that an in-place heal
+                // corrected `{id}` but its manifest digest refresh may not have
+                // landed; the next scrub consumes it to reconcile. It is never a
+                // table file, so never parse it as an id. Only the EXACT shape
+                // (numeric id + exact suffix) is owned; a foreign name merely
+                // containing `.heal-attest` falls through to the id parse and
+                // fails recovery unharmed.
+                if let Some(attest_id) = table_file_name
+                    .strip_suffix(".heal-attest")
+                    .and_then(|id| id.parse::<TableId>().ok())
+                {
+                    // A LIVE table's pending attestation is preserved (the next
+                    // scrub reconciles a crashed refresh through it). But if its
+                    // SST is absent from the manifest, the table was retired
+                    // (compacted away, its file unlinked) while the sidecar
+                    // lingered: nothing can ever reconcile a table that no longer
+                    // exists, so sweep the orphan rather than leak the directory
+                    // entry and re-process it on every future recovery.
+                    if !manifest_ids.contains(&attest_id) {
+                        log::warn!(
+                            "Removing orphaned heal attestation (its table is gone): {}",
+                            table_file_path.display()
+                        );
+                        Self::sweep_artifact(folder_fs.as_ref(), &table_file_path)?;
+                    }
+                    continue;
+                }
+
+                // A `{id}.restrict-bound.tmp` is a crashed sidecar-publish temp
+                // (written + synced for an atomic rename onto `{id}.restrict-bound`
+                // that never landed). Disposable — sweep it. Checked BEFORE the
+                // `.restrict-bound` skip because that suffix is a prefix of this one.
+                if table_file_name
+                    .strip_suffix(".restrict-bound.tmp")
+                    .is_some_and(|id| id.parse::<TableId>().is_ok())
+                {
+                    log::warn!(
+                        "Removing abandoned restrict-bound temp: {}",
+                        table_file_path.display()
+                    );
+                    Self::sweep_artifact(folder_fs.as_ref(), &table_file_path)?;
+                    continue;
+                }
+
+                // A `{id}.restrict-bound` sidecar records the exact tight-space
+                // restriction bound of a hole-punched `{id}`, so manifest repair
+                // can recover the restriction. It is never a table file, so never
+                // parse it as an id. A LIVE table's sidecar is preserved (repair
+                // needs it); an ORPHAN one (its SST retired from the manifest) is
+                // swept so a reused id cannot later pick up a stale restriction.
+                // Only the EXACT shape (numeric id + exact suffix) is owned; a
+                // foreign name merely containing the suffix falls through unharmed.
+                if let Some(bound_id) = table_file_name
+                    .strip_suffix(".restrict-bound")
+                    .and_then(|id| id.parse::<TableId>().ok())
+                {
+                    if !manifest_ids.contains(&bound_id) {
+                        log::warn!(
+                            "Removing orphaned restrict-bound sidecar (its table is gone): {}",
+                            table_file_path.display()
+                        );
+                        Self::sweep_artifact(folder_fs.as_ref(), &table_file_path)?;
+                    }
                     continue;
                 }
 
@@ -4179,9 +4378,23 @@ impl Tree {
 
         log::debug!("Successfully recovered {} tables", tables.len());
 
+        // Pair each blob file with its live-data frontier: a file whose consumed
+        // prefix was reclaimed in place records a checksum over the suffix only,
+        // so the recovered view must carry the offset that digest starts at.
+        let blob_ids_with_frontier: Vec<(crate::vlog::BlobFileId, crate::Checksum, u64)> = recovery
+            .blob_file_ids
+            .iter()
+            .map(|&(id, checksum)| {
+                (
+                    id,
+                    checksum,
+                    recovery.blob_restrictions.get(&id).copied().unwrap_or(0),
+                )
+            })
+            .collect();
         let (blob_files, orphaned_blob_files) = crate::vlog::recover_blob_files(
             &tree_path.join(crate::file::BLOBS_FOLDER),
-            &recovery.blob_file_ids,
+            &blob_ids_with_frontier,
             tree_id,
             config.descriptor_table.as_ref(),
             &config.fs,
@@ -4209,7 +4422,23 @@ impl Tree {
         Ok(version)
     }
 
-    /// Removes stale version files left over from a crash during version swap.
+    /// Removes a recovery-swept artifact (an abandoned heal copy / temp / marker),
+    /// treating a concurrent removal (`NotFound`) as success. A benign race (a
+    /// retry, or another scanner that already swept it) must not fail recovery,
+    /// matching [`Self::cleanup_orphaned_version`].
+    fn sweep_artifact(fs: &dyn Fs, path: &Path) -> crate::Result<()> {
+        match fs.remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == crate::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Removes stale manifest files left by older generations: every `v{id}`
+    /// snapshot except the live one (`v{snapshot_id}`) and every `edits-{id}`
+    /// log except the live snapshot's (`edits-{snapshot_id}`). A crashed
+    /// rotation can leak an old snapshot or its log; this sweeps them on open.
+    /// The live snapshot and log are exactly the generation `CURRENT` points at.
     ///
     /// # Behavior change vs pre-Fs-trait code
     ///
@@ -4219,11 +4448,6 @@ impl Tree {
     /// function now fails fast on non-UTF-8 names. This is intentional: version
     /// files are always `v{u64}` — any non-UTF-8 entry indicates filesystem
     /// corruption and should surface as an error rather than be silently ignored.
-    /// Removes stale manifest files left by older generations: every `v{id}`
-    /// snapshot except the live one (`v{snapshot_id}`) and every `edits-{id}`
-    /// log except the live snapshot's (`edits-{snapshot_id}`). A crashed
-    /// rotation can leak an old snapshot or its log; this sweeps them on open.
-    /// The live snapshot and log are exactly the generation `CURRENT` points at.
     fn cleanup_orphaned_version(
         path: &Path,
         snapshot_id: crate::version::VersionId,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -125,16 +125,25 @@ impl IntegrityReport {
     }
 }
 
-/// Computes a streaming XXH3 128-bit checksum for a file without loading it entirely into memory.
+/// Computes a streaming XXH3 128-bit checksum over `[start, end)` of a file,
+/// without loading it entirely into memory. Pass `start = 0` for a whole file.
 ///
-/// `pub(crate)` so [`crate::salvage`] can stamp the salvaged-source open with
-/// the file's current digest (the source may be corrupt, so its digest is
-/// whatever bytes are on disk; per-block checksums catch the actual damage).
+/// A tight-space RESTRICTED table's `[0, punch_offset)` prefix — and a
+/// relocated blob file's prefix below its live-data frontier — is hole-punched
+/// (reads as zeros) once a superseding output owns that data, so the manifest
+/// digest covers only the live suffix; verification must digest from the same
+/// `start`.
 #[cfg(feature = "std")]
-pub(crate) fn stream_checksum(path: &std::path::Path) -> std::io::Result<Checksum> {
-    use std::io::Read;
+pub(crate) fn stream_checksum_from(
+    path: &std::path::Path,
+    start: u64,
+) -> std::io::Result<Checksum> {
+    use std::io::{Read, Seek, SeekFrom};
 
     let mut reader = std::fs::File::open(path)?;
+    if start != 0 {
+        reader.seek(SeekFrom::Start(start))?;
+    }
     let mut hasher = xxhash_rust::xxh3::Xxh3Default::new();
     let mut buf = vec![0u8; 64 * 1024];
 
@@ -183,7 +192,34 @@ pub fn verify_integrity(tree: &impl crate::AbstractTree) -> IntegrityReport {
         let path = &*table.path;
         let expected = table.checksum();
 
-        match stream_checksum(path) {
+        // A tight-space RESTRICTED view digests only its live suffix (the
+        // punched prefix reads as zeros and is not part of its identity).
+        let start = match table.restrict_lower_bound() {
+            Some(bound) => match table.punch_offset_for(bound) {
+                Ok(offset) => offset,
+                // A TRANSIENT index-read failure (EINTR / EAGAIN) while resolving
+                // the punch offset is retryable I/O, not corruption: falling back
+                // to `0` would digest the hole-punched prefix and report a healthy
+                // restricted table as corrupted. Mirror `scan_one_table`, which
+                // routes the same transient failure to an unreadable/IoError
+                // classification and skips the checksum comparison.
+                Err(crate::Error::Io(error)) if error.kind().is_transient() => {
+                    report.errors.push(IntegrityError::IoError {
+                        path: (*table.path).clone(),
+                        error,
+                    });
+                    report.sst_files_checked += 1;
+                    continue;
+                }
+                // A PERSISTENT I/O failure (`Other` / EIO) and a STRUCTURAL
+                // failure both fall back to `0` (fail closed): the whole-file
+                // digest then mismatches and the table is reported rather than
+                // silently passing.
+                Err(_) => 0,
+            },
+            None => 0,
+        };
+        match stream_checksum_from(path, start) {
             Ok(got) if got != expected => {
                 report.errors.push(IntegrityError::SstFileCorrupted {
                     table_id: table.id(),
@@ -209,7 +245,11 @@ pub fn verify_integrity(tree: &impl crate::AbstractTree) -> IntegrityReport {
         let path = blob_file.path();
         let expected = blob_file.checksum();
 
-        match stream_checksum(path) {
+        // A blob file whose consumed prefix was reclaimed in place records its
+        // digest over the LIVE suffix only: hashing the whole file would fold
+        // in the punched (zeroed) prefix and report a healthy file as corrupt.
+        // `0` for a whole, unreclaimed file.
+        match stream_checksum_from(path, blob_file.live_data_start()) {
             Ok(got) if got != expected => {
                 report.errors.push(IntegrityError::BlobFileCorrupted {
                     blob_file_id: blob_file.id(),
@@ -310,6 +350,23 @@ pub enum BlockVerifyError {
         error: io::Error,
     },
 
+    /// A block's Page-ECC parity trailer did not match parity freshly
+    /// computed over its (checksum-clean) payload. The payload itself is
+    /// intact — but the block's ECC is dead: a later payload fault could no
+    /// longer be recovered from this trailer. Reported only when the payload
+    /// checksum matched (a corrupt payload legitimately mismatches the
+    /// original trailer and is already reported as `DataCorrupted`).
+    EccParityMismatch {
+        /// Table ID.
+        table_id: TableId,
+        /// Path to the SST file.
+        path: PathBuf,
+        /// File offset where the block header sits.
+        offset: u64,
+        /// Length of the on-disk data segment, in bytes.
+        data_length: u32,
+    },
+
     /// SFA TOC-level corruption: a named section's length / position
     /// fields are inconsistent (overflow on addition), or seeking to
     /// its declared start offset fails before any block is read.
@@ -384,6 +441,18 @@ impl core::fmt::Display for BlockVerifyError {
                  block at offset {offset}: {error}",
                 path.display(),
             ),
+            Self::EccParityMismatch {
+                table_id,
+                path,
+                offset,
+                data_length,
+            } => write!(
+                f,
+                "SST table {table_id} at {}: block at offset {offset} ({data_length} bytes) has a \
+                 clean payload but its ECC parity trailer does not match freshly computed parity \
+                 (dead ECC — recompact or heal in place)",
+                path.display(),
+            ),
             Self::TocCorrupted {
                 table_id,
                 path,
@@ -414,6 +483,13 @@ impl core::error::Error for BlockVerifyError {
 
 /// A non-fatal finding from a scrub run: the data is intact, but something
 /// about a table could not be fully checked.
+///
+/// Warnings do not fail [`BlockVerifyReport::is_ok`], so any consumer that
+/// renders a verdict (a CLI, an operator report) MUST surface them alongside
+/// it: a bare "OK" over a non-empty warning list misreads "nothing broken
+/// among what was checkable" as "everything verified". The skipped surface
+/// each variant names (an unverifiable parity trailer, an unwalkable ECC
+/// section) is exactly where silent rot would otherwise hide.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum BlockVerifyWarning {
@@ -425,6 +501,20 @@ pub enum BlockVerifyWarning {
     /// verification was skipped for this table. Recompaction re-stamps the
     /// table with a supported scheme.
     UnrecognizedEcc {
+        /// Table the warning applies to.
+        table_id: TableId,
+        /// On-disk path of the SST.
+        path: PathBuf,
+    },
+
+    /// The table carries a RECOGNIZED Page-ECC scheme, but this build was
+    /// compiled without the ECC codecs (the `page_ecc` feature), so its parity
+    /// trailers were consumed for walk alignment but could NOT be verified.
+    /// Block payloads still verify by their own checksums — parity-only rot is
+    /// what stays invisible on this build. Verify on a `page_ecc`-enabled
+    /// build, or recompact (on this build the rewrite is parity-less) to leave
+    /// only verifiable bytes.
+    ParityUnverifiable {
         /// Table the warning applies to.
         table_id: TableId,
         /// On-disk path of the SST.
@@ -449,15 +539,27 @@ pub struct BlockVerifyReport {
     /// some tables (unrecognized scheme — recompaction recommended). Distinct
     /// from `errors`: warnings do NOT make [`Self::is_ok`] false.
     pub warnings: Vec<BlockVerifyWarning>,
+    /// Set when the scan could NOT walk some SST-block sections — an unrecognized
+    /// ECC descriptor makes those blocks' parity-trailer length underivable, so
+    /// the walk skips them (including the DATA blocks) entirely. A report with no
+    /// errors but this flag set has verified LESS than the whole file, so it is
+    /// NOT a clean verdict: [`Self::is_ok`] returns `false`. (The data may still
+    /// be readable through the live point-read path, which frames blocks by
+    /// `data_length`; recompaction re-stamps the SST under a supported scheme.)
+    pub incomplete: bool,
 }
 
 impl BlockVerifyReport {
-    /// `true` if every block in every SST verified clean. Warnings (e.g. an
-    /// unrecognized ECC scheme whose data still checksum-verified) do NOT
-    /// make this false — only real corruption (`errors`) does.
+    /// `true` only if every SST section was walked AND every block verified
+    /// clean. A parity-unverifiable WARNING (whose blocks were still walked and
+    /// payload-checksummed) does not make this false, but a real error
+    /// (`errors`) or an INCOMPLETE walk that skipped sections
+    /// ([`Self::incomplete`], e.g. an unrecognized ECC descriptor) does — a
+    /// skipped section was never verified, so reporting it clean would be a false
+    /// success.
     #[must_use]
     pub fn is_ok(&self) -> bool {
-        self.errors.is_empty()
+        self.errors.is_empty() && !self.incomplete
     }
 
     /// `true` if the scrub produced any non-fatal warning.
@@ -514,6 +616,10 @@ fn merge_report(dst: &mut BlockVerifyReport, src: BlockVerifyReport) {
     dst.blocks_scanned += src.blocks_scanned;
     dst.errors.extend(src.errors);
     dst.warnings.extend(src.warnings);
+    // An incomplete partial (an SST whose sections were skipped unwalked) taints
+    // the whole merged report: once ANY table could not be fully scanned, the
+    // aggregate `is_ok()` must not claim a clean verdict.
+    dst.incomplete |= src.incomplete;
 }
 
 /// Scans one SST and returns a partial report (`sst_files_scanned == 1`).
@@ -549,12 +655,53 @@ fn scan_one_table(table: &crate::table::Table) -> BlockVerifyReport {
             table_id,
             path: path.to_path_buf(),
         });
+        // The block walk will skip every non-self-describing section (the data
+        // blocks included), so the scan is incomplete: a clean report here would
+        // falsely claim the data verified.
+        report.incomplete = true;
+    }
+
+    // A recognized scheme on a build WITHOUT the ECC codecs: trailers are
+    // consumed for alignment but cannot be verified (parity-only rot stays
+    // invisible) — surface the gap, mirroring the out-of-band walk.
+    #[cfg(not(feature = "page_ecc"))]
+    if table.metadata.ecc_params.is_some() {
+        report
+            .warnings
+            .push(BlockVerifyWarning::ParityUnverifiable {
+                table_id,
+                path: path.to_path_buf(),
+            });
     }
 
     // Use each Table's own `Fs` handle (StdFs, MemFs, IoUring, …).
     // Encryption overhead is per-table (different keys / AEAD suites can attach
     // to different SSTs), so feed each table's `max_overhead()` separately.
     let max_enc_overhead = table.encryption.as_ref().map_or(0u32, |e| e.max_overhead());
+    // A restricted view digests / walks only its live suffix: skip the punched
+    // data-block prefix. A TRANSIENT punch-offset lookup failure (a flaky
+    // partitioned-index read: EINTR / EAGAIN) is recorded as an unreadable-file
+    // I/O error and the walk is skipped — falling back to `0` would walk the
+    // hole-punched prefix and report its zeroed blocks as a false whole-file
+    // checksum mismatch on a healthy restricted table. A PERSISTENT I/O failure
+    // (`Other` / EIO, not retryable) and a STRUCTURAL lookup failure both fall
+    // back to `0` (walk everything, fail closed) so an unresolvable or corrupt
+    // index cannot exempt blocks.
+    let data_start = match table.restrict_lower_bound() {
+        Some(bound) => match table.punch_offset_for(bound) {
+            Ok(offset) => offset,
+            Err(crate::Error::Io(error)) if error.kind().is_transient() => {
+                report.errors.push(BlockVerifyError::SstFileUnreadable {
+                    table_id,
+                    path: path.to_path_buf(),
+                    error,
+                });
+                return report;
+            }
+            Err(_) => 0,
+        },
+        None => 0,
+    };
     match scan_sst_blocks(
         &*table.fs,
         path,
@@ -562,6 +709,7 @@ fn scan_one_table(table: &crate::table::Table) -> BlockVerifyReport {
         max_enc_overhead,
         table.metadata.ecc_params,
         ecc_unrecognized,
+        data_start,
     ) {
         Ok(per_file) => {
             report.blocks_scanned += per_file.blocks_scanned;
@@ -584,11 +732,11 @@ fn scan_one_table(table: &crate::table::Table) -> BlockVerifyReport {
 /// Pipeline per SST:
 ///
 /// 1. Open the file and parse the SFA trailer to obtain the TOC.
-/// 2. For each TOC section, skip if its name is in `RAW_FORMAT_SECTIONS`
-///    (those payloads are not `Header`-prefixed and are covered by the
-///    SFA-trailer checksum). Otherwise seek to the section's start
-///    offset and walk it as a contiguous block region in
-///    `[start, start + length)`.
+/// 2. For each TOC section, if its name is in `RAW_FORMAT_SECTIONS` (those
+///    payloads are not `Header`-prefixed and carry no per-section checksum)
+///    validate its structural shape instead of walking blocks. Otherwise
+///    seek to the section's start offset and walk it as a contiguous block
+///    region in `[start, start + length)`.
 /// 3. Inside each block region, decode each block's `Header` (which
 ///    validates the header's own XXH3), read the data segment, and
 ///    compare a fresh XXH3 over the data against `header.checksum`.
@@ -772,6 +920,45 @@ pub(crate) fn verify_sst_file_with_fs(
     fs: &dyn crate::fs::Fs,
     path: &std::path::Path,
 ) -> BlockVerifyReport {
+    verify_sst_file_with_context(fs, path, None, None, 0)
+}
+
+/// As [`verify_sst_file_with_fs`], but with an encryption context for
+/// ENCRYPTED SSTs and an optional caller-known durable table id. Block headers
+/// and payload checksums are plaintext, so the section walk itself needs no
+/// decryption — the provider (and the AAD-bound id) are used only to decode
+/// the meta block for the per-SST ECC descriptor. This makes the full
+/// out-of-band walk (every section, raw checksums — which flag even
+/// ECC-correctable persistent faults) available for encrypted tables, applying
+/// the same verification standard as the unencrypted path.
+///
+/// `known_table_id`: `Some` when the caller knows the durable id out-of-band
+/// (repair — the SST file name), enforcing the meta payload cross-check even
+/// on UNENCRYPTED reads so a checksum-clean forged tail meta falls back to the
+/// intact MID mirror instead of dictating a forged ECC descriptor to the walk;
+/// `None` for standalone tools with no id knowledge (reports then stamp
+/// `table_id = 0`).
+#[cfg(feature = "std")]
+pub(crate) fn verify_sst_file_with_context(
+    fs: &dyn crate::fs::Fs,
+    path: &std::path::Path,
+    encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+    known_table_id: Option<crate::TableId>,
+    // Byte offset to start the DATA-section walk at: `0` for a normal table, the
+    // punch offset for a tight-space RESTRICTED view (its `[0, data_start)` data
+    // blocks were hole-punched and read as zeros). The caller supplies it because
+    // this path-based walk has no `Table` to derive the restriction from.
+    data_start: u64,
+) -> BlockVerifyReport {
+    let table_id = known_table_id.unwrap_or(0);
+    // A caller-known punch offset wins; with none, derive the live frontier of
+    // a possibly-RESTRICTED SST from its colocated sidecar so a standalone
+    // walk does not condemn the intentionally punched prefix as corruption.
+    let data_start = if data_start == 0 {
+        restricted_data_start(fs, path, encryption, known_table_id)
+    } else {
+        data_start
+    };
     let mut report = BlockVerifyReport {
         sst_files_scanned: 1,
         ..BlockVerifyReport::default()
@@ -785,33 +972,69 @@ pub(crate) fn verify_sst_file_with_fs(
     // the scan and reports spurious corruption. Surface the indeterminacy and
     // skip the walk.
     let mut ecc_unrecognized = false;
-    let ecc = match read_ecc_params_out_of_band(fs, path) {
-        Ok(Some(ScrubEcc::Off)) => None,
-        Ok(Some(ScrubEcc::Scheme(params))) => Some(params),
+    let probe = match read_ecc_params_out_of_band(fs, path, encryption, known_table_id) {
+        Ok(p) => p,
+        // Real file-open / SFA-trailer failure — preserve the underlying error
+        // rather than collapsing it into the undeterminable message below.
+        Err(error) => {
+            report.errors.push(BlockVerifyError::SstFileUnreadable {
+                table_id,
+                path: path.to_path_buf(),
+                error: error.into(),
+            });
+            return report;
+        }
+    };
+    // Both mirrors decode but their FULL metadata disagrees: one is
+    // forged/rotted to another internally-consistent payload (e.g. a changed
+    // compression tag with the ECC descriptor untouched). Every byte-level
+    // check passes on both, so this comparison is the only out-of-band
+    // detector — a recovery preferring the altered tail would misread every
+    // data block. Report and keep walking (block-level findings still add
+    // signal).
+    if probe.mirrors_diverge {
+        report.errors.push(BlockVerifyError::TocCorrupted {
+            table_id,
+            path: path.to_path_buf(),
+            section_name: b"meta".to_vec(),
+            section_offset: 0,
+            reason: alloc::string::String::from(
+                "the tail meta and meta_mid mirrors decode to different metadata; \
+                 one copy is forged or rotted behind a re-stamped checksum",
+            ),
+        });
+    }
+    let ecc = match probe.ecc {
+        Some(ScrubEcc::Off) => None,
+        Some(ScrubEcc::Scheme(params)) => Some(params),
         // The descriptor decodes to a scheme this build can't apply: the
         // SST-block trailer length isn't derivable, so those sections are
         // skipped during the walk. The self-describing `meta` / `meta_mid`
         // sections still size parity from `block_flags`, so corruption there
         // is NOT downgraded. Warn + continue (don't drop the whole scrub).
-        Ok(Some(ScrubEcc::Unrecognized)) => {
+        Some(ScrubEcc::Unrecognized) => {
             log::warn!(
                 "{}: unrecognized ECC scheme — skipping the ECC-dependent block \
                  sections; recompact to re-stamp with a supported scheme",
                 path.display(),
             );
             report.warnings.push(BlockVerifyWarning::UnrecognizedEcc {
-                table_id: 0,
+                table_id,
                 path: path.to_path_buf(),
             });
+            // The walk below skips the non-self-describing sections (data blocks
+            // included), so the scan is incomplete: a clean report would falsely
+            // claim the data verified.
+            report.incomplete = true;
             ecc_unrecognized = true;
             None
         }
         // File + trailer readable, but neither meta block decodes (corrupt
         // meta, or an encrypted SST with no key out-of-band). The ECC scheme is
         // undeterminable; skip the walk rather than mis-walk an ECC-bearing SST.
-        Ok(None) => {
+        None => {
             report.errors.push(BlockVerifyError::SstFileUnreadable {
-                table_id: 0,
+                table_id,
                 path: path.to_path_buf(),
                 error: io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -823,26 +1046,48 @@ pub(crate) fn verify_sst_file_with_fs(
             });
             return report;
         }
-        // Real file-open / SFA-trailer failure — preserve the underlying error
-        // rather than collapsing it into the undeterminable message above.
-        Err(error) => {
-            report.errors.push(BlockVerifyError::SstFileUnreadable {
-                table_id: 0,
-                path: path.to_path_buf(),
-                error: error.into(),
-            });
-            return report;
-        }
     };
 
-    match scan_sst_blocks(fs, path, 0, 0, ecc, ecc_unrecognized) {
+    // A recognized scheme on a build WITHOUT the ECC codecs: the trailers are
+    // consumed for walk alignment but cannot be verified, so parity-only rot
+    // stays invisible. Surface that as a warning — the repair gate requires a
+    // warning-free report, so such a table routes to salvage (whose rewrite is
+    // parity-less on this build, leaving only verifiable bytes) instead of
+    // being stamped into a rebuilt manifest with unchecked trailer bytes.
+    #[cfg(not(feature = "page_ecc"))]
+    if ecc.is_some() {
+        report
+            .warnings
+            .push(BlockVerifyWarning::ParityUnverifiable {
+                table_id,
+                path: path.to_path_buf(),
+            });
+    }
+
+    // Encrypted blocks legitimately exceed the plaintext data_length cap by
+    // up to the provider's AEAD overhead (mirroring `Block::from_file`); a
+    // zero here would false-flag a healthy encrypted block just over the cap
+    // as HeaderCorrupted and send the whole table to quarantine/salvage.
+    let max_enc_overhead =
+        encryption.map_or(0u32, crate::encryption::EncryptionProvider::max_overhead);
+    match scan_sst_blocks(
+        fs,
+        path,
+        table_id,
+        max_enc_overhead,
+        ecc,
+        ecc_unrecognized,
+        data_start,
+    ) {
         Ok(per_file) => {
             report.blocks_scanned = per_file.blocks_scanned;
-            report.errors = per_file.errors;
+            // extend, NOT assign: the mirror-divergence finding above must
+            // survive the block walk's own error list.
+            report.errors.extend(per_file.errors);
         }
         Err(error) => {
             report.errors.push(BlockVerifyError::SstFileUnreadable {
-                table_id: 0,
+                table_id,
                 path: path.to_path_buf(),
                 error,
             });
@@ -853,6 +1098,9 @@ pub(crate) fn verify_sst_file_with_fs(
 }
 
 /// Per-SST ECC state as seen by the out-of-band scrub.
+// `PartialEq` + `Copy`: the probe compares the states decoded from the two
+// meta copies to arbitrate a forged descriptor.
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg(feature = "std")]
 enum ScrubEcc {
     /// ECC off — no parity trailer to skip.
@@ -885,13 +1133,30 @@ enum ScrubEcc {
 fn read_ecc_params_out_of_band(
     fs: &dyn crate::fs::Fs,
     path: &std::path::Path,
-) -> std::io::Result<Option<ScrubEcc>> {
+    encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+    known_table_id: Option<crate::TableId>,
+) -> std::io::Result<EccProbe> {
     let mut probe = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
     let sfa_reader = crate::sfa::Reader::from_reader(&mut probe)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     let toc = sfa_reader.toc();
-    // Tail `meta` is authoritative; `meta_mid` is the early mirror written so a
-    // single corrupt meta block doesn't lose the per-SST descriptor.
+    // Tail `meta` is authoritative for CONTENT; for the ECC descriptor the
+    // two copies ARBITRATE each other: a single forged copy (its table id
+    // intact, so the cross-check passes) must not dictate the walk's trailer
+    // sizing, whether the forge decodes to an unrecognized value or to a
+    // DIFFERENT recognized state (a forged `Off` would make the walk read
+    // parity bytes as block headers and condemn a healthy SST). Both copies
+    // are read; when two decodable copies disagree in ANY way the probe
+    // fails safe with `Unrecognized` (skip the ECC-dependent sections with a
+    // warning) — nothing out-of-band can tell which copy is legitimate.
+    let mut unrecognized_seen = false;
+    let mut recognized: Vec<ScrubEcc> = Vec::new();
+    // The FULL decoded mirrors: a tail re-stamped to another internally-consistent
+    // payload is detectable only by disagreeing with the intact `meta_mid`. Both
+    // are written from one parameter set, so any decoded difference is corruption
+    // or a forge. The divergence comparison below masks the ECC descriptor ONLY
+    // when a mirror is unrecognized; see `mirrors_diverge`.
+    let mut decoded: Vec<crate::table::meta::ParsedMeta> = Vec::new();
     for name in [b"meta".as_slice(), b"meta_mid".as_slice()] {
         let Some((pos, len)) = toc.section(name).map(|e| (e.pos(), e.len())) else {
             continue;
@@ -900,22 +1165,200 @@ fn read_ecc_params_out_of_band(
             continue;
         };
         let handle = crate::table::BlockHandle::new(crate::table::BlockOffset(pos), size);
-        // table_id is moot here: this scrub path reads unencrypted meta
-        // (encryption = None), so the AAD identity is unused.
-        if let Ok(meta) =
-            crate::table::meta::ParsedMeta::load_with_handle(probe.as_ref(), &handle, None, None)
-        {
-            let state = if meta.ecc_unrecognized {
-                ScrubEcc::Unrecognized
-            } else if let Some(params) = meta.ecc_params {
-                ScrubEcc::Scheme(params)
-            } else {
-                ScrubEcc::Off
-            };
-            return Ok(Some(state));
+        // The meta block is the ONLY read here that needs the provider: block
+        // HEADERS and payload checksums are plaintext, so the section walk
+        // below works on encrypted files without decrypting anything — only
+        // the ECC descriptor (inside the meta payload) requires decryption.
+        // The expected-id cross-check mirrors recovery's: enforced for
+        // encrypted reads (the AAD binds the id anyway) AND for unencrypted
+        // reads with a caller-known durable id — a checksum-clean forged tail
+        // then fails the check and this loop falls back to the intact MID
+        // mirror, instead of the forged tail dictating a wrong ECC descriptor
+        // to the walk. Only a standalone id-less diagnostic read skips it.
+        let expected_id = if encryption.is_some() {
+            Some(known_table_id.unwrap_or(0))
+        } else {
+            known_table_id
+        };
+        match crate::table::meta::ParsedMeta::load_with_handle(
+            probe.as_ref(),
+            &handle,
+            expected_id,
+            encryption,
+        ) {
+            Ok(meta) => {
+                if meta.ecc_unrecognized {
+                    unrecognized_seen = true;
+                } else {
+                    recognized.push(if let Some(params) = meta.ecc_params {
+                        ScrubEcc::Scheme(params)
+                    } else {
+                        ScrubEcc::Off
+                    });
+                }
+                // Keep the FULL decoded mirror; the divergence comparison below
+                // masks the ECC descriptor only when a mirror is unrecognized.
+                decoded.push(meta);
+            }
+            // Only a TRANSIENT read fault must not silently drop a mirror from
+            // arbitration: with one mirror gone the divergence check goes false
+            // and could admit an SST under the surviving (possibly forged) copy
+            // that a retry would expose. Propagate it. A PERSISTENT read failure (a
+            // bad sector a retry cannot fix) or a STRUCTURAL decode failure keeps
+            // the existing fallback (skip this mirror) so the remaining decoded
+            // copy can still supply the ECC state.
+            Err(crate::Error::Io(e)) if e.kind().is_transient() => return Err(e.into()),
+            Err(_) => {}
         }
     }
-    Ok(None)
+    // Two recognized mirrors are compared in FULL: a descriptor disagreement
+    // between two decodable schemes is a genuine forge. But when EITHER mirror
+    // carries an unrecognized descriptor, mask the ECC fields: the arbitration
+    // above tolerates a lone unrecognized sibling, so a descriptor-only forge
+    // must not condemn a healthy table, while a change to a real field (e.g.
+    // `created_at`) hidden behind that descriptor must still diverge.
+    let mirrors_diverge = match decoded.as_slice() {
+        [a, b] if unrecognized_seen => a.clone().without_ecc() != b.clone().without_ecc(),
+        [a, b] => a != b,
+        _ => false,
+    };
+    let ecc = match recognized.as_slice() {
+        // Two decodable copies that agree: trustworthy.
+        [a, b] if a == b => Some(*a),
+        // Two decodable copies that DISAGREE: one is forged/rotted and the
+        // probe cannot tell which — fail safe.
+        [_, _] => Some(ScrubEcc::Unrecognized),
+        // One decodable recognized copy: a lone unrecognized sibling does
+        // not override it (a descriptor-only forge must not condemn a
+        // healthy table whose mirror still holds the valid descriptor).
+        // A genuinely newer-scheme table with the OTHER mirror re-stamped to a
+        // recognized value would mis-size parity here; disambiguating the two by
+        // the block data (rather than trusting one descriptor) is tracked in
+        // issue #582.
+        [one] => Some(*one),
+        [] if unrecognized_seen => Some(ScrubEcc::Unrecognized),
+        [..] => None,
+    };
+    Ok(EccProbe {
+        ecc,
+        mirrors_diverge,
+    })
+}
+
+/// Result of [`read_ecc_params_out_of_band`]: the arbitrated ECC state plus
+/// whether the two FULLY-decoded meta mirrors disagree in any field.
+/// The data-walk start offset for a possibly-RESTRICTED SST verified
+/// out-of-band with no caller-known punch offset. A valid colocated
+/// `.restrict-bound` sidecar proves a committed tight-space restriction (it is
+/// written strictly after the slice's install commits), so an all-zero run
+/// inside the data section is an intentionally hole-punched consumed block.
+/// The walk starts past the LAST such run — not at the first nonzero byte:
+/// the reclaim punches top-down and stops at its first failure, so a partial
+/// reclaim leaves intact consumed blocks BELOW the holes it did punch, and
+/// anchoring at the first nonzero byte would put those holes back inside the
+/// walk and condemn a healthy SST. Without the sidecar the derive returns `0`
+/// and every zero stays part of the walk, flagging loudly — zeroed-out data on
+/// an unrestricted table is destruction, not reclaim.
+///
+/// `known_table_id`: when the caller knows the durable id, a sidecar recorded
+/// for a DIFFERENT id is ignored (a stale or foreign sidecar must not silence
+/// zeroed blocks of an unrelated table). A standalone tool has no id source,
+/// so a decodable colocated sidecar is accepted as-is there.
+///
+/// Best-effort: any probe or read failure falls back to `0` (the loud
+/// default). An ENCRYPTED sidecar with no provider reads as corrupt and also
+/// falls back — encrypted restricted SSTs need the provider-carrying path.
+#[cfg(feature = "std")]
+fn restricted_data_start(
+    fs: &dyn crate::fs::Fs,
+    path: &std::path::Path,
+    encryption: Option<&dyn crate::encryption::EncryptionProvider>,
+    known_table_id: Option<crate::TableId>,
+) -> u64 {
+    // A candidate frontier is only accepted when the byte right after a zero
+    // run DECODES as a block header (magic + its own checksum). A zero run
+    // inside a live value — legal payload — is not followed by a header, so it
+    // can never move the frontier into the middle of a frame.
+    const MIN_RUN: u64 = crate::table::block::Header::MIN_LEN as u64;
+    match crate::restrict_bound::read(fs, path, encryption) {
+        Ok(crate::restrict_bound::SidecarRead::Present(sidecar_id, _))
+            if known_table_id.is_none_or(|id| id == sidecar_id) => {}
+        _ => return 0,
+    }
+    let Ok(mut file) = fs.open(path, &crate::fs::FsOpenOptions::new().read(true)) else {
+        return 0;
+    };
+    let Ok(meta) = crate::fs::FsFile::metadata(&*file) else {
+        return 0;
+    };
+    let file_len = meta.len;
+    // Scan only the DATA section: other sections legitimately contain long
+    // zero stretches (padding, sparse index entries) that must not move the
+    // data frontier. Without a readable TOC there is no section to scan.
+    let Ok(reader) = crate::sfa::Reader::from_reader(&mut file) else {
+        return 0;
+    };
+    let Some((data_pos, data_len)) = reader
+        .toc()
+        .iter()
+        .find(|e| e.name() == b"data")
+        .map(|e| (e.pos(), e.len()))
+    else {
+        return 0;
+    };
+    let data_end = data_pos.saturating_add(data_len).min(file_len);
+    const CHUNK: usize = 64 * 1024;
+    let mut offset = data_pos;
+    let mut run: u64 = 0;
+    // End offset of the last zero run long enough to be a punched block.
+    let mut frontier = data_pos;
+    while offset < data_end {
+        let want = usize::try_from(data_end - offset)
+            .unwrap_or(CHUNK)
+            .min(CHUNK);
+        let Ok(bytes) = crate::file::read_exact(&*file, offset, want) else {
+            return 0;
+        };
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == 0 {
+                run = run.saturating_add(1);
+                continue;
+            }
+            // A run ENDS here. Accept it as a reclaimed region only when it is
+            // at least a block long AND this position decodes as a real block
+            // header — the boundary proof that separates a punched block from
+            // a zero run inside a live value's payload.
+            let candidate = offset + i as u64;
+            if run >= MIN_RUN && block_header_decodes_at(&*file, candidate) {
+                frontier = candidate;
+            }
+            run = 0;
+        }
+        offset += want as u64;
+    }
+    // `data_pos` means no validated punched run was found: nothing to skip.
+    if frontier == data_pos { 0 } else { frontier }
+}
+
+/// Whether `offset` holds a decodable block header (magic matches and the
+/// header's own checksum verifies). Proves a candidate frontier lands on a
+/// real block boundary rather than inside a live value's payload.
+#[cfg(feature = "std")]
+fn block_header_decodes_at(file: &dyn crate::fs::FsFile, offset: u64) -> bool {
+    use crate::coding::Decode;
+    let Ok(bytes) = crate::file::read_exact(file, offset, crate::table::block::Header::MAX_LEN)
+    else {
+        return false;
+    };
+    crate::table::block::Header::decode_from(&mut &bytes[..]).is_ok()
+}
+
+/// Result of [`read_ecc_params_out_of_band`]: the arbitrated ECC state plus
+/// whether the two FULLY-decoded meta mirrors disagree in any field.
+#[cfg(feature = "std")]
+struct EccProbe {
+    ecc: Option<ScrubEcc>,
+    mirrors_diverge: bool,
 }
 
 struct PerFileScan {
@@ -937,6 +1380,12 @@ fn scan_sst_blocks(
     max_enc_overhead: u32,
     ecc: Option<crate::table::block::EccParams>,
     ecc_unrecognized: bool,
+    // Byte offset to START the DATA-section walk at: `0` for a normal table, or
+    // the punch offset of a tight-space RESTRICTED view whose `[0, data_start)`
+    // data blocks were hole-punched (they read as zeros and would false-flag as
+    // corruption). All other sections (index, meta, TLI …) sit past the data
+    // region and are always walked in full.
+    data_start: u64,
 ) -> io::Result<PerFileScan> {
     use io::BufReader;
     #[cfg(not(feature = "std"))]
@@ -985,28 +1434,98 @@ fn scan_sst_blocks(
     //   - `meta`              : block-format (metadata, authoritative)
     //
     // Block-format sections are walked block-by-block (each block
-    // prefixed with the standard `Header`). Raw-format sections are
-    // skipped — their integrity is covered by the SFA-trailer
-    // checksum verified at table-open time. New section names default
-    // to "walk" (must be added to `RAW_FORMAT_SECTIONS` if they're
-    // raw), so a forgotten-to-handle section fails loud rather than
-    // silently passing a corruption.
+    // prefixed with the standard `Header`). Raw-format sections carry
+    // NO per-section checksum (the SFA-trailer checksum covers only
+    // the TOC bytes), so they get structural shape validation via
+    // `raw_section_shape_error` instead of a block walk. New section
+    // names default to "walk" (must be added to `RAW_FORMAT_SECTIONS`
+    // if they're raw), so a forgotten-to-handle section fails loud
+    // rather than silently passing a corruption.
 
     let mut reader = BufReader::with_capacity(64 * 1024, file);
     let mut blocks_scanned: usize = 0;
     let mut errors: Vec<BlockVerifyError> = Vec::new();
+
+    // The writer emits sections strictly back-to-back (the first at offset 0,
+    // each next where the previous ended, the last ending where the TOC
+    // begins), so the entries must exactly tile `[0, toc_pos)`. The SFA
+    // trailer checksum is unkeyed, so a re-stamped TOC could otherwise OMIT a
+    // correctness-bearing entry entirely — `delete_bitmap` and
+    // `range_tombstones` are optional at parse time, so a vanished section
+    // resurrects deleted rows while every remaining block still passes its
+    // byte-level checks. The tiling gap the omission leaves is the only
+    // out-of-band trace; report it and keep walking the sections that ARE
+    // present (their findings are still valid).
+    // Classify catalogue-structure defects (duplicate / shadowing names, tiling
+    // gaps, unrecognized names, a trailing hole) through the SAME pass
+    // `toc_may_hide_deletion_section` uses, so the walk's `TocCorrupted` findings
+    // and the salvage-verdict concealment check can never diverge. A re-stamped
+    // TOC that duplicates a recognized name, or renames a section to hide it,
+    // preserves the byte-level checks yet steers `Toc::section` / `ParsedRegions`
+    // away from the real section — resurrecting the range it masked.
+    for defect in toc_catalogue_defects(toc, sfa_reader.toc_pos()) {
+        errors.push(BlockVerifyError::TocCorrupted {
+            table_id,
+            path: path.to_path_buf(),
+            section_name: defect.name,
+            section_offset: defect.offset,
+            reason: defect.reason,
+        });
+    }
     // One reusable data buffer across the whole SST — sized up via
     // `resize` per block instead of a fresh `vec![0u8; N]` allocation
     // each iteration. On large trees this turns thousands of malloc
     // calls into a single growing allocation that settles at the
     // largest block size seen.
     let mut data_buf: Vec<u8> = Vec::new();
+    // Same story for the Page-ECC parity trailer (read for alignment and,
+    // when the codecs are compiled in, verified against fresh parity).
+    let mut parity_buf: Vec<u8> = Vec::new();
 
     for entry in toc.iter() {
         if RAW_FORMAT_SECTIONS.contains(&entry.name()) {
+            // Raw sections carry NO per-section checksum (the SFA trailer
+            // checksum covers only the TOC bytes), so validate their SHAPE
+            // where one is defined; a heal-enabled scrub relies on this walk
+            // before restamping the manifest digest, and skipping a broken
+            // blob-link list would launder it. Rot INSIDE a structurally
+            // valid payload (a flipped id byte) remains undetectable here —
+            // these sections have no integrity bytes to check against.
+            match raw_section_shape_error(&mut reader, entry.name(), entry.pos(), entry.len()) {
+                Ok(Some(reason)) => {
+                    errors.push(BlockVerifyError::TocCorrupted {
+                        table_id,
+                        path: path.to_path_buf(),
+                        section_name: entry.name().to_vec(),
+                        section_offset: entry.pos(),
+                        reason,
+                    });
+                }
+                Ok(None) => {}
+                // A transient read validating a raw section is retryable I/O, not
+                // corruption: record it as a DataReadError the repair verdict aborts on.
+                Err(e) => {
+                    errors.push(BlockVerifyError::DataReadError {
+                        table_id,
+                        path: path.to_path_buf(),
+                        offset: entry.pos(),
+                        data_length: 0,
+                        error: e,
+                    });
+                }
+            }
             continue;
         }
-        let start = entry.pos();
+        // A restricted view's punched data-block prefix reads as zeros; start
+        // the DATA walk at `data_start` so those blocks are not framed (only the
+        // data section is punched — every other section is walked in full). The
+        // straddling block at `data_start` is intact (the punch begins at its
+        // boundary), so `start.max(data_start)` lands on a real block header.
+        let start = if entry.name() == b"data" {
+            entry.pos().max(data_start)
+        } else {
+            entry.pos()
+        };
         // `checked_add` (not `saturating_add`) so a corrupted or
         // forged TOC length cannot silently collapse to `u64::MAX`
         // and let the walk treat the whole address space as one
@@ -1016,46 +1535,60 @@ fn scan_sst_blocks(
         // `TocCorrupted` rather than `HeaderCorrupted` because the
         // failure is at the section-catalogue layer, not inside any
         // individual block.
-        let Some(end) = start.checked_add(entry.len()) else {
+        let Some(end) = entry.pos().checked_add(entry.len()) else {
+            // Report the DECLARED TOC offset, not the walk start: the overflow
+            // is computed from `entry.pos()`, and for a restricted `data`
+            // section `start` is the live frontier — a different number, which
+            // would send repair and forensic readers to the wrong entry.
+            let declared = entry.pos();
             errors.push(BlockVerifyError::TocCorrupted {
                 table_id,
                 path: path.to_path_buf(),
                 section_name: entry.name().to_vec(),
-                section_offset: start,
+                section_offset: declared,
                 reason: format!(
-                    "section length {} overflows u64 when added to start offset {start}",
+                    "section length {} overflows u64 when added to start offset {declared}",
                     entry.len(),
                 ),
             });
             continue;
         };
-        // Mid-walk seek failure: don't propagate as a file-level Err
-        // (that would discard everything already scanned and report
-        // the whole SST as unreadable, which contradicts the
-        // function's contract). Surface as a `TocCorrupted` for this
-        // section and skip walking it; subsequent sections still run.
-        // Again `TocCorrupted` (not `HeaderCorrupted`): we never even
-        // reached a block to decode its header.
+        // Mid-walk seek failure: a forged offset still seeks fine, so a seek
+        // failure is a TRANSIENT I/O fault, not catalogue corruption. Record it as
+        // a `DataReadError` (which carries the I/O kind) so the repair verdict
+        // treats it as retryable and aborts, rather than routing a healthy SST
+        // through salvage over a flaky read. Keep walking other sections (the
+        // finding still surfaces; the caller decides).
         if let Err(e) = reader.seek(SeekFrom::Start(start)) {
-            errors.push(BlockVerifyError::TocCorrupted {
+            errors.push(BlockVerifyError::DataReadError {
                 table_id,
                 path: path.to_path_buf(),
-                section_name: entry.name().to_vec(),
-                section_offset: start,
-                reason: format!("seek to section start failed: {e}"),
+                offset: start,
+                data_length: 0,
+                error: e.into(),
             });
             continue;
         }
+        // Skip a section name this build does not know: its role expectation is
+        // unknowable, so a walk would prove nothing. `toc_catalogue_defects`
+        // above already reported it as a `TocCorrupted` finding (a re-stamped
+        // TOC can RENAME a known section out of every reader's sight while its
+        // blocks still pass their byte-level checks).
+        let Some(expected_roles) = expected_section_roles(entry.name()) else {
+            continue;
+        };
         let mut ctx = WalkCtx {
             reader: &mut reader,
             table_id,
             path,
             data_buf: &mut data_buf,
+            parity_buf: &mut parity_buf,
             blocks_scanned: &mut blocks_scanned,
             errors: &mut errors,
             max_data_length: block_data_length_cap(max_enc_overhead),
             ecc,
             ecc_unrecognized,
+            expected_roles,
         };
         walk_block_region(&mut ctx, start, end);
     }
@@ -1067,13 +1600,14 @@ fn scan_sst_blocks(
 }
 
 /// SFA TOC section names whose payload is NOT a sequence of `Block`s
-/// (i.e. NOT prefixed with the standard `Header`). The scrub skips
-/// these sections — their integrity is covered by the SFA-trailer
-/// checksum verified at table-open time. Every other section
-/// (`data` / `tli` / `tli_tail` / `index` / `filter_tli` / `filter` /
-/// `range_tombstones` / `meta` / `meta_mid`) is a `Header`-prefixed
-/// block run and gets walked. See `scan_sst_blocks` for the full
-/// section catalogue and the writer-side source of truth.
+/// (i.e. NOT prefixed with the standard `Header`). These sections carry NO
+/// per-section checksum (the SFA-trailer checksum covers only the TOC
+/// bytes), so the walk validates their SHAPE via
+/// [`raw_section_shape_error`] instead of decoding blocks. Every other
+/// section (`data` / `tli` / `tli_tail` / `index` / `filter_tli` /
+/// `filter` / `range_tombstones` / `meta` / `meta_mid`) is a
+/// `Header`-prefixed block run and gets walked. See `scan_sst_blocks` for
+/// the full section catalogue and the writer-side source of truth.
 ///
 /// `meta_separator` is the 4 KiB zero-padding section the writer
 /// emits between the MID and TAIL meta blocks so a single bad
@@ -1082,6 +1616,223 @@ fn scan_sst_blocks(
 /// to decode zeros as a `Header` and report a spurious
 /// `HeaderCorrupted` on every clean SST.
 const RAW_FORMAT_SECTIONS: &[&[u8]] = &[b"linked_blob_files", b"table_version", b"meta_separator"];
+
+/// Block ROLE(S) the writer emits into each named block-format SFA section.
+/// The walk cross-checks every decoded header against its section: a
+/// checksum-clean block whose `block_type` was re-stamped (a filter block
+/// relabeled as Data) passes every byte-level check, so this is the only
+/// out-of-band detector before the heal's digest reconciliation would
+/// launder the forge into the manifest.
+///
+/// `None` for a section name this build does not know — the CALLER fails
+/// closed on it (an error, not a skipped check): the SFA trailer checksum is
+/// unkeyed, so a re-stamped TOC can RENAME a known section (hiding it from
+/// every reader — vanished range tombstones resurrect deleted ranges) while
+/// each block inside still passes its byte-level checks. A future section
+/// name therefore requires extending this map in the same change that adds
+/// the writer section.
+///
+/// This role check is BYTE-LEVEL only. A section whose block is
+/// checksum-clean and correctly-roled but whose PAYLOAD was re-stamped to
+/// another structurally valid value (a redirected `locator`, a shrunk
+/// `zone_map` range, a widened `seqno_bounds`) passes here yet still lies to
+/// the read path. Those SEMANTIC cross-checks — comparing the section's
+/// decoded content against the blocks it summarizes — live on `Table`
+/// (`verify_locator` / `verify_zone_map` / `verify_seqno_bounds` /
+/// `verify_tli_mirrors` / `verify_block_entry_counts`) and are driven by the
+/// repair verdict and the heal digest reconciliation, not by this walk.
+fn expected_section_roles(name: &[u8]) -> Option<&'static [crate::table::block::BlockType]> {
+    use crate::table::block::BlockType;
+    Some(match name {
+        b"data" => &[BlockType::Data, BlockType::Columnar],
+        // `filter_tli` is the top-level index OVER filter partitions — the
+        // writer emits it with the Index role (same encoding as the data
+        // TLI), so expecting Filter here would flag a healthy
+        // partitioned-filter SST as corrupt.
+        b"index" | b"tli" | b"tli_tail" | b"filter_tli" => &[BlockType::Index],
+        b"filter" => &[BlockType::Filter],
+        b"range_tombstones" => &[BlockType::RangeTombstone],
+        b"meta" | b"meta_mid" => &[BlockType::Meta],
+        b"block_layout" => &[BlockType::BlockLayout],
+        b"seqno_bounds" => &[BlockType::SeqnoBounds],
+        b"zone_map" => &[BlockType::ZoneMap],
+        b"delete_bitmap" => &[BlockType::DeleteBitmap],
+        b"locator" => &[BlockType::Locator],
+        _ => return None,
+    })
+}
+
+/// One structural defect in the SFA TOC catalogue: a section a reader could not
+/// reach or that hides another. Carries the offending entry's name, its declared
+/// offset, and a human-readable reason.
+struct TocCatalogueDefect {
+    name: Vec<u8>,
+    offset: u64,
+    reason: String,
+}
+
+/// Classifies every structural defect in the TOC catalogue in one pass: a
+/// duplicate / shadowing name, a gap in the `[0, toc_pos)` tiling, an
+/// unrecognized (renamed) name, or a trailing hole. Empty when the catalogue
+/// tiles the whole data region with unique, recognized names.
+///
+/// The single source of truth for what a valid catalogue looks like:
+/// [`scan_sst_blocks`] turns each defect into a `TocCorrupted` finding and
+/// [`toc_may_hide_deletion_section`] fails closed on any, so the two can never
+/// disagree. The recognized-name set is `expected_section_roles` ∪
+/// [`RAW_FORMAT_SECTIONS`]. A `pos + len` overflow stops the tiling scan (the
+/// per-section walk reports that entry via its own `checked_add`), so it is not
+/// duplicated here.
+fn toc_catalogue_defects(toc: &crate::sfa::Toc, toc_pos: u64) -> Vec<TocCatalogueDefect> {
+    let mut defects = Vec::new();
+    let mut expected_pos: u64 = 0;
+    // A handful of section names — a linear scan keeps this no-std-clean.
+    let mut seen: Vec<&[u8]> = Vec::new();
+    for entry in toc.iter() {
+        let name = entry.name();
+        if seen.contains(&name) {
+            defects.push(TocCatalogueDefect {
+                name: name.to_vec(),
+                offset: entry.pos(),
+                reason: format!(
+                    "duplicate TOC section name {:?}; a renamed section can shadow \
+                     another and hide it from the readers that look it up by name",
+                    alloc::string::String::from_utf8_lossy(name),
+                ),
+            });
+        } else {
+            seen.push(name);
+        }
+        if entry.pos() != expected_pos {
+            defects.push(TocCatalogueDefect {
+                name: name.to_vec(),
+                offset: entry.pos(),
+                reason: format!(
+                    "section starts at {} but the previous section ended at \
+                     {expected_pos}; the gap hides an omitted TOC entry",
+                    entry.pos(),
+                ),
+            });
+        }
+        if expected_section_roles(name).is_none() && !RAW_FORMAT_SECTIONS.contains(&name) {
+            defects.push(TocCatalogueDefect {
+                name: name.to_vec(),
+                offset: entry.pos(),
+                reason: String::from(
+                    "unrecognized block-format section name; a renamed TOC entry \
+                     hides a known section from every reader",
+                ),
+            });
+        }
+        let Some(end) = entry.pos().checked_add(entry.len()) else {
+            expected_pos = u64::MAX;
+            break;
+        };
+        expected_pos = end;
+    }
+    if expected_pos != toc_pos {
+        defects.push(TocCatalogueDefect {
+            name: b"<tiling>".to_vec(),
+            offset: expected_pos,
+            reason: format!(
+                "sections end at {expected_pos} but the TOC begins at {toc_pos}; a \
+                 trailing TOC entry was omitted or truncated",
+            ),
+        });
+    }
+    defects
+}
+
+/// Whether the SST's TOC catalogue could HIDE an optional deletion section
+/// (`range_tombstones` / `delete_bitmap`) from the name-based readers. These
+/// sections are optional at parse time, so an unkeyed re-stamp that OMITS,
+/// RENAMES, or SHADOWS one leaves the parsed table reporting no deletions
+/// while every remaining block still passes its byte-level checks — a positional
+/// salvage would then re-emit the suppressed rows as live.
+///
+/// Returns `true` for the concealment classes: a duplicate/shadowing name, a
+/// gap or trailing hole in the `[0, toc_pos)` tiling, an unrecognized (renamed)
+/// name, or a length overflow. Returns `false` only when the catalogue tiles
+/// the whole data region with UNIQUE, RECOGNIZED names — then no section is
+/// hidden and the physical absence of any deletion section is established.
+///
+/// The recognized-name set mirrors the walk in [`scan_sst_blocks`] exactly
+/// (`expected_section_roles` ∪ [`RAW_FORMAT_SECTIONS`]), so a healthy table
+/// grades `false`.
+///
+/// Consumed by salvage-mode repair: a `Corrupt` verdict caused by one of these
+/// classes must be QUARANTINED, not salvaged, because the positional salvage
+/// walk reopens the same forged catalogue and resurrects the suppressed rows.
+///
+/// This catches only concealment that DISTURBS the catalogue (a missing,
+/// duplicated, or unrecognized name, or a tiling gap). A relabel that keeps the
+/// catalogue uniquely named and perfectly tiled — a deletion section RENAMED to
+/// an unused recognized name with its block re-roled — grades `false` here; it
+/// is caught instead inside salvage, which fails closed when the open degrades a
+/// rebuildable section that did not decode as its claimed type (see
+/// `Table::salvage_degraded_a_rebuildable_section`).
+pub(crate) fn toc_may_hide_deletion_section(toc: &crate::sfa::Toc, toc_pos: u64) -> bool {
+    !toc_catalogue_defects(toc, toc_pos).is_empty()
+}
+
+/// Structural validation for the raw (non-block-format) sections; returns a
+/// human-readable reason when the section's payload cannot have the shape
+/// the writer emits.
+///
+/// - `linked_blob_files`: `u32 count` followed by `count` fixed 32-byte
+///   records — the length must be exactly `4 + count * 32`.
+/// - `table_version`: exactly one byte.
+/// - `meta_separator`: pure padding, any content is acceptable.
+///
+/// This is SHAPE validation only: these sections carry no checksum, so rot
+/// inside a structurally valid payload is undetectable out-of-band.
+///
+/// `Err` is a TRANSIENT read/seek fault (retryable I/O), kept distinct from a
+/// structural shape defect (`Ok(Some(reason))`) so the caller can route it to an
+/// I/O finding the repair verdict treats as retryable rather than as corruption.
+fn raw_section_shape_error(
+    reader: &mut io::BufReader<Box<dyn crate::fs::FsFile>>,
+    name: &[u8],
+    pos: u64,
+    len: u64,
+) -> Result<Option<String>, io::Error> {
+    use alloc::string::ToString as _;
+    #[cfg(not(feature = "std"))]
+    use io::{Read as _, Seek as _, SeekFrom};
+    #[cfg(feature = "std")]
+    use std::io::{Read as _, Seek as _, SeekFrom};
+
+    match name {
+        b"linked_blob_files" => {
+            if len < 4 {
+                return Ok(Some(format!(
+                    "linked_blob_files section is {len} bytes, too short for its count prefix"
+                )));
+            }
+            reader.seek(SeekFrom::Start(pos))?;
+            let mut count_le = [0u8; 4];
+            reader.read_exact(&mut count_le)?;
+            let count = u64::from(u32::from_le_bytes(count_le));
+            // 4 fixed u64 fields per record.
+            let expected = count
+                .checked_mul(32)
+                .and_then(|records| records.checked_add(4));
+            if expected != Some(len) {
+                return Ok(Some(format!(
+                    "blob-link count {count} disagrees with the section length {len} \
+                     (expected {} bytes)",
+                    expected.map_or_else(|| "overflowing".to_string(), |e| e.to_string()),
+                )));
+            }
+            Ok(None)
+        }
+        b"table_version" => {
+            Ok((len != 1).then(|| format!("table_version section is {len} bytes, expected 1")))
+        }
+        // Padding: carries no data, nothing to validate.
+        _ => Ok(None),
+    }
+}
 
 /// Plaintext upper bound on a single block's on-disk data segment
 /// length, mirroring `table::block::MAX_DECOMPRESSION_SIZE` (256 MiB).
@@ -1116,6 +1867,10 @@ struct WalkCtx<'a> {
     table_id: TableId,
     path: &'a Path,
     data_buf: &'a mut Vec<u8>,
+    /// Reused buffer for each block's Page-ECC parity trailer: consumed for
+    /// walk alignment and, on a build with the ECC codecs, verified against
+    /// parity freshly recomputed over the payload.
+    parity_buf: &'a mut Vec<u8>,
     blocks_scanned: &'a mut usize,
     errors: &'a mut Vec<BlockVerifyError>,
     /// Effective `data_length` cap (plaintext limit + AEAD overhead).
@@ -1139,6 +1894,12 @@ struct WalkCtx<'a> {
     /// skipped (the caller warns once). Self-describing sections (`meta` /
     /// `meta_mid`) still size parity from `block_flags` and ARE walked.
     ecc_unrecognized: bool,
+    /// Roles the current section's blocks may legitimately carry (from
+    /// [`expected_section_roles`]; the caller fails closed on an unknown
+    /// name before building this context). A decoded header whose
+    /// `block_type` is not in the list is reported — see the helper's docs
+    /// for why this check is load-bearing.
+    expected_roles: &'static [crate::table::block::BlockType],
 }
 
 fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) {
@@ -1179,6 +1940,19 @@ fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) 
         }
         let header = match Header::decode_from(ctx.reader) {
             Ok(h) => h,
+            // A TRANSIENT read fault decoding the header is retryable, not
+            // corruption: record it as a DataReadError so the repair verdict
+            // aborts instead of salvaging a healthy table over a flaky read.
+            Err(crate::Error::Io(e)) => {
+                ctx.errors.push(BlockVerifyError::DataReadError {
+                    table_id: ctx.table_id,
+                    path: ctx.path.to_path_buf(),
+                    offset,
+                    data_length: 0,
+                    error: e,
+                });
+                return;
+            }
             Err(e) => {
                 ctx.errors.push(BlockVerifyError::HeaderCorrupted {
                     table_id: ctx.table_id,
@@ -1200,6 +1974,23 @@ fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) 
         // decides the whole section.
         if ctx.ecc_unrecognized && !Header::has_block_flags(header.block_type) {
             return;
+        }
+
+        // Role cross-check: a checksum-clean block whose `block_type` was
+        // re-stamped (a filter block relabeled as Data) passes every
+        // byte-level check below, so the section-vs-role comparison is the
+        // only out-of-band detector. Reported and then walked normally —
+        // the header is internally valid, so the offsets stay trustworthy.
+        if !ctx.expected_roles.contains(&header.block_type) {
+            ctx.errors.push(BlockVerifyError::HeaderCorrupted {
+                table_id: ctx.table_id,
+                path: ctx.path.to_path_buf(),
+                offset,
+                reason: format!(
+                    "block role {:?} does not belong to this section (expected one of {:?})",
+                    header.block_type, ctx.expected_roles,
+                ),
+            });
         }
 
         // Count the block as "header-read" immediately on successful
@@ -1241,6 +2032,25 @@ fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) 
                 scheme,
             ))
         });
+        // Hard cap on the parity trailer, mirroring the data_length cap
+        // below: a syntactically valid but absurd shard layout (e.g.
+        // RS(1,255), every payload byte amplified 255x into parity) drives
+        // `expected_parity_len` toward its u32::MAX saturation point, and a
+        // lying TOC length (forged, or a sparse file) would let the buffered
+        // verify reserve that whole multi-GB trailer before any corruption
+        // is reported. No real configuration produces a trailer above the
+        // payload cap itself.
+        if parity_len > MAX_BLOCK_DATA_LENGTH {
+            ctx.errors.push(BlockVerifyError::HeaderCorrupted {
+                table_id: ctx.table_id,
+                path: ctx.path.to_path_buf(),
+                offset,
+                reason: format!(
+                    "parity trailer length {parity_len} exceeds hard cap {MAX_BLOCK_DATA_LENGTH}",
+                ),
+            });
+            return;
+        }
 
         // Validate data_length against TWO bounds before allocating
         // / reading:
@@ -1335,7 +2145,8 @@ fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) 
         }
 
         let computed = Checksum::from_raw(crate::hash::hash128(ctx.data_buf));
-        if computed != header.checksum {
+        let payload_clean = computed == header.checksum;
+        if !payload_clean {
             ctx.errors.push(BlockVerifyError::DataCorrupted {
                 table_id: ctx.table_id,
                 path: ctx.path.to_path_buf(),
@@ -1347,58 +2158,57 @@ fn walk_block_region(ctx: &mut WalkCtx<'_>, start_offset: u64, end_offset: u64) 
         }
 
         // Consume the parity trailer (if any) so the reader cursor lands on
-        // the next block's header. The payload checksum above already covers
-        // correctness; parity is only consulted for ECC recovery on the live
-        // read path, so the scrub discards it — but it MUST still skip exactly
-        // `parity_len` bytes or the next iteration mis-reads parity as a header.
+        // the next block's header — it MUST advance exactly `parity_len` bytes
+        // or the next iteration mis-reads parity as a header. The trailer is
+        // read into a buffer (not drained) so a build with the ECC codecs can
+        // also VERIFY it: the payload checksum never covers the trailer, so
+        // rot confined to parity reads as a clean block while its ECC is dead.
         if parity_len > 0 {
-            // Discard the parity trailer so the cursor lands on the next block's
-            // header. `crate::io` has no `copy`/`sink`, so drain exactly
-            // `parity_len` bytes through a small scratch buffer.
-            let mut scratch = [0u8; 512];
-            let mut remaining = parity_len;
-            // A short read (EOF before `parity_len`) and an underlying read error
-            // are the same outcome for the scrub: the trailer cannot be skipped,
-            // so collapse both into one `Err` and report a single DataReadError.
-            let drain: io::Result<()> = loop {
-                if remaining == 0 {
-                    break Ok(());
-                }
-                let want =
-                    usize::try_from(remaining.min(scratch.len() as u64)).unwrap_or(scratch.len());
-                let (head, _) = scratch.split_at_mut(want);
-                match ctx.reader.read(head) {
-                    Ok(0) => {
-                        break Err(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            alloc::format!(
-                                "parity trailer truncated: read {} of {parity_len} bytes",
-                                parity_len - remaining
-                            ),
-                        ));
-                    }
-                    Ok(n) => remaining -= n as u64,
-                    Err(e) => {
-                        // EINTR is transient: retry the read rather than aborting
-                        // the parity skip with a spurious DataReadError (matches
-                        // the Interrupted handling in read_exact above). Convert
-                        // first so the kind check is uniform across std/no_std.
-                        let e: io::Error = e.into();
-                        if e.kind() != io::ErrorKind::Interrupted {
-                            break Err(e);
-                        }
-                    }
-                }
-            };
-            if let Err(error) = drain {
+            let parity_usize = usize::try_from(parity_len).unwrap_or(usize::MAX);
+            ctx.parity_buf.resize(parity_usize, 0);
+            // A short read (EOF before `parity_len`) and an underlying read
+            // error are the same outcome for the scrub: the trailer cannot be
+            // consumed, so report a single DataReadError. (`read_exact`
+            // retries `Interrupted` internally.)
+            if let Err(e) = ctx.reader.read_exact(ctx.parity_buf.as_mut_slice()) {
                 ctx.errors.push(BlockVerifyError::DataReadError {
                     table_id: ctx.table_id,
                     path: ctx.path.to_path_buf(),
                     offset,
                     data_length: header.data_length,
-                    error,
+                    error: e.into(),
                 });
                 return;
+            }
+            // Compare the stored trailer against parity freshly computed over
+            // the payload — only when the payload itself is checksum-clean (a
+            // corrupt payload legitimately mismatches its original trailer and
+            // is already reported as DataCorrupted above). Only a build with
+            // the ECC codecs can recompute parity; without `page_ecc` the
+            // trailer is consumed for alignment but stays unverified (that
+            // build cannot consume it on the read path either).
+            #[cfg(feature = "page_ecc")]
+            if payload_clean && let Some(scheme) = block_ecc {
+                let fresh = match scheme {
+                    crate::table::block::EccParams::Secded => {
+                        Some(crate::secded::encode_block_parity(ctx.data_buf))
+                    }
+                    crate::table::block::EccParams::Shard { .. } => {
+                        let (ds, ps) = scheme.as_shards();
+                        crate::ecc::encode_parity(ctx.data_buf, ds, ps).ok()
+                    }
+                };
+                // An encoder that rejects a shape the writer accepted, or a
+                // trailer that differs from the recomputed parity, both mean
+                // the block's ECC cannot be trusted — fail loud either way.
+                if fresh.as_deref() != Some(ctx.parity_buf.as_slice()) {
+                    ctx.errors.push(BlockVerifyError::EccParityMismatch {
+                        table_id: ctx.table_id,
+                        path: ctx.path.to_path_buf(),
+                        offset,
+                        data_length: header.data_length,
+                    });
+                }
             }
         }
 

--- a/src/verify/block_verify_tests.rs
+++ b/src/verify/block_verify_tests.rs
@@ -222,6 +222,84 @@ fn verify_block_checksums_clean_nondefault_ecc_tree_has_no_errors() {
     );
 }
 
+/// Rot confined to a Page-ECC parity trailer is invisible to the payload
+/// checksum (the checksum covers the payload only; parity is consulted just
+/// for recovery on a mismatch), so a walk that merely SKIPS the trailer
+/// reports the SST as healthy while its ECC is dead — a later payload fault
+/// on that block would no longer be recoverable. The out-of-band walk must
+/// compare each clean block's trailer against freshly computed parity and
+/// flag a mismatch.
+#[cfg(feature = "page_ecc")]
+#[test]
+fn verify_sst_file_detects_a_rotted_parity_trailer() {
+    use crate::coding::Decode;
+    use crate::table::block::Header;
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let any = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+        .page_ecc(true)
+        .ecc_scheme(crate::runtime_config::EccScheme::ReedSolomon {
+            data_shards: 4,
+            parity_shards: 2,
+        })
+        .open()
+        .unwrap();
+        for i in 0u64..2_000 {
+            let key = format!("k{i:08}");
+            let val = format!("v{i:08}");
+            any.insert(key.as_bytes(), val.as_bytes(), 1 + i);
+        }
+        any.flush_active_memtable(2_001).unwrap();
+        drop(any);
+    }
+    let sst_path = pick_first_sst_path(dir.path());
+
+    // The pristine SST must verify clean BEFORE the flip, so the mismatch
+    // asserted below is provably caused by the corruption, not a pre-existing
+    // problem in the freshly written file.
+    assert!(
+        verify_sst_file(&sst_path).is_ok(),
+        "the freshly written SST must verify clean before corruption",
+    );
+
+    // The first data block sits at file offset 0 (the writer opens the file
+    // with the `data` section). Its parity trailer follows the payload:
+    // header_len + data_length.
+    let mut bytes = std::fs::read(&sst_path).unwrap();
+    let mut cursor = bytes.as_slice();
+    let header = Header::decode_from(&mut cursor).unwrap();
+    let trailer_pos = Header::header_len(header.block_type) + header.data_length as usize;
+    let slot = bytes
+        .get_mut(trailer_pos)
+        .expect("parity trailer within the file");
+    *slot ^= 0xFF;
+    std::fs::write(&sst_path, &bytes).unwrap();
+
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        !report.is_ok(),
+        "a rotted parity trailer under a clean payload checksum must be \
+         flagged (dead ECC), got {report:?}",
+    );
+    let mismatch = report
+        .errors
+        .iter()
+        .find(|e| matches!(e, BlockVerifyError::EccParityMismatch { .. }))
+        .unwrap_or_else(|| panic!("expected an EccParityMismatch error, got {report:?}"));
+    // The rendered finding names the block and the dead-ECC condition.
+    let rendered = mismatch.to_string();
+    assert!(
+        rendered.contains("parity trailer") && rendered.contains("offset 0"),
+        "display names the block and the condition: {rendered}",
+    );
+}
+
 /// Returns the on-disk path of the first SST registered with the
 /// tree's current version. Drops the tree before returning so the
 /// caller can mutate the file safely (no descriptor cache, no
@@ -447,6 +525,319 @@ fn verify_sst_file_clean_file_has_no_errors() {
     );
 }
 
+/// A re-stamped TOC that OMITS a correctness-bearing entry entirely (the SFA
+/// trailer checksum is unkeyed) must fail the walk closed: `delete_bitmap` /
+/// `range_tombstones` are optional at parse time, so a vanished section
+/// resurrects deleted rows while every remaining block still passes its
+/// byte-level checks. The writer emits sections strictly back-to-back, so the
+/// gap the omission leaves in the section tiling is the only out-of-band
+/// trace.
+#[test]
+fn verify_sst_file_flags_an_omitted_toc_section() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let cfg = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(CompressionPolicy::all(CompressionType::None));
+        let tree = cfg.open().unwrap();
+        for i in 0u64..100 {
+            let key = format!("k{i:08}");
+            tree.insert(key.as_bytes(), b"v", 1 + i);
+        }
+        // A range tombstone gives the SST the optional `range_tombstones`
+        // section whose omission the walk must catch.
+        tree.remove_range("k00000010", "k00000020", 200);
+        tree.flush_active_memtable(300).unwrap();
+        drop(tree);
+    }
+    let sst_path = pick_first_sst_path(dir.path());
+
+    // Sanity: intact file verifies clean.
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.is_ok(),
+        "intact SST must be clean: {:?}",
+        report.errors
+    );
+
+    crate::test_forge::forge_section_omitted(&sst_path, b"range_tombstones").unwrap();
+
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            BlockVerifyError::TocCorrupted { reason, .. }
+                if reason.contains("the gap hides an omitted TOC entry")
+        )),
+        "an omitted TOC entry leaves a tiling gap the walk must flag with the \
+         gap-specific TocCorrupted reason, got {:?}",
+        report.errors,
+    );
+}
+
+/// A tail meta mirror re-stamped with an UNRECOGNIZED ECC descriptor must still
+/// be compared against `meta_mid` for its non-ECC fields. Excluding it from the
+/// full mirror comparison lets a forge change a correctness field (here
+/// `created_at`) behind the unknown descriptor and evade the divergence check:
+/// a backdated `created_at`, selected by tail-first recovery, can make FIFO /
+/// TTL compaction discard live data. Both copies decode, so the comparison must
+/// see the tail's changed field even though its ECC descriptor is unknown.
+#[test]
+fn verify_sst_file_flags_diverging_mirrors_behind_an_unrecognized_ecc() {
+    let dir = tempfile::tempdir().unwrap();
+    populate_tree(dir.path(), 200);
+    let sst_path = pick_first_sst_path(dir.path());
+
+    // Sanity: intact file verifies clean.
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.is_ok(),
+        "intact SST must be clean: {:?}",
+        report.errors
+    );
+
+    // Forge ONLY the tail mirror: an UNRECOGNIZED ECC descriptor (`[9,_,_,_]` =
+    // unknown kind, which would exclude the mirror from the comparison) AND a
+    // changed `created_at` (the correctness field the forge hides behind it).
+    // meta_mid stays intact, so the two now decode to different metadata.
+    crate::test_forge::forge_tail_meta_value(&sst_path, b"descriptor#page_ecc", &[9, 0, 0, 0])
+        .unwrap();
+    crate::test_forge::forge_tail_meta_value(&sst_path, b"created_at", &[0xFF; 16]).unwrap();
+
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            BlockVerifyError::TocCorrupted { reason, .. }
+                if reason.contains("mirrors decode to different metadata")
+        )),
+        "a tail mirror that changed created_at behind an unrecognized ECC \
+         descriptor must still diverge from meta_mid, got {:?}",
+        report.errors,
+    );
+}
+
+/// A table whose BOTH meta mirrors advertise an UNRECOGNIZED ECC descriptor (they
+/// agree, so no divergence) cannot have its ECC-bearing SST sections walked: the
+/// parity-trailer length is underivable, so the block walk SKIPS the data blocks
+/// entirely. The scan verified NOTHING about the data, so the report must be
+/// INCOMPLETE and `is_ok()` must be false — a clean verdict would falsely claim
+/// the data verified. The unrecognized-ECC warning is still recorded.
+#[test]
+fn verify_sst_file_reports_incomplete_when_ecc_is_unrecognized_in_both_mirrors() {
+    let dir = tempfile::tempdir().unwrap();
+    populate_tree(dir.path(), 200);
+    let sst_path = pick_first_sst_path(dir.path());
+
+    // Sanity: intact file verifies clean.
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.is_ok(),
+        "intact SST must be clean: {:?}",
+        report.errors
+    );
+
+    // Forge BOTH mirrors' ECC descriptor to an unknown kind: the two agree (no
+    // mirror divergence), but neither can be applied, so the walk skips the SST
+    // block sections.
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"descriptor#page_ecc",
+        &[9, 0, 0, 0],
+    )
+    .unwrap();
+
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.errors.is_empty(),
+        "no corruption, only an unwalkable ECC scheme: {:?}",
+        report.errors,
+    );
+    assert!(
+        report.incomplete,
+        "the walk skipped the data blocks, so the scan is incomplete",
+    );
+    assert!(
+        !report.is_ok(),
+        "an incomplete scan (data blocks never verified) must not report OK",
+    );
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| matches!(w, crate::verify::BlockVerifyWarning::UnrecognizedEcc { .. })),
+        "the unrecognized-ECC warning must still be recorded: {:?}",
+        report.warnings,
+    );
+}
+
+/// Tree-level regression for the merged report: `verify_block_checksums` folds
+/// each per-SST partial report through `merge_report`. An SST with an
+/// unrecognized ECC descriptor produces an INCOMPLETE partial (its data blocks
+/// were skipped unwalked), so the merged whole-tree report must stay incomplete
+/// and `is_ok()` false. If the merge drops the `incomplete` flag, the final
+/// report reverts to `false` and falsely reports OK with no other errors.
+/// SEVERAL SSTs, only one forged: the clean partials folded after the
+/// incomplete one would launder the flag under an OVERWRITING (rather than
+/// OR-ing) merge, so the multi-SST shape pins the accumulation itself.
+#[cfg(feature = "std")]
+#[test]
+fn verify_block_checksums_stays_incomplete_when_one_sst_has_unrecognized_ecc() {
+    let dir = tempfile::tempdir().unwrap();
+    populate_multi_sst(dir.path(), 3, 200);
+
+    // Sanity: intact tree verifies clean.
+    let tree = reopen_tree(dir.path());
+    let report = verify_block_checksums(&tree);
+    assert!(
+        report.is_ok(),
+        "intact tree must be clean: {:?}",
+        report.errors
+    );
+    drop(tree);
+
+    // Forge the first SST's ECC descriptor (both mirrors) to an unknown kind:
+    // its data-block sections become unwalkable, so its per-SST scan is
+    // incomplete. The whole-tree fold must PRESERVE that incompleteness.
+    let sst_path = pick_first_sst_path(dir.path());
+    crate::test_forge::forge_meta_value_both_mirrors(
+        &sst_path,
+        b"descriptor#page_ecc",
+        &[9, 0, 0, 0],
+    )
+    .unwrap();
+
+    let tree = reopen_tree(dir.path());
+    let report = verify_block_checksums(&tree);
+    assert!(
+        report.errors.is_empty(),
+        "no corruption, only an unwalkable ECC scheme: {:?}",
+        report.errors,
+    );
+    assert!(
+        report.incomplete,
+        "the merged report must inherit the incomplete flag from the skipped SST",
+    );
+    assert!(
+        !report.is_ok(),
+        "a merged report that skipped a whole SST's data blocks must not report OK",
+    );
+}
+
+/// A TOC entry RENAMED to a duplicate recognized name — `range_tombstones`
+/// renamed to a second `data`, its block header re-stamped with the `Data`
+/// role — preserves the tiling AND passes the recognized-role walk, yet the
+/// reader's name lookup (`Toc::section`) returns the first match, hiding the
+/// renamed section so the deleted range silently resurrects. The duplicate
+/// name is the only trace; the walk must reject it.
+#[test]
+fn verify_sst_file_flags_a_duplicate_toc_section_name() {
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let cfg = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .data_block_compression_policy(CompressionPolicy::all(CompressionType::None));
+        let tree = cfg.open().unwrap();
+        for i in 0u64..100 {
+            let key = format!("k{i:08}");
+            tree.insert(key.as_bytes(), b"v", 1 + i);
+        }
+        tree.remove_range("k00000010", "k00000020", 200);
+        tree.flush_active_memtable(300).unwrap();
+        drop(tree);
+    }
+    let sst_path = pick_first_sst_path(dir.path());
+
+    // Sanity: intact file verifies clean.
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.is_ok(),
+        "intact SST must be clean: {:?}",
+        report.errors
+    );
+
+    crate::test_forge::forge_duplicate_section_name(
+        &sst_path,
+        b"range_tombstones",
+        b"data",
+        crate::table::block::BlockType::Data,
+    )
+    .unwrap();
+
+    let report = verify_sst_file(&sst_path);
+    // Match the duplicate-name finding specifically: the forge rewrites the
+    // whole TOC, so an unrelated TocCorrupted (tiling gap, seek failure,
+    // unrecognized name) would keep this green without proving the
+    // duplicate-name detection ran.
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            BlockVerifyError::TocCorrupted { section_name, reason, .. }
+                if section_name == b"data" && reason.contains("duplicate TOC section name")
+        )),
+        "a duplicate recognized section name must be flagged as TocCorrupted, \
+         got {:?}",
+        report.errors,
+    );
+}
+
+/// A healthy SST with a PARTITIONED Bloom filter must verify clean: the
+/// writer emits the `filter_tli` block with the Index role (it is a
+/// top-level index over filter partitions, same encoding as the data
+/// TLI), so a role map expecting Filter there flags a role mismatch on an
+/// intact file — and `repair_with_salvage` would grade the healthy table
+/// corrupt and quarantine or re-salvage it.
+#[test]
+fn verify_sst_file_accepts_a_partitioned_filter() {
+    use crate::InternalValue;
+    use crate::ValueType::Value;
+    use crate::table::Writer;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sst_path = dir.path().join("partitioned");
+    let mut writer = Writer::new(sst_path.clone(), 0, 0, Arc::new(crate::fs::StdFs))
+        .unwrap()
+        .use_partitioned_filter()
+        // A tiny partition budget so several filter partitions spill and
+        // the writer emits the `filter_tli` top-level index over them.
+        .use_meta_partition_size(3);
+    for i in 0u64..64 {
+        writer
+            .write(InternalValue::from_components(
+                format!("key-{i:03}").into_bytes(),
+                format!("val-{i:03}").into_bytes(),
+                i + 1,
+                Value,
+            ))
+            .unwrap();
+    }
+    assert!(writer.finish().unwrap().is_some(), "SST is non-empty");
+
+    // Sanity: the layout actually carries the partitioned filter TLI.
+    {
+        let mut f = std::fs::File::open(&sst_path).unwrap();
+        let reader = crate::sfa::Reader::from_reader(&mut f).unwrap();
+        assert!(
+            reader.toc().iter().any(|e| e.name() == b"filter_tli"),
+            "the fixture must produce a filter_tli section",
+        );
+    }
+
+    let report = verify_sst_file(&sst_path);
+    assert!(
+        report.is_ok(),
+        "a healthy partitioned-filter SST must verify clean: {:?}",
+        report.errors,
+    );
+}
+
 /// Exercises the file-open failure branch (the only path through
 /// `verify_sst_file` that converts an underlying `io::Error` into
 /// a `BlockVerifyError::SstFileUnreadable`). A missing file is the
@@ -527,9 +918,9 @@ fn verify_sst_file_missing_file_reports_unreadable() {
               the u64 -> usize cast cannot overflow on any target \
               the test runs on (the forged archive is < 1 KiB)"
 )]
-fn walk_block_region_reports_data_read_error_on_truncated_data_segment() {
+fn walk_block_region_reports_data_read_error_on_truncated_data_segment() -> crate::Result<()> {
     use crate::coding::Encode;
-    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use crate::fs::{Fs, FsOpenOptions, StdFs};
     use crate::table::block::{BlockType, Header};
 
     // Trailer layout (38 bytes at the tail of an SFA archive):
@@ -590,31 +981,39 @@ fn walk_block_region_reports_data_read_error_on_truncated_data_segment() {
     archive_bytes[csum_field_offset..csum_field_offset + 16]
         .copy_from_slice(&new_toc_checksum.to_le_bytes());
 
-    // Materialize the forged archive in MemFs and run the scanner.
-    let fs = MemFs::new();
-    let path = std::path::Path::new("/forged.sst");
+    // Materialize the forged archive on a real temp file and run the scanner.
+    let dir = tempfile::tempdir()?;
+    let fs = StdFs;
+    let forged = dir.path().join("forged.sst");
+    let path = forged.as_path();
     {
-        let mut f = fs
-            .open(
-                path,
-                &FsOpenOptions::new().write(true).create(true).truncate(true),
-            )
-            .unwrap();
-        f.write_all(&archive_bytes).unwrap();
+        let mut f = fs.open(
+            path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        f.write_all(&archive_bytes)?;
     }
 
     let table_id: TableId = 42;
-    let scan = scan_sst_blocks(&fs, path, table_id, 0, None, false)
-        .expect("forged SFA must parse cleanly");
+    let scan = scan_sst_blocks(&fs, path, table_id, 0, None, false, 0)?;
+    // The inflated section length ALSO breaks the TOC tiling invariant
+    // (the declared section end runs past where the TOC begins), so the
+    // walk reports the tiling finding alongside the read error.
     assert_eq!(
         scan.errors.len(),
-        1,
-        "expected exactly one error, got {:?}",
+        2,
+        "expected the tiling finding plus the read error, got {:?}",
         scan.errors,
     );
-    let err = scan.errors.first().unwrap();
     assert!(
-        matches!(
+        scan.errors
+            .iter()
+            .any(|e| matches!(e, BlockVerifyError::TocCorrupted { .. })),
+        "the inflated section length must break the TOC tiling: {:?}",
+        scan.errors,
+    );
+    assert!(
+        scan.errors.iter().any(|err| matches!(
             err,
             BlockVerifyError::DataReadError {
                 table_id: t,
@@ -622,15 +1021,17 @@ fn walk_block_region_reports_data_read_error_on_truncated_data_segment() {
                 data_length: d,
                 ..
             } if *t == table_id && *d == DATA_LENGTH,
-        ),
+        )),
         "expected DataReadError {{ table_id: {table_id}, offset: 0, \
-         data_length: {DATA_LENGTH}, .. }}; got {err:?}",
+         data_length: {DATA_LENGTH}, .. }}; got {:?}",
+        scan.errors,
     );
     assert_eq!(
         scan.blocks_scanned, 1,
         "header decoded successfully, so blocks_scanned must count this block \
          even though the data segment read failed",
     );
+    Ok(())
 }
 
 /// The parity-trailer drain reports a truncated read when an SST whose ECC
@@ -647,9 +1048,9 @@ fn walk_block_region_reports_data_read_error_on_truncated_data_segment() {
     reason = "synthetic SFA forgery — offsets are in-bounds by construction (we wrote the \
               bytes ourselves) and the archive is < 8 KiB, so the casts cannot overflow"
 )]
-fn walk_block_region_reports_data_read_error_on_truncated_parity_trailer() {
+fn walk_block_region_reports_data_read_error_on_truncated_parity_trailer() -> crate::Result<()> {
     use crate::coding::Encode;
-    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use crate::fs::{Fs, FsOpenOptions, StdFs};
     use crate::table::block::{BlockType, EccParams, Header, expected_parity_len};
 
     // Trailer layout (38 bytes at the tail of an SFA archive):
@@ -700,23 +1101,22 @@ fn walk_block_region_reports_data_read_error_on_truncated_parity_trailer() {
     archive_bytes[csum_field_offset..csum_field_offset + 16]
         .copy_from_slice(&new_toc_checksum.to_le_bytes());
 
-    let fs = MemFs::new();
-    let path = std::path::Path::new("/forged-parity.sst");
+    let dir = tempfile::tempdir()?;
+    let fs = StdFs;
+    let forged = dir.path().join("forged-parity.sst");
+    let path = forged.as_path();
     {
-        let mut f = fs
-            .open(
-                path,
-                &FsOpenOptions::new().write(true).create(true).truncate(true),
-            )
-            .unwrap();
-        f.write_all(&archive_bytes).unwrap();
+        let mut f = fs.open(
+            path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        f.write_all(&archive_bytes)?;
     }
 
     // Scan as an RS(4,2) table: a non-zero parity_len is drained after the
     // (clean) payload, hitting EOF in the short SFA tail.
     let table_id: TableId = 7;
-    let scan = scan_sst_blocks(&fs, path, table_id, 0, Some(EccParams::RS_4_2), false)
-        .expect("forged SFA must parse cleanly");
+    let scan = scan_sst_blocks(&fs, path, table_id, 0, Some(EccParams::RS_4_2), false, 0)?;
     assert!(
         scan.errors.iter().any(|e| matches!(
             e,
@@ -726,6 +1126,107 @@ fn walk_block_region_reports_data_read_error_on_truncated_parity_trailer() {
         "expected a truncated-parity DataReadError, got {:?}",
         scan.errors,
     );
+    Ok(())
+}
+
+/// A syntactically valid but absurd shard layout (RS(1,255): every payload
+/// byte amplified 255x into parity) drives `expected_parity_len` toward
+/// `u32::MAX`. Combined with a lying TOC length (a forged or sparse SST), the
+/// walk would reserve the whole multi-GB trailer buffer BEFORE reporting any
+/// corruption. The trailer length must be capped like `data_length` is: over
+/// the cap it is `HeaderCorrupted`, reported without reserving anything.
+#[test]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::cast_possible_truncation,
+    reason = "synthetic SFA forgery — offsets are in-bounds by construction (we wrote the \
+              bytes ourselves) and the archive is small, so the casts cannot overflow"
+)]
+fn walk_block_region_caps_an_absurd_parity_trailer_length() -> crate::Result<()> {
+    use crate::coding::Encode;
+    use crate::fs::{Fs, FsOpenOptions, StdFs};
+    use crate::table::block::{BlockType, EccParams, Header, expected_parity_len};
+
+    // Trailer layout (38 bytes at the tail of an SFA archive):
+    //   MAGIC(4) | version(1) | csum_type(1) | toc_checksum(16) | toc_pos(8) | toc_len(8)
+    const TRAILER_LEN: usize = 4 + 1 + 1 + 16 + 8 + 8;
+    // 2 MiB of real payload: RS(1,255) turns that into a ~510 MiB claimed
+    // parity trailer — well over the 256 MiB hard cap.
+    const DATA_LENGTH: u32 = 2 * 1024 * 1024;
+    const HEADER_LEN: u64 = Header::MIN_LEN as u64;
+
+    let params = EccParams::try_new(1, 255).expect("a 1/255 shard layout parses");
+    let parity_len = u64::from(expected_parity_len(DATA_LENGTH, params));
+    assert!(
+        parity_len > u64::from(DATA_LENGTH) * 200,
+        "the forged scheme must amplify parity far past the payload",
+    );
+
+    let data = vec![0xABu8; DATA_LENGTH as usize];
+    let header = Header {
+        checksum: Checksum::from_raw(crate::hash::hash128(&data)),
+        data_length: DATA_LENGTH,
+        uncompressed_length: DATA_LENGTH,
+        ..Header::test_dummy(BlockType::Data)
+    };
+
+    // One `data` section: header + full payload, no parity bytes on disk.
+    let mut archive_bytes: Vec<u8> = Vec::new();
+    {
+        let mut writer = crate::sfa::Writer::from_writer(std::io::Cursor::new(&mut archive_bytes));
+        writer.start("data").unwrap();
+        writer.write_all(&header.encode_into_vec()).unwrap();
+        writer.write_all(&data).unwrap();
+        writer.finish().unwrap();
+    }
+
+    // Inflate the TOC section length to cover the claimed parity so the
+    // bounds check passes (the sparse-file / forged-TOC shape), recomputing
+    // the TOC checksum so crate::sfa::Reader still accepts the file.
+    let trailer_start = archive_bytes.len() - TRAILER_LEN;
+    let toc_pos = u64::from_le_bytes(
+        archive_bytes[trailer_start + 22..trailer_start + 30]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let toc_len = u64::from_le_bytes(
+        archive_bytes[trailer_start + 30..trailer_start + 38]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let len_field_offset = toc_pos + 4 + 4 + 8;
+    let lied_len: u64 = HEADER_LEN + u64::from(DATA_LENGTH) + parity_len;
+    archive_bytes[len_field_offset..len_field_offset + 8].copy_from_slice(&lied_len.to_le_bytes());
+    let new_toc_checksum = crate::hash::hash128(&archive_bytes[toc_pos..toc_pos + toc_len]);
+    let csum_field_offset = trailer_start + 4 + 1 + 1;
+    archive_bytes[csum_field_offset..csum_field_offset + 16]
+        .copy_from_slice(&new_toc_checksum.to_le_bytes());
+
+    let dir = tempfile::tempdir()?;
+    let fs = StdFs;
+    let forged = dir.path().join("forged-parity-cap.sst");
+    let path = forged.as_path();
+    {
+        let mut f = fs.open(
+            path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        f.write_all(&archive_bytes)?;
+    }
+
+    let table_id: TableId = 7;
+    let scan = scan_sst_blocks(&fs, path, table_id, 0, Some(params), false, 0)?;
+    assert!(
+        scan.errors.iter().any(|e| matches!(
+            e,
+            BlockVerifyError::HeaderCorrupted { table_id: t, offset: 0, reason, .. }
+                if *t == table_id && reason.contains("parity trailer length")
+        )),
+        "an over-cap parity trailer must be HeaderCorrupted without reserving \
+         the buffer, got {:?}",
+        scan.errors,
+    );
+    Ok(())
 }
 
 /// A block header whose own bytes extend past the section boundary must be
@@ -745,9 +1246,9 @@ fn walk_block_region_reports_data_read_error_on_truncated_parity_trailer() {
     reason = "synthetic SFA forgery — offsets are in-bounds by construction \
               and the forged archive is < 1 KiB"
 )]
-fn walk_block_region_reports_header_crossing_section_boundary() {
+fn walk_block_region_reports_header_crossing_section_boundary() -> crate::Result<()> {
     use crate::coding::Encode;
-    use crate::fs::{Fs, FsOpenOptions, MemFs};
+    use crate::fs::{Fs, FsOpenOptions, StdFs};
     use crate::table::block::{BlockType, Header};
 
     const TRAILER_LEN: usize = 4 + 1 + 1 + 16 + 8 + 8;
@@ -767,7 +1268,10 @@ fn walk_block_region_reports_header_crossing_section_boundary() {
     let mut archive_bytes: Vec<u8> = Vec::new();
     {
         let mut writer = crate::sfa::Writer::from_writer(std::io::Cursor::new(&mut archive_bytes));
-        writer.start("data").unwrap();
+        // "meta", not "data": the section-vs-role cross-check would report
+        // a Meta block inside a data section as a SECOND error, and this
+        // test pins down exactly one (the boundary violation).
+        writer.start("meta").unwrap();
         writer.write_all(&header.encode_into_vec()).unwrap();
         writer.finish().unwrap();
     }
@@ -795,36 +1299,46 @@ fn walk_block_region_reports_header_crossing_section_boundary() {
     archive_bytes[csum_field_offset..csum_field_offset + 16]
         .copy_from_slice(&new_toc_checksum.to_le_bytes());
 
-    let fs = MemFs::new();
-    let path = std::path::Path::new("/forged-boundary.sst");
+    let dir = tempfile::tempdir()?;
+    let fs = StdFs;
+    let forged = dir.path().join("forged-boundary.sst");
+    let path = forged.as_path();
     {
-        let mut f = fs
-            .open(
-                path,
-                &FsOpenOptions::new().write(true).create(true).truncate(true),
-            )
-            .unwrap();
-        f.write_all(&archive_bytes).unwrap();
+        let mut f = fs.open(
+            path,
+            &FsOpenOptions::new().write(true).create(true).truncate(true),
+        )?;
+        f.write_all(&archive_bytes)?;
     }
 
     let table_id: TableId = 7;
-    let scan = scan_sst_blocks(&fs, path, table_id, 0, None, false)
-        .expect("forged SFA must parse cleanly");
+    let scan = scan_sst_blocks(&fs, path, table_id, 0, None, false, 0)?;
+    // The shrunken section length ALSO breaks the TOC tiling invariant
+    // (the sections no longer reach the TOC start), so the walk reports
+    // the tiling finding alongside the boundary violation.
     assert_eq!(
         scan.errors.len(),
-        1,
-        "expected exactly one error, got {:?}",
+        2,
+        "expected the tiling finding plus the boundary violation, got {:?}",
         scan.errors,
     );
-    let err = scan.errors.first().unwrap();
     assert!(
-        matches!(
+        scan.errors
+            .iter()
+            .any(|e| matches!(e, BlockVerifyError::TocCorrupted { .. })),
+        "the shrunken section length must break the TOC tiling: {:?}",
+        scan.errors,
+    );
+    assert!(
+        scan.errors.iter().any(|err| matches!(
             err,
             BlockVerifyError::HeaderCorrupted { table_id: t, offset: 0, reason, .. }
                 if *t == table_id && reason.contains("extends past the section end"),
-        ),
-        "expected a section-boundary HeaderCorrupted; got {err:?}",
+        )),
+        "expected a section-boundary HeaderCorrupted; got {:?}",
+        scan.errors,
     );
+    Ok(())
 }
 
 /// Builds a tree with `batches` separate L0 SSTs (one flush per batch) so
@@ -951,6 +1465,72 @@ fn verify_checksum_with_throttle_completes_clean() {
         "throttled scrub must still verify clean: {report:?}"
     );
     assert!(report.sst_files_scanned >= 2);
+}
+
+/// Raw sections carry NO per-section checksum (the SFA trailer checksum
+/// covers only the TOC bytes), so the walk must at least STRUCTURALLY
+/// validate `linked_blob_files`: a corrupted count prefix would otherwise
+/// pass the walk clean, and a heal-enabled scrub could restamp the manifest
+/// digest over a broken blob-link list that blob GC / relocation then
+/// misreads.
+#[test]
+fn verify_sst_file_flags_a_corrupt_blob_link_count() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A KV-separated tree: large values go to a blob file, the SST carries
+    // a linked_blob_files section.
+    let crate::AnyTree::Blob(tree) = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(crate::KvSeparationOptions::default()))
+    .open()
+    .unwrap() else {
+        unreachable!("kv separation configured");
+    };
+    let big = |i: u32| format!("{i:08}").repeat(512);
+    for i in 0u32..10 {
+        tree.insert(format!("key{i:05}"), big(i), u64::from(i) + 1);
+    }
+    tree.flush_active_memtable(10).unwrap();
+    let sst_path = {
+        let binding = tree.index.version_history.read().latest_version();
+        let table = binding
+            .version
+            .iter_tables()
+            .next()
+            .expect("flush produced one table");
+        (*table.path).clone()
+    };
+    drop(tree);
+
+    // Corrupt the section's u32 count prefix: the payload length no longer
+    // matches `4 + count * 32`.
+    let pos = {
+        let mut f = std::fs::File::open(&sst_path).unwrap();
+        let reader = crate::sfa::Reader::from_reader(&mut f).expect("SFA trailer reads");
+        let entry = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"linked_blob_files")
+            .expect("the SST carries a linked_blob_files section");
+        usize::try_from(entry.pos()).expect("section offset fits usize")
+    };
+    let mut bytes = std::fs::read(&sst_path).unwrap();
+    *bytes.get_mut(pos).expect("count prefix within the file") ^= 0xFF;
+    std::fs::write(&sst_path, &bytes).unwrap();
+
+    let report = verify_sst_file_with_fs(&crate::fs::StdFs, &sst_path);
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            BlockVerifyError::TocCorrupted { section_name, reason, .. }
+                if section_name == b"linked_blob_files" && reason.contains("blob-link count")
+        )),
+        "a corrupt blob-link count must fail the out-of-band walk, not be \
+         skipped as an unchecked raw section: {report:?}",
+    );
 }
 
 #[test]

--- a/src/version/diff.rs
+++ b/src/version/diff.rs
@@ -83,6 +83,17 @@ impl Version {
             }
         }
 
+        // Per-blob-file live-data frontiers, the blob analogue of the table
+        // restrictions above: a relocated blob file's recorded checksum covers
+        // only `[frontier, end)` because its consumed prefix is punched out.
+        let mut blob_restrictions = Vec::new();
+        for bf in self.blob_files.iter() {
+            let frontier = bf.live_data_start();
+            if frontier > 0 {
+                blob_restrictions.push((bf.id(), frontier));
+            }
+        }
+
         Ok(VersionEdit {
             new_version_id: self.id(),
             changed_levels,
@@ -90,6 +101,7 @@ impl Version {
             removed_blob_file_ids,
             gc_stats,
             restrictions,
+            blob_restrictions,
         })
     }
 }

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -127,6 +127,15 @@ pub struct VersionEdit {
     /// [`Table::with_restriction`](crate::Table::with_restriction). Empty on
     /// every edit that did not run tight-space reclaim.
     pub restrictions: Vec<(u64, UserKey)>,
+    /// Per-blob-file live-data frontiers for tight-space relocation
+    /// (`blob file id → first live byte offset`). A blob file listed here has
+    /// had its consumed prefix punched out after its values were relocated, so
+    /// its recorded checksum covers only `[frontier, end)`; whole-file hashing
+    /// would read the punched (zeroed) prefix and report a healthy file as
+    /// corrupt. The blob analogue of [`Self::restrictions`], carrying a byte
+    /// offset because a blob file has no key index to resolve a bound through.
+    /// Empty on every edit that did not reclaim a blob prefix.
+    pub blob_restrictions: Vec<(u64, u64)>,
 }
 
 /// `checksum_type` byte written for XXH3-128 (matches the snapshot encoder).
@@ -177,6 +186,17 @@ impl VersionEdit {
             out.write_u64::<LittleEndian>(*id)?;
             out.write_u32::<LittleEndian>(u32_len(key.len())?)?;
             out.write_all(key)?;
+        }
+
+        // Omit the appended blob-frontier section entirely when there is nothing
+        // to record, so the overwhelmingly common edit stays byte-identical to
+        // what earlier writers produced (and decodes on them too).
+        if !self.blob_restrictions.is_empty() {
+            out.write_u32::<LittleEndian>(u32_len(self.blob_restrictions.len())?)?;
+            for (id, frontier) in &self.blob_restrictions {
+                out.write_u64::<LittleEndian>(*id)?;
+                out.write_u64::<LittleEndian>(*frontier)?;
+            }
         }
         Ok(())
     }
@@ -277,6 +297,21 @@ impl VersionEdit {
             restrictions.push((id, UserKey::from(head)));
         }
 
+        // Blob frontiers are an APPENDED section: edits written before it existed
+        // end right here. The framing checksum already passed, so a payload that
+        // stops at this boundary is an older-format edit carrying no blob
+        // frontier — not a truncated one — and decodes as an empty list.
+        let mut blob_restrictions = Vec::new();
+        if !r.is_empty() {
+            let blob_restriction_count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+            blob_restrictions.reserve(cap(blob_restriction_count));
+            for _ in 0..blob_restriction_count {
+                let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+                let frontier = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+                blob_restrictions.push((id, frontier));
+            }
+        }
+
         // A well-formed edit consumes its payload exactly. Trailing bytes mean a
         // corrupt / mis-encoded record (format drift, not power loss — the
         // framing checksum already passed), so reject rather than silently
@@ -292,6 +327,7 @@ impl VersionEdit {
             removed_blob_file_ids,
             gc_stats,
             restrictions,
+            blob_restrictions,
         })
     }
 }

--- a/src/version/edit.rs
+++ b/src/version/edit.rs
@@ -191,6 +191,16 @@ impl VersionEdit {
         // Omit the appended blob-frontier section entirely when there is nothing
         // to record, so the overwhelmingly common edit stays byte-identical to
         // what earlier writers produced (and decodes on them too).
+        //
+        // Deliberately NOT behind a bumped edit/manifest format version. A
+        // non-empty list is written only once a blob file's prefix has been
+        // physically hole-punched, and a binary without blob-restriction
+        // support cannot serve such a database anyway (it would read the
+        // punched region as zeros); its trailing-data rejection on this edit
+        // is the fail-fast that stops it from opening a store it cannot
+        // handle. Rolling back a binary stays possible for every database
+        // that never used tight-space blob reclaim — exactly the databases a
+        // rollback could still serve.
         if !self.blob_restrictions.is_empty() {
             out.write_u32::<LittleEndian>(u32_len(self.blob_restrictions.len())?)?;
             for (id, frontier) in &self.blob_restrictions {

--- a/src/version/edit/tests.rs
+++ b/src/version/edit/tests.rs
@@ -50,6 +50,9 @@ fn sample() -> VersionEdit {
             (7, UserKey::from(&b"mmm"[..])),
             (10, UserKey::from(&b"zzzz"[..])),
         ],
+        // Two blob frontiers, so the round-trip also covers the fixed-width
+        // blob-restriction codec (id + offset).
+        blob_restrictions: vec![(3, 4_096), (4, 1_048_576)],
     }
 }
 
@@ -113,6 +116,33 @@ fn empty_gc_stats_roundtrips_as_none() {
     let mut payload = Vec::new();
     framing::read_framed_record(&mut &buf[..], u64::MAX, None, &mut payload).expect("read");
     assert_eq!(VersionEdit::decode_payload(&payload).expect("decode"), edit);
+}
+
+#[test]
+fn payload_without_the_blob_frontier_section_decodes_as_empty() {
+    // Edits written before blob frontiers existed end right after `restrictions`.
+    // Reading such a payload must yield an empty blob-frontier list, not an
+    // InvalidHeader — otherwise every pre-existing manifest becomes unopenable.
+    let mut edit = sample();
+    edit.blob_restrictions = vec![];
+    let mut payload = Vec::new();
+    edit.encode_payload(&mut payload).expect("encode");
+    let decoded = VersionEdit::decode_payload(&payload).expect("decode");
+    assert!(decoded.blob_restrictions.is_empty());
+
+    // ...and an edit that carries frontiers still round-trips them.
+    let mut with_frontiers = sample();
+    with_frontiers.blob_restrictions = vec![(7, 4096), (9, 1 << 20)];
+    let mut payload = Vec::new();
+    with_frontiers
+        .encode_payload(&mut payload)
+        .expect("encode with frontiers");
+    assert_eq!(
+        VersionEdit::decode_payload(&payload)
+            .expect("decode with frontiers")
+            .blob_restrictions,
+        vec![(7, 4096), (9, 1 << 20)],
+    );
 }
 
 #[test]

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -734,6 +734,61 @@ impl Version {
         }
     }
 
+    /// Returns a version identical to this one except that the table with
+    /// `table_id` reports `checksum` as its full-file digest, or `None` when
+    /// the table is no longer part of this version (compacted away — nothing
+    /// to refresh). Used after an in-place heal rewrites a table's bytes: the
+    /// healed file's digest no longer matches the one captured at recovery,
+    /// and installing this version persists the refreshed digest to the
+    /// manifest via the version diff. Level / run structure is untouched
+    /// (same table, same key range — only the digest changes).
+    #[must_use]
+    pub(crate) fn with_refreshed_table_checksum(
+        &self,
+        table_id: TableId,
+        checksum: crate::checksum::Checksum,
+    ) -> Option<Self> {
+        if !self.iter_tables().any(|t| t.id() == table_id) {
+            return None;
+        }
+
+        let id = self.id + 1;
+
+        let mut levels = vec![];
+
+        for level in &self.levels {
+            let runs = level
+                .runs
+                .iter()
+                .map(|run| {
+                    if run.iter().any(|t| t.id() == table_id) {
+                        let mut run: Run<_> = run.deref().clone();
+                        for t in run.inner_mut().iter_mut() {
+                            if t.id() == table_id {
+                                *t = t.with_refreshed_checksum(checksum);
+                            }
+                        }
+                        Arc::new(run)
+                    } else {
+                        run.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            levels.push(Level::from_runs(runs));
+        }
+
+        Some(Self {
+            inner: Arc::new(VersionInner {
+                id,
+                tree_type: self.tree_type,
+                levels,
+                blob_files: self.blob_files.clone(),
+                gc_stats: self.gc_stats.clone(),
+            }),
+        })
+    }
+
     /// Tight-space slice install for one or more inputs: replaces each
     /// `(id, restricted view)` in `restricted` with its clamped view, drops the
     /// fully-consumed inputs in `removed_ids`, and adds the slice `outputs` as a
@@ -991,6 +1046,25 @@ impl Version {
                 u32::try_from(key.len()).map_err(|_| crate::Error::Unrecoverable)?,
             )?;
             writer.write_all(key)?;
+        }
+
+        // The blob analogue: per-blob-file live-data frontiers for files whose
+        // consumed prefix was reclaimed in place. Fixed-width entries (id then
+        // offset) — a blob frontier is a byte position, not a key. Empty on
+        // versions that never reclaimed a blob prefix.
+        writer.start("blob_restrictions")?;
+        let blob_restricted: Vec<(crate::vlog::BlobFileId, u64)> = self
+            .blob_files
+            .iter()
+            .filter(|bf| bf.live_data_start() > 0)
+            .map(|bf| (bf.id(), bf.live_data_start()))
+            .collect();
+        writer.write_u32::<LittleEndian>(
+            u32::try_from(blob_restricted.len()).map_err(|_| crate::Error::Unrecoverable)?,
+        )?;
+        for (id, frontier) in &blob_restricted {
+            writer.write_u64::<LittleEndian>(*id)?;
+            writer.write_u64::<LittleEndian>(*frontier)?;
         }
 
         Ok(())

--- a/src/version/recovery.rs
+++ b/src/version/recovery.rs
@@ -119,6 +119,34 @@ fn parse_restrictions_section(
     Ok(map)
 }
 
+/// Parses the optional `blob_restrictions` section: `count: u32 |
+/// repeat(blob file id: u64, live-data frontier: u64)`. The blob analogue of
+/// [`parse_restrictions_section`], read under the same strictness — a lost or
+/// lowered frontier would make integrity checks hash the reclaimed (zeroed)
+/// prefix and condemn a healthy blob file. Absent section is handled by the
+/// caller (legitimate: no blob prefix was ever reclaimed).
+fn parse_blob_restrictions_section(
+    mut bytes: &[u8],
+) -> crate::Result<crate::HashMap<BlobFileId, u64>> {
+    const ERR: crate::Error = crate::Error::InvalidHeader("blob_restrictions section");
+    let r = &mut bytes;
+    let count = r.read_u32::<LittleEndian>().map_err(|_| ERR)?;
+    let mut map = crate::HashMap::default();
+    for _ in 0..count {
+        let id = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+        let frontier = r.read_u64::<LittleEndian>().map_err(|_| ERR)?;
+        // Reject a duplicate id for the same reason the table section does: a
+        // second entry could silently lower an already-advanced frontier.
+        if map.insert(id, frontier).is_some() {
+            return Err(ERR);
+        }
+    }
+    if !r.is_empty() {
+        return Err(ERR);
+    }
+    Ok(map)
+}
+
 /// Reads and validates the CURRENT version pointer file.
 ///
 /// The file format is: `version_id: u64 | checksum: u128 | checksum_type: u8`
@@ -287,6 +315,13 @@ pub struct Recovery {
     /// here is rebuilt as a restricted view ([`super::Version::from_recovery`]);
     /// stale entries for tables no longer in the layout are simply never applied.
     pub restrictions: crate::HashMap<TableId, crate::UserKey>,
+    /// Per-blob-file live-data frontiers recovered from the snapshot and
+    /// advanced by replayed edits (`blob file id → first live byte`). A blob
+    /// file present here had its consumed prefix reclaimed in place, so its
+    /// recorded checksum covers only the suffix from this offset. The blob
+    /// analogue of [`Self::restrictions`]; stale entries for blob files no
+    /// longer present are simply never applied.
+    pub blob_restrictions: crate::HashMap<BlobFileId, u64>,
     /// Per-section counters describing how many records were dropped
     /// during this recovery. Always zero under
     /// [`ManifestRecoveryMode::AbsoluteConsistency`] (any corruption
@@ -387,6 +422,11 @@ impl Recovery {
         // applied by `from_recovery`, and the next snapshot rewrite drops them.
         for (id, key) in &edit.restrictions {
             self.restrictions.insert(*id, key.clone());
+        }
+
+        // Blob frontiers advance the same way, per relocation slice.
+        for (id, frontier) in &edit.blob_restrictions {
+            self.blob_restrictions.insert(*id, *frontier);
         }
 
         self.curr_version_id = edit.new_version_id;
@@ -1193,6 +1233,15 @@ pub fn recover(
         crate::HashMap::default()
     };
 
+    // The blob analogue, read under the same strictness: a lost frontier would
+    // make integrity checks hash a reclaimed (zeroed) prefix and condemn a
+    // healthy blob file.
+    let blob_restrictions = if archive.section("blob_restrictions").is_some() {
+        parse_blob_restrictions_section(&archive.read_section("blob_restrictions")?)?
+    } else {
+        crate::HashMap::default()
+    };
+
     let mut recovery = Recovery {
         tree_type: {
             if archive.section("tree_type").is_none() {
@@ -1214,6 +1263,7 @@ pub fn recover(
         blob_file_ids,
         gc_stats,
         restrictions,
+        blob_restrictions,
         stats: RecoveryStats {
             tables_dropped_to_tail,
             tables_dropped_to_corruption,

--- a/src/version/recovery/tests.rs
+++ b/src/version/recovery/tests.rs
@@ -16,6 +16,7 @@ fn recovery_with(version_id: u64, table_ids: Vec<Vec<Vec<RecoveredTable>>>) -> R
         blob_file_ids: Vec::new(),
         gc_stats: crate::blob_tree::FragmentationMap::default(),
         restrictions: crate::HashMap::default(),
+        blob_restrictions: crate::HashMap::default(),
         stats: RecoveryStats::default(),
     }
 }
@@ -144,6 +145,36 @@ fn apply_edit_merges_and_advances_restrictions() {
         rec.restrictions.get(&1),
         Some(&crate::UserKey::from(&b"mmm"[..])),
         "a later slice's higher bound overwrites the earlier one",
+    );
+}
+
+/// Blob frontiers replay exactly like table restrictions: each relocation
+/// slice records the file's new (higher) first-live byte, and a later slice
+/// overwrites the earlier one. Losing this would make a reopened tree hash a
+/// reclaimed blob file whole and report it corrupt.
+#[test]
+fn apply_edit_merges_and_advances_blob_restrictions() {
+    let mut rec = recovery_with(1, vec![vec![vec![rtable(1, 10)]]]);
+    assert!(rec.blob_restrictions.is_empty(), "starts unreclaimed");
+
+    rec.apply_edit(&VersionEdit {
+        new_version_id: 2,
+        blob_restrictions: vec![(9, 4_096)],
+        ..Default::default()
+    })
+    .expect("apply");
+    assert_eq!(rec.blob_restrictions.get(&9), Some(&4_096));
+
+    rec.apply_edit(&VersionEdit {
+        new_version_id: 3,
+        blob_restrictions: vec![(9, 65_536)],
+        ..Default::default()
+    })
+    .expect("apply");
+    assert_eq!(
+        rec.blob_restrictions.get(&9),
+        Some(&65_536),
+        "a later slice's higher frontier overwrites the earlier one",
     );
 }
 

--- a/src/vlog/blob_file/meta.rs
+++ b/src/vlog/blob_file/meta.rs
@@ -40,13 +40,21 @@ macro_rules! read_u128 {
 
 pub const METADATA_HEADER_MAGIC: &[u8] = b"META";
 
+/// The one accepted blob-file metadata version. The writer stamps it and
+/// `decode_from` rejects anything else: there is a single readable on-disk
+/// format (per-frame header CRC), never a compat range. Under the V5 disk
+/// contract this is the blob-file meta version, distinct from the tree format
+/// version.
+pub const META_VERSION: u8 = 4;
+
 // Note: `pub` for crate-internal use; parent `vlog` module is NOT
 // exported from `lib.rs`, so this struct is not public API.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Metadata {
     pub id: BlobFileId,
 
-    /// Blob file format version (3 = V3, 4 = V4 with header CRC).
+    /// Blob file format version. Always [`META_VERSION`] (the only readable
+    /// format, with per-frame header CRC); `decode_from` rejects anything else.
     pub version: u8,
 
     pub created_at: u128,
@@ -184,12 +192,14 @@ impl Metadata {
                 .ok_or(crate::Error::InvalidHeader("BlobFileMeta"))?
         };
 
-        // Reject unknown versions early to catch corrupted or
-        // future-incompatible metadata before downstream code
-        // misinterprets header fields.
-        match version {
-            3 | 4 => {}
-            _ => return Err(crate::Error::InvalidHeader("BlobFileMeta")),
+        // Exactly one blob-file format is readable (V5-only on-disk contract):
+        // [`META_VERSION`] is what the current writer stamps. Anything else,
+        // including the retired version 3, is corruption or an unsupported file,
+        // never a compat case. Covered end-to-end by
+        // `tests::test_blob_file_meta_retired_version_rejected`, which serializes a
+        // version-3 block through the production encoder and asserts this rejection.
+        if version != META_VERSION {
+            return Err(crate::Error::InvalidHeader("BlobFileMeta"));
         }
 
         let id = read_u64!(block, b"id", &cmp);

--- a/src/vlog/blob_file/meta/tests.rs
+++ b/src/vlog/blob_file/meta/tests.rs
@@ -8,6 +8,34 @@ fn test_blob_file_meta_truncated_returns_err() {
     assert!(Metadata::from_slice(&buf).is_err());
 }
 
+/// A retired-version (3) metadata block serialized through the PRODUCTION
+/// encoder must be rejected by the production decoder: the engine reads
+/// exactly one blob-file format (version 4), so a pre-V5 blob meta is
+/// `InvalidHeader`, never a compat case.
+#[test]
+#[expect(clippy::unwrap_used)]
+fn test_blob_file_meta_retired_version_rejected() {
+    let metadata = Metadata {
+        id: 0,
+        version: 3,
+        created_at: 0,
+        item_count: 1,
+        total_compressed_bytes: 8,
+        total_uncompressed_bytes: 8,
+        key_range: KeyRange::new((b"a"[..].into(), b"z"[..].into())),
+        compression: CompressionType::None,
+    };
+    let mut buf = Vec::new();
+    metadata.encode_into(&mut buf).unwrap();
+
+    let buf = Slice::from(buf);
+    let result = Metadata::from_slice(&buf);
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("BlobFileMeta"))),
+        "expected Err(InvalidHeader(\"BlobFileMeta\")), got {result:?}",
+    );
+}
+
 /// Build a metadata block that is structurally valid but omits a required
 /// property (`compression`).  `from_slice` must return `Err`, not panic.
 #[test]
@@ -66,7 +94,7 @@ fn test_blob_file_meta_missing_field_returns_err() {
 fn test_blob_file_meta_corrupted_trailer_returns_err() {
     let meta = Metadata {
         id: 0,
-        version: 4,
+        version: META_VERSION,
         created_at: 1_234_567_890,
         compression: CompressionType::None,
         item_count: 100,
@@ -104,7 +132,7 @@ fn test_blob_file_meta_corrupted_trailer_returns_err() {
 fn test_blob_file_meta_roundtrip() {
     let meta = Metadata {
         id: 0,
-        version: 4,
+        version: META_VERSION,
         created_at: 1_234_567_890,
         compression: CompressionType::None,
         item_count: 100,

--- a/src/vlog/blob_file/mod.rs
+++ b/src/vlog/blob_file/mod.rs
@@ -63,6 +63,16 @@ pub struct Inner {
 
     pub checksum: Checksum,
 
+    /// First LIVE byte of this view, or `0` for a whole file. Set on the
+    /// RESTRICTED view a tight-space relocation installs: everything below it
+    /// was relocated into a fresh file and its frames are punched out (they
+    /// read back as zeros). [`Self::checksum`] then covers only
+    /// `[live_data_start, end)`, so integrity checks must hash from here —
+    /// whole-file hashing would fold in the punched prefix and report a healthy
+    /// file as corrupt. Persisted per version edit, the blob analogue of a
+    /// table's restriction bound.
+    pub(crate) live_data_start: u64,
+
     pub(crate) file_accessor: FileAccessor,
 
     /// Filesystem backend used by [`Drop`] for the physical removal.
@@ -210,7 +220,25 @@ impl Drop for Inner {
                 let off = self
                     .punch_on_drop
                     .load(core::sync::atomic::Ordering::Acquire);
-                if off != u64::MAX {
+                // Reclaim only what this tree exclusively owns. A checkpoint
+                // hard-links blob files, and its captured SSTs still reference
+                // values in the prefix being reclaimed — punching a shared
+                // inode would zero live data inside an immutable snapshot. Same
+                // guard the delete path applies before truncating; a link-count
+                // probe that FAILS is treated as shared (fail closed), losing
+                // only reclaimable space.
+                let exclusively_owned = match self.fs.hard_link_count(&self.path) {
+                    Ok(n) => n <= 1,
+                    Err(e) => {
+                        log::warn!(
+                            "Skipping tight-space punch of blob file {:?} at {}: link-count probe failed: {e:?}",
+                            self.id,
+                            self.path.display(),
+                        );
+                        false
+                    }
+                };
+                if off != u64::MAX && exclusively_owned {
                     match data_section_start(&*self.fs, &self.path) {
                         Ok(data_start) if off > data_start => {
                             if let Err(e) =
@@ -287,24 +315,37 @@ impl BlobFile {
             .store(offset, core::sync::atomic::Ordering::Release);
     }
 
-    /// Re-opens this blob file as a DISTINCT [`Inner`] (its own file handle and a
-    /// fresh punch-on-drop atomic) over the same physical file. The tight-space
-    /// relocation loop installs the re-opened view in the new version and arms
-    /// the prior view to punch its consumed prefix once its readers drain, so a
-    /// stale blob file is reclaimed in place while the suffix keeps serving the
-    /// not-yet-relocated entries — the blob analog of [`Table::reopen_restricted`](crate::Table::reopen_restricted).
+    /// Re-opens this blob file as a DISTINCT [`Inner`] (its own file handle and
+    /// a fresh punch-on-drop atomic) restricted to `[frontier, end)`: the
+    /// tight-space relocation loop installs this view in the new version and
+    /// arms the PRIOR view to punch everything below the frontier once its
+    /// readers drain, so a stale blob file is reclaimed in place while the
+    /// suffix keeps serving the not-yet-relocated entries — the blob analog of
+    /// [`Table::reopen_restricted`](crate::Table::reopen_restricted).
+    ///
+    /// The digest is re-computed over that LIVE SUFFIX now, while the file is
+    /// still whole — the punch is what makes a whole-file digest unusable, and
+    /// reading the suffix fresh also folds in anything the relocation just
+    /// wrote. The frontier rides on the view, so `diff` / the snapshot encoder
+    /// persist it and integrity checks hash from there.
     ///
     /// # Errors
     ///
-    /// Propagates any error from re-opening the file.
+    /// Propagates any error from re-opening the file or hashing its suffix.
     #[cfg(feature = "std")]
-    pub(crate) fn reopen(&self) -> crate::Result<Self> {
-        super::recover_blob_file(
+    pub(crate) fn reopen_restricted(&self, frontier: u64) -> crate::Result<Self> {
+        let checksum = crate::Checksum::from_raw(crate::repair::compute_table_checksum_from(
+            &*self.0.fs,
+            &self.0.path,
+            frontier,
+        )?);
+        super::recover_blob_file_from(
             &self.0.path,
             self.0.id,
-            self.0.checksum,
+            checksum,
             self.0.tree_id,
             &self.0.fs,
+            frontier,
         )
     }
 
@@ -326,10 +367,26 @@ impl BlobFile {
         self.0.id
     }
 
+    /// First LIVE byte of this view: `0` for a whole file, or the frontier a
+    /// tight-space relocation left after reclaiming the consumed prefix. The
+    /// recorded [`checksum`](Self::checksum) covers `[live_data_start, end)`,
+    /// so integrity checks hash from here rather than over the punched prefix.
+    #[must_use]
+    pub fn live_data_start(&self) -> u64 {
+        self.0.live_data_start
+    }
+
     /// Returns the full blob file checksum.
     #[must_use]
     pub fn checksum(&self) -> Checksum {
         self.0.checksum
+    }
+
+    /// The compression applied to this blob file's values (the descriptor a
+    /// reader uses to decode each record's on-disk bytes).
+    #[must_use]
+    pub(crate) fn compression(&self) -> crate::CompressionType {
+        self.0.meta.compression
     }
 
     /// Returns the blob file path.

--- a/src/vlog/blob_file/multi_writer.rs
+++ b/src/vlog/blob_file/multi_writer.rs
@@ -213,6 +213,8 @@ impl MultiWriter {
                 path,
                 is_deleted: AtomicBool::new(false),
                 punch_on_drop: portable_atomic::AtomicU64::new(u64::MAX),
+                // A freshly written file is whole: nothing has been reclaimed.
+                live_data_start: 0,
                 id: blob_file_id,
                 file_accessor,
                 meta: Metadata {

--- a/src/vlog/blob_file/reader.rs
+++ b/src/vlog/blob_file/reader.rs
@@ -13,25 +13,15 @@ use crate::{
     fs::FsFile,
     vlog::{
         ValueHandle,
-        blob_file::writer::{
-            BLOB_HEADER_LEN_V4, BLOB_HEADER_MAGIC_V3, BLOB_HEADER_MAGIC_V4, validate_header_crc,
-        },
+        blob_file::writer::{BLOB_HEADER_LEN, BLOB_HEADER_MAGIC, validate_header_crc},
     },
 };
 #[cfg(feature = "std")]
 use std::io::{Cursor, Read};
 
-/// Safety cap on blob value size (256 MiB).
-///
-/// Enforced on this reader and on the write path to prevent producing
-/// or accepting blobs that are unreasonably large. Other internal
-/// readers (e.g., scanner used by compaction/GC) may impose different
-/// constraints.
-///
-/// NOTE: Intentionally duplicated in `vlog::blob_file::writer` and
-/// `table::block` rather than shared, because blocks and blobs are
-/// independent storage formats that may diverge in the future.
-const MAX_DECOMPRESSION_SIZE: usize = 256 * 1024 * 1024;
+// Safety cap on blob value size (256 MiB), defined in `writer` (the blob-format
+// definition site) and shared by this reader.
+use super::writer::MAX_DECOMPRESSION_SIZE;
 
 /// Reads a single blob from a blob file
 pub struct Reader<'a> {
@@ -78,13 +68,7 @@ impl<'a> Reader<'a> {
             return Err(crate::Error::InvalidHeader("Blob"));
         }
 
-        // Always read with V4 (max) header size so that version detection
-        // is self-describing from the frame magic — no dependency on
-        // metadata version which could be corrupted independently.
-        // For V3 frames, the extra 4 bytes read are harmless: they come
-        // from the next frame or metadata section (which always follows),
-        // and raw_data is sliced to exact on_disk_val_len before use.
-        let add_size = (BLOB_HEADER_LEN_V4 as u64) + (key.len() as u64);
+        let add_size = (BLOB_HEADER_LEN as u64) + (key.len() as u64);
 
         // Validate the full on-disk read size (header + key + value) against the limit.
         // Allow header+key overhead on top of the data cap.
@@ -120,9 +104,10 @@ impl<'a> Reader<'a> {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;
 
-        // Determine format from frame magic — self-describing, no metadata dependency.
-        let frame_is_v4 = magic == BLOB_HEADER_MAGIC_V4;
-        if !frame_is_v4 && magic != BLOB_HEADER_MAGIC_V3 {
+        // Exactly one frame format exists (V5-only on-disk contract): any
+        // other magic — including the retired pre-V5 `b"BLOB"` layout — is
+        // corruption or a misdirected handle, never a compat case.
+        if magic != BLOB_HEADER_MAGIC {
             return Err(crate::Error::InvalidHeader("Blob"));
         }
 
@@ -135,22 +120,20 @@ impl<'a> Reader<'a> {
 
         let on_disk_val_len = reader.read_u32::<LittleEndian>()?;
 
-        // V4: read and validate header CRC before cross-checks.
+        // Read and validate the header CRC before cross-checks.
         // Uses the on-disk CRC value (not recomputed) in data checksum
         // verification so that recomputing header_crc after tampering
         // header fields is still caught by the data checksum.
-        let stored_header_crc = if frame_is_v4 {
+        let stored_header_crc = {
             let crc = reader.read_u32::<LittleEndian>()?;
-            #[expect(
+            // `allow`, not `expect`: on 32-bit targets usize == u32 and the
+            // lint never fires, which would make an `expect` unfulfilled.
+            #[allow(
                 clippy::cast_possible_truncation,
                 reason = "real_val_len originates as u32, round-tripped through usize; lossless on supported targets"
             )]
             validate_header_crc(seqno, key_len, real_val_len as u32, on_disk_val_len, crc)?;
-            Some(crc)
-        } else {
-            // V3: seqno is unused (not covered by any checksum).
-            let _ = seqno;
-            None
+            crc
         };
 
         // Cross-check header fields against caller-provided inputs to catch
@@ -168,12 +151,7 @@ impl<'a> Reader<'a> {
             });
         }
 
-        // Actual header length determined from frame magic, not metadata.
-        let header_len = if frame_is_v4 {
-            BLOB_HEADER_LEN_V4
-        } else {
-            crate::vlog::blob_file::writer::BLOB_HEADER_LEN_V3
-        };
+        let header_len = BLOB_HEADER_LEN;
 
         // Zero-copy view of the on-disk key bytes for checksum and cross-check.
         // The full blob record is already in `value`, so slicing avoids an extra
@@ -187,25 +165,21 @@ impl<'a> Reader<'a> {
             return Err(crate::Error::InvalidHeader("Blob"));
         }
 
-        // Slice exactly on_disk_val_len bytes — important for V3 backward
-        // compat where the read buffer is 4 bytes larger than the actual frame
-        // (over-read from using V4 max header size).
+        // Slice exactly on_disk_val_len bytes.
         // No usize overflow: on_disk_val_len is u32, data_offset is ~42+key_len,
         // and total is bounded by MAX_DECOMPRESSION_SIZE (256 MiB) cap check above.
         let data_offset = header_len + key.len();
         let raw_data = value.slice(data_offset..data_offset + on_disk_val_len as usize);
 
         {
-            // Checksum covers on-disk key + raw value data (upstream #277).
-            // V4 additionally includes header_crc bytes so that recomputing
-            // header_crc after tampering header fields is still detected.
+            // Checksum covers on-disk key + raw value data (upstream #277)
+            // plus the header_crc bytes, so that recomputing header_crc
+            // after tampering header fields is still detected.
             let checksum = {
                 let mut hasher = xxhash_rust::xxh3::Xxh3::default();
                 hasher.update(&on_disk_key);
                 hasher.update(&raw_data);
-                if let Some(hcrc) = stored_header_crc {
-                    hasher.update(&hcrc.to_le_bytes());
-                }
+                hasher.update(&stored_header_crc.to_le_bytes());
                 hasher.digest128()
             };
 
@@ -234,7 +208,7 @@ impl<'a> Reader<'a> {
             CompressionType::Lz4 => {
                 let mut buf = vec![0u8; real_val_len];
 
-                let bytes_written = lz4_flex::decompress_into(&raw_data, &mut buf)
+                let bytes_written = lz4_flex::block::decompress_into(&raw_data, &mut buf)
                     .map_err(|_| crate::Error::Decompress(self.blob_file.0.meta.compression))?;
 
                 // Runtime validation: corrupted data may decompress to fewer bytes

--- a/src/vlog/blob_file/reader/tests.rs
+++ b/src/vlog/blob_file/reader/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::SequenceNumberCounter;
 use crate::fs::StdFs;
-use crate::vlog::blob_file::writer::BLOB_HEADER_LEN_V3;
 use std::fs::File;
 use std::sync::Arc;
 use test_log::test;
@@ -315,8 +314,8 @@ fn blob_reader_corrupted_on_disk_key_detected_by_cross_check_and_checksum() -> c
 
     // Tamper on-disk key bytes.
     // V4 header layout: MAGIC(4) + Checksum(16) + SeqNo(8) + KeyLen(2) + RealValLen(4) + OnDiskValLen(4) + HeaderCrc(4) = 42
-    // Key starts at offset 42 from blob start (BLOB_HEADER_LEN_V4).
-    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN_V4;
+    // Key starts at offset 42 from blob start (BLOB_HEADER_LEN).
+    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN;
     let mut raw = std::fs::read(&blob_file.0.path)?;
     raw[key_offset] ^= 0xFF; // flip bits in first key byte
     let corrupted_key = raw[key_offset..key_offset + 3].to_vec();
@@ -430,9 +429,8 @@ fn blob_reader_corrupted_value_payload_triggers_checksum_mismatch() -> crate::Re
     let blob_file = writer.finish()?;
     let blob_file = blob_file.first().unwrap();
 
-    // Value payload starts after header + key: offset + BLOB_HEADER_LEN_V4 + key_len
-    let payload_offset =
-        usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN_V4 + b"key".len();
+    // Value payload starts after header + key: offset + BLOB_HEADER_LEN + key_len
+    let payload_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN + b"key".len();
     let mut raw = std::fs::read(&blob_file.0.path)?;
     raw[payload_offset] ^= 0xFF; // flip bits in first value byte
     std::fs::write(&blob_file.0.path, &raw)?;
@@ -467,7 +465,7 @@ fn blob_reader_corrupted_on_disk_key_lz4_returns_invalid_header() -> crate::Resu
     let blob_file = writer.finish()?;
     let blob_file = blob_file.first().unwrap();
 
-    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN_V4;
+    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN;
     let mut raw = std::fs::read(&blob_file.0.path)?;
     raw[key_offset] ^= 0xFF;
     std::fs::write(&blob_file.0.path, &raw)?;
@@ -502,7 +500,7 @@ fn blob_reader_corrupted_on_disk_key_zstd_returns_invalid_header() -> crate::Res
     let blob_file = writer.finish()?;
     let blob_file = blob_file.first().unwrap();
 
-    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN_V4;
+    let key_offset = usize::try_from(handle.offset).unwrap() + BLOB_HEADER_LEN;
     let mut raw = std::fs::read(&blob_file.0.path)?;
     raw[key_offset] ^= 0xFF;
     std::fs::write(&blob_file.0.path, &raw)?;
@@ -589,18 +587,18 @@ fn blob_reader_v4_corrupted_header_crc_field_detected() -> crate::Result<()> {
     Ok(())
 }
 
-/// Verify V4 header layout: `BLOB_HEADER_LEN_V4` = 42 bytes
+/// Verify the frame header layout: `BLOB_HEADER_LEN` = 42 bytes
 /// (`magic:4` + `checksum:16` + `seqno:8` + `key_len:2` + `real_val_len:4` + `on_disk_val_len:4` + `header_crc:4`).
 #[test]
-fn blob_header_len_v4_is_42() {
-    assert_eq!(BLOB_HEADER_LEN_V4, 42);
-    assert_eq!(BLOB_HEADER_LEN_V3, 38);
+fn blob_header_len_is_42() {
+    assert_eq!(BLOB_HEADER_LEN, 42);
 }
 
-/// Write a V3 blob file manually and verify the reader handles it
-/// via the V3 backward compat path (no `header_crc` validation).
+/// A frame under the retired pre-V5 `b"BLOB"` magic (no header CRC) must be
+/// REJECTED: the engine reads exactly one on-disk format — there is no
+/// backward-compat decode path.
 #[test]
-fn blob_reader_v3_backward_compat_roundtrip() -> crate::Result<()> {
+fn blob_reader_rejects_retired_blob_magic_frame() -> crate::Result<()> {
     use crate::file_accessor::FileAccessor;
     use crate::io::WriteBytesExt;
     use crate::vlog::{ValueHandle, blob_file::Inner as BlobFileInner};
@@ -672,6 +670,7 @@ fn blob_reader_v3_backward_compat_roundtrip() -> crate::Result<()> {
     let blob_file = crate::BlobFile(Arc::new(BlobFileInner {
         id: 0,
         tree_id: 0,
+        live_data_start: 0,
         path: blob_file_path,
         meta: crate::vlog::blob_file::meta::Metadata {
             id: 0,
@@ -712,8 +711,11 @@ fn blob_reader_v3_backward_compat_roundtrip() -> crate::Result<()> {
         on_disk_size: value.len() as u32,
     };
 
-    let result = reader.get(key, &handle)?;
-    assert_eq!(result, value);
+    let result = reader.get(key, &handle);
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
+        "a retired-format frame must be rejected, got: {result:?}",
+    );
 
     Ok(())
 }

--- a/src/vlog/blob_file/scanner.rs
+++ b/src/vlog/blob_file/scanner.rs
@@ -2,9 +2,13 @@
 // Copyright (c) 2024-present, fjall-rs
 // Copyright (c) 2026-present, Structured World Foundation
 
-// Format constants live in writer (the format definition site).
-// Extracting to a shared module is an upstream structural decision.
-use super::writer::{BLOB_HEADER_MAGIC_V3, BLOB_HEADER_MAGIC_V4, validate_header_crc};
+// Format constants live in writer (the blob-format definition site). The
+// scalar cap is shared from there; the scanner enforces it BEFORE allocating:
+// a CRC-valid fake header inside a damaged record's user-controlled bytes can
+// declare a near-`u32::MAX` length that still fits a large data section, and
+// without the cap the salvage walk would attempt a multi-gigabyte allocation
+// before the candidate's checksum rejection.
+use super::writer::{BLOB_HEADER_MAGIC, MAX_DECOMPRESSION_SIZE, validate_header_crc};
 use crate::fs::{Fs, FsFile, FsOpenOptions};
 use crate::io::BufReader;
 use crate::io::{LittleEndian, ReadBytesExt};
@@ -31,6 +35,19 @@ pub struct Scanner {
 
     /// Byte offset where the "data" section ends (from the SFA TOC).
     data_end: u64,
+
+    /// Set when [`resync_to_next_frame`](Self::resync_to_next_frame) lands on a
+    /// magic, and STICKY thereafter: every frame read once this is set is marked
+    /// `resynced`. The resync magic was found by a byte-wise search after a
+    /// damaged frame, so it may be an original boundary OR a checksum-valid
+    /// `BLO4` frame nested inside the damaged frame's user-controlled bytes; the
+    /// two are byte-for-byte indistinguishable. Crucially, a frame CHAINED past
+    /// the resync inherits that unproven anchor: its start comes from the resync
+    /// frame's own length, so a fabricated chain can plant one checksum-valid
+    /// frame after another. There is no independent anchor mid-stream to
+    /// re-establish trust, so the taint never lifts. Callers that must not
+    /// fabricate data (salvage) treat every `resynced` entry as untrusted.
+    resync_tainted: bool,
 }
 
 impl Scanner {
@@ -117,11 +134,65 @@ impl Scanner {
             inner: file_reader,
             is_terminated: false,
             data_end,
+            resync_tainted: false,
         })
     }
     // No `with_reader` constructor: Scanner is crate-private (parent
     // `vlog` module is not re-exported from lib.rs), so there are no
     // external callers. All internal usage goes through `new()` / `resume()`.
+}
+
+impl Scanner {
+    /// Repositions the reader at the next frame magic strictly AFTER
+    /// `frame_offset`, or at the data-section end when none remains. Used
+    /// after HEADER rot (bad magic, header-CRC mismatch), where the frame's
+    /// lengths cannot be trusted to locate the next frame — without the
+    /// forward magic scan one rotted header would cost every readable later
+    /// frame. A false match inside a value payload fails its own header CRC
+    /// or payload checksum and resynchronizes again, strictly forward.
+    fn resync_to_next_frame(&mut self, frame_offset: u64) -> crate::Result<()> {
+        const MAGIC_LEN: usize = BLOB_HEADER_MAGIC.len();
+
+        // Scan in chunks, overlapping by MAGIC_LEN - 1 bytes so a magic
+        // straddling two chunks is still found.
+        let mut buf = alloc::vec![0u8; 64 * 1024];
+        let mut pos = frame_offset + 1;
+        while pos < self.data_end {
+            self.inner.seek(SeekFrom::Start(pos))?;
+            // `#[allow]`, not `#[expect]`: this is a target-width-dependent lint
+            // (`u64 as usize`), so a target where Clippy proves the `min()` bound
+            // fits usize would leave an `#[expect]` unfulfilled under `-D warnings`.
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "min() bounds the window by the buffer length, which fits usize"
+            )]
+            let want = (self.data_end - pos).min(buf.len() as u64) as usize;
+            let Some(window) = buf.get_mut(..want) else {
+                break;
+            };
+            self.inner.read_exact(window)?;
+            if let Some(hit) = window
+                .windows(MAGIC_LEN)
+                .position(|w| w == BLOB_HEADER_MAGIC)
+            {
+                self.inner.seek(SeekFrom::Start(pos + hit as u64))?;
+                // The next frame read starts at a magic found by a byte scan,
+                // NOT at a boundary vouched for by a chained frame's length: its
+                // provenance is unproven, and so is every frame chained after it
+                // (see the field doc). Arm the sticky taint.
+                self.resync_tainted = true;
+                return Ok(());
+            }
+            if want < MAGIC_LEN {
+                break;
+            }
+            pos += (want - (MAGIC_LEN - 1)) as u64;
+        }
+        // No further frame: park at the section end so the next call
+        // terminates cleanly.
+        self.inner.seek(SeekFrom::Start(self.data_end))?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -137,6 +208,17 @@ pub struct ScanEntry {
     /// once an entry is consumed, `[data_start, frame_end)` is reclaimable and a
     /// resumed scan opens here.
     pub frame_end: u64,
+    /// Whether the scanner has RESYNCED at or before this frame. Set on the frame
+    /// reached immediately by the byte-wise resync AND on every frame after it:
+    /// once the stream resyncs, this frame's boundary is UNPROVEN, either because
+    /// it IS the resync frame (the magic may be an original boundary or a
+    /// checksum-valid `BLO4` frame nested inside the damaged frame's bytes) or
+    /// because it is chained from one whose length is equally unanchored. The
+    /// taint is STICKY to EOF: no independent anchor exists mid-stream to
+    /// re-establish trust. Salvage must NOT re-emit a resynced frame as a genuine
+    /// record (doing so would fabricate data), so it drops the whole tainted
+    /// tail (fail closed) rather than trust an unanchored candidate.
+    pub resynced: bool,
 }
 
 impl Iterator for Scanner {
@@ -147,6 +229,14 @@ impl Iterator for Scanner {
             return None;
         }
 
+        // Read the sticky resync taint for THIS frame. Once any prior call ended
+        // by resyncing to a magic, this frame's boundary is unproven: either it
+        // IS the resync frame or it is chained from one, and both anchors trace
+        // back to the same byte-scanned magic. The taint never clears: there is
+        // no independent anchor mid-stream to re-establish trust, so every frame
+        // to EOF stays tainted (fail closed).
+        let was_resynced = self.resync_tainted;
+
         let offset = fail_iter!(self.inner.stream_position());
 
         // Terminate when the read position reaches the end of the "data"
@@ -156,15 +246,35 @@ impl Iterator for Scanner {
             return None;
         }
 
-        let frame_is_v4;
+        // A frame header is a fixed BLOB_HEADER_LEN bytes. A magic found within
+        // fewer than that of the data-section end (e.g. a resync landing near
+        // EOF) would let the fixed-header reads below consume bytes from the
+        // FOLLOWING SFA section. Reject the incomplete tail here, before the
+        // first read: no whole frame can start this close to the boundary. (The
+        // span check further down still rejects a full-but-overrunning frame;
+        // this only stops the header read itself from crossing the section.)
+        if offset
+            .checked_add(super::writer::BLOB_HEADER_LEN as u64)
+            .is_none_or(|end| end > self.data_end)
+        {
+            self.is_terminated = true;
+            return Some(Err(crate::Error::InvalidHeader("Blob")));
+        }
 
         {
-            let mut buf = [0; BLOB_HEADER_MAGIC_V4.len()];
+            let mut buf = [0; BLOB_HEADER_MAGIC.len()];
             fail_iter!(self.inner.read_exact(&mut buf));
 
-            frame_is_v4 = buf == BLOB_HEADER_MAGIC_V4;
-            if !frame_is_v4 && buf != BLOB_HEADER_MAGIC_V3 {
-                self.is_terminated = true;
+            if buf != BLOB_HEADER_MAGIC {
+                // Header rot: the frame's lengths are unreadable, so the
+                // next frame cannot be located from this one. Resynchronize
+                // at the next frame magic so one rotted header does not
+                // cost every readable later frame (record-granular
+                // salvage); the frame itself is lost either way.
+                if let Err(e) = self.resync_to_next_frame(offset) {
+                    self.is_terminated = true;
+                    return Some(Err(e));
+                }
                 return Some(Err(crate::Error::InvalidHeader("Blob")));
             }
         }
@@ -178,31 +288,39 @@ impl Iterator for Scanner {
 
         let on_disk_val_len = fail_iter!(self.inner.read_u32::<LittleEndian>());
 
-        // V4: read and validate header CRC using shared validator.
-        // On CRC failure, terminate the scanner so subsequent next() calls
-        // don't read from a mid-frame stream position.
-        let stored_header_crc = if frame_is_v4 {
+        // Read and validate the header CRC. On a mismatch the consumed
+        // lengths are untrusted (any of them may be the rotted field), so
+        // resynchronize at the next frame magic instead of terminating —
+        // continuing from a length-derived position could desynchronize,
+        // and stopping would drop every readable later frame.
+        let stored_header_crc = {
             let crc = fail_iter!(self.inner.read_u32::<LittleEndian>());
             if let Err(e) = validate_header_crc(seqno, key_len, real_val_len, on_disk_val_len, crc)
             {
-                self.is_terminated = true;
+                if let Err(e2) = self.resync_to_next_frame(offset) {
+                    self.is_terminated = true;
+                    return Some(Err(e2));
+                }
                 return Some(Err(e));
             }
-            Some(crc)
-        } else {
-            None
+            crc
         };
 
         // Verify the declared frame payload fits within the data section
-        // before allocating buffers. Without this, a corrupted key_len or
-        // on_disk_val_len could cause a huge allocation or read past
-        // data_end into the TOC/trailer region.
+        // before allocating buffers. A declared payload that overruns the
+        // data section or the 256 MiB cap makes the span UNTRUSTWORTHY, so
+        // resynchronize at the next
+        // real frame regardless of how this position was reached. A resync
+        // candidate's magic may sit inside a damaged record's
+        // user-controlled bytes; a writer-chained frame's header CRC vouches
+        // for its lengths at parse time, but a re-stamped length that
+        // recomputes the header CRC passes that check and can declare past
+        // the section — terminating would then leave every intact later
+        // frame uninspected. Resync parks at the section end when no further
+        // magic exists, so a genuine truncation still terminates cleanly on
+        // the next call.
         {
-            let header_len = if frame_is_v4 {
-                super::writer::BLOB_HEADER_LEN_V4 as u64
-            } else {
-                super::writer::BLOB_HEADER_LEN_V3 as u64
-            };
+            let header_len = super::writer::BLOB_HEADER_LEN as u64;
             // `key_len` / `on_disk_val_len` come from the on-disk frame header and
             // may be corrupt. Use checked adds so a value that overflows u64 fails
             // loudly here (treated as "does not fit") instead of saturating to
@@ -211,8 +329,17 @@ impl Iterator for Scanner {
                 .checked_add(header_len)
                 .and_then(|x| x.checked_add(u64::from(key_len)))
                 .and_then(|x| x.checked_add(u64::from(on_disk_val_len)));
-            if frame_end.is_none_or(|end| end > self.data_end) {
-                self.is_terminated = true;
+            // Same 256 MiB value cap as the writer / ordinary reader,
+            // checked BEFORE the buffers below are allocated: no
+            // legitimate frame exceeds it, so an over-cap declared length
+            // is corruption regardless of whether it fits the section.
+            let over_cap = u64::from(real_val_len) > MAX_DECOMPRESSION_SIZE as u64
+                || u64::from(on_disk_val_len) > MAX_DECOMPRESSION_SIZE as u64;
+            if over_cap || frame_end.is_none_or(|end| end > self.data_end) {
+                if let Err(e) = self.resync_to_next_frame(offset) {
+                    self.is_terminated = true;
+                    return Some(Err(e));
+                }
                 return Some(Err(crate::Error::InvalidHeader("Blob")));
             }
         }
@@ -229,9 +356,7 @@ impl Iterator for Scanner {
                 let mut hasher = xxhash_rust::xxh3::Xxh3::default();
                 hasher.update(&key);
                 hasher.update(&value);
-                if let Some(hcrc) = stored_header_crc {
-                    hasher.update(&hcrc.to_le_bytes());
-                }
+                hasher.update(&stored_header_crc.to_le_bytes());
                 hasher.digest128()
             };
 
@@ -241,6 +366,22 @@ impl Iterator for Scanner {
                     self.blob_file_id,
                 );
 
+                // A checksum rejection means the DECLARED SPAN is not
+                // trustworthy, so resume the magic search strictly past this
+                // frame's start regardless of how the position was reached.
+                // A resync candidate's magic came from user-controlled value
+                // bytes (a CRC-valid fake header can declare an end past
+                // intact records); a WRITER-CHAINED frame's header CRC
+                // vouches for its lengths at parse time, but a re-stamped
+                // length that recomputes the header CRC passes that check
+                // and can consume one or more intact later frames before the
+                // payload checksum fails — trusting its declared end would
+                // then skip those frames without reporting the loss. Both
+                // resynchronize at the next real frame instead.
+                if let Err(e) = self.resync_to_next_frame(offset) {
+                    self.is_terminated = true;
+                    return Some(Err(e));
+                }
                 return Some(Err(crate::Error::ChecksumMismatch {
                     got: Checksum::from_raw(checksum),
                     expected: Checksum::from_raw(expected_checksum),
@@ -259,6 +400,7 @@ impl Iterator for Scanner {
             offset,
             uncompressed_len: real_val_len,
             frame_end,
+            resynced: was_resynced,
         }))
     }
 }

--- a/src/vlog/blob_file/scanner/tests.rs
+++ b/src/vlog/blob_file/scanner/tests.rs
@@ -3,6 +3,22 @@ use crate::{Slice, fs::StdFs, vlog::blob_file::writer::Writer as BlobFileWriter}
 use tempfile::tempdir;
 use test_log::test;
 
+// Blob frame header field offsets, derived from the field widths (magic 4 +
+// checksum 16 + seqno 8 + key_len 2 + real_val_len 4 + on_disk_val_len 4 +
+// header_crc 4 = BLOB_HEADER_LEN), so a header-layout change moves these in
+// lockstep with the writer instead of desyncing hard-coded literals.
+const OD_LEN_OFF: usize = 4 + 16 + 8 + 2 + 4;
+const HDR_CRC_OFF: usize = OD_LEN_OFF + 4;
+// `real_val_len` sits immediately before `on_disk_val_len`, so derive it from
+// the same chain instead of restating a literal that a header-layout change
+// could desync.
+const RV_LEN_OFF: usize = OD_LEN_OFF - core::mem::size_of::<u32>();
+const _: () = assert!(
+    HDR_CRC_OFF + 4 == crate::vlog::blob_file::writer::BLOB_HEADER_LEN
+        && RV_LEN_OFF + core::mem::size_of::<u32>() == OD_LEN_OFF,
+    "the derived header field offsets must tile the blob header",
+);
+
 #[test]
 fn blob_scanner() -> crate::Result<()> {
     let dir = tempdir()?;
@@ -24,12 +40,13 @@ fn blob_scanner() -> crate::Result<()> {
         let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
 
         for key in keys {
-            assert_eq!(
-                (Slice::from(key), Slice::from(key.repeat(100))),
-                scanner
-                    .next()
-                    .map(|result| result.map(|entry| { (entry.key, entry.value) }))
-                    .unwrap()?,
+            let entry = scanner.next().unwrap()?;
+            assert_eq!(entry.key, Slice::from(key));
+            assert_eq!(entry.value, Slice::from(key.repeat(100)));
+            assert!(
+                !entry.resynced,
+                "a cleanly writer-chained frame is never tainted; an \
+                 always-resynced implementation would fail here",
             );
         }
 
@@ -87,11 +104,11 @@ fn blob_scanner_resume_reads_suffix_and_rejects_bad_offset() -> crate::Result<()
     Ok(())
 }
 
-/// Tamper seqno in first blob frame and verify scanner's V4 header
+/// Tamper seqno in first blob frame and verify the scanner's header
 /// CRC catches the corruption.
 #[test]
-fn blob_scanner_v4_corrupted_seqno_detected_by_header_crc() -> crate::Result<()> {
-    use crate::vlog::blob_file::writer::BLOB_HEADER_MAGIC_V4;
+fn blob_scanner_corrupted_seqno_detected_by_header_crc() -> crate::Result<()> {
+    use crate::vlog::blob_file::writer::BLOB_HEADER_MAGIC;
 
     let dir = tempdir()?;
     let blob_file_path = dir.path().join("0");
@@ -108,7 +125,7 @@ fn blob_scanner_v4_corrupted_seqno_detected_by_header_crc() -> crate::Result<()>
     let frame_start = 0usize;
 
     // Tamper seqno: header layout is [magic][checksum][seqno]...
-    let seqno_offset = frame_start + BLOB_HEADER_MAGIC_V4.len() + std::mem::size_of::<u128>();
+    let seqno_offset = frame_start + BLOB_HEADER_MAGIC.len() + std::mem::size_of::<u128>();
     let seqno_len = std::mem::size_of::<u64>();
     raw[seqno_offset..seqno_offset + seqno_len].copy_from_slice(&99u64.to_le_bytes()[..seqno_len]);
     std::fs::write(&blob_file_path, &raw)?;
@@ -127,7 +144,7 @@ fn blob_scanner_v4_corrupted_seqno_detected_by_header_crc() -> crate::Result<()>
 /// checksum catches the corruption.
 #[test]
 fn blob_scanner_corrupted_value_detected_by_data_checksum() -> crate::Result<()> {
-    use crate::vlog::blob_file::writer::BLOB_HEADER_LEN_V4;
+    use crate::vlog::blob_file::writer::BLOB_HEADER_LEN;
 
     let dir = tempdir()?;
     let blob_file_path = dir.path().join("0");
@@ -145,7 +162,7 @@ fn blob_scanner_corrupted_value_detected_by_data_checksum() -> crate::Result<()>
 
     // Tamper value payload: frame_start + header + key
     let key = b"key";
-    let value_offset = frame_start + BLOB_HEADER_LEN_V4 + key.len();
+    let value_offset = frame_start + BLOB_HEADER_LEN + key.len();
     raw[value_offset] ^= 0xFF;
     std::fs::write(&blob_file_path, &raw)?;
 
@@ -159,10 +176,11 @@ fn blob_scanner_corrupted_value_detected_by_data_checksum() -> crate::Result<()>
     Ok(())
 }
 
-/// Write a V3 blob file (b"BLOB" magic, no `header_crc`) manually,
-/// then verify the scanner can read it with V3 backward compat path.
+/// A frame under the retired pre-V5 `b"BLOB"` magic (no header CRC) is NOT
+/// readable: the engine supports exactly one on-disk format, so the scanner
+/// reports it as corruption (and, finding no other frame, terminates).
 #[test]
-fn blob_scanner_reads_v3_format() -> crate::Result<()> {
+fn blob_scanner_rejects_retired_blob_magic_frame() -> crate::Result<()> {
     use crate::io::{LittleEndian, WriteBytesExt};
     use std::io::Write;
 
@@ -172,7 +190,7 @@ fn blob_scanner_reads_v3_format() -> crate::Result<()> {
     let key = b"abc";
     let value = b"hello_v3";
 
-    // V3 data checksum: xxh3_128(key + value) — no header_crc
+    // Retired-format data checksum: xxh3_128(key + value), no header_crc.
     let checksum = {
         let mut hasher = xxhash_rust::xxh3::Xxh3::default();
         hasher.update(key);
@@ -180,13 +198,13 @@ fn blob_scanner_reads_v3_format() -> crate::Result<()> {
         hasher.digest128()
     };
 
-    // Manually write V3 blob file using sfa framing
+    // Manually write a retired-format blob file using sfa framing.
     {
         let file = std::fs::File::create(&blob_file_path)?;
         let mut sfa_writer = crate::sfa::Writer::from_writer(file);
         sfa_writer.start("data")?;
 
-        // V3 frame: BLOB magic, no header_crc
+        // Retired frame: BLOB magic, no header_crc.
         sfa_writer.write_all(b"BLOB")?;
         sfa_writer.write_u128::<LittleEndian>(checksum)?;
         sfa_writer.write_u64::<LittleEndian>(42)?; // seqno
@@ -212,7 +230,7 @@ fn blob_scanner_reads_v3_format() -> crate::Result<()> {
         sfa_writer.start("meta")?;
         let metadata = crate::vlog::blob_file::meta::Metadata {
             id: 0,
-            version: 3,
+            version: crate::vlog::blob_file::meta::META_VERSION,
             created_at: 0,
             item_count: 1,
             total_compressed_bytes: value.len() as u64,
@@ -225,21 +243,25 @@ fn blob_scanner_reads_v3_format() -> crate::Result<()> {
         inner.sync_all()?;
     }
 
-    // Scanner should read the V3 frame successfully
     let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
-    let entry = scanner.next().unwrap()?;
-    assert_eq!(entry.key, Slice::from(&key[..]));
-    assert_eq!(entry.value, Slice::from(&value[..]));
-    assert_eq!(entry.seqno, 42);
-    assert!(scanner.next().is_none());
+    let result = scanner.next().unwrap();
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
+        "a retired-format frame must be rejected, got: {result:?}",
+    );
+    assert!(
+        scanner.next().is_none(),
+        "no readable frame exists past the rejected one"
+    );
 
     Ok(())
 }
 
-/// A frame whose declared `on_disk_val_len` runs past the data section must be
-/// rejected by the checked frame-fit bound, not read past the section. Uses a
-/// V3 frame (no header CRC) so the oversized length reaches the fit check
-/// rather than being caught earlier by the V4 header CRC.
+/// A frame whose declared `on_disk_val_len` runs past the data section must
+/// be rejected by the checked frame-fit bound, not read past the section.
+/// The header CRC is forged CONSISTENT with the oversized length so the
+/// declaration survives CRC validation and reaches the fit check — the shape
+/// of a truncated file, whose remaining declared bytes simply do not exist.
 #[test]
 fn blob_scanner_rejects_oversized_on_disk_len() -> crate::Result<()> {
     use crate::io::{LittleEndian, WriteBytesExt};
@@ -254,7 +276,7 @@ fn blob_scanner_rejects_oversized_on_disk_len() -> crate::Result<()> {
         let file = std::fs::File::create(&blob_file_path)?;
         let mut sfa_writer = crate::sfa::Writer::from_writer(file);
         sfa_writer.start("data")?;
-        sfa_writer.write_all(b"BLOB")?;
+        sfa_writer.write_all(crate::vlog::blob_file::writer::BLOB_HEADER_MAGIC)?;
         sfa_writer.write_u128::<LittleEndian>(0)?; // checksum (unreached)
         sfa_writer.write_u64::<LittleEndian>(1)?; // seqno
         #[expect(clippy::cast_possible_truncation, reason = "test key fits u16")]
@@ -262,13 +284,17 @@ fn blob_scanner_rejects_oversized_on_disk_len() -> crate::Result<()> {
         sfa_writer.write_u32::<LittleEndian>(2)?; // real_val_len
         // on_disk_val_len far exceeds the data section → frame-fit reject.
         sfa_writer.write_u32::<LittleEndian>(u32::MAX)?;
+        #[expect(clippy::cast_possible_truncation, reason = "test key fits u16")]
+        let crc =
+            crate::vlog::blob_file::writer::compute_header_crc(1, key.len() as u16, 2, u32::MAX);
+        sfa_writer.write_u32::<LittleEndian>(crc)?;
         sfa_writer.write_all(key)?;
         sfa_writer.write_all(value)?;
 
         sfa_writer.start("meta")?;
         let metadata = crate::vlog::blob_file::meta::Metadata {
             id: 0,
-            version: 3,
+            version: crate::vlog::blob_file::meta::META_VERSION,
             created_at: 0,
             item_count: 1,
             total_compressed_bytes: 2,
@@ -286,6 +312,468 @@ fn blob_scanner_rejects_oversized_on_disk_len() -> crate::Result<()> {
         matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
         "an oversized on_disk_val_len must be rejected, got: {result:?}",
     );
+    assert!(
+        scanner.next().is_none(),
+        "a CRC-vouched oversized declaration means truncation: the scan terminates"
+    );
+    Ok(())
+}
+
+/// A `data` section that ends fewer than `BLOB_HEADER_LEN` bytes past a frame
+/// magic (a partial tail at the section boundary) must be rejected BEFORE the
+/// fixed-header reads, so those reads never consume bytes from the following
+/// SFA section. Without the pre-read bound, the header fields are read into the
+/// adjacent `meta` section and the frame is only rejected afterward by the
+/// header-CRC / span check, having already crossed the boundary. The bound
+/// rejects the incomplete tail directly as `InvalidHeader`.
+#[test]
+fn blob_scanner_rejects_a_partial_header_at_the_section_boundary() -> crate::Result<()> {
+    use crate::io::{LittleEndian, WriteBytesExt};
+    use std::io::Write;
+
+    let dir = tempdir()?;
+    let blob_file_path = dir.path().join("0");
+
+    // A `data` section holding a frame magic plus only a few of the header's
+    // fixed bytes, then the `meta` section. `data_end` therefore falls INSIDE
+    // the header: `magic_offset + BLOB_HEADER_LEN` overruns it.
+    {
+        let file = std::fs::File::create(&blob_file_path)?;
+        let mut sfa_writer = crate::sfa::Writer::from_writer(file);
+        sfa_writer.start("data")?;
+        sfa_writer.write_all(crate::vlog::blob_file::writer::BLOB_HEADER_MAGIC)?;
+        // Only 8 of the remaining BLOB_HEADER_LEN - 4 header bytes: the section
+        // ends mid-header (well under a full BLOB_HEADER_LEN from the magic).
+        sfa_writer.write_u64::<LittleEndian>(0)?;
+
+        sfa_writer.start("meta")?;
+        let metadata = crate::vlog::blob_file::meta::Metadata {
+            id: 0,
+            version: crate::vlog::blob_file::meta::META_VERSION,
+            created_at: 0,
+            item_count: 0,
+            total_compressed_bytes: 0,
+            total_uncompressed_bytes: 0,
+            key_range: crate::KeyRange::new((b"a"[..].into(), b"a"[..].into())),
+            compression: crate::CompressionType::None,
+        };
+        metadata.encode_into(&mut sfa_writer)?;
+        sfa_writer.into_inner()?.sync_all()?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let result = scanner.next().unwrap();
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
+        "the partial tail is rejected before the header read, not parsed into \
+         the adjacent section, got: {result:?}",
+    );
+    assert!(
+        scanner.next().is_none(),
+        "no whole frame fits in the truncated data section: the scan terminates",
+    );
+    Ok(())
+}
+
+/// A CRC-valid frame whose declared `real_val_len` exceeds the 256 MiB
+/// decompression cap must be rejected by the pre-allocation cap check even when
+/// the frame still FITS the data section. Only `on_disk_val_len` feeds the
+/// frame-fit bound, so an over-cap `real_val_len` sails past the fit check and
+/// the cap check is the sole thing that can reject it: a path the
+/// section-overrun test does not exercise. The header CRC is recomputed
+/// CONSISTENT with the oversized length so the declaration survives CRC
+/// validation and reaches the cap check.
+#[test]
+fn blob_scanner_rejects_over_cap_real_val_len() -> crate::Result<()> {
+    use crate::vlog::blob_file::writer::compute_header_crc;
+
+    let dir = tempdir()?;
+    let blob_file_path = dir.path().join("0");
+    let key = b"aaa";
+    let value = b"hi";
+    let seqno = 7u64;
+    {
+        let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, &StdFs)?;
+        writer.write(key, seqno, value)?;
+        writer.finish()?;
+    }
+
+    // Over the cap by one, but the ON-DISK length stays `value.len()` so the
+    // frame still fits the tiny data section. Only `real_val_len` breaks the
+    // cap, so the reject cannot be attributed to a section overrun. Derived from
+    // the scanner's own cap so the two never desync.
+    let over_cap: u32 = u32::try_from(MAX_DECOMPRESSION_SIZE).unwrap() + 1;
+    {
+        let mut bytes = std::fs::read(&blob_file_path)?;
+        bytes[RV_LEN_OFF..RV_LEN_OFF + 4].copy_from_slice(&over_cap.to_le_bytes());
+        // Recompute the header CRC so the oversized length survives validation
+        // and reaches the cap check instead of tripping the header CRC first.
+        let key_len = u16::try_from(key.len()).unwrap();
+        let on_disk_val_len = u32::try_from(value.len()).unwrap();
+        let crc = compute_header_crc(seqno, key_len, over_cap, on_disk_val_len);
+        bytes[HDR_CRC_OFF..HDR_CRC_OFF + 4].copy_from_slice(&crc.to_le_bytes());
+        std::fs::write(&blob_file_path, bytes)?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let result = scanner.next().unwrap();
+    assert!(
+        matches!(result, Err(crate::Error::InvalidHeader("Blob"))),
+        "an over-cap real_val_len must be rejected before allocation, got: {result:?}",
+    );
+    Ok(())
+}
+
+/// Writes two frames with the real writer and returns the path. Frame 1
+/// starts at data-section offset 0 (sfa has no inline section headers).
+fn write_two_frames(dir: &std::path::Path) -> crate::Result<std::path::PathBuf> {
+    let blob_file_path = dir.join("0");
+    let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, &StdFs)?;
+    writer.write(b"aaa", 7, b"first_value")?;
+    writer.write(b"bbb", 7, b"second_value")?;
+    writer.finish()?;
+    Ok(blob_file_path)
+}
+
+/// Rot in a frame's LENGTH field (caught by the header CRC) must not cost
+/// the readable tail: the consumed lengths are untrusted, so the scanner
+/// resynchronizes at the next frame magic instead of terminating —
+/// otherwise blob salvage drops every intact later record over one rotted
+/// header field.
+#[test]
+fn blob_scanner_header_crc_rot_resyncs_to_next_frame() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let blob_file_path = write_two_frames(dir.path())?;
+
+    // Inflate frame 1's on_disk_val_len field (offset derived from the header
+    // layout). The header CRC no longer matches, so the lengths are untrusted.
+    {
+        let mut bytes = std::fs::read(&blob_file_path)?;
+        bytes[OD_LEN_OFF..OD_LEN_OFF + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        std::fs::write(&blob_file_path, bytes)?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::HeaderCrcMismatch { .. })),
+        "the rotted length field fails the header CRC: {first:?}",
+    );
+    let Some(second) = scanner.next() else {
+        panic!("the intact second frame must survive the rotted first");
+    };
+    let second = second?;
+    assert_eq!(second.key, Slice::from(&b"bbb"[..]));
+    assert_eq!(second.value, Slice::from(&b"second_value"[..]));
+    assert!(scanner.next().is_none());
+
+    Ok(())
+}
+
+/// Rot in a frame's MAGIC bytes must not cost the readable tail either: the
+/// frame's lengths are unreachable (nothing vouches for the header), so the
+/// scanner resynchronizes at the next frame magic.
+#[test]
+fn blob_scanner_magic_rot_resyncs_to_next_frame() -> crate::Result<()> {
+    let dir = tempdir()?;
+    let blob_file_path = write_two_frames(dir.path())?;
+
+    // Rot frame 1's magic (frame offset 0..4).
+    {
+        let mut bytes = std::fs::read(&blob_file_path)?;
+        bytes[0] ^= 0xFF;
+        std::fs::write(&blob_file_path, bytes)?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::InvalidHeader("Blob"))),
+        "the rotted magic is rejected: {first:?}",
+    );
+    let Some(second) = scanner.next() else {
+        panic!("the intact second frame must survive the rotted first");
+    };
+    let second = second?;
+    assert_eq!(second.key, Slice::from(&b"bbb"[..]));
+    assert_eq!(second.value, Slice::from(&b"second_value"[..]));
+    assert!(scanner.next().is_none());
+
+    Ok(())
+}
+
+/// Writes three frames where frame 1's VALUE embeds a fake frame header
+/// (real magic + header-CRC-valid fields) whose declared lengths end exactly
+/// at frame 3's offset — the shape a resynchronizing scan must not trust.
+/// `fake_extra_len` widens the fake on-disk value length beyond that (0 =
+/// "skip exactly frame 2"; large = "declare past the data section").
+/// Returns the blob file path.
+fn write_frames_with_embedded_fake_header(
+    dir: &std::path::Path,
+    fake_extra_len: u32,
+) -> crate::Result<std::path::PathBuf> {
+    use crate::vlog::blob_file::writer::{BLOB_HEADER_LEN, compute_header_crc};
+
+    let blob_file_path = dir.join("0");
+
+    // Layout (data section starts at file offset 0):
+    //   f1: header 42 + key "aaa" (3) + value 52   -> [0, 97)
+    //   f2: header 42 + key "bbb" (3) + "second_value" (12) -> [97, 154)
+    //   f3: header 42 + key "ccc" (3) + "third_value" (11)  -> [154, 210)
+    // The fake header sits inside f1's value at absolute offset 55
+    // (10-byte prefix), so a resync from f1's rotted magic finds it first.
+    let header = BLOB_HEADER_LEN as u64;
+    let f2_off = header + 3 + 52;
+    let f3_off = f2_off + header + 3 + 12;
+    let fake_pos = header + 3 + 10;
+    // Declared end = fake_pos + header + fake_key(3) + odl == f3_off (+extra).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "test layout offsets are tiny"
+    )]
+    let odl = (f3_off - fake_pos - header - 3) as u32 + fake_extra_len;
+    let fake_seqno = 1u64;
+    let crc = compute_header_crc(fake_seqno, 3, odl, odl);
+
+    let mut fake = Vec::with_capacity(BLOB_HEADER_LEN);
+    fake.extend_from_slice(BLOB_HEADER_MAGIC);
+    fake.extend_from_slice(&0u128.to_le_bytes()); // payload checksum: never matches
+    fake.extend_from_slice(&fake_seqno.to_le_bytes());
+    fake.extend_from_slice(&3u16.to_le_bytes());
+    fake.extend_from_slice(&odl.to_le_bytes());
+    fake.extend_from_slice(&odl.to_le_bytes());
+    fake.extend_from_slice(&crc.to_le_bytes());
+    assert_eq!(fake.len(), BLOB_HEADER_LEN, "fake header fills the layout");
+
+    let mut value1 = alloc::vec![0xAAu8; 10];
+    value1.extend_from_slice(&fake);
+    assert_eq!(value1.len(), 52, "f1 value matches the planned layout");
+
+    let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, &StdFs)?;
+    writer.write(b"aaa", 7, &value1)?;
+    writer.write(b"bbb", 7, b"second_value")?;
+    writer.write(b"ccc", 7, b"third_value")?;
+    writer.finish()?;
+
+    // Rot f1's real magic so the scan resynchronizes into f1's value and
+    // lands on the embedded fake magic.
+    let mut bytes = std::fs::read(&blob_file_path)?;
+    bytes[0] ^= 0xFF;
+    std::fs::write(&blob_file_path, bytes)?;
+    Ok(blob_file_path)
+}
+
+/// A resync CANDIDATE whose payload checksum fails must not have its
+/// declared lengths trusted: the candidate magic came from user-controlled
+/// value bytes, so a CRC-valid fake header can declare an end past intact
+/// later records. The scanner must resynchronize again strictly after the
+/// candidate instead of continuing from its declared end — otherwise the
+/// fake frame silently costs frame 2.
+#[test]
+fn blob_scanner_resyncs_again_when_a_candidate_frame_fails_its_checksum() -> crate::Result<()> {
+    let dir = tempdir()?;
+    // Fake declared end == frame 3's offset: trusting it skips frame 2.
+    let blob_file_path = write_frames_with_embedded_fake_header(dir.path(), 0)?;
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::InvalidHeader("Blob"))),
+        "the rotted real magic is rejected: {first:?}",
+    );
+    let second = scanner.next().unwrap();
+    assert!(
+        matches!(second, Err(crate::Error::ChecksumMismatch { .. })),
+        "the fake candidate fails its payload checksum: {second:?}",
+    );
+    let Some(third) = scanner.next() else {
+        panic!("the intact second frame must survive the fake candidate");
+    };
+    let third = third?;
+    assert_eq!(
+        third.key,
+        Slice::from(&b"bbb"[..]),
+        "frame 2 is recovered, not skipped by the fake declared end",
+    );
+    assert_eq!(third.value, Slice::from(&b"second_value"[..]));
+    assert!(
+        third.resynced,
+        "the first frame recovered after a resync is tainted",
+    );
+    let Some(fourth) = scanner.next() else {
+        panic!("frame 3 follows");
+    };
+    let fourth = fourth?;
+    assert_eq!(fourth.key, Slice::from(&b"ccc"[..]));
+    assert!(
+        fourth.resynced,
+        "the taint is STICKY: every frame chained after a resync stays untrusted \
+         through EOF, since its boundary was re-established by search",
+    );
+    assert!(scanner.next().is_none());
+    Ok(())
+}
+
+/// A resync CANDIDATE whose declared end exceeds the data section must not
+/// TERMINATE the scan: for a chained (writer-vouched) frame that means real
+/// truncation, but a candidate's lengths come from user-controlled bytes —
+/// terminating hands one crafted value the whole readable tail. The scanner
+/// must resynchronize past the candidate instead.
+#[test]
+fn blob_scanner_resyncs_when_a_candidate_frame_declares_past_the_section() -> crate::Result<()> {
+    let dir = tempdir()?;
+    // Fake declared end far past the data section: bounds-reject the candidate.
+    let blob_file_path = write_frames_with_embedded_fake_header(dir.path(), 1_000_000)?;
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::InvalidHeader("Blob"))),
+        "the rotted real magic is rejected: {first:?}",
+    );
+    let second = scanner.next().unwrap();
+    assert!(
+        matches!(second, Err(crate::Error::InvalidHeader("Blob"))),
+        "the fake candidate is bounds-rejected: {second:?}",
+    );
+    let Some(third) = scanner.next() else {
+        panic!("the intact second frame must survive the fake candidate");
+    };
+    let third = third?;
+    assert_eq!(
+        third.key,
+        Slice::from(&b"bbb"[..]),
+        "frame 2 is recovered, not lost to a terminated scan",
+    );
+    let Some(fourth) = scanner.next() else {
+        panic!("frame 3 follows");
+    };
+    let fourth = fourth?;
+    assert_eq!(fourth.key, Slice::from(&b"ccc"[..]));
+    assert!(scanner.next().is_none());
+    Ok(())
+}
+
+/// A CRC-VALID frame at a WRITER-CHAINED position whose length was
+/// re-stamped so the declared payload OVERRUNS the data section (a bounds
+/// rejection, not a checksum one) must resynchronize too: a bounds
+/// rejection makes the declared span untrusted regardless of how the
+/// position was reached, so terminating would leave every intact later
+/// frame uninspected while salvage reports only the one corrupt record.
+#[test]
+fn blob_scanner_resyncs_when_a_chained_frame_declares_past_the_section() -> crate::Result<()> {
+    use crate::vlog::blob_file::writer::compute_header_crc;
+
+    let dir = tempdir()?;
+    let blob_file_path = dir.path().join("0");
+    {
+        let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, &StdFs)?;
+        writer.write(b"aaa", 7, b"first_value")?;
+        writer.write(b"bbb", 7, b"second_value")?;
+        writer.write(b"ccc", 7, b"third_value")?;
+        writer.finish()?;
+    }
+
+    // Re-stamp frame 1's on_disk_val_len so its declared end overruns the
+    // whole data section, and recompute the header CRC so the frame is
+    // CRC-valid (the bounds check then rejects it before any allocation).
+    {
+        let mut bytes = std::fs::read(&blob_file_path)?;
+        let huge = u32::try_from(bytes.len()).unwrap_or(u32::MAX);
+        bytes[OD_LEN_OFF..OD_LEN_OFF + 4].copy_from_slice(&huge.to_le_bytes());
+        let crc = compute_header_crc(7, 3, 11, huge);
+        bytes[HDR_CRC_OFF..HDR_CRC_OFF + 4].copy_from_slice(&crc.to_le_bytes());
+        std::fs::write(&blob_file_path, bytes)?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::InvalidHeader("Blob"))),
+        "the over-section frame is bounds-rejected: {first:?}",
+    );
+    let Some(second) = scanner.next() else {
+        panic!("the intact frame 2 must survive the over-section frame");
+    };
+    let second = second?;
+    assert_eq!(
+        second.key,
+        Slice::from(&b"bbb"[..]),
+        "frame 2 is recovered, not lost to a terminated scan",
+    );
+    let Some(third) = scanner.next() else {
+        panic!("frame 3 follows");
+    };
+    assert_eq!(third?.key, Slice::from(&b"ccc"[..]));
+    assert!(scanner.next().is_none());
+    Ok(())
+}
+
+/// A CRC-VALID frame at a WRITER-CHAINED position (not a resync candidate)
+/// whose on-disk length was re-stamped to consume an intact later frame,
+/// then fails its payload checksum, must resynchronize — a checksum
+/// rejection means the declared span is untrusted regardless of how the
+/// position was reached. Otherwise the scan resumes past the swallowed
+/// frame and salvage drops it without reporting the loss.
+#[test]
+fn blob_scanner_resyncs_when_a_chained_frame_swallows_the_next() -> crate::Result<()> {
+    use crate::vlog::blob_file::writer::{BLOB_HEADER_LEN, compute_header_crc};
+
+    let dir = tempdir()?;
+    let blob_file_path = dir.path().join("0");
+    {
+        let mut writer = BlobFileWriter::new(&blob_file_path, 0, 0, &StdFs)?;
+        writer.write(b"aaa", 7, b"first_value")?; // 11-byte value
+        writer.write(b"bbb", 7, b"second_value")?;
+        writer.write(b"ccc", 7, b"third_value")?;
+        writer.finish()?;
+    }
+
+    // Frame 1 at offset 0: header 42 + key 3 + value 11 -> ends at 56.
+    // Frame 2: 42 + 3 + 12 -> ends at 113 (= frame 3's offset).
+    // Re-stamp frame 1's on_disk_val_len so its declared end reaches frame
+    // 3, swallowing frame 2, and recompute the header CRC so the frame is
+    // CRC-valid (the payload checksum then fails on the wrong-length value).
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "BLOB_HEADER_LEN is the 42-byte header constant, well within u32"
+    )]
+    let header = BLOB_HEADER_LEN as u32;
+    // Frame 3's offset = frame 1 + frame 2, each `header + key_len + value_len`
+    // (3-byte keys; 11- and 12-byte values), derived from the header constant so
+    // a header-layout change moves it in lockstep.
+    let key_len = 3u32;
+    let f3_off = (header + key_len + 11) + (header + key_len + 12);
+    let swallow_odl = f3_off - header - key_len; // header + key + odl == f3_off
+    {
+        let mut bytes = std::fs::read(&blob_file_path)?;
+        bytes[OD_LEN_OFF..OD_LEN_OFF + 4].copy_from_slice(&swallow_odl.to_le_bytes());
+        let crc = compute_header_crc(7, 3, 11, swallow_odl);
+        bytes[HDR_CRC_OFF..HDR_CRC_OFF + 4].copy_from_slice(&crc.to_le_bytes());
+        std::fs::write(&blob_file_path, bytes)?;
+    }
+
+    let mut scanner = Scanner::new(&blob_file_path, &StdFs, 0)?;
+    let first = scanner.next().unwrap();
+    assert!(
+        matches!(first, Err(crate::Error::ChecksumMismatch { .. })),
+        "the swallowing frame fails its payload checksum: {first:?}",
+    );
+    let Some(second) = scanner.next() else {
+        panic!("the intact frame 2 must survive the swallowing frame");
+    };
+    let second = second?;
+    assert_eq!(
+        second.key,
+        Slice::from(&b"bbb"[..]),
+        "frame 2 is recovered, not skipped by the re-stamped declared end",
+    );
+    assert_eq!(second.value, Slice::from(&b"second_value"[..]));
+    let Some(third) = scanner.next() else {
+        panic!("frame 3 follows");
+    };
+    assert_eq!(third?.key, Slice::from(&b"ccc"[..]));
+    assert!(scanner.next().is_none());
     Ok(())
 }
 
@@ -329,7 +817,7 @@ fn blob_scanner_rejects_invalid_magic() -> crate::Result<()> {
 /// corruption matching those bytes caused silent data loss.
 #[test]
 fn blob_scanner_meta_corruption_is_not_silent_eof() -> crate::Result<()> {
-    use crate::vlog::blob_file::writer::BLOB_HEADER_LEN_V4;
+    use crate::vlog::blob_file::writer::BLOB_HEADER_LEN;
 
     let dir = tempdir()?;
     let blob_file_path = dir.path().join("0");
@@ -357,7 +845,7 @@ fn blob_scanner_meta_corruption_is_not_silent_eof() -> crate::Result<()> {
 
     let mut raw = std::fs::read(&blob_file_path)?;
     // Second frame offset: data_start + first frame (header + key + value).
-    let second_frame_offset = data_start + BLOB_HEADER_LEN_V4 + 1 + 50;
+    let second_frame_offset = data_start + BLOB_HEADER_LEN + 1 + 50;
 
     // Corrupt the second frame's magic to b"META".
     raw.get_mut(second_frame_offset..second_frame_offset + 4)

--- a/src/vlog/blob_file/writer.rs
+++ b/src/vlog/blob_file/writer.rs
@@ -7,7 +7,7 @@ use crate::compression::CompressionProvider as _;
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
-use super::meta::Metadata;
+use super::meta::{META_VERSION, Metadata};
 use crate::io::BufWriter;
 #[cfg(not(feature = "std"))]
 use crate::io::Write;
@@ -28,10 +28,11 @@ use std::io::Write;
 /// Enforced on the write path to prevent producing blobs that are
 /// unreasonably large. The reader applies its own copy of this limit.
 ///
-/// NOTE: Intentionally duplicated in `table::block` (as `u32`) and
-/// `vlog::blob_file::reader` rather than shared, because blocks and
-/// blobs are independent storage formats that may diverge in the future.
-const MAX_DECOMPRESSION_SIZE: usize = 256 * 1024 * 1024;
+/// The blob-format definition site: `reader` and `scanner` import this rather
+/// than duplicate it. Kept SEPARATE from `table::block`'s cap (a `u32`) on
+/// purpose, since blocks and blobs are independent storage formats that may
+/// diverge.
+pub(super) const MAX_DECOMPRESSION_SIZE: usize = 256 * 1024 * 1024;
 
 /// Returns `Err(DecompressedSizeTooLarge)` if `len > MAX_DECOMPRESSION_SIZE`.
 fn check_size_cap(len: usize) -> crate::Result<()> {
@@ -47,24 +48,25 @@ fn check_size_cap(len: usize) -> crate::Result<()> {
 // Note: these constants are `pub` for crate-internal use but the parent
 // `vlog` module is NOT exported from `lib.rs`, so they are not public API.
 
-/// V3 blob frame magic (no header checksum).
-pub const BLOB_HEADER_MAGIC_V3: &[u8] = b"BLOB";
+/// Blob frame magic. This is the ONLY readable frame shape: the engine
+/// supports exactly one on-disk format (see [`crate::FormatVersion`]) — a
+/// frame under any other magic (including the retired pre-V5 `b"BLOB"`
+/// layout without a header CRC) is corruption, not a compat case.
+pub const BLOB_HEADER_MAGIC: &[u8] = b"BLO4";
 
-/// V4 blob frame magic (includes header checksum).
-pub const BLOB_HEADER_MAGIC_V4: &[u8] = b"BLO4";
-
-/// V3 blob frame header length (38 bytes, no `header_crc`).
-pub const BLOB_HEADER_LEN_V3: usize = BLOB_HEADER_MAGIC_V3.len()
+/// Blob frame header length: 42 bytes, `header_crc` included. The fields sum to
+/// 42: 4 (magic), 16 (u128 checksum), 8 (seqno), 2 (key len), 4 (real val len),
+/// 4 (on-disk val len), 4 (header crc). Pinned by the reader tests
+/// (`assert_eq!(BLOB_HEADER_LEN, 42)`).
+pub const BLOB_HEADER_LEN: usize = BLOB_HEADER_MAGIC.len()
     + core::mem::size_of::<u128>() // Checksum
     + core::mem::size_of::<u64>() // SeqNo
     + core::mem::size_of::<u16>() // Key length
     + core::mem::size_of::<u32>() // Real value length
-    + core::mem::size_of::<u32>(); // On-disk value length
+    + core::mem::size_of::<u32>() // On-disk value length
+    + core::mem::size_of::<u32>(); // Header CRC
 
-/// V4 blob frame header length (42 bytes, includes `header_crc`).
-pub const BLOB_HEADER_LEN_V4: usize = BLOB_HEADER_LEN_V3 + core::mem::size_of::<u32>(); // Header CRC
-
-/// Compute V4 header CRC from header fields.
+/// Compute the frame header CRC from header fields.
 /// Returns a 4-byte truncated xxh3 hash.
 #[expect(
     clippy::cast_possible_truncation,
@@ -84,7 +86,7 @@ pub(super) fn compute_header_crc(
     hasher.digest() as u32
 }
 
-/// Validate V4 header CRC: recompute from header fields and compare
+/// Validate the frame header CRC: recompute from header fields and compare
 /// against the stored value.
 pub(super) fn validate_header_crc(
     seqno: u64,
@@ -164,10 +166,28 @@ impl Writer {
         let path = path.as_ref();
 
         let file = fs.open(path, &FsOpenOptions::new().write(true).create_new(true))?;
-        let writer = BufWriter::new(file);
-        let writer = ChecksummedWriter::new(writer);
-        let mut writer = crate::sfa::Writer::from_writer(writer);
-        writer.start("data")?;
+        // From here the file exists and is OURS (`create_new` proved it), so
+        // this constructor owns cleanup: an init failure below must not leak a
+        // partial file, and a CALLER must never remove `path` on a constructor
+        // error — an open failure above created nothing, so caller-side
+        // cleanup would race a concurrent creator and delete a file it does
+        // not own.
+        let mut writer =
+            crate::sfa::Writer::from_writer(ChecksummedWriter::new(BufWriter::new(file)));
+        if let Err(e) = writer.start("data") {
+            drop(writer);
+            // Best-effort cleanup of the partial file we own, but do not swallow
+            // a removal failure silently: log it with context so a leaked
+            // partial blob file is diagnosable. The original start error is still
+            // what the caller sees.
+            if let Err(remove_err) = fs.remove_file(path) {
+                log::warn!(
+                    "failed to remove partial blob file {} after a writer-init error: {remove_err}",
+                    path.display(),
+                );
+            }
+            return Err(e.into());
+        }
 
         Ok(Self {
             tree_id,
@@ -255,7 +275,7 @@ impl Writer {
 
             #[cfg(feature = "lz4")]
             CompressionType::Lz4 => {
-                let compressed = lz4_flex::compress(value);
+                let compressed = lz4_flex::block::compress(value);
                 check_size_cap(compressed.len())?;
                 alloc::borrow::Cow::Owned(compressed)
             }
@@ -303,9 +323,9 @@ impl Writer {
         self.uncompressed_bytes += u64::from(uncompressed_len);
 
         // NOTE:
-        // V4 BLOB HEADER LAYOUT
+        // BLOB HEADER LAYOUT
         //
-        // [MAGIC_BYTES; 4B]    - b"BLO4"
+        // [MAGIC_BYTES; 4B]    - BLOB_HEADER_MAGIC (b"BLO4")
         // [Checksum; 16B]      - xxh3_128(key + value + header_crc_le)
         // [Seqno; 8B]
         // [key len; 2B]
@@ -335,7 +355,7 @@ impl Writer {
         };
 
         // Write header
-        self.writer.write_all(BLOB_HEADER_MAGIC_V4)?;
+        self.writer.write_all(BLOB_HEADER_MAGIC)?;
 
         // Write data checksum
         self.writer.write_u128::<LittleEndian>(checksum)?;
@@ -359,7 +379,7 @@ impl Writer {
         self.writer.write_all(&value)?;
 
         // Update offset
-        self.offset += BLOB_HEADER_LEN_V4 as u64;
+        self.offset += BLOB_HEADER_LEN as u64;
         self.offset += key.len() as u64;
         self.offset += value.len() as u64;
 
@@ -397,7 +417,7 @@ impl Writer {
         // Write metadata
         let metadata = Metadata {
             id: self.blob_file_id,
-            version: 4,
+            version: META_VERSION,
             created_at: unix_timestamp().as_nanos(),
             item_count: self.item_count,
             total_compressed_bytes: self.written_blob_bytes,

--- a/src/vlog/mod.rs
+++ b/src/vlog/mod.rs
@@ -27,7 +27,7 @@ use core::sync::atomic::AtomicBool;
 
 pub fn recover_blob_files(
     folder: &Path,
-    ids: &[(BlobFileId, Checksum)],
+    ids: &[(BlobFileId, Checksum, u64)],
     tree_id: TreeId,
     descriptor_table: Option<&Arc<DescriptorTable>>,
     fs: &Arc<dyn Fs>,
@@ -90,7 +90,9 @@ pub fn recover_blob_files(
 
         let blob_file_path = &dirent.path;
 
-        if let Some(&(_, checksum)) = ids.iter().find(|(id, _)| id == &blob_file_id) {
+        if let Some(&(_, checksum, live_data_start)) =
+            ids.iter().find(|(id, _, _)| id == &blob_file_id)
+        {
             log::trace!(
                 "Recovering blob file #{blob_file_id:?} from {}",
                 blob_file_path.display(),
@@ -135,6 +137,7 @@ pub fn recover_blob_files(
                 is_deleted: AtomicBool::new(false),
                 punch_on_drop: portable_atomic::AtomicU64::new(u64::MAX),
                 checksum,
+                live_data_start,
                 file_accessor,
                 tree_id,
                 fs: fs.clone(),
@@ -198,6 +201,26 @@ pub fn recover_blob_file(
     tree_id: TreeId,
     fs: &Arc<dyn Fs>,
 ) -> crate::Result<BlobFile> {
+    recover_blob_file_from(path, id, checksum, tree_id, fs, 0)
+}
+
+/// As [`recover_blob_file`], but for a view whose consumed prefix below
+/// `live_data_start` was reclaimed by a tight-space relocation: `checksum`
+/// covers only `[live_data_start, end)`, and integrity checks hash from there
+/// rather than over the punched (zeroed) prefix. `live_data_start = 0` is a
+/// whole, unreclaimed file.
+///
+/// # Errors
+///
+/// Propagates any error from opening or parsing the blob file.
+pub fn recover_blob_file_from(
+    path: &Path,
+    id: BlobFileId,
+    checksum: Checksum,
+    tree_id: TreeId,
+    fs: &Arc<dyn Fs>,
+    live_data_start: u64,
+) -> crate::Result<BlobFile> {
     let mut file = fs.open(path, &crate::fs::FsOpenOptions::new().read(true))?;
 
     // Same meta-section read as `recover_blob_files`' per-id branch above.
@@ -222,6 +245,7 @@ pub fn recover_blob_file(
         is_deleted: AtomicBool::new(false),
         punch_on_drop: portable_atomic::AtomicU64::new(u64::MAX),
         checksum,
+        live_data_start,
         file_accessor: FileAccessor::File(file),
         tree_id,
         fs: fs.clone(),

--- a/src/vlog/tests.rs
+++ b/src/vlog/tests.rs
@@ -8,7 +8,7 @@ fn vlog_recovery_missing_blob_file_returns_unrecoverable() {
     let dir = tempfile::tempdir().unwrap();
     let result = recover_blob_files(
         dir.path(),
-        &[(0, Checksum::from_raw(0))],
+        &[(0, Checksum::from_raw(0), 0)],
         0,
         None,
         &(Arc::new(crate::fs::StdFs) as Arc<dyn crate::fs::Fs>),
@@ -38,7 +38,7 @@ fn vlog_recovery_nonexistent_folder_with_ids_returns_unrecoverable() {
     let missing = dir.path().join("no_such_dir");
     let result = recover_blob_files(
         &missing,
-        &[(0, Checksum::from_raw(0))],
+        &[(0, Checksum::from_raw(0), 0)],
         0,
         None,
         &(Arc::new(crate::fs::StdFs) as Arc<dyn crate::fs::Fs>),

--- a/tests/columnar_scan.rs
+++ b/tests/columnar_scan.rs
@@ -551,6 +551,111 @@ fn tree_columnar_scan_masks_per_row_seqno_when_snapshot_straddles_segment() {
     assert_eq!(scan_keys(&tree, SeqNo::MAX), vec![key(0), key(1), key(2)]);
 }
 
+/// Reads a bytes column's row values (offset-table layout: `(rows+1)` u32
+/// offsets, then the payload).
+fn bytes_rows(col: &Column, rows: usize) -> Vec<Vec<u8>> {
+    let off = |i: usize| {
+        let b: [u8; 4] = col.data[i * 4..i * 4 + 4].try_into().unwrap();
+        u32::from_le_bytes(b) as usize
+    };
+    let payload = &col.data[(rows + 1) * 4..];
+    (0..rows)
+        .map(|i| payload[off(i)..off(i + 1)].to_vec())
+        .collect()
+}
+
+#[test]
+fn tree_columnar_scan_singleton_segment_dedups_overwritten_key() {
+    // A flush-produced columnar segment holds every MVCC version of an
+    // overwritten key. A SINGLETON segment (no overlapping neighbor) must still
+    // return one row per key — the newest visible version — exactly like the
+    // overlapping-merge path does.
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    tree.insert(key(0), b"old".to_vec(), 1);
+    tree.insert(key(1), b"only".to_vec(), 2);
+    tree.insert(key(0), b"new".to_vec(), 3); // overwrite k0
+    tree.flush_active_memtable(0).expect("flush");
+
+    // All-visible scan: each key exactly once, k0 at its newest value.
+    let mut got: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY, COL_VALUE], None, SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        let rows = batch.row_count as usize;
+        let key_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .expect("key column");
+        let val_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_VALUE)
+            .expect("value column");
+        got.extend(
+            bytes_rows(key_col, rows)
+                .into_iter()
+                .zip(bytes_rows(val_col, rows)),
+        );
+    }
+    assert_eq!(
+        got,
+        vec![(key(0), b"new".to_vec()), (key(1), b"only".to_vec()),],
+        "singleton segment dedups an overwritten key to its newest version"
+    );
+
+    // A snapshot straddling the segment sees k0's OLD version (the newest one
+    // visible below the snapshot) — once, not zero or two times.
+    assert_eq!(
+        scan_keys(&tree, 2),
+        vec![key(0)],
+        "straddling snapshot keeps the newest VISIBLE version, once"
+    );
+}
+
+#[test]
+fn tree_columnar_scan_singleton_predicate_runs_after_dedup() {
+    // The newest version of k0 fails the predicate while its shadowed older
+    // version matches: the key must be dropped, not resurrected through the
+    // older matching version. Mirrors the overlapping-merge path's
+    // predicate-after-dedup ordering.
+    let folder = get_tmp_folder();
+    let tree = open_columnar(folder.path());
+    tree.insert(key(0), b"match".to_vec(), 1);
+    tree.insert(key(1), b"match".to_vec(), 2);
+    tree.insert(key(0), b"zzz-miss".to_vec(), 3); // newest k0 fails the predicate
+    tree.flush_active_memtable(0).expect("flush");
+
+    let pred = ColumnRangePredicate {
+        column_id: COL_VALUE,
+        lower: Some(b"match".to_vec()),
+        upper: Some(b"match".to_vec()),
+    };
+    let mut got: Vec<Vec<u8>> = Vec::new();
+    for batch in tree
+        .columnar_scan(&[COL_USER_KEY], Some(&pred), SeqNo::MAX, ..)
+        .expect("scan")
+    {
+        let batch = batch.expect("batch");
+        let rows = batch.row_count as usize;
+        let key_col = batch
+            .columns
+            .iter()
+            .find(|c| c.column_id == COL_USER_KEY)
+            .expect("key column");
+        got.extend(bytes_rows(key_col, rows));
+    }
+    assert_eq!(
+        got,
+        vec![key(1)],
+        "a key whose newest version fails the predicate is dropped, not \
+         served from a shadowed older matching version"
+    );
+}
+
 #[test]
 fn tree_columnar_scan_applies_delete_bitmap_masking() {
     // A columnar segment carrying a positional delete-bitmap (built by relocating

--- a/tests/recovery_healtmp_sweep.rs
+++ b/tests/recovery_healtmp_sweep.rs
@@ -1,0 +1,138 @@
+use lsm_tree::{AbstractTree, Config, SequenceNumberCounter, get_tmp_folder};
+use test_log::test;
+
+fn open(folder: &tempfile::TempDir) -> lsm_tree::Result<lsm_tree::AnyTree> {
+    Config::new(
+        folder,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .open()
+}
+
+/// An abandoned heal copy has the exact `{table-id}.healtmp-{seq}` shape (both
+/// parts numeric). Recovery owns it: the sweep removes it and the tree reopens.
+#[test]
+fn recovery_sweeps_exact_healtmp_artifact_and_reopens() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+
+    {
+        let tree = open(&folder)?;
+        tree.insert("a", "a", 0);
+        tree.flush_active_memtable(0)?;
+        assert_eq!(1, tree.table_count());
+    }
+
+    // Simulate a hard crash between the heal copy's creation and its rename.
+    let artifact = folder.path().join("tables").join("0.healtmp-3");
+    std::fs::File::create(&artifact)?;
+
+    {
+        let tree = open(&folder)?;
+        assert_eq!(1, tree.table_count());
+    }
+    assert!(
+        !artifact.try_exists()?,
+        "the abandoned heal copy must be swept on recovery"
+    );
+
+    Ok(())
+}
+
+/// Only the exact `{numeric-id}.healtmp-{numeric-seq}` shape is owned cleanup
+/// state. A foreign file whose name merely CONTAINS `.healtmp` (an operator
+/// backup like `0.healtmp.backup` or a stray `notes.healtmp`) must NOT be
+/// deleted — recovery fails on the unparseable name, exactly as it does for
+/// any other unrecognized file under `tables/`, and the file survives.
+#[test]
+fn recovery_with_non_artifact_healtmp_name_fails_without_deleting() -> lsm_tree::Result<()> {
+    for foreign_name in [
+        "0.healtmp.backup",
+        "notes.healtmp",
+        "0.healtmp-3x",
+        "x.healtmp-3",
+    ] {
+        let folder = get_tmp_folder();
+
+        {
+            let tree = open(&folder)?;
+            tree.insert("a", "a", 0);
+            tree.flush_active_memtable(0)?;
+        }
+
+        let foreign = folder.path().join("tables").join(foreign_name);
+        std::fs::File::create(&foreign)?;
+
+        let result = open(&folder);
+        assert!(
+            matches!(result, Err(lsm_tree::Error::Unrecoverable)),
+            "recovery must refuse the unrecognized file {foreign_name:?} instead of deleting it"
+        );
+        assert!(
+            foreign.try_exists()?,
+            "recovery must never delete the foreign file {foreign_name:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Recovery owns four more sidecar artifact families and sweeps the disposable
+/// ones while preserving the live ones: a `{id}.heal-attest` for a LIVE table
+/// survives (the next scrub reconciles a crashed digest refresh through it), a
+/// `{id}.heal-attest` for a RETIRED (absent-from-manifest) table is swept
+/// (nothing can ever reconcile a table that no longer exists), and the crashed
+/// publish temps `{id}.heal-attest.tmp` and `{id}.restrict-bound.tmp` are always
+/// swept. The tree reopens cleanly throughout.
+#[test]
+fn recovery_sweeps_disposable_sidecar_artifacts_and_keeps_live_ones() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+
+    {
+        let tree = open(&folder)?;
+        tree.insert("a", "a", 0);
+        tree.flush_active_memtable(0)?;
+        assert_eq!(1, tree.table_count(), "the flush produced the live table 0");
+    }
+    let tables = folder.path().join("tables");
+
+    // Live table 0's pending attestation: preserved.
+    let live_attest = tables.join("0.heal-attest");
+    std::fs::File::create(&live_attest)?;
+    // A retired (never-in-manifest) id's attestation: swept.
+    let orphan_attest = tables.join("999.heal-attest");
+    std::fs::File::create(&orphan_attest)?;
+    // Crashed atomic-publish temps of both sidecar kinds: swept.
+    let attest_tmp = tables.join("0.heal-attest.tmp");
+    std::fs::File::create(&attest_tmp)?;
+    let restrict_tmp = tables.join("0.restrict-bound.tmp");
+    std::fs::File::create(&restrict_tmp)?;
+
+    {
+        let tree = open(&folder)?;
+        assert_eq!(
+            1,
+            tree.table_count(),
+            "the tree reopens with its single table"
+        );
+    }
+
+    assert!(
+        live_attest.try_exists()?,
+        "a LIVE table's heal attestation must be preserved for the next scrub",
+    );
+    assert!(
+        !orphan_attest.try_exists()?,
+        "a retired table's orphaned heal attestation must be swept",
+    );
+    assert!(
+        !attest_tmp.try_exists()?,
+        "an abandoned heal-attest publish temp must be swept",
+    );
+    assert!(
+        !restrict_tmp.try_exists()?,
+        "an abandoned restrict-bound publish temp must be swept",
+    );
+
+    Ok(())
+}

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -47,7 +47,7 @@ fn count_sst_files(dir: &std::path::Path) -> std::io::Result<usize> {
 
 #[test]
 fn repair_rebuilds_manifest_and_preserves_all_keys() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     // Three flushes → three L0 tables, with an overwrite in the last batch so
     // repair has to preserve the latest value across overlapping L0 runs.
@@ -124,7 +124,7 @@ fn repair_rebuilds_manifest_and_preserves_all_keys() -> lsm_tree::Result<()> {
 
 #[test]
 fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     {
         let tree = Config::new(
@@ -187,7 +187,7 @@ fn repair_skips_unreadable_file_but_recovers_the_rest() -> lsm_tree::Result<()> 
 
 #[test]
 fn repair_with_no_ssts_produces_empty_readable_tree() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     // Open and close without ever flushing: the manifest exists but no SST does
     // (manifest lost before the first flush is the scenario).
@@ -226,7 +226,7 @@ fn repair_with_no_ssts_produces_empty_readable_tree() -> lsm_tree::Result<()> {
 
 #[test]
 fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     {
         let tree = Config::new(
@@ -296,7 +296,7 @@ fn repair_reports_non_table_id_filename_as_unreadable() -> lsm_tree::Result<()> 
 // and skipped — while intact SSTs still recover and the tree reopens.
 #[test]
 fn repair_rejects_corrupted_sst_and_recovers_the_rest() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     {
         let tree = Config::new(
@@ -390,7 +390,7 @@ fn repair_rejects_corrupted_sst_and_recovers_the_rest() -> lsm_tree::Result<()> 
 #[cfg(unix)]
 #[test]
 fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     {
         let tree = Config::new(
@@ -432,7 +432,7 @@ fn repair_reports_unopenable_file_as_unreadable() -> lsm_tree::Result<()> {
 
 #[test]
 fn repair_fails_when_a_bad_filename_cannot_be_quarantined() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
     let big = |i: u64| format!("{i:08}").repeat(512);
 
     {
@@ -482,7 +482,7 @@ fn repair_fails_when_a_bad_table_filename_cannot_be_quarantined() -> lsm_tree::R
     // Sibling of the blob-side test above, covering the standard `tables/`
     // quarantine path so the false-success regression cannot slip back for
     // standard trees.
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     {
         let tree = Config::new(
@@ -537,7 +537,7 @@ fn count_blob_files(dir: &std::path::Path) -> std::io::Result<usize> {
 
 #[test]
 fn repair_rebuilds_blob_tree_manifest_and_preserves_values() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
 
     // ~4 KiB values, above the 1 KiB KV-separation threshold, so they spill into
     // the value log as blob files: the artifact a blob-tree repair must
@@ -628,11 +628,32 @@ fn sorted_sst_paths(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
 /// (data is written first; index / filter / meta live at the tail), so the SST
 /// still opens but one data block fails its checksum.
 fn corrupt_data_region(path: &std::path::Path) -> std::io::Result<()> {
+    // Locate the `data` section through the SFA trailer TOC rather than assuming
+    // it begins at offset 0: a byte a fixed depth into the section's payload is
+    // stable against tail growth (the index / filter / meta / trailer that follow
+    // can change size, e.g. a new meta key) AND correct even if the data section
+    // ever stops being written first.
+    const DEPTH: u64 = 512;
+    let pos = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = lsm_tree::sfa::Reader::from_reader(&mut f)
+            .map_err(|e| std::io::Error::other(format!("read SFA TOC: {e}")))?;
+        let entry = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == b"data")
+            .expect("the SST carries a data section");
+        assert!(
+            entry.len() > DEPTH,
+            "data section (len {}) is too small to corrupt a block at depth {DEPTH}",
+            entry.len(),
+        );
+        usize::try_from(entry.pos() + DEPTH).expect("position fits usize")
+    };
     let mut bytes = std::fs::read(path)?;
-    let at = bytes.len() / 4;
-    if let Some(b) = bytes.get_mut(at) {
-        *b ^= 0xFF;
-    }
+    *bytes
+        .get_mut(pos)
+        .expect("corruption offset within the SST") ^= 0xFF;
     std::fs::write(path, &bytes)
 }
 
@@ -642,7 +663,7 @@ fn corrupt_data_region(path: &std::path::Path) -> std::io::Result<()> {
 /// instead of leaving a table that errors on read.
 #[test]
 fn repair_with_salvage_recovers_a_block_corrupt_sst() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
     {
         let tree = Config::new(
             dir.path(),
@@ -707,11 +728,70 @@ fn repair_with_salvage_recovers_a_block_corrupt_sst() -> lsm_tree::Result<()> {
     Ok(())
 }
 
+/// A salvaging repair must persist the recovered SST at the CONFIGURED
+/// durability: with `Config::sync_mode = Full`, the rebuilt manifest is
+/// synced Full while a salvage writer left at its Normal default would give
+/// the freshly recovered SST weaker durability than everything around it —
+/// a repair reported as durable could lose the recovered file across power
+/// failure on platforms where Full means `F_FULLFSYNC`.
+#[test]
+fn repair_with_salvage_syncs_the_recovered_sst_at_the_configured_mode() -> lsm_tree::Result<()> {
+    use lsm_tree::fs::{FaultFs, Fs, StdFs, SyncMode};
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt");
+    corrupt_data_region(victim)?;
+    nuke_manifest(dir.path())?;
+
+    // Repair under Full durability through a sync-observing Fs.
+    let fault = FaultFs::new(StdFs);
+    let injector = fault.injector();
+    let fs: Arc<dyn Fs> = Arc::new(fault);
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .sync_mode(SyncMode::Full)
+    .with_shared_fs(fs)
+    .repair_with_salvage(true)?;
+    assert_eq!(report.salvaged, 1, "{:?}", report.unreadable_files);
+
+    // The salvaged table file (under tables/) must have been synced at the
+    // configured Full mode, not the salvage writer's Normal default.
+    let modes = injector.sync_modes_for("tables");
+    assert!(
+        !modes.is_empty(),
+        "the salvage writer syncs the recovered SST through the injected Fs",
+    );
+    assert!(
+        modes.iter().all(|m| *m == SyncMode::Full),
+        "every sync of the recovered SST must use the configured Full mode (a single \
+         Normal sync must fail the test), got {modes:?}",
+    );
+    Ok(())
+}
+
 /// An SST whose container (SFA trailer) is corrupt cannot be opened even in
 /// salvage mode, so repair reports it unreadable rather than salvaging it.
 #[test]
 fn repair_with_salvage_reports_an_unopenable_sst_as_unreadable() -> lsm_tree::Result<()> {
-    let dir = tempfile::tempdir()?;
+    let dir = lsm_tree::get_tmp_folder();
     {
         let tree = Config::new(
             dir.path(),
@@ -751,5 +831,738 @@ fn repair_with_salvage_reports_an_unopenable_sst_as_unreadable() -> lsm_tree::Re
         "the SST is reported unreadable: {:?}",
         report.unreadable_files,
     );
+    Ok(())
+}
+
+/// Ordinary `repair()` (salvage disabled) must QUARANTINE a structurally
+/// unreadable SST before publishing the manifest, not leave it under its numeric
+/// name in `tables/`: the rebuilt manifest omits it, so the next `Tree::open`
+/// would orphan-clean (DELETE) it — contradicting the report's promise that an
+/// operator can still investigate / recover it. The file must be moved out of
+/// `tables/` (into the repair quarantine).
+#[test]
+fn repair_quarantines_an_unreadable_sst_before_publishing() -> lsm_tree::Result<()> {
+    let dir = lsm_tree::get_tmp_folder();
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..64 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt").clone();
+    // Truncate the tail (SFA trailer): the container is unparseable, so recovery
+    // fails structurally on the ordinary (no-salvage) path.
+    let mut bytes = std::fs::read(&victim)?;
+    bytes.truncate(bytes.len() / 2);
+    std::fs::write(&victim, &bytes)?;
+    nuke_manifest(dir.path())?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, 0,
+        "the only SST is unreadable: {report:?}"
+    );
+    assert_eq!(report.unreadable, 1, "it is reported unreadable");
+    assert!(
+        !victim.exists(),
+        "the unreadable SST must be MOVED out of tables/ (quarantined), not left to be \
+         orphan-deleted on the next open",
+    );
+    assert!(
+        report.unreadable_files[0].1.contains("quarantined to"),
+        "the reason records the quarantine destination: {:?}",
+        report.unreadable_files,
+    );
+    Ok(())
+}
+
+/// A PERSISTENT but ECC-correctable fault in an encrypted Page-ECC SST must
+/// drive `repair_with_salvage` into salvaging the table (rewriting it with
+/// clean bytes), not accept it as verified: the encrypted verify path scrubs
+/// through the table, and a scrub silently corrects the fault on read
+/// (`corrections_applied > 0` with no errors) while the corrupt bytes stay on
+/// disk — the unencrypted out-of-band verifier flags the same checksum
+/// mismatch and salvages.
+#[cfg(all(feature = "encryption", feature = "page_ecc"))]
+#[test]
+fn repair_with_salvage_correctable_ecc_fault_in_encrypted_sst_is_rewritten() -> lsm_tree::Result<()>
+{
+    use lsm_tree::Aes256GcmProvider;
+    use lsm_tree::runtime_config::EccScheme;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let provider = || Arc::new(Aes256GcmProvider::new(&[0x6B; 32]));
+    // Shared encrypted Page-ECC config: the initial open, the salvage repair, and
+    // the final reopen must all bind the SAME encryption provider and ECC scheme.
+    let cfg = || {
+        Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_encryption(Some(provider()))
+        .page_ecc(true)
+        .ecc_scheme(EccScheme::ReedSolomon {
+            data_shards: 4,
+            parity_shards: 2,
+        })
+    };
+    {
+        let tree = cfg().open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Flip one byte INSIDE the first data block's payload (the block header is
+    // ~33 bytes, so offset 40 into the `data` section is payload — NOT the
+    // parity trailer, which a clean-checksum read never validates). Within the
+    // RS(4,2) budget, so every read CORRECTS it in memory while the fault
+    // persists on disk. The shared helper locates the section via the TOC and
+    // bounds-checks the offset.
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt");
+    flip_byte_in_section(victim, b"data", SectionByte::FromStart(40))?;
+
+    nuke_manifest(dir.path())?;
+
+    let report = cfg().repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "a persistent correctable fault drives the table through salvage: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the rewritten table joins the manifest"
+    );
+
+    // The tree reopens and every key reads back from the clean rewrite.
+    let tree = cfg().open()?;
+    for i in 0..500 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_some(),
+            "key {} survives the salvage rewrite",
+            key(i),
+        );
+    }
+    Ok(())
+}
+
+/// A PERSISTENT but ECC-correctable fault in an encrypted table's FILTER
+/// block must drive `repair_with_salvage` into salvaging: loading the filter
+/// through the table silently corrects the fault in memory
+/// (`EccStatus::Corrected` is hidden behind an `Ok`), while the corrupt bytes
+/// stay on disk — the same standard already applied to data blocks.
+#[cfg(all(feature = "encryption", feature = "page_ecc"))]
+#[test]
+fn repair_with_salvage_correctable_ecc_fault_in_encrypted_filter_is_rewritten()
+-> lsm_tree::Result<()> {
+    use lsm_tree::Aes256GcmProvider;
+    use lsm_tree::runtime_config::EccScheme;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let provider = || Arc::new(Aes256GcmProvider::new(&[0x8D; 32]));
+    let config = |dir: &std::path::Path| {
+        Config::new(
+            dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_encryption(Some(provider()))
+        .page_ecc(true)
+        .ecc_scheme(EccScheme::ReedSolomon {
+            data_shards: 4,
+            parity_shards: 2,
+        })
+    };
+    {
+        let tree = config(dir.path()).open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Flip ONE byte inside the filter block's payload (past the ~33-byte
+    // header): within the RS(4,2) budget, so a filter load CORRECTS it in
+    // memory — but the fault persists on disk.
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt");
+    flip_byte_in_section(victim, b"filter", SectionByte::FromStart(40))?;
+
+    nuke_manifest(dir.path())?;
+
+    let report = config(dir.path()).repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "a persistent correctable filter fault drives the table through salvage: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the rewritten table joins the manifest"
+    );
+
+    // Exercise the REBUILT filter: reopen under the same configuration and
+    // point-read every key (point reads consult the filter, which loads
+    // lazily — `recovered == 1` alone only proves the table was admitted).
+    let tree = config(dir.path()).open()?;
+    for i in 0..500 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_some(),
+            "key {} survives the salvage rewrite",
+            key(i),
+        );
+    }
+    Ok(())
+}
+
+/// The same standard for SIDE sections loaded during recover (index TLI,
+/// meta, zone map, ...): those loads silently correct an ECC-recoverable
+/// fault in memory, so a persistent correctable flip there must also drive
+/// `repair_with_salvage` into a clean rewrite — the unencrypted out-of-band
+/// verifier flags the same raw checksum mismatch.
+#[cfg(all(feature = "encryption", feature = "page_ecc"))]
+#[test]
+fn repair_with_salvage_correctable_ecc_fault_in_encrypted_tli_is_rewritten() -> lsm_tree::Result<()>
+{
+    use lsm_tree::Aes256GcmProvider;
+    use lsm_tree::runtime_config::EccScheme;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let provider = || Arc::new(Aes256GcmProvider::new(&[0x9E; 32]));
+    let config = |dir: &std::path::Path| {
+        Config::new(
+            dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_encryption(Some(provider()))
+        .page_ecc(true)
+        .ecc_scheme(EccScheme::ReedSolomon {
+            data_shards: 4,
+            parity_shards: 2,
+        })
+    };
+    {
+        let tree = config(dir.path()).open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt");
+    flip_byte_in_section(victim, b"tli", SectionByte::FromStart(40))?;
+
+    nuke_manifest(dir.path())?;
+
+    let report = config(dir.path()).repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "a persistent correctable TLI fault drives the table through salvage: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the rewritten table joins the manifest"
+    );
+
+    // Exercise the REBUILT index: reopen under the same configuration and
+    // point-read every key (each read binary-searches the rewritten TLI —
+    // `recovered == 1` alone only proves the table was admitted).
+    let tree = config(dir.path()).open()?;
+    for i in 0..500 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_some(),
+            "key {} survives the salvage rewrite",
+            key(i),
+        );
+    }
+    Ok(())
+}
+
+/// Where in a section to flip a byte: a fixed offset from its start, or its
+/// midpoint (length-relative). `FromStart` is only used by the ECC-correction
+/// tests (it targets a specific payload byte), so it is gated on `page_ecc`;
+/// `Midpoint` is available under encryption alone.
+#[cfg(feature = "encryption")]
+enum SectionByte {
+    #[cfg(feature = "page_ecc")]
+    FromStart(u64),
+    Midpoint,
+}
+
+/// Flips one byte inside the named SFA section of an SST (locating it via the
+/// trailer TOC), at a fixed offset or the section midpoint.
+#[cfg(feature = "encryption")]
+fn flip_byte_in_section(
+    path: &std::path::Path,
+    section: &[u8],
+    at: SectionByte,
+) -> lsm_tree::Result<()> {
+    let pos = {
+        let mut f = std::fs::File::open(path)?;
+        let reader = lsm_tree::sfa::Reader::from_reader(&mut f)?;
+        let entry = reader
+            .toc()
+            .iter()
+            .find(|e| e.name() == section)
+            .unwrap_or_else(|| panic!("the SST carries a {section:?} section"));
+        match at {
+            #[cfg(feature = "page_ecc")]
+            SectionByte::FromStart(offset) => {
+                assert!(
+                    offset < entry.len(),
+                    "flip offset {offset} must fall within the {section:?} section \
+                     (len {}), not spill into another section",
+                    entry.len(),
+                );
+                entry.pos() + offset
+            }
+            SectionByte::Midpoint => entry.pos() + entry.len() / 2,
+        }
+    };
+    let mut bytes = std::fs::read(path)?;
+    let slot = bytes
+        .get_mut(usize::try_from(pos).expect("position fits usize"))
+        .expect("flip position within the SST");
+    *slot ^= 0x40;
+    std::fs::write(path, &bytes)?;
+    Ok(())
+}
+
+/// A corrupt BLOOM FILTER block in an encrypted SST must drive
+/// `repair_with_salvage` into salvaging the table: the encrypted verify path
+/// scrubs data blocks through the table, but the filter section loads lazily
+/// on point reads — without verifying it, repair accepts an SST whose later
+/// reads fail on the corrupt filter (the unencrypted out-of-band verifier
+/// covers the filter section).
+#[cfg(feature = "encryption")]
+#[test]
+fn repair_with_salvage_corrupt_filter_in_encrypted_sst_is_rewritten() -> lsm_tree::Result<()> {
+    use lsm_tree::Aes256GcmProvider;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let provider = || Arc::new(Aes256GcmProvider::new(&[0x7C; 32]));
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_encryption(Some(provider()))
+        .open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Corrupt the middle of the `filter` SFA section (data blocks stay intact).
+    let ssts = sorted_sst_paths(dir.path());
+    let victim = ssts.first().expect("an SST to corrupt");
+    flip_byte_in_section(victim, b"filter", SectionByte::Midpoint)?;
+
+    nuke_manifest(dir.path())?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_encryption(Some(provider()))
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 1,
+        "a corrupt filter drives the encrypted table through salvage: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the rewritten table joins the manifest"
+    );
+
+    // The tree reopens with a FRESH filter and every point read succeeds.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_encryption(Some(provider()))
+    .open()?;
+    for i in 0..500 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_some(),
+            "key {} reads back through the rebuilt filter",
+            key(i),
+        );
+    }
+    Ok(())
+}
+
+/// `repair_with_salvage` must NOT quarantine and rewrite a HEALTHY encrypted
+/// SST: the block-verify gate has to be encryption-aware (the out-of-band
+/// file walk cannot decode an encrypted meta block, so it would misreport
+/// every encrypted table as corrupt and salvage it on every repair).
+#[cfg(feature = "encryption")]
+#[test]
+fn repair_with_salvage_healthy_encrypted_sst_remains_untouched() -> lsm_tree::Result<()> {
+    use lsm_tree::Aes256GcmProvider;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let provider = || Arc::new(Aes256GcmProvider::new(&[0x5A; 32]));
+    {
+        let tree = Config::new(
+            dir.path(),
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_encryption(Some(provider()))
+        .open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    nuke_manifest(dir.path())?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_encryption(Some(provider()))
+    .repair_with_salvage(true)?;
+    assert_eq!(
+        report.salvaged, 0,
+        "a healthy encrypted SST is not quarantined + rewritten: {:?}",
+        report.unreadable_files,
+    );
+    assert_eq!(
+        report.recovered, 1,
+        "the healthy encrypted table joins the rebuilt manifest: {:?}",
+        report.unreadable_files,
+    );
+
+    // The tree reopens and every key reads back.
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_encryption(Some(provider()))
+    .open()?;
+    for i in 0..500 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_some(),
+            "key {} survives the repair untouched",
+            key(i),
+        );
+    }
+    Ok(())
+}
+
+/// When the same table id exists in two configured table folders — one damaged
+/// (block-salvaged LOSSILY) and one intact — repair must keep the INTACT copy,
+/// not the lossy salvage of the first-scanned one. The primary folder is scanned
+/// first, so putting the damaged copy there and an intact duplicate in a routed
+/// folder proves the intact copy supersedes the lossy salvage. Asserts on the
+/// report (`salvaged == 0`): without the fix, marking the id seen before
+/// verifying makes the first (damaged) copy win and get salvaged lossily.
+#[test]
+fn repair_prefers_an_intact_duplicate_over_a_lossy_salvage() -> lsm_tree::Result<()> {
+    use lsm_tree::config::LevelRoute;
+    use lsm_tree::fs::StdFs;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let primary = dir.path().join("primary");
+    let cold = dir.path().join("cold");
+    std::fs::create_dir_all(primary.join("tables"))?;
+    std::fs::create_dir_all(cold.join("tables"))?;
+
+    // Build one SST via a plain flush, then place a copy in each folder under its
+    // own id name (so the file-name id matches the stored table id).
+    let id_name = {
+        let build = dir.path().join("build");
+        let tree = Config::new(
+            &build,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..1000 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+        let ssts = sorted_sst_paths(&build);
+        assert_eq!(ssts.len(), 1, "one flush → one SST");
+        let name = ssts[0].file_name().expect("sst has a file name").to_owned();
+        std::fs::copy(&ssts[0], cold.join("tables").join(&name))?;
+        std::fs::copy(&ssts[0], primary.join("tables").join(&name))?;
+        name
+    };
+    // Damage the PRIMARY (first-scanned) copy so it can only be lossily salvaged.
+    corrupt_data_region(&primary.join("tables").join(&id_name))?;
+
+    let report = Config::new(
+        &primary,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .level_routes(vec![LevelRoute {
+        levels: 5..7,
+        path: cold,
+        fs: Arc::new(StdFs),
+    }])
+    .repair_with_salvage(true)?;
+
+    assert_eq!(report.recovered, 1, "one table recovered: {report:?}");
+    assert_eq!(
+        report.salvaged, 0,
+        "the intact duplicate must supersede the lossy salvage of the damaged copy: {report:?}",
+    );
+    Ok(())
+}
+
+/// When the same table id exists intact in two configured folders, repair keeps
+/// ONE and must QUARANTINE the duplicate out of `tables/`. The rebuilt manifest
+/// records only `id + checksum` (no path), so a duplicate left in place would let
+/// the reopened tree resolve the wrong file for that id by folder order — and
+/// reopen it against the kept copy's mismatched checksum. The primary is scanned
+/// first, so it wins; the routed (cold) duplicate must land in `cold/`'s
+/// `repair-quarantine`, not stay under `cold/tables`.
+#[test]
+fn repair_quarantines_a_duplicate_table_file() -> lsm_tree::Result<()> {
+    use lsm_tree::config::LevelRoute;
+    use lsm_tree::fs::StdFs;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let primary = dir.path().join("primary");
+    let cold = dir.path().join("cold");
+    std::fs::create_dir_all(primary.join("tables"))?;
+    std::fs::create_dir_all(cold.join("tables"))?;
+
+    // One flushed SST, copied INTACT into both folders under its id name.
+    let id_name = {
+        let build = dir.path().join("build");
+        let tree = Config::new(
+            &build,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..1000 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+        let ssts = sorted_sst_paths(&build);
+        assert_eq!(ssts.len(), 1, "one flush → one SST");
+        let name = ssts[0].file_name().expect("sst has a file name").to_owned();
+        std::fs::copy(&ssts[0], primary.join("tables").join(&name))?;
+        std::fs::copy(&ssts[0], cold.join("tables").join(&name))?;
+        name
+    };
+
+    let report = Config::new(
+        &primary,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .level_routes(vec![LevelRoute {
+        levels: 5..7,
+        path: cold.clone(),
+        fs: Arc::new(StdFs),
+    }])
+    .repair_with_salvage(true)?;
+
+    assert_eq!(report.recovered, 1, "one table recovered: {report:?}");
+    // The primary (first-scanned) copy stays; the routed duplicate is moved OUT of
+    // `cold/tables` into `cold/repair-quarantine`, so recovery can't resolve it.
+    assert!(
+        primary.join("tables").join(&id_name).exists(),
+        "the kept copy stays under the primary's tables/",
+    );
+    assert!(
+        !cold.join("tables").join(&id_name).exists(),
+        "the duplicate must NOT remain under cold/tables (recovery would resolve it \
+         for the id and reopen against a mismatched checksum): {report:?}",
+    );
+    assert!(
+        cold.join("repair-quarantine").join(&id_name).exists(),
+        "the duplicate must be quarantined into cold/repair-quarantine: {report:?}",
+    );
+    Ok(())
+}
+
+/// When two configured table folders are ALIASES of one physical directory (here
+/// a symlink), the second scan sees the SAME file the first already retained.
+/// Quarantining that repeated sighting would MOVE the kept file (both names
+/// resolve to the same directory entry) and leave the manifest referencing a
+/// missing SST. Repair must detect the alias and skip the sighting in place, so
+/// the kept SST survives and stays recovered (#69).
+#[cfg(unix)]
+#[test]
+fn repair_does_not_quarantine_an_aliased_copy_of_the_kept_sst() -> lsm_tree::Result<()> {
+    use lsm_tree::config::LevelRoute;
+    use lsm_tree::fs::StdFs;
+    use std::sync::Arc;
+
+    let dir = lsm_tree::get_tmp_folder();
+    let primary = dir.path().join("primary");
+    std::fs::create_dir_all(primary.join("tables"))?;
+    // `cold` is a SYMLINK to `primary`: both configured folders resolve to the
+    // same physical tables directory, so the SST is seen twice as one file.
+    let cold = dir.path().join("cold");
+    std::os::unix::fs::symlink(&primary, &cold)?;
+
+    let id_name = {
+        let build = dir.path().join("build");
+        let tree = Config::new(
+            &build,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..1000 {
+            tree.insert(key(i), format!("v-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+        let ssts = sorted_sst_paths(&build);
+        assert_eq!(ssts.len(), 1, "one flush → one SST");
+        let name = ssts[0].file_name().expect("sst has a file name").to_owned();
+        std::fs::copy(&ssts[0], primary.join("tables").join(&name))?;
+        name
+    };
+
+    let report = Config::new(
+        &primary,
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .level_routes(vec![LevelRoute {
+        levels: 5..7,
+        path: cold,
+        fs: Arc::new(StdFs),
+    }])
+    .repair_with_salvage(true)?;
+
+    assert_eq!(report.recovered, 1, "one table recovered: {report:?}");
+    // The aliased sighting is skipped in place, never recorded as a failure: it is
+    // the SAME physical file as the kept copy, so reporting it unreadable /
+    // quarantined would misrepresent a healthy table as damaged.
+    assert_eq!(
+        report.unreadable, 0,
+        "the aliased sighting must not be reported unreadable: {:?}",
+        report.unreadable_files,
+    );
+    // The aliased sighting was skipped in place, NOT quarantined: the kept file
+    // still exists under its (single, shared) tables directory.
+    assert!(
+        primary.join("tables").join(&id_name).exists(),
+        "the aliased SST must not be moved out of tables/ (that would orphan the \
+         manifest entry): {report:?}",
+    );
+    Ok(())
+}
+
+/// A blob file that cannot be recovered is omitted from the rebuilt manifest —
+/// but any SST still holding an indirection into it MUST be excluded too.
+/// Publishing that table produces a manifest that opens fine, yet reading an
+/// affected key resolves a handle whose blob file is gone. Repair must reject
+/// the dependent table instead of shipping the inconsistent pair.
+#[test]
+fn repair_excludes_tables_referencing_an_unrecoverable_blob_file() -> lsm_tree::Result<()> {
+    let dir = lsm_tree::get_tmp_folder();
+    let big = |i: u64| format!("{i:08}").repeat(512);
+
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(KvSeparationOptions::default()))
+        .open()?;
+        for i in 0..50 {
+            tree.insert(key(i), big(i).as_bytes(), i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+
+    // Wreck every blob file's contents so recovery fails STRUCTURALLY (the file
+    // still reads, so this is a persistent failure, not a transient one).
+    let blobs = dir.path().join("blobs");
+    for entry in std::fs::read_dir(&blobs)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            std::fs::write(entry.path(), b"not a blob file at all")?;
+        }
+    }
+
+    nuke_manifest(dir.path())?;
+
+    let report = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default()))
+    .repair()?;
+
+    assert_eq!(
+        report.recovered, 0,
+        "an SST whose blob file is unrecoverable must not be published: {report:?}",
+    );
+    assert!(
+        report
+            .unreadable_files
+            .iter()
+            .any(|(_, reason)| reason.contains("blob file")),
+        "the report must name the missing blob dependency: {:?}",
+        report.unreadable_files,
+    );
+
+    // The repaired tree opens and every surviving read is well-defined (the
+    // dependent table is gone, so its keys are simply absent).
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(KvSeparationOptions::default()))
+    .open()?;
+    for i in 0..50 {
+        assert!(
+            tree.get(key(i), MAX_SEQNO)?.is_none(),
+            "key {} must be absent, never a dangling blob handle",
+            key(i),
+        );
+    }
     Ok(())
 }

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -1566,3 +1566,115 @@ fn repair_excludes_tables_referencing_an_unrecoverable_blob_file() -> lsm_tree::
     }
     Ok(())
 }
+
+/// The live-progress handle wired via `Config::with_recovery_progress` must
+/// tick while a repair runs: table files as they are discovered / recovered,
+/// blocks and KV entries as a salvage walk re-emits a corrupted SST, and blob
+/// files on a KV-separated tree. Counter effects are asserted after the run
+/// (the run is too fast to poll mid-flight here; the handle's whole purpose is
+/// that a UI thread MAY poll it concurrently).
+#[test]
+fn repair_ticks_the_recovery_progress_counters() -> lsm_tree::Result<()> {
+    use lsm_tree::RecoveryProgress;
+    use std::sync::Arc;
+
+    // Standard tree: one intact SST + one with a corrupted data block, so the
+    // repair recovers one whole table and block-salvages the other.
+    let dir = lsm_tree::get_tmp_folder();
+    {
+        let tree = Config::new(
+            &dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .open()?;
+        for i in 0..500 {
+            tree.insert(key(i), format!("v0-{i}"), i);
+        }
+        tree.flush_active_memtable(0)?;
+        for i in 500..1000 {
+            tree.insert(key(i), format!("v0-{i}"), 1000 + i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+    let total = count_sst_files(dir.path())?;
+    let ssts = sorted_sst_paths(dir.path());
+    corrupt_data_region(ssts.first().expect("an SST to corrupt"))?;
+    nuke_manifest(dir.path())?;
+
+    let progress = Arc::new(RecoveryProgress::default());
+    Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_recovery_progress(progress.clone())
+    .repair_with_salvage(true)?;
+
+    let snap = progress.snapshot();
+    assert_eq!(
+        snap.tables_discovered, total as u64,
+        "every table file must be counted as discovered"
+    );
+    assert_eq!(
+        snap.tables_recovered, total as u64,
+        "whole and salvaged tables must both count as recovered"
+    );
+    assert!(
+        snap.blocks_scanned > 0,
+        "the salvage walk must tick inspected blocks: {snap:?}"
+    );
+    assert!(
+        snap.blocks_recovered > 0,
+        "the salvage walk must tick re-emitted blocks: {snap:?}"
+    );
+    assert!(
+        snap.kvs_recovered > 0,
+        "the salvage walk must tick recovered KV entries: {snap:?}"
+    );
+
+    // KV-separated tree: blob files must tick too.
+    let blob_dir = lsm_tree::get_tmp_folder();
+    {
+        let tree = Config::new(
+            &blob_dir,
+            SequenceNumberCounter::default(),
+            SequenceNumberCounter::default(),
+        )
+        .with_kv_separation(Some(
+            KvSeparationOptions::default().separation_threshold(16),
+        ))
+        .open()?;
+        let lsm_tree::AnyTree::Blob(tree) = tree else {
+            panic!("expected a blob tree");
+        };
+        for i in 0..20 {
+            tree.insert(key(i).as_bytes(), vec![b'v'; 128], i);
+        }
+        tree.flush_active_memtable(0)?;
+    }
+    nuke_manifest(blob_dir.path())?;
+
+    let blob_progress = Arc::new(RecoveryProgress::default());
+    Config::new(
+        blob_dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .with_kv_separation(Some(
+        KvSeparationOptions::default().separation_threshold(16),
+    ))
+    .with_recovery_progress(blob_progress.clone())
+    .repair()?;
+
+    let snap = blob_progress.snapshot();
+    assert!(
+        snap.blob_files_discovered > 0,
+        "blob files must be counted as discovered: {snap:?}"
+    );
+    assert_eq!(
+        snap.blob_files_recovered, snap.blob_files_discovered,
+        "every intact blob file must be counted as recovered"
+    );
+    Ok(())
+}

--- a/tests/tree_bulk_ingest.rs
+++ b/tests/tree_bulk_ingest.rs
@@ -203,3 +203,68 @@ fn blob_tree_copy() -> lsm_tree::Result<()> {
 
     Ok(())
 }
+
+/// End-to-end: a bulk-ingested table relies on a manifest-only `global_seqno`
+/// offset for its effective MVCC ordering, so manifest repair (which cannot
+/// recover that offset from the SST) must FAIL CLOSED and quarantine it rather
+/// than register it with offset 0 and silently age its entries. This exercises
+/// the real ingest path (which flags the SST `descriptor#bulk_ingested`) plus
+/// repair, guarding the ingest → flag → quarantine chain end to end.
+#[test]
+fn repair_quarantines_a_bulk_ingested_table() -> lsm_tree::Result<()> {
+    let folder = get_tmp_folder();
+    let seqno = SequenceNumberCounter::default();
+    let visible_seqno = SequenceNumberCounter::default();
+
+    {
+        let tree = Config::new(&folder, seqno.clone(), visible_seqno.clone()).open()?;
+        let mut ingestion = tree.ingestion()?;
+        for x in 0..64u64 {
+            ingestion.write(x.to_be_bytes(), b"v")?;
+        }
+        ingestion.finish()?;
+    }
+
+    // The ingested SST on disk before repair. Quarantine must MOVE it out of
+    // tables/ (not merely omit it from the rebuilt manifest), or the next open's
+    // orphan cleanup would delete the only copy of the preserved original.
+    let ingested_sst = std::fs::read_dir(folder.path().join("tables"))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
+        })
+        .expect("the ingest produced a numerically-named SST file");
+
+    // The ingest allocated a nonzero global_seqno (a manifest-only offset the
+    // SST does not carry), so repair cannot reconstruct it.
+    assert!(
+        seqno.get() > 0,
+        "the ingest allocated a global_seqno offset"
+    );
+
+    let report = Config::new(&folder, seqno, visible_seqno).repair()?;
+    assert_eq!(
+        report.recovered, 0,
+        "the bulk-ingested table must not be recovered with a lost offset: {report:?}",
+    );
+    assert_eq!(
+        report.unreadable, 1,
+        "the bulk-ingested table is quarantined: {:?}",
+        report.unreadable_files,
+    );
+    assert!(
+        report.unreadable_files[0].1.contains("sequence offset"),
+        "the reason names the unrecoverable ingest offset: {:?}",
+        report.unreadable_files,
+    );
+    assert!(
+        !ingested_sst.exists(),
+        "the quarantined SST must be moved out of tables/ ({}), not left in place",
+        ingested_sst.display(),
+    );
+
+    Ok(())
+}

--- a/tools/sst-dump/Cargo.toml
+++ b/tools/sst-dump/Cargo.toml
@@ -30,8 +30,10 @@ path = "src/main.rs"
 # (verify_sst_file, ParsedMeta-style helpers as they are added).
 # `lz4` + `zstd` features enabled because real production SSTs are
 # usually compressed; without them the tool refuses to walk
-# compressed blocks.
-lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["lz4", "zstd", "encryption"] }
+# compressed blocks. `page_ecc` so the ECC parity trailers of protected
+# SSTs are genuinely VERIFIED rather than skipped with a warning — a
+# forensics tool must not silently report OK over unverifiable parity.
+lsm-tree = { package = "coordinode-lsm-tree", path = "../..", features = ["lz4", "zstd", "encryption", "page_ecc"] }
 clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]

--- a/tools/sst-dump/src/main.rs
+++ b/tools/sst-dump/src/main.rs
@@ -17,7 +17,7 @@ use lsm_tree::inspect::{
     read_filter_stats, read_table_properties, read_top_level_index_entries,
 };
 use lsm_tree::table::block::Header;
-use lsm_tree::verify::{BlockVerifyError, verify_sst_file};
+use lsm_tree::verify::{BlockVerifyError, BlockVerifyWarning, verify_sst_file};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
@@ -246,14 +246,24 @@ enum Command {
     /// Salvage the readable data blocks of a (possibly corrupt) SST into a
     /// fresh SST at `<dest>`. Walks every data block, re-emits the ones that
     /// pass their checksum into a new file with fresh checksums / index /
-    /// filter, and reports the key range of every block it had to drop. A
-    /// columnar segment with a damaged sidecar (delete-bitmap / zone map)
-    /// degrades to a conservative "all rows live" state rather than failing.
-    /// The `<path>` positional is the source SST. Exits non-zero only when the
-    /// source cannot be opened or nothing was recoverable.
+    /// filter, and reports the key range of every block it had to drop. The
+    /// `<path>` positional is the source SST. Exits non-zero when the salvage
+    /// is refused (e.g. delete semantics cannot be preserved) or fails, or
+    /// when nothing was recoverable.
+    ///
+    /// Like `repair`, this uses the DEFAULT comparator, no encryption, and no
+    /// compression dictionary: a custom-comparator, encrypted, or
+    /// dictionary-compressed source is not recovered faithfully here.
     Salvage {
         /// Destination path for the recovered SST (must not already exist).
         dest: PathBuf,
+        /// Salvage a delete-bearing columnar SST whose positional delete
+        /// bitmap cannot be applied (unreadable bitmap, or a bitmap whose
+        /// positioning zone map is unreadable) by emitting EVERY row live.
+        /// Positionally-deleted rows come back in the recovered SST, so this
+        /// degradation is off by default and the salvage fails closed.
+        #[arg(long)]
+        allow_delete_resurrection: bool,
     },
 }
 
@@ -283,7 +293,10 @@ fn main() -> ExitCode {
             table_id,
             reconstruct_aad,
         } => run_dump_block(&cli.path, offset, tree_id, table_id, reconstruct_aad),
-        Command::Salvage { dest } => run_salvage(&cli.path, &dest),
+        Command::Salvage {
+            dest,
+            allow_delete_resurrection,
+        } => run_salvage(&cli.path, &dest, allow_delete_resurrection),
     }
 }
 
@@ -329,11 +342,24 @@ fn run_repair(db_dir: &std::path::Path, salvage: bool) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn run_salvage(source: &std::path::Path, dest: &std::path::Path) -> ExitCode {
+fn run_salvage(
+    source: &std::path::Path,
+    dest: &std::path::Path,
+    allow_delete_resurrection: bool,
+) -> ExitCode {
     use std::sync::Arc;
 
     let fs: Arc<dyn lsm_tree::fs::Fs> = Arc::new(lsm_tree::fs::StdFs);
-    let report = match lsm_tree::salvage::salvage_sst(source, dest.to_path_buf(), &fs) {
+    let options = lsm_tree::salvage::SalvageOptions {
+        allow_delete_resurrection,
+        ..lsm_tree::salvage::SalvageOptions::default()
+    };
+    let report = match lsm_tree::salvage::salvage_sst_with_options(
+        source,
+        dest.to_path_buf(),
+        &fs,
+        &options,
+    ) {
         Ok(report) => report,
         Err(err) => {
             eprintln!("salvage failed: {err}");
@@ -367,18 +393,32 @@ fn run_salvage(source: &std::path::Path, dest: &std::path::Path) -> ExitCode {
         );
     }
 
-    if report.is_complete() {
+    // Warn ONLY when the opt-in actually resurrected positionally-deleted rows
+    // (an unappliable delete mask that the flag let through), not merely because
+    // the flag was passed.
+    if report.delete_rows_resurrected {
+        println!(
+            "warning:         --allow-delete-resurrection re-emitted positionally-deleted \
+             rows LIVE (the delete mask could not be applied faithfully)"
+        );
+    }
+
+    // Check the destination FIRST: `is_complete()` (nothing dropped) is true even
+    // when every block was wholly deleted, in which case no file is written and
+    // `<dest>` does not exist. Reporting "fully recovered" then would tell
+    // automation the destination is ready when the command produced none.
+    if report.salvaged_path.is_none() {
+        println!("status:          nothing recoverable");
+        ExitCode::FAILURE
+    } else if report.is_complete() {
         println!("status:          fully recovered");
         ExitCode::SUCCESS
-    } else if report.salvaged_path.is_some() {
+    } else {
         println!(
             "status:          partially recovered ({} block(s) dropped)",
             report.dropped.len(),
         );
         ExitCode::SUCCESS
-    } else {
-        println!("status:          nothing recoverable");
-        ExitCode::FAILURE
     }
 }
 
@@ -388,10 +428,41 @@ fn run_verify(path: &std::path::Path, verbose: bool) -> ExitCode {
     println!("file:           {}", path.display());
     println!("blocks scanned: {}", report.blocks_scanned);
     println!("errors:         {}", report.errors.len());
+    println!("warnings:       {}", report.warnings.len());
+    // Warnings are non-fatal but must never be silent: each one names a
+    // surface the walk could NOT fully check, and a consumer treating a bare
+    // "OK" as "everything verified" would be misled.
+    for warning in &report.warnings {
+        match warning {
+            BlockVerifyWarning::UnrecognizedEcc { table_id, path } => println!(
+                "  [warning] UnrecognizedEcc: table {table_id} at {}: ECC descriptor \
+                 not recognized by this build; ECC verification skipped",
+                path.display(),
+            ),
+            BlockVerifyWarning::ParityUnverifiable { table_id, path } => println!(
+                "  [warning] ParityUnverifiable: table {table_id} at {}: recognized \
+                 ECC scheme but this build carries no ECC codecs; parity not verified",
+                path.display(),
+            ),
+            // `BlockVerifyWarning` is `#[non_exhaustive]` upstream; surface
+            // future variants through their Debug form rather than dropping
+            // them.
+            other => println!("  [warning] {other:?}"),
+        }
+    }
 
     if report.is_ok() {
         println!("status:         OK");
         return ExitCode::SUCCESS;
+    }
+
+    // No per-block errors, yet not OK: a whole section was skipped unwalked
+    // (an unrecognized ECC descriptor forced the walk past its data blocks).
+    // That is not proof of corruption, but it is not a verified file either —
+    // report it as its own non-success verdict.
+    if report.errors.is_empty() && report.incomplete {
+        println!("status:         INCOMPLETE (a section was skipped unverified)");
+        return ExitCode::FAILURE;
     }
 
     println!("status:         CORRUPT");
@@ -401,14 +472,15 @@ fn run_verify(path: &std::path::Path, verbose: bool) -> ExitCode {
     for (idx, err) in report.errors.iter().take(to_show).enumerate() {
         // Show each error with its variant tag so consumers grep'ing
         // for a specific failure mode (HeaderCorrupted, DataCorrupted,
-        // DataReadError, TocCorrupted, SstFileUnreadable) get a stable
-        // anchor. The Display impl includes file path + offset + a
-        // human reason.
+        // DataReadError, EccParityMismatch, TocCorrupted,
+        // SstFileUnreadable) get a stable anchor. The Display impl
+        // includes file path + offset + a human reason.
         let kind = match err {
             BlockVerifyError::SstFileUnreadable { .. } => "SstFileUnreadable",
             BlockVerifyError::HeaderCorrupted { .. } => "HeaderCorrupted",
             BlockVerifyError::DataCorrupted { .. } => "DataCorrupted",
             BlockVerifyError::DataReadError { .. } => "DataReadError",
+            BlockVerifyError::EccParityMismatch { .. } => "EccParityMismatch",
             BlockVerifyError::TocCorrupted { .. } => "TocCorrupted",
             // `BlockVerifyError` is `#[non_exhaustive]` upstream — a
             // future lib release can add new variants without bumping

--- a/tools/sst-dump/tests/verify_smoke.rs
+++ b/tools/sst-dump/tests/verify_smoke.rs
@@ -94,6 +94,71 @@ fn line_value(text: &str, label: &str) -> Option<String> {
     })
 }
 
+/// A Page-ECC SST must have its parity actually VERIFIED by the tool (the
+/// build enables `page_ecc`), and the verdict must surface the warning
+/// channel: a `warnings:` line is always printed, and a clean ECC SST shows
+/// zero warnings. Without the feature every ECC SST silently reported OK
+/// while its parity was skipped (a `ParityUnverifiable` warning that the
+/// output never showed).
+#[test]
+fn verify_ecc_sst_verifies_parity_and_reports_warnings() {
+    use lsm_tree::runtime_config::EccScheme;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tree = Config::new(
+        dir.path(),
+        SequenceNumberCounter::default(),
+        SequenceNumberCounter::default(),
+    )
+    .data_block_compression_policy(CompressionPolicy::all(CompressionType::None))
+    .page_ecc(true)
+    .ecc_scheme(EccScheme::ReedSolomon {
+        data_shards: 8,
+        parity_shards: 2,
+    })
+    .open()
+    .expect("open ecc tree");
+    for i in 0u64..200 {
+        tree.insert(format!("key-{i:06}"), format!("value-{i}"), 1 + i);
+    }
+    tree.flush_active_memtable(0).expect("flush");
+    drop(tree);
+    let tables = dir.path().join("tables");
+    let sst = std::fs::read_dir(&tables)
+        .expect("tables dir")
+        .filter_map(Result::ok)
+        .find(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .expect("at least one SST")
+        .path();
+
+    let out = Command::new(SST_DUMP_BIN)
+        .arg(&sst)
+        .arg("verify")
+        .output()
+        .expect("spawn sst-dump");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "expected exit 0 on a clean ECC SST; stdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert_eq!(
+        line_value(&stdout, "status"),
+        Some("OK".to_owned()),
+        "expected status=OK in output; got:\n{stdout}",
+    );
+    // warnings=0 pins BOTH halves: the line exists (the warning channel is
+    // surfaced, nothing is silently dropped) AND it is zero (the build
+    // carries the ECC codecs, so no ParityUnverifiable was emitted and the
+    // parity trailers were genuinely checked).
+    assert_eq!(
+        line_value(&stdout, "warnings"),
+        Some("0".to_owned()),
+        "expected warnings=0 (parity verified, channel surfaced); got:\n{stdout}",
+    );
+}
+
 #[test]
 fn verify_tampered_sst_exits_nonzero_with_corrupt() {
     let (_dir, sst) = build_one_sst();


### PR DESCRIPTION
Hardens recovery, salvage, and manifest repair into a total, deterministic
pipeline that always yields a valid, openable tree, for both SST tables and
vlog blob files.

## SST salvage
- Block-level SST salvage recovers readable data blocks and drops corrupt
  ones, re-emitting the survivors into a fresh, verifiable SST under the
  tree's comparator, encryption, and dictionary context.
- A fast surface copies clean blocks through verbatim (no decode/re-encode)
  and heals single-block ECC in place; the faithful surface decodes and
  rewrites when a block cannot be copied through.
- Salvage fails closed on a table it cannot re-emit faithfully (range
  tombstones), preserving correctness over a lossy rewrite.

## Blob-file salvage (KV separation)
- `salvage_blob_file` gives vlog blob files the same block-granular treatment
  as SSTs: it walks the file record by record, keeps every intact record, and
  drops only the damaged ones instead of condemning the whole file.
- `BlobSalvageReport` returns the dropped records (`Vec<DroppedBlob>`) and an
  `offset_remap` mapping every salvaged record's source offset to its offset
  in the rewritten file, so the SST value handles that point into the blob
  file can be re-targeted rather than invalidated.
- A truncated tail is never partially reconstructed: a record whose header or
  payload does not fully land is dropped, because keeping part of it would
  fabricate a value and a bogus remap entry.
- Manifest repair is blob-aware end to end: a table whose referenced blob file
  is unrecoverable is excluded (and set aside) rather than wired into a
  rebuilt manifest as a dangling reference, and blob frontiers survive across
  recovery so a reclaimed blob file verifies against its live suffix.
- When the manifest itself is lost, a punched blob file's frontier is
  re-derived from the punch geometry: the zeroed data-section prefix is
  anchored at a validly decoding frame (a zero-filled value payload can never
  move the frontier; a partially completed punch is walked hole by hole), the
  digest covers the live suffix from the derived frontier, and the rebuilt
  snapshot re-persists the restriction — so a later relocation resumes exactly
  where the punch stopped instead of erroring inside the zeroed prefix. An
  unpunched file short-circuits on its first non-zero data byte at zero extra
  read cost. See `docs/manifest-recovery.md` § Blob frontier resolution.

## Columnar scans under restriction and MVCC
- `Table::columnar_scan` clamps to a tight-space-restricted view's live
  suffix: data blocks wholly below the bound (hole-punched, reading as zeros)
  are stepped over with their zone-map row counts preserving positional
  delete mapping, and the straddling block's sub-bound rows are masked.
- The tree-level scan's singleton path dedups MVCC versions inside a single
  segment: a flush / compaction product physically stores every version of an
  overwritten key, so singletons that can carry duplicates (the writer's
  persisted `key_count` differing from `item_count`) get per-key
  newest-visible selection, with the predicate running after dedup exactly
  like the overlap-merge path. Provably-unique segments keep the zero-copy
  verbatim fast path.

## Recovery progress
- `RecoveryProgress` (wired via `Config::with_recovery_progress` or
  `SalvageOptions::progress`) exposes live counters a UI thread can poll
  while a repair runs: tables and blob files as they are discovered and
  recovered, blocks as the salvage walk inspects / re-emits / drops them,
  ECC-healed blocks, and recovered KV entries and columnar columns.

## In-place ECC autoheal
- Corrected reads emit heal hints; a background pass rewrites healed blocks
  under fresh parity, guarded by a tri-state attestation marker so an
  inconclusive check preserves rather than deletes it.

## Manifest recovery
- Rebuilding a lost manifest by scanning `tables/` is total: every branch
  yields a valid tree, and re-running is deterministic.
- A tight-space-punched SST is recovered **restricted** to its live suffix.
  The `.restrict-bound` sidecar is written strictly after the slice's
  install commits, so a valid sidecar proves a committed restriction and
  its exact bound is honored directly, with no dead-prefix probing; absent
  a trustworthy sidecar, the bound derives from the punch geometry. The
  readable suffix is never discarded, even when it is itself corrupt
  (salvaged, then re-restricted).
- The single recovery policy knob, `allow_resurrection` (default drop),
  governs the ambiguous cases: a lost restriction bound and an
  unauthenticated or concealed delete mask. Off, ambiguous data is dropped
  to avoid resurrecting superseded or deleted rows; on, it is kept. Neither
  setting requires a manual step.
- Transient I/O propagates for retry; persistent failures classify
  deterministically. Genuinely unrecoverable files (foreign name, redundant
  duplicate, undecodable) are set aside, still leaving a valid tree.

## Checkpoint interaction
- A checkpoint that reflinks a file syncs the clone at the requested
  durability before treating it as complete.
- Tight-space prefix reclamation refuses to punch a file whose inode is
  shared with a checkpoint, so reclaiming space in the live tree can never
  hole-punch a checkpoint's data.

## Tooling and CI
- A heal fuzzer drives single-bit corruption across a fixed corpus of SSTs
  (varied block size, per-KV checksum, columnar layout, compression,
  encryption, Page-ECC), asserting recover-and-scan never panics and never
  returns a wrong value, and dumping the exact failing SST for repro.
- The fuzzer needs a CI home, so this PR adds the `fuzz-heal` job that runs
  it on a fixed budget with retries disabled (a retry would overwrite the
  reproducer dump or mask a non-replaying failure) and surfaces the failing
  SST inline in the log.
- Pinning policy: first-party GitHub actions (`actions/*`, `dependabot/*`)
  are pinned by major version tag (`actions/checkout@v7`) — SHA-pinning a
  GitHub-owned org adds no supply-chain protection while churning a
  Dependabot bump PR per patch release. Third-party actions (dtolnay,
  Swatinem, taiki-e, codecov, release-plz, benchmark-action) stay pinned to
  full commit SHAs; `release-plz/action` is aligned to v0.5.131. No workflow
  behaviour changes beyond the new job.

## Testing
- Full suite green with `--all-features` (nextest), `no_std` (alloc) clean,
  `cargo doc --all-features -D warnings` and doctests clean, clippy
  all-features/all-targets clean. `docs/manifest-recovery.md` diagrams the
  recovery algorithm and its invariants.

Closes #568
Closes #570

